### PR TITLE
Reduce the amount of gke cluster nodes to 6.

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -18,8 +18,8 @@
 # resource/eviction as causes of flakiness. These env vars are consumed
 # in the test-infra/scripts/e2e-tests.sh. Use the existing value, if provided
 # with the job config.
-E2E_MIN_CLUSTER_NODES=${E2E_MIN_CLUSTER_NODES:-4}
-E2E_MAX_CLUSTER_NODES=${E2E_MAX_CLUSTER_NODES:-4}
+E2E_MIN_CLUSTER_NODES=${E2E_MIN_CLUSTER_NODES:-2}
+E2E_MAX_CLUSTER_NODES=${E2E_MAX_CLUSTER_NODES:-2}
 E2E_CLUSTER_MACHINE=${E2E_CLUSTER_MACHINE:-e2-standard-8}
 
 # This script provides helper methods to perform cluster actions.


### PR DESCRIPTION
/lint

Due to recent changes, The activator now is deployed as a daemonset
instead of a deployment, this causes the activator to be deployed on
each of the cluster nodes, given that the cluster has a total of 12 nodes
(4 max nodes * 3 regions) we end up with 13 activator pods that make passing the e2e
TestActivatorOverload really difficult without retries and backoff due
to the internal hardcoded queue depth of container concurrency * 10.

Related https://github.com/knative/serving/pull/6757

**Release Note**

NONE

```release-note

```
