### PR TITLE
Add serving-approvers as approvers to pkg/metrics

### DIFF
--- a/pkg/metrics/OWNERS
+++ b/pkg/metrics/OWNERS
@@ -2,6 +2,7 @@
 
 approvers:
 - monitoring-approvers
+- serving-api-approvers
 
 reviewers:
 - monitoring-reviewers

--- a/pkg/metrics/OWNERS
+++ b/pkg/metrics/OWNERS
@@ -2,7 +2,7 @@
 
 approvers:
 - monitoring-approvers
-- serving-api-approvers
+- serving-wg-leads
 
 reviewers:
 - monitoring-reviewers


### PR DESCRIPTION
This looks like a standard library that is quite detached from
metrics specific code.

/assign mattmoor