### PR TITLE
Add benchmark for request metric handler

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -73,7 +73,7 @@ func (a *activationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		tryContext, trySpan = trace.StartSpan(r.Context(), "throttler_try")
 	}
 
-	err := a.throttler.Try(tryContext, revID, func(dest string) error {
+	if err := a.throttler.Try(tryContext, revID, func(dest string) error {
 		trySpan.End()
 
 		proxyCtx, proxySpan := r.Context(), (*trace.Span)(nil)
@@ -87,8 +87,7 @@ func (a *activationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		proxySpan.End()
 
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		// Set error on our capacity waiting span and end it
 		trySpan.Annotate([]trace.Attribute{trace.StringAttribute("activator.throttler.error", err.Error())}, "ThrottlerTry")
 		trySpan.End()

--- a/pkg/network/probe_handler_test.go
+++ b/pkg/network/probe_handler_test.go
@@ -113,7 +113,7 @@ func BenchmarkProbeHandler(b *testing.B) {
 		prober.ExpectsStatusCodes([]int{http.StatusOK}),
 	}
 
-	b.Run(fmt.Sprint("sequential"), func(b *testing.B) {
+	b.Run("sequential", func(b *testing.B) {
 		for j := 0; j < b.N; j++ {
 			got, err := prober.Do(context.Background(), network.AutoTransport, ts.URL, options...)
 			if err != nil {
@@ -125,7 +125,7 @@ func BenchmarkProbeHandler(b *testing.B) {
 		}
 	})
 
-	b.Run(fmt.Sprint("parallel"), func(b *testing.B) {
+	b.Run("parallel", func(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				got, err := prober.Do(context.Background(), network.AutoTransport, ts.URL, options...)

--- a/pkg/queue/request_metric_test.go
+++ b/pkg/queue/request_metric_test.go
@@ -18,7 +18,6 @@ package queue
 
 import (
 	"bytes"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -148,7 +147,7 @@ func BenchmarkNewRequestMetricHandler(b *testing.B) {
 	stat, err := queuestats.NewStatsReporter("test-ns", "test-svc", "test-cfg",
 		"test-rev", "test-pod", countMetric, latencyMetric, queueSizeMetric)
 	if err != nil {
-		b.Fatalf("error setting up request metrics reporter. Request metrics will be unavailable.: %v", err)
+		b.Fatalf("Failed to setup reporter: %v", err)
 	}
 	handler, err := NewRequestMetricHandler(baseHandler, stat, breaker)
 	if err != nil {
@@ -157,13 +156,13 @@ func BenchmarkNewRequestMetricHandler(b *testing.B) {
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, targetURI, nil)
 
-	b.Run(fmt.Sprint("sequential"), func(b *testing.B) {
+	b.Run("sequential", func(b *testing.B) {
 		for j := 0; j < b.N; j++ {
 			handler.ServeHTTP(resp, req)
 		}
 	})
 
-	b.Run(fmt.Sprint("parallel"), func(b *testing.B) {
+	b.Run("parallel", func(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				handler.ServeHTTP(resp, req)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
/lint

Fixes : Part of #6749

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add benchmark for request metric handler

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

**Benchmark Result:**
```
go test -run=BenchmarkNewRequestMetricHandler -bench=. -benchmem 
goos: linux
goarch: amd64
pkg: knative.dev/serving/pkg/queue
BenchmarkNewRequestMetricHandler/sequential-8         	  239132	      4589 ns/op	    2560 B/op	      59 allocs/op
BenchmarkNewRequestMetricHandler/parallel-8           	  280334	      4135 ns/op	    2559 B/op	      58 allocs/op
PASS
ok  	knative.dev/serving/pkg/queue	2.371s
```
