### PR TITLE
Bump dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1766,7 +1766,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d5b10e1613a2a4d6bb9edbb09280879fdee628b09d5bdbeaa93376bdc12e16d9"
+  digest = "1:02d272037c4818474fc8295877dc45d18a2cf663957c33ead92ad50d8ce69f0b"
   name = "knative.dev/caching"
   packages = [
     "pkg/apis/caching",
@@ -1789,11 +1789,11 @@
     "pkg/client/listers/caching/v1alpha1",
   ]
   pruneopts = "T"
-  revision = "070d8a0d12e465291f79b03bff7cf0644a3e7dd5"
+  revision = "355618808eaded05d48a52dfb3bcaf187d8f15a0"
 
 [[projects]]
   branch = "master"
-  digest = "1:a2c7f91ca6236130b3076108f0c047d975f129419e0e68c0f23d99077bacb06f"
+  digest = "1:b9bf9be301ffbfd00981299321bddf3801a6f8c402e65bfd8411eae34f604aa8"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -1899,11 +1899,11 @@
     "websocket",
   ]
   pruneopts = "T"
-  revision = "1e31aa840f58bbcb5f33f9ab5f80bf26de2367f8"
+  revision = "32ea8458157368451b8e0383aafdacdf5ec061c8"
 
 [[projects]]
   branch = "master"
-  digest = "1:56d2e2b8c3cd00942811092455fca8a5fc5fc2f71bc8a4a3cf494d3279b6024e"
+  digest = "1:3d029ac36af60d24934bd400956dda89696c8cabd5efc0de2963f04ecdb74e9f"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
@@ -1916,7 +1916,7 @@
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "4b1d06a2c818a6c01c2934d4c27175f82e25975a"
+  revision = "82d31019ec6fe25feaf28c9907819c2ec73d1f25"
 
 [[projects]]
   digest = "1:92b88da51692abe195601cb17d35bbb9b6bc2011237a2f234fedba7411ed8122"

--- a/vendor/knative.dev/caching/Gopkg.lock
+++ b/vendor/knative.dev/caching/Gopkg.lock
@@ -966,7 +966,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0fdbfd5bd4573f59828ede757341dd6905ab4fdb0df9fd0aa8ead8fb93900e52"
+  digest = "1:50ad80e619992aab730865192c7ea1f17359a14548760bb8360180eb0797f514"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -985,18 +985,18 @@
     "metrics/metricskey",
   ]
   pruneopts = "T"
-  revision = "b9974987c245c4996a7d1299c3d162a4b0b0ad5e"
+  revision = "87875e3b427a09be8c6c688811a54c43ea8be1b1"
 
 [[projects]]
   branch = "master"
-  digest = "1:fdc3106893e9ad75a8615d1326df00899c519ea71684092b4a10b3260f3c0c15"
+  digest = "1:becb98d0dc7f7201c23df580e99e64253d79cf8894fa77bce76cfbf69009557d"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "77b975af074880c49957946a6d861e063e11f232"
+  revision = "b09617df210766782b2b8f164476ac3887c2baec"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"

--- a/vendor/knative.dev/caching/OWNERS_ALIASES
+++ b/vendor/knative.dev/caching/OWNERS_ALIASES
@@ -6,10 +6,9 @@ aliases:
   - vaikas
 
   productivity-approvers:
-  - adrcunha
   - chaodaiG
+  - chizhg
   productivity-reviewers:
-  - adrcunha
   - chaodaiG
   - coryrc
   - chizhg

--- a/vendor/knative.dev/pkg/Gopkg.lock
+++ b/vendor/knative.dev/pkg/Gopkg.lock
@@ -1323,14 +1323,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:fdc3106893e9ad75a8615d1326df00899c519ea71684092b4a10b3260f3c0c15"
+  digest = "1:becb98d0dc7f7201c23df580e99e64253d79cf8894fa77bce76cfbf69009557d"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "ae2eca5b05181add212724579f1d85d3b104cdd7"
+  revision = "b09617df210766782b2b8f164476ac3887c2baec"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"

--- a/vendor/knative.dev/pkg/apis/duck/v1alpha1/addressable_types.go
+++ b/vendor/knative.dev/pkg/apis/duck/v1alpha1/addressable_types.go
@@ -82,7 +82,13 @@ func (*Addressable) GetFullType() duck.Populatable {
 
 // ConvertUp implements apis.Convertible
 func (a *Addressable) ConvertUp(ctx context.Context, to apis.Convertible) error {
-	url := a.GetURL()
+	var url *apis.URL
+	if a.URL != nil {
+		url = a.URL
+	} else if a.Hostname != "" {
+		u := a.GetURL()
+		url = &u
+	}
 	switch sink := to.(type) {
 	case *v1.Addressable:
 		sink.URL = url.DeepCopy()

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -18,6 +18,7 @@ package generators
 
 import (
 	"io"
+
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"

--- a/vendor/knative.dev/test-infra/scripts/README.md
+++ b/vendor/knative.dev/test-infra/scripts/README.md
@@ -307,6 +307,9 @@ This is a helper script for Knative release scripts. To use it:
      if `--release-gcs` was passed, otherwise the default value
      `knative-nightly/<repo>` will be used. It is empty if `--publish` was not
      passed.
+   - `RELEASE_DIR`: contains the directory to store the manifests if
+     `--release-dir` was passed. Defaults to empty value, but if `--nopublish`
+     was passed then points to the repository root directory.
    - `BUILD_COMMIT_HASH`: the commit short hash for the current repo. If the
      current git tree is dirty, it will have `-dirty` appended to it.
    - `BUILD_YYYYMMDD`: current UTC date in `YYYYMMDD` format.
@@ -332,7 +335,7 @@ This is a helper script for Knative release scripts. To use it:
    All environment variables above, except `KO_FLAGS`, are marked read-only once
    `main()` is called (see below).
 
-1. Call the `main()` function passing `$@` (without quotes).
+1. Call the `main()` function passing `"$@"` (with quotes).
 
 ### Sample release script
 
@@ -345,5 +348,5 @@ function build_release() {
   ARTIFACTS_TO_PUBLISH="release.yaml"
 }
 
-main $@
+main "$@"
 ```

--- a/vendor/knative.dev/test-infra/scripts/library.sh
+++ b/vendor/knative.dev/test-infra/scripts/library.sh
@@ -135,8 +135,8 @@ function wait_until_pods_running() {
   local failed_pod=""
   for i in {1..150}; do  # timeout after 5 minutes
     local pods="$(kubectl get pods --no-headers -n $1 2>/dev/null)"
-    # All pods must be running
-    local not_running_pods=$(echo "${pods}" | grep -v Running | grep -v Completed)
+    # All pods must be running (ignore ImagePull error to allow the pod to retry)
+    local not_running_pods=$(echo "${pods}" | grep -v Running | grep -v Completed | grep -v ErrImagePull | grep -v ImagePullBackOff)
     if [[ -n "${pods}" ]] && [[ -z "${not_running_pods}" ]]; then
       # All Pods are running or completed. Verify the containers on each Pod.
       local all_ready=1


### PR DESCRIPTION
Done via running the command
```
dep ensure -update knative.dev/test-infra knative.dev/pkg knative.dev/caching
```

The test-infra bump includes the PR https://github.com/knative/test-infra/pull/1678
which makes it more robust to ImagePull failures

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes failing smoke tests
