### PR TITLE
Backport fixes for updating ingress.class annotation issue

### DIFF
--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -76,11 +76,13 @@ func (c *Reconciler) reconcileIngress(ctx context.Context, r *v1alpha1.Route, de
 		// It is notable that one reason for differences here may be defaulting.
 		// When that is the case, the Update will end up being a nop because the
 		// webhook will bring them into alignment and no new reconciliation will occur.
-		if !equality.Semantic.DeepEqual(ingress.Spec, desired.Spec) {
+		// Also, compare annotation in case ingress.Class is updated.
+		if !equality.Semantic.DeepEqual(ingress.Spec, desired.Spec) ||
+			!equality.Semantic.DeepEqual(ingress.Annotations, desired.Annotations) {
 			// Don't modify the informers copy
 			origin := ingress.DeepCopy()
 			origin.Spec = desired.Spec
-
+			origin.Annotations = desired.Annotations
 			updated, err := c.ServingClientSet.NetworkingV1alpha1().Ingresses(origin.Namespace).Update(origin)
 			if err != nil {
 				return nil, fmt.Errorf("failed to update Ingress: %w", err)

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -29,6 +29,7 @@ import (
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/system"
+	"knative.dev/serving/pkg/apis/networking"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -257,6 +258,36 @@ func TestReconcileCertificateUpdate(t *testing.T) {
 	}
 	if diff := cmp.Diff(certificate, updated); diff == "" {
 		t.Error("Expected difference, but found none")
+	}
+}
+
+func TestReconcileIngressClassAnnotation(t *testing.T) {
+	ctx, _, reconciler, _, cancel := newTestReconciler(t)
+	defer cancel()
+
+	const expClass = "foo.ingress.networking.knative.dev"
+
+	r := Route("test-ns", "test-route")
+	ci := newTestIngress(t, r)
+	if _, err := reconciler.reconcileIngress(TestContextWithLogger(t), r, ci); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	updated := getRouteIngressFromClient(ctx, t, r)
+	fakeciinformer.Get(ctx).Informer().GetIndexer().Add(updated)
+
+	ci2 := newTestIngress(t, r)
+	// Add ingress.class annotation.
+	ci2.ObjectMeta.Annotations[networking.IngressClassAnnotationKey] = expClass
+
+	if _, err := reconciler.reconcileIngress(TestContextWithLogger(t), r, ci2); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	updated = getRouteIngressFromClient(ctx, t, r)
+	updatedClass := updated.ObjectMeta.Annotations[networking.IngressClassAnnotationKey]
+	if expClass != updatedClass {
+		t.Errorf("Unexpected annotation got %q want %q", expClass, updatedClass)
 	}
 }
 


### PR DESCRIPTION
This patch cherry picks two patches:

* https://github.com/knative/serving/commit/5c909f23fb31da62ecaef01286990cef48f09587
* https://github.com/knative/serving/commit/263ad0f88a31e7ded2978bca46a051d5c94d33a5

to properly update kingress and to clean up VirtualService when ingress.class is updated.
