### PR TITLE
Drop primary-key listers.

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/controller.go
+++ b/pkg/reconciler/autoscaling/hpa/controller.go
@@ -58,7 +58,6 @@ func NewController(
 	c := &Reconciler{
 		Base: &areconciler.Base{
 			Base:              reconciler.NewBase(ctx, controllerAgentName, cmw),
-			PALister:          paInformer.Lister(),
 			SKSLister:         sksInformer.Lister(),
 			ServiceLister:     serviceInformer.Lister(),
 			MetricLister:      metricInformer.Lister(),

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -465,7 +465,6 @@ func TestReconcile(t *testing.T) {
 		r := &Reconciler{
 			Base: &areconciler.Base{
 				Base:              reconciler.NewBase(ctx, controllerAgentName, cmw),
-				PALister:          listers.GetPodAutoscalerLister(),
 				SKSLister:         listers.GetServerlessServiceLister(),
 				MetricLister:      listers.GetMetricLister(),
 				ServiceLister:     listers.GetK8sServiceLister(),

--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -65,7 +65,6 @@ func NewController(
 	c := &Reconciler{
 		Base: &areconciler.Base{
 			Base:              reconciler.NewBase(ctx, controllerAgentName, cmw),
-			PALister:          paInformer.Lister(),
 			SKSLister:         sksInformer.Lister(),
 			ServiceLister:     serviceInformer.Lister(),
 			MetricLister:      metricInformer.Lister(),

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -58,6 +58,7 @@ type podCounts struct {
 // information from Deciders.
 type Reconciler struct {
 	*areconciler.Base
+
 	endpointsLister corev1listers.EndpointsLister
 	podsLister      corev1listers.PodLister
 	deciders        resources.Deciders

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -998,7 +998,6 @@ func TestReconcile(t *testing.T) {
 		r := &Reconciler{
 			Base: &areconciler.Base{
 				Base:              reconciler.NewBase(ctx, controllerAgentName, newConfigWatcher()),
-				PALister:          listers.GetPodAutoscalerLister(),
 				SKSLister:         listers.GetServerlessServiceLister(),
 				ServiceLister:     listers.GetK8sServiceLister(),
 				MetricLister:      listers.GetMetricLister(),

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -19,6 +19,7 @@ package autoscaling
 import (
 	"context"
 	"fmt"
+
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/logging"
 	"knative.dev/serving/pkg/apis/autoscaling"
@@ -42,7 +43,6 @@ import (
 // Base implements the core controller logic for autoscaling, given a Reconciler.
 type Base struct {
 	*reconciler.Base
-	PALister          listers.PodAutoscalerLister
 	ServiceLister     corev1listers.ServiceLister
 	SKSLister         nlisters.ServerlessServiceLister
 	MetricLister      listers.MetricLister

--- a/pkg/reconciler/gc/controller.go
+++ b/pkg/reconciler/gc/controller.go
@@ -45,9 +45,8 @@ func NewController(
 	revisionInformer := revisioninformer.Get(ctx)
 
 	c := &reconciler{
-		Base:                pkgreconciler.NewBase(ctx, controllerAgentName, cmw),
-		configurationLister: configurationInformer.Lister(),
-		revisionLister:      revisionInformer.Lister(),
+		Base:           pkgreconciler.NewBase(ctx, controllerAgentName, cmw),
+		revisionLister: revisionInformer.Lister(),
 	}
 	return configreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
 		c.Logger.Info("Setting up event handlers")

--- a/pkg/reconciler/gc/gc.go
+++ b/pkg/reconciler/gc/gc.go
@@ -41,8 +41,7 @@ type reconciler struct {
 	*spkgreconciler.Base
 
 	// listers index properties about resources
-	configurationLister listers.ConfigurationLister
-	revisionLister      listers.RevisionLister
+	revisionLister listers.RevisionLister
 }
 
 // Check that our reconciler implements configreconciler.Interface

--- a/pkg/reconciler/gc/gc_test.go
+++ b/pkg/reconciler/gc/gc_test.go
@@ -184,9 +184,8 @@ func TestGCReconcile(t *testing.T) {
 
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		r := &reconciler{
-			Base:                pkgreconciler.NewBase(ctx, controllerAgentName, cmw),
-			configurationLister: listers.GetConfigurationLister(),
-			revisionLister:      listers.GetRevisionLister(),
+			Base:           pkgreconciler.NewBase(ctx, controllerAgentName, cmw),
+			revisionLister: listers.GetRevisionLister(),
 		}
 		return configreconciler.NewReconciler(ctx, r.Logger, r.ServingClientSet, listers.GetConfigurationLister(), r.Recorder, r, controller.Options{
 			ConfigStore: &testConfigStore{

--- a/pkg/reconciler/metric/controller.go
+++ b/pkg/reconciler/metric/controller.go
@@ -45,9 +45,8 @@ func NewController(
 	metricInformer := metricinformer.Get(ctx)
 
 	c := &reconciler{
-		Base:         pkgreconciler.NewBase(ctx, controllerAgentName, cmw),
-		collector:    collector,
-		metricLister: metricInformer.Lister(),
+		Base:      pkgreconciler.NewBase(ctx, controllerAgentName, cmw),
+		collector: collector,
 	}
 	impl := metricreconciler.NewImpl(ctx, c)
 

--- a/pkg/reconciler/metric/metric.go
+++ b/pkg/reconciler/metric/metric.go
@@ -25,15 +25,14 @@ import (
 
 	pkgreconciler "knative.dev/pkg/reconciler"
 	metricreconciler "knative.dev/serving/pkg/client/injection/reconciler/autoscaling/v1alpha1/metric"
-	listers "knative.dev/serving/pkg/client/listers/autoscaling/v1alpha1"
 	rbase "knative.dev/serving/pkg/reconciler"
 )
 
 // reconciler implements controller.Reconciler for Metric resources.
 type reconciler struct {
 	*rbase.Base
-	collector    metrics.Collector
-	metricLister listers.MetricLister
+
+	collector metrics.Collector
 }
 
 // Check that our Reconciler implements metricreconciler.Interface

--- a/pkg/reconciler/metric/metric_test.go
+++ b/pkg/reconciler/metric/metric_test.go
@@ -150,9 +150,8 @@ func TestReconcile(t *testing.T) {
 			col = c.(*testCollector)
 		}
 		r := &reconciler{
-			Base:         rpkg.NewBase(ctx, controllerAgentName, cmw),
-			collector:    col,
-			metricLister: listers.GetMetricLister(),
+			Base:      rpkg.NewBase(ctx, controllerAgentName, cmw),
+			collector: col,
 		}
 
 		return metricreconciler.NewReconciler(ctx, r.Logger, r.ServingClientSet, listers.GetMetricLister(), r.Recorder, r)

--- a/pkg/reconciler/serverlessservice/controller.go
+++ b/pkg/reconciler/serverlessservice/controller.go
@@ -52,7 +52,6 @@ func NewController(
 		Base:              pkgreconciler.NewBase(ctx, controllerAgentName, cmw),
 		endpointsLister:   endpointsInformer.Lister(),
 		serviceLister:     serviceInformer.Lister(),
-		sksLister:         sksInformer.Lister(),
 		psInformerFactory: podscalable.Get(ctx),
 	}
 	impl := sksreconciler.NewImpl(ctx, c)

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -39,7 +39,6 @@ import (
 	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/apis/networking"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
-	listers "knative.dev/serving/pkg/client/listers/networking/v1alpha1"
 	rbase "knative.dev/serving/pkg/reconciler"
 	"knative.dev/serving/pkg/reconciler/serverlessservice/resources"
 	presources "knative.dev/serving/pkg/resources"
@@ -50,7 +49,6 @@ type reconciler struct {
 	*rbase.Base
 
 	// listers index properties about resources
-	sksLister       listers.ServerlessServiceLister
 	serviceLister   corev1listers.ServiceLister
 	endpointsLister corev1listers.EndpointsLister
 

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -645,7 +645,6 @@ func TestReconcile(t *testing.T) {
 
 		r := &reconciler{
 			Base:              rpkg.NewBase(ctx, controllerAgentName, cmw),
-			sksLister:         listers.GetServerlessServiceLister(),
 			serviceLister:     listers.GetK8sServiceLister(),
 			endpointsLister:   listers.GetEndpointsLister(),
 			psInformerFactory: podscalable.Get(ctx),


### PR DESCRIPTION
The way genreconciler is set up, most of these types no longer need their own listers for their primary key resource because it is simple passed in to and mutations returned from ReconcileKind (and it's ilk).

I had been refraining from doing this in prior changes mostly to simplify things.