### PR TITLE
Route controller uses v1 APIs

### DIFF
--- a/pkg/apis/serving/v1/route_lifecycle.go
+++ b/pkg/apis/serving/v1/route_lifecycle.go
@@ -17,9 +17,14 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 )
 
 var routeCondSet = apis.NewLivingConditionSet(
@@ -40,4 +45,120 @@ func (rs *RouteStatus) IsReady() bool {
 // InitializeConditions sets the initial values to the conditions.
 func (rs *RouteStatus) InitializeConditions() {
 	routeCondSet.Manage(rs).InitializeConditions()
+}
+
+// MarkServiceNotOwned changes the IngressReady status to be false with the reason being that
+// there is a pre-existing placeholder service with the name we wanted to use.
+func (rs *RouteStatus) MarkServiceNotOwned(name string) {
+	routeCondSet.Manage(rs).MarkFalse(RouteConditionIngressReady, "NotOwned",
+		fmt.Sprintf("There is an existing placeholder Service %q that we do not own.", name))
+}
+
+// MarkIngressNotConfigured changes the IngressReady condition to be unknown to reflect
+// that the Ingress does not yet have a Status
+func (rs *RouteStatus) MarkIngressNotConfigured() {
+	routeCondSet.Manage(rs).MarkUnknown(RouteConditionIngressReady,
+		"IngressNotConfigured", "Ingress has not yet been reconciled.")
+}
+
+func (rs *RouteStatus) MarkTrafficAssigned() {
+	routeCondSet.Manage(rs).MarkTrue(RouteConditionAllTrafficAssigned)
+}
+
+func (rs *RouteStatus) MarkUnknownTrafficError(msg string) {
+	routeCondSet.Manage(rs).MarkUnknown(RouteConditionAllTrafficAssigned, "Unknown", msg)
+}
+
+func (rs *RouteStatus) MarkConfigurationNotReady(name string) {
+	routeCondSet.Manage(rs).MarkUnknown(RouteConditionAllTrafficAssigned,
+		"RevisionMissing",
+		"Configuration %q is waiting for a Revision to become ready.", name)
+}
+
+func (rs *RouteStatus) MarkConfigurationFailed(name string) {
+	routeCondSet.Manage(rs).MarkFalse(RouteConditionAllTrafficAssigned,
+		"RevisionMissing",
+		"Configuration %q does not have any ready Revision.", name)
+}
+
+func (rs *RouteStatus) MarkRevisionNotReady(name string) {
+	routeCondSet.Manage(rs).MarkUnknown(RouteConditionAllTrafficAssigned,
+		"RevisionMissing",
+		"Revision %q is not yet ready.", name)
+}
+
+func (rs *RouteStatus) MarkRevisionFailed(name string) {
+	routeCondSet.Manage(rs).MarkFalse(RouteConditionAllTrafficAssigned,
+		"RevisionMissing",
+		"Revision %q failed to become ready.", name)
+}
+
+func (rs *RouteStatus) MarkMissingTrafficTarget(kind, name string) {
+	routeCondSet.Manage(rs).MarkFalse(RouteConditionAllTrafficAssigned,
+		kind+"Missing",
+		"%s %q referenced in traffic not found.", kind, name)
+}
+
+func (rs *RouteStatus) MarkCertificateProvisionFailed(name string) {
+	routeCondSet.Manage(rs).SetCondition(apis.Condition{
+		Type:     RouteConditionCertificateProvisioned,
+		Status:   corev1.ConditionFalse,
+		Severity: apis.ConditionSeverityWarning,
+		Reason:   "CertificateProvisionFailed",
+		Message:  fmt.Sprintf("Certificate %s fails to be provisioned.", name),
+	})
+}
+
+func (rs *RouteStatus) MarkCertificateReady(name string) {
+	routeCondSet.Manage(rs).SetCondition(apis.Condition{
+		Type:     RouteConditionCertificateProvisioned,
+		Status:   corev1.ConditionTrue,
+		Severity: apis.ConditionSeverityWarning,
+		Reason:   "CertificateReady",
+		Message:  fmt.Sprintf("Certificate %s is successfully provisioned", name),
+	})
+}
+
+func (rs *RouteStatus) MarkCertificateNotReady(name string) {
+	routeCondSet.Manage(rs).SetCondition(apis.Condition{
+		Type:     RouteConditionCertificateProvisioned,
+		Status:   corev1.ConditionUnknown,
+		Severity: apis.ConditionSeverityWarning,
+		Reason:   "CertificateNotReady",
+		Message:  fmt.Sprintf("Certificate %s is not ready.", name),
+	})
+}
+
+func (rs *RouteStatus) MarkCertificateNotOwned(name string) {
+	routeCondSet.Manage(rs).SetCondition(apis.Condition{
+		Type:     RouteConditionCertificateProvisioned,
+		Status:   corev1.ConditionFalse,
+		Severity: apis.ConditionSeverityWarning,
+		Reason:   "CertificateNotOwned",
+		Message:  fmt.Sprintf("There is an existing certificate %s that we don't own.", name),
+	})
+}
+
+// PropagateIngressStatus update RouteConditionIngressReady condition
+// in RouteStatus according to IngressStatus.
+func (rs *RouteStatus) PropagateIngressStatus(cs v1alpha1.IngressStatus) {
+	cc := cs.GetCondition(v1alpha1.IngressConditionReady)
+	if cc == nil {
+		rs.MarkIngressNotConfigured()
+		return
+	}
+
+	m := routeCondSet.Manage(rs)
+	switch cc.Status {
+	case corev1.ConditionTrue:
+		m.MarkTrue(RouteConditionIngressReady)
+	case corev1.ConditionFalse:
+		m.MarkFalse(RouteConditionIngressReady, cc.Reason, cc.Message)
+	case corev1.ConditionUnknown:
+		m.MarkUnknown(RouteConditionIngressReady, cc.Reason, cc.Message)
+	}
+}
+
+func (rs *RouteStatus) duck() *duckv1.Status {
+	return &rs.Status
 }

--- a/pkg/reconciler/route/controller.go
+++ b/pkg/reconciler/route/controller.go
@@ -22,9 +22,9 @@ import (
 	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	certificateinformer "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/certificate"
 	ingressinformer "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/ingress"
-	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/configuration"
-	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
-	routeinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/route"
+	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration"
+	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
+	routeinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/route"
 
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
@@ -32,7 +32,7 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/tracker"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler"
 	"knative.dev/serving/pkg/reconciler/route/config"
@@ -82,7 +82,7 @@ func NewControllerWithClock(
 	routeInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	serviceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Route")),
+		FilterFunc: controller.FilterGroupKind(v1.Kind("Route")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
@@ -96,7 +96,7 @@ func NewControllerWithClock(
 		// populated.
 		controller.EnsureTypeMeta(
 			c.tracker.OnChanged,
-			v1alpha1.SchemeGroupVersion.WithKind("Configuration"),
+			v1.SchemeGroupVersion.WithKind("Configuration"),
 		),
 	))
 
@@ -106,12 +106,12 @@ func NewControllerWithClock(
 		// populated.
 		controller.EnsureTypeMeta(
 			c.tracker.OnChanged,
-			v1alpha1.SchemeGroupVersion.WithKind("Revision"),
+			v1.SchemeGroupVersion.WithKind("Revision"),
 		),
 	))
 
 	certificateInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Route")),
+		FilterFunc: controller.FilterGroupKind(v1.Kind("Route")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -23,23 +23,21 @@ import (
 	"strings"
 	"text/template"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 	pkgnet "knative.dev/pkg/network"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler/route/config"
 	"knative.dev/serving/pkg/reconciler/route/resources/labels"
-
-	"knative.dev/pkg/apis"
 )
 
 // HTTPScheme is the string representation of http.
 const HTTPScheme string = "http"
 
 // GetAllDomainsAndTags returns all of the domains and tags(including subdomains) associated with a Route
-func GetAllDomainsAndTags(ctx context.Context, r *v1alpha1.Route, names []string, visibility map[string]netv1alpha1.IngressVisibility) (map[string]string, error) {
+func GetAllDomainsAndTags(ctx context.Context, r *v1.Route, names []string, visibility map[string]netv1alpha1.IngressVisibility) (map[string]string, error) {
 	domainTagMap := make(map[string]string)
 
 	for _, name := range names {
@@ -63,7 +61,7 @@ func GetAllDomainsAndTags(ctx context.Context, r *v1alpha1.Route, names []string
 
 // DomainNameFromTemplate generates domain name base on the template specified in the `config-network` ConfigMap.
 // name is the "subdomain" which will be referred as the "name" in the template
-func DomainNameFromTemplate(ctx context.Context, r v1.ObjectMeta, name string) (string, error) {
+func DomainNameFromTemplate(ctx context.Context, r metav1.ObjectMeta, name string) (string, error) {
 	domainConfig := config.FromContext(ctx).Domain
 	rLabels := r.Labels
 	domain := domainConfig.LookupDomainForLabels(rLabels)

--- a/pkg/reconciler/route/domains/domains_test.go
+++ b/pkg/reconciler/route/domains/domains_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis"
 
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/gc"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler/route/config"
@@ -108,7 +108,7 @@ func TestDomainNameFromTemplate(t *testing.T) {
 	}}
 
 	meta := metav1.ObjectMeta{
-		SelfLink:  "/apis/serving/v1alpha1/namespaces/test/Routes/myapp",
+		SelfLink:  "/apis/serving/v1/namespaces/test/Routes/myapp",
 		Name:      "myroute",
 		Namespace: "default",
 		Labels: map[string]string{
@@ -223,9 +223,9 @@ func TestGetAllDomainsAndTags(t *testing.T) {
 		wantErr:        true,
 	}}
 
-	route := &v1alpha1.Route{
+	route := &v1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			SelfLink:  "/apis/serving/v1alpha1/namespaces/test/Routes/myapp",
+			SelfLink:  "/apis/serving/v1/namespaces/test/Routes/myapp",
 			Name:      "myroute",
 			Namespace: "default",
 			Labels: map[string]string{

--- a/pkg/reconciler/route/queueing_test.go
+++ b/pkg/reconciler/route/queueing_test.go
@@ -31,14 +31,13 @@ import (
 	"knative.dev/pkg/system"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	"knative.dev/serving/pkg/gc"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler/route/config"
 
 	. "knative.dev/pkg/reconciler/testing"
-	. "knative.dev/serving/pkg/testing/v1alpha1"
+	. "knative.dev/serving/pkg/testing/v1"
 )
 
 func TestNewRouteCallsSyncHandler(t *testing.T) {
@@ -47,12 +46,11 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 	// A standalone revision
 	rev := getTestRevision("test-rev")
 	// A route targeting the revision
-	route := getTestRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
+	route := getTestRouteWithTrafficTargets(WithSpecTraffic(
+		v1.TrafficTarget{
 			RevisionName: "test-rev",
 			Percent:      ptr.Int64(100),
-		},
-	}))
+		}))
 
 	// Create fake clients
 	configMapWatcher := configmap.NewStaticWatcher(&corev1.ConfigMap{
@@ -111,7 +109,7 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 		return ctrl.Run(2, ctx.Done())
 	})
 
-	if _, err := servingClient.ServingV1alpha1().Revisions(rev.Namespace).Create(rev); err != nil {
+	if _, err := servingClient.ServingV1().Revisions(rev.Namespace).Create(rev); err != nil {
 		t.Errorf("Unexpected error creating revision: %v", err)
 	}
 
@@ -121,7 +119,7 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 		}
 	}
 
-	if _, err := servingClient.ServingV1alpha1().Routes(route.Namespace).Create(route); err != nil {
+	if _, err := servingClient.ServingV1().Routes(route.Namespace).Create(route); err != nil {
 		t.Errorf("Unexpected error creating route: %v", err)
 	}
 

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -32,18 +32,17 @@ import (
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	fakecertinformer "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/certificate/fake"
 	fakeciinformer "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/ingress/fake"
-	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision/fake"
+	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
 	"knative.dev/serving/pkg/gc"
 	"knative.dev/serving/pkg/reconciler/route/config"
 	"knative.dev/serving/pkg/reconciler/route/resources"
 	"knative.dev/serving/pkg/reconciler/route/traffic"
 
 	. "knative.dev/pkg/logging/testing"
-	. "knative.dev/serving/pkg/testing/v1alpha1"
+	. "knative.dev/serving/pkg/testing/v1"
 )
 
 func TestReconcileIngressInsert(t *testing.T) {
@@ -115,7 +114,7 @@ func TestReconcileTargetValidRevision(t *testing.T) {
 		},
 	})
 
-	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(r.Namespace).Create(rev)
+	fakeservingclient.Get(ctx).ServingV1().Revisions(r.Namespace).Create(rev)
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
 
 	// Get timestamp before reconciling, so that we can compare this to the last pinned timestamp
@@ -130,7 +129,7 @@ func TestReconcileTargetValidRevision(t *testing.T) {
 	}
 
 	// Verify last pinned annotation is updated correctly
-	newRev, err := fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(r.Namespace).Get(rev.Name, metav1.GetOptions{})
+	newRev, err := fakeservingclient.Get(ctx).ServingV1().Revisions(r.Namespace).Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error getting revision: %v", err)
 	}
@@ -162,7 +161,7 @@ func TestReconcileRevisionTargetDoesNotExist(t *testing.T) {
 			StaleRevisionLastpinnedDebounce: time.Minute,
 		},
 	})
-	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(r.Namespace).Create(rev)
+	fakeservingclient.Get(ctx).ServingV1().Revisions(r.Namespace).Create(rev)
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
 
 	// Try reconciling target revisions for a revision that does not exist. No err should be returned
@@ -171,20 +170,20 @@ func TestReconcileRevisionTargetDoesNotExist(t *testing.T) {
 	}
 }
 
-func newTestRevision(namespace string, name string) *v1alpha1.Revision {
-	return &v1alpha1.Revision{
+func newTestRevision(namespace string, name string) *v1.Revision {
+	return &v1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Annotations: map[string]string{
-				serving.RevisionLastPinnedAnnotationKey: v1alpha1.RevisionLastPinnedString(time.Now().Add(-1 * time.Hour)),
+				serving.RevisionLastPinnedAnnotationKey: v1.RevisionLastPinnedString(time.Now().Add(-1 * time.Hour)),
 			},
 		},
-		Spec: v1alpha1.RevisionSpec{},
+		Spec: v1.RevisionSpec{},
 	}
 }
 
-func getLastPinnedTimestamp(t *testing.T, rev *v1alpha1.Revision) (string, error) {
+func getLastPinnedTimestamp(t *testing.T, rev *v1.Revision) (string, error) {
 	lastPinnedTime, ok := rev.ObjectMeta.Annotations[serving.RevisionLastPinnedAnnotationKey]
 	if !ok {
 		return "", errors.New("last pinned annotation not found")
@@ -192,7 +191,7 @@ func getLastPinnedTimestamp(t *testing.T, rev *v1alpha1.Revision) (string, error
 	return lastPinnedTime, nil
 }
 
-func newTestIngress(t *testing.T, r *v1alpha1.Route, trafficOpts ...func(tc *traffic.Config)) *netv1alpha1.Ingress {
+func newTestIngress(t *testing.T, r *v1.Route, trafficOpts ...func(tc *traffic.Config)) *netv1alpha1.Ingress {
 	tc := &traffic.Config{Targets: map[string]traffic.RevisionTargets{
 		traffic.DefaultTarget: {{
 			TrafficTarget: v1.TrafficTarget{
@@ -290,7 +289,7 @@ func TestReconcileIngressClassAnnotation(t *testing.T) {
 	}
 }
 
-func newCerts(dnsNames []string, r *v1alpha1.Route) *netv1alpha1.Certificate {
+func newCerts(dnsNames []string, r *v1.Route) *netv1alpha1.Certificate {
 	return &netv1alpha1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "test-cert",

--- a/pkg/reconciler/route/resources/certificate.go
+++ b/pkg/reconciler/route/resources/certificate.go
@@ -29,7 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/kmeta"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler/route/resources/names"
 )
 
@@ -37,7 +37,7 @@ import (
 // domainTagMap is an one-to-one mapping between domain and tag, for major domain (tag-less),
 // the value is an empty string
 // Returns one certificate for each domain
-func MakeCertificates(route *v1alpha1.Route, domainTagMap map[string]string, certClass string) []*networkingv1alpha1.Certificate {
+func MakeCertificates(route *v1.Route, domainTagMap map[string]string, certClass string) []*networkingv1alpha1.Certificate {
 	order := make(sort.StringSlice, 0, len(domainTagMap))
 	for dnsName := range domainTagMap {
 		order = append(order, dnsName)

--- a/pkg/reconciler/route/resources/certificate_test.go
+++ b/pkg/reconciler/route/resources/certificate_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 
-	. "knative.dev/serving/pkg/testing/v1alpha1"
+	. "knative.dev/serving/pkg/testing/v1"
 )
 
 var (

--- a/pkg/reconciler/route/resources/ingress.go
+++ b/pkg/reconciler/route/resources/ingress.go
@@ -30,7 +30,7 @@ import (
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
-	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler/route/domains"
 	"knative.dev/serving/pkg/reconciler/route/resources/labels"
 	"knative.dev/serving/pkg/reconciler/route/resources/names"
@@ -51,7 +51,7 @@ func MakeIngressTLS(cert *v1alpha1.Certificate, hostNames []string) v1alpha1.Ing
 // which Hosts that it applies to, as well as the routing rules.
 func MakeIngress(
 	ctx context.Context,
-	r *servingv1alpha1.Route,
+	r *servingv1.Route,
 	tc *traffic.Config,
 	tls []v1alpha1.IngressTLS,
 	ingressClass string,
@@ -83,7 +83,7 @@ func MakeIngress(
 // MakeIngressSpec creates a new IngressSpec
 func MakeIngressSpec(
 	ctx context.Context,
-	r *servingv1alpha1.Route,
+	r *servingv1.Route,
 	tls []v1alpha1.IngressTLS,
 	targets map[string]traffic.RevisionTargets,
 	visibility map[string]netv1alpha1.IngressVisibility,
@@ -138,7 +138,7 @@ func getChallengeHosts(challenges []v1alpha1.HTTP01Challenge) map[string]v1alpha
 	return c
 }
 
-func routeDomain(ctx context.Context, targetName string, r *servingv1alpha1.Route, visibility netv1alpha1.IngressVisibility) (string, error) {
+func routeDomain(ctx context.Context, targetName string, r *servingv1.Route, visibility netv1alpha1.IngressVisibility) (string, error) {
 	hostname, err := domains.HostnameFromTemplate(ctx, r.Name, targetName)
 	if err != nil {
 		return "", err

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -28,20 +28,18 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/ptr"
+	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/apis/networking"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler/route/config"
 	"knative.dev/serving/pkg/reconciler/route/traffic"
 
-	"knative.dev/pkg/ptr"
-	"knative.dev/pkg/system"
-
 	_ "knative.dev/pkg/system/testing"
-	. "knative.dev/serving/pkg/testing/v1alpha1"
+	. "knative.dev/serving/pkg/testing/v1"
 )
 
 const (
@@ -227,7 +225,7 @@ func TestMakeIngressSpec_CorrectRules(t *testing.T) {
 func TestMakeIngressSpec_CorrectRuleVisibility(t *testing.T) {
 	cases := []struct {
 		name               string
-		route              *v1alpha1.Route
+		route              *v1.Route
 		targets            map[string]traffic.RevisionTargets
 		serviceVisibility  map[string]netv1alpha1.IngressVisibility
 		expectedVisibility map[string]netv1alpha1.IngressVisibility
@@ -763,13 +761,13 @@ func TestMakeClusterIngress_ACMEChallenges(t *testing.T) {
 		}},
 	}
 
-	r := &v1alpha1.Route{
+	r := &v1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
 			Namespace: "test-ns",
 		},
-		Status: v1alpha1.RouteStatus{
-			RouteStatusFields: v1alpha1.RouteStatusFields{
+		Status: v1.RouteStatus{
+			RouteStatusFields: v1.RouteStatusFields{
 				URL: &apis.URL{
 					Scheme: "http",
 					Host:   "domain.com",

--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -30,7 +30,7 @@ import (
 	"knative.dev/serving/pkg/apis/networking"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler/route/domains"
 )
 
@@ -48,13 +48,13 @@ func GetNames(services []*corev1.Service) sets.String {
 }
 
 // SelectorFromRoute creates a label selector given a specific route.
-func SelectorFromRoute(route *v1alpha1.Route) labels.Selector {
+func SelectorFromRoute(route *v1.Route) labels.Selector {
 	return labels.SelectorFromSet(labels.Set{serving.RouteLabelKey: route.Name})
 }
 
 // MakeK8sPlaceholderService creates a placeholder Service to prevent naming collisions. It's owned by the
-// provided v1alpha1.Route. The purpose of this service is to provide a placeholder domain name for Istio routing.
-func MakeK8sPlaceholderService(ctx context.Context, route *v1alpha1.Route, targetName string) (*corev1.Service, error) {
+// provided v1.Route. The purpose of this service is to provide a placeholder domain name for Istio routing.
+func MakeK8sPlaceholderService(ctx context.Context, route *v1.Route, targetName string) (*corev1.Service, error) {
 	hostname, err := domains.HostnameFromTemplate(ctx, route.Name, targetName)
 	if err != nil {
 		return nil, err
@@ -78,9 +78,9 @@ func MakeK8sPlaceholderService(ctx context.Context, route *v1alpha1.Route, targe
 }
 
 // MakeK8sService creates a Service that redirect to the loadbalancer specified
-// in Ingress status. It's owned by the provided v1alpha1.Route.
+// in Ingress status. It's owned by the provided v1.Route.
 // The purpose of this service is to provide a domain name for Istio routing.
-func MakeK8sService(ctx context.Context, route *v1alpha1.Route, targetName string, ingress *netv1alpha1.Ingress, isPrivate bool) (*corev1.Service, error) {
+func MakeK8sService(ctx context.Context, route *v1.Route, targetName string, ingress *netv1alpha1.Ingress, isPrivate bool) (*corev1.Service, error) {
 	svcSpec, err := makeServiceSpec(ingress, isPrivate)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func MakeK8sService(ctx context.Context, route *v1alpha1.Route, targetName strin
 	return service, nil
 }
 
-func makeK8sService(ctx context.Context, route *v1alpha1.Route, targetName string) (*corev1.Service, error) {
+func makeK8sService(ctx context.Context, route *v1.Route, targetName string) (*corev1.Service, error) {
 	hostname, err := domains.HostnameFromTemplate(ctx, route.Name, targetName)
 	if err != nil {
 		return nil, err
@@ -176,7 +176,7 @@ func makeServiceSpec(ingress *netv1alpha1.Ingress, isPrivate bool) (*corev1.Serv
 }
 
 // GetDesiredServiceNames returns a list of service names that we expect to create
-func GetDesiredServiceNames(ctx context.Context, route *v1alpha1.Route) (sets.String, error) {
+func GetDesiredServiceNames(ctx context.Context, route *v1.Route) (sets.String, error) {
 	traffic := route.Spec.Traffic
 
 	// We always want create the route with the service name.

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -41,7 +41,6 @@ import (
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/gc"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler"
@@ -51,9 +50,9 @@ import (
 	"knative.dev/serving/pkg/reconciler/route/traffic"
 
 	. "knative.dev/pkg/reconciler/testing"
-	. "knative.dev/serving/pkg/reconciler/testing/v1alpha1"
+	. "knative.dev/serving/pkg/reconciler/testing/v1"
 	. "knative.dev/serving/pkg/testing"
-	. "knative.dev/serving/pkg/testing/v1alpha1"
+	. "knative.dev/serving/pkg/testing/v1"
 )
 
 const TestIngressClass = "ingress-class-foo"
@@ -156,13 +155,12 @@ func TestReconcile(t *testing.T) {
 				WithRouteUID("12-34"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithURL, WithAddress, WithInitRouteConditions,
-				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
-					},
-				})),
+					})),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "becomes-ready"),
@@ -208,13 +206,12 @@ func TestReconcile(t *testing.T) {
 				WithRouteUID("12-34"), WithIngressClass("custom-ingress-class"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithURL, WithAddress, WithInitRouteConditions,
-				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
-					},
-				})),
+					})),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "becomes-ready"),
@@ -267,13 +264,12 @@ func TestReconcile(t *testing.T) {
 				// Populated by reconciliation when all traffic has been assigned.
 				WithLocalDomain, WithAddress, WithInitRouteConditions,
 				WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"}),
-				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
-					},
-				})),
+					})),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "becomes-ready"),
@@ -314,12 +310,10 @@ func TestReconcile(t *testing.T) {
 				// Populated by reconciliation when the route becomes ready.
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 		}},
 		WantEvents: []string{
@@ -349,12 +343,10 @@ func TestReconcile(t *testing.T) {
 				// the K8s service.
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 		}},
 		WantEvents: []string{
@@ -408,13 +400,12 @@ func TestReconcile(t *testing.T) {
 				// Populated by reconciliation when we fail to create
 				// the cluster ingress.
 				WithURL, WithAddress, WithInitRouteConditions,
-				MarkTrafficAssigned, WithStatusTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				MarkTrafficAssigned, WithStatusTraffic(
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
-					},
-				})),
+					})),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "ingress-create-failure"),
@@ -429,12 +420,10 @@ func TestReconcile(t *testing.T) {
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady,
 				WithRouteFinalizer, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
@@ -467,11 +456,9 @@ func TestReconcile(t *testing.T) {
 			Route("default", "unhappy-owner", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      ptr.Int64(100),
-						},
+					v1.TrafficTarget{
+						RevisionName: "config-00001",
+						Percent:      ptr.Int64(100),
 					})),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
@@ -486,12 +473,10 @@ func TestReconcile(t *testing.T) {
 			Object: Route("default", "unhappy-owner", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					}),
 				// The owner is not us, so we are unhappy.
 				MarkServiceNotOwned),
@@ -509,13 +494,12 @@ func TestReconcile(t *testing.T) {
 			Route("default", "different-domain", WithConfigTarget("config"),
 				WithAnotherDomain, WithAddress,
 				WithInitRouteConditions, MarkTrafficAssigned, MarkIngressReady,
-				WithRouteFinalizer, WithStatusTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				WithRouteFinalizer, WithStatusTraffic(
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
-					},
-				}), WithRouteLabel(map[string]string{"app": "prod"})),
+					}), WithRouteLabel(map[string]string{"app": "prod"})),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
 				// The Route controller attaches our label to this Configuration.
@@ -573,12 +557,10 @@ func TestReconcile(t *testing.T) {
 			Route("default", "new-latest-created", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 			cfg("default", "config",
 				WithGeneration(2), WithLatestReady("config-00001"), WithLatestCreated("config-00002"),
@@ -613,11 +595,9 @@ func TestReconcile(t *testing.T) {
 			Route("default", "new-latest-ready", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      ptr.Int64(100),
-						},
+					v1.TrafficTarget{
+						RevisionName: "config-00001",
+						Percent:      ptr.Int64(100),
 					})),
 			cfg("default", "config",
 				WithGeneration(2), WithLatestCreated("config-00002"), WithLatestReady("config-00002"),
@@ -668,12 +648,10 @@ func TestReconcile(t *testing.T) {
 			Object: Route("default", "new-latest-ready", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00002",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00002",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 		}},
 		Key: "default/new-latest-ready",
@@ -735,13 +713,12 @@ func TestReconcile(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressNotConfigured,
 				WithLocalDomain, WithAddress, WithInitRouteConditions,
 				WithRouteLabel(map[string]string{"serving.knative.dev/visibility": "cluster-local"}),
-				WithStatusTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				WithStatusTraffic(
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
-					},
-				})),
+					})),
 		}},
 		Key: "default/becomes-local",
 	}, {
@@ -799,13 +776,12 @@ func TestReconcile(t *testing.T) {
 				WithRouteUID("65-23"),
 				MarkTrafficAssigned, MarkIngressNotConfigured,
 				WithAddress, WithInitRouteConditions, WithURL,
-				WithStatusTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				WithStatusTraffic(
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
-					},
-				})),
+					})),
 		}},
 		Key: "default/becomes-public",
 	}, {
@@ -819,11 +795,9 @@ func TestReconcile(t *testing.T) {
 			Route("default", "update-ci-failure", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName: "config-00001",
-							Percent:      ptr.Int64(100),
-						},
+					v1.TrafficTarget{
+						RevisionName: "config-00001",
+						Percent:      ptr.Int64(100),
 					})),
 			cfg("default", "config",
 				WithGeneration(2), WithLatestCreated("config-00002"), WithLatestReady("config-00002"),
@@ -873,12 +847,10 @@ func TestReconcile(t *testing.T) {
 			Object: Route("default", "update-ci-failure", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00002",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00002",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 		}},
 		WantEvents: []string{
@@ -891,12 +863,10 @@ func TestReconcile(t *testing.T) {
 			Route("default", "svc-mutation", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
@@ -937,12 +907,10 @@ func TestReconcile(t *testing.T) {
 			Route("default", "svc-mutation", WithConfigTarget("config"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
@@ -984,12 +952,10 @@ func TestReconcile(t *testing.T) {
 			Route("default", "cluster-ip", WithConfigTarget("config"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
@@ -1026,12 +992,10 @@ func TestReconcile(t *testing.T) {
 			Route("default", "external-name", WithConfigTarget("config"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
@@ -1067,12 +1031,10 @@ func TestReconcile(t *testing.T) {
 			Route("default", "ingress-mutation", WithConfigTarget("config"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
@@ -1124,11 +1086,9 @@ func TestReconcile(t *testing.T) {
 			Route("default", "change-configs", WithConfigTarget("newconfig"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName: "oldconfig-00001",
-							Percent:      ptr.Int64(100),
-						},
+					v1.TrafficTarget{
+						RevisionName: "oldconfig-00001",
+						Percent:      ptr.Int64(100),
 					})),
 			// Both configs exist, but only "oldconfig" is labelled.
 			cfg("default", "oldconfig",
@@ -1182,12 +1142,10 @@ func TestReconcile(t *testing.T) {
 			Object: Route("default", "change-configs", WithConfigTarget("newconfig"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "newconfig-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "newconfig-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 		}},
 		Key: "default/change-configs",
@@ -1265,12 +1223,10 @@ func TestReconcile(t *testing.T) {
 				WithRevTarget("config-00001"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(false),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(false),
 					})),
 		}},
 		Key: "default/pinned-becomes-ready",
@@ -1278,16 +1234,12 @@ func TestReconcile(t *testing.T) {
 		Name: "traffic split becomes ready",
 		Objects: []runtime.Object{
 			Route("default", "named-traffic-split", WithSpecTraffic(
-				v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
-						ConfigurationName: "blue",
-						Percent:           ptr.Int64(50),
-					},
-				}, v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
-						ConfigurationName: "green",
-						Percent:           ptr.Int64(50),
-					},
+				v1.TrafficTarget{
+					ConfigurationName: "blue",
+					Percent:           ptr.Int64(50),
+				}, v1.TrafficTarget{
+					ConfigurationName: "green",
+					Percent:           ptr.Int64(50),
 				}), WithRouteUID("34-78"), WithRouteFinalizer),
 			cfg("default", "blue",
 				WithGeneration(1), WithLatestCreated("blue-00001"), WithLatestReady("blue-00001")),
@@ -1299,16 +1251,12 @@ func TestReconcile(t *testing.T) {
 		WantCreates: []runtime.Object{
 			simpleIngress(
 				Route("default", "named-traffic-split", WithURL, WithSpecTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							ConfigurationName: "blue",
-							Percent:           ptr.Int64(50),
-						},
-					}, v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							ConfigurationName: "green",
-							Percent:           ptr.Int64(50),
-						},
+					v1.TrafficTarget{
+						ConfigurationName: "blue",
+						Percent:           ptr.Int64(50),
+					}, v1.TrafficTarget{
+						ConfigurationName: "green",
+						Percent:           ptr.Int64(50),
 					}), WithRouteUID("34-78")),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
@@ -1335,47 +1283,36 @@ func TestReconcile(t *testing.T) {
 			simplePlaceholderK8sService(
 				getContext(),
 				Route("default", "named-traffic-split", WithSpecTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							ConfigurationName: "blue",
-							Percent:           ptr.Int64(50),
-						},
-					}, v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							ConfigurationName: "green",
-							Percent:           ptr.Int64(50),
-						},
+					v1.TrafficTarget{
+						ConfigurationName: "blue",
+						Percent:           ptr.Int64(50),
+					},
+					v1.TrafficTarget{
+						ConfigurationName: "green",
+						Percent:           ptr.Int64(50),
 					}), WithRouteUID("34-78"), WithRouteFinalizer),
 				"",
 			),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: Route("default", "named-traffic-split", WithRouteFinalizer,
-				WithSpecTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
-						ConfigurationName: "blue",
-						Percent:           ptr.Int64(50),
-					},
-				}, v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
-						ConfigurationName: "green",
-						Percent:           ptr.Int64(50),
-					},
+				WithSpecTraffic(v1.TrafficTarget{
+					ConfigurationName: "blue",
+					Percent:           ptr.Int64(50),
+				}, v1.TrafficTarget{
+					ConfigurationName: "green",
+					Percent:           ptr.Int64(50),
 				}), WithRouteUID("34-78"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "blue-00001",
-							Percent:        ptr.Int64(50),
-							LatestRevision: ptr.Bool(true),
-						},
-					}, v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "green-00001",
-							Percent:        ptr.Int64(50),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "blue-00001",
+						Percent:        ptr.Int64(50),
+						LatestRevision: ptr.Bool(true),
+					}, v1.TrafficTarget{
+						RevisionName:   "green-00001",
+						Percent:        ptr.Int64(50),
+						LatestRevision: ptr.Bool(true),
 					})),
 		}},
 		WantEvents: []string{
@@ -1387,18 +1324,14 @@ func TestReconcile(t *testing.T) {
 		Name: "same revision targets",
 		Objects: []runtime.Object{
 			Route("default", "same-revision-targets", WithSpecTraffic(
-				v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
-						Tag:               "gray",
-						ConfigurationName: "gray",
-						Percent:           ptr.Int64(50),
-					},
-				}, v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
-						Tag:          "also-gray",
-						RevisionName: "gray-00001",
-						Percent:      ptr.Int64(50),
-					},
+				v1.TrafficTarget{
+					Tag:               "gray",
+					ConfigurationName: "gray",
+					Percent:           ptr.Int64(50),
+				}, v1.TrafficTarget{
+					Tag:          "also-gray",
+					RevisionName: "gray-00001",
+					Percent:      ptr.Int64(50),
 				}), WithRouteUID("1-2"), WithRouteFinalizer),
 			cfg("default", "gray",
 				WithGeneration(1), WithLatestCreated("gray-00001"), WithLatestReady("gray-00001")),
@@ -1407,18 +1340,14 @@ func TestReconcile(t *testing.T) {
 		WantCreates: []runtime.Object{
 			simpleIngress(
 				Route("default", "same-revision-targets", WithURL, WithSpecTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							Tag:               "gray",
-							ConfigurationName: "gray",
-							Percent:           ptr.Int64(50),
-						},
-					}, v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							Tag:          "also-gray",
-							RevisionName: "gray-00001",
-							Percent:      ptr.Int64(50),
-						},
+					v1.TrafficTarget{
+						Tag:               "gray",
+						ConfigurationName: "gray",
+						Percent:           ptr.Int64(50),
+					}, v1.TrafficTarget{
+						Tag:          "also-gray",
+						RevisionName: "gray-00001",
+						Percent:      ptr.Int64(50),
 					}), WithRouteUID("1-2")),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
@@ -1455,96 +1384,82 @@ func TestReconcile(t *testing.T) {
 			simplePlaceholderK8sService(
 				getContext(),
 				Route("default", "same-revision-targets", WithSpecTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							Tag:               "gray",
-							ConfigurationName: "gray",
-							Percent:           ptr.Int64(50),
-						},
-					}, v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							Tag:          "also-gray",
-							RevisionName: "gray-00001",
-							Percent:      ptr.Int64(50),
-						},
+					v1.TrafficTarget{
+						Tag:               "gray",
+						ConfigurationName: "gray",
+						Percent:           ptr.Int64(50),
+					},
+					v1.TrafficTarget{
+						Tag:          "also-gray",
+						RevisionName: "gray-00001",
+						Percent:      ptr.Int64(50),
 					}), WithRouteUID("1-2"), WithRouteFinalizer),
 				"",
 			),
 			simplePlaceholderK8sService(
 				getContext(),
 				Route("default", "same-revision-targets", WithSpecTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							Tag:               "gray",
-							ConfigurationName: "gray",
-							Percent:           ptr.Int64(50),
-						},
-					}, v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							Tag:          "also-gray",
-							RevisionName: "gray-00001",
-							Percent:      ptr.Int64(50),
-						},
+					v1.TrafficTarget{
+						Tag:               "gray",
+						ConfigurationName: "gray",
+						Percent:           ptr.Int64(50),
+					},
+					v1.TrafficTarget{
+						Tag:          "also-gray",
+						RevisionName: "gray-00001",
+						Percent:      ptr.Int64(50),
 					}), WithRouteUID("1-2"), WithRouteFinalizer),
 				"also-gray",
 			),
 			simplePlaceholderK8sService(
 				getContext(),
 				Route("default", "same-revision-targets", WithSpecTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							Tag:               "gray",
-							ConfigurationName: "gray",
-							Percent:           ptr.Int64(50),
-						},
-					}, v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							Tag:          "also-gray",
-							RevisionName: "gray-00001",
-							Percent:      ptr.Int64(50),
-						},
+					v1.TrafficTarget{
+						Tag:               "gray",
+						ConfigurationName: "gray",
+						Percent:           ptr.Int64(50),
+					},
+					v1.TrafficTarget{
+						Tag:          "also-gray",
+						RevisionName: "gray-00001",
+						Percent:      ptr.Int64(50),
 					}), WithRouteUID("1-2"), WithRouteFinalizer),
 				"gray",
 			),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: Route("default", "same-revision-targets",
-				WithSpecTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				WithSpecTraffic(
+					v1.TrafficTarget{
 						Tag:               "gray",
 						ConfigurationName: "gray",
 						Percent:           ptr.Int64(50),
 					},
-				}, v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+					v1.TrafficTarget{
 						Tag:          "also-gray",
 						RevisionName: "gray-00001",
 						Percent:      ptr.Int64(50),
-					},
-				}), WithRouteUID("1-2"), WithRouteFinalizer,
+					}), WithRouteUID("1-2"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							Tag:            "gray",
-							RevisionName:   "gray-00001",
-							Percent:        ptr.Int64(50),
-							LatestRevision: ptr.Bool(true),
-							URL: &apis.URL{
-								Scheme: "http",
-								Host:   "gray-same-revision-targets.default.example.com",
-							},
+					v1.TrafficTarget{
+						Tag:            "gray",
+						RevisionName:   "gray-00001",
+						Percent:        ptr.Int64(50),
+						LatestRevision: ptr.Bool(true),
+						URL: &apis.URL{
+							Scheme: "http",
+							Host:   "gray-same-revision-targets.default.example.com",
 						},
-					}, v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							Tag:            "also-gray",
-							RevisionName:   "gray-00001",
-							Percent:        ptr.Int64(50),
-							LatestRevision: ptr.Bool(false),
-							URL: &apis.URL{
-								Scheme: "http",
-								Host:   "also-gray-same-revision-targets.default.example.com",
-							},
+					},
+					v1.TrafficTarget{
+						Tag:            "also-gray",
+						RevisionName:   "gray-00001",
+						Percent:        ptr.Int64(50),
+						LatestRevision: ptr.Bool(false),
+						URL: &apis.URL{
+							Scheme: "http",
+							Host:   "also-gray-same-revision-targets.default.example.com",
 						},
 					})),
 		}},
@@ -1562,12 +1477,11 @@ func TestReconcile(t *testing.T) {
 			Route("default", "switch-configs", WithConfigTarget("green"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							Tag:          "blue",
-							RevisionName: "blue-00001",
-							Percent:      ptr.Int64(100),
-						},
+					v1.TrafficTarget{
+						Tag:          "blue",
+						RevisionName: "blue-00001",
+						Percent:      ptr.Int64(100),
+						URL:          url("http://blue.example.com"),
 					}), WithRouteFinalizer),
 			cfg("default", "blue",
 				WithGeneration(1), WithLatestCreated("blue-00001"), WithLatestReady("blue-00001"),
@@ -1618,12 +1532,10 @@ func TestReconcile(t *testing.T) {
 			Object: Route("default", "switch-configs", WithConfigTarget("green"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "green-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "green-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					}), WithRouteFinalizer),
 		}},
 		Key: "default/switch-configs",
@@ -1635,24 +1547,18 @@ func TestReconcile(t *testing.T) {
 			Route("default", "split", WithURL, WithAddress,
 				WithInitRouteConditions, MarkTrafficAssigned, MarkIngressReady,
 				WithSpecTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							ConfigurationName: "blue",
-							Percent:           ptr.Int64(50),
-						},
-					}, v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							ConfigurationName: "green",
-							Percent:           ptr.Int64(50),
-						},
+					v1.TrafficTarget{
+						ConfigurationName: "blue",
+						Percent:           ptr.Int64(50),
+					},
+					v1.TrafficTarget{
+						ConfigurationName: "green",
+						Percent:           ptr.Int64(50),
 					}),
 				WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							ConfigurationName: "blue",
-							Percent:           ptr.Int64(100),
-							LatestRevision:    ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName: "blue-00001",
+						Percent:      ptr.Int64(100),
 					},
 				)),
 			cfg("default", "blue", WithGeneration(1),
@@ -1668,24 +1574,18 @@ func TestReconcile(t *testing.T) {
 				WithInitRouteConditions, MarkTrafficAssigned, MarkIngressReady,
 				MarkConfigurationNotReady("green"),
 				WithSpecTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							ConfigurationName: "blue",
-							Percent:           ptr.Int64(50),
-						},
-					}, v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							ConfigurationName: "green",
-							Percent:           ptr.Int64(50),
-						},
+					v1.TrafficTarget{
+						ConfigurationName: "blue",
+						Percent:           ptr.Int64(50),
+					},
+					v1.TrafficTarget{
+						ConfigurationName: "green",
+						Percent:           ptr.Int64(50),
 					}),
 				WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							ConfigurationName: "blue",
-							Percent:           ptr.Int64(100),
-							LatestRevision:    ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName: "blue-00001",
+						Percent:      ptr.Int64(100),
 					})),
 		}},
 		Key: "default/split",
@@ -1695,12 +1595,10 @@ func TestReconcile(t *testing.T) {
 			Route("default", "stale-lastpinned", WithConfigTarget("config"),
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithRouteFinalizer, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
@@ -1737,12 +1635,10 @@ func TestReconcile(t *testing.T) {
 			Route("default", "old-naming", WithConfigTarget("config"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 			cfg("default", "config",
 				WithGeneration(1),
@@ -1776,12 +1672,10 @@ func TestReconcile(t *testing.T) {
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady,
 				WithRouteFinalizer, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
@@ -1831,12 +1725,10 @@ func TestReconcile(t *testing.T) {
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, MarkIngressReady,
 				WithRouteFinalizer, WithStatusTraffic(
-					v1alpha1.TrafficTarget{
-						TrafficTarget: v1.TrafficTarget{
-							RevisionName:   "config-00001",
-							Percent:        ptr.Int64(100),
-							LatestRevision: ptr.Bool(true),
-						},
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
 					})),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
@@ -1932,13 +1824,12 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				WithRouteUID("12-34"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithAddress, WithInitRouteConditions,
-				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
-					},
-				}), WithReadyCertificateName("default.example.com"), WithHTTPSDomain),
+					}), WithReadyCertificateName("default.example.com"), WithHTTPSDomain),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "becomes-ready"),
@@ -1989,13 +1880,12 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				WithRouteUID("12-34"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithURL, WithAddress, WithInitRouteConditions,
-				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
-					},
-				}), MarkCertificateNotReady),
+					}), MarkCertificateNotReady),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "becomes-ready"),
@@ -2071,13 +1961,12 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				WithRouteUID("12-34"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithAddress, WithInitRouteConditions,
-				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
-					},
-				}), MarkCertificateReady,
+					}), MarkCertificateReady,
 				// The certificate is ready. So we want to have HTTPS URL.
 				WithHTTPSDomain),
 		}},
@@ -2174,13 +2063,12 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				WithRouteUID("12-34"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithAddress, WithInitRouteConditions,
-				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
-					},
-				}),
+					}),
 				// The certificate has to be created in the not ready state for the ACME challenge
 				// ingress rules to be added.
 				MarkCertificateNotReady,
@@ -2225,17 +2113,16 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 			Object: Route("default", "becomes-ready", WithConfigTarget("config"),
 				WithRouteUID("12-34"),
 				WithAddress, WithInitRouteConditions, WithURL,
-				MarkTrafficAssigned, WithStatusTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				MarkTrafficAssigned, WithStatusTraffic(
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
-					},
-				}), MarkCertificateNotOwned),
+					}), MarkCertificateNotOwned),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "becomes-ready"),
-			Eventf(corev1.EventTypeWarning, "InternalError", kaccessor.NewAccessorError(fmt.Errorf("owner: %s with Type %T does not own Certificate: %q", "becomes-ready", &v1alpha1.Route{}, "route-12-34"), kaccessor.NotOwnResource).Error()),
+			Eventf(corev1.EventTypeWarning, "InternalError", kaccessor.NewAccessorError(fmt.Errorf("owner: %s with Type %T does not own Certificate: %q", "becomes-ready", &v1.Route{}, "route-12-34"), kaccessor.NotOwnResource).Error()),
 		},
 		Key: "default/becomes-ready",
 	}, {
@@ -2306,13 +2193,12 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				WithRouteUID("12-34"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithAddress, WithInitRouteConditions,
-				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
-					},
-				}), MarkCertificateNotReady, MarkIngressNotConfigured,
+					}), MarkCertificateNotReady, MarkIngressNotConfigured,
 				// The certificate is not ready. So we want to have HTTP URL.
 				WithURL),
 		}},
@@ -2381,13 +2267,12 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				MarkTrafficAssigned, MarkIngressNotConfigured,
 				WithLocalDomain, WithAddress, WithInitRouteConditions,
 				WithRouteLabel(map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal}),
-				WithStatusTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				WithStatusTraffic(
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
-					},
-				})),
+					})),
 		}},
 		Key: "default/becomes-local",
 	}}
@@ -2497,13 +2382,12 @@ func TestReconcile_EnableAutoTLS_HTTPDisabled(t *testing.T) {
 				WithRouteUID("12-34"),
 				// Populated by reconciliation when all traffic has been assigned.
 				WithAddress, WithInitRouteConditions,
-				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(v1alpha1.TrafficTarget{
-					TrafficTarget: v1.TrafficTarget{
+				MarkTrafficAssigned, MarkIngressNotConfigured, WithStatusTraffic(
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
 						Percent:        ptr.Int64(100),
 						LatestRevision: ptr.Bool(true),
-					},
-				}), MarkCertificateNotReady, MarkIngressNotConfigured,
+					}), MarkCertificateNotReady, MarkIngressNotConfigured,
 				// The certificate is not ready. But we still want to have HTTPS URL.
 				WithHTTPSDomain),
 		}},
@@ -2534,22 +2418,20 @@ func TestReconcile_EnableAutoTLS_HTTPDisabled(t *testing.T) {
 	}))
 }
 
-func cfg(namespace, name string, co ...ConfigOption) *v1alpha1.Configuration {
-	cfg := &v1alpha1.Configuration{
+func cfg(namespace, name string, co ...ConfigOption) *v1.Configuration {
+	cfg := &v1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       namespace,
 			Name:            name,
 			ResourceVersion: "v1",
 		},
-		Spec: v1alpha1.ConfigurationSpec{
-			Template: &v1alpha1.RevisionTemplateSpec{
-				Spec: v1alpha1.RevisionSpec{
-					RevisionSpec: v1.RevisionSpec{
-						PodSpec: corev1.PodSpec{
-							Containers: []corev1.Container{{
-								Image: "busybox",
-							}},
-						},
+		Spec: v1.ConfigurationSpec{
+			Template: v1.RevisionTemplateSpec{
+				Spec: v1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Image: "busybox",
+						}},
 					},
 				},
 			},
@@ -2561,7 +2443,7 @@ func cfg(namespace, name string, co ...ConfigOption) *v1alpha1.Configuration {
 	return cfg
 }
 
-func simplePlaceholderK8sService(ctx context.Context, r *v1alpha1.Route, targetName string, so ...K8sServiceOption) *corev1.Service {
+func simplePlaceholderK8sService(ctx context.Context, r *v1.Route, targetName string, so ...K8sServiceOption) *corev1.Service {
 	// omit the error here, as we are sure the loadbalancer info is porvided.
 	// return the service instance only, so that the result can be used in TableRow.
 	svc, _ := resources.MakeK8sPlaceholderService(ctx, r, targetName)
@@ -2573,7 +2455,7 @@ func simplePlaceholderK8sService(ctx context.Context, r *v1alpha1.Route, targetN
 	return svc
 }
 
-func simpleK8sService(r *v1alpha1.Route, so ...K8sServiceOption) *corev1.Service {
+func simpleK8sService(r *v1.Route, so ...K8sServiceOption) *corev1.Service {
 	cs := &testConfigStore{
 		config: ReconcilerTestConfig(false),
 	}
@@ -2590,15 +2472,15 @@ func simpleK8sService(r *v1alpha1.Route, so ...K8sServiceOption) *corev1.Service
 	return svc
 }
 
-func simpleIngress(r *v1alpha1.Route, tc *traffic.Config, io ...IngressOption) *netv1alpha1.Ingress {
+func simpleIngress(r *v1.Route, tc *traffic.Config, io ...IngressOption) *netv1alpha1.Ingress {
 	return baseIngressWithClass(r, tc, TestIngressClass, io...)
 }
 
-func ingressWithClass(r *v1alpha1.Route, tc *traffic.Config, class string, io ...IngressOption) *netv1alpha1.Ingress {
+func ingressWithClass(r *v1.Route, tc *traffic.Config, class string, io ...IngressOption) *netv1alpha1.Ingress {
 	return baseIngressWithClass(r, tc, class, io...)
 }
 
-func baseIngressWithClass(r *v1alpha1.Route, tc *traffic.Config, class string, io ...IngressOption) *netv1alpha1.Ingress {
+func baseIngressWithClass(r *v1.Route, tc *traffic.Config, class string, io ...IngressOption) *netv1alpha1.Ingress {
 	ingress, _ := resources.MakeIngress(getContext(), r, tc, nil, class)
 
 	for _, opt := range io {
@@ -2608,11 +2490,11 @@ func baseIngressWithClass(r *v1alpha1.Route, tc *traffic.Config, class string, i
 	return ingress
 }
 
-func ingressWithTLS(r *v1alpha1.Route, tc *traffic.Config, tls []netv1alpha1.IngressTLS, challenges []netv1alpha1.HTTP01Challenge, io ...IngressOption) *netv1alpha1.Ingress {
+func ingressWithTLS(r *v1.Route, tc *traffic.Config, tls []netv1alpha1.IngressTLS, challenges []netv1alpha1.HTTP01Challenge, io ...IngressOption) *netv1alpha1.Ingress {
 	return baseIngressWithTLS(r, tc, tls, challenges, io...)
 }
 
-func baseIngressWithTLS(r *v1alpha1.Route, tc *traffic.Config, tls []netv1alpha1.IngressTLS, challenges []netv1alpha1.HTTP01Challenge, io ...IngressOption) *netv1alpha1.Ingress {
+func baseIngressWithTLS(r *v1.Route, tc *traffic.Config, tls []netv1alpha1.IngressTLS, challenges []netv1alpha1.HTTP01Challenge, io ...IngressOption) *netv1alpha1.Ingress {
 	ingress, _ := resources.MakeIngress(getContext(), r, tc, tls, TestIngressClass, challenges...)
 
 	for _, opt := range io {
@@ -2622,7 +2504,7 @@ func baseIngressWithTLS(r *v1alpha1.Route, tc *traffic.Config, tls []netv1alpha1
 	return ingress
 }
 
-func simpleReadyIngress(r *v1alpha1.Route, tc *traffic.Config, io ...IngressOption) *netv1alpha1.Ingress {
+func simpleReadyIngress(r *v1.Route, tc *traffic.Config, io ...IngressOption) *netv1alpha1.Ingress {
 	ingress := ingressWithStatus(r, tc, readyIngressStatus())
 
 	for _, opt := range io {
@@ -2651,7 +2533,7 @@ func readyIngressStatus() netv1alpha1.IngressStatus {
 	return status
 }
 
-func ingressWithStatus(r *v1alpha1.Route, tc *traffic.Config, status netv1alpha1.IngressStatus) *netv1alpha1.Ingress {
+func ingressWithStatus(r *v1.Route, tc *traffic.Config, status netv1alpha1.IngressStatus) *netv1alpha1.Ingress {
 	ci := simpleIngress(r, tc)
 	ci.SetName(r.Name)
 	ci.Status = status
@@ -2669,22 +2551,22 @@ func patchLastPinned(namespace, name string) clientgotesting.PatchActionImpl {
 	action := clientgotesting.PatchActionImpl{}
 	action.Name = name
 	action.Namespace = namespace
-	lastPinStr := v1alpha1.RevisionLastPinnedString(fakeCurTime)
+	lastPinStr := v1.RevisionLastPinnedString(fakeCurTime)
 	patch := fmt.Sprintf(`{"metadata":{"annotations":{"serving.knative.dev/lastPinned":%q}}}`, lastPinStr)
 	action.Patch = []byte(patch)
 	return action
 }
 
-func rev(namespace, name string, generation int64, ro ...RevisionOption) *v1alpha1.Revision {
-	r := &v1alpha1.Revision{
+func rev(namespace, name string, generation int64, ro ...RevisionOption) *v1.Revision {
+	r := &v1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Annotations: map[string]string{
-				"serving.knative.dev/lastPinned": v1alpha1.RevisionLastPinnedString(
+				"serving.knative.dev/lastPinned": v1.RevisionLastPinnedString(
 					fakeCurTime.Add(-1 * time.Second)),
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+				APIVersion:         v1.SchemeGroupVersion.String(),
 				Kind:               "Configuration",
 				Name:               name,
 				Controller:         ptr.Bool(true),
@@ -2747,4 +2629,13 @@ func notReadyCertStatus() netv1alpha1.CertificateStatus {
 func certificateWithStatus(cert *netv1alpha1.Certificate, status netv1alpha1.CertificateStatus) *netv1alpha1.Certificate {
 	cert.Status = status
 	return cert
+}
+
+func url(s string) *apis.URL {
+	url, err := apis.ParseURL(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return url
 }

--- a/pkg/reconciler/route/traffic/errors.go
+++ b/pkg/reconciler/route/traffic/errors.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 // TargetError gives details about an invalid traffic target.
@@ -29,7 +29,7 @@ type TargetError interface {
 
 	// MarkBadTrafficTarget marks a RouteStatus with Condition corresponding
 	// to the error case of the traffic target.
-	MarkBadTrafficTarget(rs *v1alpha1.RouteStatus)
+	MarkBadTrafficTarget(rs *v1.RouteStatus)
 
 	// IsFailure returns whether a TargetError is a true failure, e.g.
 	// a Configuration fails to become ready.
@@ -49,7 +49,7 @@ func (e *missingTargetError) Error() string {
 }
 
 // MarkBadTrafficTarget implements TargetError.
-func (e *missingTargetError) MarkBadTrafficTarget(rs *v1alpha1.RouteStatus) {
+func (e *missingTargetError) MarkBadTrafficTarget(rs *v1.RouteStatus) {
 	rs.MarkMissingTrafficTarget(e.kind, e.name)
 }
 
@@ -71,7 +71,7 @@ func (e *unreadyConfigError) Error() string {
 }
 
 // MarkBadTrafficTarget implements TargetError.
-func (e *unreadyConfigError) MarkBadTrafficTarget(rs *v1alpha1.RouteStatus) {
+func (e *unreadyConfigError) MarkBadTrafficTarget(rs *v1.RouteStatus) {
 	if e.IsFailure() {
 		rs.MarkConfigurationFailed(e.name)
 	} else {
@@ -96,7 +96,7 @@ func (e *unreadyRevisionError) Error() string {
 }
 
 // MarkBadTrafficTarget implements TargetError.
-func (e *unreadyRevisionError) MarkBadTrafficTarget(rs *v1alpha1.RouteStatus) {
+func (e *unreadyRevisionError) MarkBadTrafficTarget(rs *v1.RouteStatus) {
 	if e.IsFailure() {
 		rs.MarkRevisionFailed(e.name)
 	} else {
@@ -109,9 +109,9 @@ func (e *unreadyRevisionError) IsFailure() bool {
 }
 
 // errUnreadyConfiguration returns a TargetError for a Configuration that is not ready.
-func errUnreadyConfiguration(config *v1alpha1.Configuration) TargetError {
+func errUnreadyConfiguration(config *v1.Configuration) TargetError {
 	status := corev1.ConditionUnknown
-	if c := config.Status.GetCondition(v1alpha1.ConfigurationConditionReady); c != nil {
+	if c := config.Status.GetCondition(v1.ConfigurationConditionReady); c != nil {
 		status = c.Status
 	}
 	return &unreadyConfigError{
@@ -121,9 +121,9 @@ func errUnreadyConfiguration(config *v1alpha1.Configuration) TargetError {
 }
 
 // errUnreadyRevision returns a TargetError for a Revision that is not ready.
-func errUnreadyRevision(rev *v1alpha1.Revision) TargetError {
+func errUnreadyRevision(rev *v1.Revision) TargetError {
 	status := corev1.ConditionUnknown
-	if c := rev.Status.GetCondition(v1alpha1.RevisionConditionReady); c != nil {
+	if c := rev.Status.GetCondition(v1.RevisionConditionReady); c != nil {
 		status = c.Status
 	}
 	return &unreadyRevisionError{

--- a/pkg/reconciler/route/traffic/errors_test.go
+++ b/pkg/reconciler/route/traffic/errors_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	. "knative.dev/serving/pkg/testing/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	. "knative.dev/serving/pkg/testing/v1"
 )
 
 func TestIsFailure_Missing(t *testing.T) {
@@ -35,12 +35,12 @@ func TestIsFailure_Missing(t *testing.T) {
 
 func TestMarkBadTrafficTarget_Missing(t *testing.T) {
 	err := errMissingRevision("missing-rev")
-	r := testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{}))
+	r := testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{}))
 
 	err.MarkBadTrafficTarget(&r.Status)
 	for _, condType := range []apis.ConditionType{
-		v1alpha1.RouteConditionAllTrafficAssigned,
-		v1alpha1.RouteConditionReady,
+		v1.RouteConditionAllTrafficAssigned,
+		v1.RouteConditionReady,
 	} {
 		got := r.Status.GetCondition(condType)
 		want := &apis.Condition{
@@ -67,12 +67,12 @@ func TestIsFailure_NotYetReady(t *testing.T) {
 
 func TestMarkBadTrafficTarget_NotYetReady(t *testing.T) {
 	err := errUnreadyConfiguration(unreadyConfig)
-	r := testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{}))
+	r := testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{}))
 
 	err.MarkBadTrafficTarget(&r.Status)
 	for _, condType := range []apis.ConditionType{
-		v1alpha1.RouteConditionAllTrafficAssigned,
-		v1alpha1.RouteConditionReady,
+		v1.RouteConditionAllTrafficAssigned,
+		v1.RouteConditionReady,
 	} {
 		got := r.Status.GetCondition(condType)
 		want := &apis.Condition{
@@ -99,12 +99,12 @@ func TestIsFailure_ConfigFailedToBeReady(t *testing.T) {
 
 func TestMarkBadTrafficTarget_ConfigFailedToBeReady(t *testing.T) {
 	err := errUnreadyConfiguration(failedConfig)
-	r := testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{}))
+	r := testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{}))
 
 	err.MarkBadTrafficTarget(&r.Status)
 	for _, condType := range []apis.ConditionType{
-		v1alpha1.RouteConditionAllTrafficAssigned,
-		v1alpha1.RouteConditionReady,
+		v1.RouteConditionAllTrafficAssigned,
+		v1.RouteConditionReady,
 	} {
 		got := r.Status.GetCondition(condType)
 		want := &apis.Condition{
@@ -123,12 +123,12 @@ func TestMarkBadTrafficTarget_ConfigFailedToBeReady(t *testing.T) {
 
 func TestMarkBadTrafficTarget_RevisionFailedToBeReady(t *testing.T) {
 	err := errUnreadyRevision(failedRev)
-	r := testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{}))
+	r := testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{}))
 
 	err.MarkBadTrafficTarget(&r.Status)
 	for _, condType := range []apis.ConditionType{
-		v1alpha1.RouteConditionAllTrafficAssigned,
-		v1alpha1.RouteConditionReady,
+		v1.RouteConditionAllTrafficAssigned,
+		v1.RouteConditionReady,
 	} {
 		got := r.Status.GetCondition(condType)
 		want := &apis.Condition{
@@ -155,12 +155,12 @@ func TestIsFailure_RevFailedToBeReady(t *testing.T) {
 
 func TestMarkBadTrafficTarget_RevisionNotYetReady(t *testing.T) {
 	err := errUnreadyRevision(unreadyRev)
-	r := testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{}))
+	r := testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{}))
 
 	err.MarkBadTrafficTarget(&r.Status)
 	for _, condType := range []apis.ConditionType{
-		v1alpha1.RouteConditionAllTrafficAssigned,
-		v1alpha1.RouteConditionReady,
+		v1.RouteConditionAllTrafficAssigned,
+		v1.RouteConditionReady,
 	} {
 		got := r.Status.GetCondition(condType)
 		want := &apis.Condition{

--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -27,8 +27,7 @@ import (
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	listers "knative.dev/serving/pkg/client/listers/serving/v1alpha1"
+	listers "knative.dev/serving/pkg/client/listers/serving/v1"
 	"knative.dev/serving/pkg/reconciler/route/domains"
 	"knative.dev/serving/pkg/reconciler/route/resources/labels"
 )
@@ -67,8 +66,8 @@ type Config struct {
 	revisionTargets RevisionTargets
 
 	// The referred `Configuration`s and `Revision`s.
-	Configurations map[string]*v1alpha1.Configuration
-	Revisions      map[string]*v1alpha1.Revision
+	Configurations map[string]*v1.Configuration
+	Revisions      map[string]*v1.Revision
 
 	// MissingTargets are references to Configuration's or Revision's
 	// that are missing
@@ -81,15 +80,15 @@ type Config struct {
 //
 // In the case that some target is missing, an error of type TargetError will be returned.
 func BuildTrafficConfiguration(configLister listers.ConfigurationLister, revLister listers.RevisionLister,
-	r *v1alpha1.Route) (*Config, error) {
+	r *v1.Route) (*Config, error) {
 	builder := newBuilder(configLister, revLister, r.Namespace, len(r.Spec.Traffic))
 	builder.applySpecTraffic(r.Spec.Traffic)
 	return builder.build()
 }
 
 // GetRevisionTrafficTargets returns a list of TrafficTarget flattened to the RevisionName, and having ConfigurationName cleared out.
-func (t *Config) GetRevisionTrafficTargets(ctx context.Context, r *v1alpha1.Route) ([]v1alpha1.TrafficTarget, error) {
-	results := make([]v1alpha1.TrafficTarget, len(t.revisionTargets))
+func (t *Config) GetRevisionTrafficTargets(ctx context.Context, r *v1.Route) ([]v1.TrafficTarget, error) {
+	results := make([]v1.TrafficTarget, len(t.revisionTargets))
 	for i, tt := range t.revisionTargets {
 		var pp *int64
 		if tt.Percent != nil {
@@ -98,13 +97,11 @@ func (t *Config) GetRevisionTrafficTargets(ctx context.Context, r *v1alpha1.Rout
 
 		// We cannot `DeepCopy` here, since tt.TrafficTarget might contain both
 		// configuration and revision.
-		results[i] = v1alpha1.TrafficTarget{
-			TrafficTarget: v1.TrafficTarget{
-				Tag:            tt.Tag,
-				RevisionName:   tt.RevisionName,
-				Percent:        pp,
-				LatestRevision: tt.LatestRevision,
-			},
+		results[i] = v1.TrafficTarget{
+			Tag:            tt.Tag,
+			RevisionName:   tt.RevisionName,
+			Percent:        pp,
+			LatestRevision: tt.LatestRevision,
 		}
 		if tt.Tag != "" {
 			meta := r.ObjectMeta.DeepCopy()
@@ -139,9 +136,9 @@ type configBuilder struct {
 	revisionTargets RevisionTargets
 
 	// configurations contains all the referred Configuration, keyed by their name.
-	configurations map[string]*v1alpha1.Configuration
+	configurations map[string]*v1.Configuration
 	// revisions contains all the referred Revision, keyed by their name.
-	revisions map[string]*v1alpha1.Revision
+	revisions map[string]*v1.Revision
 
 	// missingTargets is a collection of targets that weren't present
 	// in our listers
@@ -161,12 +158,12 @@ func newBuilder(
 		targets:         make(map[string]RevisionTargets),
 		revisionTargets: make(RevisionTargets, 0, trafficSize),
 
-		configurations: make(map[string]*v1alpha1.Configuration),
-		revisions:      make(map[string]*v1alpha1.Revision),
+		configurations: make(map[string]*v1.Configuration),
+		revisions:      make(map[string]*v1.Revision),
 	}
 }
 
-func (t *configBuilder) applySpecTraffic(traffic []v1alpha1.TrafficTarget) error {
+func (t *configBuilder) applySpecTraffic(traffic []v1.TrafficTarget) error {
 	for _, tt := range traffic {
 		if err := t.addTrafficTarget(&tt); err != nil {
 			// Other non-traffic target errors shouldn't be ignored.
@@ -176,7 +173,7 @@ func (t *configBuilder) applySpecTraffic(traffic []v1alpha1.TrafficTarget) error
 	return nil
 }
 
-func (t *configBuilder) getConfiguration(name string) (*v1alpha1.Configuration, error) {
+func (t *configBuilder) getConfiguration(name string) (*v1.Configuration, error) {
 	if _, ok := t.configurations[name]; !ok {
 		config, err := t.configLister.Configurations(t.namespace).Get(name)
 		if errors.IsNotFound(err) {
@@ -189,7 +186,7 @@ func (t *configBuilder) getConfiguration(name string) (*v1alpha1.Configuration, 
 	return t.configurations[name], nil
 }
 
-func (t *configBuilder) getRevision(name string) (*v1alpha1.Revision, error) {
+func (t *configBuilder) getRevision(name string) (*v1.Revision, error) {
 	if _, ok := t.revisions[name]; !ok {
 		rev, err := t.revLister.Revisions(t.namespace).Get(name)
 		if errors.IsNotFound(err) {
@@ -210,7 +207,7 @@ func (t *configBuilder) deferTargetError(err TargetError) {
 	}
 }
 
-func (t *configBuilder) addTrafficTarget(tt *v1alpha1.TrafficTarget) error {
+func (t *configBuilder) addTrafficTarget(tt *v1.TrafficTarget) error {
 	var err error
 	if tt.RevisionName != "" {
 		err = t.addRevisionTarget(tt)
@@ -218,7 +215,7 @@ func (t *configBuilder) addTrafficTarget(tt *v1alpha1.TrafficTarget) error {
 		err = t.addConfigurationTarget(tt)
 	}
 	if err, ok := err.(*missingTargetError); err != nil && ok {
-		apiVersion, kind := v1alpha1.SchemeGroupVersion.
+		apiVersion, kind := v1.SchemeGroupVersion.
 			WithKind(err.kind).
 			ToAPIVersionAndKind()
 
@@ -240,7 +237,7 @@ func (t *configBuilder) addTrafficTarget(tt *v1alpha1.TrafficTarget) error {
 
 // addConfigurationTarget flattens a traffic target to the Revision level, by looking up for the LatestReadyRevisionName
 // on the referred Configuration.  It adds both to the lists of directly referred targets.
-func (t *configBuilder) addConfigurationTarget(tt *v1alpha1.TrafficTarget) error {
+func (t *configBuilder) addConfigurationTarget(tt *v1.TrafficTarget) error {
 	config, err := t.getConfiguration(tt.ConfigurationName)
 	if err != nil {
 		return err
@@ -252,7 +249,7 @@ func (t *configBuilder) addConfigurationTarget(tt *v1alpha1.TrafficTarget) error
 	if err != nil {
 		return err
 	}
-	ntt := tt.TrafficTarget.DeepCopy()
+	ntt := tt.DeepCopy()
 	target := RevisionTarget{
 		TrafficTarget: *ntt,
 		Active:        !rev.Status.IsActivationRequired(),
@@ -264,7 +261,7 @@ func (t *configBuilder) addConfigurationTarget(tt *v1alpha1.TrafficTarget) error
 	return nil
 }
 
-func (t *configBuilder) addRevisionTarget(tt *v1alpha1.TrafficTarget) error {
+func (t *configBuilder) addRevisionTarget(tt *v1.TrafficTarget) error {
 	rev, err := t.getRevision(tt.RevisionName)
 	if err != nil {
 		return err
@@ -272,7 +269,7 @@ func (t *configBuilder) addRevisionTarget(tt *v1alpha1.TrafficTarget) error {
 	if !rev.Status.IsReady() {
 		return errUnreadyRevision(rev)
 	}
-	ntt := tt.TrafficTarget.DeepCopy()
+	ntt := tt.DeepCopy()
 	target := RevisionTarget{
 		TrafficTarget: *ntt,
 		Active:        !rev.Status.IsActivationRequired(),

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -30,15 +30,14 @@ import (
 	net "knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	fakeclientset "knative.dev/serving/pkg/client/clientset/versioned/fake"
 	informers "knative.dev/serving/pkg/client/informers/externalversions"
-	listers "knative.dev/serving/pkg/client/listers/serving/v1alpha1"
+	listers "knative.dev/serving/pkg/client/listers/serving/v1"
 	"knative.dev/serving/pkg/gc"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler/route/config"
 	"knative.dev/serving/pkg/reconciler/route/domains"
-	. "knative.dev/serving/pkg/testing/v1alpha1"
+	. "knative.dev/serving/pkg/testing/v1"
 )
 
 const testNamespace string = "test"
@@ -47,36 +46,36 @@ const testNamespace string = "test"
 // Tests should not modify these objects.
 var (
 	// These are objects never inserted.
-	missingConfig *v1alpha1.Configuration
-	missingRev    *v1alpha1.Revision
+	missingConfig *v1.Configuration
+	missingRev    *v1.Revision
 
 	// emptyConfig never has any revision.
-	emptyConfig *v1alpha1.Configuration
+	emptyConfig *v1.Configuration
 
 	// revDeletedConfig has a Ready revision but was deleted.
-	revDeletedConfig *v1alpha1.Configuration
+	revDeletedConfig *v1.Configuration
 
 	// unreadyConfig only has unreadyRev, and it's not ready.
-	unreadyConfig *v1alpha1.Configuration
-	unreadyRev    *v1alpha1.Revision
+	unreadyConfig *v1.Configuration
+	unreadyRev    *v1.Revision
 
 	// failedConfig only has failedRev, and it fails to be ready.
-	failedConfig *v1alpha1.Configuration
-	failedRev    *v1alpha1.Revision
+	failedConfig *v1.Configuration
+	failedRev    *v1.Revision
 
 	// inactiveConfig only has inactiveRevision, and it's not active.
-	inactiveConfig *v1alpha1.Configuration
-	inactiveRev    *v1alpha1.Revision
+	inactiveConfig *v1.Configuration
+	inactiveRev    *v1.Revision
 
 	// goodConfig has two good revisions: goodOldRev and goodNewRev
-	goodConfig *v1alpha1.Configuration
-	goodOldRev *v1alpha1.Revision
-	goodNewRev *v1alpha1.Revision
+	goodConfig *v1.Configuration
+	goodOldRev *v1.Revision
+	goodNewRev *v1.Revision
 
 	// niceConfig has two good revisions: niceOldRev and niceNewRev
-	niceConfig *v1alpha1.Configuration
-	niceOldRev *v1alpha1.Revision
-	niceNewRev *v1alpha1.Revision
+	niceConfig *v1.Configuration
+	niceOldRev *v1.Revision
+	niceNewRev *v1.Revision
 
 	configLister listers.ConfigurationLister
 	revLister    listers.RevisionLister
@@ -95,9 +94,9 @@ func setUp() {
 	servingClient := fakeclientset.NewSimpleClientset()
 
 	servingInformer := informers.NewSharedInformerFactory(servingClient, 0)
-	configInformer := servingInformer.Serving().V1alpha1().Configurations()
+	configInformer := servingInformer.Serving().V1().Configurations()
 	configLister = configInformer.Lister()
-	revInformer := servingInformer.Serving().V1alpha1().Revisions()
+	revInformer := servingInformer.Serving().V1().Revisions()
 	revLister = revInformer.Lister()
 
 	// Add these test objects to the informers.
@@ -113,9 +112,9 @@ func setUp() {
 
 	for _, obj := range objs {
 		switch o := obj.(type) {
-		case *v1alpha1.Configuration:
+		case *v1.Configuration:
 			configInformer.Informer().GetIndexer().Add(o)
-		case *v1alpha1.Revision:
+		case *v1.Revision:
 			revInformer.Informer().GetIndexer().Add(o)
 		}
 	}
@@ -125,11 +124,9 @@ func setUp() {
 
 // The vanilla use case of 100% directing to latest ready revision of a single configuration.
 func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
-	tts := v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: goodConfig.Name,
-			Percent:           ptr.Int64(100),
-		},
+	tts := v1.TrafficTarget{
+		ConfigurationName: goodConfig.Name,
+		Percent:           ptr.Int64(100),
 	}
 
 	expected := &Config{
@@ -155,10 +152,10 @@ func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
 			Active:   true,
 			Protocol: net.ProtocolH2C,
 		}},
-		Configurations: map[string]*v1alpha1.Configuration{
+		Configurations: map[string]*v1.Configuration{
 			goodConfig.Name: goodConfig,
 		},
-		Revisions: map[string]*v1alpha1.Revision{
+		Revisions: map[string]*v1.Revision{
 			goodNewRev.Name: goodNewRev,
 		},
 	}
@@ -169,16 +166,14 @@ func TestBuildTrafficConfiguration_Vanilla(t *testing.T) {
 	}
 }
 
-func testRouteWithTrafficTargets(trafficTarget RouteOption) *v1alpha1.Route {
+func testRouteWithTrafficTargets(trafficTarget RouteOption) *v1.Route {
 	return Route(testNamespace, "test-route", WithRouteLabel(map[string]string{"route": "test-route"}), trafficTarget)
 }
 
 func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
-	tts := v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodNewRev.Name,
-			Percent:      ptr.Int64(100),
-		},
+	tts := v1.TrafficTarget{
+		RevisionName: goodNewRev.Name,
+		Percent:      ptr.Int64(100),
 	}
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
@@ -203,8 +198,8 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 			Active:   true,
 			Protocol: net.ProtocolH2C,
 		}},
-		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig},
-		Revisions:      map[string]*v1alpha1.Revision{goodNewRev.Name: goodNewRev},
+		Configurations: map[string]*v1.Configuration{goodConfig.Name: goodConfig},
+		Revisions:      map[string]*v1.Revision{goodNewRev.Name: goodNewRev},
 	}
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(tts))); err != nil {
 		t.Errorf("Unexpected error %v", err)
@@ -215,11 +210,9 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 
 // The vanilla use case of 100% directing to latest revision of an inactive configuration.
 func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
-	tts := v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: inactiveConfig.Name,
-			Percent:           ptr.Int64(100),
-		},
+	tts := v1.TrafficTarget{
+		ConfigurationName: inactiveConfig.Name,
+		Percent:           ptr.Int64(100),
 	}
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
@@ -244,10 +237,10 @@ func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
 			Active:   false,
 			Protocol: net.ProtocolHTTP1,
 		}},
-		Configurations: map[string]*v1alpha1.Configuration{
+		Configurations: map[string]*v1.Configuration{
 			inactiveConfig.Name: inactiveConfig,
 		},
-		Revisions: map[string]*v1alpha1.Revision{
+		Revisions: map[string]*v1.Revision{
 			inactiveRev.Name: inactiveRev,
 		},
 	}
@@ -301,25 +294,21 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 			Active:   true,
 			Protocol: net.ProtocolH2C,
 		}},
-		Configurations: map[string]*v1alpha1.Configuration{
+		Configurations: map[string]*v1.Configuration{
 			goodConfig.Name: goodConfig,
 			niceConfig.Name: niceConfig,
 		},
-		Revisions: map[string]*v1alpha1.Revision{
+		Revisions: map[string]*v1.Revision{
 			goodNewRev.Name: goodNewRev,
 			niceNewRev.Name: niceNewRev,
 		},
 	}
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: niceConfig.Name,
-			Percent:           ptr.Int64(90),
-		},
-	}, v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: goodConfig.Name,
-			Percent:           ptr.Int64(10),
-		},
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+		ConfigurationName: niceConfig.Name,
+		Percent:           ptr.Int64(90),
+	}, v1.TrafficTarget{
+		ConfigurationName: goodConfig.Name,
+		Percent:           ptr.Int64(10),
 	}))); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
@@ -370,24 +359,20 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 			Active:   true,
 			Protocol: net.ProtocolH2C,
 		}},
-		Configurations: map[string]*v1alpha1.Configuration{
+		Configurations: map[string]*v1.Configuration{
 			goodConfig.Name: goodConfig,
 		},
-		Revisions: map[string]*v1alpha1.Revision{
+		Revisions: map[string]*v1.Revision{
 			goodOldRev.Name: goodOldRev,
 			goodNewRev.Name: goodNewRev,
 		},
 	}
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodOldRev.Name,
-			Percent:      ptr.Int64(90),
-		},
-	}, v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: goodConfig.Name,
-			Percent:           ptr.Int64(10),
-		},
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+		RevisionName: goodOldRev.Name,
+		Percent:      ptr.Int64(90),
+	}, v1.TrafficTarget{
+		ConfigurationName: goodConfig.Name,
+		Percent:           ptr.Int64(10),
 	}))); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
@@ -485,32 +470,26 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 			Active:   true,
 			Protocol: net.ProtocolH2C,
 		}},
-		Configurations: map[string]*v1alpha1.Configuration{
+		Configurations: map[string]*v1.Configuration{
 			goodConfig.Name: goodConfig,
 		},
-		Revisions: map[string]*v1alpha1.Revision{
+		Revisions: map[string]*v1.Revision{
 			goodOldRev.Name: goodOldRev,
 			goodNewRev.Name: goodNewRev,
 		},
 	}
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			Tag:          "one",
-			RevisionName: goodOldRev.Name,
-			Percent:      ptr.Int64(49),
-		},
-	}, v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			Tag:          "two",
-			RevisionName: goodNewRev.Name,
-			Percent:      ptr.Int64(50),
-		},
-	}, v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			Tag:               "also-two",
-			ConfigurationName: goodConfig.Name,
-			Percent:           ptr.Int64(1),
-		},
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+		Tag:          "one",
+		RevisionName: goodOldRev.Name,
+		Percent:      ptr.Int64(49),
+	}, v1.TrafficTarget{
+		Tag:          "two",
+		RevisionName: goodNewRev.Name,
+		Percent:      ptr.Int64(50),
+	}, v1.TrafficTarget{
+		Tag:               "also-two",
+		ConfigurationName: goodConfig.Name,
+		Percent:           ptr.Int64(1),
 	}))); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
@@ -561,24 +540,20 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 			Active:   true,
 			Protocol: net.ProtocolH2C,
 		}},
-		Configurations: map[string]*v1alpha1.Configuration{
+		Configurations: map[string]*v1.Configuration{
 			goodConfig.Name: goodConfig,
 		},
-		Revisions: map[string]*v1alpha1.Revision{
+		Revisions: map[string]*v1.Revision{
 			goodNewRev.Name: goodNewRev,
 			goodOldRev.Name: goodOldRev,
 		},
 	}
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodOldRev.Name,
-			Percent:      ptr.Int64(90),
-		},
-	}, v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodNewRev.Name,
-			Percent:      ptr.Int64(10),
-		},
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+		RevisionName: goodOldRev.Name,
+		Percent:      ptr.Int64(90),
+	}, v1.TrafficTarget{
+		RevisionName: goodNewRev.Name,
+		Percent:      ptr.Int64(10),
 	}))); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
@@ -629,25 +604,21 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 			Active:   true,
 			Protocol: net.ProtocolH2C,
 		}},
-		Configurations: map[string]*v1alpha1.Configuration{
+		Configurations: map[string]*v1.Configuration{
 			goodConfig.Name: goodConfig,
 			niceConfig.Name: niceConfig,
 		},
-		Revisions: map[string]*v1alpha1.Revision{
+		Revisions: map[string]*v1.Revision{
 			goodNewRev.Name: goodNewRev,
 			niceNewRev.Name: niceNewRev,
 		},
 	}
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodNewRev.Name,
-			Percent:      ptr.Int64(40),
-		},
-	}, v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: niceNewRev.Name,
-			Percent:      ptr.Int64(60),
-		},
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+		RevisionName: goodNewRev.Name,
+		Percent:      ptr.Int64(40),
+	}, v1.TrafficTarget{
+		RevisionName: niceNewRev.Name,
+		Percent:      ptr.Int64(60),
 	}))); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
@@ -738,31 +709,25 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 			Active:   true,
 			Protocol: net.ProtocolH2C,
 		}},
-		Configurations: map[string]*v1alpha1.Configuration{
+		Configurations: map[string]*v1.Configuration{
 			goodConfig.Name: goodConfig,
 			niceConfig.Name: niceConfig,
 		},
-		Revisions: map[string]*v1alpha1.Revision{
+		Revisions: map[string]*v1.Revision{
 			goodOldRev.Name: goodOldRev,
 			goodNewRev.Name: goodNewRev,
 			niceNewRev.Name: niceNewRev,
 		},
 	}
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodOldRev.Name,
-			Percent:      ptr.Int64(100),
-		},
-	}, v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			Tag:          "beta",
-			RevisionName: goodNewRev.Name,
-		},
-	}, v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			Tag:               "alpha",
-			ConfigurationName: niceConfig.Name,
-		},
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+		RevisionName: goodOldRev.Name,
+		Percent:      ptr.Int64(100),
+	}, v1.TrafficTarget{
+		Tag:          "beta",
+		RevisionName: goodNewRev.Name,
+	}, v1.TrafficTarget{
+		Tag:               "alpha",
+		ConfigurationName: niceConfig.Name,
 	}))); err != nil {
 		t.Errorf("Unexpected error %v", err)
 	} else if want, got := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
@@ -773,15 +738,15 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 func TestBuildTrafficConfiguration_MissingConfig(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{},
-		Configurations: map[string]*v1alpha1.Configuration{
+		Configurations: map[string]*v1.Configuration{
 			goodConfig.Name: goodConfig,
 		},
-		Revisions: map[string]*v1alpha1.Revision{
+		Revisions: map[string]*v1.Revision{
 			goodOldRev.Name: goodOldRev,
 			goodNewRev.Name: goodNewRev,
 		},
 		MissingTargets: []corev1.ObjectReference{{
-			APIVersion: "serving.knative.dev/v1alpha1",
+			APIVersion: "serving.knative.dev/v1",
 			Kind:       "Configuration",
 			Name:       missingConfig.Name,
 			Namespace:  missingConfig.Namespace,
@@ -789,21 +754,15 @@ func TestBuildTrafficConfiguration_MissingConfig(t *testing.T) {
 	}
 
 	expectedErr := errMissingConfiguration(missingConfig.Name)
-	r := testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodOldRev.Name,
-			Percent:      ptr.Int64(100),
-		},
-	}, v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			Tag:          "beta",
-			RevisionName: goodNewRev.Name,
-		},
-	}, v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			Tag:               "alpha",
-			ConfigurationName: missingConfig.Name,
-		},
+	r := testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+		RevisionName: goodOldRev.Name,
+		Percent:      ptr.Int64(100),
+	}, v1.TrafficTarget{
+		Tag:          "beta",
+		RevisionName: goodNewRev.Name,
+	}, v1.TrafficTarget{
+		Tag:               "alpha",
+		ConfigurationName: missingConfig.Name,
 	}))
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, r); err != nil && expectedErr.Error() != err.Error() {
 		t.Errorf("Expected %v, saw %v", expectedErr, err)
@@ -815,15 +774,13 @@ func TestBuildTrafficConfiguration_MissingConfig(t *testing.T) {
 func TestBuildTrafficConfiguration_NotRoutableRevision(t *testing.T) {
 	expected := &Config{
 		Targets:        map[string]RevisionTargets{},
-		Configurations: map[string]*v1alpha1.Configuration{},
-		Revisions:      map[string]*v1alpha1.Revision{unreadyRev.Name: unreadyRev},
+		Configurations: map[string]*v1.Configuration{},
+		Revisions:      map[string]*v1.Revision{unreadyRev.Name: unreadyRev},
 	}
 	expectedErr := errUnreadyRevision(unreadyRev)
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: unreadyRev.Name,
-			Percent:      ptr.Int64(100),
-		},
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+		RevisionName: unreadyRev.Name,
+		Percent:      ptr.Int64(100),
 	}))); err != nil && expectedErr.Error() != err.Error() {
 		t.Errorf("Expected error %v, saw %v", expectedErr, err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
@@ -834,15 +791,13 @@ func TestBuildTrafficConfiguration_NotRoutableRevision(t *testing.T) {
 func TestBuildTrafficConfiguration_NotRoutableConfiguration(t *testing.T) {
 	expected := &Config{
 		Targets:        map[string]RevisionTargets{},
-		Configurations: map[string]*v1alpha1.Configuration{unreadyConfig.Name: unreadyConfig},
-		Revisions:      map[string]*v1alpha1.Revision{},
+		Configurations: map[string]*v1.Configuration{unreadyConfig.Name: unreadyConfig},
+		Revisions:      map[string]*v1.Revision{},
 	}
 	expectedErr := errUnreadyConfiguration(unreadyConfig)
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: unreadyConfig.Name,
-			Percent:           ptr.Int64(100),
-		},
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+		ConfigurationName: unreadyConfig.Name,
+		Percent:           ptr.Int64(100),
 	}))); err != nil && expectedErr.Error() != err.Error() {
 		t.Errorf("Expected error %v, saw %v", expectedErr, err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
@@ -853,18 +808,16 @@ func TestBuildTrafficConfiguration_NotRoutableConfiguration(t *testing.T) {
 func TestBuildTrafficConfiguration_EmptyConfiguration(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{},
-		Configurations: map[string]*v1alpha1.Configuration{
+		Configurations: map[string]*v1.Configuration{
 			emptyConfig.Name: emptyConfig,
 		},
-		Revisions: map[string]*v1alpha1.Revision{},
+		Revisions: map[string]*v1.Revision{},
 	}
 
 	expectedErr := errUnreadyConfiguration(emptyConfig)
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: emptyConfig.Name,
-			Percent:           ptr.Int64(100),
-		},
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+		ConfigurationName: emptyConfig.Name,
+		Percent:           ptr.Int64(100),
 	}))); err != nil && expectedErr.Error() != err.Error() {
 		t.Errorf("Expected error %v, saw %v", expectedErr, err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
@@ -875,23 +828,19 @@ func TestBuildTrafficConfiguration_EmptyConfiguration(t *testing.T) {
 func TestBuildTrafficConfiguration_EmptyAndFailedConfigurations(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{},
-		Configurations: map[string]*v1alpha1.Configuration{
+		Configurations: map[string]*v1.Configuration{
 			emptyConfig.Name:  emptyConfig,
 			failedConfig.Name: failedConfig,
 		},
-		Revisions: map[string]*v1alpha1.Revision{},
+		Revisions: map[string]*v1.Revision{},
 	}
 	expectedErr := errUnreadyConfiguration(failedConfig)
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: emptyConfig.Name,
-			Percent:           ptr.Int64(50),
-		},
-	}, v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: failedConfig.Name,
-			Percent:           ptr.Int64(50),
-		},
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+		ConfigurationName: emptyConfig.Name,
+		Percent:           ptr.Int64(50),
+	}, v1.TrafficTarget{
+		ConfigurationName: failedConfig.Name,
+		Percent:           ptr.Int64(50),
 	}))); err != nil && expectedErr.Error() != err.Error() {
 		t.Errorf("Expected error %v, saw %v", expectedErr, err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
@@ -902,23 +851,19 @@ func TestBuildTrafficConfiguration_EmptyAndFailedConfigurations(t *testing.T) {
 func TestBuildTrafficConfiguration_FailedAndEmptyConfigurations(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{},
-		Configurations: map[string]*v1alpha1.Configuration{
+		Configurations: map[string]*v1.Configuration{
 			emptyConfig.Name:  emptyConfig,
 			failedConfig.Name: failedConfig,
 		},
-		Revisions: map[string]*v1alpha1.Revision{},
+		Revisions: map[string]*v1.Revision{},
 	}
 	expectedErr := errUnreadyConfiguration(failedConfig)
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: failedConfig.Name,
-			Percent:           ptr.Int64(50),
-		},
-	}, v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			ConfigurationName: emptyConfig.Name,
-			Percent:           ptr.Int64(50),
-		},
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+		ConfigurationName: failedConfig.Name,
+		Percent:           ptr.Int64(50),
+	}, v1.TrafficTarget{
+		ConfigurationName: emptyConfig.Name,
+		Percent:           ptr.Int64(50),
 	}))); err != nil && expectedErr.Error() != err.Error() {
 		t.Errorf("Expected error %v, saw %v", expectedErr, err)
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
@@ -929,26 +874,22 @@ func TestBuildTrafficConfiguration_FailedAndEmptyConfigurations(t *testing.T) {
 func TestBuildTrafficConfiguration_MissingRevision(t *testing.T) {
 	expected := &Config{
 		Targets:        map[string]RevisionTargets{},
-		Configurations: map[string]*v1alpha1.Configuration{goodConfig.Name: goodConfig},
-		Revisions:      map[string]*v1alpha1.Revision{goodNewRev.Name: goodNewRev},
+		Configurations: map[string]*v1.Configuration{goodConfig.Name: goodConfig},
+		Revisions:      map[string]*v1.Revision{goodNewRev.Name: goodNewRev},
 		MissingTargets: []corev1.ObjectReference{{
-			APIVersion: "serving.knative.dev/v1alpha1",
+			APIVersion: "serving.knative.dev/v1",
 			Kind:       "Revision",
 			Name:       missingRev.Name,
 			Namespace:  missingRev.Namespace,
 		}},
 	}
 	expectedErr := errMissingRevision(missingRev.Name)
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: missingRev.Name,
-			Percent:      ptr.Int64(50),
-		},
-	}, v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodNewRev.Name,
-			Percent:      ptr.Int64(50),
-		},
+	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+		RevisionName: missingRev.Name,
+		Percent:      ptr.Int64(50),
+	}, v1.TrafficTarget{
+		RevisionName: goodNewRev.Name,
+		Percent:      ptr.Int64(50),
 	}))); err != nil && expectedErr.Error() != err.Error() {
 		t.Errorf("Expected %s, saw %s", expectedErr.Error(), err.Error())
 	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
@@ -957,42 +898,30 @@ func TestBuildTrafficConfiguration_MissingRevision(t *testing.T) {
 }
 
 func TestRoundTripping(t *testing.T) {
-	expected := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName:   goodOldRev.Name,
-			Percent:        ptr.Int64(100),
-			LatestRevision: ptr.Bool(false),
-		},
+	expected := []v1.TrafficTarget{{
+		RevisionName:   goodOldRev.Name,
+		Percent:        ptr.Int64(100),
+		LatestRevision: ptr.Bool(false),
 	}, {
-		TrafficTarget: v1.TrafficTarget{
-			Tag:            "beta",
-			RevisionName:   goodNewRev.Name,
-			URL:            domains.URL(domains.HTTPScheme, "beta-test-route.test.example.com"),
-			LatestRevision: ptr.Bool(false),
-		},
+		Tag:            "beta",
+		RevisionName:   goodNewRev.Name,
+		URL:            domains.URL(domains.HTTPScheme, "beta-test-route.test.example.com"),
+		LatestRevision: ptr.Bool(false),
 	}, {
-		TrafficTarget: v1.TrafficTarget{
-			Tag:            "alpha",
-			RevisionName:   niceNewRev.Name,
-			URL:            domains.URL(domains.HTTPScheme, "alpha-test-route.test.example.com"),
-			LatestRevision: ptr.Bool(true),
-		},
+		Tag:            "alpha",
+		RevisionName:   niceNewRev.Name,
+		URL:            domains.URL(domains.HTTPScheme, "alpha-test-route.test.example.com"),
+		LatestRevision: ptr.Bool(true),
 	}}
-	route := testRouteWithTrafficTargets(WithSpecTraffic(v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			RevisionName: goodOldRev.Name,
-			Percent:      ptr.Int64(100),
-		},
-	}, v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			Tag:          "beta",
-			RevisionName: goodNewRev.Name,
-		},
-	}, v1alpha1.TrafficTarget{
-		TrafficTarget: v1.TrafficTarget{
-			Tag:               "alpha",
-			ConfigurationName: niceConfig.Name,
-		},
+	route := testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+		RevisionName: goodOldRev.Name,
+		Percent:      ptr.Int64(100),
+	}, v1.TrafficTarget{
+		Tag:          "beta",
+		RevisionName: goodNewRev.Name,
+	}, v1.TrafficTarget{
+		Tag:               "alpha",
+		ConfigurationName: niceConfig.Name,
 	}))
 	if tc, err := BuildTrafficConfiguration(configLister, revLister, route); err != nil {
 		t.Errorf("Unexpected error %v", err)
@@ -1007,21 +936,19 @@ func TestRoundTripping(t *testing.T) {
 	}
 }
 
-func testConfig(name string) *v1alpha1.Configuration {
-	return &v1alpha1.Configuration{
+func testConfig(name string) *v1.Configuration {
+	return &v1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: testNamespace,
 		},
-		Spec: v1alpha1.ConfigurationSpec{
-			Template: &v1alpha1.RevisionTemplateSpec{
-				Spec: v1alpha1.RevisionSpec{
-					RevisionSpec: v1.RevisionSpec{
-						PodSpec: corev1.PodSpec{
-							Containers: []corev1.Container{{
-								Image: "test-image",
-							}},
-						},
+		Spec: v1.ConfigurationSpec{
+			Template: v1.RevisionTemplateSpec{
+				Spec: v1.RevisionSpec{
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Image: "test-image",
+						}},
 					},
 				},
 			},
@@ -1029,8 +956,8 @@ func testConfig(name string) *v1alpha1.Configuration {
 	}
 }
 
-func testRevForConfig(config *v1alpha1.Configuration, name string) *v1alpha1.Revision {
-	return &v1alpha1.Revision{
+func testRevForConfig(config *v1.Configuration, name string) *v1.Revision {
+	return &v1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: testNamespace,
@@ -1042,13 +969,13 @@ func testRevForConfig(config *v1alpha1.Configuration, name string) *v1alpha1.Rev
 	}
 }
 
-func getTestEmptyConfig(name string) *v1alpha1.Configuration {
+func getTestEmptyConfig(name string) *v1.Configuration {
 	config := testConfig(name + "-config")
 	config.Status.InitializeConditions()
 	return config
 }
 
-func testConfigWithDeletedRevision(name string) *v1alpha1.Configuration {
+func testConfigWithDeletedRevision(name string) *v1.Configuration {
 	config := testConfig(name + "-config")
 	config.Status.SetLatestCreatedRevisionName("i-was-deleted")
 	config.Status.SetLatestReadyRevisionName("")
@@ -1056,23 +983,23 @@ func testConfigWithDeletedRevision(name string) *v1alpha1.Configuration {
 	return config
 }
 
-func getTestUnreadyConfig(name string) (*v1alpha1.Configuration, *v1alpha1.Revision) {
+func getTestUnreadyConfig(name string) (*v1.Configuration, *v1.Revision) {
 	config := testConfig(name + "-config")
 	rev := testRevForConfig(config, name+"-revision")
 	config.Status.SetLatestCreatedRevisionName(rev.Name)
 	return config, rev
 }
 
-func getTestFailedConfig(name string) (*v1alpha1.Configuration, *v1alpha1.Revision) {
+func getTestFailedConfig(name string) (*v1.Configuration, *v1.Revision) {
 	config := testConfig(name + "-config")
 	rev := testRevForConfig(config, name+"-revision")
 	config.Status.SetLatestCreatedRevisionName(rev.Name)
 	config.Status.MarkLatestCreatedFailed(rev.Name, "Permanently failed")
-	rev.Status.MarkContainerHealthyFalse(v1alpha1.ContainerMissing, "Should have used ko")
+	rev.Status.MarkContainerHealthyFalse(v1.ReasonContainerMissing, "Should have used ko")
 	return config, rev
 }
 
-func getTestInactiveConfig(name string) (*v1alpha1.Configuration, *v1alpha1.Revision) {
+func getTestInactiveConfig(name string) (*v1.Configuration, *v1.Revision) {
 	config := testConfig(name + "-config")
 	rev := testRevForConfig(config, name+"-revision")
 	config.Status.SetLatestReadyRevisionName(rev.Name)
@@ -1082,7 +1009,7 @@ func getTestInactiveConfig(name string) (*v1alpha1.Configuration, *v1alpha1.Revi
 	return config, rev
 }
 
-func getTestReadyConfig(name string) (*v1alpha1.Configuration, *v1alpha1.Revision, *v1alpha1.Revision) {
+func getTestReadyConfig(name string) (*v1.Configuration, *v1.Revision, *v1.Revision) {
 	config := testConfig(name + "-config")
 	rev1 := testRevForConfig(config, name+"-revision-1")
 	rev1.Status.MarkResourcesAvailableTrue()

--- a/pkg/reconciler/route/visibility/visibility.go
+++ b/pkg/reconciler/route/visibility/visibility.go
@@ -26,7 +26,7 @@ import (
 	"knative.dev/pkg/network"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler/route/config"
 	"knative.dev/serving/pkg/reconciler/route/domains"
 	"knative.dev/serving/pkg/reconciler/route/resources/labels"
@@ -43,7 +43,7 @@ func NewResolver(l listers.ServiceLister) *Resolver {
 	return &Resolver{serviceLister: l}
 }
 
-func (b *Resolver) getServices(route *v1alpha1.Route) (map[string]*corev1.Service, error) {
+func (b *Resolver) getServices(route *v1.Route) (map[string]*corev1.Service, error) {
 	// List all the Services owned by this Route.
 	currentServices, err := b.serviceLister.Services(route.Namespace).List(apilabels.SelectorFromSet(
 		apilabels.Set{
@@ -62,7 +62,7 @@ func (b *Resolver) getServices(route *v1alpha1.Route) (map[string]*corev1.Servic
 	return serviceCopy, err
 }
 
-func (b *Resolver) routeVisibility(ctx context.Context, route *v1alpha1.Route) netv1alpha1.IngressVisibility {
+func (b *Resolver) routeVisibility(ctx context.Context, route *v1.Route) netv1alpha1.IngressVisibility {
 	domainConfig := config.FromContext(ctx).Domain
 	domain := domainConfig.LookupDomainForLabels(route.Labels)
 	if domain == "svc."+network.GetClusterDomainName() {
@@ -71,7 +71,7 @@ func (b *Resolver) routeVisibility(ctx context.Context, route *v1alpha1.Route) n
 	return netv1alpha1.IngressVisibilityExternalIP
 }
 
-func trafficNames(route *v1alpha1.Route) sets.String {
+func trafficNames(route *v1.Route) sets.String {
 	names := sets.NewString(traffic.DefaultTarget)
 	for _, tt := range route.Spec.Traffic {
 		names.Insert(tt.Tag)
@@ -80,7 +80,7 @@ func trafficNames(route *v1alpha1.Route) sets.String {
 }
 
 // GetVisibility returns a map from traffic target name to their corresponding netv1alpha1.IngressVisibility.
-func (b *Resolver) GetVisibility(ctx context.Context, route *v1alpha1.Route) (map[string]netv1alpha1.IngressVisibility, error) {
+func (b *Resolver) GetVisibility(ctx context.Context, route *v1.Route) (map[string]netv1alpha1.IngressVisibility, error) {
 	// Find out the default visibility of the Route.
 	defaultVisibility := b.routeVisibility(ctx, route)
 

--- a/pkg/reconciler/route/visibility/visibility_test.go
+++ b/pkg/reconciler/route/visibility/visibility_test.go
@@ -29,7 +29,6 @@ import (
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler/route/config"
 	"knative.dev/serving/pkg/reconciler/route/traffic"
@@ -59,12 +58,12 @@ func TestVisibility(t *testing.T) {
 		domainSuffix string
 		services     []*corev1.Service
 		listerErr    error
-		route        *v1alpha1.Route
+		route        *v1.Route
 		expected     map[string]netv1alpha1.IngressVisibility
 		expectedErr  error
 	}{{
 		name: "default",
-		route: &v1alpha1.Route{
+		route: &v1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
@@ -74,7 +73,7 @@ func TestVisibility(t *testing.T) {
 		},
 	}, {
 		name: "no tag, route marked local",
-		route: &v1alpha1.Route{
+		route: &v1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 				Labels: map[string]string{
@@ -87,7 +86,7 @@ func TestVisibility(t *testing.T) {
 		},
 	}, {
 		name: "no tag, svc marked local",
-		route: &v1alpha1.Route{
+		route: &v1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
@@ -114,14 +113,12 @@ func TestVisibility(t *testing.T) {
 		},
 	}, {
 		name: "one tag, tag marked local",
-		route: &v1alpha1.Route{
+		route: &v1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
-			Spec: v1alpha1.RouteSpec{
-				Traffic: []v1alpha1.TrafficTarget{{
-					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
-				}},
+			Spec: v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{{Tag: "blue"}},
 			},
 		},
 		services: []*corev1.Service{{
@@ -146,14 +143,12 @@ func TestVisibility(t *testing.T) {
 		},
 	}, {
 		name: "one tag initial default",
-		route: &v1alpha1.Route{
+		route: &v1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
-			Spec: v1alpha1.RouteSpec{
-				Traffic: []v1alpha1.TrafficTarget{{
-					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
-				}},
+			Spec: v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{{Tag: "blue"}},
 			},
 		},
 		services: []*corev1.Service{},
@@ -163,14 +158,12 @@ func TestVisibility(t *testing.T) {
 		},
 	}, {
 		name: "one tag svc not marked",
-		route: &v1alpha1.Route{
+		route: &v1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
-			Spec: v1alpha1.RouteSpec{
-				Traffic: []v1alpha1.TrafficTarget{{
-					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
-				}},
+			Spec: v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{{Tag: "blue"}},
 			},
 		},
 		services: []*corev1.Service{{
@@ -194,16 +187,15 @@ func TestVisibility(t *testing.T) {
 		},
 	}, {
 		name: "two tags initial default",
-		route: &v1alpha1.Route{
+		route: &v1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
-			Spec: v1alpha1.RouteSpec{
-				Traffic: []v1alpha1.TrafficTarget{{
-					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
-				}, {
-					TrafficTarget: v1.TrafficTarget{Tag: "green"},
-				}},
+			Spec: v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{
+					{Tag: "blue"},
+					{Tag: "green"},
+				},
 			},
 		},
 		expected: map[string]netv1alpha1.IngressVisibility{
@@ -213,16 +205,15 @@ func TestVisibility(t *testing.T) {
 		},
 	}, {
 		name: "two tags initial default with .svc.cluster.local domain suffix",
-		route: &v1alpha1.Route{
+		route: &v1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
-			Spec: v1alpha1.RouteSpec{
-				Traffic: []v1alpha1.TrafficTarget{{
-					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
-				}, {
-					TrafficTarget: v1.TrafficTarget{Tag: "green"},
-				}},
+			Spec: v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{
+					{Tag: "blue"},
+					{Tag: "green"},
+				},
 			},
 		},
 		domainSuffix: "svc.cluster.local",
@@ -233,16 +224,15 @@ func TestVisibility(t *testing.T) {
 		},
 	}, {
 		name: "two tags, svc not marked",
-		route: &v1alpha1.Route{
+		route: &v1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
-			Spec: v1alpha1.RouteSpec{
-				Traffic: []v1alpha1.TrafficTarget{{
-					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
-				}, {
-					TrafficTarget: v1.TrafficTarget{Tag: "green"},
-				}},
+			Spec: v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{
+					{Tag: "blue"},
+					{Tag: "green"},
+				},
 			},
 		},
 		services: []*corev1.Service{{
@@ -274,19 +264,18 @@ func TestVisibility(t *testing.T) {
 		},
 	}, {
 		name: "two tags, route marked local",
-		route: &v1alpha1.Route{
+		route: &v1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 				Labels: map[string]string{
 					config.VisibilityLabelKey: config.VisibilityClusterLocal,
 				},
 			},
-			Spec: v1alpha1.RouteSpec{
-				Traffic: []v1alpha1.TrafficTarget{{
-					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
-				}, {
-					TrafficTarget: v1.TrafficTarget{Tag: "green"},
-				}},
+			Spec: v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{
+					{Tag: "blue"},
+					{Tag: "green"},
+				},
 			},
 		},
 		services: []*corev1.Service{{
@@ -318,16 +307,15 @@ func TestVisibility(t *testing.T) {
 		},
 	}, {
 		name: "two tags blue marked local",
-		route: &v1alpha1.Route{
+		route: &v1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
-			Spec: v1alpha1.RouteSpec{
-				Traffic: []v1alpha1.TrafficTarget{{
-					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
-				}, {
-					TrafficTarget: v1.TrafficTarget{Tag: "green"},
-				}},
+			Spec: v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{
+					{Tag: "blue"},
+					{Tag: "green"},
+				},
 			},
 		},
 		services: []*corev1.Service{{
@@ -346,16 +334,15 @@ func TestVisibility(t *testing.T) {
 		},
 	}, {
 		name: "two tags, both marked local",
-		route: &v1alpha1.Route{
+		route: &v1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
-			Spec: v1alpha1.RouteSpec{
-				Traffic: []v1alpha1.TrafficTarget{{
-					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
-				}, {
-					TrafficTarget: v1.TrafficTarget{Tag: "green"},
-				}},
+			Spec: v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{
+					{Tag: "blue"},
+					{Tag: "green"},
+				},
 			},
 		},
 		services: []*corev1.Service{{
@@ -382,16 +369,15 @@ func TestVisibility(t *testing.T) {
 		},
 	}, {
 		name: "two tags, all marked local",
-		route: &v1alpha1.Route{
+		route: &v1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},
-			Spec: v1alpha1.RouteSpec{
-				Traffic: []v1alpha1.TrafficTarget{{
-					TrafficTarget: v1.TrafficTarget{Tag: "blue"},
-				}, {
-					TrafficTarget: v1.TrafficTarget{Tag: "green"},
-				}},
+			Spec: v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{
+					{Tag: "blue"},
+					{Tag: "green"},
+				},
 			},
 		},
 		services: []*corev1.Service{{
@@ -427,7 +413,7 @@ func TestVisibility(t *testing.T) {
 	}, {
 		name:      "lister error",
 		listerErr: listerErr,
-		route: &v1alpha1.Route{
+		route: &v1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 			},

--- a/pkg/testing/v1/configuration.go
+++ b/pkg/testing/v1/configuration.go
@@ -54,6 +54,13 @@ func WithConfigContainerConcurrency(cc int64) ConfigOption {
 	}
 }
 
+// WithGeneration sets the generation of the Configuration.
+func WithGeneration(gen int64) ConfigOption {
+	return func(cfg *v1.Configuration) {
+		cfg.Generation = gen
+	}
+}
+
 // WithObservedGen sets the observed generation of the Configuration.
 func WithObservedGen(cfg *v1.Configuration) {
 	cfg.Status.ObservedGeneration = cfg.Generation
@@ -86,5 +93,15 @@ func MarkRevisionCreationFailed(msg string) ConfigOption {
 func MarkLatestCreatedFailed(msg string) ConfigOption {
 	return func(cfg *v1.Configuration) {
 		cfg.Status.MarkLatestCreatedFailed(cfg.Status.LatestCreatedRevisionName, msg)
+	}
+}
+
+// WithConfigLabel attaches a particular label to the configuration.
+func WithConfigLabel(key, value string) ConfigOption {
+	return func(config *v1.Configuration) {
+		if config.Labels == nil {
+			config.Labels = make(map[string]string)
+		}
+		config.Labels[key] = value
 	}
 }

--- a/pkg/testing/v1/route.go
+++ b/pkg/testing/v1/route.go
@@ -17,8 +17,247 @@ limitations under the License.
 package v1
 
 import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/networking"
+	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	routenames "knative.dev/serving/pkg/reconciler/route/resources/names"
 )
 
 // RouteOption enables further configuration of a Route.
 type RouteOption func(*v1.Route)
+
+// WithSpecTraffic sets the Route's traffic block to the specified traffic targets.
+func WithSpecTraffic(traffic ...v1.TrafficTarget) RouteOption {
+	return func(r *v1.Route) {
+		r.Spec.Traffic = traffic
+	}
+}
+
+// WithRouteUID sets the Route's UID
+func WithRouteUID(uid types.UID) RouteOption {
+	return func(r *v1.Route) {
+		r.ObjectMeta.UID = uid
+	}
+}
+
+// WithRouteGeneration sets the route's generation
+func WithRouteGeneration(generation int64) RouteOption {
+	return func(svc *v1.Route) {
+		svc.Status.ObservedGeneration = generation
+	}
+}
+
+// WithRouteObservedGeneneration sets the route's observed generation to it's generation
+func WithRouteObservedGeneration(r *v1.Route) {
+	r.Status.ObservedGeneration = r.Generation
+}
+
+// WithRouteFinalizer adds the Route finalizer to the Route.
+func WithRouteFinalizer(r *v1.Route) {
+	r.ObjectMeta.Finalizers = append(r.ObjectMeta.Finalizers, "routes.serving.knative.dev")
+}
+
+// WithConfigTarget sets the Route's traffic block to point at a particular Configuration.
+func WithConfigTarget(config string) RouteOption {
+	return WithSpecTraffic(v1.TrafficTarget{
+		ConfigurationName: config,
+		Percent:           ptr.Int64(100),
+	})
+}
+
+// WithRevTarget sets the Route's traffic block to point at a particular Revision.
+func WithRevTarget(revision string) RouteOption {
+	return WithSpecTraffic(v1.TrafficTarget{
+		RevisionName: revision,
+		Percent:      ptr.Int64(100),
+	})
+}
+
+// WithStatusTraffic sets the Route's status traffic block to the specified traffic targets.
+func WithStatusTraffic(traffic ...v1.TrafficTarget) RouteOption {
+	ctx := apis.WithinStatus(context.Background())
+
+	for _, t := range traffic {
+		if err := t.Validate(ctx); err != nil {
+			panic(err)
+		}
+	}
+
+	return func(r *v1.Route) {
+		r.Status.Traffic = traffic
+	}
+}
+
+// WithRouteOwnersRemoved clears the owner references of this Route.
+func WithRouteOwnersRemoved(r *v1.Route) {
+	r.OwnerReferences = nil
+}
+
+// MarkServiceNotOwned calls the function of the same name on the Service's status.
+func MarkServiceNotOwned(r *v1.Route) {
+	r.Status.MarkServiceNotOwned(routenames.K8sService(r))
+}
+
+// WithURL sets the .Status.Domain field to the prototypical domain.
+func WithURL(r *v1.Route) {
+	r.Status.URL = &apis.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("%s.%s.example.com", r.Name, r.Namespace),
+	}
+}
+
+func WithHTTPSDomain(r *v1.Route) {
+	r.Status.URL = &apis.URL{
+		Scheme: "https",
+		Host:   fmt.Sprintf("%s.%s.example.com", r.Name, r.Namespace),
+	}
+}
+
+// WithAddress sets the .Status.Address field to the prototypical internal hostname.
+func WithAddress(r *v1.Route) {
+	r.Status.Address = &duckv1.Addressable{
+		URL: &apis.URL{
+			Scheme: "http",
+			Host:   fmt.Sprintf("%s.%s.svc.cluster.local", r.Name, r.Namespace),
+		},
+	}
+}
+
+// WithAnotherDomain sets the .Status.Domain field to an atypical domain.
+func WithAnotherDomain(r *v1.Route) {
+	r.Status.URL = &apis.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("%s.%s.another-example.com", r.Name, r.Namespace),
+	}
+}
+
+// WithLocalDomain sets the .Status.Domain field to use `svc.cluster.local` suffix.
+func WithLocalDomain(r *v1.Route) {
+	r.Status.URL = &apis.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("%s.%s.svc.cluster.local", r.Name, r.Namespace),
+	}
+}
+
+// WithInitRouteConditions initializes the Service's conditions.
+func WithInitRouteConditions(rt *v1.Route) {
+	rt.Status.InitializeConditions()
+}
+
+// MarkTrafficAssigned calls the method of the same name on .Status
+func MarkTrafficAssigned(r *v1.Route) {
+	r.Status.MarkTrafficAssigned()
+}
+
+// MarkCertificateNotReady calls the method of the same name on .Status
+func MarkCertificateNotReady(r *v1.Route) {
+	r.Status.MarkCertificateNotReady(routenames.Certificate(r))
+}
+
+// MarkCertificateNotOwned calls the method of the same name on .Status
+func MarkCertificateNotOwned(r *v1.Route) {
+	r.Status.MarkCertificateNotOwned(routenames.Certificate(r))
+}
+
+// MarkCertificateReady calls the method of the same name on .Status
+func MarkCertificateReady(r *v1.Route) {
+	r.Status.MarkCertificateReady(routenames.Certificate(r))
+}
+
+// WithReadyCertificateName marks the certificate specified by name as ready.
+func WithReadyCertificateName(name string) func(*v1.Route) {
+	return func(r *v1.Route) {
+		r.Status.MarkCertificateReady(name)
+	}
+}
+
+// MarkIngressReady propagates a Ready=True Ingress status to the Route.
+func MarkIngressReady(r *v1.Route) {
+	r.Status.PropagateIngressStatus(netv1alpha1.IngressStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   "Ready",
+				Status: "True",
+			}},
+		},
+	})
+}
+
+// MarkIngressNotConfigured calls the method of the same name on .Status
+func MarkIngressNotConfigured(r *v1.Route) {
+	r.Status.MarkIngressNotConfigured()
+}
+
+// MarkMissingTrafficTarget calls the method of the same name on .Status
+func MarkMissingTrafficTarget(kind, revision string) RouteOption {
+	return func(r *v1.Route) {
+		r.Status.MarkMissingTrafficTarget(kind, revision)
+	}
+}
+
+// MarkConfigurationNotReady calls the method of the same name on .Status
+func MarkConfigurationNotReady(name string) RouteOption {
+	return func(r *v1.Route) {
+		r.Status.MarkConfigurationNotReady(name)
+	}
+}
+
+// MarkConfigurationFailed calls the method of the same name on .Status
+func MarkConfigurationFailed(name string) RouteOption {
+	return func(r *v1.Route) {
+		r.Status.MarkConfigurationFailed(name)
+	}
+}
+
+// WithRouteLabel sets the specified label on the Route.
+func WithRouteLabel(labels map[string]string) RouteOption {
+	return func(r *v1.Route) {
+		if r.Labels == nil {
+			r.Labels = make(map[string]string)
+		}
+		r.Labels = labels
+	}
+}
+
+// WithIngressClass sets the ingress class annotation on the Route.
+func WithIngressClass(ingressClass string) RouteOption {
+	return func(r *v1.Route) {
+		if r.Annotations == nil {
+			r.Annotations = make(map[string]string)
+		}
+		r.Annotations[networking.IngressClassAnnotationKey] = ingressClass
+	}
+}
+
+// WithRouteAnnotation sets the specified annotation on the Route.
+func WithRouteAnnotation(annotation map[string]string) RouteOption {
+	return func(r *v1.Route) {
+		if r.Annotations == nil {
+			r.Annotations = make(map[string]string)
+		}
+		r.Annotations = annotation
+	}
+}
+
+// Route creates a route with RouteOptions
+func Route(namespace, name string, ro ...RouteOption) *v1.Route {
+	r := &v1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+	for _, opt := range ro {
+		opt(r)
+	}
+	r.SetDefaults(context.Background())
+	return r
+}


### PR DESCRIPTION
Contributes to issue #6035

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Route controller now uses v1 API types

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
