### PR TITLE
Switch revision reconciler to use V1 APIs

### DIFF
--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -41,7 +41,7 @@ const (
 
 	// AutoscalingQueueMetricsPortName specifies the port name to use for metrics
 	// emitted by queue-proxy for autoscaler.
-	AutoscalingQueueMetricsPortName = "queue-metrics"
+	AutoscalingQueueMetricsPortName = "http-autometric"
 
 	// UserQueueMetricsPortName specifies the port name to use for metrics
 	// emitted by queue-proxy for end user.

--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -111,7 +111,7 @@ func (r *Revision) SetLastPinned(t time.Time) {
 	r.ObjectMeta.Annotations[serving.RevisionLastPinnedAnnotationKey] = RevisionLastPinnedString(t)
 }
 
-// GetLastPinned returns the
+// GetLastPinned returns the time the revision was last pinned
 func (r *Revision) GetLastPinned() (time.Time, error) {
 	if r.Annotations == nil {
 		return time.Time{}, LastPinnedParseError{

--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	net "knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/serving"
+)
+
+const (
+	// DefaultUserPort is the system default port value exposed on the user-container.
+	DefaultUserPort = 8080
+
+	// UserPortName is the name that will be used for the Port on the
+	// Deployment and Pod created by a Revision. This name will be set regardless of if
+	// a user specifies a port or the default value is chosen.
+	UserPortName = "user-port"
+
+	// QueueAdminPortName specifies the port name for
+	// health check and lifecycle hooks for queue-proxy.
+	QueueAdminPortName string = "http-queueadm"
+
+	// AutoscalingQueueMetricsPortName specifies the port name to use for metrics
+	// emitted by queue-proxy for autoscaler.
+	AutoscalingQueueMetricsPortName = "queue-metrics"
+
+	// UserQueueMetricsPortName specifies the port name to use for metrics
+	// emitted by queue-proxy for end user.
+	UserQueueMetricsPortName = "http-usermetric"
+
+	AnnotationParseErrorTypeMissing = "Missing"
+	AnnotationParseErrorTypeInvalid = "Invalid"
+	LabelParserErrorTypeMissing     = "Missing"
+	LabelParserErrorTypeInvalid     = "Invalid"
+)
+
+type (
+	// +k8s:deepcopy-gen=false
+	AnnotationParseError struct {
+		Type  string
+		Value string
+		Err   error
+	}
+
+	// +k8s:deepcopy-gen=false
+	LastPinnedParseError AnnotationParseError
+)
+
+func (e LastPinnedParseError) Error() string {
+	return fmt.Sprintf("%v lastPinned value: %q", e.Type, e.Value)
+}
+
+// GetContainer returns a pointer to the relevant corev1.Container field.
+// It is never nil and should be exactly the specified container as guaranteed
+// by validation.
+func (rs *RevisionSpec) GetContainer() *corev1.Container {
+	if len(rs.Containers) > 0 {
+		return &rs.Containers[0]
+	}
+	// Should be unreachable post-validation, but here to ease testing.
+	return &corev1.Container{}
+}
+
+// IsReachable returns whether or not the revision can be reached by a route.
+func (r *Revision) IsReachable() bool {
+	return r.ObjectMeta.Labels[serving.RouteLabelKey] != ""
+}
+
+// GetProtocol returns the app level network protocol.
+func (r *Revision) GetProtocol() (p net.ProtocolType) {
+	p = net.ProtocolHTTP1
+
+	ports := r.Spec.GetContainer().Ports
+	if len(ports) <= 0 {
+		return
+	}
+
+	if ports[0].Name == string(net.ProtocolH2C) {
+		p = net.ProtocolH2C
+	}
+
+	return
+}
+
+// SetLastPinned sets the revision's last pinned annotations
+// to be the specified time
+func (r *Revision) SetLastPinned(t time.Time) {
+	if r.ObjectMeta.Annotations == nil {
+		r.ObjectMeta.Annotations = make(map[string]string)
+	}
+
+	r.ObjectMeta.Annotations[serving.RevisionLastPinnedAnnotationKey] = RevisionLastPinnedString(t)
+}
+
+// GetLastPinned returns the
+func (r *Revision) GetLastPinned() (time.Time, error) {
+	if r.Annotations == nil {
+		return time.Time{}, LastPinnedParseError{
+			Type: AnnotationParseErrorTypeMissing,
+		}
+	}
+
+	str, ok := r.ObjectMeta.Annotations[serving.RevisionLastPinnedAnnotationKey]
+	if !ok {
+		// If a revision is past the create delay without an annotation it is stale
+		return time.Time{}, LastPinnedParseError{
+			Type: AnnotationParseErrorTypeMissing,
+		}
+	}
+
+	secs, err := strconv.ParseInt(str, 10, 64)
+	if err != nil {
+		return time.Time{}, LastPinnedParseError{
+			Type:  AnnotationParseErrorTypeInvalid,
+			Value: str,
+			Err:   err,
+		}
+	}
+
+	return time.Unix(secs, 0), nil
+}
+
+// IsActivationRequired returns true if activation is required.
+func (rs *RevisionStatus) IsActivationRequired() bool {
+	if c := revisionCondSet.Manage(rs).GetCondition(RevisionConditionActive); c != nil {
+		return c.Status != corev1.ConditionTrue
+	}
+	return false
+}
+
+// RevisionLastPinnedString returns a string representation of the specified time
+func RevisionLastPinnedString(t time.Time) string {
+	return fmt.Sprintf("%d", t.Unix())
+}
+
+func (rs *RevisionStatus) duck() *duckv1.Status {
+	return &rs.Status
+}

--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -17,15 +17,34 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/pkg/apis"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/config"
+	"knative.dev/serving/pkg/apis/serving"
 )
 
 const (
-	// DefaultUserPort is the system default port value exposed on the user-container.
-	DefaultUserPort = 8080
+	// ReasonContainerMissing defines the reason for marking container healthiness status
+	// as false if the a container image for the revision is missing.
+	ReasonContainerMissing = "ContainerMissing"
+
+	// ReasonDeploying defines the reason for marking revision availability status as
+	// unknown if the revision is still deploying.
+	ReasonDeploying = "Deploying"
+
+	// ReasonNotOwned defines the reason for marking revision availability status as
+	// false due to resource ownership issues.
+	ReasonNotOwned = "NotOwned"
+
+	// ReasonProgressDeadlineExceeded defines the reason for marking revision availability
+	// status as false if progress has exceeded the deadline.
+	ReasonProgressDeadlineExceeded = "ProgressDeadlineExceeded"
 )
 
 var revisionCondSet = apis.NewLivingConditionSet(
@@ -60,4 +79,119 @@ func (rs *RevisionSpec) GetContainerConcurrency() int64 {
 // InitializeConditions sets the initial values to the conditions.
 func (rs *RevisionStatus) InitializeConditions() {
 	revisionCondSet.Manage(rs).InitializeConditions()
+}
+
+// MarkActiveTrue marks Active status on revision as True
+func (rs *RevisionStatus) MarkActiveTrue() {
+	revisionCondSet.Manage(rs).MarkTrue(RevisionConditionActive)
+}
+
+// MarkActiveFalse marks Active status on revision as False
+func (rs *RevisionStatus) MarkActiveFalse(reason, message string) {
+	revisionCondSet.Manage(rs).MarkFalse(RevisionConditionActive, reason, message)
+}
+
+// MarkActiveUnknown marks Active status on revision as Unknown
+func (rs *RevisionStatus) MarkActiveUnknown(reason, message string) {
+	revisionCondSet.Manage(rs).MarkUnknown(RevisionConditionActive, reason, message)
+}
+
+// MarkContainerHealthyTrue marks ContainerHealthy status on revision as True
+func (rs *RevisionStatus) MarkContainerHealthyTrue() {
+	revisionCondSet.Manage(rs).MarkTrue(RevisionConditionContainerHealthy)
+}
+
+// MarkContainerHealthyFalse marks ContainerHealthy status on revision as False
+func (rs *RevisionStatus) MarkContainerHealthyFalse(reason, message string) {
+	revisionCondSet.Manage(rs).MarkFalse(RevisionConditionContainerHealthy, reason, message)
+}
+
+// MarkContainerHealthyUnknown marks ContainerHealthy status on revision as Unknown
+func (rs *RevisionStatus) MarkContainerHealthyUnknown(reason, message string) {
+	revisionCondSet.Manage(rs).MarkUnknown(RevisionConditionContainerHealthy, reason, message)
+}
+
+// MarkResourcesAvailableTrue marks ResourcesAvailable status on revision as True
+func (rs *RevisionStatus) MarkResourcesAvailableTrue() {
+	revisionCondSet.Manage(rs).MarkTrue(RevisionConditionResourcesAvailable)
+}
+
+// MarkResourcesAvailableFalse marks ResourcesAvailable status on revision as False
+func (rs *RevisionStatus) MarkResourcesAvailableFalse(reason, message string) {
+	revisionCondSet.Manage(rs).MarkFalse(RevisionConditionResourcesAvailable, reason, message)
+}
+
+// MarkResourcesAvailableUnknown marks ResourcesAvailable status on revision as Unknown
+func (rs *RevisionStatus) MarkResourcesAvailableUnknown(reason, message string) {
+	revisionCondSet.Manage(rs).MarkUnknown(RevisionConditionResourcesAvailable, reason, message)
+}
+
+// PropagateDeploymentStatus takes the Deployment status and applies its values
+// to the Revision status.
+func (rs *RevisionStatus) PropagateDeploymentStatus(original *appsv1.DeploymentStatus) {
+	ds := serving.TransformDeploymentStatus(original)
+	cond := ds.GetCondition(serving.DeploymentConditionReady)
+	if cond == nil {
+		return
+	}
+
+	m := revisionCondSet.Manage(rs)
+	switch cond.Status {
+	case corev1.ConditionTrue:
+		m.MarkTrue(RevisionConditionResourcesAvailable)
+	case corev1.ConditionFalse:
+		m.MarkFalse(RevisionConditionResourcesAvailable, cond.Reason, cond.Message)
+	case corev1.ConditionUnknown:
+		m.MarkUnknown(RevisionConditionResourcesAvailable, cond.Reason, cond.Message)
+	}
+}
+
+// PropagateAutoscalerStatus propagates autoscaler's status to the revision's status.
+func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *av1alpha1.PodAutoscalerStatus) {
+	// Propagate the service name from the PA.
+	rs.ServiceName = ps.ServiceName
+
+	// Reflect the PA status in our own.
+	cond := ps.GetCondition(av1alpha1.PodAutoscalerConditionReady)
+	if cond == nil {
+		rs.MarkActiveUnknown("Deploying", "")
+		return
+	}
+
+	switch cond.Status {
+	case corev1.ConditionUnknown:
+		rs.MarkActiveUnknown(cond.Reason, cond.Message)
+	case corev1.ConditionFalse:
+		rs.MarkActiveFalse(cond.Reason, cond.Message)
+	case corev1.ConditionTrue:
+		rs.MarkActiveTrue()
+
+		// Precondition for PA being active is SKS being active and
+		// that entices that |service.endpoints| > 0.
+		rs.MarkResourcesAvailableTrue()
+		rs.MarkContainerHealthyTrue()
+	}
+}
+
+// ResourceNotOwnedMessage constructs the status message if ownership on the
+// resource is not right.
+func ResourceNotOwnedMessage(kind, name string) string {
+	return fmt.Sprintf("There is an existing %s %q that we do not own.", kind, name)
+}
+
+// ExitCodeReason constructs the status message from an exit code
+func ExitCodeReason(exitCode int32) string {
+	return fmt.Sprintf("ExitCode%d", exitCode)
+}
+
+// RevisionContainerExitingMessage constructs the status message if a container
+// fails to come up.
+func RevisionContainerExitingMessage(message string) string {
+	return fmt.Sprintf("Container failed with: %s", message)
+}
+
+// RevisionContainerMissingMessage constructs the status message if a given image
+// cannot be pulled correctly.
+func RevisionContainerMissingMessage(image string, message string) string {
+	return fmt.Sprintf("Unable to fetch image %q: %s", image, message)
 }

--- a/pkg/apis/serving/v1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1/revision_lifecycle_test.go
@@ -16,15 +16,25 @@ limitations under the License.
 package v1
 
 import (
+	"sort"
 	"testing"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	apitestv1 "knative.dev/pkg/apis/testing/v1"
 	"knative.dev/pkg/ptr"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/config"
+	net "knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/serving"
 )
 
 func TestRevisionDuckTypes(t *testing.T) {
@@ -84,55 +94,700 @@ func TestGetContainerConcurrency(t *testing.T) {
 
 }
 
-func TestRevisionIsReady(t *testing.T) {
-	tests := []struct {
-		name     string
-		rs       *RevisionStatus
-		expected bool
+func TestIsActivationRequired(t *testing.T) {
+	cases := []struct {
+		name                 string
+		status               RevisionStatus
+		isActivationRequired bool
 	}{{
-		name:     "Ready undefined",
-		rs:       &RevisionStatus{},
-		expected: false,
+		name:                 "empty status should not be inactive",
+		status:               RevisionStatus{},
+		isActivationRequired: false,
 	}, {
-		name: "Ready=False",
-		rs: &RevisionStatus{
+		name: "Ready status should not be inactive",
+		status: RevisionStatus{
 			Status: duckv1.Status{
 				Conditions: duckv1.Conditions{{
-					Type:   apis.ConditionReady,
-					Status: corev1.ConditionFalse,
-				}},
-			},
-		},
-		expected: false,
-	}, {
-		name: "Ready=Unknown",
-		rs: &RevisionStatus{
-			Status: duckv1.Status{
-				Conditions: duckv1.Conditions{{
-					Type:   apis.ConditionReady,
-					Status: corev1.ConditionUnknown,
-				}},
-			},
-		},
-		expected: false,
-	}, {
-		name: "Ready=True",
-		rs: &RevisionStatus{
-			Status: duckv1.Status{
-				Conditions: duckv1.Conditions{{
-					Type:   apis.ConditionReady,
+					Type:   RevisionConditionReady,
 					Status: corev1.ConditionTrue,
 				}},
 			},
 		},
-		expected: true,
+		isActivationRequired: false,
+	}, {
+		name: "Inactive status should be inactive",
+		status: RevisionStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   RevisionConditionActive,
+					Status: corev1.ConditionFalse,
+				}},
+			},
+		},
+		isActivationRequired: true,
+	}, {
+		name: "Updating status should be inactive",
+		status: RevisionStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   RevisionConditionReady,
+					Status: corev1.ConditionUnknown,
+					Reason: "Updating",
+				}, {
+					Type:   RevisionConditionActive,
+					Status: corev1.ConditionUnknown,
+					Reason: "Updating",
+				}},
+			},
+		},
+		isActivationRequired: true,
+	}, {
+		name: "NotReady status without reason should not be inactive",
+		status: RevisionStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   RevisionConditionReady,
+					Status: corev1.ConditionFalse,
+				}},
+			},
+		},
+		isActivationRequired: false,
+	}, {
+		name: "Ready/Unknown status without reason should not be inactive",
+		status: RevisionStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   RevisionConditionReady,
+					Status: corev1.ConditionUnknown,
+				}},
+			},
+		},
+		isActivationRequired: false,
 	}}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			ready := test.rs.IsReady()
-			if ready != test.expected {
-				t.Errorf("IsReady() = %t; expected %t", ready, test.expected)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if e, a := tc.isActivationRequired, tc.status.IsActivationRequired(); e != a {
+				t.Errorf("%q expected: %v got: %v", tc.name, e, a)
+			}
+		})
+	}
+}
+
+func TestRevisionIsReady(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  RevisionStatus
+		isReady bool
+	}{{
+		name:    "empty status should not be ready",
+		status:  RevisionStatus{},
+		isReady: false,
+	}, {
+		name: "Different condition type should not be ready",
+		status: RevisionStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   RevisionConditionResourcesAvailable,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+		},
+		isReady: false,
+	}, {
+		name: "False condition status should not be ready",
+		status: RevisionStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   RevisionConditionReady,
+					Status: corev1.ConditionFalse,
+				}},
+			},
+		},
+		isReady: false,
+	}, {
+		name: "Unknown condition status should not be ready",
+		status: RevisionStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   RevisionConditionReady,
+					Status: corev1.ConditionUnknown,
+				}},
+			},
+		},
+		isReady: false,
+	}, {
+		name: "Missing condition status should not be ready",
+		status: RevisionStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type: RevisionConditionReady,
+				}},
+			},
+		},
+		isReady: false,
+	}, {
+		name: "True condition status should be ready",
+		status: RevisionStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   RevisionConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+		},
+		isReady: true,
+	}, {
+		name: "Multiple conditions with ready status should be ready",
+		status: RevisionStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   RevisionConditionResourcesAvailable,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   RevisionConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+		},
+		isReady: true,
+	}, {
+		name: "Multiple conditions with ready status false should not be ready",
+		status: RevisionStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   RevisionConditionResourcesAvailable,
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   RevisionConditionReady,
+					Status: corev1.ConditionFalse,
+				}},
+			},
+		},
+		isReady: false,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if e, a := tc.isReady, tc.status.IsReady(); e != a {
+				t.Errorf("%q expected: %v got: %v", tc.name, e, a)
+			}
+		})
+	}
+}
+
+func TestRevisionInitializeConditions(t *testing.T) {
+	rs := &RevisionStatus{}
+	rs.InitializeConditions()
+
+	var types []string
+	for _, cond := range rs.Conditions {
+		types = append(types, string(cond.Type))
+	}
+
+	expected := []string{
+		string(apis.ConditionReady),
+		string(RevisionConditionResourcesAvailable),
+		string(RevisionConditionContainerHealthy),
+	}
+
+	sort.Strings(types)
+	sort.Strings(expected)
+
+	if diff := cmp.Diff(expected, types); diff != "" {
+		t.Errorf("unexpected conditions %s", diff)
+	}
+}
+
+func TestTypicalFlowWithProgressDeadlineExceeded(t *testing.T) {
+	r := &RevisionStatus{}
+	r.InitializeConditions()
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
+
+	const want = "the error message"
+	r.MarkResourcesAvailableFalse(ReasonProgressDeadlineExceeded, want)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionReady, t)
+	if got := r.GetCondition(RevisionConditionResourcesAvailable); got == nil || got.Message != want {
+		t.Errorf("MarkProgressDeadlineExceeded = %v, want %v", got, want)
+	}
+	if got := r.GetCondition(RevisionConditionReady); got == nil || got.Message != want {
+		t.Errorf("MarkProgressDeadlineExceeded = %v, want %v", got, want)
+	}
+}
+
+func TestTypicalFlowWithContainerMissing(t *testing.T) {
+	r := &RevisionStatus{}
+	r.InitializeConditions()
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
+
+	const want = "something about the container being not found"
+	r.MarkContainerHealthyFalse(ReasonContainerMissing, want)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionFailed(r.duck(), RouteConditionReady, t)
+	if got := r.GetCondition(RevisionConditionContainerHealthy); got == nil || got.Message != want {
+		t.Errorf("MarkContainerMissing = %v, want %v", got, want)
+	} else if got.Reason != "ContainerMissing" {
+		t.Errorf("MarkContainerMissing = %v, want %v", got, "ContainerMissing")
+	}
+	if got := r.GetCondition(RevisionConditionReady); got == nil || got.Message != want {
+		t.Errorf("MarkContainerMissing = %v, want %v", got, want)
+	} else if got.Reason != "ContainerMissing" {
+		t.Errorf("MarkContainerMissing = %v, want %v", got, "ContainerMissing")
+	}
+
+	r.MarkContainerHealthyUnknown(ReasonDeploying, want)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
+}
+
+func TestTypicalFlowWithSuspendResume(t *testing.T) {
+	r := &RevisionStatus{}
+	r.InitializeConditions()
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
+
+	// Enter a Ready state.
+	r.MarkActiveTrue()
+	r.MarkContainerHealthyTrue()
+	r.MarkResourcesAvailableTrue()
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
+
+	// From a Ready state, make the revision inactive to simulate scale to zero.
+	const want = "Deactivated"
+	r.MarkActiveFalse(want, "Reserve")
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionActive, t)
+	if got := r.GetCondition(RevisionConditionActive); got == nil || got.Reason != want {
+		t.Errorf("MarkInactive = %v, want %v", got, want)
+	}
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
+
+	// From an Inactive state, start to activate the revision.
+	const want2 = "Activating"
+	r.MarkActiveUnknown(want2, "blah blah blah")
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionActive, t)
+	if got := r.GetCondition(RevisionConditionActive); got == nil || got.Reason != want2 {
+		t.Errorf("MarkInactive = %v, want %v", got, want2)
+	}
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
+
+	// From the activating state, simulate the transition back to readiness.
+	r.MarkActiveTrue()
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
+}
+
+func TestRevisionNotOwnedStuff(t *testing.T) {
+	r := &RevisionStatus{}
+	r.InitializeConditions()
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
+
+	const want = "NotOwned"
+	r.MarkResourcesAvailableFalse(ReasonNotOwned, "mark")
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionReady, t)
+	if got := r.GetCondition(RevisionConditionResourcesAvailable); got == nil || got.Reason != want {
+		t.Errorf("MarkResourceNotOwned = %v, want %v", got, want)
+	}
+	if got := r.GetCondition(RevisionConditionReady); got == nil || got.Reason != want {
+		t.Errorf("MarkResourceNotOwned = %v, want %v", got, want)
+	}
+}
+
+func TestRevisionResourcesUnavailable(t *testing.T) {
+	r := &RevisionStatus{}
+	r.InitializeConditions()
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
+
+	const wantReason, wantMessage = "unschedulable", "insufficient energy"
+	r.MarkResourcesAvailableFalse(wantReason, wantMessage)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionReady, t)
+	if got := r.GetCondition(RevisionConditionResourcesAvailable); got == nil || got.Reason != wantReason {
+		t.Errorf("RevisionConditionResourcesAvailable.Reason = %v, want %v", got, wantReason)
+	}
+	if got := r.GetCondition(RevisionConditionResourcesAvailable); got == nil || got.Message != wantMessage {
+		t.Errorf("RevisionConditionResourcesAvailable.Message = %v, want %v", got, wantMessage)
+	}
+
+	r.MarkResourcesAvailableUnknown(wantReason, wantMessage)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
+}
+
+func TestRevisionGetProtocol(t *testing.T) {
+	containerWithPortName := func(name string) corev1.Container {
+		return corev1.Container{Ports: []corev1.ContainerPort{{Name: name}}}
+	}
+
+	tests := []struct {
+		name      string
+		container corev1.Container
+		protocol  net.ProtocolType
+	}{{
+		name:      "undefined",
+		container: corev1.Container{},
+		protocol:  net.ProtocolHTTP1,
+	}, {
+		name:      "http1",
+		container: containerWithPortName("http1"),
+		protocol:  net.ProtocolHTTP1,
+	}, {
+		name:      "h2c",
+		container: containerWithPortName("h2c"),
+		protocol:  net.ProtocolH2C,
+	}, {
+		name:      "unknown",
+		container: containerWithPortName("whatever"),
+		protocol:  net.ProtocolHTTP1,
+	}, {
+		name:      "empty",
+		container: containerWithPortName(""),
+		protocol:  net.ProtocolHTTP1,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Revision{
+				Spec: RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							tt.container,
+						},
+					},
+				},
+			}
+
+			got := r.GetProtocol()
+			want := tt.protocol
+
+			if got != want {
+				t.Errorf("got: %#v, want: %#v", got, want)
+			}
+		})
+	}
+}
+
+func TestRevisionGetLastPinned(t *testing.T) {
+	cases := []struct {
+		name              string
+		annotations       map[string]string
+		expectTime        time.Time
+		setLastPinnedTime time.Time
+		expectErr         error
+	}{{
+		name:        "Nil annotations",
+		annotations: nil,
+		expectErr: LastPinnedParseError{
+			Type: AnnotationParseErrorTypeMissing,
+		},
+	}, {
+		name:        "Empty map annotations",
+		annotations: map[string]string{},
+		expectErr: LastPinnedParseError{
+			Type: AnnotationParseErrorTypeMissing,
+		},
+	}, {
+		name:              "Empty map annotations - with set time",
+		annotations:       map[string]string{},
+		setLastPinnedTime: time.Unix(1000, 0),
+		expectTime:        time.Unix(1000, 0),
+	}, {
+		name:        "Invalid time",
+		annotations: map[string]string{serving.RevisionLastPinnedAnnotationKey: "abcd"},
+		expectErr: LastPinnedParseError{
+			Type:  AnnotationParseErrorTypeInvalid,
+			Value: "abcd",
+		},
+	}, {
+		name:        "Valid time",
+		annotations: map[string]string{serving.RevisionLastPinnedAnnotationKey: "10000"},
+		expectTime:  time.Unix(10000, 0),
+	}, {
+		name:              "Valid time empty annotations",
+		annotations:       nil,
+		setLastPinnedTime: time.Unix(1000, 0),
+		expectTime:        time.Unix(1000, 0),
+		expectErr:         nil,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rev := Revision{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tc.annotations,
+				},
+			}
+
+			if tc.setLastPinnedTime != (time.Time{}) {
+				rev.SetLastPinned(tc.setLastPinnedTime)
+			}
+
+			pt, err := rev.GetLastPinned()
+			failErr := func() {
+				t.Fatalf("Expected error %v got %v", tc.expectErr, err)
+			}
+
+			if tc.expectErr == nil {
+				if err != nil {
+					failErr()
+				}
+			} else {
+				if tc.expectErr.Error() != err.Error() {
+					failErr()
+				}
+			}
+
+			if tc.expectTime != pt {
+				t.Fatalf("Expected pin time %v got %v", tc.expectTime, pt)
+			}
+		})
+	}
+}
+
+func TestRevisionIsReachable(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{{
+		name:   "has route annotation",
+		labels: map[string]string{serving.RouteLabelKey: "the-route"},
+		want:   true,
+	}, {
+		name:   "empty route annotation",
+		labels: map[string]string{serving.RouteLabelKey: ""},
+		want:   false,
+	}, {
+		name:   "no route annotation",
+		labels: nil,
+		want:   false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rev := Revision{ObjectMeta: metav1.ObjectMeta{Labels: tt.labels}}
+
+			got := rev.IsReachable()
+
+			if got != tt.want {
+				t.Errorf("got: %t, want: %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPropagateDeploymentStatus(t *testing.T) {
+	rev := &RevisionStatus{}
+	rev.InitializeConditions()
+
+	// We start out ongoing.
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionResourcesAvailable, t)
+
+	// Empty deployment conditions shouldn't affect our readiness.
+	rev.PropagateDeploymentStatus(&appsv1.DeploymentStatus{
+		Conditions: []appsv1.DeploymentCondition{},
+	})
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionResourcesAvailable, t)
+
+	// Deployment failures should be propagated and not affect ContainerHealthy.
+	rev.PropagateDeploymentStatus(&appsv1.DeploymentStatus{
+		Conditions: []appsv1.DeploymentCondition{{
+			Type:   appsv1.DeploymentProgressing,
+			Status: corev1.ConditionFalse,
+		}, {
+			Type:   appsv1.DeploymentReplicaFailure,
+			Status: corev1.ConditionUnknown,
+		}},
+	})
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionContainerHealthy, t)
+
+	// Marking container healthy doesn't affect deployment status.
+	rev.MarkContainerHealthyTrue()
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
+
+	// We can recover from deployment failures.
+	rev.PropagateDeploymentStatus(&appsv1.DeploymentStatus{
+		Conditions: []appsv1.DeploymentCondition{{
+			Type:   appsv1.DeploymentProgressing,
+			Status: corev1.ConditionTrue,
+		}},
+	})
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
+
+	// We can go unknown.
+	rev.PropagateDeploymentStatus(&appsv1.DeploymentStatus{
+		Conditions: []appsv1.DeploymentCondition{{
+			Type:   appsv1.DeploymentProgressing,
+			Status: corev1.ConditionUnknown,
+		}},
+	})
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionOngoing(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
+
+	// ReplicaFailure=True translates into Ready=False.
+	rev.PropagateDeploymentStatus(&appsv1.DeploymentStatus{
+		Conditions: []appsv1.DeploymentCondition{{
+			Type:   appsv1.DeploymentReplicaFailure,
+			Status: corev1.ConditionTrue,
+		}},
+	})
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
+
+	// ReplicaFailure=True trumps Progressing=Unknown.
+	rev.PropagateDeploymentStatus(&appsv1.DeploymentStatus{
+		Conditions: []appsv1.DeploymentCondition{{
+			Type:   appsv1.DeploymentProgressing,
+			Status: corev1.ConditionUnknown,
+		}, {
+			Type:   appsv1.DeploymentReplicaFailure,
+			Status: corev1.ConditionTrue,
+		}},
+	})
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionFailed(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
+
+	// ReplicaFailure=False + Progressing=True yields Ready.
+	rev.PropagateDeploymentStatus(&appsv1.DeploymentStatus{
+		Conditions: []appsv1.DeploymentCondition{{
+			Type:   appsv1.DeploymentProgressing,
+			Status: corev1.ConditionTrue,
+		}, {
+			Type:   appsv1.DeploymentReplicaFailure,
+			Status: corev1.ConditionFalse,
+		}},
+	})
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionResourcesAvailable, t)
+	apitestv1.CheckConditionSucceeded(rev.duck(), RevisionConditionContainerHealthy, t)
+}
+
+func TestPropagateAutoscalerStatus(t *testing.T) {
+	r := &RevisionStatus{}
+	r.InitializeConditions()
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionReady, t)
+
+	// PodAutoscaler has no active condition, so we are just coming up.
+	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
+		Status: duckv1.Status{},
+	})
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionActive, t)
+
+	// PodAutoscaler becomes ready, making us active.
+	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   av1alpha1.PodAutoscalerConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	})
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionActive, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
+
+	// PodAutoscaler flipping back to Unknown causes Active become ongoing immediately.
+	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   av1alpha1.PodAutoscalerConditionReady,
+				Status: corev1.ConditionUnknown,
+			}},
+		},
+	})
+	apitestv1.CheckConditionOngoing(r.duck(), RevisionConditionActive, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
+
+	// PodAutoscaler becoming unready makes Active false, but doesn't affect readiness.
+	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   av1alpha1.PodAutoscalerConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	})
+	apitestv1.CheckConditionFailed(r.duck(), RevisionConditionActive, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionReady, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionContainerHealthy, t)
+	apitestv1.CheckConditionSucceeded(r.duck(), RevisionConditionResourcesAvailable, t)
+}
+
+func TestGetContainer(t *testing.T) {
+	cases := []struct {
+		name   string
+		status RevisionSpec
+		want   *corev1.Container
+	}{{
+		name:   "empty revisionSpec should return default value",
+		status: RevisionSpec{},
+		want:   &corev1.Container{},
+	}, {
+		name: "get deprecatedContainer info",
+		status: RevisionSpec{
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "deprecatedContainer",
+					Image: "foo",
+				}},
+			},
+		},
+		want: &corev1.Container{
+			Name:  "deprecatedContainer",
+			Image: "foo",
+		},
+	}, {
+		name: "get first container info even after passing multiple",
+		status: RevisionSpec{
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "firstContainer",
+					Image: "firstImage",
+				}, {
+					Name:  "secondContainer",
+					Image: "secondImage",
+				}},
+			},
+		},
+		want: &corev1.Container{
+			Name:  "firstContainer",
+			Image: "firstImage",
+		},
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if want, got := tc.want, tc.status.GetContainer(); !equality.Semantic.DeepEqual(want, got) {
+				t.Errorf("got: %v want: %v", got, want)
 			}
 		})
 	}

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -308,7 +308,7 @@ func TestReconcile(t *testing.T) {
 					return false, nil, nil
 				}
 				retryAttempted = true
-				return true, nil, apierrors.NewConflict(v1alpha1.Resource("foo"), "bar", errors.New("foo"))
+				return true, nil, apierrors.NewConflict(v1.Resource("foo"), "bar", errors.New("foo"))
 			},
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -41,7 +41,7 @@ import (
 	fakemetricinformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/metric/fake"
 	fakepainformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler/fake"
 	fakesksinformer "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/serverlessservice/fake"
-	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision/fake"
+	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
 	pareconciler "knative.dev/serving/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler"
 	"knative.dev/serving/pkg/reconciler"
 
@@ -62,6 +62,7 @@ import (
 	"knative.dev/serving/pkg/apis/networking"
 	nv1a1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler"
 	"knative.dev/serving/pkg/autoscaler/scaling"
@@ -1136,7 +1137,7 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 	}()
 
 	rev := newTestRevision(testNamespace, testRevision)
-	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Create(rev)
+	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Create(rev)
 
 	ep := makeSKSPrivateEndpoints(1, testNamespace, testRevision)
 	fakekubeclient.Get(ctx).CoreV1().Endpoints(testNamespace).Create(ep)
@@ -1193,7 +1194,7 @@ func TestUpdate(t *testing.T) {
 	ctl := NewController(ctx, newConfigWatcher(), fakeDeciders)
 
 	rev := newTestRevision(testNamespace, testRevision)
-	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Create(rev)
+	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Create(rev)
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
 
 	newDeployment(t, fakedynamicclient.Get(ctx), testRevision+"-deployment", 3)
@@ -1498,10 +1499,10 @@ func (km *failingDeciders) Update(ctx context.Context, decider *scaling.Decider)
 	return decider, nil
 }
 
-func newTestRevision(namespace, name string) *v1alpha1.Revision {
-	return &v1alpha1.Revision{
+func newTestRevision(namespace, name string) *v1.Revision {
+	return &v1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
-			SelfLink:  fmt.Sprintf("/apis/ela/v1alpha1/namespaces/%s/revisions/%s", namespace, name),
+			SelfLink:  fmt.Sprintf("/apis/ela/v1/namespaces/%s/revisions/%s", namespace, name),
 			Name:      name,
 			Namespace: namespace,
 			Annotations: map[string]string{
@@ -1512,7 +1513,7 @@ func newTestRevision(namespace, name string) *v1alpha1.Revision {
 				serving.ConfigurationLabelKey: "test-service",
 			},
 		},
-		Spec: v1alpha1.RevisionSpec{},
+		Spec: v1.RevisionSpec{},
 	}
 }
 

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -63,7 +63,6 @@ import (
 	nv1a1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler"
 	"knative.dev/serving/pkg/autoscaler/scaling"
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -40,13 +40,13 @@ import (
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	nv1a1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
 	revisionresources "knative.dev/serving/pkg/reconciler/revision/resources"
 	"knative.dev/serving/pkg/reconciler/revision/resources/names"
 
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -472,7 +472,7 @@ func TestDisableScaleToZero(t *testing.T) {
 	}
 }
 
-func newKPA(t *testing.T, servingClient clientset.Interface, revision *v1alpha1.Revision) *pav1alpha1.PodAutoscaler {
+func newKPA(t *testing.T, servingClient clientset.Interface, revision *v1.Revision) *pav1alpha1.PodAutoscaler {
 	pa := revisionresources.MakePA(revision)
 	pa.Status.InitializeConditions()
 	_, err := servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(pa)
@@ -482,7 +482,7 @@ func newKPA(t *testing.T, servingClient clientset.Interface, revision *v1alpha1.
 	return pa
 }
 
-func newRevision(t *testing.T, servingClient clientset.Interface, minScale, maxScale int32) *v1alpha1.Revision {
+func newRevision(t *testing.T, servingClient clientset.Interface, minScale, maxScale int32) *v1.Revision {
 	annotations := map[string]string{}
 	if minScale > 0 {
 		annotations[autoscaling.MinScaleAnnotationKey] = strconv.Itoa(int(minScale))
@@ -490,14 +490,14 @@ func newRevision(t *testing.T, servingClient clientset.Interface, minScale, maxS
 	if maxScale > 0 {
 		annotations[autoscaling.MaxScaleAnnotationKey] = strconv.Itoa(int(maxScale))
 	}
-	rev := &v1alpha1.Revision{
+	rev := &v1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   testNamespace,
 			Name:        testRevision,
 			Annotations: annotations,
 		},
 	}
-	rev, err := servingClient.ServingV1alpha1().Revisions(testNamespace).Create(rev)
+	rev, err := servingClient.ServingV1().Revisions(testNamespace).Create(rev)
 	if err != nil {
 		t.Fatal("Failed to create revision.", err)
 	}
@@ -505,7 +505,7 @@ func newRevision(t *testing.T, servingClient clientset.Interface, minScale, maxS
 	return rev
 }
 
-func newDeployment(t *testing.T, dynamicClient dynamic.Interface, name string, replicas int) *v1.Deployment {
+func newDeployment(t *testing.T, dynamicClient dynamic.Interface, name string, replicas int) *appsv1.Deployment {
 	t.Helper()
 
 	uns := &unstructured.Unstructured{
@@ -540,7 +540,7 @@ func newDeployment(t *testing.T, dynamicClient dynamic.Interface, name string, r
 		t.Fatalf("Create() = %v", err)
 	}
 
-	deployment := &v1.Deployment{}
+	deployment := &appsv1.Deployment{}
 	if err := duck.FromUnstructured(u, deployment); err != nil {
 		t.Fatalf("FromUnstructured() = %v", err)
 	}
@@ -568,7 +568,7 @@ func paMarkActivating(pa *pav1alpha1.PodAutoscaler, ltt time.Time) {
 	pa.Status.Conditions[0].LastTransitionTime = apis.VolatileTime{Inner: metav1.NewTime(ltt)}
 }
 
-func checkReplicas(t *testing.T, dynamicClient *fakedynamic.FakeDynamicClient, deployment *v1.Deployment, expectedScale int32) {
+func checkReplicas(t *testing.T, dynamicClient *fakedynamic.FakeDynamicClient, deployment *appsv1.Deployment, expectedScale int32) {
 	t.Helper()
 
 	found := false

--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -26,7 +26,7 @@ import (
 	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap"
 	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	painformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler"
-	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
+	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
@@ -34,7 +34,7 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
 	apisconfig "knative.dev/serving/pkg/apis/config"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler"
@@ -85,12 +85,12 @@ func NewController(
 	revisionInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Revision")),
+		FilterFunc: controller.Filter(v1.SchemeGroupVersion.WithKind("Revision")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
 	paInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Revision")),
+		FilterFunc: controller.Filter(v1.SchemeGroupVersion.WithKind("Revision")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
@@ -99,7 +99,7 @@ func NewController(
 	// a functioning Image controller.
 
 	configMapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Revision")),
+		FilterFunc: controller.Filter(v1.SchemeGroupVersion.WithKind("Revision")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -25,14 +25,14 @@ import (
 	caching "knative.dev/caching/pkg/apis/caching/v1alpha1"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
-	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	autoscaling "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler/revision/config"
 	"knative.dev/serving/pkg/reconciler/revision/resources"
 	presources "knative.dev/serving/pkg/resources"
 )
 
-func (c *Reconciler) createDeployment(ctx context.Context, rev *v1alpha1.Revision) (*appsv1.Deployment, error) {
+func (c *Reconciler) createDeployment(ctx context.Context, rev *v1.Revision) (*appsv1.Deployment, error) {
 	cfgs := config.FromContext(ctx)
 
 	deployment, err := resources.MakeDeployment(
@@ -52,7 +52,7 @@ func (c *Reconciler) createDeployment(ctx context.Context, rev *v1alpha1.Revisio
 	return c.KubeClientSet.AppsV1().Deployments(deployment.Namespace).Create(deployment)
 }
 
-func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1alpha1.Revision, have *appsv1.Deployment) (*appsv1.Deployment, error) {
+func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1.Revision, have *appsv1.Deployment) (*appsv1.Deployment, error) {
 	logger := logging.FromContext(ctx)
 	cfgs := config.FromContext(ctx)
 
@@ -109,13 +109,13 @@ func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1alpha1
 	return d, nil
 }
 
-func (c *Reconciler) createImageCache(ctx context.Context, rev *v1alpha1.Revision) (*caching.Image, error) {
+func (c *Reconciler) createImageCache(ctx context.Context, rev *v1.Revision) (*caching.Image, error) {
 	image := resources.MakeImageCache(rev)
 
 	return c.CachingClientSet.CachingV1alpha1().Images(image.Namespace).Create(image)
 }
 
-func (c *Reconciler) createPA(ctx context.Context, rev *v1alpha1.Revision) (*av1alpha1.PodAutoscaler, error) {
+func (c *Reconciler) createPA(ctx context.Context, rev *v1.Revision) (*autoscaling.PodAutoscaler, error) {
 	pa := resources.MakePA(rev)
 
 	return c.ServingClientSet.AutoscalingV1alpha1().PodAutoscalers(pa.Namespace).Create(pa)

--- a/pkg/reconciler/revision/queueing_test.go
+++ b/pkg/reconciler/revision/queueing_test.go
@@ -21,10 +21,12 @@ import (
 	"testing"
 	"time"
 
-	"knative.dev/serving/pkg/apis/config"
-
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -34,18 +36,14 @@ import (
 	"knative.dev/pkg/tracing"
 	tracingconfig "knative.dev/pkg/tracing/config"
 	tracetesting "knative.dev/pkg/tracing/testing"
-	autoscaling "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
-
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	. "knative.dev/pkg/reconciler/testing"
 )
@@ -236,7 +234,7 @@ func TestNewRevisionCallsSyncHandler(t *testing.T) {
 
 	// Check for a service created as a signal that syncHandler ran
 	h.OnCreate(&servingClient.Fake, "podautoscalers", func(obj runtime.Object) HookResult {
-		pa := obj.(*autoscaling.PodAutoscaler)
+		pa := obj.(*autoscalingv1alpha1.PodAutoscaler)
 		t.Logf("PA created: %s", pa.Name)
 		return HookComplete
 	})

--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -28,12 +28,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler/revision/resources"
 	resourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
 )
 
-func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revision) error {
+func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1.Revision) error {
 	ns := rev.Namespace
 	deploymentName := resourcenames.Deployment(rev)
 	logger := logging.FromContext(ctx).With(zap.String(logkey.Deployment, deploymentName))
@@ -41,8 +41,8 @@ func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revi
 	deployment, err := c.deploymentLister.Deployments(ns).Get(deploymentName)
 	if apierrs.IsNotFound(err) {
 		// Deployment does not exist. Create it.
-		rev.Status.MarkResourcesAvailableUnknown(v1alpha1.Deploying, "")
-		rev.Status.MarkContainerHealthyUnknown(v1alpha1.Deploying, "")
+		rev.Status.MarkResourcesAvailableUnknown(v1.ReasonDeploying, "")
+		rev.Status.MarkContainerHealthyUnknown(v1.ReasonDeploying, "")
 		deployment, err = c.createDeployment(ctx, rev)
 		if err != nil {
 			return fmt.Errorf("failed to create deployment %q: %w", deploymentName, err)
@@ -52,7 +52,7 @@ func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revi
 		return fmt.Errorf("failed to get deployment %q: %w", deploymentName, err)
 	} else if !metav1.IsControlledBy(deployment, rev) {
 		// Surface an error in the revision's status, and return an error.
-		rev.Status.MarkResourcesAvailableFalse(v1alpha1.NotOwned, v1alpha1.ResourceNotOwnedMessage("Deployment", deploymentName))
+		rev.Status.MarkResourcesAvailableFalse(v1.ReasonNotOwned, v1.ResourceNotOwnedMessage("Deployment", deploymentName))
 		return fmt.Errorf("revision: %q does not own Deployment: %q", rev.Name, deploymentName)
 	} else {
 		// The deployment exists, but make sure that it has the shape that we expect.
@@ -95,7 +95,7 @@ func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revi
 				if status.Name == rev.Spec.GetContainer().Name {
 					if t := status.LastTerminationState.Terminated; t != nil {
 						logger.Infof("%s marking exiting with: %d/%s", rev.Name, t.ExitCode, t.Message)
-						rev.Status.MarkContainerHealthyFalse(v1alpha1.ExitCodeReason(t.ExitCode), v1alpha1.RevisionContainerExitingMessage(t.Message))
+						rev.Status.MarkContainerHealthyFalse(v1.ExitCodeReason(t.ExitCode), v1.RevisionContainerExitingMessage(t.Message))
 					} else if w := status.State.Waiting; w != nil && hasDeploymentTimedOut(deployment) {
 						logger.Infof("%s marking resources unavailable with: %s: %s", rev.Name, w.Reason, w.Message)
 						rev.Status.MarkResourcesAvailableFalse(w.Reason, w.Message)
@@ -109,7 +109,7 @@ func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1alpha1.Revi
 	return nil
 }
 
-func (c *Reconciler) reconcileImageCache(ctx context.Context, rev *v1alpha1.Revision) error {
+func (c *Reconciler) reconcileImageCache(ctx context.Context, rev *v1.Revision) error {
 	logger := logging.FromContext(ctx)
 
 	ns := rev.Namespace
@@ -128,7 +128,7 @@ func (c *Reconciler) reconcileImageCache(ctx context.Context, rev *v1alpha1.Revi
 	return nil
 }
 
-func (c *Reconciler) reconcilePA(ctx context.Context, rev *v1alpha1.Revision) error {
+func (c *Reconciler) reconcilePA(ctx context.Context, rev *v1.Revision) error {
 	ns := rev.Namespace
 	paName := resourcenames.PA(rev)
 	logger := logging.FromContext(ctx)
@@ -146,7 +146,7 @@ func (c *Reconciler) reconcilePA(ctx context.Context, rev *v1alpha1.Revision) er
 		return fmt.Errorf("failed to get PA %q: %w", paName, err)
 	} else if !metav1.IsControlledBy(pa, rev) {
 		// Surface an error in the revision's status, and return an error.
-		rev.Status.MarkResourcesAvailableFalse(v1alpha1.NotOwned, v1alpha1.ResourceNotOwnedMessage("PodAutoscaler", paName))
+		rev.Status.MarkResourcesAvailableFalse(v1.ReasonNotOwned, v1.ResourceNotOwnedMessage("PodAutoscaler", paName))
 		return fmt.Errorf("revision: %q does not own PodAutoscaler: %q", rev.Name, paName)
 	}
 

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -28,7 +28,7 @@ import (
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
@@ -135,7 +135,7 @@ func rewriteUserProbe(p *corev1.Probe, userPort int) {
 	}
 }
 
-func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, tracingConfig *tracingconfig.Config, observabilityConfig *metrics.ObservabilityConfig, autoscalerConfig *autoscaler.Config, deploymentConfig *deployment.Config) (*corev1.PodSpec, error) {
+func makePodSpec(rev *v1.Revision, loggingConfig *logging.Config, tracingConfig *tracingconfig.Config, observabilityConfig *metrics.ObservabilityConfig, autoscalerConfig *autoscaler.Config, deploymentConfig *deployment.Config) (*corev1.PodSpec, error) {
 	queueContainer, err := makeQueueContainer(rev, loggingConfig, tracingConfig, observabilityConfig, autoscalerConfig, deploymentConfig)
 
 	if err != nil {
@@ -202,19 +202,19 @@ func makePodSpec(rev *v1alpha1.Revision, loggingConfig *logging.Config, tracingC
 	return podSpec, nil
 }
 
-func getUserPort(rev *v1alpha1.Revision) int32 {
+func getUserPort(rev *v1.Revision) int32 {
 	ports := rev.Spec.GetContainer().Ports
 
 	if len(ports) > 0 && ports[0].ContainerPort != 0 {
 		return ports[0].ContainerPort
 	}
 
-	return v1alpha1.DefaultUserPort
+	return v1.DefaultUserPort
 }
 
 func buildContainerPorts(userPort int32) []corev1.ContainerPort {
 	return []corev1.ContainerPort{{
-		Name:          v1alpha1.UserPortName,
+		Name:          v1.UserPortName,
 		ContainerPort: userPort,
 	}}
 }
@@ -227,7 +227,7 @@ func buildUserPortEnv(userPort string) corev1.EnvVar {
 }
 
 // MakeDeployment constructs a K8s Deployment resource from a revision.
-func MakeDeployment(rev *v1alpha1.Revision,
+func MakeDeployment(rev *v1.Revision,
 	loggingConfig *logging.Config, tracingConfig *tracingconfig.Config, networkConfig *network.Config, observabilityConfig *metrics.ObservabilityConfig,
 	autoscalerConfig *autoscaler.Config, deploymentConfig *deployment.Config) (*appsv1.Deployment, error) {
 

--- a/pkg/reconciler/revision/resources/env_var.go
+++ b/pkg/reconciler/revision/resources/env_var.go
@@ -19,7 +19,7 @@ package resources
 import (
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 const (
@@ -28,7 +28,7 @@ const (
 	knativeServiceEnvVariableKey       = "K_SERVICE"
 )
 
-func getKnativeEnvVar(rev *v1alpha1.Revision) []corev1.EnvVar {
+func getKnativeEnvVar(rev *v1.Revision) []corev1.EnvVar {
 	return []corev1.EnvVar{{
 		Name:  knativeRevisionEnvVariableKey,
 		Value: rev.Name,

--- a/pkg/reconciler/revision/resources/imagecache.go
+++ b/pkg/reconciler/revision/resources/imagecache.go
@@ -22,13 +22,13 @@ import (
 	caching "knative.dev/caching/pkg/apis/caching/v1alpha1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler/revision/resources/names"
 	"knative.dev/serving/pkg/resources"
 )
 
 // MakeImageCache makes an caching.Image resources from a revision.
-func MakeImageCache(rev *v1alpha1.Revision) *caching.Image {
+func MakeImageCache(rev *v1.Revision) *caching.Image {
 	image := rev.Status.ImageDigest
 	if image == "" {
 		image = rev.Spec.GetContainer().Image

--- a/pkg/reconciler/revision/resources/imagecache_test.go
+++ b/pkg/reconciler/revision/resources/imagecache_test.go
@@ -27,17 +27,16 @@ import (
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
 func TestMakeImageCache(t *testing.T) {
 	tests := []struct {
 		name string
-		rev  *v1alpha1.Revision
+		rev  *v1.Revision
 		want *caching.Image
 	}{{
 		name: "simple container",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
@@ -47,15 +46,15 @@ func TestMakeImageCache(t *testing.T) {
 				},
 				UID: "1234",
 			},
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(1),
-				},
-				DeprecatedContainer: &corev1.Container{
-					Image: "busybox",
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(1),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "busybox",
+					}},
 				},
 			},
-			Status: v1alpha1.RevisionStatus{
+			Status: v1.RevisionStatus{
 				ImageDigest: "busybox@sha256:deadbeef",
 			},
 		},
@@ -72,7 +71,7 @@ func TestMakeImageCache(t *testing.T) {
 					"a": "b",
 				},
 				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Revision",
 					Name:               "bar",
 					UID:                "1234",
@@ -86,21 +85,19 @@ func TestMakeImageCache(t *testing.T) {
 		},
 	}, {
 		name: "with service account",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
 				UID:       "1234",
 			},
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(1),
-					PodSpec: corev1.PodSpec{
-						ServiceAccountName: "privilegeless",
-					},
-				},
-				DeprecatedContainer: &corev1.Container{
-					Image: "busybox",
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(1),
+				PodSpec: corev1.PodSpec{
+					ServiceAccountName: "privilegeless",
+					Containers: []corev1.Container{{
+						Image: "busybox",
+					}},
 				},
 			},
 		},
@@ -115,7 +112,7 @@ func TestMakeImageCache(t *testing.T) {
 				},
 				Annotations: map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Revision",
 					Name:               "bar",
 					UID:                "1234",

--- a/pkg/reconciler/revision/resources/meta.go
+++ b/pkg/reconciler/revision/resources/meta.go
@@ -19,12 +19,12 @@ package resources
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/resources"
 )
 
 // makeLabels constructs the labels we will apply to K8s resources.
-func makeLabels(revision *v1alpha1.Revision) map[string]string {
+func makeLabels(revision *v1.Revision) map[string]string {
 	labels := resources.FilterMap(revision.GetLabels(), func(k string) bool {
 		// Exclude the Route label so that a Revision becoming routable
 		// doesn't trigger deployment updates.
@@ -45,7 +45,7 @@ func makeLabels(revision *v1alpha1.Revision) map[string]string {
 }
 
 // makeSelector constructs the Selector we will apply to K8s resources.
-func makeSelector(revision *v1alpha1.Revision) *metav1.LabelSelector {
+func makeSelector(revision *v1.Revision) *metav1.LabelSelector {
 	return &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			serving.RevisionUID: string(revision.UID),

--- a/pkg/reconciler/revision/resources/meta_test.go
+++ b/pkg/reconciler/revision/resources/meta_test.go
@@ -23,17 +23,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 func TestMakeLabels(t *testing.T) {
 	tests := []struct {
 		name string
-		rev  *v1alpha1.Revision
+		rev  *v1.Revision
 		want map[string]string
 	}{{
 		name: "no user labels",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
@@ -47,7 +47,7 @@ func TestMakeLabels(t *testing.T) {
 		},
 	}, {
 		name: "propagate user labels",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
@@ -67,7 +67,7 @@ func TestMakeLabels(t *testing.T) {
 		},
 	}, {
 		name: "override app label key",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",

--- a/pkg/reconciler/revision/resources/names/names_test.go
+++ b/pkg/reconciler/revision/resources/names/names_test.go
@@ -23,18 +23,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/kmeta"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 func TestNamer(t *testing.T) {
 	tests := []struct {
 		name string
-		rev  *v1alpha1.Revision
+		rev  *v1.Revision
 		f    func(kmeta.Accessor) string
 		want string
 	}{{
 		name: "Deployment too long",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: strings.Repeat("f", 63),
 			},
@@ -43,7 +43,7 @@ func TestNamer(t *testing.T) {
 		want: "ffffffffffffffffffff105d7597f637e83cc711605ac3ea4957-deployment",
 	}, {
 		name: "Deployment long enough",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: strings.Repeat("f", 52),
 			},
@@ -52,7 +52,7 @@ func TestNamer(t *testing.T) {
 		want: strings.Repeat("f", 52) + "-deployment",
 	}, {
 		name: "Deployment",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
@@ -61,7 +61,7 @@ func TestNamer(t *testing.T) {
 		want: "foo-deployment",
 	}, {
 		name: "ImageCache, barely fits",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: strings.Repeat("u", 57),
 			},
@@ -70,7 +70,7 @@ func TestNamer(t *testing.T) {
 		want: strings.Repeat("u", 57) + "-cache",
 	}, {
 		name: "ImageCache, already too long",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: strings.Repeat("u", 63),
 			},
@@ -79,7 +79,7 @@ func TestNamer(t *testing.T) {
 		want: "uuuuuuuuuuuuuuuuuuuuuuuuuca47ad1ce8479df271ec0d23653ce256-cache",
 	}, {
 		name: "ImageCache",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
@@ -88,7 +88,7 @@ func TestNamer(t *testing.T) {
 		want: "foo-cache",
 	}, {
 		name: "PA",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "baz",
 			},

--- a/pkg/reconciler/revision/resources/pa.go
+++ b/pkg/reconciler/revision/resources/pa.go
@@ -23,13 +23,13 @@ import (
 	"knative.dev/pkg/kmeta"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler/revision/resources/names"
 	"knative.dev/serving/pkg/resources"
 )
 
 // MakePA makes a Knative Pod Autoscaler resource from a revision.
-func MakePA(rev *v1alpha1.Revision) *av1alpha1.PodAutoscaler {
+func MakePA(rev *v1.Revision) *av1alpha1.PodAutoscaler {
 	return &av1alpha1.PodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.PA(rev),
@@ -51,7 +51,7 @@ func MakePA(rev *v1alpha1.Revision) *av1alpha1.PodAutoscaler {
 			ProtocolType: rev.GetProtocol(),
 			Reachability: func() av1alpha1.ReachabilityType {
 				// If the Revision has failed to become Ready, then mark the PodAutoscaler as unreachable.
-				if cond := rev.Status.GetCondition(v1alpha1.RevisionConditionReady); cond != nil && cond.Status == corev1.ConditionFalse {
+				if cond := rev.Status.GetCondition(v1.RevisionConditionReady); cond != nil && cond.Status == corev1.ConditionFalse {
 					// As a sanity check, also make sure that we don't do this when a
 					// newly failing revision is marked reachable by outside forces.
 					if !rev.IsReachable() {
@@ -61,7 +61,7 @@ func MakePA(rev *v1alpha1.Revision) *av1alpha1.PodAutoscaler {
 
 				// We don't know the reachability if the revision has just been created
 				// or it is activating.
-				if cond := rev.Status.GetCondition(v1alpha1.RevisionConditionActive); cond != nil && cond.Status == corev1.ConditionUnknown {
+				if cond := rev.Status.GetCondition(v1.RevisionConditionActive); cond != nil && cond.Status == corev1.ConditionUnknown {
 					return av1alpha1.ReachabilityUnknown
 				}
 

--- a/pkg/reconciler/revision/resources/pa_test.go
+++ b/pkg/reconciler/revision/resources/pa_test.go
@@ -30,18 +30,17 @@ import (
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
 func TestMakePA(t *testing.T) {
 	tests := []struct {
 		name string
-		rev  *v1alpha1.Revision
+		rev  *v1.Revision
 		want *av1alpha1.PodAutoscaler
 	}{{
 		name: "name is bar (Concurrency=1, Reachable=true)",
-		rev: func() *v1alpha1.Revision {
-			rev := v1alpha1.Revision{
+		rev: func() *v1.Revision {
+			rev := v1.Revision{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "foo",
 					Name:      "bar",
@@ -54,10 +53,8 @@ func TestMakePA(t *testing.T) {
 						serving.RevisionLastPinnedAnnotationKey: "timeless",
 					},
 				},
-				Spec: v1alpha1.RevisionSpec{
-					RevisionSpec: v1.RevisionSpec{
-						ContainerConcurrency: ptr.Int64(1),
-					},
+				Spec: v1.RevisionSpec{
+					ContainerConcurrency: ptr.Int64(1),
 				},
 			}
 			rev.Status.MarkActiveTrue()
@@ -76,7 +73,7 @@ func TestMakePA(t *testing.T) {
 					"a": "b",
 				},
 				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Revision",
 					Name:               "bar",
 					UID:                "1234",
@@ -97,21 +94,21 @@ func TestMakePA(t *testing.T) {
 		},
 	}, {
 		name: "name is baz (Concurrency=0, Reachable=false)",
-		rev: func() *v1alpha1.Revision {
-			rev := v1alpha1.Revision{
+		rev: func() *v1.Revision {
+			rev := v1.Revision{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "blah",
 					Name:      "baz",
 					UID:       "4321",
 				},
-				Spec: v1alpha1.RevisionSpec{
-					RevisionSpec: v1.RevisionSpec{
-						ContainerConcurrency: ptr.Int64(0),
-					},
-					DeprecatedContainer: &corev1.Container{
-						Ports: []corev1.ContainerPort{{
-							Name:     "h2c",
-							HostPort: int32(443),
+				Spec: v1.RevisionSpec{
+					ContainerConcurrency: ptr.Int64(0),
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Ports: []corev1.ContainerPort{{
+								Name:     "h2c",
+								HostPort: int32(443),
+							}},
 						}},
 					},
 				},
@@ -130,7 +127,7 @@ func TestMakePA(t *testing.T) {
 				},
 				Annotations: map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Revision",
 					Name:               "baz",
 					UID:                "4321",
@@ -150,21 +147,21 @@ func TestMakePA(t *testing.T) {
 			}},
 	}, {
 		name: "name is baz (Concurrency=0, Reachable=false, Activating)",
-		rev: func() *v1alpha1.Revision {
-			rev := v1alpha1.Revision{
+		rev: func() *v1.Revision {
+			rev := v1.Revision{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "blah",
 					Name:      "baz",
 					UID:       "4321",
 				},
-				Spec: v1alpha1.RevisionSpec{
-					RevisionSpec: v1.RevisionSpec{
-						ContainerConcurrency: ptr.Int64(0),
-					},
-					DeprecatedContainer: &corev1.Container{
-						Ports: []corev1.ContainerPort{{
-							Name:     "h2c",
-							HostPort: int32(443),
+				Spec: v1.RevisionSpec{
+					ContainerConcurrency: ptr.Int64(0),
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Ports: []corev1.ContainerPort{{
+								Name:     "h2c",
+								HostPort: int32(443),
+							}},
 						}},
 					},
 				},
@@ -183,7 +180,7 @@ func TestMakePA(t *testing.T) {
 				},
 				Annotations: map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Revision",
 					Name:               "baz",
 					UID:                "4321",
@@ -203,21 +200,21 @@ func TestMakePA(t *testing.T) {
 			}},
 	}, {
 		name: "name is batman (Activating, Revision failed)",
-		rev: func() *v1alpha1.Revision {
-			rev := v1alpha1.Revision{
+		rev: func() *v1.Revision {
+			rev := v1.Revision{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "blah",
 					Name:      "batman",
 					UID:       "4321",
 				},
-				Spec: v1alpha1.RevisionSpec{
-					RevisionSpec: v1.RevisionSpec{
-						ContainerConcurrency: ptr.Int64(0),
-					},
-					DeprecatedContainer: &corev1.Container{
-						Ports: []corev1.ContainerPort{{
-							Name:     "h2c",
-							HostPort: int32(443),
+				Spec: v1.RevisionSpec{
+					ContainerConcurrency: ptr.Int64(0),
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Ports: []corev1.ContainerPort{{
+								Name:     "h2c",
+								HostPort: int32(443),
+							}},
 						}},
 					},
 				},
@@ -237,7 +234,7 @@ func TestMakePA(t *testing.T) {
 				},
 				Annotations: map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Revision",
 					Name:               "batman",
 					UID:                "4321",
@@ -258,8 +255,8 @@ func TestMakePA(t *testing.T) {
 			}},
 	}, {
 		name: "name is robin (Activating, Revision routable but failed)",
-		rev: func() *v1alpha1.Revision {
-			rev := v1alpha1.Revision{
+		rev: func() *v1.Revision {
+			rev := v1.Revision{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "blah",
 					Name:      "robin",
@@ -268,14 +265,14 @@ func TestMakePA(t *testing.T) {
 						serving.RouteLabelKey: "asdf",
 					},
 				},
-				Spec: v1alpha1.RevisionSpec{
-					RevisionSpec: v1.RevisionSpec{
-						ContainerConcurrency: ptr.Int64(0),
-					},
-					DeprecatedContainer: &corev1.Container{
-						Ports: []corev1.ContainerPort{{
-							Name:     "h2c",
-							HostPort: int32(443),
+				Spec: v1.RevisionSpec{
+					ContainerConcurrency: ptr.Int64(0),
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Ports: []corev1.ContainerPort{{
+								Name:     "h2c",
+								HostPort: int32(443),
+							}},
 						}},
 					},
 				},
@@ -295,7 +292,7 @@ func TestMakePA(t *testing.T) {
 				},
 				Annotations: map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Revision",
 					Name:               "robin",
 					UID:                "4321",

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -34,7 +34,7 @@ import (
 	tracingconfig "knative.dev/pkg/tracing/config"
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
@@ -59,13 +59,13 @@ var (
 	}
 	queueNonServingPorts = []corev1.ContainerPort{{
 		// Provides health checks and lifecycle hooks.
-		Name:          v1alpha1.QueueAdminPortName,
+		Name:          v1.QueueAdminPortName,
 		ContainerPort: int32(networking.QueueAdminPort),
 	}, {
-		Name:          v1alpha1.AutoscalingQueueMetricsPortName,
+		Name:          v1.AutoscalingQueueMetricsPortName,
 		ContainerPort: int32(networking.AutoscalingQueueMetricsPort),
 	}, {
-		Name:          v1alpha1.UserQueueMetricsPortName,
+		Name:          v1.UserQueueMetricsPortName,
 		ContainerPort: int32(networking.UserQueueMetricsPort),
 	}}
 
@@ -187,7 +187,7 @@ func makeQueueProbe(in *corev1.Probe) *corev1.Probe {
 }
 
 // makeQueueContainer creates the container spec for the queue sidecar.
-func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, tracingConfig *tracingconfig.Config, observabilityConfig *metrics.ObservabilityConfig,
+func makeQueueContainer(rev *v1.Revision, loggingConfig *logging.Config, tracingConfig *tracingconfig.Config, observabilityConfig *metrics.ObservabilityConfig,
 	autoscalerConfig *autoscaler.Config, deploymentConfig *deployment.Config) (*corev1.Container, error) {
 	configName := ""
 	if owner := metav1.GetControllerOf(rev); owner != nil && owner.Kind == "Configuration" {
@@ -228,7 +228,8 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, t
 		volumeMounts = append(volumeMounts, labelVolumeMount)
 	}
 
-	rp := rev.Spec.GetContainer().ReadinessProbe.DeepCopy()
+	container := rev.Spec.GetContainer()
+	rp := container.ReadinessProbe.DeepCopy()
 
 	applyReadinessProbeDefaults(rp, userPort)
 
@@ -240,7 +241,7 @@ func makeQueueContainer(rev *v1alpha1.Revision, loggingConfig *logging.Config, t
 	return &corev1.Container{
 		Name:            QueueContainerName,
 		Image:           deploymentConfig.QueueSidecarImage,
-		Resources:       createQueueResources(rev.GetAnnotations(), rev.Spec.GetContainer()),
+		Resources:       createQueueResources(rev.GetAnnotations(), container),
 		Ports:           ports,
 		ReadinessProbe:  makeQueueProbe(rp),
 		VolumeMounts:    volumeMounts,

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -40,7 +40,6 @@ import (
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
@@ -78,7 +77,7 @@ const testProbeJSONTemplate = `{"tcpSocket":{"port":%d,"host":"127.0.0.1"}}`
 func TestMakeQueueContainer(t *testing.T) {
 	tests := []struct {
 		name string
-		rev  *v1alpha1.Revision
+		rev  *v1.Revision
 		lc   *logging.Config
 		tc   *tracingconfig.Config
 		oc   *metrics.ObservabilityConfig
@@ -87,17 +86,15 @@ func TestMakeQueueContainer(t *testing.T) {
 		want *corev1.Container
 	}{{
 		name: "no owner no autoscaler single",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
 				UID:       "1234",
 			},
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(1),
-					TimeoutSeconds:       ptr.Int64(45),
-				},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(1),
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{},
@@ -117,26 +114,24 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 	}, {
 		name: "no owner no autoscaler single",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
 				UID:       "1234",
 			},
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(1),
-					TimeoutSeconds:       ptr.Int64(45),
-					PodSpec: corev1.PodSpec{
-						Containers: []corev1.Container{{
-							Name:           containerName,
-							ReadinessProbe: testProbe,
-							Ports: []corev1.ContainerPort{{
-								ContainerPort: 1955,
-								Name:          string(networking.ProtocolH2C),
-							}},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(1),
+				TimeoutSeconds:       ptr.Int64(45),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:           containerName,
+						ReadinessProbe: testProbe,
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 1955,
+							Name:          string(networking.ProtocolH2C),
 						}},
-					},
+					}},
 				},
 			},
 		},
@@ -163,7 +158,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 	}, {
 		name: "service name in labels",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
@@ -172,11 +167,9 @@ func TestMakeQueueContainer(t *testing.T) {
 					serving.ServiceLabelKey: "svc",
 				},
 			},
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(1),
-					TimeoutSeconds:       ptr.Int64(45),
-				},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(1),
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{},
@@ -200,24 +193,22 @@ func TestMakeQueueContainer(t *testing.T) {
 			}),
 		}}, {
 		name: "config owner as env var, zero concurrency",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "baz",
 				Name:      "blah",
 				UID:       "1234",
 				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Configuration",
 					Name:               "the-parent-config-name",
 					Controller:         ptr.Bool(true),
 					BlockOwnerDeletion: ptr.Bool(true),
 				}},
 			},
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(0),
-					TimeoutSeconds:       ptr.Int64(45),
-				},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(0),
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{},
@@ -242,17 +233,15 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 	}, {
 		name: "logging configuration as env var",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "log",
 				Name:      "this",
 				UID:       "1234",
 			},
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(0),
-					TimeoutSeconds:       ptr.Int64(45),
-				},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(0),
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{
@@ -283,17 +272,15 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 	}, {
 		name: "container concurrency 10",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
 				UID:       "1234",
 			},
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(10),
-					TimeoutSeconds:       ptr.Int64(45),
-				},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(10),
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{},
@@ -315,17 +302,15 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 	}, {
 		name: "request log configuration as env var",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
 				UID:       "1234",
 			},
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(0),
-					TimeoutSeconds:       ptr.Int64(45),
-				},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(0),
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{},
@@ -352,17 +337,15 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 	}, {
 		name: "request metrics backend as env var",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
 				UID:       "1234",
 			},
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(0),
-					TimeoutSeconds:       ptr.Int64(45),
-				},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(0),
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{},
@@ -387,17 +370,15 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 	}, {
 		name: "enable profiling",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
 				UID:       "1234",
 			},
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(0),
-					TimeoutSeconds:       ptr.Int64(45),
-				},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(0),
+				TimeoutSeconds:       ptr.Int64(45),
 			},
 		},
 		lc: &logging.Config{},
@@ -452,7 +433,7 @@ func TestMakeQueueContainer(t *testing.T) {
 func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 	tests := []struct {
 		name string
-		rev  *v1alpha1.Revision
+		rev  *v1.Revision
 		lc   *logging.Config
 		tc   *tracingconfig.Config
 		oc   *metrics.ObservabilityConfig
@@ -461,7 +442,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 		want *corev1.Container
 	}{{
 		name: "resources percentage in annotations",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
@@ -473,22 +454,20 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 					serving.QueueSideCarResourcePercentageAnnotation: "20",
 				},
 			},
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(1),
-					TimeoutSeconds:       ptr.Int64(45),
-					PodSpec: corev1.PodSpec{
-						Containers: []corev1.Container{{
-							Name:           containerName,
-							ReadinessProbe: testProbe,
-							Resources: corev1.ResourceRequirements{
-								Limits: corev1.ResourceList{
-									corev1.ResourceName("memory"): resource.MustParse("2Gi"),
-									corev1.ResourceName("cpu"):    resource.MustParse("2"),
-								},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(1),
+				TimeoutSeconds:       ptr.Int64(45),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:           containerName,
+						ReadinessProbe: testProbe,
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceName("memory"): resource.MustParse("2Gi"),
+								corev1.ResourceName("cpu"):    resource.MustParse("2"),
 							},
-						}},
-					},
+						},
+					}},
 				},
 			},
 		},
@@ -521,7 +500,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 			}),
 		}}, {
 		name: "resources percentage in annotations small than min allowed",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
@@ -533,22 +512,20 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 					serving.QueueSideCarResourcePercentageAnnotation: "0.2",
 				},
 			},
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(1),
-					TimeoutSeconds:       ptr.Int64(45),
-					PodSpec: corev1.PodSpec{
-						Containers: []corev1.Container{{
-							Name:           containerName,
-							ReadinessProbe: testProbe,
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceName("cpu"):    resource.MustParse("50m"),
-									corev1.ResourceName("memory"): resource.MustParse("128Mi"),
-								},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(1),
+				TimeoutSeconds:       ptr.Int64(45),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:           containerName,
+						ReadinessProbe: testProbe,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceName("cpu"):    resource.MustParse("50m"),
+								corev1.ResourceName("memory"): resource.MustParse("128Mi"),
 							},
-						}},
-					},
+						},
+					}},
 				},
 			},
 		},
@@ -578,7 +555,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 			}),
 		}}, {
 		name: "Invalid resources percentage in annotations",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
@@ -590,22 +567,20 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 					serving.QueueSideCarResourcePercentageAnnotation: "foo",
 				},
 			},
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(1),
-					TimeoutSeconds:       ptr.Int64(45),
-					PodSpec: corev1.PodSpec{
-						Containers: []corev1.Container{{
-							Name:           containerName,
-							ReadinessProbe: testProbe,
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceName("cpu"):    resource.MustParse("50m"),
-									corev1.ResourceName("memory"): resource.MustParse("128Mi"),
-								},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(1),
+				TimeoutSeconds:       ptr.Int64(45),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:           containerName,
+						ReadinessProbe: testProbe,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceName("cpu"):    resource.MustParse("50m"),
+								corev1.ResourceName("memory"): resource.MustParse("128Mi"),
 							},
-						}},
-					},
+						},
+					}},
 				},
 			},
 		},
@@ -634,7 +609,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 			}),
 		}}, {
 		name: "resources percentage in annotations bigger than than math.MaxInt64",
-		rev: &v1alpha1.Revision{
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
@@ -646,21 +621,19 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 					serving.QueueSideCarResourcePercentageAnnotation: "100",
 				},
 			},
-			Spec: v1alpha1.RevisionSpec{
-				RevisionSpec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(1),
-					TimeoutSeconds:       ptr.Int64(45),
-					PodSpec: corev1.PodSpec{
-						Containers: []corev1.Container{{
-							Name:           containerName,
-							ReadinessProbe: testProbe,
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceName("memory"): resource.MustParse("900000Pi"),
-								},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(1),
+				TimeoutSeconds:       ptr.Int64(45),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:           containerName,
+						ReadinessProbe: testProbe,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceName("memory"): resource.MustParse("900000Pi"),
 							},
-						}},
-					},
+						},
+					}},
 				},
 			},
 		},
@@ -723,30 +696,28 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 }
 
 func TestProbeGenerationHTTPDefaults(t *testing.T) {
-	rev := &v1alpha1.Revision{
+	rev := &v1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "bar",
 			UID:       "1234",
 		},
-		Spec: v1alpha1.RevisionSpec{
-			RevisionSpec: v1.RevisionSpec{
-				ContainerConcurrency: ptr.Int64(1),
-				TimeoutSeconds:       ptr.Int64(45),
-				PodSpec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name: containerName,
-						ReadinessProbe: &corev1.Probe{
-							Handler: corev1.Handler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path: "/",
-								},
+		Spec: v1.RevisionSpec{
+			ContainerConcurrency: ptr.Int64(1),
+			TimeoutSeconds:       ptr.Int64(45),
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: containerName,
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/",
 							},
-							PeriodSeconds:  1,
-							TimeoutSeconds: 10,
 						},
-					}},
-				},
+						PeriodSeconds:  1,
+						TimeoutSeconds: 10,
+					},
+				}},
 			},
 		},
 	}
@@ -756,7 +727,7 @@ func TestProbeGenerationHTTPDefaults(t *testing.T) {
 			HTTPGet: &corev1.HTTPGetAction{
 				Host:   "127.0.0.1",
 				Path:   "/",
-				Port:   intstr.FromInt(int(v1alpha1.DefaultUserPort)),
+				Port:   intstr.FromInt(int(v1.DefaultUserPort)),
 				Scheme: corev1.URISchemeHTTP,
 				HTTPHeaders: []corev1.HTTPHeader{{
 					Name:  network.KubeletProbeHeaderName,
@@ -813,34 +784,32 @@ func TestProbeGenerationHTTP(t *testing.T) {
 	userPort := 12345
 	probePath := "/health"
 
-	rev := &v1alpha1.Revision{
+	rev := &v1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "bar",
 			UID:       "1234",
 		},
-		Spec: v1alpha1.RevisionSpec{
-			RevisionSpec: v1.RevisionSpec{
-				ContainerConcurrency: ptr.Int64(1),
-				TimeoutSeconds:       ptr.Int64(45),
-				PodSpec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name: containerName,
-						Ports: []corev1.ContainerPort{{
-							ContainerPort: int32(userPort),
-						}},
-						ReadinessProbe: &corev1.Probe{
-							Handler: corev1.Handler{
-								HTTPGet: &corev1.HTTPGetAction{
-									Path:   probePath,
-									Scheme: corev1.URISchemeHTTPS,
-								},
-							},
-							PeriodSeconds:  2,
-							TimeoutSeconds: 10,
-						},
+		Spec: v1.RevisionSpec{
+			ContainerConcurrency: ptr.Int64(1),
+			TimeoutSeconds:       ptr.Int64(45),
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: containerName,
+					Ports: []corev1.ContainerPort{{
+						ContainerPort: int32(userPort),
 					}},
-				},
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   probePath,
+								Scheme: corev1.URISchemeHTTPS,
+							},
+						},
+						PeriodSeconds:  2,
+						TimeoutSeconds: 10,
+					},
+				}},
 			},
 		},
 	}
@@ -908,7 +877,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 	userPort := 12345
 	tests := []struct {
 		name      string
-		rev       v1alpha1.RevisionSpec
+		rev       v1.RevisionSpec
 		want      *corev1.Container
 		wantProbe *corev1.Probe
 	}{{
@@ -923,25 +892,23 @@ func TestTCPProbeGeneration(t *testing.T) {
 			PeriodSeconds:    0,
 			SuccessThreshold: 3,
 		},
-		rev: v1alpha1.RevisionSpec{
-			RevisionSpec: v1.RevisionSpec{
-				ContainerConcurrency: ptr.Int64(1),
-				TimeoutSeconds:       ptr.Int64(45),
-				PodSpec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name: containerName,
-						Ports: []corev1.ContainerPort{{
-							ContainerPort: int32(userPort),
-						}},
-						ReadinessProbe: &corev1.Probe{
-							Handler: corev1.Handler{
-								TCPSocket: &corev1.TCPSocketAction{},
-							},
-							PeriodSeconds:    0,
-							SuccessThreshold: 3,
-						},
+		rev: v1.RevisionSpec{
+			ContainerConcurrency: ptr.Int64(1),
+			TimeoutSeconds:       ptr.Int64(45),
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: containerName,
+					Ports: []corev1.ContainerPort{{
+						ContainerPort: int32(userPort),
 					}},
-				},
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							TCPSocket: &corev1.TCPSocketAction{},
+						},
+						PeriodSeconds:    0,
+						SuccessThreshold: 3,
+					},
+				}},
 			},
 		},
 		want: &corev1.Container{
@@ -964,28 +931,26 @@ func TestTCPProbeGeneration(t *testing.T) {
 		},
 	}, {
 		name: "tcp defaults",
-		rev: v1alpha1.RevisionSpec{
-			RevisionSpec: v1.RevisionSpec{
-				ContainerConcurrency: ptr.Int64(1),
-				TimeoutSeconds:       ptr.Int64(45),
-				PodSpec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name: containerName,
-						ReadinessProbe: &corev1.Probe{
-							Handler: corev1.Handler{
-								TCPSocket: &corev1.TCPSocketAction{},
-							},
-							PeriodSeconds: 1,
+		rev: v1.RevisionSpec{
+			ContainerConcurrency: ptr.Int64(1),
+			TimeoutSeconds:       ptr.Int64(45),
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: containerName,
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							TCPSocket: &corev1.TCPSocketAction{},
 						},
-					}},
-				},
+						PeriodSeconds: 1,
+					},
+				}},
 			},
 		},
 		wantProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				TCPSocket: &corev1.TCPSocketAction{
 					Host: "127.0.0.1",
-					Port: intstr.FromInt(int(v1alpha1.DefaultUserPort)),
+					Port: intstr.FromInt(int(v1.DefaultUserPort)),
 				},
 			},
 			PeriodSeconds:  1,
@@ -1024,28 +989,26 @@ func TestTCPProbeGeneration(t *testing.T) {
 			FailureThreshold:    7,
 			InitialDelaySeconds: 3,
 		},
-		rev: v1alpha1.RevisionSpec{
-			RevisionSpec: v1.RevisionSpec{
-				ContainerConcurrency: ptr.Int64(1),
-				TimeoutSeconds:       ptr.Int64(45),
-				PodSpec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name: containerName,
-						Ports: []corev1.ContainerPort{{
-							ContainerPort: int32(userPort),
-						}},
-						ReadinessProbe: &corev1.Probe{
-							Handler: corev1.Handler{
-								TCPSocket: &corev1.TCPSocketAction{},
-							},
-							PeriodSeconds:       2,
-							TimeoutSeconds:      15,
-							SuccessThreshold:    2,
-							FailureThreshold:    7,
-							InitialDelaySeconds: 3,
-						},
+		rev: v1.RevisionSpec{
+			ContainerConcurrency: ptr.Int64(1),
+			TimeoutSeconds:       ptr.Int64(45),
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name: containerName,
+					Ports: []corev1.ContainerPort{{
+						ContainerPort: int32(userPort),
 					}},
-				},
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							TCPSocket: &corev1.TCPSocketAction{},
+						},
+						PeriodSeconds:       2,
+						TimeoutSeconds:      15,
+						SuccessThreshold:    2,
+						FailureThreshold:    7,
+						InitialDelaySeconds: 3,
+					},
+				}},
 			},
 		},
 		want: &corev1.Container{
@@ -1077,7 +1040,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 			oc := &metrics.ObservabilityConfig{}
 			ac := &autoscaler.Config{}
 			cc := &deployment.Config{}
-			testRev := &v1alpha1.Revision{
+			testRev := &v1.Revision{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "foo",
 					Name:      "bar",
@@ -1123,7 +1086,7 @@ var defaultEnv = map[string]string{
 	"TRACING_CONFIG_DEBUG":                  "false",
 	"SERVING_REQUEST_LOG_TEMPLATE":          "",
 	"SERVING_REQUEST_METRICS_BACKEND":       "",
-	"USER_PORT":                             strconv.Itoa(v1alpha1.DefaultUserPort),
+	"USER_PORT":                             strconv.Itoa(v1.DefaultUserPort),
 	"SYSTEM_NAMESPACE":                      system.Namespace(),
 	"METRICS_DOMAIN":                        metrics.Domain(),
 	"QUEUE_SERVING_PORT":                    "8012",
@@ -1138,13 +1101,13 @@ var defaultEnv = map[string]string{
 
 func probeJSON(container *corev1.Container) string {
 	if container == nil {
-		return fmt.Sprintf(testProbeJSONTemplate, v1alpha1.DefaultUserPort)
+		return fmt.Sprintf(testProbeJSONTemplate, v1.DefaultUserPort)
 	}
 
 	if ports := container.Ports; len(ports) > 0 && ports[0].ContainerPort != 0 {
 		return fmt.Sprintf(testProbeJSONTemplate, ports[0].ContainerPort)
 	}
-	return fmt.Sprintf(testProbeJSONTemplate, v1alpha1.DefaultUserPort)
+	return fmt.Sprintf(testProbeJSONTemplate, v1.DefaultUserPort)
 }
 
 func env(overrides map[string]string) []corev1.EnvVar {

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -61,7 +61,6 @@ import (
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
@@ -71,10 +70,10 @@ import (
 	. "knative.dev/pkg/reconciler/testing"
 )
 
-func testConfiguration() *v1alpha1.Configuration {
-	return &v1alpha1.Configuration{
+func testConfiguration() *v1.Configuration {
+	return &v1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
-			SelfLink:  "/apis/serving/v1alpha1/namespaces/test/configurations/test-config",
+			SelfLink:  "/apis/serving/v1/namespaces/test/configurations/test-config",
 			Name:      "test-config",
 			Namespace: testNamespace,
 		},

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -37,7 +37,7 @@ import (
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	fakepainformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler/fake"
-	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision/fake"
+	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
@@ -60,6 +60,7 @@ import (
 	tracingconfig "knative.dev/pkg/tracing/config"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler"
 	"knative.dev/serving/pkg/deployment"
@@ -101,7 +102,7 @@ func testReadyEndpoints(revName string) *corev1.Endpoints {
 	}
 }
 
-func testReadyPA(rev *v1alpha1.Revision) *av1alpha1.PodAutoscaler {
+func testReadyPA(rev *v1.Revision) *av1alpha1.PodAutoscaler {
 	pa := resources.MakePA(rev)
 	pa.Status.InitializeConditions()
 	pa.Status.MarkActive()
@@ -180,10 +181,10 @@ func createRevision(
 	t *testing.T,
 	ctx context.Context,
 	controller *controller.Impl,
-	rev *v1alpha1.Revision,
-) *v1alpha1.Revision {
+	rev *v1.Revision,
+) *v1.Revision {
 	t.Helper()
-	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(rev.Namespace).Create(rev)
+	fakeservingclient.Get(ctx).ServingV1().Revisions(rev.Namespace).Create(rev)
 	// Since Reconcile looks in the lister, we need to add it to the informer
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
 
@@ -197,10 +198,10 @@ func updateRevision(
 	t *testing.T,
 	ctx context.Context,
 	controller *controller.Impl,
-	rev *v1alpha1.Revision,
+	rev *v1.Revision,
 ) {
 	t.Helper()
-	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(rev.Namespace).Update(rev)
+	fakeservingclient.Get(ctx).ServingV1().Revisions(rev.Namespace).Update(rev)
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Update(rev)
 
 	if err := controller.Reconciler.Reconcile(context.Background(), KeyOrDie(rev)); err == nil {
@@ -208,24 +209,20 @@ func updateRevision(
 	}
 }
 
-func addResourcesToInformers(t *testing.T, ctx context.Context, rev *v1alpha1.Revision) (*v1alpha1.Revision, *appsv1.Deployment, *av1alpha1.PodAutoscaler) {
+func addResourcesToInformers(t *testing.T, ctx context.Context, rev *v1.Revision) (*v1.Revision, *appsv1.Deployment, *av1alpha1.PodAutoscaler) {
 	t.Helper()
 
-	rev, err := fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(rev.Namespace).Get(rev.Name, metav1.GetOptions{})
+	rev, err := fakeservingclient.Get(ctx).ServingV1().Revisions(rev.Namespace).Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Revisions.Get(%v) = %v", rev.Name, err)
 	}
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
 
-	haveBuild := rev.Spec.DeprecatedBuildRef != nil
-
 	ns := rev.Namespace
 
 	paName := resourcenames.PA(rev)
 	pa, err := fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(rev.Namespace).Get(paName, metav1.GetOptions{})
-	if apierrs.IsNotFound(err) && haveBuild {
-		// If we're doing a Build this won't exist yet.
-	} else if err != nil {
+	if err != nil {
 		t.Errorf("PodAutoscalers.Get(%v) = %v", paName, err)
 	} else {
 		fakepainformer.Get(ctx).Informer().GetIndexer().Add(pa)
@@ -233,9 +230,7 @@ func addResourcesToInformers(t *testing.T, ctx context.Context, rev *v1alpha1.Re
 
 	imageName := resourcenames.ImageCache(rev)
 	image, err := fakecachingclient.Get(ctx).CachingV1alpha1().Images(rev.Namespace).Get(imageName, metav1.GetOptions{})
-	if apierrs.IsNotFound(err) && haveBuild {
-		// If we're doing a Build this won't exist yet.
-	} else if err != nil {
+	if err != nil {
 		t.Errorf("Caching.Images.Get(%v) = %v", imageName, err)
 	} else {
 		fakeimageinformer.Get(ctx).Informer().GetIndexer().Add(image)
@@ -243,9 +238,7 @@ func addResourcesToInformers(t *testing.T, ctx context.Context, rev *v1alpha1.Re
 
 	deploymentName := resourcenames.Deployment(rev)
 	deployment, err := fakekubeclient.Get(ctx).AppsV1().Deployments(ns).Get(deploymentName, metav1.GetOptions{})
-	if apierrs.IsNotFound(err) && haveBuild {
-		// If we're doing a Build this won't exist yet.
-	} else if err != nil {
+	if err != nil {
 		t.Errorf("Deployments.Get(%v) = %v", deploymentName, err)
 	} else {
 		fakedeploymentinformer.Get(ctx).Informer().GetIndexer().Add(deployment)
@@ -284,7 +277,7 @@ func TestResolutionFailed(t *testing.T) {
 
 	createRevision(t, ctx, controller, rev)
 
-	rev, err := fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Get(rev.Name, metav1.GetOptions{})
+	rev, err := fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Couldn't get revision: %v", err)
 	}
@@ -296,7 +289,7 @@ func TestResolutionFailed(t *testing.T) {
 			Type:   ct,
 			Status: corev1.ConditionFalse,
 			Reason: "ContainerMissing",
-			Message: v1alpha1.RevisionContainerMissingMessage(
+			Message: v1.RevisionContainerMissingMessage(
 				rev.Spec.GetContainer().Image, "failed to resolve image to digest: "+innerError.Error()),
 			LastTransitionTime: got.LastTransitionTime,
 			Severity:           apis.ConditionSeverityError,
@@ -321,7 +314,7 @@ func TestUpdateRevWithWithUpdatedLoggingURL(t *testing.T) {
 		},
 	}, getTestDeploymentConfigMap(),
 	)
-	revClient := fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace)
+	revClient := fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace)
 
 	rev := testRevision()
 	createRevision(t, ctx, controller, rev)
@@ -541,7 +534,7 @@ func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 		},
 		callback: func(t *testing.T) func(runtime.Object) HookResult {
 			return func(obj runtime.Object) HookResult {
-				revision := obj.(*v1alpha1.Revision)
+				revision := obj.(*v1.Revision)
 				t.Logf("Revision updated: %v", revision.Name)
 
 				expected := "http://log-here.test.com?filter="
@@ -567,7 +560,7 @@ func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 		},
 		callback: func(t *testing.T) func(runtime.Object) HookResult {
 			return func(obj runtime.Object) HookResult {
-				revision := obj.(*v1alpha1.Revision)
+				revision := obj.(*v1.Revision)
 				t.Logf("Revision updated: %v", revision.Name)
 
 				expected := int64(3)
@@ -593,7 +586,7 @@ func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 			servingClient := fakeservingclient.Get(ctx)
 
 			rev := testRevision()
-			revClient := servingClient.ServingV1alpha1().Revisions(rev.Namespace)
+			revClient := servingClient.ServingV1().Revisions(rev.Namespace)
 
 			h := NewHooks()
 
@@ -749,7 +742,7 @@ func TestGlobalResyncOnConfigMapUpdateDeployment(t *testing.T) {
 			kubeClient := fakekubeclient.Get(ctx)
 
 			rev := testRevision()
-			revClient := fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(rev.Namespace)
+			revClient := fakeservingclient.Get(ctx).ServingV1().Revisions(rev.Namespace)
 			h := NewHooks()
 			h.OnUpdate(&kubeClient.Fake, "deployments", test.callback(t))
 

--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -20,7 +20,7 @@ import (
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
-	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/resources"
 
 	corev1 "k8s.io/api/core/v1"
@@ -134,15 +134,15 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 				// port queue-proxy listens on.
 				TargetPort: targetPort(sks),
 			}, {
-				Name:       servingv1alpha1.AutoscalingQueueMetricsPortName,
+				Name:       servingv1.AutoscalingQueueMetricsPortName,
 				Protocol:   corev1.ProtocolTCP,
 				Port:       networking.AutoscalingQueueMetricsPort,
-				TargetPort: intstr.FromString(servingv1alpha1.AutoscalingQueueMetricsPortName),
+				TargetPort: intstr.FromString(servingv1.AutoscalingQueueMetricsPortName),
 			}, {
-				Name:       servingv1alpha1.UserQueueMetricsPortName,
+				Name:       servingv1.UserQueueMetricsPortName,
 				Protocol:   corev1.ProtocolTCP,
 				Port:       networking.UserQueueMetricsPort,
-				TargetPort: intstr.FromString(servingv1alpha1.UserQueueMetricsPortName),
+				TargetPort: intstr.FromString(servingv1.UserQueueMetricsPortName),
 			}, {
 				// When run with the Istio mesh, Envoy blocks traffic to any ports not
 				// recognized, and has special treatment for probes, but not PreStop hooks.
@@ -151,7 +151,7 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 				// causing requests to be dropped.
 				//
 				// So we expose this port here to work around this Istio bug.
-				Name:       servingv1alpha1.QueueAdminPortName,
+				Name:       servingv1.QueueAdminPortName,
 				Protocol:   corev1.ProtocolTCP,
 				Port:       networking.QueueAdminPort,
 				TargetPort: intstr.FromInt(networking.QueueAdminPort),

--- a/pkg/reconciler/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/serverlessservice/resources/services_test.go
@@ -28,7 +28,7 @@ import (
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
-	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 var (
@@ -595,17 +595,17 @@ func TestMakePrivateService(t *testing.T) {
 					Port:       networking.ServiceHTTPPort,
 					TargetPort: intstr.FromInt(networking.BackendHTTPPort),
 				}, {
-					Name:       servingv1alpha1.AutoscalingQueueMetricsPortName,
+					Name:       servingv1.AutoscalingQueueMetricsPortName,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.AutoscalingQueueMetricsPort,
-					TargetPort: intstr.FromString(servingv1alpha1.AutoscalingQueueMetricsPortName),
+					TargetPort: intstr.FromString(servingv1.AutoscalingQueueMetricsPortName),
 				}, {
-					Name:       servingv1alpha1.UserQueueMetricsPortName,
+					Name:       servingv1.UserQueueMetricsPortName,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.UserQueueMetricsPort,
-					TargetPort: intstr.FromString(servingv1alpha1.UserQueueMetricsPortName),
+					TargetPort: intstr.FromString(servingv1.UserQueueMetricsPortName),
 				}, {
-					Name:       servingv1alpha1.QueueAdminPortName,
+					Name:       servingv1.QueueAdminPortName,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.QueueAdminPort,
 					TargetPort: intstr.FromInt(networking.QueueAdminPort),
@@ -668,17 +668,17 @@ func TestMakePrivateService(t *testing.T) {
 					Port:       networking.ServiceHTTPPort,
 					TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
 				}, {
-					Name:       servingv1alpha1.AutoscalingQueueMetricsPortName,
+					Name:       servingv1.AutoscalingQueueMetricsPortName,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.AutoscalingQueueMetricsPort,
-					TargetPort: intstr.FromString(servingv1alpha1.AutoscalingQueueMetricsPortName),
+					TargetPort: intstr.FromString(servingv1.AutoscalingQueueMetricsPortName),
 				}, {
-					Name:       servingv1alpha1.UserQueueMetricsPortName,
+					Name:       servingv1.UserQueueMetricsPortName,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.UserQueueMetricsPort,
-					TargetPort: intstr.FromString(servingv1alpha1.UserQueueMetricsPortName),
+					TargetPort: intstr.FromString(servingv1.UserQueueMetricsPortName),
 				}, {
-					Name:       servingv1alpha1.QueueAdminPortName,
+					Name:       servingv1.QueueAdminPortName,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       networking.QueueAdminPort,
 					TargetPort: intstr.FromInt(networking.QueueAdminPort),

--- a/pkg/reconciler/testing/v1/factory.go
+++ b/pkg/reconciler/testing/v1/factory.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	fakecachingclient "knative.dev/caching/pkg/client/injection/client/fake"
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	fakecertmanagerclient "knative.dev/serving/pkg/client/certmanager/injection/client/fake"
+	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
+	fakeistioclient "knative.dev/serving/pkg/client/istio/injection/client/fake"
+
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	logtesting "knative.dev/pkg/logging/testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ktesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
+
+	rtesting "knative.dev/pkg/reconciler/testing"
+	"knative.dev/serving/pkg/reconciler"
+)
+
+const (
+	// maxEventBufferSize is the estimated max number of event notifications that
+	// can be buffered during reconciliation.
+	maxEventBufferSize = 10
+)
+
+// Ctor functions create a k8s controller with given params.
+type Ctor func(context.Context, *Listers, configmap.Watcher) controller.Reconciler
+
+// MakeFactory creates a reconciler factory with fake clients and controller created by `ctor`.
+func MakeFactory(ctor Ctor) rtesting.Factory {
+	return func(t *testing.T, r *rtesting.TableRow) (
+		controller.Reconciler, rtesting.ActionRecorderList, rtesting.EventList, *rtesting.FakeStatsReporter) {
+		ls := NewListers(r.Objects)
+
+		ctx := r.Ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		logger := logtesting.TestLogger(t)
+		ctx = logging.WithLogger(ctx, logger)
+
+		ctx, kubeClient := fakekubeclient.With(ctx, ls.GetKubeObjects()...)
+		ctx, istioClient := fakeistioclient.With(ctx, ls.GetIstioObjects()...)
+		ctx, client := fakeservingclient.With(ctx, ls.GetServingObjects()...)
+		ctx, dynamicClient := fakedynamicclient.With(ctx,
+			ls.NewScheme(), ToUnstructured(t, ls.NewScheme(), r.Objects)...)
+		ctx, cachingClient := fakecachingclient.With(ctx, ls.GetCachingObjects()...)
+		ctx, certManagerClient := fakecertmanagerclient.With(ctx, ls.GetCMCertificateObjects()...)
+		ctx = context.WithValue(ctx, TrackerKey, &rtesting.FakeTracker{})
+
+		// The dynamic client's support for patching is BS.  Implement it
+		// here via PrependReactor (this can be overridden below by the
+		// provided reactors).
+		dynamicClient.PrependReactor("patch", "*",
+			func(action ktesting.Action) (bool, runtime.Object, error) {
+				return true, nil, nil
+			})
+
+		eventRecorder := record.NewFakeRecorder(maxEventBufferSize)
+		ctx = controller.WithEventRecorder(ctx, eventRecorder)
+		statsReporter := &rtesting.FakeStatsReporter{}
+		ctx = reconciler.WithStatsReporter(ctx, statsReporter)
+
+		// This is needed for the tests that use generated names and
+		// the object cannot be created beforehand.
+		kubeClient.PrependReactor("create", "*",
+			func(action ktesting.Action) (bool, runtime.Object, error) {
+				ca := action.(ktesting.CreateAction)
+				ls.IndexerFor(ca.GetObject()).Add(ca.GetObject())
+				return false, nil, nil
+			},
+		)
+		// This is needed by the Configuration controller tests, which
+		// use GenerateName to produce Revisions.
+		rtesting.PrependGenerateNameReactor(&client.Fake)
+
+		// Set up our Controller from the fakes.
+		c := ctor(ctx, &ls, configmap.NewStaticWatcher())
+		// Update the context with the stuff we decorated it with.
+		r.Ctx = ctx
+
+		for _, reactor := range r.WithReactors {
+			kubeClient.PrependReactor("*", "*", reactor)
+			istioClient.PrependReactor("*", "*", reactor)
+			client.PrependReactor("*", "*", reactor)
+			dynamicClient.PrependReactor("*", "*", reactor)
+			cachingClient.PrependReactor("*", "*", reactor)
+			certManagerClient.PrependReactor("*", "*", reactor)
+		}
+
+		// Validate all Create operations through the serving client.
+		client.PrependReactor("create", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+			// TODO(n3wscott): context.Background is the best we can do at the moment, but it should be set-able.
+			return rtesting.ValidateCreates(context.Background(), action)
+		})
+		client.PrependReactor("update", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+			// TODO(n3wscott): context.Background is the best we can do at the moment, but it should be set-able.
+			return rtesting.ValidateUpdates(context.Background(), action)
+		})
+
+		actionRecorderList := rtesting.ActionRecorderList{istioClient, dynamicClient, client, kubeClient, cachingClient, certManagerClient}
+		eventList := rtesting.EventList{Recorder: eventRecorder}
+
+		return c, actionRecorderList, eventList, statsReporter
+	}
+}
+
+// ToUnstructured takes a list of k8s resources and converts them to
+// Unstructured objects.
+// We must pass objects as Unstructured to the dynamic client fake, or it
+// won't handle them properly.
+func ToUnstructured(t *testing.T, sch *runtime.Scheme, objs []runtime.Object) (us []runtime.Object) {
+	for _, obj := range objs {
+		obj = obj.DeepCopyObject() // Don't mess with the primary copy
+		// Determine and set the TypeMeta for this object based on our test scheme.
+		gvks, _, err := sch.ObjectKinds(obj)
+		if err != nil {
+			t.Fatalf("Unable to determine kind for type: %v", err)
+		}
+		apiv, k := gvks[0].ToAPIVersionAndKind()
+		ta, err := meta.TypeAccessor(obj)
+		if err != nil {
+			t.Fatalf("Unable to create type accessor: %v", err)
+		}
+		ta.SetAPIVersion(apiv)
+		ta.SetKind(k)
+
+		b, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("Unable to marshal: %v", err)
+		}
+		u := &unstructured.Unstructured{}
+		if err := json.Unmarshal(b, u); err != nil {
+			t.Fatalf("Unable to unmarshal: %v", err)
+		}
+		us = append(us, u)
+	}
+	return
+}
+
+type key struct{}
+
+// TrackerKey is used to looking a FakeTracker in a context.Context
+var TrackerKey key = struct{}{}
+
+// AssertTrackingConfig will ensure the provided Configuration is being tracked
+func AssertTrackingConfig(namespace, name string) func(*testing.T, *rtesting.TableRow) {
+	gvk := v1.SchemeGroupVersion.WithKind("Configuration")
+	return AssertTrackingObject(gvk, namespace, name)
+}
+
+// AssertTrackingRevision will ensure the provided Revision is being tracked
+func AssertTrackingRevision(namespace, name string) func(*testing.T, *rtesting.TableRow) {
+	gvk := v1.SchemeGroupVersion.WithKind("Revision")
+	return AssertTrackingObject(gvk, namespace, name)
+}
+
+// AssertTrackingObject will ensure the following objects are being tracked
+func AssertTrackingObject(gvk schema.GroupVersionKind, namespace, name string) func(*testing.T, *rtesting.TableRow) {
+	apiVersion, kind := gvk.ToAPIVersionAndKind()
+
+	return func(t *testing.T, r *rtesting.TableRow) {
+		tracker := r.Ctx.Value(TrackerKey).(*rtesting.FakeTracker)
+		refs := tracker.References()
+
+		for _, ref := range refs {
+			if ref.APIVersion == apiVersion &&
+				ref.Name == name &&
+				ref.Namespace == namespace &&
+				ref.Kind == kind {
+				return
+			}
+		}
+
+		t.Errorf("Object was not tracked - %s, Name=%s, Namespace=%s", gvk.String(), name, namespace)
+	}
+
+}

--- a/pkg/reconciler/testing/v1/listers.go
+++ b/pkg/reconciler/testing/v1/listers.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	acmev1alpha2 "github.com/jetstack/cert-manager/pkg/apis/acme/v1alpha2"
+	cmv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	istiov1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	autoscalingv2beta1listers "k8s.io/client-go/listers/autoscaling/v2beta1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	cachingv1alpha1 "knative.dev/caching/pkg/apis/caching/v1alpha1"
+	fakecachingclientset "knative.dev/caching/pkg/client/clientset/versioned/fake"
+	cachinglisters "knative.dev/caching/pkg/client/listers/caching/v1alpha1"
+	"knative.dev/pkg/reconciler/testing"
+	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	networking "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	acmelisters "knative.dev/serving/pkg/client/certmanager/listers/acme/v1alpha2"
+	certmanagerlisters "knative.dev/serving/pkg/client/certmanager/listers/certmanager/v1alpha2"
+	fakeservingclientset "knative.dev/serving/pkg/client/clientset/versioned/fake"
+	fakeistioclientset "knative.dev/serving/pkg/client/istio/clientset/versioned/fake"
+	istiolisters "knative.dev/serving/pkg/client/istio/listers/networking/v1alpha3"
+	palisters "knative.dev/serving/pkg/client/listers/autoscaling/v1alpha1"
+	networkinglisters "knative.dev/serving/pkg/client/listers/networking/v1alpha1"
+	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
+)
+
+var clientSetSchemes = []func(*runtime.Scheme) error{
+	fakekubeclientset.AddToScheme,
+	fakeistioclientset.AddToScheme,
+	fakeservingclientset.AddToScheme,
+	fakecachingclientset.AddToScheme,
+	cmv1alpha2.AddToScheme,
+	acmev1alpha2.AddToScheme,
+	autoscalingv2beta1.AddToScheme,
+}
+
+type Listers struct {
+	sorter testing.ObjectSorter
+}
+
+func NewListers(objs []runtime.Object) Listers {
+	scheme := NewScheme()
+
+	ls := Listers{
+		sorter: testing.NewObjectSorter(scheme),
+	}
+
+	ls.sorter.AddObjects(objs...)
+
+	return ls
+}
+
+func NewScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+
+	for _, addTo := range clientSetSchemes {
+		addTo(scheme)
+	}
+	return scheme
+}
+
+func (*Listers) NewScheme() *runtime.Scheme {
+	return NewScheme()
+}
+
+// IndexerFor returns the indexer for the given object.
+func (l *Listers) IndexerFor(obj runtime.Object) cache.Indexer {
+	return l.sorter.IndexerForObjectType(obj)
+}
+
+func (l *Listers) GetKubeObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(fakekubeclientset.AddToScheme)
+}
+
+func (l *Listers) GetCachingObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(fakecachingclientset.AddToScheme)
+}
+
+func (l *Listers) GetServingObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(fakeservingclientset.AddToScheme)
+}
+
+func (l *Listers) GetIstioObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(fakeistioclientset.AddToScheme)
+}
+
+// GetCMCertificateObjects gets a list of Cert-Manager Certificate objects.
+func (l *Listers) GetCMCertificateObjects() []runtime.Object {
+	return l.sorter.ObjectsForSchemeFunc(cmv1alpha2.AddToScheme)
+}
+
+func (l *Listers) GetServiceLister() servinglisters.ServiceLister {
+	return servinglisters.NewServiceLister(l.IndexerFor(&v1.Service{}))
+}
+
+func (l *Listers) GetRouteLister() servinglisters.RouteLister {
+	return servinglisters.NewRouteLister(l.IndexerFor(&v1.Route{}))
+}
+
+// GetServerlessServiceLister returns a lister for the ServerlessService objects.
+func (l *Listers) GetServerlessServiceLister() networkinglisters.ServerlessServiceLister {
+	return networkinglisters.NewServerlessServiceLister(l.IndexerFor(&networking.ServerlessService{}))
+}
+
+func (l *Listers) GetConfigurationLister() servinglisters.ConfigurationLister {
+	return servinglisters.NewConfigurationLister(l.IndexerFor(&v1.Configuration{}))
+}
+
+func (l *Listers) GetRevisionLister() servinglisters.RevisionLister {
+	return servinglisters.NewRevisionLister(l.IndexerFor(&v1.Revision{}))
+}
+
+func (l *Listers) GetPodAutoscalerLister() palisters.PodAutoscalerLister {
+	return palisters.NewPodAutoscalerLister(l.IndexerFor(&av1alpha1.PodAutoscaler{}))
+}
+
+// GetMetricLister returns a lister for the Metric objects.
+func (l *Listers) GetMetricLister() palisters.MetricLister {
+	return palisters.NewMetricLister(l.IndexerFor(&av1alpha1.Metric{}))
+}
+
+// GetHorizontalPodAutoscalerLister gets lister for HorizontalPodAutoscaler resources.
+func (l *Listers) GetHorizontalPodAutoscalerLister() autoscalingv2beta1listers.HorizontalPodAutoscalerLister {
+	return autoscalingv2beta1listers.NewHorizontalPodAutoscalerLister(l.IndexerFor(&autoscalingv2beta1.HorizontalPodAutoscaler{}))
+}
+
+// GetIngressLister get lister for Ingress resource.
+func (l *Listers) GetIngressLister() networkinglisters.IngressLister {
+	return networkinglisters.NewIngressLister(l.IndexerFor(&networking.Ingress{}))
+}
+
+// GetCertificateLister get lister for Certificate resource.
+func (l *Listers) GetCertificateLister() networkinglisters.CertificateLister {
+	return networkinglisters.NewCertificateLister(l.IndexerFor(&networking.Certificate{}))
+}
+
+func (l *Listers) GetVirtualServiceLister() istiolisters.VirtualServiceLister {
+	return istiolisters.NewVirtualServiceLister(l.IndexerFor(&istiov1alpha3.VirtualService{}))
+}
+
+// GetGatewayLister gets lister for Istio Gateway resource.
+func (l *Listers) GetGatewayLister() istiolisters.GatewayLister {
+	return istiolisters.NewGatewayLister(l.IndexerFor(&istiov1alpha3.Gateway{}))
+}
+
+// GetKnCertificateLister gets lister for Knative Certificate resource.
+func (l *Listers) GetKnCertificateLister() networkinglisters.CertificateLister {
+	return networkinglisters.NewCertificateLister(l.IndexerFor(&networking.Certificate{}))
+}
+
+// GetCMCertificateLister gets lister for Cert Manager Certificate resource.
+func (l *Listers) GetCMCertificateLister() certmanagerlisters.CertificateLister {
+	return certmanagerlisters.NewCertificateLister(l.IndexerFor(&cmv1alpha2.Certificate{}))
+}
+
+// GetCMClusterIssuerLister gets lister for Cert Manager ClusterIssuer resource.
+func (l *Listers) GetCMClusterIssuerLister() certmanagerlisters.ClusterIssuerLister {
+	return certmanagerlisters.NewClusterIssuerLister(l.IndexerFor(&cmv1alpha2.ClusterIssuer{}))
+}
+
+// GetCMChallengeLister gets lister for Cert Manager Challenge resource.
+func (l *Listers) GetCMChallengeLister() acmelisters.ChallengeLister {
+	return acmelisters.NewChallengeLister(l.IndexerFor(&acmev1alpha2.Challenge{}))
+}
+
+func (l *Listers) GetImageLister() cachinglisters.ImageLister {
+	return cachinglisters.NewImageLister(l.IndexerFor(&cachingv1alpha1.Image{}))
+}
+
+func (l *Listers) GetDeploymentLister() appsv1listers.DeploymentLister {
+	return appsv1listers.NewDeploymentLister(l.IndexerFor(&appsv1.Deployment{}))
+}
+
+func (l *Listers) GetK8sServiceLister() corev1listers.ServiceLister {
+	return corev1listers.NewServiceLister(l.IndexerFor(&corev1.Service{}))
+}
+
+func (l *Listers) GetEndpointsLister() corev1listers.EndpointsLister {
+	return corev1listers.NewEndpointsLister(l.IndexerFor(&corev1.Endpoints{}))
+}
+
+// GetPodsLister gets lister for pods.
+func (l *Listers) GetPodsLister() corev1listers.PodLister {
+	return corev1listers.NewPodLister(l.IndexerFor(&corev1.Pod{}))
+}
+
+func (l *Listers) GetSecretLister() corev1listers.SecretLister {
+	return corev1listers.NewSecretLister(l.IndexerFor(&corev1.Secret{}))
+}
+
+func (l *Listers) GetConfigMapLister() corev1listers.ConfigMapLister {
+	return corev1listers.NewConfigMapLister(l.IndexerFor(&corev1.ConfigMap{}))
+}
+
+// GetNamespaceLister gets lister for Namespace resource.
+func (l *Listers) GetNamespaceLister() corev1listers.NamespaceLister {
+	return corev1listers.NewNamespaceLister(l.IndexerFor(&corev1.Namespace{}))
+}

--- a/pkg/testing/v1/revision.go
+++ b/pkg/testing/v1/revision.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+)
+
+// RevisionOption enables further configuration of a Revision.
+type RevisionOption func(*v1.Revision)
+
+// WithRevisionDeletionTimestamp will set the DeletionTimestamp on the Revision.
+func WithRevisionDeletionTimestamp(r *v1.Revision) {
+	t := metav1.NewTime(time.Unix(1e9, 0))
+	r.ObjectMeta.SetDeletionTimestamp(&t)
+}
+
+// WithInitRevConditions calls .Status.InitializeConditions() on a Revision.
+func WithInitRevConditions(r *v1.Revision) {
+	r.Status.InitializeConditions()
+}
+
+// WithRevName sets the name of the revision
+func WithRevName(name string) RevisionOption {
+	return func(rev *v1.Revision) {
+		rev.Name = name
+	}
+}
+
+// WithServiceName propagates the given service name to the revision status.
+func WithServiceName(sn string) RevisionOption {
+	return func(rev *v1.Revision) {
+		rev.Status.ServiceName = sn
+	}
+}
+
+// MarkResourceNotOwned calls the function of the same name on the Revision's status.
+func MarkResourceNotOwned(kind, name string) RevisionOption {
+	return func(rev *v1.Revision) {
+		rev.Status.MarkResourcesAvailableFalse(
+			v1.ReasonNotOwned,
+			v1.ResourceNotOwnedMessage(kind, name),
+		)
+	}
+}
+
+// WithRevContainerConcurrency sets the given Revision's concurrency.
+func WithRevContainerConcurrency(cc int64) RevisionOption {
+	return func(rev *v1.Revision) {
+		rev.Spec.ContainerConcurrency = &cc
+	}
+}
+
+// WithLogURL sets the .Status.LogURL to the expected value.
+func WithLogURL(r *v1.Revision) {
+	r.Status.LogURL = "http://logger.io/test-uid"
+}
+
+// WithCreationTimestamp sets the Revision's timestamp to the provided time.
+// TODO(mattmoor): Ideally this could be a more generic Option and use meta.Accessor,
+// but unfortunately Go's type system cannot support that.
+func WithCreationTimestamp(t time.Time) RevisionOption {
+	return func(rev *v1.Revision) {
+		rev.ObjectMeta.CreationTimestamp = metav1.Time{Time: t}
+	}
+}
+
+// WithLastPinned updates the "last pinned" annotation to the provided timestamp.
+func WithLastPinned(t time.Time) RevisionOption {
+	return func(rev *v1.Revision) {
+		rev.SetLastPinned(t)
+	}
+}
+
+// WithRevStatus is a generic escape hatch for creating hard-to-craft
+// status orientations.
+func WithRevStatus(st v1.RevisionStatus) RevisionOption {
+	return func(rev *v1.Revision) {
+		rev.Status = st
+	}
+}
+
+// WithImagePullSecrets updates the revision spec ImagePullSecrets to
+// the provided secrets
+func WithImagePullSecrets(secretName string) RevisionOption {
+	return func(rev *v1.Revision) {
+		rev.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{
+			Name: secretName,
+		}}
+	}
+}
+
+// MarkActive calls .Status.MarkActive on the Revision.
+func MarkActive(r *v1.Revision) {
+	r.Status.MarkActiveTrue()
+}
+
+// MarkInactive calls .Status.MarkInactive on the Revision.
+func MarkInactive(reason, message string) RevisionOption {
+	return func(r *v1.Revision) {
+		r.Status.MarkActiveFalse(reason, message)
+	}
+}
+
+// MarkActivating calls .Status.MarkActivating on the Revision.
+func MarkActivating(reason, message string) RevisionOption {
+	return func(r *v1.Revision) {
+		r.Status.MarkActiveUnknown(reason, message)
+	}
+}
+
+// MarkDeploying calls .Status.MarkDeploying on the Revision.
+func MarkDeploying(reason string) RevisionOption {
+	return func(r *v1.Revision) {
+		r.Status.MarkResourcesAvailableUnknown(reason, "")
+		r.Status.MarkContainerHealthyUnknown(reason, "")
+	}
+}
+
+// MarkProgressDeadlineExceeded calls the method of the same name on the Revision
+// with the message we expect the Revision Reconciler to pass.
+func MarkProgressDeadlineExceeded(message string) RevisionOption {
+	return func(r *v1.Revision) {
+		r.Status.MarkResourcesAvailableFalse(
+			v1.ReasonProgressDeadlineExceeded,
+			message,
+		)
+	}
+}
+
+// MarkContainerMissing calls .Status.MarkContainerMissing on the Revision.
+func MarkContainerMissing(rev *v1.Revision) {
+	rev.Status.MarkContainerHealthyFalse(v1.ReasonContainerMissing, "It's the end of the world as we know it")
+}
+
+// MarkContainerExiting calls .Status.MarkContainerExiting on the Revision.
+func MarkContainerExiting(exitCode int32, message string) RevisionOption {
+	return func(r *v1.Revision) {
+		r.Status.MarkContainerHealthyFalse(v1.ExitCodeReason(exitCode), message)
+	}
+}
+
+// MarkResourcesUnavailable calls .Status.MarkResourcesUnavailable on the Revision.
+func MarkResourcesUnavailable(reason, message string) RevisionOption {
+	return func(r *v1.Revision) {
+		r.Status.MarkResourcesAvailableFalse(reason, message)
+	}
+}
+
+// MarkRevisionReady calls the necessary helpers to make the Revision Ready=True.
+func MarkRevisionReady(r *v1.Revision) {
+	WithInitRevConditions(r)
+	MarkActive(r)
+	r.Status.MarkResourcesAvailableTrue()
+	r.Status.MarkContainerHealthyTrue()
+}
+
+// WithRevisionLabel attaches a particular label to the revision.
+func WithRevisionLabel(key, value string) RevisionOption {
+	return func(config *v1.Revision) {
+		if config.Labels == nil {
+			config.Labels = make(map[string]string)
+		}
+		config.Labels[key] = value
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Baby Step for https://github.com/knative/serving/issues/6035

Note: I'm not deleting anything from the `v1alpha1` package _yet_ since things are still used as fixtures in other reconciler testing

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Revision Reconciler uses V1 APIs

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
