### PR TITLE
Fix the load test scale to 0 logic

### DIFF
--- a/test/performance/benchmarks/load-test/continuous/load-test.yaml
+++ b/test/performance/benchmarks/load-test/continuous/load-test.yaml
@@ -23,8 +23,8 @@ metadata:
   name: load-testing
 rules:
   - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list"]
+    resources: ["nodes", "pods"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch"]

--- a/test/performance/benchmarks/load-test/continuous/main.go
+++ b/test/performance/benchmarks/load-test/continuous/main.go
@@ -117,7 +117,7 @@ func main() {
 	tbcTag := "tbc=" + *flavor
 	mc, err := mako.Setup(ctx, tbcTag)
 	if err != nil {
-		log.Fatalf("failed to setup mako: %v", err)
+		log.Fatalf("Failed to setup mako: %v", err)
 	}
 	q, qclose, ctx := mc.Quickstore, mc.ShutDownFunc, mc.Context
 	// Use a fresh context here so that our RPC to terminate the sidecar

--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -24,9 +24,10 @@ import (
 	"testing"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
-	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
+	podinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/prometheus"
@@ -115,20 +116,21 @@ func ProbeTargetTillReady(target string, duration time.Duration) error {
 
 // WaitForScaleToZero will wait for the deployments in the indexer to scale to 0
 func WaitForScaleToZero(ctx context.Context, namespace string, selector labels.Selector, duration time.Duration) error {
-	dl := deploymentinformer.Get(ctx).Lister()
+	pl := podinformer.Get(ctx).Lister()
+	begin := time.Now()
 	return wait.PollImmediate(1*time.Second, duration, func() (bool, error) {
-		ds, err := dl.Deployments(namespace).List(selector)
+		pods, err := pl.Pods(namespace).List(selector)
 		if err != nil {
-			return true, err
+			return false, err
 		}
-		scaledToZero := true
-		for _, d := range ds {
-			if d.Status.ReadyReplicas != 0 {
-				scaledToZero = false
-				break
+		for _, pod := range pods {
+			// Pending or Running w/o deletion timestamp (i.e. terminating).
+			if pod.Status.Phase == v1.PodPending || pod.Status.Phase == v1.PodRunning && pod.ObjectMeta.DeletionTimestamp == nil {
+				return false, nil
 			}
 		}
-		return scaledToZero, nil
+		log.Printf("All pods are done or terminating after %v", time.Since(begin))
+		return true, nil
 	})
 }
 


### PR DESCRIPTION
Now that activator forwards data to the unready pods it is possible to immediately
pass the check after ther pod came to life and before the deployment ever has the chance
to set it's ready replicas to 1, this skews our results in our favor.
So instead watch pods until all of them are succeeded, failed or terminating.

/lint

/assign mattmoor @chizhg 
/cc @markusthoemmes 