### PR TITLE
Attempt to deflake the KPA test

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1144,11 +1144,11 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 	newDeployment(t, fakedynamicclient.Get(ctx), testRevision+"-deployment", 3)
 
 	kpa := revisionresources.MakePA(rev)
-	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
-
 	sks := sks(testNamespace, testRevision, WithDeployRef(kpa.Spec.ScaleTargetRef.Name),
 		WithSKSReady)
 	fakeservingclient.Get(ctx).NetworkingV1alpha1().ServerlessServices(testNamespace).Create(sks)
+
+	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
 
 	select {
 	case <-time.After(5 * time.Second):

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -81,7 +81,7 @@ func (c *Base) ReconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler, m
 			}
 		}
 	}
-	logger.Debug("Done reconciling SKS", sksName)
+	logger.Debug("Done reconciling SKS ", sksName)
 	return sks, nil
 }
 


### PR DESCRIPTION
This one is a tricky one.
 The test is:

- create KPA
- create SKS
- wait for decider to be created

Step 1 will trigger reconciliation.
Inside that process:

```go
if not sks_exists:
  create_sks
  return
create_decider
```

So if fake SKS is not _yet_ created by the time reconciliation reaches
SKS existence check
decider will never be created...

This kind of has always existed, but somehow until recent reconciler
refactors was not surfacing
I did `go test` and `go test -race` with `-count=20` and no flakes
were observed on my machine :-)

/assign mattmoor @markusthoemmes 