### PR TITLE
Refactor traffic target visibility logic into its own pkg

### DIFF
--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -24,9 +24,9 @@ import (
 	"text/template"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	pkgnet "knative.dev/pkg/network"
+	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler/route/config"
@@ -39,7 +39,7 @@ import (
 const HTTPScheme string = "http"
 
 // GetAllDomainsAndTags returns all of the domains and tags(including subdomains) associated with a Route
-func GetAllDomainsAndTags(ctx context.Context, r *v1alpha1.Route, names []string, localServiceNames sets.String) (map[string]string, error) {
+func GetAllDomainsAndTags(ctx context.Context, r *v1alpha1.Route, names []string, visibility map[string]netv1alpha1.IngressVisibility) (map[string]string, error) {
 	domainTagMap := make(map[string]string)
 
 	for _, name := range names {
@@ -50,7 +50,7 @@ func GetAllDomainsAndTags(ctx context.Context, r *v1alpha1.Route, names []string
 			return nil, err
 		}
 
-		labels.SetVisibility(meta, localServiceNames.Has(hostname))
+		labels.SetVisibility(meta, visibility[name] == netv1alpha1.IngressVisibilityClusterLocal)
 
 		subDomain, err := DomainNameFromTemplate(ctx, *meta, hostname)
 		if err != nil {

--- a/pkg/reconciler/route/domains/domains_test.go
+++ b/pkg/reconciler/route/domains/domains_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis"
@@ -244,7 +243,7 @@ func TestGetAllDomainsAndTags(t *testing.T) {
 			ctx = config.ToContext(ctx, cfg)
 
 			// here, a tag-less major domain will have empty string as the input
-			got, err := GetAllDomainsAndTags(ctx, route, []string{"", "target-1", "target-2"}, sets.String{})
+			got, err := GetAllDomainsAndTags(ctx, route, []string{"", "target-1", "target-2"}, nil /* visibility */)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetAllDomains() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -104,8 +104,14 @@ func (c *Reconciler) deleteServices(namespace string, serviceNames sets.String) 
 	return nil
 }
 
-func (c *Reconciler) reconcilePlaceholderServices(ctx context.Context, route *v1alpha1.Route, targets map[string]traffic.RevisionTargets, existingServiceNames sets.String) ([]*corev1.Service, error) {
+func (c *Reconciler) reconcilePlaceholderServices(ctx context.Context, route *v1alpha1.Route, targets map[string]traffic.RevisionTargets) ([]*corev1.Service, error) {
 	logger := logging.FromContext(ctx)
+	existingServices, err := c.getServices(route)
+	if err != nil {
+		return nil, err
+	}
+	existingServiceNames := resources.GetNames(existingServices)
+
 	ns := route.Namespace
 
 	names := sets.NewString()

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/ptr"
@@ -212,7 +211,7 @@ func newTestIngress(t *testing.T, r *v1alpha1.Route, trafficOpts ...func(tc *tra
 		SecretName:      "test-secret",
 		SecretNamespace: "test-ns",
 	}}
-	ingress, err := resources.MakeIngress(getContext(), r, tc, tls, sets.NewString(), "foo-ingress")
+	ingress, err := resources.MakeIngress(getContext(), r, tc, tls, "foo-ingress")
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
 	}

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -56,6 +56,7 @@ import (
 	"knative.dev/serving/pkg/reconciler/route/resources/labels"
 	resourcenames "knative.dev/serving/pkg/reconciler/route/resources/names"
 	"knative.dev/serving/pkg/reconciler/route/traffic"
+	"knative.dev/serving/pkg/reconciler/route/visibility"
 )
 
 // routeFinalizer is the name that we put into the resource finalizer list, e.g.
@@ -192,17 +193,8 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 
 	logger.Infof("Reconciling route: %#v", r)
 
-	serviceNames, err := c.getServiceNames(ctx, r)
-	if err != nil {
-		return err
-	}
-
-	if err := c.updateRouteStatusURL(ctx, r, serviceNames.clusterLocal()); err != nil {
-		return err
-	}
-
 	// Configure traffic based on the RouteSpec.
-	traffic, err := c.configureTraffic(ctx, r, serviceNames.desiredClusterLocalServiceNames)
+	traffic, err := c.configureTraffic(ctx, r)
 	if traffic == nil || err != nil {
 		// Traffic targets aren't ready, no need to configure child resources.
 		// Need to update ObservedGeneration, otherwise Route's Ready state won't
@@ -229,19 +221,18 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 	}
 
 	logger.Info("Creating placeholder k8s services")
-	services, err := c.reconcilePlaceholderServices(ctx, r, traffic.Targets, serviceNames.existing())
+	services, err := c.reconcilePlaceholderServices(ctx, r, traffic.Targets)
 	if err != nil {
 		return err
 	}
 
-	clusterLocalServiceNames := serviceNames.clusterLocal()
-	tls, acmeChallenges, err := c.tls(ctx, r.Status.URL.Host, r, traffic, clusterLocalServiceNames)
+	tls, acmeChallenges, err := c.tls(ctx, r.Status.URL.Host, r, traffic)
 	if err != nil {
 		return err
 	}
 
 	// Reconcile ingress and its children resources.
-	ingress, err := c.reconcileIngressResources(ctx, r, traffic, tls, clusterLocalServiceNames, ingressClassForRoute(ctx, r), acmeChallenges...)
+	ingress, err := c.reconcileIngressResources(ctx, r, traffic, tls, ingressClassForRoute(ctx, r), acmeChallenges...)
 
 	if err != nil {
 		return err
@@ -264,9 +255,9 @@ func (c *Reconciler) reconcile(ctx context.Context, r *v1alpha1.Route) error {
 }
 
 func (c *Reconciler) reconcileIngressResources(ctx context.Context, r *v1alpha1.Route, tc *traffic.Config, tls []netv1alpha1.IngressTLS,
-	clusterLocalServices sets.String, ingressClass string, acmeChallenges ...netv1alpha1.HTTP01Challenge) (*netv1alpha1.Ingress, error) {
+	ingressClass string, acmeChallenges ...netv1alpha1.HTTP01Challenge) (*netv1alpha1.Ingress, error) {
 
-	desired, err := resources.MakeIngress(ctx, r, tc, tls, clusterLocalServices, ingressClass, acmeChallenges...)
+	desired, err := resources.MakeIngress(ctx, r, tc, tls, ingressClass, acmeChallenges...)
 	if err != nil {
 		return nil, err
 	}
@@ -279,12 +270,12 @@ func (c *Reconciler) reconcileIngressResources(ctx context.Context, r *v1alpha1.
 	return ingress, nil
 }
 
-func (c *Reconciler) tls(ctx context.Context, host string, r *v1alpha1.Route, traffic *traffic.Config, clusterLocalServiceNames sets.String) ([]netv1alpha1.IngressTLS, []netv1alpha1.HTTP01Challenge, error) {
+func (c *Reconciler) tls(ctx context.Context, host string, r *v1alpha1.Route, traffic *traffic.Config) ([]netv1alpha1.IngressTLS, []netv1alpha1.HTTP01Challenge, error) {
 	tls := []netv1alpha1.IngressTLS{}
 	if !config.FromContext(ctx).Network.AutoTLS {
 		return tls, nil, nil
 	}
-	domainToTagMap, err := domains.GetAllDomainsAndTags(ctx, r, getTrafficNames(traffic.Targets), clusterLocalServiceNames)
+	domainToTagMap, err := domains.GetAllDomainsAndTags(ctx, r, getTrafficNames(traffic.Targets), traffic.Visibility)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -389,14 +380,23 @@ func (c *Reconciler) reconcileDeletion(ctx context.Context, r *v1alpha1.Route) e
 //
 // If traffic is configured we update the RouteStatus with AllTrafficAssigned = True.  Otherwise we
 // mark AllTrafficAssigned = False, with a message referring to one of the missing target.
-func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route, clusterLocalServices sets.String) (*traffic.Config, error) {
+func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route) (*traffic.Config, error) {
 	logger := logging.FromContext(ctx)
-	t, err := traffic.BuildTrafficConfiguration(c.configurationLister, c.revisionLister, r)
-
+	t, trafficErr := traffic.BuildTrafficConfiguration(c.configurationLister, c.revisionLister, r)
 	if t == nil {
+		return nil, trafficErr
+	}
+	// Augment traffic configuration with visibility information.  Do not overwrite trafficErr,
+	// since we will use it later.
+	visibility, err := visibility.NewResolver(c.serviceLister).GetVisibility(ctx, r)
+	if err != nil {
 		return nil, err
 	}
-
+	t.Visibility = visibility
+	// Update the Route URL.
+	if err := c.updateRouteStatusURL(ctx, r, t.Visibility); err != nil {
+		return nil, err
+	}
 	// Tell our trackers to reconcile Route whenever the things referred to by our
 	// traffic stanza change. We also track missing targets since there may be
 	// race conditions were routes are reconciled before their targets appear
@@ -420,12 +420,12 @@ func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route, cl
 		}
 	}
 
-	badTarget, isTargetError := err.(traffic.TargetError)
-	if err != nil && !isTargetError {
+	badTarget, isTargetError := trafficErr.(traffic.TargetError)
+	if trafficErr != nil && !isTargetError {
 		// An error that's not due to missing traffic target should
 		// make us fail fast.
-		r.Status.MarkUnknownTrafficError(err.Error())
-		return nil, err
+		r.Status.MarkUnknownTrafficError(trafficErr.Error())
+		return nil, trafficErr
 	}
 	if badTarget != nil && isTargetError {
 		logger.Infof("Marking bad traffic target: %v", badTarget)
@@ -436,8 +436,9 @@ func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route, cl
 	}
 
 	logger.Info("All referred targets are routable, marking AllTrafficAssigned with traffic information.")
+
 	// Domain should already be present
-	r.Status.Traffic, err = t.GetRevisionTrafficTargets(ctx, r, clusterLocalServices)
+	r.Status.Traffic, err = t.GetRevisionTrafficTargets(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -447,14 +448,10 @@ func (c *Reconciler) configureTraffic(ctx context.Context, r *v1alpha1.Route, cl
 	return t, nil
 }
 
-func (c *Reconciler) updateRouteStatusURL(ctx context.Context, route *v1alpha1.Route, clusterLocalServices sets.String) error {
-	mainRouteServiceName, err := domains.HostnameFromTemplate(ctx, route.Name, "")
-	if err != nil {
-		return err
-	}
+func (c *Reconciler) updateRouteStatusURL(ctx context.Context, route *v1alpha1.Route, visibility map[string]netv1alpha1.IngressVisibility) error {
+	isClusterLocal := visibility[traffic.DefaultTarget] == netv1alpha1.IngressVisibilityClusterLocal
 
 	mainRouteMeta := route.ObjectMeta.DeepCopy()
-	isClusterLocal := clusterLocalServices.Has(mainRouteServiceName) || labels.IsObjectLocalVisibility(route.ObjectMeta)
 	labels.SetVisibility(mainRouteMeta, isClusterLocal)
 
 	host, err := domains.DomainNameFromTemplate(ctx, *mainRouteMeta, route.Name)
@@ -470,45 +467,6 @@ func (c *Reconciler) updateRouteStatusURL(ctx context.Context, route *v1alpha1.R
 	return nil
 }
 
-func (c *Reconciler) getServiceNames(ctx context.Context, route *v1alpha1.Route) (*serviceNames, error) {
-	// Populate existing service name sets
-	existingServices, err := c.getServices(route)
-	if err != nil {
-		return nil, err
-	}
-	existingServiceNames := resources.GetNames(existingServices)
-	existingClusterLocalServices := resources.FilterService(existingServices, resources.IsClusterLocalService)
-	existingClusterLocalServiceNames := resources.GetNames(existingClusterLocalServices)
-	existingPublicServiceNames := existingServiceNames.Difference(existingClusterLocalServiceNames)
-
-	// Populate desired service name sets
-	desiredServiceNames, err := resources.GetDesiredServiceNames(ctx, route)
-	if err != nil {
-		return nil, err
-	}
-	if labels.IsObjectLocalVisibility(route.ObjectMeta) {
-		return &serviceNames{
-			existingPublicServiceNames:       existingPublicServiceNames,
-			existingClusterLocalServiceNames: existingClusterLocalServiceNames,
-			desiredPublicServiceNames:        sets.NewString(),
-			desiredClusterLocalServiceNames:  desiredServiceNames,
-		}, nil
-	}
-	desiredPublicServiceNames := desiredServiceNames.Intersection(existingPublicServiceNames)
-	desiredClusterLocalServiceNames := desiredServiceNames.Intersection(existingClusterLocalServiceNames)
-
-	// Any new desired services will follow the default route visibility, which is public.
-	serviceWithDefaultVisibility := desiredServiceNames.Difference(existingServiceNames)
-	desiredPublicServiceNames = desiredPublicServiceNames.Union(serviceWithDefaultVisibility)
-
-	return &serviceNames{
-		existingPublicServiceNames:       existingPublicServiceNames,
-		existingClusterLocalServiceNames: existingClusterLocalServiceNames,
-		desiredPublicServiceNames:        desiredPublicServiceNames,
-		desiredClusterLocalServiceNames:  desiredClusterLocalServiceNames,
-	}, nil
-}
-
 // GetServingClient returns the client to access Knative serving resources.
 func (c *Reconciler) GetServingClient() clientset.Interface {
 	return c.ServingClientSet
@@ -522,21 +480,6 @@ func (c *Reconciler) GetCertificateLister() networkinglisters.CertificateLister 
 /////////////////////////////////////////
 // Misc helpers.
 /////////////////////////////////////////
-
-type serviceNames struct {
-	existingPublicServiceNames       sets.String
-	existingClusterLocalServiceNames sets.String
-	desiredPublicServiceNames        sets.String
-	desiredClusterLocalServiceNames  sets.String
-}
-
-func (sn serviceNames) existing() sets.String {
-	return sn.existingPublicServiceNames.Union(sn.existingClusterLocalServiceNames)
-}
-
-func (sn serviceNames) clusterLocal() sets.String {
-	return sn.existingClusterLocalServiceNames.Union(sn.desiredClusterLocalServiceNames)
-}
 
 type accessor interface {
 	GetGroupVersionKind() schema.GroupVersionKind

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -277,13 +277,13 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
 	expectedSpec := netv1alpha1.IngressSpec{
-		Visibility: netv1alpha1.IngressVisibilityExternalIP,
-		TLS:        []netv1alpha1.IngressTLS{},
+		TLS: []netv1alpha1.IngressTLS{},
 		Rules: []netv1alpha1.IngressRule{{
 			Hosts: []string{
 				"test-route.test.svc.cluster.local",
 				domain,
 			},
+			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 			HTTP: &netv1alpha1.HTTPIngressRuleValue{
 				Paths: []netv1alpha1.HTTPIngressPath{{
 					Splits: []netv1alpha1.IngressBackendSplit{{
@@ -300,7 +300,6 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 					}},
 				}},
 			},
-			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 		}},
 	}
 	if diff := cmp.Diff(expectedSpec, ci.Spec); diff != "" {
@@ -388,8 +387,7 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 	ci := getRouteIngressFromClient(ctx, t, route)
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
 	expectedSpec := netv1alpha1.IngressSpec{
-		Visibility: netv1alpha1.IngressVisibilityExternalIP,
-		TLS:        []netv1alpha1.IngressTLS{},
+		TLS: []netv1alpha1.IngressTLS{},
 		Rules: []netv1alpha1.IngressRule{{
 			Hosts: []string{
 				"test-route.test.svc.cluster.local",
@@ -476,8 +474,7 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 	ci := getRouteIngressFromClient(ctx, t, route)
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
 	expectedSpec := netv1alpha1.IngressSpec{
-		Visibility: netv1alpha1.IngressVisibilityExternalIP,
-		TLS:        []netv1alpha1.IngressTLS{},
+		TLS: []netv1alpha1.IngressTLS{},
 		Rules: []netv1alpha1.IngressRule{{
 			Hosts: []string{
 				"test-route.test.svc.cluster.local",
@@ -588,8 +585,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 	ci := getRouteIngressFromClient(ctx, t, route)
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
 	expectedSpec := netv1alpha1.IngressSpec{
-		Visibility: netv1alpha1.IngressVisibilityExternalIP,
-		TLS:        []netv1alpha1.IngressTLS{},
+		TLS: []netv1alpha1.IngressTLS{},
 		Rules: []netv1alpha1.IngressRule{{
 			Hosts: []string{
 				"test-route.test.svc.cluster.local",
@@ -721,8 +717,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 	ci := getRouteIngressFromClient(ctx, t, route)
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
 	expectedSpec := netv1alpha1.IngressSpec{
-		Visibility: netv1alpha1.IngressVisibilityExternalIP,
-		TLS:        []netv1alpha1.IngressTLS{},
+		TLS: []netv1alpha1.IngressTLS{},
 		Rules: []netv1alpha1.IngressRule{{
 			Hosts: []string{
 				"test-route.test.svc.cluster.local",

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -198,7 +198,6 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 				"custom-ingress-class",
-				sets.NewString(),
 			),
 			simplePlaceholderK8sService(
 				getContext(),
@@ -236,7 +235,7 @@ func TestReconcile(t *testing.T) {
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("tb")),
 		},
 		WantCreates: []runtime.Object{
-			simpleIngressWithVisibility(
+			simpleIngress(
 				Route("default", "becomes-ready", WithConfigTarget("config"),
 					WithLocalDomain, WithRouteUID("65-23"),
 					WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"})),
@@ -252,8 +251,10 @@ func TestReconcile(t *testing.T) {
 							Active:      true,
 						}},
 					},
+					Visibility: map[string]netv1alpha1.IngressVisibility{
+						traffic.DefaultTarget: netv1alpha1.IngressVisibilityClusterLocal,
+					},
 				},
-				sets.NewString("becomes-ready"),
 			),
 			simplePlaceholderK8sService(
 				getContext(),
@@ -710,7 +711,7 @@ func TestReconcile(t *testing.T) {
 				WithRouteUID("65-23"))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: simpleIngressWithVisibility(
+			Object: simpleIngress(
 				Route("default", "becomes-local", WithConfigTarget("config"),
 					WithRouteUID("65-23"),
 					WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"})),
@@ -726,8 +727,10 @@ func TestReconcile(t *testing.T) {
 							Active:      true,
 						}},
 					},
+					Visibility: map[string]netv1alpha1.IngressVisibility{
+						traffic.DefaultTarget: netv1alpha1.IngressVisibilityClusterLocal,
+					},
 				},
-				sets.NewString("becomes-local"),
 			),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -753,7 +756,7 @@ func TestReconcile(t *testing.T) {
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
 			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("tb")),
-			simpleIngressWithVisibility(
+			simpleIngress(
 				Route("default", "becomes-public", WithConfigTarget("config"), WithRouteUID("65-23"),
 					WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"})),
 				&traffic.Config{
@@ -768,8 +771,10 @@ func TestReconcile(t *testing.T) {
 							Active:      true,
 						}},
 					},
+					Visibility: map[string]netv1alpha1.IngressVisibility{
+						traffic.DefaultTarget: netv1alpha1.IngressVisibilityClusterLocal,
+					},
 				},
-				sets.NewString("becomes-public"),
 			),
 			simpleK8sService(Route("default", "becomes-public", WithConfigTarget("config"),
 				WithRouteUID("65-23"))),
@@ -2352,7 +2357,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				WithRouteUID("65-23"))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: simpleIngressWithVisibility(
+			Object: simpleIngress(
 				Route("default", "becomes-local", WithConfigTarget("config"),
 					WithRouteUID("65-23"),
 					WithRouteLabel(map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal})),
@@ -2368,8 +2373,10 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 							Active:      true,
 						}},
 					},
+					Visibility: map[string]netv1alpha1.IngressVisibility{
+						traffic.DefaultTarget: netv1alpha1.IngressVisibilityClusterLocal,
+					},
 				},
-				sets.NewString("becomes-local"),
 			),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -2597,19 +2604,15 @@ type ingressCtor func(ctx context.Context,
 ) (*netv1alpha1.Ingress, error)
 
 func simpleIngress(r *v1alpha1.Route, tc *traffic.Config, io ...IngressOption) *netv1alpha1.Ingress {
-	return simpleIngressWithVisibility(r, tc, sets.NewString(), io...)
+	return baseIngressWithClass(r, tc, TestIngressClass, io...)
 }
 
-func simpleIngressWithVisibility(r *v1alpha1.Route, tc *traffic.Config, serviceVisibility sets.String, io ...IngressOption) *netv1alpha1.Ingress {
-	return baseIngressWithClass(r, tc, TestIngressClass, serviceVisibility, resources.MakeIngress, io...)
+func ingressWithClass(r *v1alpha1.Route, tc *traffic.Config, class string, io ...IngressOption) *netv1alpha1.Ingress {
+	return baseIngressWithClass(r, tc, class, io...)
 }
 
-func ingressWithClass(r *v1alpha1.Route, tc *traffic.Config, class string, serviceVisibility sets.String, io ...IngressOption) *netv1alpha1.Ingress {
-	return baseIngressWithClass(r, tc, class, serviceVisibility, resources.MakeIngress, io...)
-}
-
-func baseIngressWithClass(r *v1alpha1.Route, tc *traffic.Config, class string, serviceVisibility sets.String, ctor ingressCtor, io ...IngressOption) *netv1alpha1.Ingress {
-	ingress, _ := ctor(getContext(), r, tc, nil, serviceVisibility, class)
+func baseIngressWithClass(r *v1alpha1.Route, tc *traffic.Config, class string, io ...IngressOption) *netv1alpha1.Ingress {
+	ingress, _ := resources.MakeIngress(getContext(), r, tc, nil, class)
 
 	for _, opt := range io {
 		opt(ingress)
@@ -2619,11 +2622,11 @@ func baseIngressWithClass(r *v1alpha1.Route, tc *traffic.Config, class string, s
 }
 
 func ingressWithTLS(r *v1alpha1.Route, tc *traffic.Config, tls []netv1alpha1.IngressTLS, challenges []netv1alpha1.HTTP01Challenge, io ...IngressOption) *netv1alpha1.Ingress {
-	return baseIngressWithTLS(r, tc, tls, resources.MakeIngress, challenges, io...)
+	return baseIngressWithTLS(r, tc, tls, challenges, io...)
 }
 
-func baseIngressWithTLS(r *v1alpha1.Route, tc *traffic.Config, tls []netv1alpha1.IngressTLS, ctor ingressCtor, challenges []netv1alpha1.HTTP01Challenge, io ...IngressOption) *netv1alpha1.Ingress {
-	ingress, _ := ctor(getContext(), r, tc, tls, sets.NewString(), TestIngressClass, challenges...)
+func baseIngressWithTLS(r *v1alpha1.Route, tc *traffic.Config, tls []netv1alpha1.IngressTLS, challenges []netv1alpha1.HTTP01Challenge, io ...IngressOption) *netv1alpha1.Ingress {
+	ingress, _ := resources.MakeIngress(getContext(), r, tc, tls, TestIngressClass, challenges...)
 
 	for _, opt := range io {
 		opt(ingress)

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -25,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"knative.dev/pkg/ptr"
 	net "knative.dev/serving/pkg/apis/networking"
@@ -998,7 +997,7 @@ func TestRoundTripping(t *testing.T) {
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, route); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else {
-		targets, err := tc.GetRevisionTrafficTargets(getContext(), route, sets.String{})
+		targets, err := tc.GetRevisionTrafficTargets(getContext(), route)
 		if err != nil {
 			t.Errorf("Unexpected error %v", err)
 		}

--- a/pkg/reconciler/route/visibility/doc.go
+++ b/pkg/reconciler/route/visibility/doc.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This package contains code that translate our TrafficTarget to an
+intermediate format that has less semantic.  In particular it deals
+with flattening the TrafficTarget to the revision level -- it also
+does the grouping of traffic target into their traffic groups.
+*/
+
+package visibility

--- a/pkg/reconciler/route/visibility/visibility.go
+++ b/pkg/reconciler/route/visibility/visibility.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package visibility
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apilabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	listers "k8s.io/client-go/listers/core/v1"
+	"knative.dev/pkg/network"
+	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/apis/serving"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	"knative.dev/serving/pkg/reconciler/route/config"
+	"knative.dev/serving/pkg/reconciler/route/domains"
+	"knative.dev/serving/pkg/reconciler/route/resources/labels"
+	"knative.dev/serving/pkg/reconciler/route/traffic"
+)
+
+// Resolver resolves the visibility of traffic targets, based on both the Route and placeholder Services labels.
+type Resolver struct {
+	serviceLister listers.ServiceLister
+}
+
+// NewResolver returns a new Resolver.
+func NewResolver(l listers.ServiceLister) *Resolver {
+	return &Resolver{serviceLister: l}
+}
+
+func (b *Resolver) getServices(route *v1alpha1.Route) (map[string]*corev1.Service, error) {
+	// List all the Services owned by this Route.
+	currentServices, err := b.serviceLister.Services(route.Namespace).List(apilabels.SelectorFromSet(
+		apilabels.Set{
+			serving.RouteLabelKey: route.Name,
+		},
+	))
+	if err != nil {
+		return nil, err
+	}
+
+	serviceCopy := make(map[string]*corev1.Service, len(currentServices))
+	for _, svc := range currentServices {
+		serviceCopy[svc.Name] = svc.DeepCopy()
+	}
+
+	return serviceCopy, err
+}
+
+func (b *Resolver) routeVisibility(ctx context.Context, route *v1alpha1.Route) netv1alpha1.IngressVisibility {
+	domainConfig := config.FromContext(ctx).Domain
+	domain := domainConfig.LookupDomainForLabels(route.Labels)
+	if domain == "svc."+network.GetClusterDomainName() {
+		return netv1alpha1.IngressVisibilityClusterLocal
+	}
+	return netv1alpha1.IngressVisibilityExternalIP
+}
+
+func trafficNames(route *v1alpha1.Route) sets.String {
+	names := sets.NewString(traffic.DefaultTarget)
+	for _, tt := range route.Spec.Traffic {
+		names.Insert(tt.Tag)
+	}
+	return names
+}
+
+// GetVisibility returns a map from traffic target name to their corresponding netv1alpha1.IngressVisibility.
+func (b *Resolver) GetVisibility(ctx context.Context, route *v1alpha1.Route) (map[string]netv1alpha1.IngressVisibility, error) {
+	// Find out the default visibility of the Route.
+	defaultVisibility := b.routeVisibility(ctx, route)
+
+	// Get all the placeholder Services to check for additional visibility settings.
+	services, err := b.getServices(route)
+	if err != nil {
+		return nil, err
+	}
+	trafficNames := trafficNames(route)
+	m := make(map[string]netv1alpha1.IngressVisibility, trafficNames.Len())
+	for tt := range trafficNames {
+		hostname, err := domains.HostnameFromTemplate(ctx, route.Name, tt)
+		if err != nil {
+			return nil, err
+		}
+		ttVisibility := netv1alpha1.IngressVisibilityExternalIP
+		// Is there a visibility setting on the placeholder Service?
+		if svc, ok := services[hostname]; ok {
+			if labels.IsObjectLocalVisibility(svc.ObjectMeta) {
+				ttVisibility = netv1alpha1.IngressVisibilityClusterLocal
+			}
+		}
+
+		// Now, choose the lowest visibility.
+		m[tt] = minVisibility(ttVisibility, defaultVisibility)
+	}
+	return m, nil
+}
+
+func minVisibility(a, b netv1alpha1.IngressVisibility) netv1alpha1.IngressVisibility {
+	if a == netv1alpha1.IngressVisibilityClusterLocal || b == netv1alpha1.IngressVisibilityClusterLocal {
+		return netv1alpha1.IngressVisibilityClusterLocal
+	}
+	return a
+}

--- a/pkg/reconciler/route/visibility/visibility_test.go
+++ b/pkg/reconciler/route/visibility/visibility_test.go
@@ -1,0 +1,481 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package visibility
+
+import (
+	"context"
+	"errors"
+	"log"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	listers "k8s.io/client-go/listers/core/v1"
+	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/apis/serving"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	"knative.dev/serving/pkg/network"
+	"knative.dev/serving/pkg/reconciler/route/config"
+	"knative.dev/serving/pkg/reconciler/route/traffic"
+)
+
+func getContext(domainSuffix string) context.Context {
+	if domainSuffix == "" {
+		domainSuffix = "example.com"
+	}
+	return config.ToContext(context.Background(), &config.Config{
+		Domain: &config.Domain{
+			Domains: map[string]*config.LabelSelector{
+				domainSuffix: {},
+			},
+		},
+		Network: &network.Config{
+			TagTemplate:    network.DefaultTagTemplate,
+			DomainTemplate: network.DefaultDomainTemplate,
+		},
+	})
+}
+
+func TestVisibility(t *testing.T) {
+	listerErr := errors.New("lister error")
+	for _, tt := range []struct {
+		name         string
+		domainSuffix string
+		services     []*corev1.Service
+		listerErr    error
+		route        *v1alpha1.Route
+		expected     map[string]netv1alpha1.IngressVisibility
+		expectedErr  error
+	}{{
+		name: "default",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		},
+		expected: map[string]netv1alpha1.IngressVisibility{
+			traffic.DefaultTarget: netv1alpha1.IngressVisibilityExternalIP,
+		},
+	}, {
+		name: "no tag, route marked local",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+				Labels: map[string]string{
+					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+				},
+			},
+		},
+		expected: map[string]netv1alpha1.IngressVisibility{
+			traffic.DefaultTarget: netv1alpha1.IngressVisibilityClusterLocal,
+		},
+	}, {
+		name: "no tag, svc marked local",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		},
+		services: []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey:     "foo",
+					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+				},
+			},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "irrelevance",
+				Labels: map[string]string{
+					serving.RouteLabelKey:     "bar",
+					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+				},
+			},
+		}},
+		expected: map[string]netv1alpha1.IngressVisibility{
+			traffic.DefaultTarget: netv1alpha1.IngressVisibilityClusterLocal,
+		},
+	}, {
+		name: "one tag, tag marked local",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: v1alpha1.RouteSpec{
+				Traffic: []v1alpha1.TrafficTarget{{
+					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
+				}},
+			},
+		},
+		services: []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "blue-foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey:     "foo",
+					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+				},
+			},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey: "foo",
+				},
+			},
+		}},
+		expected: map[string]netv1alpha1.IngressVisibility{
+			traffic.DefaultTarget: netv1alpha1.IngressVisibilityExternalIP,
+			"blue":                netv1alpha1.IngressVisibilityClusterLocal,
+		},
+	}, {
+		name: "one tag initial default",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: v1alpha1.RouteSpec{
+				Traffic: []v1alpha1.TrafficTarget{{
+					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
+				}},
+			},
+		},
+		services: []*corev1.Service{},
+		expected: map[string]netv1alpha1.IngressVisibility{
+			traffic.DefaultTarget: netv1alpha1.IngressVisibilityExternalIP,
+			"blue":                netv1alpha1.IngressVisibilityExternalIP,
+		},
+	}, {
+		name: "one tag svc not marked",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: v1alpha1.RouteSpec{
+				Traffic: []v1alpha1.TrafficTarget{{
+					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
+				}},
+			},
+		},
+		services: []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "blue-foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey: "foo",
+				},
+			},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey: "foo",
+				},
+			},
+		}},
+		expected: map[string]netv1alpha1.IngressVisibility{
+			traffic.DefaultTarget: netv1alpha1.IngressVisibilityExternalIP,
+			"blue":                netv1alpha1.IngressVisibilityExternalIP,
+		},
+	}, {
+		name: "two tags initial default",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: v1alpha1.RouteSpec{
+				Traffic: []v1alpha1.TrafficTarget{{
+					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
+				}, {
+					TrafficTarget: v1.TrafficTarget{Tag: "green"},
+				}},
+			},
+		},
+		expected: map[string]netv1alpha1.IngressVisibility{
+			traffic.DefaultTarget: netv1alpha1.IngressVisibilityExternalIP,
+			"blue":                netv1alpha1.IngressVisibilityExternalIP,
+			"green":               netv1alpha1.IngressVisibilityExternalIP,
+		},
+	}, {
+		name: "two tags initial default with .svc.cluster.local domain suffix",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: v1alpha1.RouteSpec{
+				Traffic: []v1alpha1.TrafficTarget{{
+					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
+				}, {
+					TrafficTarget: v1.TrafficTarget{Tag: "green"},
+				}},
+			},
+		},
+		domainSuffix: "svc.cluster.local",
+		expected: map[string]netv1alpha1.IngressVisibility{
+			traffic.DefaultTarget: netv1alpha1.IngressVisibilityClusterLocal,
+			"blue":                netv1alpha1.IngressVisibilityClusterLocal,
+			"green":               netv1alpha1.IngressVisibilityClusterLocal,
+		},
+	}, {
+		name: "two tags, svc not marked",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: v1alpha1.RouteSpec{
+				Traffic: []v1alpha1.TrafficTarget{{
+					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
+				}, {
+					TrafficTarget: v1.TrafficTarget{Tag: "green"},
+				}},
+			},
+		},
+		services: []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "blue-foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey: "foo",
+				},
+			},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "green-foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey: "foo",
+				},
+			},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey: "foo",
+				},
+			},
+		}},
+		expected: map[string]netv1alpha1.IngressVisibility{
+			traffic.DefaultTarget: netv1alpha1.IngressVisibilityExternalIP,
+			"blue":                netv1alpha1.IngressVisibilityExternalIP,
+			"green":               netv1alpha1.IngressVisibilityExternalIP,
+		},
+	}, {
+		name: "two tags, route marked local",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+				Labels: map[string]string{
+					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+				},
+			},
+			Spec: v1alpha1.RouteSpec{
+				Traffic: []v1alpha1.TrafficTarget{{
+					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
+				}, {
+					TrafficTarget: v1.TrafficTarget{Tag: "green"},
+				}},
+			},
+		},
+		services: []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "blue-foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey: "foo",
+				},
+			},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "green-foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey: "foo",
+				},
+			},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey: "foo",
+				},
+			},
+		}},
+		expected: map[string]netv1alpha1.IngressVisibility{
+			traffic.DefaultTarget: netv1alpha1.IngressVisibilityClusterLocal,
+			"blue":                netv1alpha1.IngressVisibilityClusterLocal,
+			"green":               netv1alpha1.IngressVisibilityClusterLocal,
+		},
+	}, {
+		name: "two tags blue marked local",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: v1alpha1.RouteSpec{
+				Traffic: []v1alpha1.TrafficTarget{{
+					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
+				}, {
+					TrafficTarget: v1.TrafficTarget{Tag: "green"},
+				}},
+			},
+		},
+		services: []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "blue-foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey:     "foo",
+					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+				},
+			},
+		}},
+		expected: map[string]netv1alpha1.IngressVisibility{
+			traffic.DefaultTarget: netv1alpha1.IngressVisibilityExternalIP,
+			"blue":                netv1alpha1.IngressVisibilityClusterLocal,
+			"green":               netv1alpha1.IngressVisibilityExternalIP,
+		},
+	}, {
+		name: "two tags, both marked local",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: v1alpha1.RouteSpec{
+				Traffic: []v1alpha1.TrafficTarget{{
+					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
+				}, {
+					TrafficTarget: v1.TrafficTarget{Tag: "green"},
+				}},
+			},
+		},
+		services: []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "blue-foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey:     "foo",
+					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+				},
+			},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "green-foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey:     "foo",
+					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+				},
+			},
+		}},
+		expected: map[string]netv1alpha1.IngressVisibility{
+			traffic.DefaultTarget: netv1alpha1.IngressVisibilityExternalIP,
+			"blue":                netv1alpha1.IngressVisibilityClusterLocal,
+			"green":               netv1alpha1.IngressVisibilityClusterLocal,
+		},
+	}, {
+		name: "two tags, all marked local",
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: v1alpha1.RouteSpec{
+				Traffic: []v1alpha1.TrafficTarget{{
+					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
+				}, {
+					TrafficTarget: v1.TrafficTarget{Tag: "green"},
+				}},
+			},
+		},
+		services: []*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "blue-foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey:     "foo",
+					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+				},
+			},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "green-foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey:     "foo",
+					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+				},
+			},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+				Labels: map[string]string{
+					serving.RouteLabelKey:     "foo",
+					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+				},
+			},
+		}},
+		expected: map[string]netv1alpha1.IngressVisibility{
+			traffic.DefaultTarget: netv1alpha1.IngressVisibilityClusterLocal,
+			"blue":                netv1alpha1.IngressVisibilityClusterLocal,
+			"green":               netv1alpha1.IngressVisibilityClusterLocal,
+		},
+	}, {
+		name:      "lister error",
+		listerErr: listerErr,
+		route: &v1alpha1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		},
+		expectedErr: listerErr,
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			lister := &fakeServiceLister{services: tt.services, listerErr: tt.listerErr}
+			ctx := getContext(tt.domainSuffix)
+			visibility, err := NewResolver(lister).GetVisibility(ctx, tt.route)
+			if diff := cmp.Diff(tt.expected, visibility); diff != "" {
+				t.Errorf("Unexpected visibility diff (-want +got): %v", diff)
+			}
+			if tt.expectedErr != err {
+				t.Errorf("Expected err=%v, saw %v", tt.expectedErr, err)
+			}
+		})
+	}
+}
+
+type fakeServiceLister struct {
+	services  []*corev1.Service
+	listerErr error
+}
+
+func (l *fakeServiceLister) List(selector labels.Selector) ([]*corev1.Service, error) {
+	if l.listerErr != nil {
+		return nil, l.listerErr
+	}
+	results := []*corev1.Service{}
+	for _, svc := range l.services {
+		if selector.Matches(labels.Set(svc.Labels)) {
+			results = append(results, svc)
+		}
+	}
+	return results, nil
+}
+
+func (l *fakeServiceLister) Services(namespace string) listers.ServiceNamespaceLister {
+	return l
+}
+
+func (l *fakeServiceLister) Get(name string) (*corev1.Service, error) {
+	log.Panic("not implemented")
+	return nil, nil
+}
+
+func (l *fakeServiceLister) GetPodServices(pod *corev1.Pod) ([]*corev1.Service, error) {
+	log.Panic("not implemented")
+	return nil, nil
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:
/lint
-->

Part of #6727 

To prepare for #6727 we refactor the traffic target visibility logic into its own pkg.  Also fixes #6702 as a side effect.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
