### PR TITLE
Return 504 on error and other sweeps

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -479,7 +479,7 @@ func buildServer(env config, healthState *health.State, rp *readiness.Probe, req
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first.
 	var composedHandler http.Handler = httpProxy
 	if metricsSupported {
-		composedHandler = requestAppMetricsHandler(httpProxy, breaker, env)
+		composedHandler = requestAppMetricsHandler(composedHandler, breaker, env)
 	}
 	composedHandler = proxyHandler(reqChan, breaker, tracingEnabled, composedHandler)
 	composedHandler = queue.ForwardedShimHandler(composedHandler)

--- a/pkg/queue/timeout.go
+++ b/pkg/queue/timeout.go
@@ -33,7 +33,7 @@ import (
 //
 // The new Handler calls h.ServeHTTP to handle each request, but if a
 // call runs for longer than its time limit, the handler responds with
-// a 503 Service Unavailable error and the given message in its body.
+// a 504 Service Unavailable error and the given message in its body.
 // (If msg is empty, a suitable default message will be sent.)
 // After such a timeout, writes by h to its ResponseWriter will return
 // ErrHandlerTimeout.
@@ -47,14 +47,14 @@ func TimeToFirstByteTimeoutHandler(h http.Handler, dt time.Duration, msg string)
 	return &timeoutHandler{
 		handler: h,
 		body:    msg,
-		dt:      dt,
+		timeout: dt,
 	}
 }
 
 type timeoutHandler struct {
 	handler http.Handler
 	body    string
-	dt      time.Duration
+	timeout time.Duration
 }
 
 func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -80,7 +80,7 @@ func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handler.ServeHTTP(tw, r.WithContext(ctx))
 	}()
 
-	timeout := time.NewTimer(h.dt)
+	timeout := time.NewTimer(h.timeout)
 	defer timeout.Stop()
 	for {
 		select {
@@ -161,7 +161,7 @@ func (tw *timeoutWriter) TimeoutAndWriteError(msg string) bool {
 	defer tw.mu.Unlock()
 
 	if !tw.wroteOnce {
-		tw.w.WriteHeader(http.StatusServiceUnavailable)
+		tw.w.WriteHeader(http.StatusGatewayTimeout)
 		io.WriteString(tw.w, msg)
 
 		tw.timedOut = true

--- a/pkg/queue/timeout.go
+++ b/pkg/queue/timeout.go
@@ -33,7 +33,7 @@ import (
 //
 // The new Handler calls h.ServeHTTP to handle each request, but if a
 // call runs for longer than its time limit, the handler responds with
-// a 504 Service Unavailable error and the given message in its body.
+// a 504 Gateway Timeout error and the given message in its body.
 // (If msg is empty, a suitable default message will be sent.)
 // After such a timeout, writes by h to its ResponseWriter will return
 // ErrHandlerTimeout.

--- a/pkg/queue/timeout_test.go
+++ b/pkg/queue/timeout_test.go
@@ -61,7 +61,7 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 			})
 		},
 		timeoutMessage: "request timeout",
-		wantStatus:     http.StatusServiceUnavailable,
+		wantStatus:     http.StatusGatewayTimeout,
 		wantBody:       "request timeout",
 		wantWriteError: true,
 	}, {
@@ -72,7 +72,7 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 				panic(http.ErrAbortHandler)
 			})
 		},
-		wantStatus: http.StatusServiceUnavailable,
+		wantStatus: http.StatusGatewayTimeout,
 		wantBody:   "request timeout",
 		wantPanic:  true,
 	}}
@@ -91,7 +91,7 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 			defer func() {
 				if test.wantPanic {
 					if recovered := recover(); recovered != http.ErrAbortHandler {
-						t.Error("Expected the handler to panic, but it didn't.")
+						t.Errorf("Recover = %v, want: %v", recovered, http.ErrAbortHandler)
 					}
 				}
 			}()
@@ -109,8 +109,7 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 			}
 
 			if test.wantWriteError {
-				err := <-writeErrors
-				if err != http.ErrHandlerTimeout {
+				if err := <-writeErrors; err != http.ErrHandlerTimeout {
 					t.Errorf("Expected a timeout error, got %v", err)
 				}
 			}

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -224,10 +224,10 @@ func TestRevisionTimeout(t *testing.T) {
 	}
 
 	// Fail by surpassing the initial timeout.
-	if err := sendRequest(t, clients, rev2sURL, 5, 0, http.StatusServiceUnavailable); err != nil {
+	if err := sendRequest(t, clients, rev2sURL, 5, 0, http.StatusGatewayTimeout); err != nil {
 		t.Errorf("Did not fail request with sleep 5s with revision timeout 2s: %v", err)
 	}
-	if err := sendRequest(t, clients, rev5sURL, 7, 0, http.StatusServiceUnavailable); err != nil {
+	if err := sendRequest(t, clients, rev5sURL, 7, 0, http.StatusGatewayTimeout); err != nil {
 		t.Errorf("Did not fail request with sleep 7s with revision timeout 5s: %v", err)
 	}
 

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -229,10 +229,10 @@ func TestRevisionTimeout(t *testing.T) {
 	}
 
 	// Fail by surpassing the initial timeout.
-	if err := sendRequest(t, clients, rev2sURL, 5, 0, http.StatusServiceUnavailable); err != nil {
+	if err := sendRequest(t, clients, rev2sURL, 5, 0, http.StatusGatewayTimeout); err != nil {
 		t.Errorf("Did not fail request with sleep 5s with revision timeout 2s: %v", err)
 	}
-	if err := sendRequest(t, clients, rev5sURL, 7, 0, http.StatusServiceUnavailable); err != nil {
+	if err := sendRequest(t, clients, rev5sURL, 7, 0, http.StatusGatewayTimeout); err != nil {
 		t.Errorf("Did not fail request with sleep 7s with revision timeout 5s: %v", err)
 	}
 

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -225,10 +225,10 @@ func TestRevisionTimeout(t *testing.T) {
 	}
 
 	// Fail by surpassing the initial timeout.
-	if err := sendRequest(t, clients, rev2sURL, 5, 0, http.StatusServiceUnavailable); err != nil {
+	if err := sendRequest(t, clients, rev2sURL, 5, 0, http.StatusGatewayTimeout); err != nil {
 		t.Errorf("Did not fail request with sleep 5s with revision timeout 2s: %v", err)
 	}
-	if err := sendRequest(t, clients, rev5sURL, 7, 0, http.StatusServiceUnavailable); err != nil {
+	if err := sendRequest(t, clients, rev5sURL, 7, 0, http.StatusGatewayTimeout); err != nil {
 		t.Errorf("Did not fail request with sleep 7s with revision timeout 5s: %v", err)
 	}
 


### PR DESCRIPTION
There exists a more proper response code than 503 to report a timeout
that is 504. QP is a proxy and hence this code is more than suiting for this use case.
We do not guarantee which reponse code is going to be returned in this case (or I could not find).

Other minor nits and bits

/assing @dgerd mattmoor