### PR TITLE
fix support for private revisions

### DIFF
--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -24,6 +24,7 @@ import (
 	"knative.dev/pkg/kmp"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/serving"
+	"knative.dev/serving/pkg/reconciler/route/config"
 )
 
 // Validate ensures Revision is properly configured.
@@ -118,7 +119,7 @@ func (rs *RevisionStatus) Validate(ctx context.Context) *apis.FieldError {
 func (r *Revision) ValidateLabels() (errs *apis.FieldError) {
 	for key, val := range r.GetLabels() {
 		switch {
-		case key == serving.RouteLabelKey || key == serving.ServiceLabelKey || key == serving.ConfigurationGenerationLabelKey:
+		case key == serving.RouteLabelKey || key == serving.ServiceLabelKey || key == serving.ConfigurationGenerationLabelKey || key == config.VisibilityLabelKey:
 		case key == serving.ConfigurationLabelKey:
 			errs = errs.Also(verifyLabelOwnerRef(val, serving.ConfigurationLabelKey, "Configuration", r.GetOwnerReferences()))
 		case strings.HasPrefix(key, serving.GroupNamePrefix):

--- a/pkg/apis/serving/v1/revision_validation_test.go
+++ b/pkg/apis/serving/v1/revision_validation_test.go
@@ -29,6 +29,7 @@ import (
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
+	rconfig "knative.dev/serving/pkg/reconciler/route/config"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -231,6 +232,18 @@ func TestRevisionLabelAnnotationValidation(t *testing.T) {
 			Spec: validRevisionSpec,
 		},
 		want: apis.ErrInvalidKeyName("serving.knative.dev/testlabel", "metadata.labels"),
+	}, {
+		name: "valid visibility label",
+		r: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "private-service",
+				Labels: map[string]string{
+					rconfig.VisibilityLabelKey: "cluster-local",
+				},
+			},
+			Spec: validRevisionSpec,
+		},
+		want: nil,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/apis/serving/v1beta1/revision_validation.go
+++ b/pkg/apis/serving/v1beta1/revision_validation.go
@@ -23,6 +23,7 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmp"
 	"knative.dev/serving/pkg/apis/serving"
+	"knative.dev/serving/pkg/reconciler/route/config"
 )
 
 // Validate ensures Revision is properly configured.
@@ -57,7 +58,7 @@ func (r *Revision) Validate(ctx context.Context) *apis.FieldError {
 func (r *Revision) ValidateLabels() (errs *apis.FieldError) {
 	for key, val := range r.GetLabels() {
 		switch {
-		case key == serving.RouteLabelKey || key == serving.ServiceLabelKey || key == serving.ConfigurationGenerationLabelKey:
+		case key == serving.RouteLabelKey || key == serving.ServiceLabelKey || key == serving.ConfigurationGenerationLabelKey || key == config.VisibilityLabelKey:
 		case key == serving.ConfigurationLabelKey:
 			errs = errs.Also(verifyLabelOwnerRef(val, serving.ConfigurationLabelKey, "Configuration", r.GetOwnerReferences()))
 		case strings.HasPrefix(key, serving.GroupNamePrefix):

--- a/pkg/apis/serving/v1beta1/revision_validation_test.go
+++ b/pkg/apis/serving/v1beta1/revision_validation_test.go
@@ -29,6 +29,7 @@ import (
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
+	rconfig "knative.dev/serving/pkg/reconciler/route/config"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -233,6 +234,18 @@ func TestRevisionLabelAnnotationValidation(t *testing.T) {
 			Spec: validRevisionSpec,
 		},
 		want: apis.ErrInvalidKeyName("serving.knative.dev/testlabel", "metadata.labels"),
+	}, {
+		name: "valid visibility label",
+		r: &Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "private-service",
+				Labels: map[string]string{
+					rconfig.VisibilityLabelKey: "cluster-local",
+				},
+			},
+			Spec: validRevisionSpec,
+		},
+		want: nil,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
https://github.com/knative/serving/pull/6770 introduced a bug where:
```
kn service create echo-internal --image gcr.io/knative-samples/helloworld-go -l serving.knative.dev/visibility=cluster-local
```
would fail with this error:
```
Revision creation failed with message: admission webhook "validation.webhook.serving.knative.dev" denied the request: validation failed: invalid key name "serving.knative.dev/visibility": metadata.labels.
```

This PR will add this label to the Revision.ValidateLabels() func. This is a hotfix PR to unblock people who might be using HEAD. I think a more correct long term approach would be to have the code build up (register) the list of valid labels so that this func can just loop over an array of valid labels instead of having them hard-coded in the switch/case statement.

@dprotaso @mattmoor 

Signed-off-by: Doug Davis <dug@us.ibm.com>

/lint

**Release Note**

```release-note
NONE
```
