### PR TITLE
Remove the redundant call of build_knative_from_source

### DIFF
--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -56,9 +56,6 @@ function install_head() {
 }
 
 function knative_setup() {
-  # Build Knative to generate Istio manifests from HEAD for install_latest_release
-  # We do it here because it's a one-time setup
-  build_knative_from_source
   install_latest_release
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #6903

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* The upgrade test script e2e-upgrade-tests.sh calls this `build_knative_from_source` functions twice. Once is in `knative_setup`, the other is in `install_knative_serving_standard`. This PR removes the first call, since the second call in `install_knative_serving_standard` is shared by the e2e-tests.sh.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
