### PR TITLE
Migrate reconcilers to use configstore from generated reconcilers.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1800,7 +1800,8 @@
   revision = "fec8f7913697607ffec0b75f5dd9dd46bb3b9f0b"
 
 [[projects]]
-  digest = "1:b6925c86623139fd32a0dad4cbbf913d19e5168fb69606d86d61af4032fb7306"
+  branch = "master"
+  digest = "1:f6f3b0324b5b20cf0a4fb5681ce1bdbad1e4a3a1f7ba106c59ca37b5b53ab442"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -1907,8 +1908,7 @@
     "websocket",
   ]
   pruneopts = "T"
-  revision = "bfc59bd4cca7f71cff3cde48af0d909da3e0de35"
-  source = "github.com/n3wscott/pkg"
+  revision = "d93ce78496d52cd7ae4f6af5f9ec0303080cf5d8"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1008,6 +1008,14 @@
   revision = "fbec762f837dc349b73d1eaa820552e2ad177942"
 
 [[projects]]
+  digest = "1:8392b5c29adedc5f85c66b48bb53b6c49dd91d8540f3cad5d43ef7277946718f"
+  name = "gomodules.xyz/jsonpatch"
+  packages = ["v2"]
+  pruneopts = "NUT"
+  revision = "e8422f09d27ee2c8cfb2c7f8089eb9eeb0764849"
+  version = "v2.0.1"
+
+[[projects]]
   branch = "master"
   digest = "1:316acdd3d33465ea10eb1a5a10d4de4918f0a2373f87233d6dee80e8aba14c91"
   name = "google.golang.org/api"
@@ -1792,8 +1800,7 @@
   revision = "fec8f7913697607ffec0b75f5dd9dd46bb3b9f0b"
 
 [[projects]]
-  branch = "master"
-  digest = "1:9baf7494df34e555a6a2c9ab5c951a7b07c593d8176a679eab98897b1bb50d0d"
+  digest = "1:b6925c86623139fd32a0dad4cbbf913d19e5168fb69606d86d61af4032fb7306"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -1900,7 +1907,8 @@
     "websocket",
   ]
   pruneopts = "T"
-  revision = "a447f39709f1ee8c1854517c247330b8ecb9a6ca"
+  revision = "bfc59bd4cca7f71cff3cde48af0d909da3e0de35"
+  source = "github.com/n3wscott/pkg"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,8 +30,7 @@ required = [
 
 [[override]]
   name = "knative.dev/pkg"
-  source = "github.com/n3wscott/pkg"
-  revision = "bfc59bd4cca7f71cff3cde48af0d909da3e0de35"
+  branch = "master"
 
 [[constraint]]
   name = "knative.dev/caching"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,7 +30,8 @@ required = [
 
 [[override]]
   name = "knative.dev/pkg"
-  branch = "master"
+  source = "github.com/n3wscott/pkg"
+  revision = "bfc59bd4cca7f71cff3cde48af0d909da3e0de35"
 
 [[constraint]]
   name = "knative.dev/caching"

--- a/pkg/client/injection/reconciler/autoscaling/v1alpha1/metric/controller.go
+++ b/pkg/client/injection/reconciler/autoscaling/v1alpha1/metric/controller.go
@@ -19,7 +19,7 @@ limitations under the License.
 package metric
 
 import (
-	"context"
+	context "context"
 
 	corev1 "k8s.io/api/core/v1"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/injection/reconciler/autoscaling/v1alpha1/metric/controller.go
+++ b/pkg/client/injection/reconciler/autoscaling/v1alpha1/metric/controller.go
@@ -42,9 +42,16 @@ const (
 
 // NewImpl returns a controller.Impl that handles queuing and feeding work from
 // the queue through an implementation of controller.Reconciler, delegating to
-// the provided Interface and optional Finalizer methods.
-func NewImpl(ctx context.Context, r Interface) *controller.Impl {
+// the provided Interface and optional Finalizer methods. OptionsFn is used to return
+// controller.Options to be used but the internal reconciler.
+func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsFn) *controller.Impl {
 	logger := logging.FromContext(ctx)
+
+	// Check the options function input. It should be 0 or 1.
+	if len(optionsFns) > 1 {
+		logger.Fatalf("up to one options function is supported, found %d", len(optionsFns))
+	}
+
 	metricInformer := metric.Get(ctx)
 
 	recorder := controller.GetEventRecorder(ctx)
@@ -72,7 +79,17 @@ func NewImpl(ctx context.Context, r Interface) *controller.Impl {
 		Recorder:   recorder,
 		reconciler: r,
 	}
-	return controller.NewImpl(rec, logger, defaultQueueName)
+	impl := controller.NewImpl(rec, logger, defaultQueueName)
+
+	// Pass impl to the options. Save any optional results.
+	for _, fn := range optionsFns {
+		opts := fn(impl)
+		if opts.ConfigStore != nil {
+			rec.configStore = opts.ConfigStore
+		}
+	}
+
+	return impl
 }
 
 func init() {

--- a/pkg/client/injection/reconciler/autoscaling/v1alpha1/metric/reconciler.go
+++ b/pkg/client/injection/reconciler/autoscaling/v1alpha1/metric/reconciler.go
@@ -75,6 +75,10 @@ type reconcilerImpl struct {
 	// Kubernetes API.
 	Recorder record.EventRecorder
 
+	// configStore allows for decorating a context with config maps.
+	// +optional
+	configStore reconciler.ConfigStore
+
 	// reconciler is the implementation of the business logic of the resource.
 	reconciler Interface
 }
@@ -82,18 +86,36 @@ type reconcilerImpl struct {
 // Check that our Reconciler implements controller.Reconciler
 var _ controller.Reconciler = (*reconcilerImpl)(nil)
 
-func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister autoscalingv1alpha1.MetricLister, recorder record.EventRecorder, r Interface) controller.Reconciler {
-	return &reconcilerImpl{
+func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister autoscalingv1alpha1.MetricLister, recorder record.EventRecorder, r Interface, options ...controller.Options) controller.Reconciler {
+	// Check the options function input. It should be 0 or 1.
+	if len(options) > 1 {
+		logger.Fatalf("up to one options struct is supported, found %d", len(options))
+	}
+
+	rec := &reconcilerImpl{
 		Client:     client,
 		Lister:     lister,
 		Recorder:   recorder,
 		reconciler: r,
 	}
+
+	for _, opts := range options {
+		if opts.ConfigStore != nil {
+			rec.configStore = opts.ConfigStore
+		}
+	}
+
+	return rec
 }
 
 // Reconcile implements controller.Reconciler
 func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
+
+	// If configStore is set, attach the frozen configuration to the context.
+	if r.configStore {
+		ctx = r.configStore.ToContext(ctx)
+	}
 
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
@@ -101,11 +123,6 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		logger.Errorf("invalid resource key: %s", key)
 		return nil
 	}
-
-	// TODO(n3wscott): this is needed for serving.
-	// If our controller has configuration state, we'd "freeze" it and
-	// attach the frozen configuration to the context.
-	//    ctx = r.configStore.ToContext(ctx)
 
 	// Get the resource with this namespace/name.
 	original, err := r.Lister.Metrics(namespace).Get(name)
@@ -121,6 +138,9 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	var reconcileEvent reconciler.Event
 	if resource.GetDeletionTimestamp().IsZero() {
+		// Append the target method to the logger.
+		logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
+
 		// Set and update the finalizer on resource if r.reconciler
 		// implements Finalizer.
 		if err := r.setFinalizerIfFinalizer(ctx, resource); err != nil {
@@ -131,6 +151,9 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		// updates regardless of whether the reconciliation errored out.
 		reconcileEvent = r.reconciler.ReconcileKind(ctx, resource)
 	} else if fin, ok := r.reconciler.(Finalizer); ok {
+		// Append the target method to the logger.
+		logger = logger.With(zap.String("targetMethod", "FinalizeKind"))
+
 		// For finalizing reconcilers, if this resource being marked for deletion
 		// and reconciled cleanly (nil or normal event), remove the finalizer.
 		reconcileEvent = fin.FinalizeKind(ctx, resource)
@@ -156,11 +179,11 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	if reconcileEvent != nil {
 		var event *reconciler.ReconcilerEvent
 		if reconciler.EventAs(reconcileEvent, &event) {
-			logger.Infow("ReconcileKind returned an event", zap.Any("event", reconcileEvent))
+			logger.Infow("returned an event", zap.Any("event", reconcileEvent))
 			r.Recorder.Eventf(resource, event.EventType, event.Reason, event.Format, event.Args...)
 			return nil
 		} else {
-			logger.Errorw("ReconcileKind returned an error", zap.Error(reconcileEvent))
+			logger.Errorw("returned an error", zap.Error(reconcileEvent))
 			r.Recorder.Event(resource, v1.EventTypeWarning, "InternalError", reconcileEvent.Error())
 			return reconcileEvent
 		}

--- a/pkg/client/injection/reconciler/autoscaling/v1alpha1/metric/reconciler.go
+++ b/pkg/client/injection/reconciler/autoscaling/v1alpha1/metric/reconciler.go
@@ -19,7 +19,7 @@ limitations under the License.
 package metric
 
 import (
-	"context"
+	context "context"
 	"encoding/json"
 	"reflect"
 
@@ -113,7 +113,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
 
 	// If configStore is set, attach the frozen configuration to the context.
-	if r.configStore {
+	if r.configStore != nil {
 		ctx = r.configStore.ToContext(ctx)
 	}
 

--- a/pkg/client/injection/reconciler/autoscaling/v1alpha1/metric/stub/controller.go
+++ b/pkg/client/injection/reconciler/autoscaling/v1alpha1/metric/stub/controller.go
@@ -19,9 +19,9 @@ limitations under the License.
 package metric
 
 import (
-	"context"
+	context "context"
 
-	"knative.dev/pkg/configmap"
+	configmap "knative.dev/pkg/configmap"
 	controller "knative.dev/pkg/controller"
 	logging "knative.dev/pkg/logging"
 	metric "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/metric"

--- a/pkg/client/injection/reconciler/autoscaling/v1alpha1/metric/stub/reconciler.go
+++ b/pkg/client/injection/reconciler/autoscaling/v1alpha1/metric/stub/reconciler.go
@@ -19,7 +19,7 @@ limitations under the License.
 package metric
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/api/core/v1"
 	reconciler "knative.dev/pkg/reconciler"

--- a/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler/controller.go
+++ b/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler/controller.go
@@ -42,9 +42,16 @@ const (
 
 // NewImpl returns a controller.Impl that handles queuing and feeding work from
 // the queue through an implementation of controller.Reconciler, delegating to
-// the provided Interface and optional Finalizer methods.
-func NewImpl(ctx context.Context, r Interface) *controller.Impl {
+// the provided Interface and optional Finalizer methods. OptionsFn is used to return
+// controller.Options to be used but the internal reconciler.
+func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsFn) *controller.Impl {
 	logger := logging.FromContext(ctx)
+
+	// Check the options function input. It should be 0 or 1.
+	if len(optionsFns) > 1 {
+		logger.Fatalf("up to one options function is supported, found %d", len(optionsFns))
+	}
+
 	podautoscalerInformer := podautoscaler.Get(ctx)
 
 	recorder := controller.GetEventRecorder(ctx)
@@ -72,7 +79,17 @@ func NewImpl(ctx context.Context, r Interface) *controller.Impl {
 		Recorder:   recorder,
 		reconciler: r,
 	}
-	return controller.NewImpl(rec, logger, defaultQueueName)
+	impl := controller.NewImpl(rec, logger, defaultQueueName)
+
+	// Pass impl to the options. Save any optional results.
+	for _, fn := range optionsFns {
+		opts := fn(impl)
+		if opts.ConfigStore != nil {
+			rec.configStore = opts.ConfigStore
+		}
+	}
+
+	return impl
 }
 
 func init() {

--- a/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler/controller.go
+++ b/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler/controller.go
@@ -19,7 +19,7 @@ limitations under the License.
 package podautoscaler
 
 import (
-	"context"
+	context "context"
 
 	corev1 "k8s.io/api/core/v1"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler/reconciler.go
+++ b/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler/reconciler.go
@@ -19,7 +19,7 @@ limitations under the License.
 package podautoscaler
 
 import (
-	"context"
+	context "context"
 	"encoding/json"
 	"reflect"
 
@@ -113,7 +113,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
 
 	// If configStore is set, attach the frozen configuration to the context.
-	if r.configStore {
+	if r.configStore != nil {
 		ctx = r.configStore.ToContext(ctx)
 	}
 

--- a/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler/reconciler.go
+++ b/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler/reconciler.go
@@ -75,6 +75,10 @@ type reconcilerImpl struct {
 	// Kubernetes API.
 	Recorder record.EventRecorder
 
+	// configStore allows for decorating a context with config maps.
+	// +optional
+	configStore reconciler.ConfigStore
+
 	// reconciler is the implementation of the business logic of the resource.
 	reconciler Interface
 }
@@ -82,18 +86,36 @@ type reconcilerImpl struct {
 // Check that our Reconciler implements controller.Reconciler
 var _ controller.Reconciler = (*reconcilerImpl)(nil)
 
-func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister autoscalingv1alpha1.PodAutoscalerLister, recorder record.EventRecorder, r Interface) controller.Reconciler {
-	return &reconcilerImpl{
+func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister autoscalingv1alpha1.PodAutoscalerLister, recorder record.EventRecorder, r Interface, options ...controller.Options) controller.Reconciler {
+	// Check the options function input. It should be 0 or 1.
+	if len(options) > 1 {
+		logger.Fatalf("up to one options struct is supported, found %d", len(options))
+	}
+
+	rec := &reconcilerImpl{
 		Client:     client,
 		Lister:     lister,
 		Recorder:   recorder,
 		reconciler: r,
 	}
+
+	for _, opts := range options {
+		if opts.ConfigStore != nil {
+			rec.configStore = opts.ConfigStore
+		}
+	}
+
+	return rec
 }
 
 // Reconcile implements controller.Reconciler
 func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
+
+	// If configStore is set, attach the frozen configuration to the context.
+	if r.configStore {
+		ctx = r.configStore.ToContext(ctx)
+	}
 
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
@@ -101,11 +123,6 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		logger.Errorf("invalid resource key: %s", key)
 		return nil
 	}
-
-	// TODO(n3wscott): this is needed for serving.
-	// If our controller has configuration state, we'd "freeze" it and
-	// attach the frozen configuration to the context.
-	//    ctx = r.configStore.ToContext(ctx)
 
 	// Get the resource with this namespace/name.
 	original, err := r.Lister.PodAutoscalers(namespace).Get(name)
@@ -121,6 +138,9 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	var reconcileEvent reconciler.Event
 	if resource.GetDeletionTimestamp().IsZero() {
+		// Append the target method to the logger.
+		logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
+
 		// Set and update the finalizer on resource if r.reconciler
 		// implements Finalizer.
 		if err := r.setFinalizerIfFinalizer(ctx, resource); err != nil {
@@ -131,6 +151,9 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		// updates regardless of whether the reconciliation errored out.
 		reconcileEvent = r.reconciler.ReconcileKind(ctx, resource)
 	} else if fin, ok := r.reconciler.(Finalizer); ok {
+		// Append the target method to the logger.
+		logger = logger.With(zap.String("targetMethod", "FinalizeKind"))
+
 		// For finalizing reconcilers, if this resource being marked for deletion
 		// and reconciled cleanly (nil or normal event), remove the finalizer.
 		reconcileEvent = fin.FinalizeKind(ctx, resource)
@@ -156,11 +179,11 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	if reconcileEvent != nil {
 		var event *reconciler.ReconcilerEvent
 		if reconciler.EventAs(reconcileEvent, &event) {
-			logger.Infow("ReconcileKind returned an event", zap.Any("event", reconcileEvent))
+			logger.Infow("returned an event", zap.Any("event", reconcileEvent))
 			r.Recorder.Eventf(resource, event.EventType, event.Reason, event.Format, event.Args...)
 			return nil
 		} else {
-			logger.Errorw("ReconcileKind returned an error", zap.Error(reconcileEvent))
+			logger.Errorw("returned an error", zap.Error(reconcileEvent))
 			r.Recorder.Event(resource, v1.EventTypeWarning, "InternalError", reconcileEvent.Error())
 			return reconcileEvent
 		}

--- a/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler/stub/controller.go
+++ b/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler/stub/controller.go
@@ -19,9 +19,9 @@ limitations under the License.
 package podautoscaler
 
 import (
-	"context"
+	context "context"
 
-	"knative.dev/pkg/configmap"
+	configmap "knative.dev/pkg/configmap"
 	controller "knative.dev/pkg/controller"
 	logging "knative.dev/pkg/logging"
 	podautoscaler "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler"

--- a/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler/stub/reconciler.go
+++ b/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler/stub/reconciler.go
@@ -19,7 +19,7 @@ limitations under the License.
 package podautoscaler
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/api/core/v1"
 	reconciler "knative.dev/pkg/reconciler"

--- a/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice/controller.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice/controller.go
@@ -19,7 +19,7 @@ limitations under the License.
 package serverlessservice
 
 import (
-	"context"
+	context "context"
 
 	corev1 "k8s.io/api/core/v1"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice/controller.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice/controller.go
@@ -42,9 +42,16 @@ const (
 
 // NewImpl returns a controller.Impl that handles queuing and feeding work from
 // the queue through an implementation of controller.Reconciler, delegating to
-// the provided Interface and optional Finalizer methods.
-func NewImpl(ctx context.Context, r Interface) *controller.Impl {
+// the provided Interface and optional Finalizer methods. OptionsFn is used to return
+// controller.Options to be used but the internal reconciler.
+func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsFn) *controller.Impl {
 	logger := logging.FromContext(ctx)
+
+	// Check the options function input. It should be 0 or 1.
+	if len(optionsFns) > 1 {
+		logger.Fatalf("up to one options function is supported, found %d", len(optionsFns))
+	}
+
 	serverlessserviceInformer := serverlessservice.Get(ctx)
 
 	recorder := controller.GetEventRecorder(ctx)
@@ -72,7 +79,17 @@ func NewImpl(ctx context.Context, r Interface) *controller.Impl {
 		Recorder:   recorder,
 		reconciler: r,
 	}
-	return controller.NewImpl(rec, logger, defaultQueueName)
+	impl := controller.NewImpl(rec, logger, defaultQueueName)
+
+	// Pass impl to the options. Save any optional results.
+	for _, fn := range optionsFns {
+		opts := fn(impl)
+		if opts.ConfigStore != nil {
+			rec.configStore = opts.ConfigStore
+		}
+	}
+
+	return impl
 }
 
 func init() {

--- a/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice/reconciler.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice/reconciler.go
@@ -75,6 +75,10 @@ type reconcilerImpl struct {
 	// Kubernetes API.
 	Recorder record.EventRecorder
 
+	// configStore allows for decorating a context with config maps.
+	// +optional
+	configStore reconciler.ConfigStore
+
 	// reconciler is the implementation of the business logic of the resource.
 	reconciler Interface
 }
@@ -82,18 +86,36 @@ type reconcilerImpl struct {
 // Check that our Reconciler implements controller.Reconciler
 var _ controller.Reconciler = (*reconcilerImpl)(nil)
 
-func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister networkingv1alpha1.ServerlessServiceLister, recorder record.EventRecorder, r Interface) controller.Reconciler {
-	return &reconcilerImpl{
+func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister networkingv1alpha1.ServerlessServiceLister, recorder record.EventRecorder, r Interface, options ...controller.Options) controller.Reconciler {
+	// Check the options function input. It should be 0 or 1.
+	if len(options) > 1 {
+		logger.Fatalf("up to one options struct is supported, found %d", len(options))
+	}
+
+	rec := &reconcilerImpl{
 		Client:     client,
 		Lister:     lister,
 		Recorder:   recorder,
 		reconciler: r,
 	}
+
+	for _, opts := range options {
+		if opts.ConfigStore != nil {
+			rec.configStore = opts.ConfigStore
+		}
+	}
+
+	return rec
 }
 
 // Reconcile implements controller.Reconciler
 func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
+
+	// If configStore is set, attach the frozen configuration to the context.
+	if r.configStore {
+		ctx = r.configStore.ToContext(ctx)
+	}
 
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
@@ -101,11 +123,6 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		logger.Errorf("invalid resource key: %s", key)
 		return nil
 	}
-
-	// TODO(n3wscott): this is needed for serving.
-	// If our controller has configuration state, we'd "freeze" it and
-	// attach the frozen configuration to the context.
-	//    ctx = r.configStore.ToContext(ctx)
 
 	// Get the resource with this namespace/name.
 	original, err := r.Lister.ServerlessServices(namespace).Get(name)
@@ -121,6 +138,9 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	var reconcileEvent reconciler.Event
 	if resource.GetDeletionTimestamp().IsZero() {
+		// Append the target method to the logger.
+		logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
+
 		// Set and update the finalizer on resource if r.reconciler
 		// implements Finalizer.
 		if err := r.setFinalizerIfFinalizer(ctx, resource); err != nil {
@@ -131,6 +151,9 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		// updates regardless of whether the reconciliation errored out.
 		reconcileEvent = r.reconciler.ReconcileKind(ctx, resource)
 	} else if fin, ok := r.reconciler.(Finalizer); ok {
+		// Append the target method to the logger.
+		logger = logger.With(zap.String("targetMethod", "FinalizeKind"))
+
 		// For finalizing reconcilers, if this resource being marked for deletion
 		// and reconciled cleanly (nil or normal event), remove the finalizer.
 		reconcileEvent = fin.FinalizeKind(ctx, resource)
@@ -156,11 +179,11 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	if reconcileEvent != nil {
 		var event *reconciler.ReconcilerEvent
 		if reconciler.EventAs(reconcileEvent, &event) {
-			logger.Infow("ReconcileKind returned an event", zap.Any("event", reconcileEvent))
+			logger.Infow("returned an event", zap.Any("event", reconcileEvent))
 			r.Recorder.Eventf(resource, event.EventType, event.Reason, event.Format, event.Args...)
 			return nil
 		} else {
-			logger.Errorw("ReconcileKind returned an error", zap.Error(reconcileEvent))
+			logger.Errorw("returned an error", zap.Error(reconcileEvent))
 			r.Recorder.Event(resource, v1.EventTypeWarning, "InternalError", reconcileEvent.Error())
 			return reconcileEvent
 		}

--- a/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice/reconciler.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice/reconciler.go
@@ -19,7 +19,7 @@ limitations under the License.
 package serverlessservice
 
 import (
-	"context"
+	context "context"
 	"encoding/json"
 	"reflect"
 
@@ -113,7 +113,7 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
 
 	// If configStore is set, attach the frozen configuration to the context.
-	if r.configStore {
+	if r.configStore != nil {
 		ctx = r.configStore.ToContext(ctx)
 	}
 

--- a/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice/stub/controller.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice/stub/controller.go
@@ -19,9 +19,9 @@ limitations under the License.
 package serverlessservice
 
 import (
-	"context"
+	context "context"
 
-	"knative.dev/pkg/configmap"
+	configmap "knative.dev/pkg/configmap"
 	controller "knative.dev/pkg/controller"
 	logging "knative.dev/pkg/logging"
 	serverlessservice "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/serverlessservice"

--- a/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice/stub/reconciler.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice/stub/reconciler.go
@@ -19,7 +19,7 @@ limitations under the License.
 package serverlessservice
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/api/core/v1"
 	reconciler "knative.dev/pkg/reconciler"

--- a/pkg/client/injection/reconciler/serving/v1alpha1/configuration/controller.go
+++ b/pkg/client/injection/reconciler/serving/v1alpha1/configuration/controller.go
@@ -19,7 +19,7 @@ limitations under the License.
 package configuration
 
 import (
-	"context"
+	context "context"
 
 	corev1 "k8s.io/api/core/v1"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/injection/reconciler/serving/v1alpha1/configuration/controller.go
+++ b/pkg/client/injection/reconciler/serving/v1alpha1/configuration/controller.go
@@ -42,9 +42,16 @@ const (
 
 // NewImpl returns a controller.Impl that handles queuing and feeding work from
 // the queue through an implementation of controller.Reconciler, delegating to
-// the provided Interface and optional Finalizer methods.
-func NewImpl(ctx context.Context, r Interface) *controller.Impl {
+// the provided Interface and optional Finalizer methods. OptionsFn is used to return
+// controller.Options to be used but the internal reconciler.
+func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsFn) *controller.Impl {
 	logger := logging.FromContext(ctx)
+
+	// Check the options function input. It should be 0 or 1.
+	if len(optionsFns) > 1 {
+		logger.Fatalf("up to one options function is supported, found %d", len(optionsFns))
+	}
+
 	configurationInformer := configuration.Get(ctx)
 
 	recorder := controller.GetEventRecorder(ctx)
@@ -72,7 +79,17 @@ func NewImpl(ctx context.Context, r Interface) *controller.Impl {
 		Recorder:   recorder,
 		reconciler: r,
 	}
-	return controller.NewImpl(rec, logger, defaultQueueName)
+	impl := controller.NewImpl(rec, logger, defaultQueueName)
+
+	// Pass impl to the options. Save any optional results.
+	for _, fn := range optionsFns {
+		opts := fn(impl)
+		if opts.ConfigStore != nil {
+			rec.configStore = opts.ConfigStore
+		}
+	}
+
+	return impl
 }
 
 func init() {

--- a/pkg/client/injection/reconciler/serving/v1alpha1/configuration/reconciler.go
+++ b/pkg/client/injection/reconciler/serving/v1alpha1/configuration/reconciler.go
@@ -75,6 +75,10 @@ type reconcilerImpl struct {
 	// Kubernetes API.
 	Recorder record.EventRecorder
 
+	// configStore allows for decorating a context with config maps.
+	// +optional
+	configStore reconciler.ConfigStore
+
 	// reconciler is the implementation of the business logic of the resource.
 	reconciler Interface
 }
@@ -82,18 +86,36 @@ type reconcilerImpl struct {
 // Check that our Reconciler implements controller.Reconciler
 var _ controller.Reconciler = (*reconcilerImpl)(nil)
 
-func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister servingv1alpha1.ConfigurationLister, recorder record.EventRecorder, r Interface) controller.Reconciler {
-	return &reconcilerImpl{
+func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister servingv1alpha1.ConfigurationLister, recorder record.EventRecorder, r Interface, options ...controller.Options) controller.Reconciler {
+	// Check the options function input. It should be 0 or 1.
+	if len(options) > 1 {
+		logger.Fatalf("up to one options struct is supported, found %d", len(options))
+	}
+
+	rec := &reconcilerImpl{
 		Client:     client,
 		Lister:     lister,
 		Recorder:   recorder,
 		reconciler: r,
 	}
+
+	for _, opts := range options {
+		if opts.ConfigStore != nil {
+			rec.configStore = opts.ConfigStore
+		}
+	}
+
+	return rec
 }
 
 // Reconcile implements controller.Reconciler
 func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	logger := logging.FromContext(ctx)
+
+	// If configStore is set, attach the frozen configuration to the context.
+	if r.configStore != nil {
+		ctx = r.configStore.ToContext(ctx)
+	}
 
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
@@ -101,11 +123,6 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		logger.Errorf("invalid resource key: %s", key)
 		return nil
 	}
-
-	// TODO(n3wscott): this is needed for serving.
-	// If our controller has configuration state, we'd "freeze" it and
-	// attach the frozen configuration to the context.
-	//    ctx = r.configStore.ToContext(ctx)
 
 	// Get the resource with this namespace/name.
 	original, err := r.Lister.Configurations(namespace).Get(name)
@@ -121,6 +138,9 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 
 	var reconcileEvent reconciler.Event
 	if resource.GetDeletionTimestamp().IsZero() {
+		// Append the target method to the logger.
+		logger = logger.With(zap.String("targetMethod", "ReconcileKind"))
+
 		// Set and update the finalizer on resource if r.reconciler
 		// implements Finalizer.
 		if err := r.setFinalizerIfFinalizer(ctx, resource); err != nil {
@@ -131,6 +151,9 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		// updates regardless of whether the reconciliation errored out.
 		reconcileEvent = r.reconciler.ReconcileKind(ctx, resource)
 	} else if fin, ok := r.reconciler.(Finalizer); ok {
+		// Append the target method to the logger.
+		logger = logger.With(zap.String("targetMethod", "FinalizeKind"))
+
 		// For finalizing reconcilers, if this resource being marked for deletion
 		// and reconciled cleanly (nil or normal event), remove the finalizer.
 		reconcileEvent = fin.FinalizeKind(ctx, resource)
@@ -156,11 +179,11 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 	if reconcileEvent != nil {
 		var event *reconciler.ReconcilerEvent
 		if reconciler.EventAs(reconcileEvent, &event) {
-			logger.Infow("ReconcileKind returned an event", zap.Any("event", reconcileEvent))
+			logger.Infow("returned an event", zap.Any("event", reconcileEvent))
 			r.Recorder.Eventf(resource, event.EventType, event.Reason, event.Format, event.Args...)
 			return nil
 		} else {
-			logger.Errorw("ReconcileKind returned an error", zap.Error(reconcileEvent))
+			logger.Errorw("returned an error", zap.Error(reconcileEvent))
 			r.Recorder.Event(resource, v1.EventTypeWarning, "InternalError", reconcileEvent.Error())
 			return reconcileEvent
 		}

--- a/pkg/client/injection/reconciler/serving/v1alpha1/configuration/reconciler.go
+++ b/pkg/client/injection/reconciler/serving/v1alpha1/configuration/reconciler.go
@@ -19,7 +19,7 @@ limitations under the License.
 package configuration
 
 import (
-	"context"
+	context "context"
 	"encoding/json"
 	"reflect"
 

--- a/pkg/client/injection/reconciler/serving/v1alpha1/configuration/stub/controller.go
+++ b/pkg/client/injection/reconciler/serving/v1alpha1/configuration/stub/controller.go
@@ -19,9 +19,9 @@ limitations under the License.
 package configuration
 
 import (
-	"context"
+	context "context"
 
-	"knative.dev/pkg/configmap"
+	configmap "knative.dev/pkg/configmap"
 	controller "knative.dev/pkg/controller"
 	logging "knative.dev/pkg/logging"
 	configuration "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/configuration"

--- a/pkg/client/injection/reconciler/serving/v1alpha1/configuration/stub/reconciler.go
+++ b/pkg/client/injection/reconciler/serving/v1alpha1/configuration/stub/reconciler.go
@@ -19,7 +19,7 @@ limitations under the License.
 package configuration
 
 import (
-	"context"
+	context "context"
 
 	v1 "k8s.io/api/core/v1"
 	reconciler "knative.dev/pkg/reconciler"

--- a/pkg/reconciler/autoscaling/hpa/controller.go
+++ b/pkg/reconciler/autoscaling/hpa/controller.go
@@ -53,6 +53,8 @@ func NewController(
 	serviceInformer := serviceinformer.Get(ctx)
 	metricInformer := metricinformer.Get(ctx)
 
+	onlyHpaClass := reconciler.AnnotationFilterFunc(autoscaling.ClassAnnotationKey, autoscaling.HPA, false)
+
 	c := &Reconciler{
 		Base: &areconciler.Base{
 			Base:              reconciler.NewBase(ctx, controllerAgentName, cmw),
@@ -64,10 +66,21 @@ func NewController(
 		},
 		hpaLister: hpaInformer.Lister(),
 	}
-	impl := pareconciler.NewImpl(ctx, c)
+	impl := pareconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
+		c.Logger.Info("Setting up ConfigMap receivers")
+		configsToResync := []interface{}{
+			&autoscalerconfig.Config{},
+		}
+		resync := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
+			impl.FilteredGlobalResync(onlyHpaClass, paInformer.Informer())
+		})
+		configStore := config.NewStore(c.Logger.Named("config-store"), resync)
+		configStore.WatchConfigs(cmw)
+		return controller.Options{ConfigStore: configStore}
+	})
 
 	c.Logger.Info("Setting up hpa-class event handlers")
-	onlyHpaClass := reconciler.AnnotationFilterFunc(autoscaling.ClassAnnotationKey, autoscaling.HPA, false)
+
 	paHandler := cache.FilteringResourceEventHandler{
 		FilterFunc: onlyHpaClass,
 		Handler:    controller.HandleAll(impl.Enqueue),
@@ -88,17 +101,6 @@ func NewController(
 		FilterFunc: onlyHpaClass,
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
-
-	c.Logger.Info("Setting up ConfigMap receivers")
-	configsToResync := []interface{}{
-		&autoscalerconfig.Config{},
-	}
-	resync := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
-		impl.FilteredGlobalResync(onlyHpaClass, paInformer.Informer())
-	})
-	configStore := config.NewStore(c.Logger.Named("config-store"), resync)
-	configStore.WatchConfigs(cmw)
-	c.ConfigStore = configStore
 
 	return impl
 }

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -46,12 +46,7 @@ type Reconciler struct {
 var _ pareconciler.Interface = (*Reconciler)(nil)
 
 func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutoscaler) pkgreconciler.Event {
-	if pa.GetDeletionTimestamp() != nil {
-		return nil
-	}
 	logger := logging.FromContext(ctx)
-	// TODO(n3wscott): We should not need this.
-	ctx = c.ConfigStore.ToContext(ctx)
 
 	// We may be reading a version of the object that was stored at an older version
 	// and may not have had all of the assumed defaults specified.  This won't result

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -45,6 +45,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
+	pkgrec "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	asv1a1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
@@ -467,13 +468,15 @@ func TestReconcile(t *testing.T) {
 				PALister:          listers.GetPodAutoscalerLister(),
 				SKSLister:         listers.GetServerlessServiceLister(),
 				MetricLister:      listers.GetMetricLister(),
-				ConfigStore:       &testConfigStore{config: defaultConfig()},
 				ServiceLister:     listers.GetK8sServiceLister(),
 				PSInformerFactory: podscalable.Get(ctx),
 			},
 			hpaLister: listers.GetHorizontalPodAutoscalerLister(),
 		}
-		return pareconciler.NewReconciler(ctx, r.Logger, r.ServingClientSet, listers.GetPodAutoscalerLister(), r.Recorder, r)
+		return pareconciler.NewReconciler(ctx, r.Logger, r.ServingClientSet, listers.GetPodAutoscalerLister(), r.Recorder, r,
+			controller.Options{
+				ConfigStore: &testConfigStore{config: defaultConfig()},
+			})
 	}))
 }
 
@@ -601,4 +604,4 @@ func (t *testConfigStore) ToContext(ctx context.Context) context.Context {
 	return config.ToContext(ctx, t.config)
 }
 
-var _ reconciler.ConfigStore = (*testConfigStore)(nil)
+var _ pkgrec.ConfigStore = (*testConfigStore)(nil)

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -68,12 +68,7 @@ type Reconciler struct {
 var _ pareconciler.Interface = (*Reconciler)(nil)
 
 func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutoscaler) pkgreconciler.Event {
-	if pa.GetDeletionTimestamp() != nil {
-		return nil
-	}
 	logger := logging.FromContext(ctx)
-	// TODO(n3wscott): We should not need this.
-	ctx = c.ConfigStore.ToContext(ctx)
 
 	// We may be reading a version of the object that was stored at an older version
 	// and may not have had all of the assumed defaults specified.  This won't result

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -55,6 +55,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/ptr"
+	pkgrec "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
 	"knative.dev/serving/pkg/apis/autoscaling"
@@ -1001,7 +1002,6 @@ func TestReconcile(t *testing.T) {
 				SKSLister:         listers.GetServerlessServiceLister(),
 				ServiceLister:     listers.GetK8sServiceLister(),
 				MetricLister:      listers.GetMetricLister(),
-				ConfigStore:       &testConfigStore{config: defaultConfig()},
 				PSInformerFactory: psf,
 			},
 			endpointsLister: listers.GetEndpointsLister(),
@@ -1009,7 +1009,10 @@ func TestReconcile(t *testing.T) {
 			deciders:        fakeDeciders,
 			scaler:          scaler,
 		}
-		return pareconciler.NewReconciler(ctx, r.Logger, r.ServingClientSet, listers.GetPodAutoscalerLister(), r.Recorder, r)
+		return pareconciler.NewReconciler(ctx, r.Logger, r.ServingClientSet, listers.GetPodAutoscalerLister(), r.Recorder, r,
+			controller.Options{
+				ConfigStore: &testConfigStore{config: defaultConfig()},
+			})
 	}))
 }
 
@@ -1582,7 +1585,7 @@ func (t *testConfigStore) ToContext(ctx context.Context) context.Context {
 	return config.ToContext(ctx, t.config)
 }
 
-var _ reconciler.ConfigStore = (*testConfigStore)(nil)
+var _ pkgrec.ConfigStore = (*testConfigStore)(nil)
 
 func TestMetricsReporter(t *testing.T) {
 	pa := kpa(testNamespace, testRevision)

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -19,7 +19,6 @@ package autoscaling
 import (
 	"context"
 	"fmt"
-
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/logging"
 	"knative.dev/serving/pkg/apis/autoscaling"
@@ -47,7 +46,6 @@ type Base struct {
 	ServiceLister     corev1listers.ServiceLister
 	SKSLister         nlisters.ServerlessServiceLister
 	MetricLister      listers.MetricLister
-	ConfigStore       reconciler.ConfigStore
 	PSInformerFactory duck.InformerFactory
 }
 

--- a/pkg/reconciler/certificate/certificate.go
+++ b/pkg/reconciler/certificate/certificate.go
@@ -79,7 +79,7 @@ type Reconciler struct {
 	certManagerClient   certmanagerclientset.Interface
 	tracker             tracker.Interface
 
-	configStore reconciler.ConfigStore
+	configStore pkgreconciler.ConfigStore
 }
 
 // Check that our Reconciler implements controller.Reconciler

--- a/pkg/reconciler/certificate/certificate_test.go
+++ b/pkg/reconciler/certificate/certificate_test.go
@@ -43,6 +43,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/reconciler"
@@ -516,7 +517,7 @@ func (t *testConfigStore) ToContext(ctx context.Context) context.Context {
 	return config.ToContext(ctx, t.config)
 }
 
-var _ reconciler.ConfigStore = (*testConfigStore)(nil)
+var _ pkgreconciler.ConfigStore = (*testConfigStore)(nil)
 
 func certmanagerConfig() *config.CertManagerConfig {
 	return &config.CertManagerConfig{

--- a/pkg/reconciler/gc/controller.go
+++ b/pkg/reconciler/gc/controller.go
@@ -36,21 +36,6 @@ const (
 	controllerAgentName = "revision-gc-controller"
 )
 
-//
-//func configStore () {
-//	configsToResync := []interface{}{
-//		&gcconfig.Config{},
-//	}
-//	resync := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
-//		// Triggers syncs on all revisions when configuration changes.
-//		impl.GlobalResync(revisionInformer.Informer())
-//	})
-//
-//	c.Logger.Info("Setting up ConfigMap receivers")
-//	configStore := configns.NewStore(logging.WithLogger(ctx, c.Logger.Named("config-store")), resync)
-//	configStore.WatchConfigs(c.ConfigMapWatcher)
-//}
-
 // NewController creates a new Garbage Collection controller
 func NewController(
 	ctx context.Context,

--- a/pkg/reconciler/gc/gc.go
+++ b/pkg/reconciler/gc/gc.go
@@ -43,17 +43,12 @@ type reconciler struct {
 	// listers index properties about resources
 	configurationLister listers.ConfigurationLister
 	revisionLister      listers.RevisionLister
-
-	configStore spkgreconciler.ConfigStore
 }
 
 // Check that our reconciler implements configreconciler.Interface
 var _ configreconciler.Interface = (*reconciler)(nil)
 
 func (c *reconciler) ReconcileKind(ctx context.Context, config *v1alpha1.Configuration) pkgreconciler.Event {
-	// TODO(n3wscott): We should not need this.
-	ctx = c.configStore.ToContext(ctx)
-
 	cfg := configns.FromContext(ctx).RevisionGC
 	logger := logging.FromContext(ctx)
 

--- a/pkg/reconciler/gc/gc_test.go
+++ b/pkg/reconciler/gc/gc_test.go
@@ -186,7 +186,9 @@ func TestGCReconcile(t *testing.T) {
 			Base:                pkgreconciler.NewBase(ctx, controllerAgentName, cmw),
 			configurationLister: listers.GetConfigurationLister(),
 			revisionLister:      listers.GetRevisionLister(),
-			configStore: &testConfigStore{
+		}
+		return configreconciler.NewReconciler(ctx, r.Logger, r.ServingClientSet, listers.GetConfigurationLister(), r.Recorder, r, controller.Options{
+			ConfigStore: &testConfigStore{
 				config: &config.Config{
 					RevisionGC: &gcconfig.Config{
 						StaleRevisionCreateDelay:        5 * time.Minute,
@@ -194,9 +196,7 @@ func TestGCReconcile(t *testing.T) {
 						StaleRevisionMinimumGenerations: 2,
 					},
 				},
-			},
-		}
-		return configreconciler.NewReconciler(ctx, r.Logger, r.ServingClientSet, listers.GetConfigurationLister(), r.Recorder, r)
+			}})
 	}))
 }
 

--- a/pkg/reconciler/gc/gc_test.go
+++ b/pkg/reconciler/gc/gc_test.go
@@ -31,6 +31,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/ptr"
+	pkgrec "knative.dev/pkg/reconciler"
 	. "knative.dev/pkg/reconciler/testing"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -358,4 +359,4 @@ func (t *testConfigStore) ToContext(ctx context.Context) context.Context {
 	return config.ToContext(ctx, t.config)
 }
 
-var _ pkgreconciler.ConfigStore = (*testConfigStore)(nil)
+var _ pkgrec.ConfigStore = (*testConfigStore)(nil)

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -83,7 +83,7 @@ type Reconciler struct {
 	secretLister         corev1listers.SecretLister
 	ingressLister        listers.IngressLister
 
-	configStore reconciler.ConfigStore
+	configStore pkgreconciler.ConfigStore
 	tracker     tracker.Interface
 	finalizer   string
 

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -55,6 +55,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
+	pkgreconciler "knative.dev/pkg/reconciler"
 
 	pkgnet "knative.dev/pkg/network"
 	"knative.dev/pkg/system"
@@ -1129,7 +1130,7 @@ func (t *testConfigStore) ToContext(ctx context.Context) context.Context {
 	return config.ToContext(ctx, t.config)
 }
 
-var _ reconciler.ConfigStore = (*testConfigStore)(nil)
+var _ pkgreconciler.ConfigStore = (*testConfigStore)(nil)
 
 func ReconcilerTestConfig() *config.Config {
 	return &config.Config{

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -53,11 +53,6 @@ const (
 }]`
 )
 
-// ConfigStore is a minimal interface to the config stores used by our controllers.
-type ConfigStore interface {
-	ToContext(ctx context.Context) context.Context
-}
-
 // Base implements the core controller logic, given a Reconciler.
 type Base struct {
 	// KubeClientSet allows us to talk to the k8s for core APIs

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -62,7 +62,7 @@ type Reconciler struct {
 	configMapLister     corev1listers.ConfigMapLister
 
 	resolver    resolver
-	configStore reconciler.ConfigStore
+	configStore pkgreconciler.ConfigStore
 }
 
 // Check that our Reconciler implements controller.Reconciler

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -31,6 +31,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	tracingconfig "knative.dev/pkg/tracing/config"
 	asv1a1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/networking"
@@ -729,7 +730,7 @@ func (t *testConfigStore) ToContext(ctx context.Context) context.Context {
 	return config.ToContext(ctx, t.config)
 }
 
-var _ reconciler.ConfigStore = (*testConfigStore)(nil)
+var _ pkgreconciler.ConfigStore = (*testConfigStore)(nil)
 
 func ReconcilerTestConfig() *config.Config {
 	return &config.Config{

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -18,6 +18,7 @@ package route
 
 import (
 	"context"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"sort"
 	"strings"
 
@@ -79,7 +80,7 @@ type Reconciler struct {
 	serviceLister       corev1listers.ServiceLister
 	ingressLister       networkinglisters.IngressLister
 	certificateLister   networkinglisters.CertificateLister
-	configStore         reconciler.ConfigStore
+	configStore         pkgreconciler.ConfigStore
 	tracker             tracker.Interface
 
 	clock system.Clock

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -22,14 +22,11 @@ import (
 	"testing"
 	"time"
 
-	"knative.dev/serving/pkg/apis/networking"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	clientgotesting "k8s.io/client-go/testing"
 
 	"knative.dev/pkg/apis"
@@ -38,7 +35,9 @@ import (
 	"knative.dev/pkg/kmeta"
 	pkgnet "knative.dev/pkg/network"
 	"knative.dev/pkg/ptr"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/tracker"
+	"knative.dev/serving/pkg/apis/networking"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -2707,7 +2706,7 @@ func (t *testConfigStore) ToContext(ctx context.Context) context.Context {
 	return config.ToContext(ctx, t.config)
 }
 
-var _ reconciler.ConfigStore = (*testConfigStore)(nil)
+var _ pkgreconciler.ConfigStore = (*testConfigStore)(nil)
 
 func ReconcilerTestConfig(enableAutoTLS bool) *config.Config {
 	return &config.Config{

--- a/third_party/VENDOR-LICENSE
+++ b/third_party/VENDOR-LICENSE
@@ -6590,214 +6590,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 ===========================================================
-Import: knative.dev/serving/vendor/github.com/mattbaird/jsonpatch
-
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright {yyyy} {name of copyright owner}
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-
-
-
-===========================================================
 Import: knative.dev/serving/vendor/github.com/matttproud/golang_protobuf_extensions
 
                                  Apache License
@@ -9067,6 +8859,214 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+===========================================================
+Import: knative.dev/serving/vendor/gomodules.xyz/jsonpatch
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
 
 
 

--- a/vendor/gomodules.xyz/jsonpatch/LICENSE
+++ b/vendor/gomodules.xyz/jsonpatch/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/gomodules.xyz/jsonpatch/v2/jsonpatch.go
+++ b/vendor/gomodules.xyz/jsonpatch/v2/jsonpatch.go
@@ -1,0 +1,336 @@
+package jsonpatch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+var errBadJSONDoc = fmt.Errorf("invalid JSON Document")
+
+type JsonPatchOperation = Operation
+
+type Operation struct {
+	Operation string      `json:"op"`
+	Path      string      `json:"path"`
+	Value     interface{} `json:"value,omitempty"`
+}
+
+func (j *Operation) Json() string {
+	b, _ := json.Marshal(j)
+	return string(b)
+}
+
+func (j *Operation) MarshalJSON() ([]byte, error) {
+	var b bytes.Buffer
+	b.WriteString("{")
+	b.WriteString(fmt.Sprintf(`"op":"%s"`, j.Operation))
+	b.WriteString(fmt.Sprintf(`,"path":"%s"`, j.Path))
+	// Consider omitting Value for non-nullable operations.
+	if j.Value != nil || j.Operation == "replace" || j.Operation == "add" {
+		v, err := json.Marshal(j.Value)
+		if err != nil {
+			return nil, err
+		}
+		b.WriteString(`,"value":`)
+		b.Write(v)
+	}
+	b.WriteString("}")
+	return b.Bytes(), nil
+}
+
+type ByPath []Operation
+
+func (a ByPath) Len() int           { return len(a) }
+func (a ByPath) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByPath) Less(i, j int) bool { return a[i].Path < a[j].Path }
+
+func NewPatch(operation, path string, value interface{}) Operation {
+	return Operation{Operation: operation, Path: path, Value: value}
+}
+
+// CreatePatch creates a patch as specified in http://jsonpatch.com/
+//
+// 'a' is original, 'b' is the modified document. Both are to be given as json encoded content.
+// The function will return an array of JsonPatchOperations
+//
+// An error will be returned if any of the two documents are invalid.
+func CreatePatch(a, b []byte) ([]Operation, error) {
+	var aI interface{}
+	var bI interface{}
+	err := json.Unmarshal(a, &aI)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+	err = json.Unmarshal(b, &bI)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+	return handleValues(aI, bI, "", []Operation{})
+}
+
+// Returns true if the values matches (must be json types)
+// The types of the values must match, otherwise it will always return false
+// If two map[string]interface{} are given, all elements must match.
+func matchesValue(av, bv interface{}) bool {
+	if reflect.TypeOf(av) != reflect.TypeOf(bv) {
+		return false
+	}
+	switch at := av.(type) {
+	case string:
+		bt, ok := bv.(string)
+		if ok && bt == at {
+			return true
+		}
+	case float64:
+		bt, ok := bv.(float64)
+		if ok && bt == at {
+			return true
+		}
+	case bool:
+		bt, ok := bv.(bool)
+		if ok && bt == at {
+			return true
+		}
+	case map[string]interface{}:
+		bt, ok := bv.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		for key := range at {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		for key := range bt {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		return true
+	case []interface{}:
+		bt, ok := bv.([]interface{})
+		if !ok {
+			return false
+		}
+		if len(bt) != len(at) {
+			return false
+		}
+		for key := range at {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		for key := range bt {
+			if !matchesValue(at[key], bt[key]) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// From http://tools.ietf.org/html/rfc6901#section-4 :
+//
+// Evaluation of each reference token begins by decoding any escaped
+// character sequence.  This is performed by first transforming any
+// occurrence of the sequence '~1' to '/', and then transforming any
+// occurrence of the sequence '~0' to '~'.
+//   TODO decode support:
+//   var rfc6901Decoder = strings.NewReplacer("~1", "/", "~0", "~")
+
+var rfc6901Encoder = strings.NewReplacer("~", "~0", "/", "~1")
+
+func makePath(path string, newPart interface{}) string {
+	key := rfc6901Encoder.Replace(fmt.Sprintf("%v", newPart))
+	if path == "" {
+		return "/" + key
+	}
+	if strings.HasSuffix(path, "/") {
+		return path + key
+	}
+	return path + "/" + key
+}
+
+// diff returns the (recursive) difference between a and b as an array of JsonPatchOperations.
+func diff(a, b map[string]interface{}, path string, patch []Operation) ([]Operation, error) {
+	for key, bv := range b {
+		p := makePath(path, key)
+		av, ok := a[key]
+		// value was added
+		if !ok {
+			patch = append(patch, NewPatch("add", p, bv))
+			continue
+		}
+		// Types are the same, compare values
+		var err error
+		patch, err = handleValues(av, bv, p, patch)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Now add all deleted values as nil
+	for key := range a {
+		_, found := b[key]
+		if !found {
+			p := makePath(path, key)
+
+			patch = append(patch, NewPatch("remove", p, nil))
+		}
+	}
+	return patch, nil
+}
+
+func handleValues(av, bv interface{}, p string, patch []Operation) ([]Operation, error) {
+	{
+		at := reflect.TypeOf(av)
+		bt := reflect.TypeOf(bv)
+		if at == nil && bt == nil {
+			// do nothing
+			return patch, nil
+		} else if at == nil && bt != nil {
+			return append(patch, NewPatch("add", p, bv)), nil
+		} else if at != bt {
+			// If types have changed, replace completely (preserves null in destination)
+			return append(patch, NewPatch("replace", p, bv)), nil
+		}
+	}
+
+	var err error
+	switch at := av.(type) {
+	case map[string]interface{}:
+		bt := bv.(map[string]interface{})
+		patch, err = diff(at, bt, p, patch)
+		if err != nil {
+			return nil, err
+		}
+	case string, float64, bool:
+		if !matchesValue(av, bv) {
+			patch = append(patch, NewPatch("replace", p, bv))
+		}
+	case []interface{}:
+		bt := bv.([]interface{})
+		if isSimpleArray(at) && isSimpleArray(bt) {
+			patch = append(patch, compareEditDistance(at, bt, p)...)
+		} else {
+			n := min(len(at), len(bt))
+			for i := len(at) - 1; i >= n; i-- {
+				patch = append(patch, NewPatch("remove", makePath(p, i), nil))
+			}
+			for i := n; i < len(bt); i++ {
+				patch = append(patch, NewPatch("add", makePath(p, i), bt[i]))
+			}
+			for i := 0; i < n; i++ {
+				var err error
+				patch, err = handleValues(at[i], bt[i], makePath(p, i), patch)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	default:
+		panic(fmt.Sprintf("Unknown type:%T ", av))
+	}
+	return patch, nil
+}
+
+func isBasicType(a interface{}) bool {
+	switch a.(type) {
+	case string, float64, bool:
+	default:
+		return false
+	}
+	return true
+}
+
+func isSimpleArray(a []interface{}) bool {
+	for i := range a {
+		switch a[i].(type) {
+		case string, float64, bool:
+		default:
+			val := reflect.ValueOf(a[i])
+			if val.Kind() == reflect.Map {
+				for _, k := range val.MapKeys() {
+					av := val.MapIndex(k)
+					if av.Kind() == reflect.Ptr || av.Kind() == reflect.Interface {
+						if av.IsNil() {
+							continue
+						}
+						av = av.Elem()
+					}
+					if av.Kind() != reflect.String && av.Kind() != reflect.Float64 && av.Kind() != reflect.Bool {
+						return false
+					}
+				}
+				return true
+			}
+			return false
+		}
+	}
+	return true
+}
+
+// https://en.wikipedia.org/wiki/Wagner%E2%80%93Fischer_algorithm
+// Adapted from https://github.com/texttheater/golang-levenshtein
+func compareEditDistance(s, t []interface{}, p string) []Operation {
+	m := len(s)
+	n := len(t)
+
+	d := make([][]int, m+1)
+	for i := 0; i <= m; i++ {
+		d[i] = make([]int, n+1)
+		d[i][0] = i
+	}
+	for j := 0; j <= n; j++ {
+		d[0][j] = j
+	}
+
+	for j := 1; j <= n; j++ {
+		for i := 1; i <= m; i++ {
+			if reflect.DeepEqual(s[i-1], t[j-1]) {
+				d[i][j] = d[i-1][j-1] // no op required
+			} else {
+				del := d[i-1][j] + 1
+				add := d[i][j-1] + 1
+				rep := d[i-1][j-1] + 1
+				d[i][j] = min(rep, min(add, del))
+			}
+		}
+	}
+
+	return backtrace(s, t, p, m, n, d)
+}
+
+func min(x int, y int) int {
+	if y < x {
+		return y
+	}
+	return x
+}
+
+func backtrace(s, t []interface{}, p string, i int, j int, matrix [][]int) []Operation {
+	if i > 0 && matrix[i-1][j]+1 == matrix[i][j] {
+		op := NewPatch("remove", makePath(p, i-1), nil)
+		return append([]Operation{op}, backtrace(s, t, p, i-1, j, matrix)...)
+	}
+	if j > 0 && matrix[i][j-1]+1 == matrix[i][j] {
+		op := NewPatch("add", makePath(p, i), t[j-1])
+		return append([]Operation{op}, backtrace(s, t, p, i, j-1, matrix)...)
+	}
+	if i > 0 && j > 0 && matrix[i-1][j-1]+1 == matrix[i][j] {
+		if isBasicType(s[0]) {
+			op := NewPatch("replace", makePath(p, i-1), t[j-1])
+			return append([]Operation{op}, backtrace(s, t, p, i-1, j-1, matrix)...)
+		}
+
+		p2, _ := handleValues(s[i-1], t[j-1], makePath(p, i-1), []Operation{})
+		return append(p2, backtrace(s, t, p, i-1, j-1, matrix)...)
+	}
+	if i > 0 && j > 0 && matrix[i-1][j-1] == matrix[i][j] {
+		return backtrace(s, t, p, i-1, j-1, matrix)
+	}
+	return []Operation{}
+}

--- a/vendor/knative.dev/pkg/Gopkg.lock
+++ b/vendor/knative.dev/pkg/Gopkg.lock
@@ -423,14 +423,6 @@
   version = "v1.0.4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:0e9bfc47ab9941ecc3344e580baca5deb4091177e84dd9773b48b38ec26b93d5"
-  name = "github.com/mattbaird/jsonpatch"
-  packages = ["."]
-  pruneopts = "NUT"
-  revision = "81af80346b1a01caae0cbc27fd3c1ba5b11e189f"
-
-[[projects]]
   digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
@@ -751,6 +743,14 @@
   ]
   pruneopts = "NUT"
   revision = "8b927904ee0dec805c89aaf9172f4459296ed6e8"
+
+[[projects]]
+  digest = "1:8392b5c29adedc5f85c66b48bb53b6c49dd91d8540f3cad5d43ef7277946718f"
+  name = "gomodules.xyz/jsonpatch"
+  packages = ["v2"]
+  pruneopts = "NUT"
+  revision = "e8422f09d27ee2c8cfb2c7f8089eb9eeb0764849"
+  version = "v2.0.1"
 
 [[projects]]
   digest = "1:081608ceb454c46b54d24b7561e5744088f3ff69478b23f50277ec83bd8636b0"
@@ -1323,14 +1323,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9fc1b7e84778267884b614c45b0939aa8984dcab5794eb3c6bb5e57bd0a99c41"
+  digest = "1:d2545cd71ef3604f5d2d792e569c6e3a4df31e336d76e709b0b8bac759c0faf7"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "1b5477b12d75ea7210d970ff9a234277dcd9ee18"
+  revision = "c7c50ccd8082344a5f8ea85a5ae8de59308d325c"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"
@@ -1371,7 +1371,6 @@
     "github.com/gorilla/websocket",
     "github.com/kballard/go-shellquote",
     "github.com/markbates/inflect",
-    "github.com/mattbaird/jsonpatch",
     "github.com/openzipkin/zipkin-go",
     "github.com/openzipkin/zipkin-go/model",
     "github.com/openzipkin/zipkin-go/reporter",
@@ -1397,6 +1396,7 @@
     "golang.org/x/net/http2/h2c",
     "golang.org/x/oauth2",
     "golang.org/x/sync/errgroup",
+    "gomodules.xyz/jsonpatch/v2",
     "google.golang.org/api/container/v1beta1",
     "google.golang.org/api/iterator",
     "google.golang.org/api/option",

--- a/vendor/knative.dev/pkg/apis/duck/patch.go
+++ b/vendor/knative.dev/pkg/apis/duck/patch.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 
 	jsonmergepatch "github.com/evanphx/json-patch"
-	"github.com/mattbaird/jsonpatch"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
 )
 
 func marshallBeforeAfter(before, after interface{}) ([]byte, []byte, error) {

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -133,6 +133,10 @@ func (g *reconcilerControllerGenerator) GenerateType(c *generator.Context, t *ty
 			Package: "knative.dev/pkg/controller",
 			Name:    "OptionsFn",
 		}),
+		"contextContext": c.Universe.Type(types.Name{
+			Package: "context",
+			Name:    "Context",
+		}),
 	}
 
 	sw.Do(reconcilerControllerNewImpl, m)
@@ -151,7 +155,7 @@ const (
 // the queue through an implementation of {{.controllerReconciler|raw}}, delegating to
 // the provided Interface and optional Finalizer methods. OptionsFn is used to return
 // {{.controllerOptions|raw}} to be used but the internal reconciler.
-func NewImpl(ctx context.Context, r Interface, optionsFns ...{{.controllerOptionsFn|raw}}) *{{.controllerImpl|raw}} {
+func NewImpl(ctx {{.contextContext|raw}}, r Interface, optionsFns ...{{.controllerOptionsFn|raw}}) *{{.controllerImpl|raw}} {
 	logger := {{.loggingFromContext|raw}}(ctx)
 
 	// Check the options function input. It should be 0 or 1.

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -125,6 +125,14 @@ func (g *reconcilerControllerGenerator) GenerateType(c *generator.Context, t *ty
 			Package: "knative.dev/pkg/controller",
 			Name:    "GetEventRecorder",
 		}),
+		"controllerOptions": c.Universe.Type(types.Name{
+			Package: "knative.dev/pkg/controller",
+			Name:    "Options",
+		}),
+		"controllerOptionsFn": c.Universe.Type(types.Name{
+			Package: "knative.dev/pkg/controller",
+			Name:    "OptionsFn",
+		}),
 	}
 
 	sw.Do(reconcilerControllerNewImpl, m)
@@ -141,9 +149,16 @@ const (
 
 // NewImpl returns a {{.controllerImpl|raw}} that handles queuing and feeding work from
 // the queue through an implementation of {{.controllerReconciler|raw}}, delegating to
-// the provided Interface and optional Finalizer methods.
-func NewImpl(ctx context.Context, r Interface) *{{.controllerImpl|raw}} {
+// the provided Interface and optional Finalizer methods. OptionsFn is used to return
+// {{.controllerOptions|raw}} to be used but the internal reconciler.
+func NewImpl(ctx context.Context, r Interface, optionsFns ...{{.controllerOptionsFn|raw}}) *{{.controllerImpl|raw}} {
 	logger := {{.loggingFromContext|raw}}(ctx)
+
+	// Check the options function input. It should be 0 or 1.
+	if len(optionsFns) > 1 {
+		logger.Fatalf("up to one options function is supported, found %d", len(optionsFns))
+	}
+
 	{{.type|lowercaseSingular}}Informer := {{.informerGet|raw}}(ctx)
 
 	recorder := {{.controllerGetEventRecorder|raw}}(ctx)
@@ -171,7 +186,17 @@ func NewImpl(ctx context.Context, r Interface) *{{.controllerImpl|raw}} {
 		Recorder: recorder,
 		reconciler:    r,
 	}
-	return {{.controllerNewImpl|raw}}(rec, logger, defaultQueueName)
+	impl := {{.controllerNewImpl|raw}}(rec, logger, defaultQueueName)
+
+	// Pass impl to the options. Save any optional results.
+	for _, fn := range optionsFns {
+		opts := fn(impl)
+		if opts.ConfigStore != nil {
+			rec.configStore = opts.ConfigStore
+		}
+	}
+
+	return impl
 }
 
 func init() {

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
@@ -18,7 +18,6 @@ package generators
 
 import (
 	"io"
-
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
@@ -75,6 +74,14 @@ func (g *reconcilerControllerStubGenerator) GenerateType(c *generator.Context, t
 			Package: "knative.dev/pkg/logging",
 			Name:    "FromContext",
 		}),
+		"contextContext": c.Universe.Type(types.Name{
+			Package: "context",
+			Name:    "Context",
+		}),
+		"configmapWatcher": c.Universe.Type(types.Name{
+			Package: "knative.dev/pkg/configmap",
+			Name:    "Watcher",
+		}),
 	}
 
 	sw.Do(reconcilerControllerStub, m)
@@ -87,8 +94,8 @@ var reconcilerControllerStub = `
 
 // NewController creates a Reconciler for {{.type|public}} and returns the result of NewImpl.
 func NewController(
-	ctx context.Context,
-	cmw configmap.Watcher,
+	ctx {{.contextContext|raw}},
+	cmw {{.configmapWatcher|raw}},
 ) *{{.controllerImpl|raw}} {
 	logger := {{.loggingFromContext|raw}}(ctx)
 

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
@@ -81,6 +81,10 @@ func (g *reconcilerReconcilerStubGenerator) GenerateType(c *generator.Context, t
 			Package: "k8s.io/api/core/v1",
 			Name:    "EventTypeNormal",
 		}),
+		"contextContext": c.Universe.Type(types.Name{
+			Package: "context",
+			Name:    "Context",
+		}),
 	}
 
 	sw.Do(reconcilerReconcilerStub, m)
@@ -110,7 +114,7 @@ var _ {{.reconcilerInterface|raw}} = (*Reconciler)(nil)
 
 
 // ReconcileKind implements Interface.ReconcileKind.
-func (r *Reconciler) ReconcileKind(ctx context.Context, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
+func (r *Reconciler) ReconcileKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
 	o.Status.InitializeConditions()
 
 	// TODO: add custom reconciliation logic here.
@@ -121,7 +125,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, o *{{.type|raw}}) {{.rec
 
 // Optionally, use FinalizeKind to add finalizers. FinalizeKind will be called
 // when the resource is deleted.
-//func (r *Reconciler) FinalizeKind(ctx context.Context, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
+//func (r *Reconciler) FinalizeKind(ctx {{.contextContext|raw}}, o *{{.type|raw}}) {{.reconcilerEvent|raw}} {
 //	// TODO: add custom finalization logic here.
 //	return nil
 //}

--- a/vendor/knative.dev/pkg/controller/controller.go
+++ b/vendor/knative.dev/pkg/controller/controller.go
@@ -86,15 +86,48 @@ func HandleAll(h func(interface{})) cache.ResourceEventHandler {
 // Filter makes it simple to create FilterFunc's for use with
 // cache.FilteringResourceEventHandler that filter based on the
 // schema.GroupVersionKind of the controlling resources.
+//
+// Deprecated: Use FilterGroupVersionKind or FilterGroupKind instead
 func Filter(gvk schema.GroupVersionKind) func(obj interface{}) bool {
+	return FilterGroupVersionKind(gvk)
+}
+
+// FilterGroupVersionKind makes it simple to create FilterFunc's for use with
+// cache.FilteringResourceEventHandler that filter based on the
+// schema.GroupVersionKind of the controlling resources.
+func FilterGroupVersionKind(gvk schema.GroupVersionKind) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
-		if object, ok := obj.(metav1.Object); ok {
-			owner := metav1.GetControllerOf(object)
-			return owner != nil &&
-				owner.APIVersion == gvk.GroupVersion().String() &&
-				owner.Kind == gvk.Kind
+		object, ok := obj.(metav1.Object)
+		if !ok {
+			return false
 		}
-		return false
+
+		owner := metav1.GetControllerOf(object)
+		return owner != nil &&
+			owner.APIVersion == gvk.GroupVersion().String() &&
+			owner.Kind == gvk.Kind
+	}
+}
+
+// FilterGroupKind makes it simple to create FilterFunc's for use with
+// cache.FilteringResourceEventHandler that filter based on the
+// schema.GroupKind of the controlling resources.
+func FilterGroupKind(gk schema.GroupKind) func(obj interface{}) bool {
+	return func(obj interface{}) bool {
+		object, ok := obj.(metav1.Object)
+		if !ok {
+			return false
+		}
+
+		owner := metav1.GetControllerOf(object)
+		if owner == nil {
+			return false
+		}
+
+		ownerGV, err := schema.ParseGroupVersion(owner.APIVersion)
+		return err == nil &&
+			ownerGV.Group == gk.Group &&
+			owner.Kind == gk.Kind
 	}
 }
 

--- a/vendor/knative.dev/pkg/controller/options.go
+++ b/vendor/knative.dev/pkg/controller/options.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import "knative.dev/pkg/reconciler"
+
+// Options is additional resources a Controller might want to use depending
+// on implementation.
+type Options struct {
+	// ConfigStore is used to attach the frozen configuration to the context.
+	ConfigStore reconciler.ConfigStore
+}
+
+// OptionsFn is a callback method signature that accepts an Impl and returns
+// Options. Used for controllers that need access to the members of Options but
+// to build Options, integrators need an Impl.
+type OptionsFn func(impl *Impl) Options

--- a/vendor/knative.dev/pkg/reconciler/configstore.go
+++ b/vendor/knative.dev/pkg/reconciler/configstore.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Veroute.on 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import "context"
+
+// ConfigStore is used to attach the frozen configuration to the context.
+type ConfigStore interface {
+	// ConfigStore is used to attach the frozen configuration to the context.
+	ToContext(ctx context.Context) context.Context
+}

--- a/vendor/knative.dev/pkg/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/vendor/knative.dev/pkg/webhook/resourcesemantics/defaulting/defaulting.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 
 	"github.com/markbates/inflect"
-	"github.com/mattbaird/jsonpatch"
 	"go.uber.org/zap"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/vendor/knative.dev/pkg/webhook/testing/testing.go
+++ b/vendor/knative.dev/pkg/webhook/testing/testing.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/mattbaird/jsonpatch"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/system"


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Use configStore from generated reconcilers.
* Delete reconciler.ConfigStore interface out of serving, use new reconciler.ConfigStore from pkg.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
