### PR TITLE
Create VS name with `-ingress` suffix

### DIFF
--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -235,7 +235,7 @@ func TestReconcile(t *testing.T) {
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "no-virtualservice-yet-mesh"),
-			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "no-virtualservice-yet"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "no-virtualservice-yet-ingress"),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for Ingress %q", "no-virtualservice-yet"),
 		},
 		Key: "test-ns/no-virtualservice-yet",
@@ -264,7 +264,7 @@ func TestReconcile(t *testing.T) {
 			),
 			&v1alpha3.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "reconcile-failed",
+					Name:      "reconcile-failed-ingress",
 					Namespace: "test-ns",
 					Labels: map[string]string{
 						networking.IngressLabelKey: "reconcile-failed",
@@ -317,7 +317,7 @@ func TestReconcile(t *testing.T) {
 			ing("reconcile-virtualservice", 1234),
 			&v1alpha3.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "reconcile-virtualservice",
+					Name:      "reconcile-virtualservice-ingress",
 					Namespace: "test-ns",
 					Labels: map[string]string{
 						networking.IngressLabelKey: "reconcile-virtualservice",
@@ -391,7 +391,7 @@ func TestReconcile(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconcile-virtualservice-mesh"),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated VirtualService %s/%s",
-				"test-ns", "reconcile-virtualservice"),
+				"test-ns", "reconcile-virtualservice-ingress"),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for Ingress %q", "reconcile-virtualservice"),
 		},
 		Key: "test-ns/reconcile-virtualservice",
@@ -583,7 +583,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-mesh"),
-			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-ingress"),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Gateway %s/%s", system.Namespace(), networking.KnativeIngressGateway),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for Ingress %q", "reconciling-ingress"),
 		},
@@ -628,7 +628,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-mesh"),
-			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-ingress"),
 			Eventf(corev1.EventTypeWarning, "InternalError", `failed to get Gateway: gateway.networking.istio.io "%s" not found`, networking.KnativeIngressGateway),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for Ingress %q", "reconciling-ingress"),
 		},
@@ -714,7 +714,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-mesh"),
-			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-ingress"),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Gateway %s/%s", system.Namespace(), networking.KnativeIngressGateway),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for Ingress %q", "reconciling-ingress"),
 		},
@@ -790,7 +790,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-mesh"),
-			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-ingress"),
 			Eventf(corev1.EventTypeNormal, "Created", "Created Secret %s/%s", "istio-system", targetSecretName),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Gateway %s/%s", system.Namespace(), networking.KnativeIngressGateway),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for Ingress %q", "reconciling-ingress"),
@@ -892,7 +892,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-mesh"),
-			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created VirtualService %q", "reconciling-ingress-ingress"),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated Secret %s/%s", "istio-system", targetSecretName),
 			Eventf(corev1.EventTypeNormal, "Updated", "Updated status for Ingress %q", "reconciling-ingress"),
 		},

--- a/pkg/reconciler/ingress/resources/names/names.go
+++ b/pkg/reconciler/ingress/resources/names/names.go
@@ -24,7 +24,7 @@ import (
 // resource for given Ingress that programs traffic for Ingress
 // Gateways.
 func IngressVirtualService(i kmeta.Accessor) string {
-	return kmeta.ChildName(i.GetName(), "")
+	return kmeta.ChildName(i.GetName(), "-ingress")
 }
 
 // MeshVirtualService returns the name of the VirtualService child

--- a/pkg/reconciler/ingress/resources/names/names_test.go
+++ b/pkg/reconciler/ingress/resources/names/names_test.go
@@ -39,7 +39,7 @@ func TestNamer(t *testing.T) {
 			},
 		},
 		f:    IngressVirtualService,
-		want: "foo",
+		want: "foo-ingress",
 	}, {
 		name: "IngressVirtualService",
 		ingress: &v1alpha1.Ingress{
@@ -49,7 +49,7 @@ func TestNamer(t *testing.T) {
 			},
 		},
 		f:    IngressVirtualService,
-		want: "foo",
+		want: "foo-ingress",
 	}, {
 		name: "MeshVirtualService",
 		ingress: &v1alpha1.Ingress{

--- a/pkg/reconciler/ingress/resources/virtual_service_test.go
+++ b/pkg/reconciler/ingress/resources/virtual_service_test.go
@@ -63,7 +63,7 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 		gateways: makeGatewayMap([]string{"gateway"}, []string{"private-gateway"}),
 		ci: &v1alpha1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-ingress",
+				Name:      "test",
 				Namespace: system.Namespace(),
 				Labels: map[string]string{
 					networking.IngressLabelKey:     "test-ingress",
@@ -80,10 +80,10 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 			}}},
 		},
 		expected: []metav1.ObjectMeta{{
-			Name:      "test-ingress-mesh",
+			Name:      "test-mesh",
 			Namespace: system.Namespace(),
 			Labels: map[string]string{
-				networking.IngressLabelKey:     "test-ingress",
+				networking.IngressLabelKey:     "test",
 				serving.RouteLabelKey:          "test-route",
 				serving.RouteNamespaceLabelKey: "test-ns",
 			},
@@ -91,7 +91,7 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 			Name:      "test-ingress",
 			Namespace: system.Namespace(),
 			Labels: map[string]string{
-				networking.IngressLabelKey:     "test-ingress",
+				networking.IngressLabelKey:     "test",
 				serving.RouteLabelKey:          "test-route",
 				serving.RouteNamespaceLabelKey: "test-ns",
 			},
@@ -101,7 +101,7 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 		gateways: makeGatewayMap([]string{"gateway"}, []string{"private-gateway"}),
 		ci: &v1alpha1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-ingress",
+				Name:      "test",
 				Namespace: system.Namespace(),
 				Labels: map[string]string{
 					serving.RouteLabelKey:          "test-route",
@@ -120,7 +120,7 @@ func TestMakeVirtualServices_CorrectMetadata(t *testing.T) {
 			Name:      "test-ingress",
 			Namespace: system.Namespace(),
 			Labels: map[string]string{
-				networking.IngressLabelKey:     "test-ingress",
+				networking.IngressLabelKey:     "test",
 				serving.RouteLabelKey:          "test-route",
 				serving.RouteNamespaceLabelKey: "test-ns",
 			},


### PR DESCRIPTION
Fixes #6362 


/lint


## Proposed Changes

* VirtualService name will be created with `-ingress` suffix

/assign @tcnghia 
