### PR TITLE
Simplify stats reporter and the activator main, by removing the report ticker channel from args

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -211,9 +211,7 @@ func main() {
 	go statReporter(statSink, ctx.Done(), statCh, logger)
 
 	// Create and run our concurrency reporter
-	reportTicker := time.NewTicker(time.Second)
-	defer reportTicker.Stop()
-	cr := activatorhandler.NewConcurrencyReporter(ctx, env.PodName, reqCh, reportTicker.C, statCh)
+	cr := activatorhandler.NewConcurrencyReporter(ctx, env.PodName, reqCh, statCh)
 	go cr.Run(ctx.Done())
 
 	// Create activation handler chain


### PR DESCRIPTION
It's a constant channel, it's created and passed and nothing else
happens to it in main.
So internalize it in the reporter.
Also do some cleanups to the test.


/lint
/assign @markusthoemmes mattmoor