### PR TITLE
Fix network probe benchmark

### DIFF
--- a/pkg/network/probe_handler_test.go
+++ b/pkg/network/probe_handler_test.go
@@ -126,7 +126,6 @@ func BenchmarkProbeHandlerNoProbeHeader(b *testing.B) {
 func BenchmarkProbeHandlerWithProbeHeader(b *testing.B) {
 	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
 	req.Header.Set(ProbeHeaderName, ProbeHeaderValue)
-	// This will cause 1 alloc
 	req.Header.Set(HashHeaderName, "ok")
 	var h http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	h = NewProbeHandler(h)

--- a/pkg/network/probe_handler_test.go
+++ b/pkg/network/probe_handler_test.go
@@ -102,39 +102,47 @@ func TestProbeHandlerSuccessfulProbe(t *testing.T) {
 	}
 }
 
-func BenchmarkProbeHandler(b *testing.B) {
-	var h http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("Inner Body"))
-	})
+func BenchmarkProbeHandlerNoProbeHeader(b *testing.B) {
+	var h http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	h = NewProbeHandler(h)
-	ts := httptest.NewServer(h)
-	defer ts.Close()
-	options := []interface{}{
-		prober.ExpectsStatusCodes([]int{http.StatusOK}),
-	}
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
 
-	b.Run("sequential", func(b *testing.B) {
+	b.Run("sequential-no-header", func(b *testing.B) {
 		for j := 0; j < b.N; j++ {
-			got, err := prober.Do(context.Background(), network.AutoTransport, ts.URL, options...)
-			if err != nil {
-				b.Errorf("Do = %v", err)
-			}
-			if !got {
-				b.Errorf("Unexpected probe result: got: %t, want: true", got)
-			}
+			h.ServeHTTP(resp, req)
 		}
 	})
 
-	b.Run("parallel", func(b *testing.B) {
+	b.Run("parallel-no-header", func(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				got, err := prober.Do(context.Background(), network.AutoTransport, ts.URL, options...)
-				if err != nil {
-					b.Errorf("Do = %v", err)
-				}
-				if !got {
-					b.Errorf("Unexpected probe result: got: %t, want: true", got)
-				}
+				h.ServeHTTP(resp, req)
+			}
+		})
+	})
+}
+
+func BenchmarkProbeHandlerWithProbeHeader(b *testing.B) {
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	req.Header.Set(ProbeHeaderName, ProbeHeaderValue)
+	// This will cause 1 alloc
+	req.Header.Set(HashHeaderName, "ok")
+	var h http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	h = NewProbeHandler(h)
+	b.Run("sequential-probe-header", func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			h.ServeHTTP(resp, req)
+		}
+	})
+
+	b.Run("parallel-probe-header", func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			// Need to create a separate response writer because of the write on header at the end of ServeHttp
+			respParallel := httptest.NewRecorder()
+			for pb.Next() {
+				h.ServeHTTP(respParallel, req)
 			}
 		})
 	})


### PR DESCRIPTION
/lint

Part of #6749 and based on the comments of the previous PR https://github.com/knative/serving/pull/6797#discussion_r377471344

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
This PR makes the network probe benchmark actually tests the probe handler instead of probe.Do. Also reduces overhead of creating unnecessary objects and add test case of with probe header.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
/cc @markusthoemmes 
/cc @vagababov 