### PR TITLE
v1alpha1.Revision constants now alias their v1 counterpart

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/revision_lifecycle.go
@@ -30,29 +30,35 @@ import (
 	"knative.dev/serving/pkg/apis/config"
 	net "knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 const (
 	// UserPortName is the name that will be used for the Port on the
 	// Deployment and Pod created by a Revision. This name will be set regardless of if
 	// a user specifies a port or the default value is chosen.
-	UserPortName = "user-port"
+	UserPortName = v1.UserPortName
 
 	// DefaultUserPort is the default port value the QueueProxy will
 	// use for connecting to the user container.
-	DefaultUserPort = 8080
+	DefaultUserPort = v1.DefaultUserPort
 
 	// QueueAdminPortName specifies the port name for
 	// health check and lifecycle hooks for queue-proxy.
-	QueueAdminPortName string = "http-queueadm"
+	QueueAdminPortName = v1.QueueAdminPortName
 
 	// AutoscalingQueueMetricsPortName specifies the port name to use for metrics
 	// emitted by queue-proxy for autoscaler.
-	AutoscalingQueueMetricsPortName = "http-autometric"
+	AutoscalingQueueMetricsPortName = v1.AutoscalingQueueMetricsPortName
 
 	// UserQueueMetricsPortName specifies the port name to use for metrics
 	// emitted by queue-proxy for end user.
-	UserQueueMetricsPortName = "http-usermetric"
+	UserQueueMetricsPortName = v1.UserQueueMetricsPortName
+
+	AnnotationParseErrorTypeMissing = v1.AnnotationParseErrorTypeMissing
+	AnnotationParseErrorTypeInvalid = v1.AnnotationParseErrorTypeInvalid
+	LabelParserErrorTypeMissing     = v1.LabelParserErrorTypeMissing
+	LabelParserErrorTypeInvalid     = v1.LabelParserErrorTypeInvalid
 )
 
 var revCondSet = apis.NewLivingConditionSet(
@@ -160,19 +166,19 @@ func (rs *RevisionStatus) MarkResourceNotConvertible(err *CannotConvertError) {
 const (
 	// NotOwned defines the reason for marking revision availability status as
 	// false due to resource ownership issues.
-	NotOwned = "NotOwned"
+	NotOwned = v1.ReasonNotOwned
 
 	// Deploying defines the reason for marking revision availability status as
 	// unknown if the revision is still deploying.
-	Deploying = "Deploying"
+	Deploying = v1.ReasonDeploying
 
 	// ProgressDeadlineExceeded defines the reason for marking revision availability
 	// status as false if progress has exceeded the deadline.
-	ProgressDeadlineExceeded = "ProgressDeadlineExceeded"
+	ProgressDeadlineExceeded = v1.ReasonProgressDeadlineExceeded
 
 	// ContainerMissing defines the reason for marking container healthiness status
 	// as false if the a container image for the revision is missing.
-	ContainerMissing = "ContainerMissing"
+	ContainerMissing = v1.ReasonContainerMissing
 )
 
 // MarkResourcesAvailableTrue marks ResourcesAvailable status on revision as True
@@ -269,13 +275,6 @@ func ResourceNotOwnedMessage(kind, name string) string {
 func ExitCodeReason(exitCode int32) string {
 	return fmt.Sprintf("ExitCode%d", exitCode)
 }
-
-const (
-	AnnotationParseErrorTypeMissing = "Missing"
-	AnnotationParseErrorTypeInvalid = "Invalid"
-	LabelParserErrorTypeMissing     = "Missing"
-	LabelParserErrorTypeInvalid     = "Invalid"
-)
 
 // +k8s:deepcopy-gen=false
 type AnnotationParseError struct {

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -161,14 +161,14 @@ type RevisionSpec struct {
 const (
 	// RevisionConditionReady is set when the revision is starting to materialize
 	// runtime resources, and becomes true when those resources are ready.
-	RevisionConditionReady = apis.ConditionReady
+	RevisionConditionReady = v1.RevisionConditionReady
 	// RevisionConditionResourcesAvailable is set when underlying
 	// Kubernetes resources have been provisioned.
-	RevisionConditionResourcesAvailable apis.ConditionType = "ResourcesAvailable"
+	RevisionConditionResourcesAvailable = v1.RevisionConditionResourcesAvailable
 	// RevisionConditionContainerHealthy is set when the revision readiness check completes.
-	RevisionConditionContainerHealthy apis.ConditionType = "ContainerHealthy"
+	RevisionConditionContainerHealthy = v1.RevisionConditionContainerHealthy
 	// RevisionConditionActive is set when the revision is receiving traffic.
-	RevisionConditionActive apis.ConditionType = "Active"
+	RevisionConditionActive = v1.RevisionConditionActive
 )
 
 // RevisionStatus communicates the observed state of the Revision (from the controller).


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Doing this as part of the migration to v1 to prevent these from being out of sync


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
