### PR TITLE
Move the context manipulation to util.

### DIFF
--- a/pkg/activator/handler/context_handler.go
+++ b/pkg/activator/handler/context_handler.go
@@ -27,13 +27,10 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
 	"knative.dev/serving/pkg/activator"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	"knative.dev/serving/pkg/activator/util"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
 	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1alpha1"
 )
-
-type revisionKey struct{}
-type revIDKey struct{}
 
 // NewContextHandler creates a handler that extracts the necessary context from the request
 // and makes it available on the request's context.
@@ -67,26 +64,10 @@ func (h *contextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	ctx = logging.WithLogger(ctx, logger)
-	ctx = withRevision(ctx, revision)
-	ctx = withRevID(ctx, revID)
+	ctx = util.WithRevision(ctx, revision)
+	ctx = util.WithRevID(ctx, revID)
 
 	h.nextHandler.ServeHTTP(w, r.WithContext(ctx))
-}
-
-func withRevision(ctx context.Context, rev *v1alpha1.Revision) context.Context {
-	return context.WithValue(ctx, revisionKey{}, rev)
-}
-
-func revisionFrom(ctx context.Context) *v1alpha1.Revision {
-	return ctx.Value(revisionKey{}).(*v1alpha1.Revision)
-}
-
-func withRevID(ctx context.Context, revID types.NamespacedName) context.Context {
-	return context.WithValue(ctx, revIDKey{}, revID)
-}
-
-func revIDFrom(ctx context.Context) types.NamespacedName {
-	return ctx.Value(revIDKey{}).(types.NamespacedName)
 }
 
 func sendError(err error, w http.ResponseWriter) {

--- a/pkg/activator/handler/context_handler_test.go
+++ b/pkg/activator/handler/context_handler_test.go
@@ -26,6 +26,7 @@ import (
 
 	rtesting "knative.dev/pkg/reconciler/testing"
 	"knative.dev/serving/pkg/activator"
+	"knative.dev/serving/pkg/activator/util"
 )
 
 func TestContextHandler(t *testing.T) {
@@ -36,11 +37,11 @@ func TestContextHandler(t *testing.T) {
 	revisionInformer(ctx, revision)
 
 	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := revisionFrom(r.Context()); got != revision {
+		if got := util.RevisionFrom(r.Context()); got != revision {
 			t.Errorf("revisionFrom() = %v, want %v", got, revision)
 		}
 
-		if got := revIDFrom(r.Context()); got != revID {
+		if got := util.RevIDFrom(r.Context()); got != revID {
 			t.Errorf("revIDFrom() = %v, want %v", got, revID)
 		}
 	})

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -64,7 +64,7 @@ func New(ctx context.Context, t Throttler) http.Handler {
 }
 
 func (a *activationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	revID := revIDFrom(r.Context())
+	revID := util.RevIDFrom(r.Context())
 	logger := logging.FromContext(r.Context())
 	tracingEnabled := activatorconfig.FromContext(r.Context()).Tracing.Backend != tracingconfig.None
 

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -41,6 +41,7 @@ import (
 	activatorconfig "knative.dev/serving/pkg/activator/config"
 	anet "knative.dev/serving/pkg/activator/net"
 	activatortest "knative.dev/serving/pkg/activator/testing"
+	"knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -141,8 +142,7 @@ func TestActivationHandler(t *testing.T) {
 			// Set up config store to populate context.
 			configStore := setupConfigStore(t, logging.FromContext(ctx))
 			ctx = configStore.ToContext(ctx)
-			ctx = withRevision(ctx, revision(testNamespace, testRevName))
-			ctx = withRevID(ctx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
+			ctx = util.WithRevID(ctx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
 
 			handler.ServeHTTP(resp, req.WithContext(ctx))
 
@@ -181,8 +181,7 @@ func TestActivationHandlerProxyHeader(t *testing.T) {
 	// Set up config store to populate context.
 	configStore := setupConfigStore(t, logging.FromContext(ctx))
 	ctx = configStore.ToContext(req.Context())
-	ctx = withRevision(ctx, revision(testNamespace, testRevName))
-	ctx = withRevID(ctx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
+	ctx = util.WithRevID(ctx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
 
 	handler.ServeHTTP(writer, req.WithContext(ctx))
 
@@ -281,8 +280,7 @@ func sendRequest(namespace, revName string, handler *activationHandler, store *a
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
 	ctx := store.ToContext(req.Context())
-	ctx = withRevision(ctx, revision(namespace, revName))
-	ctx = withRevID(ctx, types.NamespacedName{Namespace: namespace, Name: revName})
+	ctx = util.WithRevID(ctx, types.NamespacedName{Namespace: namespace, Name: revName})
 	handler.ServeHTTP(resp, req.WithContext(ctx))
 	return resp
 }
@@ -336,8 +334,7 @@ func BenchmarkHandler(b *testing.B) {
 			req.Host = "test-host"
 
 			reqCtx := configStore.ToContext(context.Background())
-			reqCtx = withRevision(reqCtx, revision(testNamespace, testRevName))
-			reqCtx = withRevID(reqCtx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
+			reqCtx = util.WithRevID(reqCtx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
 			return req.WithContext(reqCtx)
 		}
 

--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"knative.dev/serving/pkg/activator"
+	"knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/apis/serving"
 	pkghttp "knative.dev/serving/pkg/http"
 )
@@ -42,7 +43,7 @@ type MetricHandler struct {
 }
 
 func (h *MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	revision := revisionFrom(r.Context())
+	revision := util.RevisionFrom(r.Context())
 	configurationName := revision.Labels[serving.ConfigurationLabelKey]
 	serviceName := revision.Labels[serving.ServiceLabelKey]
 

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -32,6 +32,7 @@ import (
 
 	rtesting "knative.dev/pkg/reconciler/testing"
 	"knative.dev/serving/pkg/activator"
+	"knative.dev/serving/pkg/activator/util"
 )
 
 var ignoreDurationOption = cmpopts.IgnoreFields(reporterCall{}, "Duration")
@@ -129,8 +130,8 @@ func TestRequestMetricHandler(t *testing.T) {
 				}
 			}()
 
-			reqCtx := withRevision(context.Background(), revision(testNamespace, testRevName))
-			reqCtx = withRevID(reqCtx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
+			reqCtx := util.WithRevision(context.Background(), revision(testNamespace, testRevName))
+			reqCtx = util.WithRevID(reqCtx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
 			handler.ServeHTTP(resp, req.WithContext(reqCtx))
 		})
 	}
@@ -143,7 +144,7 @@ func BenchmarkMetricHandler(b *testing.B) {
 		b.Fatalf("Failed to create a reporter: %v", err)
 	}
 	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	reqCtx := withRevision(context.Background(), revision(testNamespace, testRevName))
+	reqCtx := util.WithRevision(context.Background(), revision(testNamespace, testRevName))
 
 	handler := &MetricHandler{reporter: reporter, nextHandler: baseHandler}
 

--- a/pkg/activator/handler/requestevent_handler.go
+++ b/pkg/activator/handler/requestevent_handler.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/serving/pkg/activator/util"
 )
 
 // ReqEvent represents an incoming/finished request with a given key
@@ -53,7 +54,7 @@ type RequestEventHandler struct {
 }
 
 func (h *RequestEventHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	revisionKey := revIDFrom(r.Context())
+	revisionKey := util.RevIDFrom(r.Context())
 
 	h.ReqChan <- ReqEvent{Key: revisionKey, EventType: ReqIn}
 	defer func() {

--- a/pkg/activator/handler/requestevent_handler_test.go
+++ b/pkg/activator/handler/requestevent_handler_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/serving/pkg/activator/util"
 )
 
 func TestRequestEventHandler(t *testing.T) {
@@ -36,7 +37,7 @@ func TestRequestEventHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewBufferString(""))
-	ctx := withRevID(context.Background(), types.NamespacedName{Namespace: namespace, Name: revision})
+	ctx := util.WithRevID(context.Background(), types.NamespacedName{Namespace: namespace, Name: revision})
 	handler.ServeHTTP(resp, req.WithContext(ctx))
 
 	in := <-handler.ReqChan

--- a/pkg/activator/util/context.go
+++ b/pkg/activator/util/context.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 /*
 This file contains the context manipulation routines used within
-the activator binar
+the activator binary.
 */
 
 package util

--- a/pkg/activator/util/context.go
+++ b/pkg/activator/util/context.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file contains the context manipulation routines used within
+the activator binar
+*/
+
+package util
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+)
+
+type revisionKey struct{}
+type revIDKey struct{}
+
+// WithRevision attaches the Revision object to the context.
+func WithRevision(ctx context.Context, rev *v1alpha1.Revision) context.Context {
+	return context.WithValue(ctx, revisionKey{}, rev)
+}
+
+// RevisionFrom retrieves the Revision object from the context.
+func RevisionFrom(ctx context.Context) *v1alpha1.Revision {
+	return ctx.Value(revisionKey{}).(*v1alpha1.Revision)
+}
+
+// WithRevID attaches the the revisionID to the context.
+func WithRevID(ctx context.Context, revID types.NamespacedName) context.Context {
+	return context.WithValue(ctx, revIDKey{}, revID)
+}
+
+// RevIDFrom retrieves the the revisionID from the context.
+func RevIDFrom(ctx context.Context) types.NamespacedName {
+	return ctx.Value(revIDKey{}).(types.NamespacedName)
+}


### PR DESCRIPTION
I am going to use the context helpers in throttler and possibly revision backend manager for code streamlining and deduplication.
So I want to move them to a place where all of the activator components
will be able to access the methods.
Also I trimmed the ones that were not actually used

/lint

/assign mattmoor @markusthoemmes 