### PR TITLE
Add benchmark for network probe handler

### DIFF
--- a/pkg/network/probe_handler_test.go
+++ b/pkg/network/probe_handler_test.go
@@ -101,3 +101,41 @@ func TestProbeHandlerSuccessfulProbe(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkProbeHandler(b *testing.B) {
+	var h http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Inner Body"))
+	})
+	h = NewProbeHandler(h)
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+	options := []interface{}{
+		prober.ExpectsStatusCodes([]int{http.StatusOK}),
+	}
+
+	b.Run(fmt.Sprint("sequential"), func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			got, err := prober.Do(context.Background(), network.AutoTransport, ts.URL, options...)
+			if err != nil {
+				b.Errorf("got error %v", err)
+			}
+			if want := true; got != want {
+				b.Errorf("unexpected probe result: want: %t, got: %t", want, got)
+			}
+		}
+	})
+
+	b.Run(fmt.Sprint("parallel"), func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				got, err := prober.Do(context.Background(), network.AutoTransport, ts.URL, options...)
+				if err != nil {
+					b.Errorf("got error %v", err)
+				}
+				if want := true; got != want {
+					b.Errorf("unexpected probe result: want: %t, got: %t", want, got)
+				}
+			}
+		})
+	})
+}

--- a/pkg/network/probe_handler_test.go
+++ b/pkg/network/probe_handler_test.go
@@ -96,7 +96,7 @@ func TestProbeHandlerSuccessfulProbe(t *testing.T) {
 				t.Errorf("prober.Do() = nil, expected an error")
 			}
 			if got != c.want {
-				t.Errorf("unexpected probe result: want: %t, got: %t", c.want, got)
+				t.Errorf("Unexpected probe result: want: %t, got: %t", c.want, got)
 			}
 		})
 	}
@@ -120,7 +120,7 @@ func BenchmarkProbeHandler(b *testing.B) {
 				b.Errorf("Do = %v", err)
 			}
 			if !got {
-				b.Errorf("unexpected probe result: got: %t, want: true", got)
+				b.Errorf("Unexpected probe result: got: %t, want: true", got)
 			}
 		}
 	})
@@ -133,7 +133,7 @@ func BenchmarkProbeHandler(b *testing.B) {
 					b.Errorf("Do = %v", err)
 				}
 				if !got {
-					b.Errorf("unexpected probe result: got: %t, want: true", got)
+					b.Errorf("Unexpected probe result: got: %t, want: true", got)
 				}
 			}
 		})

--- a/pkg/network/probe_handler_test.go
+++ b/pkg/network/probe_handler_test.go
@@ -120,7 +120,7 @@ func BenchmarkProbeHandler(b *testing.B) {
 				b.Errorf("Do = %v", err)
 			}
 			if !got {
-				b.Errorf("unexpected probe result: want: true, got: %t", got)
+				b.Errorf("unexpected probe result: got: %t, want: true", got)
 			}
 		}
 	})
@@ -133,7 +133,7 @@ func BenchmarkProbeHandler(b *testing.B) {
 					b.Errorf("Do = %v", err)
 				}
 				if !got {
-					b.Errorf("unexpected probe result: want: true, got: %t", got)
+					b.Errorf("unexpected probe result: got: %t, want: true", got)
 				}
 			}
 		})

--- a/pkg/network/probe_handler_test.go
+++ b/pkg/network/probe_handler_test.go
@@ -117,10 +117,10 @@ func BenchmarkProbeHandler(b *testing.B) {
 		for j := 0; j < b.N; j++ {
 			got, err := prober.Do(context.Background(), network.AutoTransport, ts.URL, options...)
 			if err != nil {
-				b.Errorf("got error %v", err)
+				b.Errorf("Do = %v", err)
 			}
-			if want := true; got != want {
-				b.Errorf("unexpected probe result: want: %t, got: %t", want, got)
+			if !got {
+				b.Errorf("unexpected probe result: want: true, got: %t", got)
 			}
 		}
 	})
@@ -130,10 +130,10 @@ func BenchmarkProbeHandler(b *testing.B) {
 			for pb.Next() {
 				got, err := prober.Do(context.Background(), network.AutoTransport, ts.URL, options...)
 				if err != nil {
-					b.Errorf("got error %v", err)
+					b.Errorf("Do = %v", err)
 				}
-				if want := true; got != want {
-					b.Errorf("unexpected probe result: want: %t, got: %t", want, got)
+				if !got {
+					b.Errorf("unexpected probe result: want: true, got: %t", got)
 				}
 			}
 		})


### PR DESCRIPTION
/lint

Part of #6749

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
Add benchmark for network probe handler

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
