### PR TITLE
Fix indentation of activator-hpa yaml

### DIFF
--- a/config/core/deployments/activator-hpa.yaml
+++ b/config/core/deployments/activator-hpa.yaml
@@ -20,13 +20,13 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 spec:
-    minReplicas: 1
-    maxReplicas: 1
-    scaleTargetRef:
-      apiVersion: apps/v1
-      kind: Deployment
-      name: activator
-    metrics:
+  minReplicas: 1
+  maxReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: activator
+  metrics:
     - type: Resource
       resource:
         name: cpu


### PR DESCRIPTION
/lint

I thought this could be related to #6757 , but looks like it's not.