### PR TITLE
Fix #6878: move the constants around

### DIFF
--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -28,7 +28,6 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/config"
-	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
 )
 
 var (
@@ -104,8 +103,8 @@ func ValidateContainerConcurrency(containerConcurrency *int64) *apis.FieldError 
 
 // ValidateClusterVisibilityLabel function validates the visibility label on a Route
 func ValidateClusterVisibilityLabel(label string) (errs *apis.FieldError) {
-	if label != routeconfig.VisibilityClusterLocal {
-		errs = apis.ErrInvalidValue(label, routeconfig.VisibilityLabelKey)
+	if label != VisibilityClusterLocal {
+		errs = apis.ErrInvalidValue(label, VisibilityLabelKey)
 	}
 	return
 }

--- a/pkg/apis/serving/metadata_validation_test.go
+++ b/pkg/apis/serving/metadata_validation_test.go
@@ -30,7 +30,6 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/config"
-	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
 )
 
 func TestValidateObjectMetadata(t *testing.T) {
@@ -290,15 +289,15 @@ func TestValidateClusterVisibilityLabel(t *testing.T) {
 	}{{
 		name:      "empty label",
 		label:     "",
-		expectErr: apis.ErrInvalidValue("", routeconfig.VisibilityLabelKey),
+		expectErr: apis.ErrInvalidValue("", VisibilityLabelKey),
 	}, {
 		name:      "valid label",
-		label:     routeconfig.VisibilityClusterLocal,
+		label:     VisibilityClusterLocal,
 		expectErr: (*apis.FieldError)(nil),
 	}, {
 		name:      "invalid label",
 		label:     "not-cluster-local",
-		expectErr: apis.ErrInvalidValue("not-cluster-local", routeconfig.VisibilityLabelKey),
+		expectErr: apis.ErrInvalidValue("not-cluster-local", VisibilityLabelKey),
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -71,6 +71,16 @@ const (
 	// QueueSideCarResourcePercentageAnnotation is the percentage of user container resources to be used for queue-proxy
 	// It has to be in [0.1,100]
 	QueueSideCarResourcePercentageAnnotation = "queue.sidecar." + GroupName + "/resourcePercentage"
+
+	// VisibilityLabelKey is the label to indicate visibility of Route
+	// and KServices.  It can be an annotation too but since users are
+	// already using labels for domain, it probably best to keep this
+	// consistent.
+	VisibilityLabelKey = "serving.knative.dev/visibility"
+	// VisibilityClusterLocal is the label value for VisibilityLabelKey
+	// that will result to the Route/KService getting a cluster local
+	// domain suffix.
+	VisibilityClusterLocal = "cluster-local"
 )
 
 var (

--- a/pkg/apis/serving/v1/configuration_validation.go
+++ b/pkg/apis/serving/v1/configuration_validation.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/reconciler/route/config"
 )
 
 // Validate makes sure that Configuration is properly configured.
@@ -75,7 +74,7 @@ func (csf *ConfigurationStatusFields) Validate(ctx context.Context) *apis.FieldE
 func (c *Configuration) validateLabels() (errs *apis.FieldError) {
 	for key, val := range c.GetLabels() {
 		switch {
-		case key == config.VisibilityLabelKey:
+		case key == serving.VisibilityLabelKey:
 			errs = errs.Also(validateClusterVisibilityLabel(val))
 		case key == serving.RouteLabelKey:
 		case key == serving.ServiceLabelKey:

--- a/pkg/apis/serving/v1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1/configuration_validation_test.go
@@ -20,16 +20,14 @@ import (
 	"context"
 	"testing"
 
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
-	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"knative.dev/pkg/apis"
 )
 
 func TestConfigurationValidation(t *testing.T) {
@@ -275,7 +273,7 @@ func TestConfigurationLabelValidation(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "byo-name",
 				Labels: map[string]string{
-					routeconfig.VisibilityLabelKey: "cluster-local",
+					serving.VisibilityLabelKey: "cluster-local",
 				},
 			},
 			Spec: validConfigSpec,
@@ -287,7 +285,7 @@ func TestConfigurationLabelValidation(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "byo-name",
 				Labels: map[string]string{
-					routeconfig.VisibilityLabelKey: "bad-value",
+					serving.VisibilityLabelKey: "bad-value",
 				},
 			},
 			Spec: validConfigSpec,

--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/reconciler/route/config"
 )
 
 // Validate makes sure that Route is properly configured.
@@ -204,8 +203,8 @@ func (rsf *RouteStatusFields) Validate(ctx context.Context) *apis.FieldError {
 }
 
 func validateClusterVisibilityLabel(label string) (errs *apis.FieldError) {
-	if label != config.VisibilityClusterLocal {
-		errs = apis.ErrInvalidValue(label, config.VisibilityLabelKey)
+	if label != serving.VisibilityClusterLocal {
+		errs = apis.ErrInvalidValue(label, serving.VisibilityLabelKey)
 	}
 	return
 }
@@ -214,7 +213,7 @@ func validateClusterVisibilityLabel(label string) (errs *apis.FieldError) {
 func (r *Route) validateLabels() (errs *apis.FieldError) {
 	for key, val := range r.GetLabels() {
 		switch {
-		case key == config.VisibilityLabelKey:
+		case key == serving.VisibilityLabelKey:
 			errs = errs.Also(validateClusterVisibilityLabel(val))
 		case key == serving.ServiceLabelKey:
 			errs = errs.Also(verifyLabelOwnerRef(val, serving.ServiceLabelKey, "Service", r.GetOwnerReferences()))

--- a/pkg/apis/serving/v1/route_validation_test.go
+++ b/pkg/apis/serving/v1/route_validation_test.go
@@ -26,7 +26,6 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving"
-	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
 )
 
 func TestTrafficTargetValidation(t *testing.T) {
@@ -523,7 +522,7 @@ func TestRouteLabelValidation(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "byo-name",
 				Labels: map[string]string{
-					routeconfig.VisibilityLabelKey: "cluster-local",
+					serving.VisibilityLabelKey: "cluster-local",
 				},
 			},
 			Spec: validRouteSpec,
@@ -535,7 +534,7 @@ func TestRouteLabelValidation(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "byo-name",
 				Labels: map[string]string{
-					routeconfig.VisibilityLabelKey: "bad-value",
+					serving.VisibilityLabelKey: "bad-value",
 				},
 			},
 			Spec: validRouteSpec,

--- a/pkg/apis/serving/v1/service_validation.go
+++ b/pkg/apis/serving/v1/service_validation.go
@@ -22,7 +22,6 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/reconciler/route/config"
 )
 
 // Validate makes sure that Service is properly configured.
@@ -69,7 +68,7 @@ func (ss *ServiceStatus) Validate(ctx context.Context) *apis.FieldError {
 func (s *Service) validateLabels() (errs *apis.FieldError) {
 	for key, val := range s.GetLabels() {
 		switch {
-		case key == config.VisibilityLabelKey:
+		case key == serving.VisibilityLabelKey:
 			errs = errs.Also(validateClusterVisibilityLabel(val))
 		case strings.HasPrefix(key, serving.GroupNamePrefix):
 			errs = errs.Also(apis.ErrInvalidKeyName(key, apis.CurrentField))

--- a/pkg/apis/serving/v1/service_validation_test.go
+++ b/pkg/apis/serving/v1/service_validation_test.go
@@ -23,12 +23,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
-	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
-
-	"knative.dev/pkg/apis"
 )
 
 func TestServiceValidation(t *testing.T) {
@@ -77,7 +75,7 @@ func TestServiceValidation(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "valid",
 				Labels: map[string]string{
-					routeconfig.VisibilityLabelKey: "cluster-local",
+					serving.VisibilityLabelKey: "cluster-local",
 				},
 			},
 			Spec: ServiceSpec{
@@ -122,7 +120,7 @@ func TestServiceValidation(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "valid",
 				Labels: map[string]string{
-					routeconfig.VisibilityLabelKey: "bad-label",
+					serving.VisibilityLabelKey: "bad-label",
 				},
 			},
 			Spec: ServiceSpec{

--- a/pkg/apis/serving/v1beta1/configuration_validation.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/reconciler/route/config"
 )
 
 // Validate makes sure that Configuration is properly configured.
@@ -60,7 +59,7 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 func (c *Configuration) validateLabels() (errs *apis.FieldError) {
 	for key, val := range c.GetLabels() {
 		switch {
-		case key == config.VisibilityLabelKey:
+		case key == serving.VisibilityLabelKey:
 			errs = errs.Also(serving.ValidateClusterVisibilityLabel(val))
 		case key == serving.RouteLabelKey:
 		case key == serving.ServiceLabelKey:

--- a/pkg/apis/serving/v1beta1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation_test.go
@@ -24,7 +24,6 @@ import (
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
@@ -252,7 +251,7 @@ func TestConfigurationLabelValidation(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "byo-name",
 				Labels: map[string]string{
-					routeconfig.VisibilityLabelKey: "cluster-local",
+					serving.VisibilityLabelKey: "cluster-local",
 				},
 			},
 			Spec: validConfigSpec,
@@ -264,7 +263,7 @@ func TestConfigurationLabelValidation(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "byo-name",
 				Labels: map[string]string{
-					routeconfig.VisibilityLabelKey: "bad-value",
+					serving.VisibilityLabelKey: "bad-value",
 				},
 			},
 			Spec: validConfigSpec,

--- a/pkg/apis/serving/v1beta1/route_validation.go
+++ b/pkg/apis/serving/v1beta1/route_validation.go
@@ -22,7 +22,6 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/reconciler/route/config"
 )
 
 // Validate makes sure that Route is properly configured.
@@ -48,7 +47,7 @@ func (r *Route) Validate(ctx context.Context) *apis.FieldError {
 func (r *Route) validateLabels() (errs *apis.FieldError) {
 	for key, val := range r.GetLabels() {
 		switch {
-		case key == config.VisibilityLabelKey:
+		case key == serving.VisibilityLabelKey:
 			errs = errs.Also(serving.ValidateClusterVisibilityLabel(val))
 		case key == serving.ServiceLabelKey:
 			errs = errs.Also(verifyLabelOwnerRef(val, serving.ServiceLabelKey, "Service", r.GetOwnerReferences()))

--- a/pkg/apis/serving/v1beta1/route_validation_test.go
+++ b/pkg/apis/serving/v1beta1/route_validation_test.go
@@ -23,11 +23,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
 )
 
 func TestTrafficTargetValidation(t *testing.T) {
@@ -507,7 +507,7 @@ func TestRouteLabelValidation(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "byo-name",
 				Labels: map[string]string{
-					routeconfig.VisibilityLabelKey: "cluster-local",
+					serving.VisibilityLabelKey: "cluster-local",
 				},
 			},
 			Spec: validRouteSpec,
@@ -519,7 +519,7 @@ func TestRouteLabelValidation(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "byo-name",
 				Labels: map[string]string{
-					routeconfig.VisibilityLabelKey: "bad-value",
+					serving.VisibilityLabelKey: "bad-value",
 				},
 			},
 			Spec: validRouteSpec,

--- a/pkg/apis/serving/v1beta1/service_validation.go
+++ b/pkg/apis/serving/v1beta1/service_validation.go
@@ -22,7 +22,6 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/reconciler/route/config"
 )
 
 // Validate makes sure that Service is properly configured.
@@ -55,7 +54,7 @@ func (s *Service) Validate(ctx context.Context) (errs *apis.FieldError) {
 func (s *Service) validateLabels() (errs *apis.FieldError) {
 	for key, val := range s.GetLabels() {
 		switch {
-		case key == config.VisibilityLabelKey:
+		case key == serving.VisibilityLabelKey:
 			errs = errs.Also(serving.ValidateClusterVisibilityLabel(val))
 		case strings.HasPrefix(key, serving.GroupNamePrefix):
 			errs = errs.Also(apis.ErrInvalidKeyName(key, apis.CurrentField))

--- a/pkg/apis/serving/v1beta1/service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/service_validation_test.go
@@ -27,7 +27,6 @@ import (
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
 
 	"knative.dev/pkg/apis"
 )
@@ -78,7 +77,7 @@ func TestServiceValidation(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "valid",
 				Labels: map[string]string{
-					routeconfig.VisibilityLabelKey: "cluster-local",
+					serving.VisibilityLabelKey: "cluster-local",
 				},
 			},
 			Spec: v1.ServiceSpec{
@@ -123,7 +122,7 @@ func TestServiceValidation(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "valid",
 				Labels: map[string]string{
-					routeconfig.VisibilityLabelKey: "bad-label",
+					serving.VisibilityLabelKey: "bad-label",
 				},
 			},
 			Spec: v1.ServiceSpec{

--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -27,6 +27,7 @@ import (
 	"knative.dev/pkg/apis"
 	pkgnet "knative.dev/pkg/network"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler/route/config"
@@ -82,7 +83,7 @@ func DomainNameFromTemplate(ctx context.Context, r metav1.ObjectMeta, name strin
 	var templ *template.Template
 	// If the route is "cluster local" then don't use the user-defined
 	// domain template, use the default one
-	if rLabels[config.VisibilityLabelKey] == config.VisibilityClusterLocal {
+	if rLabels[serving.VisibilityLabelKey] == serving.VisibilityClusterLocal {
 		templ = template.Must(template.New("domain-template").Parse(
 			network.DefaultDomainTemplate))
 	} else {

--- a/pkg/reconciler/route/domains/domains_test.go
+++ b/pkg/reconciler/route/domains/domains_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis"
 
+	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/gc"
 	"knative.dev/serving/pkg/network"
@@ -127,9 +128,9 @@ func TestDomainNameFromTemplate(t *testing.T) {
 			ctx = config.ToContext(ctx, cfg)
 
 			if tt.local {
-				meta.Labels[config.VisibilityLabelKey] = config.VisibilityClusterLocal
+				meta.Labels[serving.VisibilityLabelKey] = serving.VisibilityClusterLocal
 			} else {
-				delete(meta.Labels, config.VisibilityLabelKey)
+				delete(meta.Labels, serving.VisibilityLabelKey)
 			}
 
 			got, err := DomainNameFromTemplate(ctx, meta, tt.args.name)

--- a/pkg/reconciler/route/resources/filters.go
+++ b/pkg/reconciler/route/resources/filters.go
@@ -18,7 +18,7 @@ package resources
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"knative.dev/serving/pkg/reconciler/route/config"
+	"knative.dev/serving/pkg/apis/serving"
 )
 
 // Filter is used for applying a function to a service
@@ -42,9 +42,6 @@ func FilterService(services []*corev1.Service, acceptFilter Filter) []*corev1.Se
 
 // IsClusterLocalService returns whether a service is cluster local.
 func IsClusterLocalService(svc *corev1.Service) bool {
-	if visibility, ok := svc.GetLabels()[config.VisibilityLabelKey]; ok {
-		return config.VisibilityClusterLocal == visibility
-	}
-
-	return false
+	visibility, ok := svc.GetLabels()[serving.VisibilityLabelKey]
+	return ok && serving.VisibilityClusterLocal == visibility
 }

--- a/pkg/reconciler/route/resources/filters_test.go
+++ b/pkg/reconciler/route/resources/filters_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"knative.dev/serving/pkg/reconciler/route/config"
+	"knative.dev/serving/pkg/apis/serving"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,7 +89,7 @@ func TestIsClusterLocalService(t *testing.T) {
 			svc: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						config.VisibilityLabelKey: "something-unknown",
+						serving.VisibilityLabelKey: "something-unknown",
 					},
 				},
 			},
@@ -100,7 +100,7 @@ func TestIsClusterLocalService(t *testing.T) {
 			svc: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						config.VisibilityLabelKey: config.VisibilityClusterLocal,
+						serving.VisibilityLabelKey: serving.VisibilityClusterLocal,
 					},
 				},
 			},

--- a/pkg/reconciler/route/resources/labels/labels.go
+++ b/pkg/reconciler/route/resources/labels/labels.go
@@ -18,20 +18,20 @@ package labels
 
 import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/serving/pkg/reconciler/route/config"
+	"knative.dev/serving/pkg/apis/serving"
 )
 
 // IsObjectLocalVisibility returns whether an ObjectMeta is of cluster-local visibility
 func IsObjectLocalVisibility(meta v1.ObjectMeta) bool {
-	return meta.Labels != nil && meta.Labels[config.VisibilityLabelKey] != ""
+	return meta.Labels != nil && meta.Labels[serving.VisibilityLabelKey] != ""
 }
 
 // SetVisibility sets the visibility on an ObjectMeta
 func SetVisibility(meta *v1.ObjectMeta, isClusterLocal bool) {
 	if isClusterLocal {
-		SetLabel(meta, config.VisibilityLabelKey, config.VisibilityClusterLocal)
+		SetLabel(meta, serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
 	} else {
-		DeleteLabel(meta, config.VisibilityLabelKey)
+		DeleteLabel(meta, serving.VisibilityLabelKey)
 	}
 }
 

--- a/pkg/reconciler/route/resources/labels/labels_test.go
+++ b/pkg/reconciler/route/resources/labels/labels_test.go
@@ -19,10 +19,9 @@ package labels
 import (
 	"testing"
 
-	"knative.dev/serving/pkg/reconciler/route/config"
-
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/serving/pkg/apis/serving"
 )
 
 func TestDeleteLabel(t *testing.T) {
@@ -130,20 +129,17 @@ func TestSetVisibility(t *testing.T) {
 		meta           *v1.ObjectMeta
 		isClusterLocal bool
 		expected       v1.ObjectMeta
-	}{
-		{
-			name:           "Set cluster local true",
-			meta:           &v1.ObjectMeta{},
-			isClusterLocal: true,
-			expected:       v1.ObjectMeta{Labels: map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal}},
-		},
-		{
-			name:           "Set cluster local false",
-			meta:           &v1.ObjectMeta{Labels: map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal}},
-			isClusterLocal: false,
-			expected:       v1.ObjectMeta{Labels: map[string]string{}},
-		},
-	}
+	}{{
+		name:           "Set cluster local true",
+		meta:           &v1.ObjectMeta{},
+		isClusterLocal: true,
+		expected:       v1.ObjectMeta{Labels: map[string]string{serving.VisibilityLabelKey: serving.VisibilityClusterLocal}},
+	}, {
+		name:           "Set cluster local false",
+		meta:           &v1.ObjectMeta{Labels: map[string]string{serving.VisibilityLabelKey: serving.VisibilityClusterLocal}},
+		isClusterLocal: false,
+		expected:       v1.ObjectMeta{Labels: map[string]string{}},
+	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetVisibility(tt.meta, tt.isClusterLocal)

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -267,7 +267,7 @@ func TestMakeK8sPlaceholderService(t *testing.T) {
 		wantErr: false,
 	}, {
 		name:  "cluster local route",
-		route: Route("test-ns", "test-route", WithRouteLabel(map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal})),
+		route: Route("test-ns", "test-route", WithRouteLabel(map[string]string{serving.VisibilityLabelKey: serving.VisibilityClusterLocal})),
 		expectedSpec: corev1.ServiceSpec{
 			Type:            corev1.ServiceTypeExternalName,
 			ExternalName:    "foo-test-route.test-ns.svc.cluster.local",

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -2251,7 +2251,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		Name: "public becomes cluster local w/ autoTLS",
 		Objects: []runtime.Object{
 			Route("default", "becomes-local", WithConfigTarget("config"),
-				WithRouteLabel(map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal}),
+				WithRouteLabel(map[string]string{serving.VisibilityLabelKey: serving.VisibilityClusterLocal}),
 				WithRouteUID("65-23")),
 			cfg("default", "config",
 				WithGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
@@ -2273,14 +2273,14 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				},
 			),
 			simpleK8sService(Route("default", "becomes-local", WithConfigTarget("config"),
-				WithRouteLabel(map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal}),
+				WithRouteLabel(map[string]string{serving.VisibilityLabelKey: serving.VisibilityClusterLocal}),
 				WithRouteUID("65-23"))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleIngress(
 				Route("default", "becomes-local", WithConfigTarget("config"),
 					WithRouteUID("65-23"),
-					WithRouteLabel(map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal})),
+					WithRouteLabel(map[string]string{serving.VisibilityLabelKey: serving.VisibilityClusterLocal})),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{
@@ -2304,7 +2304,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				WithRouteUID("65-23"),
 				MarkTrafficAssigned, MarkIngressNotConfigured,
 				WithLocalDomain, WithAddress, WithInitRouteConditions,
-				WithRouteLabel(map[string]string{config.VisibilityLabelKey: config.VisibilityClusterLocal}),
+				WithRouteLabel(map[string]string{serving.VisibilityLabelKey: serving.VisibilityClusterLocal}),
 				WithStatusTraffic(
 					v1.TrafficTarget{
 						RevisionName:   "config-00001",

--- a/pkg/reconciler/route/visibility/visibility_test.go
+++ b/pkg/reconciler/route/visibility/visibility_test.go
@@ -77,7 +77,7 @@ func TestVisibility(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 				Labels: map[string]string{
-					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+					serving.VisibilityLabelKey: serving.VisibilityClusterLocal,
 				},
 			},
 		},
@@ -95,16 +95,16 @@ func TestVisibility(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 				Labels: map[string]string{
-					serving.RouteLabelKey:     "foo",
-					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+					serving.RouteLabelKey:      "foo",
+					serving.VisibilityLabelKey: serving.VisibilityClusterLocal,
 				},
 			},
 		}, {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "irrelevance",
 				Labels: map[string]string{
-					serving.RouteLabelKey:     "bar",
-					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+					serving.RouteLabelKey:      "bar",
+					serving.VisibilityLabelKey: serving.VisibilityClusterLocal,
 				},
 			},
 		}},
@@ -125,8 +125,8 @@ func TestVisibility(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "blue-foo",
 				Labels: map[string]string{
-					serving.RouteLabelKey:     "foo",
-					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+					serving.RouteLabelKey:      "foo",
+					serving.VisibilityLabelKey: serving.VisibilityClusterLocal,
 				},
 			},
 		}, {
@@ -268,7 +268,7 @@ func TestVisibility(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 				Labels: map[string]string{
-					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+					serving.VisibilityLabelKey: serving.VisibilityClusterLocal,
 				},
 			},
 			Spec: v1.RouteSpec{
@@ -322,8 +322,8 @@ func TestVisibility(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "blue-foo",
 				Labels: map[string]string{
-					serving.RouteLabelKey:     "foo",
-					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+					serving.RouteLabelKey:      "foo",
+					serving.VisibilityLabelKey: serving.VisibilityClusterLocal,
 				},
 			},
 		}},
@@ -349,16 +349,16 @@ func TestVisibility(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "blue-foo",
 				Labels: map[string]string{
-					serving.RouteLabelKey:     "foo",
-					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+					serving.RouteLabelKey:      "foo",
+					serving.VisibilityLabelKey: serving.VisibilityClusterLocal,
 				},
 			},
 		}, {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "green-foo",
 				Labels: map[string]string{
-					serving.RouteLabelKey:     "foo",
-					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+					serving.RouteLabelKey:      "foo",
+					serving.VisibilityLabelKey: serving.VisibilityClusterLocal,
 				},
 			},
 		}},
@@ -384,24 +384,24 @@ func TestVisibility(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "blue-foo",
 				Labels: map[string]string{
-					serving.RouteLabelKey:     "foo",
-					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+					serving.RouteLabelKey:      "foo",
+					serving.VisibilityLabelKey: serving.VisibilityClusterLocal,
 				},
 			},
 		}, {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "green-foo",
 				Labels: map[string]string{
-					serving.RouteLabelKey:     "foo",
-					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+					serving.RouteLabelKey:      "foo",
+					serving.VisibilityLabelKey: serving.VisibilityClusterLocal,
 				},
 			},
 		}, {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
 				Labels: map[string]string{
-					serving.RouteLabelKey:     "foo",
-					config.VisibilityLabelKey: config.VisibilityClusterLocal,
+					serving.RouteLabelKey:      "foo",
+					serving.VisibilityLabelKey: serving.VisibilityClusterLocal,
 				},
 			},
 		}},

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -29,7 +29,7 @@ import (
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/pkg/apis/autoscaling"
-	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
+	"knative.dev/serving/pkg/apis/serving"
 	v1alph1testing "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
@@ -195,7 +195,7 @@ func TestServiceToServiceCall(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	withInternalVisibility := v1alph1testing.WithServiceLabel(
-		routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
+		serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
 	resources, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
 		test.ServingFlags.Https,
 		withInternalVisibility,
@@ -242,7 +242,7 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 	}
 
 	withInternalVisibility := v1alph1testing.WithServiceLabel(
-		routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
+		serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
 
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, testNames) })
 	defer test.TearDown(clients, testNames)

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -25,13 +25,14 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/test/logstream"
+	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	routeconfig "knative.dev/serving/pkg/reconciler/route/config"
 	"knative.dev/serving/pkg/reconciler/route/resources/labels"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
@@ -63,7 +64,7 @@ func TestSubrouteLocalSTS(t *testing.T) { // We can't use a longer more descript
 
 	tag := "current"
 
-	withInternalVisibility := WithServiceLabel(routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
+	withInternalVisibility := WithServiceLabel(serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
 	withTrafficSpec := WithInlineRouteSpec(v1alpha1.RouteSpec{
 		Traffic: []v1alpha1.TrafficTarget{
 			{
@@ -236,7 +237,7 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 	subrouteTag1 := "my-tag"
 	subrouteTag2 := "my-tag2"
 
-	withInternalVisibility := WithServiceLabel(routeconfig.VisibilityLabelKey, routeconfig.VisibilityClusterLocal)
+	withInternalVisibility := WithServiceLabel(serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
 	withTrafficSpec := WithInlineRouteSpec(v1alpha1.RouteSpec{
 		Traffic: []v1alpha1.TrafficTarget{
 			{


### PR DESCRIPTION
This removes all 'reconciler' dependencies from API package.
I think now APIs only depend on knative.dev/pkg or other API packages.

/lint


Fixes #6878


/assign @markusthoemmes mattmoor @dgerd 