### PR TITLE
Nominate pods that are candidate for removal

### DIFF
--- a/pkg/autoscaler/fake/fake_metric_client.go
+++ b/pkg/autoscaler/fake/fake_metric_client.go
@@ -50,6 +50,7 @@ type MetricClient struct {
 	StableRPS         float64
 	PanicRPS          float64
 	ErrF              func(key types.NamespacedName, now time.Time) error
+	RemovalCandidates []string
 }
 
 // A ManualTickProvider holds a channel that delivers `ticks' of a clock at intervals.
@@ -83,6 +84,11 @@ func (t *MetricClient) StableAndPanicRPS(key types.NamespacedName, now time.Time
 		err = t.ErrF(key, now)
 	}
 	return t.StableRPS, t.PanicRPS, err
+}
+
+// CandidatesForRemoval returns names of pods which are candidate for removal
+func (t *MetricClient) CandidatesForRemoval(key types.NamespacedName, readyCount, desiredScale int) ([]string, error) {
+	return t.RemovalCandidates, nil
 }
 
 // StaticMetricClient returns stable/panic concurrency and RPS with static value, i.e. 10.

--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -229,8 +229,7 @@ func TestCandidatesForRemoval(t *testing.T) {
 		coll := NewMetricCollector(factory, logger)
 		coll.CreateOrUpdate(&defaultMetric)
 
-		_, err := coll.CandidatesForRemoval(metricKey, 1, 2)
-		if err != ErrNotScraping {
+		if _, err := coll.CandidatesForRemoval(metricKey, 1, 2); err != ErrNotScraping {
 			t.Errorf("CandidatesForRemoval() = %v, want %v", err, ErrNotScraping)
 		}
 	})

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -190,6 +190,7 @@ func (s *ServiceScraper) doScrape(statCh chan Stat, sampleSize int) error {
 	return grp.Wait()
 }
 
+// Scrape calls the destination service then sends it
 // calculate calls the destination service then sends it
 // to the given stats channel.
 func (s *ServiceScraper) Scrape(window time.Duration) (Stat, error) {

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -143,8 +143,7 @@ func (s *ServiceScraper) ScrapeForRemoval(readyCount, desiredScale int) ([]strin
 	sampleSize := readyCount
 
 	statChan := make(chan Stat, sampleSize)
-	err := s.doScrape(statChan, sampleSize)
-	if err != nil {
+	if err := s.doScrape(statChan, sampleSize); err != nil {
 		return nil, err
 	}
 
@@ -188,14 +187,10 @@ func (s *ServiceScraper) doScrape(statCh chan Stat, sampleSize int) error {
 		})
 	}
 
-	// Return the inner error, if any.
-	if err := grp.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return grp.Wait()
 }
 
-// Scrape calls the destination service then sends it
+// calculate calls the destination service then sends it
 // to the given stats channel.
 func (s *ServiceScraper) Scrape(window time.Duration) (Stat, error) {
 	readyPodsCount, err := s.counter.ReadyCount()

--- a/pkg/autoscaler/metrics/stats_scraper_test.go
+++ b/pkg/autoscaler/metrics/stats_scraper_test.go
@@ -318,10 +318,12 @@ func TestScrapeReportErrorIfAnyFails(t *testing.T) {
 }
 
 func TestScrapeForRemoval(t *testing.T) {
-	const numP = 8
-	const desiredScale = 6
-	var toBeRemovedCount = numP - desiredScale
+	const (
+		numP         = 8
+		desiredScale = 6
+	)
 
+	var toBeRemovedCount = numP - desiredScale
 	testStats := testStatsWithTime(numP, 0)
 
 	client := newTestScrapeClient(testStats, []error{nil})
@@ -362,8 +364,7 @@ func TestScrapeForRemovalReportErrorIfAnyFails(t *testing.T) {
 	// Make an Endpoints with 2 pods.
 	fake.Endpoints(2, fake.TestService)
 
-	_, err = scraper.ScrapeForRemoval(2, 1)
-	if !errors.Is(err, errTest) {
+	if _, err = scraper.ScrapeForRemoval(2, 1); !errors.Is(err, errTest) {
 		t.Errorf("scraper.Scrape() = %v, want %v wrapped", err, errTest)
 	}
 }

--- a/pkg/autoscaler/scaling/multiscaler.go
+++ b/pkg/autoscaler/scaling/multiscaler.go
@@ -61,6 +61,8 @@ type DeciderSpec struct {
 	StableWindow time.Duration
 	// The name of the k8s service for pod information.
 	ServiceName string
+	// Whether or not the feature flag for graceful scaledown is enabled
+	EnableGracefulScaledown bool
 }
 
 // DeciderStatus is the current scale recommendation.
@@ -68,6 +70,10 @@ type DeciderStatus struct {
 	// DesiredScale is the target number of instances that autoscaler
 	// this revision needs.
 	DesiredScale int32
+
+	// RemovalCandidates, when scaling down, holds the list of pod names selected by the
+	// autoscaler as the the ideal set of pods for removal
+	RemovalCandidates []string
 
 	// ExcessBurstCapacity is the difference between spare capacity
 	// (how much more load the pods in the revision deployment can take before being
@@ -83,6 +89,10 @@ type UniScaler interface {
 	// or skips proposing. The proposal is requested at the given time.
 	// The returned boolean is true if and only if a proposal was returned.
 	Scale(context.Context, time.Time) (int32, int32, bool)
+
+	// PrepareForRemoval pod names that are good candidates for removal
+	// based on what the desired scale requires to be
+	PrepareForRemoval(context.Context, int32) ([]string, error)
 
 	// Update reconfigures the UniScaler according to the DeciderSpec.
 	Update(*DeciderSpec) error
@@ -112,7 +122,7 @@ func sameSign(a, b int32) bool {
 	return (a&math.MinInt32)^(b&math.MinInt32) == 0
 }
 
-func (sr *scalerRunner) updateLatestScale(proposed, ebc int32) bool {
+func (sr *scalerRunner) updateLatestScale(removalCandidates []string, proposed, ebc int32) bool {
 	ret := false
 	sr.mux.Lock()
 	defer sr.mux.Unlock()
@@ -126,6 +136,8 @@ func (sr *scalerRunner) updateLatestScale(proposed, ebc int32) bool {
 
 	// Update with the latest calculation anyway.
 	sr.decider.Status.ExcessBurstCapacity = ebc
+
+	sr.decider.Status.RemovalCandidates = removalCandidates
 	return ret
 }
 
@@ -321,7 +333,20 @@ func (m *MultiScaler) tickScaler(ctx context.Context, scaler UniScaler, runner *
 		return
 	}
 
-	if runner.updateLatestScale(desiredScale, excessBC) {
+	var (
+		removalCandidates []string
+		err               error
+	)
+
+	if runner.decider.Spec.EnableGracefulScaledown {
+		removalCandidates, err = scaler.PrepareForRemoval(ctx, desiredScale)
+		if err != nil {
+			logger.Errorf("Cannot scale: %w", err)
+			return
+		}
+	}
+
+	if runner.updateLatestScale(removalCandidates, desiredScale, excessBC) {
 		m.Inform(metricKey)
 	}
 }

--- a/pkg/autoscaler/scaling/multiscaler.go
+++ b/pkg/autoscaler/scaling/multiscaler.go
@@ -341,8 +341,7 @@ func (m *MultiScaler) tickScaler(ctx context.Context, scaler UniScaler, runner *
 	if runner.decider.Spec.EnableGracefulScaledown {
 		removalCandidates, err = scaler.PrepareForRemoval(ctx, desiredScale)
 		if err != nil {
-			logger.Errorf("Cannot scale: %w", err)
-			return
+			logger.Errorf("Cannot find removalCandidates: %w", err)
 		}
 	}
 

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -144,6 +144,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 		// Check if there is anything to remove
 		readyCount := int32(intReadyCount)
 		if readyCount > want && decider.Status.RemovalCandidates != nil {
+			logger.Debugf("removalCandidates: %#v", decider.Status.RemovalCandidates)
 			err := c.markPodsForRemoval(ctx, decider.Status.RemovalCandidates, pa, want, readyCount, podCounter)
 			if err != nil {
 				return fmt.Errorf("error marking pods for removal: %w", err)

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -243,6 +243,7 @@ func (c *Reconciler) markPodsForRemoval(ctx context.Context, removalCandidates [
 			return err
 		}
 
+		logger.Debugf("Patching pod: %s(%s)", p.ObjectMeta.Name, p.Status.PodIP)
 		if _, err = c.KubeClient.CoreV1().Pods(pa.Namespace).Patch(p.ObjectMeta.Name, types.JSONPatchType, patchBytes); err != nil {
 			return err
 		}

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -24,11 +24,11 @@ import (
 	"go.opencensus.io/stats"
 	"go.uber.org/zap"
 
-	"knative.dev/pkg/ptr"
-	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/logging"
 	pkgmetrics "knative.dev/pkg/metrics"
+	"knative.dev/pkg/ptr"
+	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	nv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
@@ -56,7 +56,7 @@ const (
 	EndpointConvergenceWaitTime = 500 * time.Millisecond
 	// EndpointConvergenceTimeout is how long the reconciler is willing to wait
 	// for the number of endpoints to converge to the desired scale
-	EndpointConvergenceTimeout  = 1 * time.Minute
+	EndpointConvergenceTimeout = 1 * time.Minute
 )
 
 // podCounts keeps record of various numbers of pods
@@ -128,7 +128,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 
 	// Get the appropriate current scale from the metric, and right size
 	// the scaleTargetRef based on it.
-	want, ps, err := c.scaler.Scale(ctx, pa, sks, decider.Status.DesiredScale)
+	want, ps, err := c.scaler.calculate(ctx, pa, sks, decider.Status.DesiredScale)
 	if err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 		}
 	}
 
-	if err := c.scaler.Apply(ctx, pa, ps, want); err != nil {
+	if err := c.scaler.apply(ctx, pa, ps, want); err != nil {
 		return fmt.Errorf("error scaling target: %v", err)
 	}
 

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -242,7 +242,7 @@ func (c *Reconciler) markPodsForRemoval(ctx context.Context, removalCandidates [
 			return err
 		}
 
-		if _, err = c.KubeClientSet.CoreV1().Pods(pa.Namespace).Patch(p.ObjectMeta.Name, types.JSONPatchType, patchBytes); err != nil {
+		if _, err = c.KubeClient.CoreV1().Pods(pa.Namespace).Patch(p.ObjectMeta.Name, types.JSONPatchType, patchBytes); err != nil {
 			return err
 		}
 	}

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -47,8 +47,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 const (

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -141,18 +141,18 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 			return err
 		}
 
-		// check if there is anything to remove
+		// Check if there is anything to remove
 		readyCount := int32(intReadyCount)
 		if readyCount > want && decider.Status.RemovalCandidates != nil {
 			err := c.markPodsForRemoval(ctx, decider.Status.RemovalCandidates, pa, want, readyCount, podCounter)
 			if err != nil {
-				return fmt.Errorf("error marking pods for removal: %v", err)
+				return fmt.Errorf("error marking pods for removal: %w", err)
 			}
 		}
 	}
 
 	if err := c.scaler.apply(ctx, pa, ps, want); err != nil {
-		return fmt.Errorf("error scaling target: %v", err)
+		return fmt.Errorf("error scaling target: %w", err)
 	}
 
 	mode := nv1alpha1.SKSOperationModeServe
@@ -247,7 +247,7 @@ func (c *Reconciler) markPodsForRemoval(ctx context.Context, removalCandidates [
 		}
 	}
 
-	// wait for endpoint counts to converge before scaling down
+	// Wait for endpoint counts to converge before scaling down
 	wait.PollImmediate(endpointConvergenceWaitTime, endpointConvergenceTimeout, func() (bool, error) {
 		readyCount, err := pc.ReadyCount()
 		if err != nil {

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1033,8 +1033,7 @@ func TestReconcile(t *testing.T) {
 		if gsd := ctx.Value(gracefuleScaleDownConfigKey); gsd != nil {
 			defaultConfig.Autoscaler.EnableGracefulScaledown = true
 			removalCandidates = []string{"pod-1"}
-			_, err := fakekubeclient.Get(ctx).CoreV1().Pods(testNamespace).Create(pod(testNamespace, "pod-1"))
-			if err != nil {
+			if _, err := fakekubeclient.Get(ctx).CoreV1().Pods(testNamespace).Create(pod(testNamespace, "pod-1")); err != nil {
 				t.Errorf("Failed %v", err)
 			}
 		}

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -63,16 +63,17 @@ func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autosc
 	return &scaling.Decider{
 		ObjectMeta: *pa.ObjectMeta.DeepCopy(),
 		Spec: scaling.DeciderSpec{
-			TickInterval:        config.TickInterval,
-			MaxScaleUpRate:      config.MaxScaleUpRate,
-			MaxScaleDownRate:    config.MaxScaleDownRate,
-			ScalingMetric:       pa.Metric(),
-			TargetValue:         target,
-			TotalValue:          total,
-			TargetBurstCapacity: tbc,
-			PanicThreshold:      panicThreshold,
-			StableWindow:        resources.StableWindow(pa, config),
-			ServiceName:         svc,
+			TickInterval:            config.TickInterval,
+			MaxScaleUpRate:          config.MaxScaleUpRate,
+			MaxScaleDownRate:        config.MaxScaleDownRate,
+			EnableGracefulScaledown: config.EnableGracefulScaledown,
+			ScalingMetric:           pa.Metric(),
+			TargetValue:             target,
+			TotalValue:              total,
+			TargetBurstCapacity:     tbc,
+			PanicThreshold:          panicThreshold,
+			StableWindow:            resources.StableWindow(pa, config),
+			ServiceName:             svc,
 		},
 	}
 }

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -229,8 +229,8 @@ func (ks *scaler) handleScaleToZero(ctx context.Context, pa *pav1alpha1.PodAutos
 	return desiredScale, true
 }
 
-// Apply updates the PodScalable to the desiredScale calculated during the Scale decision making
-func (ks *scaler) Apply(ctx context.Context, pa *pav1alpha1.PodAutoscaler, ps *pav1alpha1.PodScalable, desiredScale int32) error {
+// apply updates the PodScalable to the desiredScale calculated during the Scale decision making
+func (ks *scaler) apply(ctx context.Context, pa *pav1alpha1.PodAutoscaler, ps *pav1alpha1.PodScalable, desiredScale int32) error {
 	// if no PodScalable is provided, return without scaling.
 	// This happens when the desiredScale == currentScale
 	if ps == nil {
@@ -265,8 +265,8 @@ func (ks *scaler) Apply(ctx context.Context, pa *pav1alpha1.PodAutoscaler, ps *p
 	return nil
 }
 
-// Scale decides the desired scale and creates PodScalable required to scale the given PA's target reference to the desired scale.
-func (ks *scaler) Scale(ctx context.Context, pa *pav1alpha1.PodAutoscaler, sks *nv1a1.ServerlessService, desiredScale int32) (int32, *pav1alpha1.PodScalable, error) {
+// calculate decides the desired scale and creates PodScalable required to scale the given PA's target reference to the desired scale.
+func (ks *scaler) calculate(ctx context.Context, pa *pav1alpha1.PodAutoscaler, sks *nv1a1.ServerlessService, desiredScale int32) (int32, *pav1alpha1.PodScalable, error) {
 	logger := logging.FromContext(ctx)
 
 	if desiredScale < 0 && !pa.Status.IsActivating() {

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -369,9 +369,13 @@ func TestScaler(t *testing.T) {
 			}
 
 			ctx = config.ToContext(ctx, defaultConfig())
-			desiredScale, err := revisionScaler.Scale(ctx, pa, sks, test.scaleTo)
+			desiredScale, ps, err := revisionScaler.Scale(ctx, pa, sks, test.scaleTo)
 			if err != nil {
 				t.Error("Scale got an unexpected error: ", err)
+			}
+
+			if err = revisionScaler.Apply(ctx, pa, ps, desiredScale); err != nil {
+				t.Error("Apply got an unexpected error: ", err)
 			}
 			if err == nil && desiredScale != test.wantReplicas {
 				t.Errorf("desiredScale = %d, wanted %d", desiredScale, test.wantReplicas)
@@ -454,11 +458,15 @@ func TestDisableScaleToZero(t *testing.T) {
 			conf := defaultConfig()
 			conf.Autoscaler.EnableScaleToZero = false
 			ctx = config.ToContext(ctx, conf)
-			desiredScale, err := revisionScaler.Scale(ctx, pa, nil /*sks doesn't matter in this test*/, test.scaleTo)
-
+			desiredScale, ps, err := revisionScaler.Scale(ctx, pa, nil /*sks doesn't matter in this test*/, test.scaleTo)
 			if err != nil {
 				t.Error("Scale got an unexpected error: ", err)
 			}
+
+			if err = revisionScaler.Apply(ctx, pa, ps, desiredScale); err != nil {
+				t.Error("Apply got an unexpected error: ", err)
+			}
+
 			if err == nil && desiredScale != test.wantReplicas {
 				t.Errorf("desiredScale = %d, wanted %d", desiredScale, test.wantReplicas)
 			}

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -369,12 +369,12 @@ func TestScaler(t *testing.T) {
 			}
 
 			ctx = config.ToContext(ctx, defaultConfig())
-			desiredScale, ps, err := revisionScaler.Scale(ctx, pa, sks, test.scaleTo)
+			desiredScale, ps, err := revisionScaler.calculate(ctx, pa, sks, test.scaleTo)
 			if err != nil {
 				t.Error("Scale got an unexpected error: ", err)
 			}
 
-			if err = revisionScaler.Apply(ctx, pa, ps, desiredScale); err != nil {
+			if err = revisionScaler.apply(ctx, pa, ps, desiredScale); err != nil {
 				t.Error("Apply got an unexpected error: ", err)
 			}
 			if err == nil && desiredScale != test.wantReplicas {
@@ -458,12 +458,12 @@ func TestDisableScaleToZero(t *testing.T) {
 			conf := defaultConfig()
 			conf.Autoscaler.EnableScaleToZero = false
 			ctx = config.ToContext(ctx, conf)
-			desiredScale, ps, err := revisionScaler.Scale(ctx, pa, nil /*sks doesn't matter in this test*/, test.scaleTo)
+			desiredScale, ps, err := revisionScaler.calculate(ctx, pa, nil /*sks doesn't matter in this test*/, test.scaleTo)
 			if err != nil {
 				t.Error("Scale got an unexpected error: ", err)
 			}
 
-			if err = revisionScaler.Apply(ctx, pa, ps, desiredScale); err != nil {
+			if err = revisionScaler.apply(ctx, pa, ps, desiredScale); err != nil {
 				t.Error("Apply got an unexpected error: ", err)
 			}
 

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -390,11 +390,12 @@ func assertGracefulScaledown(t *testing.T, ctx *testContext, size int) error {
 	if err != nil {
 		return err
 	}
-	deleteHostConnections(hostConnMap, upscale)
+	deleteHostConnections(t, hostConnMap, upscale)
 
 	// give some time in between
 	time.Sleep(5 * time.Second)
 
+	// start x running pods; x == size
 	hostConnMap, err = uniqueHostConnections(t, ctx.names, size)
 	if err != nil {
 		return err
@@ -402,7 +403,7 @@ func assertGracefulScaledown(t *testing.T, ctx *testContext, size int) error {
 
 	// only keep openConnCount connections open for the test
 	openConnCount := size / 2
-	deleteHostConnections(hostConnMap, size-openConnCount)
+	deleteHostConnections(t, hostConnMap, size-openConnCount)
 
 	hostConnMap.Range(func(key, value interface{}) bool {
 		return true
@@ -436,6 +437,7 @@ func assertGracefulScaledown(t *testing.T, ctx *testContext, size int) error {
 					continue
 				}
 
+				t.Logf("inspecting pod %s (%s:%s)", p.Name, p.Status.Phase, p.DeletionTimestamp)
 				if _, ok := hostConnMap.Load(p.Name); !ok {
 					return fmt.Errorf("failed by keeping the wrong pod %s", p.Name)
 				}

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -391,6 +391,8 @@ func assertGracefulScaledown(t *testing.T, ctx *testContext, size int) error {
 		return err
 	}
 	deleteHostConnections(hostConnMap, size)
+
+	// give some time in between
 	time.Sleep(5 * time.Second)
 
 	hostConnMap, err = uniqueHostConnections(t, ctx.names, size)
@@ -451,7 +453,6 @@ func TestGracefulScaledown(t *testing.T) {
 
 	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency, 1 /* target */, 1, /* targetUtilization */
 		wsHostnameTestImageName, nil, /* no validation */
-		rtesting.WithContainerConcurrency(1),
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 		}))

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -437,7 +437,7 @@ func assertGracefulScaledown(t *testing.T, ctx *testContext, size int) error {
 					continue
 				}
 
-				t.Logf("inspecting pod %s (%s:%s)", p.Name, p.Status.Phase, p.DeletionTimestamp)
+				t.Logf("inspecting pod %s (%s:%s:%s)", p.Name, p.Status.PodIP, p.Status.Phase, p.DeletionTimestamp)
 				if _, ok := hostConnMap.Load(p.Name); !ok {
 					return fmt.Errorf("failed by keeping the wrong pod %s", p.Name)
 				}

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -385,12 +385,12 @@ func assertAutoscaleUpToNumPods(ctx *testContext, curPods, targetPods float64, d
 }
 
 func assertGracefulScaledown(t *testing.T, ctx *testContext, size int) error {
-	// start x running pods; x == size
-	hostConnMap, err := uniqueHostConnections(t, ctx.names, size)
+	upscale := 2 * size
+	hostConnMap, err := uniqueHostConnections(t, ctx.names, upscale)
 	if err != nil {
 		return err
 	}
-	deleteHostConnections(hostConnMap, size)
+	deleteHostConnections(hostConnMap, upscale)
 
 	// give some time in between
 	time.Sleep(5 * time.Second)

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -431,7 +431,6 @@ func assertGracefulScaledown(t *testing.T, ctx *testContext, size int) error {
 }
 
 func TestGracefulScaledown(t *testing.T) {
-	t.Skip()
 	cancel := logstream.Start(t)
 	defer cancel()
 

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -395,6 +395,10 @@ func assertGracefulScaledown(t *testing.T, ctx *testContext, size int) error {
 	openConnCount := size / 2
 	deleteHostConnections(hostConnMap, size-openConnCount)
 
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+	go pingOpenConnections(doneCh, hostConnMap)
+
 	defer deleteHostConnections(hostConnMap, openConnCount)
 
 	timer := time.NewTicker(2 * time.Second)

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -413,7 +413,7 @@ func assertGracefulScaledown(t *testing.T, ctx *testContext, size int) error {
 	defer close(doneCh)
 	go pingOpenConnections(doneCh, hostConnMap)
 
-	defer deleteHostConnections(hostConnMap, openConnCount)
+	defer deleteHostConnections(t, hostConnMap, openConnCount)
 
 	timer := time.NewTicker(2 * time.Second)
 	for range timer.C {

--- a/test/e2e/websocket.go
+++ b/test/e2e/websocket.go
@@ -177,9 +177,7 @@ func pingOpenConnections(doneCh chan struct{}, hostConnMap *sync.Map) error {
 			var err error
 			hostConnMap.Range(func(key, value interface{}) bool {
 				if conn, ok := value.(*websocket.Conn); ok {
-					if err = conn.WriteMessage(websocket.TextMessage, []byte("keepAlive")); err != nil {
-						return false
-					}
+					return conn.WriteMessage(websocket.TextMessage, []byte("keepAlive")) == nil
 				}
 				return true
 			})

--- a/test/e2e/websocket.go
+++ b/test/e2e/websocket.go
@@ -143,7 +143,7 @@ func uniqueHostConnections(t *testing.T, names test.ResourceNames, size int) (*s
 
 // deleteHostConnections closes and removees x number of open websocket connections
 // from the hostConnMap where x == size
-func deleteHostConnections(hostConnMap *sync.Map, size int) error {
+func deleteHostConnections(t *testing.T, hostConnMap *sync.Map, size int) error {
 	hostConnMap.Range(func(key, value interface{}) bool {
 		if size <= 0 {
 			return false
@@ -153,6 +153,7 @@ func deleteHostConnections(hostConnMap *sync.Map, size int) error {
 			conn.Close()
 			hostConnMap.Delete(key)
 			size -= 1
+			t.Logf("Closed connection to pod: %s", key.(string))
 			return true
 		}
 		return false

--- a/test/e2e/websocket.go
+++ b/test/e2e/websocket.go
@@ -188,8 +188,6 @@ func pingOpenConnections(doneCh chan struct{}, hostConnMap *sync.Map) error {
 			}
 		case <-doneCh:
 			return nil
-		default:
-			time.Sleep(20 * time.Second)
 		}
 	}
 }


### PR DESCRIPTION
- scrape metrics on pods at the time of scale down
- sort pods by the number of requests they are processing
- select and label the subset that are considered better candidates for
removal

as part of #6134

/lint

fyi @markusthoemmes @vagababov 

This is the last PR on the graceful scale down work. A few considerations for discussion:

- right now when scraping for removal, I go through all the pods as this seemed to be the most optimal way of choosing pods. Since this only executes at scaledown time it may not be too bad. Alternatively we can choose to have a large upper cap on it.
- I activated the the e2e test and expecting it to pass.

