### PR TITLE
Move metric context constructors to a general place and enable caching everywhere.

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -52,6 +52,7 @@ import (
 	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
 	"knative.dev/serving/pkg/autoscaler/scaling"
 	"knative.dev/serving/pkg/autoscaler/statserver"
+	smetrics "knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/reconciler/autoscaling/kpa"
 	"knative.dev/serving/pkg/reconciler/metric"
 	"knative.dev/serving/pkg/resources"
@@ -207,7 +208,7 @@ func uniScalerFactoryFunc(endpointsInformer corev1informers.EndpointsInformer,
 		configName := decider.Labels[serving.ConfigurationLabelKey]
 
 		// Create a stats reporter which tags statistics by PA namespace, configuration name, and PA name.
-		ctx, err := scaling.NewStatsReporterContext(decider.Namespace, serviceName, configName, decider.Name)
+		ctx, err := smetrics.RevisionContext(decider.Namespace, serviceName, configName, decider.Name)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/activator/stats_reporter.go
+++ b/pkg/activator/stats_reporter.go
@@ -25,7 +25,6 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	pkgmetrics "knative.dev/pkg/metrics"
-	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/serving/pkg/metrics"
 )
 
@@ -105,20 +104,8 @@ func NewStatsReporter(pod string) (StatsReporter, error) {
 	return &reporter{ctx: ctx}, nil
 }
 
-func valueOrUnknown(v string) string {
-	if v != "" {
-		return v
-	}
-	return metricskey.ValueUnknown
-}
-
 func (r *reporter) GetRevisionStatsReporter(ns, service, config, rev string) (RevisionStatsReporter, error) {
-	ctx, err := tag.New(
-		r.ctx,
-		tag.Upsert(metrics.NamespaceTagKey, ns),
-		tag.Upsert(metrics.ServiceTagKey, valueOrUnknown(service)),
-		tag.Upsert(metrics.ConfigTagKey, config),
-		tag.Upsert(metrics.RevisionTagKey, rev))
+	ctx, err := metrics.AugmentWithRevision(r.ctx, ns, service, config, rev)
 	if err != nil {
 		return &revisionReporter{}, err
 	}

--- a/pkg/activator/stats_reporter_test.go
+++ b/pkg/activator/stats_reporter_test.go
@@ -101,7 +101,7 @@ func TestActivatorReporterEmptyServiceName(t *testing.T) {
 		t.Fatalf("Failed to create a new reporter: %v", err)
 	}
 
-	rr, err := r.GetRevisionStatsReporter("testns", "" /*service=*/, "testconfig", "testrev")
+	rr, err := r.GetRevisionStatsReporter("testns", "" /*service=*/, "testconfig", "testrev_missing_svc")
 	if err != nil {
 		t.Fatalf("Failed to create revision reporter: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestActivatorReporterEmptyServiceName(t *testing.T) {
 		metricskey.LabelNamespaceName:     "testns",
 		metricskey.LabelServiceName:       metricskey.ValueUnknown,
 		metricskey.LabelConfigurationName: "testconfig",
-		metricskey.LabelRevisionName:      "testrev",
+		metricskey.LabelRevisionName:      "testrev_missing_svc",
 		"pod_name":                        "testpod",
 		"container_name":                  "activator",
 	}
@@ -124,7 +124,7 @@ func TestActivatorReporterEmptyServiceName(t *testing.T) {
 		metricskey.LabelNamespaceName:     "testns",
 		metricskey.LabelServiceName:       metricskey.ValueUnknown,
 		metricskey.LabelConfigurationName: "testconfig",
-		metricskey.LabelRevisionName:      "testrev",
+		metricskey.LabelRevisionName:      "testrev_missing_svc",
 		"pod_name":                        "testpod",
 		"container_name":                  "activator",
 		"response_code":                   "200",
@@ -138,7 +138,7 @@ func TestActivatorReporterEmptyServiceName(t *testing.T) {
 		metricskey.LabelNamespaceName:     "testns",
 		metricskey.LabelServiceName:       metricskey.ValueUnknown,
 		metricskey.LabelConfigurationName: "testconfig",
-		metricskey.LabelRevisionName:      "testrev",
+		metricskey.LabelRevisionName:      "testrev_missing_svc",
 		"pod_name":                        "testpod",
 		"container_name":                  "activator",
 		"response_code":                   "200",

--- a/pkg/autoscaler/scaling/metrics.go
+++ b/pkg/autoscaler/scaling/metrics.go
@@ -17,14 +17,10 @@ limitations under the License.
 package scaling
 
 import (
-	"context"
-
-	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/serving/pkg/metrics"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
-	"go.opencensus.io/tag"
 )
 
 var (
@@ -132,25 +128,4 @@ func register() {
 	); err != nil {
 		panic(err)
 	}
-}
-
-func valueOrUnknown(v string) string {
-	if v != "" {
-		return v
-	}
-	return metricskey.ValueUnknown
-}
-
-// NewStatsReporterContext returns a context that has the required stats
-// reporter tags attached.
-func NewStatsReporterContext(ns, service, config, revision string) (context.Context, error) {
-	// Our tags are static. So, we can get away with creating a single context
-	// per revision and reuse it for reporting all of our metrics.
-	// Note that service names can be an empty string, so it needs a special treatment.
-	return tag.New(
-		context.Background(),
-		tag.Upsert(metrics.NamespaceTagKey, ns),
-		tag.Upsert(metrics.ServiceTagKey, valueOrUnknown(service)),
-		tag.Upsert(metrics.ConfigTagKey, config),
-		tag.Upsert(metrics.RevisionTagKey, revision))
 }

--- a/pkg/metrics/tags.go
+++ b/pkg/metrics/tags.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+
+	lru "github.com/hashicorp/golang-lru"
+	"knative.dev/pkg/metrics/metricskey"
+
+	"go.opencensus.io/tag"
+)
+
+var (
+	// contextCache stores the metrics recorder contexts
+	// in an LRU cache.
+	// Hashicorp LRU cache is synchronized.
+	contextCache *lru.Cache
+)
+
+const lruCacheSize = 1024
+
+func init() {
+	// The only possible error is when cache size is not positive.
+	lc, _ := lru.New(lruCacheSize)
+	contextCache = lc
+}
+
+func valueOrUnknown(v string) string {
+	if v != "" {
+		return v
+	}
+	return metricskey.ValueUnknown
+}
+
+// RevisionContext generates a new base metric reporting context containing
+// the respective revision specific tags.
+func RevisionContext(ns, service, config, revision string) (context.Context, error) {
+	return AugmentWithRevision(context.Background(), ns, service, config, revision)
+}
+
+// AugmentWithRevision augments the given context with revision specific tags.
+// Note: The passed in context will be cached as part of the new context. Do not
+// use this function if the tags of the underlying contexts are non-static.
+func AugmentWithRevision(baseCtx context.Context, ns, service, config, revision string) (context.Context, error) {
+	key := ns + "/" + revision
+	ctx, ok := contextCache.Get(key)
+	if !ok {
+		//  Note that service names can be an empty string, so they needs a special treatment.
+		rctx, err := tag.New(
+			baseCtx,
+			tag.Upsert(NamespaceTagKey, ns),
+			tag.Upsert(ServiceTagKey, valueOrUnknown(service)),
+			tag.Upsert(ConfigTagKey, config),
+			tag.Upsert(RevisionTagKey, revision))
+		if err != nil {
+			return nil, err
+		}
+		contextCache.Add(key, rctx)
+		ctx = rctx
+	}
+	return ctx.(context.Context), nil
+}

--- a/pkg/metrics/tags_test.go
+++ b/pkg/metrics/tags_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scaling
+package metrics
 
 import (
 	"strings"
@@ -23,7 +23,27 @@ import (
 	pkgmetrics "knative.dev/pkg/metrics"
 	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/pkg/metrics/metricstest"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
 )
+
+var testM = stats.Int64(
+	"test_metric",
+	"A metric just for tests",
+	stats.UnitDimensionless)
+
+func register() {
+	if err := view.Register(
+		&view.View{
+			Description: "Number of pods autoscaler wants to allocate",
+			Measure:     testM,
+			Aggregation: view.LastValue(),
+			TagKeys:     CommonRevisionKeys,
+		}); err != nil {
+		panic(err)
+	}
+}
 
 func TestNewStatsReporterCtxErrors(t *testing.T) {
 	// These are invalid as defined by the current OpenCensus library.
@@ -33,7 +53,7 @@ func TestNewStatsReporterCtxErrors(t *testing.T) {
 	}
 
 	for _, v := range invalidTagValues {
-		if _, err := NewStatsReporterContext(v, v, v, v); err == nil {
+		if _, err := RevisionContext(v, v, v, v); err == nil {
 			t.Errorf("Expected err to not be nil for value %q, got nil", v)
 		}
 	}
@@ -43,25 +63,16 @@ func TestNewStatsReporterCtxErrors(t *testing.T) {
 // Required to run at the beginning of tests that check metrics' values
 // to make the tests idempotent.
 func resetMetrics() {
-	metricstest.Unregister(
-		desiredPodCountM.Name(),
-		stableRequestConcurrencyM.Name(),
-		panicRequestConcurrencyM.Name(),
-		excessBurstCapacityM.Name(),
-		targetRequestConcurrencyM.Name(),
-		panicM.Name(),
-		stableRPSM.Name(),
-		panicRPSM.Name(),
-		targetRPSM.Name())
+	metricstest.Unregister(testM.Name())
 	register()
 }
 
 func TestReporterEmptyServiceName(t *testing.T) {
 	resetMetrics()
 	// Metrics reported to an empty service name will be recorded with service "unknown" (metricskey.ValueUnknown).
-	rctx, err := NewStatsReporterContext("testns", "" /*service=*/, "testconfig", "testrev")
+	rctx, err := RevisionContext("testns", "" /*service=*/, "testconfig", "testrev")
 	if err != nil {
-		t.Fatalf("Failed to create a new reporter: %v", err)
+		t.Fatalf("Failed to create a new context: %v", err)
 	}
 	wantTags := map[string]string{
 		metricskey.LabelNamespaceName:     "testns",
@@ -69,6 +80,6 @@ func TestReporterEmptyServiceName(t *testing.T) {
 		metricskey.LabelConfigurationName: "testconfig",
 		metricskey.LabelRevisionName:      "testrev",
 	}
-	pkgmetrics.Record(rctx, desiredPodCountM.M(42))
-	metricstest.CheckLastValueData(t, "desired_pods", wantTags, 42)
+	pkgmetrics.Record(rctx, testM.M(42))
+	metricstest.CheckLastValueData(t, "test_metric", wantTags, 42)
 }

--- a/pkg/queue/stats/stats_reporter_test.go
+++ b/pkg/queue/stats/stats_reporter_test.go
@@ -143,7 +143,7 @@ func TestReporterReport(t *testing.T) {
 	metricstest.Unregister(countName, latencyName, qdepthName)
 
 	// Test reporter with empty service name
-	r, err = NewStatsReporter(testNs, "" /*service name*/, testConf, testRev, testPod, countMetric, latencyMetric, queueSizeMetric)
+	r, err = NewStatsReporter(testNs, "" /*service name*/, testConf, "testrev_svc_missing", testPod, countMetric, latencyMetric, queueSizeMetric)
 	if err != nil {
 		t.Fatalf("Unexpected error from NewStatsReporter() = %v", err)
 	}
@@ -151,7 +151,7 @@ func TestReporterReport(t *testing.T) {
 		metricskey.LabelNamespaceName:     testNs,
 		metricskey.LabelServiceName:       "unknown",
 		metricskey.LabelConfigurationName: testConf,
-		metricskey.LabelRevisionName:      testRev,
+		metricskey.LabelRevisionName:      "testrev_svc_missing",
 		"pod_name":                        testPod,
 		"container_name":                  "queue-proxy",
 		"response_code":                   "200",

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -32,6 +32,7 @@ import (
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/autoscaler/scaling"
 	pareconciler "knative.dev/serving/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler"
+	"knative.dev/serving/pkg/metrics"
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
 	"knative.dev/serving/pkg/reconciler/autoscaling/kpa/resources"
@@ -220,7 +221,7 @@ func reportMetrics(pa *pav1alpha1.PodAutoscaler, pc podCounts) error {
 	serviceLabel := pa.Labels[serving.ServiceLabelKey] // This might be empty.
 	configLabel := pa.Labels[serving.ConfigurationLabelKey]
 
-	ctx, err := reporterContext(pa.Namespace, serviceLabel, configLabel, pa.Name)
+	ctx, err := metrics.RevisionContext(pa.Namespace, serviceLabel, configLabel, pa.Name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This is a steppingstone needed for converting the activator and queue-proxy to drop their stats_reporter types as well. It centralizes the creation (or augmentation) of the contexts that we need for writing metrics to remove all code duplication.

It also enables context caching for all callers of the API to benefit from reduced allocation need everywhere.

I also renamed the already converted files from `stat_reporter.go` to `metrics.go` as they now only contain constants for the metrics of the respective component.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
