### PR TITLE
Cleanup some SkipNamespaceValidation settings

### DIFF
--- a/pkg/reconciler/certificate/certificate_test.go
+++ b/pkg/reconciler/certificate/certificate_test.go
@@ -371,10 +371,9 @@ func TestReconcile(t *testing.T) {
 
 func TestReconcile_HTTP01Challenges(t *testing.T) {
 	table := TableTest{{
-		Name:                    "fail to set status.HTTP01Challenges",
-		Key:                     "foo/knCert",
-		SkipNamespaceValidation: true,
-		WantErr:                 true,
+		Name:    "fail to set status.HTTP01Challenges",
+		Key:     "foo/knCert",
+		WantErr: true,
 		Objects: []runtime.Object{
 			knCert("knCert", "foo"),
 			http01Issuer,

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -2120,8 +2120,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 				WithURL,
 			),
 		}},
-		Key:                     "default/becomes-ready",
-		SkipNamespaceValidation: true,
+		Key: "default/becomes-ready",
 	}, {
 		Name:    "check that Route updates status and produces event log when valid name but not owned certificate",
 		WantErr: true,


### PR DESCRIPTION
I was hoping to clean up more, but the ingress controller still potentially reconciles Gateways :(

