### PR TITLE
Remove Istio clients from base serving reconciler.

### DIFF
--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -29,6 +29,7 @@ import (
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	ingressinformer "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/ingress"
+	istioclient "knative.dev/serving/pkg/client/istio/injection/client"
 	gatewayinformer "knative.dev/serving/pkg/client/istio/injection/informers/networking/v1alpha3/gateway"
 	virtualserviceinformer "knative.dev/serving/pkg/client/istio/injection/informers/networking/v1alpha3/virtualservice"
 	"knative.dev/serving/pkg/network"
@@ -57,6 +58,7 @@ func NewController(
 
 	c := &Reconciler{
 		Base:                 reconciler.NewBase(ctx, controllerAgentName, cmw),
+		istioClientSet:       istioclient.Get(ctx),
 		virtualServiceLister: virtualServiceInformer.Lister(),
 		gatewayLister:        gatewayInformer.Lister(),
 		secretLister:         secretInformer.Lister(),

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -77,6 +77,7 @@ var (
 type Reconciler struct {
 	*reconciler.Base
 
+	istioClientSet       istioclientset.Interface
 	virtualServiceLister istiolisters.VirtualServiceLister
 	gatewayLister        istiolisters.GatewayLister
 	secretLister         corev1listers.SecretLister
@@ -290,7 +291,7 @@ func (r *Reconciler) reconcileVirtualServices(ctx context.Context, ing *v1alpha1
 			// We shouldn't remove resources not controlled by us.
 			continue
 		}
-		if err = r.IstioClientSet.NetworkingV1alpha3().VirtualServices(ns).Delete(n, &metav1.DeleteOptions{}); err != nil {
+		if err = r.istioClientSet.NetworkingV1alpha3().VirtualServices(ns).Delete(n, &metav1.DeleteOptions{}); err != nil {
 			return fmt.Errorf("failed to delete VirtualService: %w", err)
 		}
 	}
@@ -395,7 +396,7 @@ func (r *Reconciler) reconcileGateway(ctx context.Context, ing *v1alpha1.Ingress
 
 	copy := gateway.DeepCopy()
 	copy = resources.UpdateGateway(copy, desired, existing)
-	if _, err := r.IstioClientSet.NetworkingV1alpha3().Gateways(copy.Namespace).Update(copy); err != nil {
+	if _, err := r.istioClientSet.NetworkingV1alpha3().Gateways(copy.Namespace).Update(copy); err != nil {
 		return fmt.Errorf("failed to update Gateway: %w", err)
 	}
 	r.Recorder.Eventf(ing, corev1.EventTypeNormal, "Updated", "Updated Gateway %s/%s", gateway.Namespace, gateway.Name)
@@ -414,7 +415,7 @@ func (r *Reconciler) GetSecretLister() corev1listers.SecretLister {
 
 // GetIstioClient returns the client to access Istio resources.
 func (r *Reconciler) GetIstioClient() istioclientset.Interface {
-	return r.IstioClientSet
+	return r.istioClientSet
 }
 
 // GetVirtualServiceLister returns the lister for VirtualService.

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -31,6 +31,7 @@ import (
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	_ "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/ingress/fake"
+	istioclient "knative.dev/serving/pkg/client/istio/injection/client"
 	fakeistioclient "knative.dev/serving/pkg/client/istio/injection/client/fake"
 	_ "knative.dev/serving/pkg/client/istio/injection/informers/networking/v1alpha3/gateway/fake"
 	_ "knative.dev/serving/pkg/client/istio/injection/informers/networking/v1alpha3/virtualservice/fake"
@@ -550,6 +551,7 @@ func TestReconcile(t *testing.T) {
 		retryAttempted = false
 		return &Reconciler{
 			Base:                 reconciler.NewBase(ctx, controllerAgentName, cmw),
+			istioClientSet:       istioclient.Get(ctx),
 			virtualServiceLister: listers.GetVirtualServiceLister(),
 			gatewayLister:        listers.GetGatewayLister(),
 			finalizer:            ingressFinalizer,
@@ -1012,6 +1014,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 
 		return &Reconciler{
 			Base:                 reconciler.NewBase(ctx, controllerAgentName, cmw),
+			istioClientSet:       istioclient.Get(ctx),
 			virtualServiceLister: listers.GetVirtualServiceLister(),
 			gatewayLister:        listers.GetGatewayLister(),
 			secretLister:         listers.GetSecretLister(),

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -35,7 +35,6 @@ import (
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
-	istioclient "knative.dev/serving/pkg/client/istio/injection/client"
 
 	cachingclientset "knative.dev/caching/pkg/client/clientset/versioned"
 	"knative.dev/pkg/configmap"
@@ -44,7 +43,6 @@ import (
 	"knative.dev/pkg/logging/logkey"
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
 	servingScheme "knative.dev/serving/pkg/client/clientset/versioned/scheme"
-	istioclientset "knative.dev/serving/pkg/client/istio/clientset/versioned"
 )
 
 const (
@@ -64,9 +62,6 @@ type ConfigStore interface {
 type Base struct {
 	// KubeClientSet allows us to talk to the k8s for core APIs
 	KubeClientSet kubernetes.Interface
-
-	// IstioClientSet allows us to configure Istio objects
-	IstioClientSet istioclientset.Interface
 
 	// ServingClientSet allows us to configure Serving objects
 	ServingClientSet clientset.Interface
@@ -137,7 +132,6 @@ func NewBase(ctx context.Context, controllerAgentName string, cmw configmap.Watc
 
 	base := &Base{
 		KubeClientSet:    kubeClient,
-		IstioClientSet:   istioclient.Get(ctx),
 		DynamicClientSet: dynamicclient.Get(ctx),
 		ServingClientSet: servingclient.Get(ctx),
 		CachingClientSet: cachingclient.Get(ctx),


### PR DESCRIPTION
I noticed that using the base serving reconciler was causing contour to vendor Istio, which seems...  unnecessary.

