### PR TITLE
Fix timing issues in pool unit tests.

### DIFF
--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -50,6 +50,12 @@ func New(workers int) Interface {
 	return NewWithCapacity(workers, defaultCapacity)
 }
 
+// NewWithCapacity creates a fresh worker pool with the specified size.
+func NewWithCapacity(workers, capacity int) Interface {
+	i, _ := NewWithContext(context.Background(), workers, capacity)
+	return i
+}
+
 // NewWithContext creates a pool that is driven by a cancelable context.
 // Just like errgroup.Group on first error the context will be canceled as well.
 func NewWithContext(ctx context.Context, workers, capacity int) (Interface, context.Context) {
@@ -61,7 +67,7 @@ func NewWithContext(ctx context.Context, workers, capacity int) (Interface, cont
 
 	// Start a go routine for each worker, which:
 	// 1. reads off of the work channel,
-	// 2. (optionally) sends errors on the error channel,
+	// 2. (optionally) sets the error as the result,
 	// 3. marks work as done in our sync.WaitGroup.
 	for idx := 0; idx < workers; idx++ {
 		go func() {
@@ -83,12 +89,6 @@ func (i *impl) exec(w func() error) {
 			i.result = err
 		})
 	}
-}
-
-// NewWithCapacity creates a fresh worker pool with the specified size.
-func NewWithCapacity(workers, capacity int) Interface {
-	i, _ := NewWithContext(context.Background(), workers, capacity)
-	return i
 }
 
 // Go implements Interface.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

These tests have been prone to timing issues. This should solve this by concurrently scheduling all requests, including the one we expect to finish first. All requests will be held by the barrier until the one we expect has finished, as indicated by the context being closed. We can then safely allow all other requests to finish and verify that the error indeed was the one that was returned by the request we expected to finish first, even if it wasn't scheduled first.

Failure in https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1229589211145834496

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @mattmoor 
