### PR TITLE
Silence error logs of probe errors.

### DIFF
--- a/pkg/queue/readiness/probe_test.go
+++ b/pkg/queue/readiness/probe_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package readiness
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"net/http"
@@ -472,9 +473,11 @@ func TestKnHTTPTimeoutFailure(t *testing.T) {
 		},
 	})
 	pb.pollTimeout = time.Second
+	var logs bytes.Buffer
+	pb.out = &logs
 
 	if pb.ProbeContainer() {
-		t.Error("Probe succeeded. Expected failure due to timeout.")
+		t.Errorf("Probe succeeded. Expected failure due to timeout. Logs:\n%s", logs.String())
 	}
 }
 
@@ -531,9 +534,11 @@ func TestKnTCPProbeFailure(t *testing.T) {
 		},
 	})
 	pb.pollTimeout = time.Second
+	var logs bytes.Buffer
+	pb.out = &logs
 
 	if pb.ProbeContainer() {
-		t.Error("Got probe success. Wanted failure.")
+		t.Errorf("Got probe success. Wanted failure. Logs:\n%s", logs.String())
 	}
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

These tests write logs on **success** that cause spyglass to mark them as red. That's misleading. We only need these logs in case of failures anyway.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
