### PR TITLE
Add a benchmark for the metric handler in the activator.

### DIFF
--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -42,13 +42,12 @@ type MetricHandler struct {
 }
 
 func (h *MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	revID := revIDFrom(r.Context())
 	revision := revisionFrom(r.Context())
 	configurationName := revision.Labels[serving.ConfigurationLabelKey]
 	serviceName := revision.Labels[serving.ServiceLabelKey]
 
 	// It's safe to ignore this error as the RevisionStatsReporter is nil-pointer safe. Calls will be noops.
-	reporter, _ := h.reporter.GetRevisionStatsReporter(revID.Namespace, serviceName, configurationName, revID.Name)
+	reporter, _ := h.reporter.GetRevisionStatsReporter(revision.Namespace, serviceName, configurationName, revision.Name)
 
 	start := time.Now()
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

A benchmark here will be needed to measure the impact of the metric reporter changes we're doing currently.

### Currently

```
goos: darwin
goarch: amd64
pkg: knative.dev/serving/pkg/activator/handler
BenchmarkMetricHandler/sequential-12         	  285974	      3698 ns/op	    2472 B/op	      49 allocs/op
BenchmarkMetricHandler/parallel-12           	  676272	      1912 ns/op	    2472 B/op	      48 allocs/op
PASS
```

That's a ton of allocations just for metric reporting. I'd hope we can that with the caching work we're doing.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
