### PR TITLE
Tune concurrency in the activator test to avoid 503 errors

### DIFF
--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -42,7 +42,13 @@ func TestActivatorOverload(t *testing.T) {
 
 	const (
 		// The number of concurrent requests to hit the activator with.
-		concurrency = 100
+		// This number needs to be at most equal to the "queue depth" defined in
+		// the queue proxy. If it's greater than that number, there could be 503
+		// errors ("queue full").
+		// queue depth is defined as 10*container_concurrency
+		// (cmd/queue/main.go), so in this case, concurrency should be 10 at
+		// most.
+		concurrency = 10
 		// How long the service will process the request in ms.
 		serviceSleep = 300
 	)


### PR DESCRIPTION
/lint

I think that with the current constants defined, the activator test can return some 503 "queue full" errors.

The queue depth defined in `cmd/queue/main.go` is  `10*container_concurrency`. If I understood that correctly, that means that if we make more than 10 concurrent requests, we could get 503 "queue full" errors. However, this test makes 100 concurrent requests.

Maybe I'm missing something. Is there some logic in the activator that guarantees that the caller will not get any 503 with that number of requests?