### PR TITLE
the revision controller's child informers now ignore resource version

### DIFF
--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -115,12 +115,12 @@ func newControllerWithOptions(
 	revisionInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.Filter(v1.SchemeGroupVersion.WithKind("Revision")),
+		FilterFunc: controller.FilterGroupKind(v1.Kind("Revision")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
 	paInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.Filter(v1.SchemeGroupVersion.WithKind("Revision")),
+		FilterFunc: controller.FilterGroupKind(v1.Kind("Revision")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
@@ -129,7 +129,7 @@ func newControllerWithOptions(
 	// a functioning Image controller.
 
 	configMapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.Filter(v1.SchemeGroupVersion.WithKind("Revision")),
+		FilterFunc: controller.FilterGroupKind(v1.Kind("Revision")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

The revision controller will reconcile revisions when child resources
change. This is accomplished by having informers for the child resource
types and filtering them based on the controlling owner.

The filtering of the owner would take into account it's version
(which is included in the apiVersion). Now that we support different
versions of our resources this PR relaxes the version constraint by
only comparing Group & Kind.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
