### PR TITLE
golang format tools

### DIFF
--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -91,7 +91,7 @@ func TestHandlerReqEvent(t *testing.T) {
 	select {
 	case e := <-reqChan:
 		if e.EventType != queue.ProxiedIn {
-			t.Errorf("Got: %v, Want: %v\n", e.EventType, queue.ProxiedIn, )
+			t.Errorf("Got: %v, Want: %v\n", e.EventType, queue.ProxiedIn)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Timed out waiting for an event to be intercepted")
@@ -524,10 +524,10 @@ func BenchmarkProxyHandler(b *testing.B) {
 		label   string
 		breaker *queue.Breaker
 	}{{
-		label: "breaker-10",
+		label:   "breaker-10",
 		breaker: queue.NewBreaker(queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}),
 	}, {
-		label: "breaker-infinite",
+		label:   "breaker-infinite",
 		breaker: nil,
 	}}
 	for _, tc := range tests {

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -18,9 +18,10 @@ package route
 
 import (
 	"context"
-	pkgreconciler "knative.dev/pkg/reconciler"
 	"sort"
 	"strings"
+
+	pkgreconciler "knative.dev/pkg/reconciler"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -type f -name '*.go' -print)`
  `goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party)`
/assign vagababov
/cc vagababov
