### PR TITLE
Fix the graceful scaledown test setup

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -436,7 +436,11 @@ func TestGracefulScaledown(t *testing.T) {
 	defer cancel()
 
 	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency, 1 /* target */, 1, /* targetUtilization */
-		wsHostnameTestImageName, nil /* no validation */)
+		wsHostnameTestImageName, nil, /* no validation */
+		rtesting.WithContainerConcurrency(1),
+		rtesting.WithConfigAnnotations(map[string]string{
+			autoscaling.TargetBurstCapacityKey: "-1",
+		}))
 	defer test.TearDown(ctx.clients, ctx.names)
 
 	autoscalerConfigMap, err := rawCM(ctx.clients, autoscalerconfig.ConfigName)


### PR DESCRIPTION
1. make sure we container concurrency (target just controls soft limits, we need hard here).
2. log useful stuff during connection creation.


/assign @nimakaviani 