### PR TITLE
Remove 'num_tries' tag from activator metrics.

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -89,7 +89,7 @@ func (a *activationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		// Do not report response time here. It is reported in pkg/activator/metric_handler.go to
 		// sum up all time spent on multiple handlers.
-		reporterFrom(r.Context()).ReportRequestCount(httpStatus, 1)
+		reporterFrom(r.Context()).ReportRequestCount(httpStatus)
 
 		return nil
 	})

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -97,7 +97,6 @@ func TestActivationHandler(t *testing.T) {
 			Service:    "service-real-name",
 			Config:     "config-real-name",
 			StatusCode: http.StatusOK,
-			Attempts:   1,
 			Value:      1,
 		}},
 	}, {
@@ -113,7 +112,6 @@ func TestActivationHandler(t *testing.T) {
 			Service:    "service-real-name",
 			Config:     "config-real-name",
 			StatusCode: http.StatusBadGateway,
-			Attempts:   1,
 			Value:      1,
 		}},
 	}, {
@@ -344,7 +342,6 @@ type reporterCall struct {
 	Config     string
 	Revision   string
 	StatusCode int
-	Attempts   int
 	Value      int64
 	Duration   time.Duration
 }
@@ -382,7 +379,7 @@ func (f *fakeReporter) ReportRequestConcurrency(v int64) {
 	})
 }
 
-func (f *fakeReporter) ReportRequestCount(responseCode, numTries int) {
+func (f *fakeReporter) ReportRequestCount(responseCode int) {
 	f.mux.Lock()
 	defer f.mux.Unlock()
 	f.calls = append(f.calls, reporterCall{
@@ -392,7 +389,6 @@ func (f *fakeReporter) ReportRequestCount(responseCode, numTries int) {
 		Config:     f.config,
 		Revision:   f.rev,
 		StatusCode: responseCode,
-		Attempts:   numTries,
 		Value:      1,
 	})
 }

--- a/pkg/activator/stats_reporter.go
+++ b/pkg/activator/stats_reporter.go
@@ -56,7 +56,7 @@ type StatsReporter interface {
 // RevisionStatsReporter defines the interface for sending revision specific metrics.
 type RevisionStatsReporter interface {
 	ReportRequestConcurrency(v int64)
-	ReportRequestCount(responseCode, numTries int)
+	ReportRequestCount(responseCode int)
 	ReportResponseTime(responseCode int, d time.Duration)
 }
 
@@ -89,7 +89,7 @@ func NewStatsReporter(pod string) (StatsReporter, error) {
 			Measure:     requestCountM,
 			Aggregation: view.Count(),
 			TagKeys: append(metrics.CommonRevisionKeys, metrics.PodTagKey, metrics.ContainerTagKey,
-				metrics.ResponseCodeKey, metrics.ResponseCodeClassKey, metrics.NumTriesKey),
+				metrics.ResponseCodeKey, metrics.ResponseCodeClassKey),
 		},
 		&view.View{
 			Description: "The response time in millisecond",
@@ -140,7 +140,7 @@ func (r *revisionReporter) ReportRequestConcurrency(v int64) {
 }
 
 // ReportRequestCount captures request count.
-func (r *revisionReporter) ReportRequestCount(responseCode, numTries int) {
+func (r *revisionReporter) ReportRequestCount(responseCode int) {
 	if r.ctx == nil {
 		return
 	}
@@ -149,8 +149,7 @@ func (r *revisionReporter) ReportRequestCount(responseCode, numTries int) {
 	ctx, _ := tag.New(
 		r.ctx,
 		tag.Upsert(metrics.ResponseCodeKey, strconv.Itoa(responseCode)),
-		tag.Upsert(metrics.ResponseCodeClassKey, responseCodeClass(responseCode)),
-		tag.Upsert(metrics.NumTriesKey, strconv.Itoa(numTries)))
+		tag.Upsert(metrics.ResponseCodeClassKey, responseCodeClass(responseCode)))
 
 	pkgmetrics.Record(ctx, requestCountM.M(1))
 }

--- a/pkg/activator/stats_reporter_test.go
+++ b/pkg/activator/stats_reporter_test.go
@@ -72,11 +72,10 @@ func TestActivatorReporter(t *testing.T) {
 		"container_name":                  "activator",
 		"response_code":                   "200",
 		"response_code_class":             "2xx",
-		"num_tries":                       "6",
 	}
 
-	rr.ReportRequestCount(http.StatusOK, 6)
-	rr.ReportRequestCount(http.StatusOK, 6)
+	rr.ReportRequestCount(http.StatusOK)
+	rr.ReportRequestCount(http.StatusOK)
 	metricstest.CheckCountData(t, "request_count", wantTags2, 2)
 
 	// test ReportResponseTime
@@ -130,9 +129,8 @@ func TestActivatorReporterEmptyServiceName(t *testing.T) {
 		"container_name":                  "activator",
 		"response_code":                   "200",
 		"response_code_class":             "2xx",
-		"num_tries":                       "6",
 	}
-	rr.ReportRequestCount(200, 6)
+	rr.ReportRequestCount(200)
 	metricstest.CheckCountData(t, "request_count", wantTags2, 1)
 
 	// test ReportResponseTime
@@ -165,7 +163,7 @@ func TestActivatorReporterErrorToNoop(t *testing.T) {
 	}
 
 	rr.ReportRequestConcurrency(100)
-	rr.ReportRequestCount(200, 6)
+	rr.ReportRequestCount(200)
 	rr.ReportResponseTime(200, 7100*time.Millisecond)
 	rr.ReportResponseTime(200, 5100*time.Millisecond)
 }

--- a/pkg/metrics/key.go
+++ b/pkg/metrics/key.go
@@ -35,7 +35,6 @@ var (
 	ContainerTagKey      = tag.MustNewKey("container_name")
 	ResponseCodeKey      = tag.MustNewKey("response_code")
 	ResponseCodeClassKey = tag.MustNewKey("response_code_class")
-	NumTriesKey          = tag.MustNewKey("num_tries")
 
 	CommonRevisionKeys = []tag.Key{NamespaceTagKey, ServiceTagKey, ConfigTagKey, RevisionTagKey}
 )


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

This tag used to signify how many retries the activator needed to reach a downstream pod. We don't retry anymore at all, so this is always statically '1'. We can just remove it altogether (it's not used in our dashboards seemingly).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
