### PR TITLE
Ridiculously small nits in the KPA tests

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1169,7 +1169,7 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 		}
 		return newKPA.Status.IsReady(), nil
 	}); err != nil {
-		t.Errorf("PA failed to become ready: %v", err)
+		t.Fatalf("PA failed to become ready: %v", err)
 	}
 
 	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Delete(testRevision, nil)
@@ -1395,10 +1395,7 @@ func pollDeciders(deciders *testDeciders, namespace, name string, cond func(*sca
 		if err != nil {
 			return false, nil
 		}
-		if cond == nil {
-			return true, nil
-		}
-		return cond(decider), nil
+		return cond == nil || cond(decider), nil
 	})
 	return decider, err
 }
@@ -1406,11 +1403,11 @@ func pollDeciders(deciders *testDeciders, namespace, name string, cond func(*sca
 func newTestDeciders() *testDeciders {
 	return &testDeciders{
 		createCallCount:    atomic.NewUint32(0),
-		createCall:         make(chan struct{}, 100),
+		createCall:         make(chan struct{}, 1),
 		deleteCallCount:    atomic.NewUint32(0),
-		deleteCall:         make(chan struct{}, 100),
+		deleteCall:         make(chan struct{}, 1),
 		updateCallCount:    atomic.NewUint32(0),
-		updateCall:         make(chan struct{}, 100),
+		updateCall:         make(chan struct{}, 1),
 		deleteBeforeCreate: atomic.NewBool(false),
 	}
 }

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -473,16 +473,18 @@ func TestDisableScaleToZero(t *testing.T) {
 }
 
 func newKPA(t *testing.T, servingClient clientset.Interface, revision *v1.Revision) *pav1alpha1.PodAutoscaler {
+	t.Helper()
 	pa := revisionresources.MakePA(revision)
 	pa.Status.InitializeConditions()
 	_, err := servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(pa)
 	if err != nil {
-		t.Fatal("Failed to create PA.", err)
+		t.Fatal("Failed to create PA:", err)
 	}
 	return pa
 }
 
 func newRevision(t *testing.T, servingClient clientset.Interface, minScale, maxScale int32) *v1.Revision {
+	t.Helper()
 	annotations := map[string]string{}
 	if minScale > 0 {
 		annotations[autoscaling.MinScaleAnnotationKey] = strconv.Itoa(int(minScale))
@@ -499,7 +501,7 @@ func newRevision(t *testing.T, servingClient clientset.Interface, minScale, maxS
 	}
 	rev, err := servingClient.ServingV1().Revisions(testNamespace).Create(rev)
 	if err != nil {
-		t.Fatal("Failed to create revision.", err)
+		t.Fatal("Failed to create revision:", err)
 	}
 
 	return rev
@@ -588,7 +590,7 @@ func checkReplicas(t *testing.T, dynamicClient *fakedynamic.FakeDynamicClient, d
 	}
 
 	if !found {
-		t.Errorf("Did not see scale update for %v", deployment.Name)
+		t.Errorf("Did not see scale update for %q", deployment.Name)
 	}
 }
 
@@ -621,7 +623,6 @@ func TestActivatorProbe(t *testing.T) {
 			rsp.Write([]byte("wrong header, I guess?"))
 			return rsp.Result(), nil
 		},
-		wantRes: false,
 		wantErr: true,
 	}, {
 		name: "wrong body",
@@ -630,14 +631,12 @@ func TestActivatorProbe(t *testing.T) {
 			rsp.Write([]byte("haxoorprober"))
 			return rsp.Result(), nil
 		},
-		wantRes: false,
 		wantErr: true,
 	}, {
 		name: "all wrong",
 		rt: func(r *http.Request) (*http.Response, error) {
 			return nil, theErr
 		},
-		wantRes: false,
 		wantErr: true,
 	}}
 


### PR DESCRIPTION
Found some small annoyances while reading the tests.
The main change is to `Error->Fatal` transition, since test does not make sense to continue from that point onward.

/assign mattmoor