### PR TITLE
Configuration controller uses v1 API

### DIFF
--- a/pkg/apis/serving/v1/configuration_lifecycle.go
+++ b/pkg/apis/serving/v1/configuration_lifecycle.go
@@ -20,9 +20,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-var configurationCondSet = apis.NewLivingConditionSet()
+var configCondSet = apis.NewLivingConditionSet()
 
 // GetGroupVersionKind returns the GroupVersionKind.
 func (r *Configuration) GetGroupVersionKind() schema.GroupVersionKind {
@@ -31,10 +32,65 @@ func (r *Configuration) GetGroupVersionKind() schema.GroupVersionKind {
 
 // IsReady returns if the configuration is ready to serve the requested configuration.
 func (cs *ConfigurationStatus) IsReady() bool {
-	return configurationCondSet.Manage(cs).IsHappy()
+	return configCondSet.Manage(cs).IsHappy()
 }
 
 // InitializeConditions sets the initial values to the conditions.
 func (cs *ConfigurationStatus) InitializeConditions() {
-	configurationCondSet.Manage(cs).InitializeConditions()
+	configCondSet.Manage(cs).InitializeConditions()
+}
+
+// GetTemplate returns a pointer to the relevant RevisionTemplateSpec field.
+// It is never nil and should be exactly the specified template as guaranteed
+// by validation.
+func (cs *ConfigurationSpec) GetTemplate() *RevisionTemplateSpec {
+	return &cs.Template
+}
+
+// IsLatestReadyRevisionNameUpToDate returns true if the Configuration is ready
+// and LatestCreateRevisionName is equal to LatestReadyRevisionName. Otherwise
+// it returns false.
+func (cs *ConfigurationStatus) IsLatestReadyRevisionNameUpToDate() bool {
+	return cs.IsReady() &&
+		cs.LatestCreatedRevisionName == cs.LatestReadyRevisionName
+}
+
+func (cs *ConfigurationStatus) SetLatestCreatedRevisionName(name string) {
+	cs.LatestCreatedRevisionName = name
+	if cs.LatestReadyRevisionName != name {
+		configCondSet.Manage(cs).
+			MarkUnknown(ConfigurationConditionReady, "", "")
+	}
+}
+
+func (cs *ConfigurationStatus) SetLatestReadyRevisionName(name string) {
+	cs.LatestReadyRevisionName = name
+	if cs.LatestReadyRevisionName == cs.LatestCreatedRevisionName {
+		configCondSet.Manage(cs).MarkTrue(ConfigurationConditionReady)
+	}
+}
+
+func (cs *ConfigurationStatus) MarkLatestCreatedFailed(name, message string) {
+	configCondSet.Manage(cs).MarkFalse(
+		ConfigurationConditionReady,
+		"RevisionFailed",
+		"Revision %q failed with message: %s.", name, message)
+}
+
+func (cs *ConfigurationStatus) MarkRevisionCreationFailed(message string) {
+	configCondSet.Manage(cs).MarkFalse(
+		ConfigurationConditionReady,
+		"RevisionFailed",
+		"Revision creation failed with message: %s.", message)
+}
+
+func (cs *ConfigurationStatus) MarkLatestReadyDeleted() {
+	configCondSet.Manage(cs).MarkFalse(
+		ConfigurationConditionReady,
+		"RevisionDeleted",
+		"Revision %q was deleted.", cs.LatestReadyRevisionName)
+}
+
+func (cs *ConfigurationStatus) duck() *duckv1.Status {
+	return &cs.Status
 }

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	// Inject the fake informers we need.
-	_ "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/configuration/fake"
-	_ "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision/fake"
+	_ "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration/fake"
+	_ "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -36,24 +36,21 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/ptr"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/reconciler"
 	"knative.dev/serving/pkg/reconciler/configuration/resources"
 
 	. "knative.dev/pkg/reconciler/testing"
-	. "knative.dev/serving/pkg/reconciler/testing/v1alpha1"
-	. "knative.dev/serving/pkg/testing/v1alpha1"
+	. "knative.dev/serving/pkg/reconciler/testing/v1"
+	. "knative.dev/serving/pkg/testing/v1"
 )
 
-var revisionSpec = v1alpha1.RevisionSpec{
-	RevisionSpec: v1.RevisionSpec{
-		PodSpec: corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Image: "busybox",
-			}},
-		},
-		TimeoutSeconds: ptr.Int64(60),
+var revisionSpec = v1.RevisionSpec{
+	PodSpec: corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Image: "busybox",
+		}},
 	},
+	TimeoutSeconds: ptr.Int64(60),
 }
 
 // This is heavily based on the way the OpenShift Ingress controller tests its reconciliation method.
@@ -85,7 +82,7 @@ func TestReconcile(t *testing.T) {
 					return false, nil, nil
 				}
 				retryAttempted = true
-				return true, nil, apierrs.NewConflict(v1alpha1.Resource("foo"), "bar", errors.New("foo"))
+				return true, nil, apierrs.NewConflict(v1.Resource("foo"), "bar", errors.New("foo"))
 			},
 		},
 		WantCreates: []runtime.Object{
@@ -109,18 +106,18 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "create revision byo name",
 		Objects: []runtime.Object{
-			cfg("byo-name-create", "foo", 1234, func(cfg *v1alpha1.Configuration) {
+			cfg("byo-name-create", "foo", 1234, func(cfg *v1.Configuration) {
 				cfg.Spec.GetTemplate().Name = "byo-name-create-foo"
 			}),
 		},
 		WantCreates: []runtime.Object{
-			rev("byo-name-create", "foo", 1234, func(rev *v1alpha1.Revision) {
+			rev("byo-name-create", "foo", 1234, func(rev *v1.Revision) {
 				rev.Name = "byo-name-create-foo"
 				rev.GenerateName = ""
 			}),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfg("byo-name-create", "foo", 1234, func(cfg *v1alpha1.Configuration) {
+			Object: cfg("byo-name-create", "foo", 1234, func(cfg *v1.Configuration) {
 				cfg.Spec.GetTemplate().Name = "byo-name-create-foo"
 			},
 				// The following properties are set when we first reconcile a
@@ -134,13 +131,13 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "create revision byo name (exists)",
 		Objects: []runtime.Object{
-			cfg("byo-name-exists", "foo", 1234, func(cfg *v1alpha1.Configuration) {
+			cfg("byo-name-exists", "foo", 1234, func(cfg *v1.Configuration) {
 				cfg.Spec.GetTemplate().Name = "byo-name-exists-foo"
 			},
 				// The following properties are set when we first reconcile a
 				// Configuration and a Revision is created.
 				WithLatestCreated("byo-name-exists-foo"), WithObservedGen),
-			rev("byo-name-exists", "foo", 1234, WithCreationTimestamp(now), func(rev *v1alpha1.Revision) {
+			rev("byo-name-exists", "foo", 1234, WithCreationTimestamp(now), func(rev *v1.Revision) {
 				rev.Name = "byo-name-exists-foo"
 				rev.GenerateName = ""
 			}),
@@ -150,16 +147,16 @@ func TestReconcile(t *testing.T) {
 		Name: "create revision byo name (exists, wrong generation, right spec)",
 		// This example shows what we might see with a `git revert` in GitOps.
 		Objects: []runtime.Object{
-			cfg("byo-name-git-revert", "foo", 1234, func(cfg *v1alpha1.Configuration) {
+			cfg("byo-name-git-revert", "foo", 1234, func(cfg *v1.Configuration) {
 				cfg.Spec.GetTemplate().Name = "byo-name-git-revert-foo"
 			}),
-			rev("byo-name-git-revert", "foo", 1200, WithCreationTimestamp(now), func(rev *v1alpha1.Revision) {
+			rev("byo-name-git-revert", "foo", 1200, WithCreationTimestamp(now), func(rev *v1.Revision) {
 				rev.Name = "byo-name-git-revert-foo"
 				rev.GenerateName = ""
 			}),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfg("byo-name-git-revert", "foo", 1234, func(cfg *v1alpha1.Configuration) {
+			Object: cfg("byo-name-git-revert", "foo", 1234, func(cfg *v1.Configuration) {
 				cfg.Spec.GetTemplate().Name = "byo-name-git-revert-foo"
 			}, WithLatestCreated("byo-name-git-revert-foo"), WithObservedGen),
 		}},
@@ -167,10 +164,10 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "create revision byo name (exists @ wrong generation w/ wrong spec)",
 		Objects: []runtime.Object{
-			cfg("byo-name-wrong-gen-wrong-spec", "foo", 1234, func(cfg *v1alpha1.Configuration) {
+			cfg("byo-name-wrong-gen-wrong-spec", "foo", 1234, func(cfg *v1.Configuration) {
 				cfg.Spec.GetTemplate().Name = "byo-name-wrong-gen-wrong-spec-foo"
 			}),
-			rev("byo-name-wrong-gen-wrong-spec", "foo", 1200, func(rev *v1alpha1.Revision) {
+			rev("byo-name-wrong-gen-wrong-spec", "foo", 1200, func(rev *v1.Revision) {
 				rev.Name = "byo-name-wrong-gen-wrong-spec-foo"
 				rev.GenerateName = ""
 				rev.Spec.GetContainer().Env = append(rev.Spec.GetContainer().Env, corev1.EnvVar{
@@ -180,7 +177,7 @@ func TestReconcile(t *testing.T) {
 			}),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfg("byo-name-wrong-gen-wrong-spec", "foo", 1234, func(cfg *v1alpha1.Configuration) {
+			Object: cfg("byo-name-wrong-gen-wrong-spec", "foo", 1234, func(cfg *v1.Configuration) {
 				cfg.Spec.GetTemplate().Name = "byo-name-wrong-gen-wrong-spec-foo"
 			}, MarkRevisionCreationFailed(`revisions.serving.knative.dev "byo-name-wrong-gen-wrong-spec-foo" already exists`), WithObservedGen),
 		}},
@@ -188,17 +185,17 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "create revision byo name (exists not owned)",
 		Objects: []runtime.Object{
-			cfg("byo-rev-not-owned", "foo", 1234, func(cfg *v1alpha1.Configuration) {
+			cfg("byo-rev-not-owned", "foo", 1234, func(cfg *v1.Configuration) {
 				cfg.Spec.GetTemplate().Name = "byo-rev-not-owned-foo"
 			}),
-			rev("byo-rev-not-owned", "foo", 1200, func(rev *v1alpha1.Revision) {
+			rev("byo-rev-not-owned", "foo", 1200, func(rev *v1.Revision) {
 				rev.Name = "byo-rev-not-owned-foo"
 				rev.GenerateName = ""
 				rev.OwnerReferences = nil
 			}),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfg("byo-rev-not-owned", "foo", 1234, func(cfg *v1alpha1.Configuration) {
+			Object: cfg("byo-rev-not-owned", "foo", 1234, func(cfg *v1.Configuration) {
 				cfg.Spec.GetTemplate().Name = "byo-rev-not-owned-foo"
 			}, MarkRevisionCreationFailed(`revisions.serving.knative.dev "byo-rev-not-owned-foo" already exists`), WithObservedGen),
 		}},
@@ -293,10 +290,10 @@ func TestReconcile(t *testing.T) {
 			cfg("bad-condition", "foo", 5555, WithLatestCreated("bad-condition"), WithObservedGen),
 			rev("bad-condition", "foo", 5555,
 				WithRevName("bad-condition"),
-				WithRevStatus(v1alpha1.RevisionStatus{
+				WithRevStatus(v1.RevisionStatus{
 					Status: duckv1.Status{
 						Conditions: duckv1.Conditions{{
-							Type:     v1alpha1.RevisionConditionReady,
+							Type:     v1.RevisionConditionReady,
 							Status:   "Bad",
 							Severity: "Error",
 						}},
@@ -409,7 +406,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			cfg("threerevs", "foo", 3,
 				WithLatestCreated("threerevs-00002"),
-				WithLatestReady("threerevs-00001"), WithObservedGen, func(cfg *v1alpha1.Configuration) {
+				WithLatestReady("threerevs-00001"), WithObservedGen, func(cfg *v1.Configuration) {
 					cfg.Spec.GetTemplate().Name = "threerevs-00003"
 				},
 			),
@@ -427,7 +424,7 @@ func TestReconcile(t *testing.T) {
 			Object: cfg("threerevs", "foo", 3,
 				WithLatestCreated("threerevs-00003"),
 				WithLatestReady("threerevs-00002"),
-				WithObservedGen, func(cfg *v1alpha1.Configuration) {
+				WithObservedGen, func(cfg *v1.Configuration) {
 					cfg.Spec.GetTemplate().Name = "threerevs-00003"
 				},
 			),
@@ -441,7 +438,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			cfg("revnotready", "foo", 3,
 				WithLatestCreated("revnotready-00002"),
-				WithLatestReady("revnotready-00001"), WithObservedGen, func(cfg *v1alpha1.Configuration) {
+				WithLatestReady("revnotready-00001"), WithObservedGen, func(cfg *v1.Configuration) {
 					cfg.Spec.GetTemplate().Name = "revnotready-00003"
 				},
 			),
@@ -460,7 +457,7 @@ func TestReconcile(t *testing.T) {
 				// The config should NOT be ready, because LCR != LRR
 				WithLatestCreated("revnotready-00003"),
 				WithLatestReady("revnotready-00002"),
-				WithObservedGen, func(cfg *v1alpha1.Configuration) {
+				WithObservedGen, func(cfg *v1.Configuration) {
 					cfg.Spec.GetTemplate().Name = "revnotready-00003"
 				},
 			),
@@ -481,15 +478,15 @@ func TestReconcile(t *testing.T) {
 	}))
 }
 
-func cfg(name, namespace string, generation int64, co ...ConfigOption) *v1alpha1.Configuration {
-	c := &v1alpha1.Configuration{
+func cfg(name, namespace string, generation int64, co ...ConfigOption) *v1.Configuration {
+	c := &v1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       name,
 			Namespace:  namespace,
 			Generation: generation,
 		},
-		Spec: v1alpha1.ConfigurationSpec{
-			Template: &v1alpha1.RevisionTemplateSpec{
+		Spec: v1.ConfigurationSpec{
+			Template: v1.RevisionTemplateSpec{
 				Spec: *revisionSpec.DeepCopy(),
 			},
 		},
@@ -501,7 +498,7 @@ func cfg(name, namespace string, generation int64, co ...ConfigOption) *v1alpha1
 	return c
 }
 
-func rev(name, namespace string, generation int64, ro ...RevisionOption) *v1alpha1.Revision {
+func rev(name, namespace string, generation int64, ro ...RevisionOption) *v1.Revision {
 	r := resources.MakeRevision(cfg(name, namespace, generation))
 	r.SetDefaults(v1.WithUpgradeViaDefaulting(context.Background()))
 	for _, opt := range ro {

--- a/pkg/reconciler/configuration/controller.go
+++ b/pkg/reconciler/configuration/controller.go
@@ -22,9 +22,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/configuration"
-	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration"
+	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 	"knative.dev/serving/pkg/reconciler"
 )
 
@@ -50,7 +50,7 @@ func NewController(
 	configurationInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	revisionInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Configuration")),
+		FilterFunc: controller.FilterGroupKind(v1.Kind("Configuration")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/pkg/reconciler/configuration/queueing_test.go
+++ b/pkg/reconciler/configuration/queueing_test.go
@@ -28,9 +28,8 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/system"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
-	fakeconfigurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/configuration/fake"
+	fakeconfigurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration/fake"
 	"knative.dev/serving/pkg/gc"
 
 	. "knative.dev/pkg/reconciler/testing"
@@ -40,40 +39,38 @@ const (
 	testNamespace = "test"
 )
 
-func getTestConfiguration() *v1alpha1.Configuration {
-	cfg := &v1alpha1.Configuration{
+func getTestConfiguration() *v1.Configuration {
+	cfg := &v1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
-			SelfLink:  "/apis/serving/v1alpha1/namespaces/test/configurations/test-config",
+			SelfLink:  "/apis/serving/v1/namespaces/test/configurations/test-config",
 			Name:      "test-config",
 			Namespace: testNamespace,
 		},
-		Spec: v1alpha1.ConfigurationSpec{
-			Template: &v1alpha1.RevisionTemplateSpec{
-				Spec: v1alpha1.RevisionSpec{
-					RevisionSpec: v1.RevisionSpec{
-						PodSpec: corev1.PodSpec{
-							ServiceAccountName: "test-account",
-							// corev1.Container has a lot of setting.  We try to pass many
-							// of them here to verify that we pass through the settings to
-							// the derived Revisions.
-							Containers: []corev1.Container{{
-								Image:      "gcr.io/repo/image",
-								Command:    []string{"echo"},
-								Args:       []string{"hello", "world"},
-								WorkingDir: "/tmp",
-								Env: []corev1.EnvVar{{
-									Name:  "EDITOR",
-									Value: "emacs",
-								}},
-								LivenessProbe: &corev1.Probe{
-									TimeoutSeconds: 42,
-								},
-								ReadinessProbe: &corev1.Probe{
-									TimeoutSeconds: 43,
-								},
-								TerminationMessagePath: "/dev/null",
+		Spec: v1.ConfigurationSpec{
+			Template: v1.RevisionTemplateSpec{
+				Spec: v1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						ServiceAccountName: "test-account",
+						// corev1.Container has a lot of setting.  We try to pass many
+						// of them here to verify that we pass through the settings to
+						// the derived Revisions.
+						Containers: []corev1.Container{{
+							Image:      "gcr.io/repo/image",
+							Command:    []string{"echo"},
+							Args:       []string{"hello", "world"},
+							WorkingDir: "/tmp",
+							Env: []corev1.EnvVar{{
+								Name:  "EDITOR",
+								Value: "emacs",
 							}},
-						},
+							LivenessProbe: &corev1.Probe{
+								TimeoutSeconds: 42,
+							},
+							ReadinessProbe: &corev1.Probe{
+								TimeoutSeconds: 43,
+							},
+							TerminationMessagePath: "/dev/null",
+						}},
 					},
 				},
 			},
@@ -109,7 +106,7 @@ func TestNewConfigurationCallsSyncHandler(t *testing.T) {
 
 	// Check for revision created as a signal that syncHandler ran.
 	h.OnCreate(&servingClient.Fake, "revisions", func(obj runtime.Object) HookResult {
-		rev := obj.(*v1alpha1.Revision)
+		rev := obj.(*v1.Revision)
 		t.Logf("Revision created: %q", rev.Name)
 
 		return HookComplete

--- a/pkg/reconciler/configuration/resources/revision.go
+++ b/pkg/reconciler/configuration/resources/revision.go
@@ -19,15 +19,16 @@ package resources
 import (
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 // MakeRevision creates a revision object from configuration.
-func MakeRevision(config *v1alpha1.Configuration) *v1alpha1.Revision {
+func MakeRevision(config *v1.Configuration) *v1.Revision {
 	// Start from the ObjectMeta/Spec inlined in the Configuration resources.
-	rev := &v1alpha1.Revision{
+	rev := &v1.Revision{
 		ObjectMeta: config.Spec.GetTemplate().ObjectMeta,
 		Spec:       config.Spec.GetTemplate().Spec,
 	}
@@ -48,9 +49,10 @@ func MakeRevision(config *v1alpha1.Configuration) *v1alpha1.Revision {
 }
 
 // UpdateRevisionLabels sets the revisions labels given a Configuration.
-func UpdateRevisionLabels(rev *v1alpha1.Revision, config *v1alpha1.Configuration) {
-	if rev.Labels == nil {
-		rev.Labels = make(map[string]string)
+func UpdateRevisionLabels(rev, config metav1.Object) {
+	labels := rev.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
 	}
 
 	for _, key := range []string{
@@ -58,32 +60,37 @@ func UpdateRevisionLabels(rev *v1alpha1.Revision, config *v1alpha1.Configuration
 		serving.ServiceLabelKey,
 		serving.ConfigurationGenerationLabelKey,
 	} {
-		rev.Labels[key] = RevisionLabelValueForKey(key, config)
+		labels[key] = RevisionLabelValueForKey(key, config)
 	}
+
+	rev.SetLabels(labels)
 }
 
 // UpdateRevisionAnnotations sets the revisions annotations given a Configuration's updater annotation.
-func UpdateRevisionAnnotations(rev *v1alpha1.Revision, config *v1alpha1.Configuration) {
-	if rev.Annotations == nil {
-		rev.Annotations = make(map[string]string)
+func UpdateRevisionAnnotations(rev, config metav1.Object) {
+	annotations := rev.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
 	}
 
 	// Populate the CreatorAnnotation from configuration.
 	cans := config.GetAnnotations()
 	if c, ok := cans[serving.UpdaterAnnotation]; ok {
-		rev.Annotations[serving.CreatorAnnotation] = c
+		annotations[serving.CreatorAnnotation] = c
 	}
+
+	rev.SetAnnotations(annotations)
 }
 
 // RevisionLabelValueForKey returns the label value for the given key.
-func RevisionLabelValueForKey(key string, config *v1alpha1.Configuration) string {
+func RevisionLabelValueForKey(key string, config metav1.Object) string {
 	switch key {
 	case serving.ConfigurationLabelKey:
-		return config.Name
+		return config.GetName()
 	case serving.ServiceLabelKey:
-		return config.Labels[serving.ServiceLabelKey]
+		return config.GetLabels()[serving.ServiceLabelKey]
 	case serving.ConfigurationGenerationLabelKey:
-		return fmt.Sprintf("%d", config.Generation)
+		return fmt.Sprintf("%d", config.GetGeneration())
 	}
 
 	return ""

--- a/pkg/reconciler/configuration/resources/revision_test.go
+++ b/pkg/reconciler/configuration/resources/revision_test.go
@@ -22,41 +22,42 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/ptr"
-
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 func TestMakeRevisions(t *testing.T) {
 	tests := []struct {
 		name          string
-		configuration *v1alpha1.Configuration
-		want          *v1alpha1.Revision
+		configuration *v1.Configuration
+		want          *v1.Revision
 	}{{
 		name: "no build",
-		configuration: &v1alpha1.Configuration{
+		configuration: &v1.Configuration{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:  "no",
 				Name:       "build",
 				Generation: 10,
 			},
-			Spec: v1alpha1.ConfigurationSpec{
-				DeprecatedRevisionTemplate: &v1alpha1.RevisionTemplateSpec{
-					Spec: v1alpha1.RevisionSpec{
-						DeprecatedContainer: &corev1.Container{
-							Image: "busybox",
+			Spec: v1.ConfigurationSpec{
+				Template: v1.RevisionTemplateSpec{
+					Spec: v1.RevisionSpec{
+						PodSpec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Image: "busybox",
+							}},
 						},
 					},
 				},
 			},
 		},
-		want: &v1alpha1.Revision{
+		want: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    "no",
 				GenerateName: "build-",
 				Annotations:  map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Configuration",
 					Name:               "build",
 					Controller:         ptr.Bool(true),
@@ -68,43 +69,47 @@ func TestMakeRevisions(t *testing.T) {
 					serving.ServiceLabelKey:                 "",
 				},
 			},
-			Spec: v1alpha1.RevisionSpec{
-				DeprecatedContainer: &corev1.Container{
-					Image: "busybox",
+			Spec: v1.RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "busybox",
+					}},
 				},
 			},
 		},
 	}, {
 		name: "with labels",
-		configuration: &v1alpha1.Configuration{
+		configuration: &v1.Configuration{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:  "with",
 				Name:       "labels",
 				Generation: 100,
 			},
-			Spec: v1alpha1.ConfigurationSpec{
-				DeprecatedRevisionTemplate: &v1alpha1.RevisionTemplateSpec{
+			Spec: v1.ConfigurationSpec{
+				Template: v1.RevisionTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
 							"foo": "bar",
 							"baz": "blah",
 						},
 					},
-					Spec: v1alpha1.RevisionSpec{
-						DeprecatedContainer: &corev1.Container{
-							Image: "busybox",
+					Spec: v1.RevisionSpec{
+						PodSpec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Image: "busybox",
+							}},
 						},
 					},
 				},
 			},
 		},
-		want: &v1alpha1.Revision{
+		want: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    "with",
 				GenerateName: "labels-",
 				Annotations:  map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Configuration",
 					Name:               "labels",
 					Controller:         ptr.Bool(true),
@@ -118,42 +123,46 @@ func TestMakeRevisions(t *testing.T) {
 					"baz":                                   "blah",
 				},
 			},
-			Spec: v1alpha1.RevisionSpec{
-				DeprecatedContainer: &corev1.Container{
-					Image: "busybox",
+			Spec: v1.RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "busybox",
+					}},
 				},
 			},
 		},
 	}, {
 		name: "with annotations",
-		configuration: &v1alpha1.Configuration{
+		configuration: &v1.Configuration{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:  "with",
 				Name:       "annotations",
 				Generation: 100,
 			},
-			Spec: v1alpha1.ConfigurationSpec{
-				DeprecatedRevisionTemplate: &v1alpha1.RevisionTemplateSpec{
+			Spec: v1.ConfigurationSpec{
+				Template: v1.RevisionTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							"foo": "bar",
 							"baz": "blah",
 						},
 					},
-					Spec: v1alpha1.RevisionSpec{
-						DeprecatedContainer: &corev1.Container{
-							Image: "busybox",
+					Spec: v1.RevisionSpec{
+						PodSpec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Image: "busybox",
+							}},
 						},
 					},
 				},
 			},
 		},
-		want: &v1alpha1.Revision{
+		want: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    "with",
 				GenerateName: "annotations-",
 				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Configuration",
 					Name:               "annotations",
 					Controller:         ptr.Bool(true),
@@ -169,15 +178,17 @@ func TestMakeRevisions(t *testing.T) {
 					"baz": "blah",
 				},
 			},
-			Spec: v1alpha1.RevisionSpec{
-				DeprecatedContainer: &corev1.Container{
-					Image: "busybox",
+			Spec: v1.RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "busybox",
+					}},
 				},
 			},
 		},
 	}, {
 		name: "with creator annotation from config",
-		configuration: &v1alpha1.Configuration{
+		configuration: &v1.Configuration{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "anno",
 				Name:      "config",
@@ -187,17 +198,19 @@ func TestMakeRevisions(t *testing.T) {
 				},
 				Generation: 10,
 			},
-			Spec: v1alpha1.ConfigurationSpec{
-				DeprecatedRevisionTemplate: &v1alpha1.RevisionTemplateSpec{
-					Spec: v1alpha1.RevisionSpec{
-						DeprecatedContainer: &corev1.Container{
-							Image: "busybox",
+			Spec: v1.ConfigurationSpec{
+				Template: v1.RevisionTemplateSpec{
+					Spec: v1.RevisionSpec{
+						PodSpec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Image: "busybox",
+							}},
 						},
 					},
 				},
 			},
 		},
-		want: &v1alpha1.Revision{
+		want: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    "anno",
 				GenerateName: "config-",
@@ -205,7 +218,7 @@ func TestMakeRevisions(t *testing.T) {
 					"serving.knative.dev/creator": "someone",
 				},
 				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Configuration",
 					Name:               "config",
 					Controller:         ptr.Bool(true),
@@ -217,15 +230,17 @@ func TestMakeRevisions(t *testing.T) {
 					serving.ServiceLabelKey:                 "",
 				},
 			},
-			Spec: v1alpha1.RevisionSpec{
-				DeprecatedContainer: &corev1.Container{
-					Image: "busybox",
+			Spec: v1.RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "busybox",
+					}},
 				},
 			},
 		},
 	}, {
 		name: "with creator annotation from config with other annotations",
-		configuration: &v1alpha1.Configuration{
+		configuration: &v1.Configuration{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "anno",
 				Name:      "config",
@@ -235,23 +250,25 @@ func TestMakeRevisions(t *testing.T) {
 				},
 				Generation: 10,
 			},
-			Spec: v1alpha1.ConfigurationSpec{
-				DeprecatedRevisionTemplate: &v1alpha1.RevisionTemplateSpec{
-					Spec: v1alpha1.RevisionSpec{
-						DeprecatedContainer: &corev1.Container{
-							Image: "busybox",
-						},
-					},
+			Spec: v1.ConfigurationSpec{
+				Template: v1.RevisionTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							"foo": "bar",
 							"baz": "blah",
 						},
 					},
+					Spec: v1.RevisionSpec{
+						PodSpec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Image: "busybox",
+							}},
+						},
+					},
 				},
 			},
 		},
-		want: &v1alpha1.Revision{
+		want: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    "anno",
 				GenerateName: "config-",
@@ -261,7 +278,7 @@ func TestMakeRevisions(t *testing.T) {
 					"baz":                         "blah",
 				},
 				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Configuration",
 					Name:               "config",
 					Controller:         ptr.Bool(true),
@@ -273,9 +290,11 @@ func TestMakeRevisions(t *testing.T) {
 					serving.ServiceLabelKey:                 "",
 				},
 			},
-			Spec: v1alpha1.RevisionSpec{
-				DeprecatedContainer: &corev1.Container{
-					Image: "busybox",
+			Spec: v1.RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "busybox",
+					}},
 				},
 			},
 		},
@@ -283,16 +302,6 @@ func TestMakeRevisions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := MakeRevision(test.configuration)
-			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("MakeRevision (-want, +got) = %v", diff)
-			}
-		})
-
-		t.Run(test.name+"(template)", func(t *testing.T) {
-			// Test the Template variant.
-			test.configuration.Spec.Template = test.configuration.Spec.DeprecatedRevisionTemplate
-			test.configuration.Spec.DeprecatedRevisionTemplate = nil
 			got := MakeRevision(test.configuration)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("MakeRevision (-want, +got) = %v", diff)

--- a/pkg/reconciler/gc/gc_test.go
+++ b/pkg/reconciler/gc/gc_test.go
@@ -342,12 +342,20 @@ func cfg(name, namespace string, generation int64, co ...ConfigOption) *v1alpha1
 }
 
 func rev(name, namespace string, generation int64, ro ...RevisionOption) *v1alpha1.Revision {
-	r := resources.MakeRevision(cfg(name, namespace, generation))
-	r.SetDefaults(v1.WithUpgradeViaDefaulting(context.Background()))
+	// TODO(dprotaso) cleanup once we switch this
+	// reconciler to use v1 APIs
+	ctx := context.Background()
+
+	config := &v1.Configuration{}
+	cfg(name, namespace, generation).ConvertUp(ctx, config)
+
+	rev := &v1alpha1.Revision{}
+	rev.ConvertDown(ctx, resources.MakeRevision(config))
+
 	for _, opt := range ro {
-		opt(r)
+		opt(rev)
 	}
-	return r
+	return rev
 }
 
 type testConfigStore struct {

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -392,6 +392,8 @@ func (c *Reconciler) reconcileRoute(ctx context.Context, service *v1alpha1.Servi
 
 // CheckNameAvailability checks that if the named Revision specified by the Configuration
 // is available (not found), exists (but matches), or exists with conflict (doesn't match).
+//
+// TODO(dprotaso) de-dupe once this controller is migrated to v1 apis
 func CheckNameAvailability(config *v1alpha1.Configuration, lister listers.RevisionLister) error {
 	// If config.Spec.GetTemplate().Name is set, then we can directly look up
 	// the revision by name.

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -32,9 +32,11 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/reconciler"
+	configresources "knative.dev/serving/pkg/reconciler/configuration/resources"
 	"knative.dev/serving/pkg/reconciler/service/resources"
 	presources "knative.dev/serving/pkg/resources"
 
@@ -96,6 +98,95 @@ func TestReconcile(t *testing.T) {
 				retryAttempted = true
 				return true, nil, apierrs.NewConflict(v1alpha1.Resource("foo"), "bar", errors.New("foo"))
 			},
+		},
+	}, {
+		Name: "inline - byo rev name - existing revision - same spec",
+		Objects: []runtime.Object{
+			DefaultService("byo-rev", "foo", WithInlineNamedRevision,
+				WithServiceGeneration(2), WithServiceObservedGeneration),
+			config("byo-rev", "foo", WithInlineNamedRevision,
+				WithGeneration(2), WithObservedGen),
+			route("byo-rev", "foo", WithInlineNamedRevision,
+				WithRouteGeneration(2), WithRouteObservedGeneration),
+			&v1alpha1.Revision{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "byo-rev-byo",
+					Namespace: "foo",
+					OwnerReferences: []metav1.OwnerReference{
+						*metav1.NewControllerRef(
+							config("byo-rev", "foo", WithInlineNamedRevision),
+							v1alpha1.SchemeGroupVersion.WithKind("Configuration"),
+						),
+					},
+					Labels: map[string]string{
+						serving.ConfigurationGenerationLabelKey: "2",
+					},
+				},
+			},
+		},
+		Key: "foo/byo-rev",
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: DefaultService("byo-rev", "foo", WithInlineNamedRevision,
+				// The first reconciliation will initialize the status conditions.
+				WithInitSvcConditions),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "byo-rev"),
+		},
+	}, {
+		Name: "inline - byo rev name - existing older revision with same spec",
+		Objects: []runtime.Object{
+			DefaultService("byo-rev", "foo", WithInlineNamedRevision,
+				WithServiceGeneration(2), WithServiceObservedGeneration),
+			config("byo-rev", "foo", WithInlineNamedRevision,
+				WithGeneration(2), WithObservedGen),
+			route("byo-rev", "foo", WithInlineNamedRevision,
+				WithRouteGeneration(2), WithRouteObservedGeneration),
+			rev("byo-rev", "foo", WithInlineNamedRevision,
+				// Older Revision
+				WithGeneration(1), WithObservedGen),
+		},
+		Key: "foo/byo-rev",
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: DefaultService("byo-rev", "foo",
+				WithInlineNamedRevision, WithInitSvcConditions),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "byo-rev"),
+		},
+	}, {
+		Name: "inline - byo rev name - existing older revision with different spec",
+		Objects: []runtime.Object{
+			DefaultService("byo-rev", "foo", WithInlineNamedRevision,
+				WithServiceGeneration(2), WithServiceObservedGeneration),
+			config("byo-rev", "foo", WithInlineNamedRevision,
+				WithGeneration(2), WithObservedGen),
+			route("byo-rev", "foo", WithInlineNamedRevision,
+				WithRouteGeneration(2), WithRouteObservedGeneration),
+
+			&v1alpha1.Revision{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "byo-rev-byo",
+					Namespace: "foo",
+					OwnerReferences: []metav1.OwnerReference{
+						*metav1.NewControllerRef(
+							config("byo-rev", "foo", WithInlineNamedRevision),
+							v1alpha1.SchemeGroupVersion.WithKind("Configuration"),
+						),
+					},
+					Labels: map[string]string{
+						serving.ConfigurationGenerationLabelKey: "1",
+					},
+				},
+			},
+		},
+		Key: "foo/byo-rev",
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: DefaultService("byo-rev", "foo", WithInlineNamedRevision,
+				WithInitSvcConditions, MarkRevisionNameTaken),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Updated", "Updated Service %q", "byo-rev"),
 		},
 	}, {
 		Name: "inline - byo rev name used in traffic",
@@ -1477,4 +1568,17 @@ func RouteFailed(reason, message string) RouteOption {
 			},
 		}
 	}
+}
+
+func rev(name, namespace string, so ServiceOption, co ...ConfigOption) *v1alpha1.Revision {
+	cfg := config(name, namespace, so, co...)
+
+	cfgV1 := &v1.Configuration{}
+	cfg.ConvertUp(context.Background(), cfgV1)
+
+	revV1 := configresources.MakeRevision(cfgV1)
+	rev := &v1alpha1.Revision{}
+	rev.ConvertDown(context.Background(), revV1)
+
+	return rev
 }

--- a/pkg/testing/v1/configuration.go
+++ b/pkg/testing/v1/configuration.go
@@ -17,8 +17,10 @@ limitations under the License.
 package v1
 
 import (
-	corev1 "k8s.io/api/core/v1"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -37,5 +39,52 @@ func WithConfigReadinessProbe(p *corev1.Probe) ConfigOption {
 func WithConfigImage(img string) ConfigOption {
 	return func(cfg *v1.Configuration) {
 		cfg.Spec.Template.Spec.Containers[0].Image = img
+	}
+}
+
+func WithConfigDeletionTimestamp(r *v1.Configuration) {
+	t := metav1.NewTime(time.Unix(1e9, 0))
+	r.ObjectMeta.SetDeletionTimestamp(&t)
+}
+
+// WithConfigContainerConcurrency sets the given Configuration's concurrency.
+func WithConfigContainerConcurrency(cc int64) ConfigOption {
+	return func(cfg *v1.Configuration) {
+		cfg.Spec.GetTemplate().Spec.ContainerConcurrency = &cc
+	}
+}
+
+// WithObservedGen sets the observed generation of the Configuration.
+func WithObservedGen(cfg *v1.Configuration) {
+	cfg.Status.ObservedGeneration = cfg.Generation
+}
+
+// WithLatestCreated initializes the .status.latestCreatedRevisionName to be the name
+// of the latest revision that the Configuration would have created.
+func WithLatestCreated(name string) ConfigOption {
+	return func(cfg *v1.Configuration) {
+		cfg.Status.SetLatestCreatedRevisionName(name)
+	}
+}
+
+// WithLatestReady initializes the .status.latestReadyRevisionName to be the name
+// of the latest revision that the Configuration would have created.
+func WithLatestReady(name string) ConfigOption {
+	return func(cfg *v1.Configuration) {
+		cfg.Status.SetLatestReadyRevisionName(name)
+	}
+}
+
+// MarkRevisionCreationFailed calls .Status.MarkRevisionCreationFailed.
+func MarkRevisionCreationFailed(msg string) ConfigOption {
+	return func(cfg *v1.Configuration) {
+		cfg.Status.MarkRevisionCreationFailed(msg)
+	}
+}
+
+// MarkLatestCreatedFailed calls .Status.MarkLatestCreatedFailed.
+func MarkLatestCreatedFailed(msg string) ConfigOption {
+	return func(cfg *v1.Configuration) {
+		cfg.Status.MarkLatestCreatedFailed(cfg.Status.LatestCreatedRevisionName, msg)
 	}
 }

--- a/pkg/testing/v1alpha1/route.go
+++ b/pkg/testing/v1alpha1/route.go
@@ -51,6 +51,18 @@ func WithRouteUID(uid types.UID) RouteOption {
 	}
 }
 
+// WithRouteGeneration sets the route's generation
+func WithRouteGeneration(generation int64) RouteOption {
+	return func(svc *v1alpha1.Route) {
+		svc.Status.ObservedGeneration = generation
+	}
+}
+
+// WithRouteObservedGeneneration sets the route's observed generation to it's generation
+func WithRouteObservedGeneration(r *v1alpha1.Route) {
+	r.Status.ObservedGeneration = r.Generation
+}
+
 // WithRouteFinalizer adds the Route finalizer to the Route.
 func WithRouteFinalizer(r *v1alpha1.Route) {
 	r.ObjectMeta.Finalizers = append(r.ObjectMeta.Finalizers, "routes.serving.knative.dev")

--- a/pkg/testing/v1alpha1/service.go
+++ b/pkg/testing/v1alpha1/service.go
@@ -171,6 +171,18 @@ func WithInlineConfigSpec(config v1alpha1.ConfigurationSpec) ServiceOption {
 	}
 }
 
+// WithServiceGeneration sets the service's generation
+func WithServiceGeneration(generation int64) ServiceOption {
+	return func(svc *v1alpha1.Service) {
+		svc.Status.ObservedGeneration = generation
+	}
+}
+
+// WithServiceGeneration sets the service's observed generation to it's generation
+func WithServiceObservedGeneration(svc *v1alpha1.Service) {
+	svc.Status.ObservedGeneration = svc.Generation
+}
+
 // WithInlineRouteSpec configures the Service to use the given route spec
 func WithInlineRouteSpec(config v1alpha1.RouteSpec) ServiceOption {
 	return func(svc *v1alpha1.Service) {
@@ -317,6 +329,11 @@ func MarkConfigurationNotOwned(service *v1alpha1.Service) {
 // MarkRouteNotOwned calls the function of the same name on the Service's status.
 func MarkRouteNotOwned(service *v1alpha1.Service) {
 	service.Status.MarkRouteNotOwned(servicenames.Route(service))
+}
+
+// MarkRevisionNameTake calls the function of the same name on the Service's status
+func MarkRevisionNameTaken(service *v1alpha1.Service) {
+	service.Status.MarkRevisionNameTaken(service.Spec.GetTemplate().GetName())
 }
 
 // WithPinnedRollout configures the Service to use a "pinned" rollout,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Contributes to issue #6726, builds upon the PR #6825

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Configuration controller now uses v1 API types

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
