### PR TITLE
Add istio canonical service and canonical revision to deployments

### DIFF
--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -25,6 +25,7 @@ import (
 
 	// Inject our fakes
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/secret/fake"

--- a/pkg/reconciler/ingress/label_provider.go
+++ b/pkg/reconciler/ingress/label_provider.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// IstioCanonicalServiceLabelName is the name of label for the Istio Canonical Service for a workload instance.
+	IstioCanonicalServiceLabelName = "service.istio.io/canonical-name"
+
+	// IstioCanonicalServiceRevisionLabelName is the name of label for the Istio Canonical Service revision for a workload instance.
+	IstioCanonicalServiceRevisionLabelName = "service.istio.io/canonical-revision"
+)
+
+// LabelProvider provides a way to add istio labels to a PodSpec.
+type LabelProvider struct {
+	logger *zap.SugaredLogger
+
+	client kubernetes.Interface
+}
+
+// NewLabelProvider provides a label provider
+func NewLabelProvider(
+	logger *zap.SugaredLogger, client kubernetes.Interface) *LabelProvider {
+	return &LabelProvider{
+		logger: logger,
+		client: client,
+	}
+}
+
+func (m *LabelProvider) process(oldObj, newObj interface{}) {
+	m.logger.Infof("Received object: %#v", newObj)
+	deployment, ok := newObj.(*appsv1.Deployment)
+
+	if !ok {
+		m.logger.Errorf("Object was not a deployment: %#v", newObj)
+		return
+	}
+
+	newDeployment := addLabels(deployment)
+
+	if deploymentsEqual(deployment, newDeployment) {
+		return
+	}
+
+	m.updateDeployment(newDeployment)
+}
+
+func (m *LabelProvider) updateDeployment(deployment *appsv1.Deployment) {
+	updatedDeployment, err := m.client.AppsV1().Deployments(deployment.Namespace).Update(deployment)
+
+	if err != nil {
+		m.logger.Errorf("Failed to update deployment: %v", err)
+		return
+	}
+
+	m.logger.Infof("Updated deployment: %v", updatedDeployment)
+}
+
+func deploymentsEqual(oldDeployment, newDeployment *appsv1.Deployment) bool {
+	return equality.Semantic.DeepEqual(newDeployment.Spec, oldDeployment.Spec)
+}
+
+func addLabels(deployment *appsv1.Deployment) *appsv1.Deployment {
+	newDeployment := deployment.DeepCopy()
+
+	serviceName := deployment.Labels["serving.knative.dev/service"]
+	revisionName := deployment.Labels["serving.knative.dev/revision"]
+
+	newDeployment.Labels[IstioCanonicalServiceLabelName] = serviceName
+	newDeployment.Labels[IstioCanonicalServiceRevisionLabelName] = revisionName
+	newDeployment.Spec.Template.Labels[IstioCanonicalServiceLabelName] = serviceName
+	newDeployment.Spec.Template.Labels[IstioCanonicalServiceRevisionLabelName] = revisionName
+
+	return newDeployment
+}

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -77,6 +77,13 @@ func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1.Revis
 	// TODO(dprotaso): determine other immutable properties.
 	deployment.Spec.Selector = have.Spec.Selector
 
+	// Preserve PodSpec labels added by other systems
+	for key, value := range have.Spec.Template.Labels {
+		if deployment.Spec.Template.Labels[key] == "" {
+			deployment.Spec.Template.Labels[key] = value
+		}
+	}
+
 	// If the spec we want is the spec we have, then we're good.
 	if equality.Semantic.DeepEqual(have.Spec, deployment.Spec) {
 		return have, nil


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #6832

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add canonical service and canonical revision labels to pods when istio is the ingress provider.

This unfortunately creates a deployment and then quickly updates the deployment, resulting in pods that get scheduled and then immediately terminated.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add istio canonical service and canonical revision labels to pods
```
