### PR TITLE
Move certificate reconciler from webhook to controller binary

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -28,10 +28,22 @@ import (
 
 	// This defines the shared main for injected controllers.
 	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/pkg/signals"
+	"knative.dev/pkg/webhook"
+	"knative.dev/pkg/webhook/certificates"
 )
 
 func main() {
-	sharedmain.Main("controller",
+	// Set up a signal context with our webhook options so that the certificate
+	// controller has the right information to work from.
+	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
+		ServiceName: "webhook",
+		Port:        8443,
+		SecretName:  "webhook-certs",
+	})
+
+	sharedmain.MainWithContext(ctx, "controller",
+		certificates.NewController,
 		configuration.NewController,
 		labeler.NewController,
 		revision.NewController,

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -27,7 +27,6 @@ import (
 	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/webhook"
-	"knative.dev/pkg/webhook/certificates"
 	"knative.dev/pkg/webhook/configmaps"
 	"knative.dev/pkg/webhook/resourcesemantics"
 	"knative.dev/pkg/webhook/resourcesemantics/conversion"
@@ -217,7 +216,6 @@ func main() {
 	})
 
 	sharedmain.MainWithContext(ctx, "webhook",
-		certificates.NewController,
 		NewDefaultingAdmissionController,
 		NewValidationAdmissionController,
 		NewConfigValidationController,


### PR DESCRIPTION
## Proposed Changes

* Webhooks should be stateless; moves the cert control loop (which does API writes) from the webhook to the controller binary

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
