### PR TITLE
Move queue health path probe to after sugared logger initialization and use default logger for error handling

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -204,8 +204,8 @@ func proxyHandler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, tracingEn
 
 func preferPodForScaledown(downwardAPILabelsPath string) (bool, error) {
 	// Short circuit a rejection when no label path file is mounted
-	if _, err := os.Stat(downwardAPILabelsPath); err != nil {
-		return false, err
+	if _, err := os.Stat(downwardAPILabelsPath); os.IsNotExist(err) {
+		return false, nil
 	}
 
 	contentBytes, err := ioutil.ReadFile(downwardAPILabelsPath)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -205,7 +205,7 @@ func proxyHandler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, tracingEn
 func preferPodForScaledown(downwardAPILabelsPath string) (bool, error) {
 	// Short circuit a rejection when no label path file is mounted
 	if _, err := os.Stat(downwardAPILabelsPath); err != nil {
-		return false, nil
+		return false, err
 	}
 
 	contentBytes, err := ioutil.ReadFile(downwardAPILabelsPath)


### PR DESCRIPTION
/lint

Fixes #6808

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
* Move queue health path probe to after sugared logger initialization and use default logger for error handling, so that the log output is clearer instead of in json format in k8s event

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @nimakaviani 
