### PR TITLE
Add e2e tests for gRPC load balancing

### DIFF
--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -83,9 +84,13 @@ func dial(host, domain string) (*grpc.ClientConn, error) {
 func unaryTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
 	t.Helper()
 	t.Logf("Connecting to grpc-ping using host %q and authority %q", host, domain)
-	const msg = "Hello!"
-	if err := pingGRPC(host, domain, msg); err != nil {
+	const want = "Hello!"
+	got, err := pingGRPC(host, domain, want)
+	if err != nil {
 		t.Fatalf("gRPC ping = %v", err)
+	}
+	if got != want {
+		t.Fatalf("response = %q, want = %q", got, want)
 	}
 }
 
@@ -105,6 +110,85 @@ func autoscaleTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *t
 	assertGRPCAutoscaleUpToNumPods(ctx, 0, 2, 60*time.Second, host, domain)
 }
 
+func loadBalancingTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
+	t.Helper()
+	t.Logf("Connecting to grpc-ping using host %q and authority %q", host, domain)
+
+	var (
+		grp         errgroup.Group
+		wantHosts   = 3
+		wantPrefix  = "hello-"
+		uniqueHosts sync.Map
+		stopChan    = make(chan struct{})
+		done        = time.After(60 * time.Second)
+		timer       = time.Tick(1 * time.Second)
+	)
+
+	ctx := &testContext{
+		t:                 t,
+		clients:           clients,
+		resources:         resources,
+		names:             names,
+		targetUtilization: targetUtilization,
+	}
+
+	countKeys := func(m sync.Map) int {
+		count := 0
+		uniqueHosts.Range(func(k, v interface{}) bool {
+			count++
+			return true
+		})
+		return count
+	}
+
+	for i := 0; i < wantHosts; i++ {
+		grp.Go(func() error {
+			for {
+				select {
+				case <-stopChan:
+					return nil
+				default:
+					got, err := pingGRPC(host, domain, wantPrefix)
+					if err != nil {
+						return fmt.Errorf("ping gRPC error: %v", err)
+					}
+					if !strings.HasPrefix(got, wantPrefix) {
+						return fmt.Errorf("response = %q, wantPrefix = %q", got, wantPrefix)
+					}
+
+					if host := strings.TrimPrefix(got, wantPrefix); host != "" {
+						uniqueHosts.Store(host, true)
+					}
+				}
+			}
+			return nil
+		})
+	}
+
+	grp.Go(func() error {
+		defer close(stopChan)
+		for {
+			select {
+			case <-done:
+				return nil
+			case <-timer:
+				if countKeys(uniqueHosts) >= wantHosts {
+					return nil
+				}
+			}
+		}
+	})
+
+	if err := grp.Wait(); err != nil {
+		ctx.t.Fatalf("error: %v", err)
+	}
+
+	gotHosts := countKeys(uniqueHosts)
+	if gotHosts < wantHosts {
+		ctx.t.Fatalf("Wanted %d hosts, got %d hosts", wantHosts, gotHosts)
+	}
+}
+
 func generateGRPCTraffic(concurrentRequests int, host, domain string, stopChan chan struct{}) error {
 	var grp errgroup.Group
 
@@ -116,9 +200,14 @@ func generateGRPCTraffic(concurrentRequests int, host, domain string, stopChan c
 				case <-stopChan:
 					return nil
 				default:
-					msg := fmt.Sprintf("Hello! stream:%d request: %d", i, j)
-					if err := pingGRPC(host, domain, msg); err != nil {
-						return err
+					want := fmt.Sprintf("Hello! stream:%d request: %d", i, j)
+					got, err := pingGRPC(host, domain, want)
+
+					if err != nil {
+						return fmt.Errorf("ping gRPC error: %v", err)
+					}
+					if got != want {
+						return fmt.Errorf("response = %q, want = %q", got, want)
 					}
 				}
 			}
@@ -131,10 +220,10 @@ func generateGRPCTraffic(concurrentRequests int, host, domain string, stopChan c
 	return nil
 }
 
-func pingGRPC(host, domain, message string) error {
+func pingGRPC(host, domain, message string) (string, error) {
 	conn, err := dial(host, domain)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer conn.Close()
 
@@ -143,13 +232,9 @@ func pingGRPC(host, domain, message string) error {
 
 	got, err := pc.Ping(context.Background(), want)
 	if err != nil {
-		return fmt.Errorf("could not send request: %v", err)
+		return "", fmt.Errorf("could not send request: %v", err)
 	}
-
-	if got.Msg != want.Msg {
-		return fmt.Errorf("response = %q, want = %q", got.Msg, want.Msg)
-	}
-	return nil
+	return got.Msg, nil
 }
 
 func assertGRPCAutoscaleUpToNumPods(ctx *testContext, curPods, targetPods float64, duration time.Duration, host, domain string) {
@@ -332,6 +417,24 @@ func TestGRPCAutoscaleUpDownUp(t *testing.T) {
 		rtesting.WithEnv(corev1.EnvVar{
 			Name:  "DELAY",
 			Value: "500",
+		}),
+	)
+}
+
+func TestGRPCLoadBalancing(t *testing.T) {
+	testGRPC(t,
+		func(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
+			loadBalancingTest(t, resources, clients, names, host, domain)
+		},
+		rtesting.WithConfigAnnotations(map[string]string{
+			autoscaling.TargetUtilizationPercentageKey: strconv.FormatFloat(targetUtilization*100, 'f', -1, 64),
+			autoscaling.TargetAnnotationKey:            strconv.FormatFloat(grpcContainerConcurrency, 'f', -1, 64),
+			autoscaling.MinScaleAnnotationKey:          "3",
+			autoscaling.TargetBurstCapacityKey:         strconv.FormatFloat(-1, 'f', -1, 64),
+		}),
+		rtesting.WithEnv(corev1.EnvVar{
+			Name:  "HOSTNAME",
+			Value: "true",
 		}),
 	)
 }

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -138,7 +138,7 @@ func loadBalancingTest(t *testing.T, resources *v1a1test.ResourceObjects, client
 		targetUtilization: targetUtilization,
 	}
 
-	countKeys := func(m sync.Map) int {
+	countKeys := func() int {
 		count := 0
 		uniqueHosts.Range(func(k, v interface{}) bool {
 			count++
@@ -178,7 +178,7 @@ func loadBalancingTest(t *testing.T, resources *v1a1test.ResourceObjects, client
 			case <-done:
 				return nil
 			case <-timer:
-				if countKeys(uniqueHosts) >= wantHosts {
+				if countKeys() >= wantHosts {
 					return nil
 				}
 			}
@@ -189,7 +189,7 @@ func loadBalancingTest(t *testing.T, resources *v1a1test.ResourceObjects, client
 		ctx.t.Fatalf("error: %v", err)
 	}
 
-	gotHosts := countKeys(uniqueHosts)
+	gotHosts := countKeys()
 	if gotHosts < wantHosts {
 		ctx.t.Fatalf("Wanted %d hosts, got %d hosts", wantHosts, gotHosts)
 	}

--- a/test/test_images/grpc-ping/main.go
+++ b/test/test_images/grpc-ping/main.go
@@ -30,9 +30,10 @@ import (
 )
 
 var delay int64
+var hostname string
 
 func pong(req *ping.Request) *ping.Response {
-	return &ping.Response{Msg: req.Msg + os.Getenv("SUFFIX")}
+	return &ping.Response{Msg: req.Msg + hostname + os.Getenv("SUFFIX")}
 }
 
 type server struct{}
@@ -89,6 +90,11 @@ func main() {
 
 	delay, _ = strconv.ParseInt(os.Getenv("DELAY"), 10, 64)
 	log.Printf("Using DELAY of %d ms", delay)
+
+	if wantHostname, _ := strconv.ParseBool(os.Getenv("HOSTNAME")); wantHostname {
+		hostname, _ = os.Hostname()
+		log.Printf("Setting hostname in response %s", hostname)
+	}
 
 	g := grpc.NewServer()
 	s := network.NewServer(":"+os.Getenv("PORT"), httpWrapper(g))

--- a/test/test_images/grpc-ping/main.go
+++ b/test/test_images/grpc-ping/main.go
@@ -29,8 +29,10 @@ import (
 	ping "knative.dev/serving/test/test_images/grpc-ping/proto"
 )
 
-var delay int64
-var hostname string
+var (
+	delay    int64
+	hostname string
+)
 
 func pong(req *ping.Request) *ping.Response {
 	return &ping.Response{Msg: req.Msg + hostname + os.Getenv("SUFFIX")}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #6681 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add e2e test that concurrent gRPC requests are load balanced across all available pods

