### PR TITLE
Add benchmark for queue proxy

### DIFF
--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -487,11 +487,9 @@ func BenchmarkProxyHandler(b *testing.B) {
 }
 
 func BenchmarkProxyHandlerInfiniteBreaker(b *testing.B) {
-	params := queue.BreakerParams{QueueDepth: 10000000, MaxConcurrency: 10000000, InitialCapacity: 10000000}
-	breaker := queue.NewBreaker(params)
 	// Make the channel as big as possible to account for the largest b.N
 	reqChan := make(chan queue.ReqEvent, 10000000)
-	h := proxyHandler(reqChan, breaker, true /*tracingEnabled*/, fakeHandler{})
+	h := proxyHandler(reqChan, nil /* infinite breaker */, true /*tracingEnabled*/, fakeHandler{})
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
 	req.Header.Set(network.OriginalHostHeader, wantHost)
 	resp := httptest.NewRecorder()

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -49,18 +48,6 @@ const wantHost = "a-better-host.com"
 type fakeHandler struct {}
 
 func (h fakeHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {}
-
-type fakeInfiniteBreaker struct {}
-
-func (ib *fakeInfiniteBreaker) Capacity() int { return 0 }
-
-func (ib *fakeInfiniteBreaker) UpdateConcurrency(cc int) error { return nil }
-
-func (ib *fakeInfiniteBreaker) Maybe(ctx context.Context, thunk func()) error { return nil }
-
-func (ib *fakeInfiniteBreaker) Reserve(context.Context) (func(), bool) { return noop, true }
-
-func noop() {}
 
 func TestHandlerReqEvent(t *testing.T) {
 	var httpHandler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -90,7 +90,7 @@ func TestHandlerReqEvent(t *testing.T) {
 	select {
 	case e := <-reqChan:
 		if e.EventType != queue.ProxiedIn {
-			t.Errorf("Want: %v, got: %v\n", queue.ProxiedIn, e.EventType)
+			t.Errorf("Got: %v, Want: %v\n", e.EventType, queue.ProxiedIn, )
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Timed out waiting for an event to be intercepted")
@@ -444,23 +444,7 @@ func TestQueueTraceSpans(t *testing.T) {
 }
 
 func BenchmarkProxyHandler(b *testing.B) {
-	var httpHandler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get(activator.RevisionHeaderName) != "" {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		if r.Header.Get(activator.RevisionHeaderNamespace) != "" {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		if got, want := r.Host, wantHost; got != want {
-			b.Errorf("Host header = %q, want: %q", got, want)
-		}
-		if got, want := r.Header.Get(network.OriginalHostHeader), ""; got != want {
-			b.Errorf("%s header was preserved", network.OriginalHostHeader)
-		}
-		w.WriteHeader(http.StatusOK)
-	}
+	var httpHandler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {}
 	server := httptest.NewServer(httpHandler)
 	serverURL, _ := url.Parse(server.URL)
 	defer server.Close()


### PR DESCRIPTION
/lint

Part of #6749

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
* Add benchmark for queue proxy

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

```
goos: darwin
goarch: amd64
pkg: knative.dev/serving/cmd/queue
BenchmarkProxyHandler/sequential-breaker-10-8         	  641940	      1591 ns/op	     576 B/op	       5 allocs/op
BenchmarkProxyHandler/parallel-breaker-10-8           	  879390	      1391 ns/op	     576 B/op	       5 allocs/op
BenchmarkProxyHandler/sequential-breaker-infinite-8   	  882534	      1373 ns/op	     576 B/op	       5 allocs/op
BenchmarkProxyHandler/parallel-breaker-infinite-8     	  859856	      1409 ns/op	     576 B/op	       5 allocs/op
```