### PR TITLE
Add AugmentWithResponse to our context factory and unify usages.

### DIFF
--- a/pkg/activator/stats_reporter.go
+++ b/pkg/activator/stats_reporter.go
@@ -132,13 +132,7 @@ func (r *revisionReporter) ReportRequestCount(responseCode int) {
 		return
 	}
 
-	// It's safe to ignore the error as the tags are guaranteed to pass the checks in all cases.
-	ctx, _ := tag.New(
-		r.ctx,
-		tag.Upsert(metrics.ResponseCodeKey, strconv.Itoa(responseCode)),
-		tag.Upsert(metrics.ResponseCodeClassKey, responseCodeClass(responseCode)))
-
-	pkgmetrics.Record(ctx, requestCountM.M(1))
+	pkgmetrics.Record(metrics.AugmentWithResponse(r.ctx, responseCode), requestCountM.M(1))
 }
 
 // ReportResponseTime captures response time requests
@@ -147,13 +141,7 @@ func (r *revisionReporter) ReportResponseTime(responseCode int, d time.Duration)
 		return
 	}
 
-	// It's safe to ignore the error as the tags are guaranteed to pass the checks in all cases.
-	ctx, _ := tag.New(
-		r.ctx,
-		tag.Upsert(metrics.ResponseCodeKey, strconv.Itoa(responseCode)),
-		tag.Upsert(metrics.ResponseCodeClassKey, responseCodeClass(responseCode)))
-
-	pkgmetrics.Record(ctx, responseTimeInMsecM.M(float64(d.Milliseconds())))
+	pkgmetrics.Record(metrics.AugmentWithResponse(r.ctx, responseCode), responseTimeInMsecM.M(float64(d.Milliseconds())))
 }
 
 // responseCodeClass converts response code to a string of response code class.

--- a/pkg/metrics/key.go
+++ b/pkg/metrics/key.go
@@ -33,8 +33,8 @@ var (
 	RevisionTagKey       = tag.MustNewKey(metricskey.LabelRevisionName)
 	PodTagKey            = tag.MustNewKey("pod_name")
 	ContainerTagKey      = tag.MustNewKey("container_name")
-	ResponseCodeKey      = tag.MustNewKey("response_code")
-	ResponseCodeClassKey = tag.MustNewKey("response_code_class")
+	ResponseCodeKey      = tag.MustNewKey(metricskey.LabelResponseCode)
+	ResponseCodeClassKey = tag.MustNewKey(metricskey.LabelResponseCodeClass)
 
 	CommonRevisionKeys = []tag.Key{NamespaceTagKey, ServiceTagKey, ConfigTagKey, RevisionTagKey}
 )

--- a/pkg/metrics/tags.go
+++ b/pkg/metrics/tags.go
@@ -93,6 +93,6 @@ func AugmentWithResponse(baseCtx context.Context, responseCode int) context.Cont
 // responseCodeClass converts response code to a string of response code class.
 // e.g. The response code class is "5xx" for response code 503.
 func responseCodeClass(responseCode int) string {
-	// Get the hundred digit of the response code and concatenate "xx".
+	// Get the hundreds digit of the response code and concatenate "xx".
 	return strconv.Itoa(responseCode/100) + "xx"
 }

--- a/pkg/metrics/tags.go
+++ b/pkg/metrics/tags.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+	"strconv"
 
 	lru "github.com/hashicorp/golang-lru"
 	"knative.dev/pkg/metrics/metricskey"
@@ -74,4 +75,24 @@ func AugmentWithRevision(baseCtx context.Context, ns, service, config, revision 
 		ctx = rctx
 	}
 	return ctx.(context.Context), nil
+}
+
+// AugmentWithResponse augments the given context with response-code specific tags.
+func AugmentWithResponse(baseCtx context.Context, responseCode int) context.Context {
+	ctx, err := tag.New(
+		baseCtx,
+		tag.Upsert(ResponseCodeKey, strconv.Itoa(responseCode)),
+		tag.Upsert(ResponseCodeClassKey, responseCodeClass(responseCode)))
+	if err != nil {
+		// This should never happen but swallow the error regardless.
+		return baseCtx
+	}
+	return ctx
+}
+
+// responseCodeClass converts response code to a string of response code class.
+// e.g. The response code class is "5xx" for response code 503.
+func responseCodeClass(responseCode int) string {
+	// Get the hundred digit of the response code and concatenate "xx".
+	return strconv.Itoa(responseCode/100) + "xx"
 }

--- a/pkg/metrics/tags_test.go
+++ b/pkg/metrics/tags_test.go
@@ -34,7 +34,7 @@ var testM = stats.Int64(
 	"A metric just for tests",
 	stats.UnitDimensionless)
 
-func register(t *testing.T) {
+func register(t *testing.T) func() {
 	if err := view.Register(
 		&view.View{
 			Description: "Number of pods autoscaler wants to allocate",
@@ -44,10 +44,10 @@ func register(t *testing.T) {
 		}); err != nil {
 		t.Fatalf("Failed to register view: %v", err)
 	}
-}
 
-func reset() {
-	metricstest.Unregister(testM.Name())
+	return func() {
+		metricstest.Unregister(testM.Name())
+	}
 }
 
 func TestRevisionContextErrors(t *testing.T) {
@@ -65,8 +65,8 @@ func TestRevisionContextErrors(t *testing.T) {
 }
 
 func TestRevisionContextEmptyService(t *testing.T) {
-	register(t)
-	defer reset()
+	cancel := register(t)
+	defer cancel()
 
 	// Metrics reported to an empty service name will be recorded with service "unknown" (metricskey.ValueUnknown).
 	rctx, err := RevisionContext("testns", "" /*service=*/, "testconfig", "testrev")
@@ -84,8 +84,8 @@ func TestRevisionContextEmptyService(t *testing.T) {
 }
 
 func TestAugmentWithResponse(t *testing.T) {
-	register(t)
-	defer reset()
+	cancel := register(t)
+	defer cancel()
 
 	// Metrics reported to an empty service name will be recorded with service "unknown" (metricskey.ValueUnknown).
 	rctx, err := RevisionContext("testns", "" /*service=*/, "testconfig", "testrev")

--- a/pkg/metrics/tags_test.go
+++ b/pkg/metrics/tags_test.go
@@ -46,7 +46,7 @@ func register(t *testing.T) {
 	}
 }
 
-func reset(t *testing.T) {
+func reset() {
 	metricstest.Unregister(testM.Name())
 }
 
@@ -66,7 +66,7 @@ func TestRevisionContextErrors(t *testing.T) {
 
 func TestRevisionContextEmptyService(t *testing.T) {
 	register(t)
-	defer reset(t)
+	defer reset()
 
 	// Metrics reported to an empty service name will be recorded with service "unknown" (metricskey.ValueUnknown).
 	rctx, err := RevisionContext("testns", "" /*service=*/, "testconfig", "testrev")
@@ -85,7 +85,7 @@ func TestRevisionContextEmptyService(t *testing.T) {
 
 func TestAugmentWithResponse(t *testing.T) {
 	register(t)
-	defer reset(t)
+	defer reset()
 
 	// Metrics reported to an empty service name will be recorded with service "unknown" (metricskey.ValueUnknown).
 	rctx, err := RevisionContext("testns", "" /*service=*/, "testconfig", "testrev")

--- a/pkg/metrics/tags_test.go
+++ b/pkg/metrics/tags_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"net/http"
 	"strings"
 	"testing"
 
@@ -33,7 +34,23 @@ var testM = stats.Int64(
 	"A metric just for tests",
 	stats.UnitDimensionless)
 
-func TestNewStatsReporterCtxErrors(t *testing.T) {
+func register(t *testing.T) {
+	if err := view.Register(
+		&view.View{
+			Description: "Number of pods autoscaler wants to allocate",
+			Measure:     testM,
+			Aggregation: view.LastValue(),
+			TagKeys:     append(CommonRevisionKeys, ResponseCodeKey, ResponseCodeClassKey),
+		}); err != nil {
+		t.Fatalf("Failed to register view: %v", err)
+	}
+}
+
+func reset(t *testing.T) {
+	metricstest.Unregister(testM.Name())
+}
+
+func TestRevisionContextErrors(t *testing.T) {
 	// These are invalid as defined by the current OpenCensus library.
 	invalidTagValues := []string{
 		"naïve",                  // Includes non-ASCII character.
@@ -47,16 +64,9 @@ func TestNewStatsReporterCtxErrors(t *testing.T) {
 	}
 }
 
-func TestReporterEmptyServiceName(t *testing.T) {
-	if err := view.Register(
-		&view.View{
-			Description: "Number of pods autoscaler wants to allocate",
-			Measure:     testM,
-			Aggregation: view.LastValue(),
-			TagKeys:     CommonRevisionKeys,
-		}); err != nil {
-		t.Fatalf("Failed to register view: %v", err)
-	}
+func TestRevisionContextEmptyService(t *testing.T) {
+	register(t)
+	defer reset(t)
 
 	// Metrics reported to an empty service name will be recorded with service "unknown" (metricskey.ValueUnknown).
 	rctx, err := RevisionContext("testns", "" /*service=*/, "testconfig", "testrev")
@@ -68,6 +78,29 @@ func TestReporterEmptyServiceName(t *testing.T) {
 		metricskey.LabelServiceName:       metricskey.ValueUnknown,
 		metricskey.LabelConfigurationName: "testconfig",
 		metricskey.LabelRevisionName:      "testrev",
+	}
+	pkgmetrics.Record(rctx, testM.M(42))
+	metricstest.CheckLastValueData(t, "test_metric", wantTags, 42)
+}
+
+func TestAugmentWithResponse(t *testing.T) {
+	register(t)
+	defer reset(t)
+
+	// Metrics reported to an empty service name will be recorded with service "unknown" (metricskey.ValueUnknown).
+	rctx, err := RevisionContext("testns", "" /*service=*/, "testconfig", "testrev")
+	if err != nil {
+		t.Fatalf("Failed to create a new context: %v", err)
+	}
+
+	rctx = AugmentWithResponse(rctx, http.StatusNotFound)
+	wantTags := map[string]string{
+		metricskey.LabelNamespaceName:     "testns",
+		metricskey.LabelServiceName:       metricskey.ValueUnknown,
+		metricskey.LabelConfigurationName: "testconfig",
+		metricskey.LabelRevisionName:      "testrev",
+		metricskey.LabelResponseCode:      "404",
+		metricskey.LabelResponseCodeClass: "4xx",
 	}
 	pkgmetrics.Record(rctx, testM.M(42))
 	metricstest.CheckLastValueData(t, "test_metric", wantTags, 42)

--- a/pkg/queue/request_metric_test.go
+++ b/pkg/queue/request_metric_test.go
@@ -182,21 +182,18 @@ type fakeStatsReporter struct {
 	lastReqLatency      time.Duration
 }
 
-func (r *fakeStatsReporter) ReportQueueDepth(qd int) error {
+func (r *fakeStatsReporter) ReportQueueDepth(qd int) {
 	r.queueDepthTimes++
-	return nil
 }
 
-func (r *fakeStatsReporter) ReportRequestCount(responseCode int) error {
+func (r *fakeStatsReporter) ReportRequestCount(responseCode int) {
 	r.reqCountReportTimes++
 	r.lastRespCode = responseCode
 	r.lastReqCount = 1
-	return nil
 }
 
-func (r *fakeStatsReporter) ReportResponseTime(responseCode int, d time.Duration) error {
+func (r *fakeStatsReporter) ReportResponseTime(responseCode int, d time.Duration) {
 	r.respTimeReportTimes++
 	r.lastRespCode = responseCode
 	r.lastReqLatency = d
-	return nil
 }

--- a/pkg/queue/stats/stats_reporter.go
+++ b/pkg/queue/stats/stats_reporter.go
@@ -34,9 +34,9 @@ var defaultLatencyDistribution = view.Distribution(5, 10, 20, 40, 60, 80, 100, 1
 
 // StatsReporter defines the interface for sending queue proxy metrics.
 type StatsReporter interface {
-	ReportRequestCount(responseCode int) error
-	ReportResponseTime(responseCode int, d time.Duration) error
-	ReportQueueDepth(depth int) error
+	ReportRequestCount(responseCode int)
+	ReportResponseTime(responseCode int, d time.Duration)
+	ReportQueueDepth(depth int)
 }
 
 // reporter holds cached metric objects to report queue proxy metrics.
@@ -115,19 +115,16 @@ func NewStatsReporter(ns, service, config, rev, pod string, countMetric *stats.I
 }
 
 // ReportRequestCount captures request count metric.
-func (r *reporter) ReportRequestCount(responseCode int) error {
+func (r *reporter) ReportRequestCount(responseCode int) {
 	pkgmetrics.Record(metrics.AugmentWithResponse(r.ctx, responseCode), r.countMetric.M(1))
-	return nil
 }
 
 // ReportQueueDepth captures queue depth metric.
-func (r *reporter) ReportQueueDepth(d int) error {
+func (r *reporter) ReportQueueDepth(d int) {
 	pkgmetrics.Record(r.ctx, r.queueSizeMetric.M(int64(d)))
-	return nil
 }
 
 // ReportResponseTime captures response time requests
-func (r *reporter) ReportResponseTime(responseCode int, d time.Duration) error {
+func (r *reporter) ReportResponseTime(responseCode int, d time.Duration) {
 	pkgmetrics.Record(metrics.AugmentWithResponse(r.ctx, responseCode), r.latencyMetric.M(float64(d.Milliseconds())))
-	return nil
 }

--- a/pkg/queue/stats/stats_reporter_test.go
+++ b/pkg/queue/stats/stats_reporter_test.go
@@ -111,21 +111,21 @@ func TestReporterReport(t *testing.T) {
 	}
 
 	// Send statistics only once and observe the results
-	expectSuccess(t, "ReportRequestCount", func() error { return r.ReportRequestCount(200) })
+	r.ReportRequestCount(200)
 	metricstest.CheckCountData(t, "request_count", wantTags, 1)
 
 	// The stats are cumulative - record multiple entries, should get sum
-	expectSuccess(t, "ReportRequestCount", func() error { return r.ReportRequestCount(200) })
-	expectSuccess(t, "ReportRequestCount", func() error { return r.ReportRequestCount(200) })
+	r.ReportRequestCount(200)
+	r.ReportRequestCount(200)
 	metricstest.CheckCountData(t, "request_count", wantTags, 3)
 
 	// Send statistics only once and observe the results
-	expectSuccess(t, "ReportResponseTime", func() error { return r.ReportResponseTime(200, 100*time.Millisecond) })
+	r.ReportResponseTime(200, 100*time.Millisecond)
 	metricstest.CheckDistributionData(t, "request_latencies", wantTags, 1, 100, 100)
 
 	// The stats are cumulative - record multiple entries, should get count sum
-	expectSuccess(t, "ReportRequestCount", func() error { return r.ReportResponseTime(200, 200*time.Millisecond) })
-	expectSuccess(t, "ReportRequestCount", func() error { return r.ReportResponseTime(200, 300*time.Millisecond) })
+	r.ReportResponseTime(200, 200*time.Millisecond)
+	r.ReportResponseTime(200, 300*time.Millisecond)
 	metricstest.CheckDistributionData(t, "request_latencies", wantTags, 3, 100, 300)
 
 	wantTags = map[string]string{
@@ -136,8 +136,8 @@ func TestReporterReport(t *testing.T) {
 		"pod_name":                        testPod,
 		"container_name":                  "queue-proxy",
 	}
-	expectSuccess(t, "QueueDepth", func() error { return r.ReportQueueDepth(1) })
-	expectSuccess(t, "QueueDepth", func() error { return r.ReportQueueDepth(2) })
+	r.ReportQueueDepth(1)
+	r.ReportQueueDepth(2)
 	metricstest.CheckLastValueData(t, "queue_depth", wantTags, 2)
 
 	metricstest.Unregister(countName, latencyName, qdepthName)
@@ -159,14 +159,8 @@ func TestReporterReport(t *testing.T) {
 	}
 
 	// Send statistics only once and observe the results
-	expectSuccess(t, "ReportRequestCount", func() error { return r.ReportRequestCount(200) })
+	r.ReportRequestCount(200)
 	metricstest.CheckCountData(t, "request_count", wantTags, 1)
 
 	metricstest.Unregister(countName, latencyName, qdepthName)
-}
-
-func expectSuccess(t *testing.T, funcName string, f func() error) {
-	if err := f(); err != nil {
-		t.Errorf("Reporter.%v() expected success but got error %v", funcName, err)
-	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As per title, the responscode tags have a unified place now as well. Replaced all lingering occurrences and cleaned out the interfaces a bit while at it.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
