### PR TITLE
Split HTTP server and HTTPS server reconcilation when reconciling Istio Gateway

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -216,8 +216,8 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 	// TODO(zhiminx): figure out a better way to handle HTTP behavior.
 	// https://github.com/knative/serving/issues/6373
 	if config.FromContext(ctx).Network.AutoTLS {
+		desiredHTTPServer := resources.MakeHTTPServer(config.FromContext(ctx).Network.HTTPProtocol, []string{"*"})
 		for _, gw := range config.FromContext(ctx).Istio.IngressGateways {
-			desiredHTTPServer := resources.MakeHTTPServer(config.FromContext(ctx).Network.HTTPProtocol, []string{"*"})
 			if err := r.reconcileHTTPServer(ctx, ing, gw, desiredHTTPServer); err != nil {
 				return err
 			}

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -206,7 +206,11 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 			if err != nil {
 				return err
 			}
-			if err := r.reconcileGateway(ctx, ing, gw, desired); err != nil {
+			if err := r.reconcileIngressServers(ctx, ing, gw, desired); err != nil {
+				return err
+			}
+			desiredHTTPServer := resources.MakeHTTPServer(config.FromContext(ctx).Network.HTTPProtocol, []string{"*"})
+			if err := r.reconcileHTTPServer(ctx, ing, gw, desiredHTTPServer); err != nil {
 				return err
 			}
 		}
@@ -310,7 +314,7 @@ func (r *Reconciler) reconcileDeletion(ctx context.Context, ing *v1alpha1.Ingres
 	logger.Infof("Cleaning up Gateway Servers for Ingress %s", ing.GetName())
 	for _, gws := range [][]config.Gateway{istiocfg.IngressGateways, istiocfg.LocalGateways} {
 		for _, gw := range gws {
-			if err := r.reconcileGateway(ctx, ing, gw, []*istiov1alpha3.Server{}); err != nil {
+			if err := r.reconcileIngressServers(ctx, ing, gw, []*istiov1alpha3.Server{}); err != nil {
 				return err
 			}
 		}
@@ -369,27 +373,36 @@ func (r *Reconciler) ensureFinalizer(ing *v1alpha1.Ingress) error {
 	return err
 }
 
-func (r *Reconciler) reconcileGateway(ctx context.Context, ing *v1alpha1.Ingress, gw config.Gateway, desired []*istiov1alpha3.Server) error {
-	// TODO(zhiminx): Need to handle the scenario when deleting Ingress. In this scenario,
-	// the Gateway servers of the Ingress need also be removed from Gateway.
+func (r *Reconciler) reconcileIngressServers(ctx context.Context, ing *v1alpha1.Ingress, gw config.Gateway, desired []*istiov1alpha3.Server) error {
 	gateway, err := r.gatewayLister.Gateways(gw.Namespace).Get(gw.Name)
 	if err != nil {
 		// Unlike VirtualService, a default gateway needs to be existent.
 		// It should be installed when installing Knative.
 		return fmt.Errorf("failed to get Gateway: %w", err)
 	}
-
 	existing := resources.GetServers(gateway, ing)
-	existingHTTPServer := resources.GetHTTPServer(gateway)
-	if existingHTTPServer != nil {
-		existing = append(existing, existingHTTPServer)
-	}
+	return r.reconcileGateway(ctx, ing, gateway, existing, desired)
+}
 
-	desiredHTTPServer := resources.MakeHTTPServer(config.FromContext(ctx).Network.HTTPProtocol, []string{"*"})
-	if desiredHTTPServer != nil {
-		desired = append(desired, desiredHTTPServer)
+func (r *Reconciler) reconcileHTTPServer(ctx context.Context, ing *v1alpha1.Ingress, gw config.Gateway, desiredHTTP *istiov1alpha3.Server) error {
+	gateway, err := r.gatewayLister.Gateways(gw.Namespace).Get(gw.Name)
+	if err != nil {
+		// Unlike VirtualService, a default gateway needs to be existent.
+		// It should be installed when installing Knative.
+		return fmt.Errorf("failed to get Gateway: %w", err)
 	}
+	existing := []*istiov1alpha3.Server{}
+	if e := resources.GetHTTPServer(gateway); e != nil {
+		existing = append(existing, e)
+	}
+	desired := []*istiov1alpha3.Server{}
+	if desiredHTTP != nil {
+		desired = append(desired, desiredHTTP)
+	}
+	return r.reconcileGateway(ctx, ing, gateway, existing, desired)
+}
 
+func (r *Reconciler) reconcileGateway(ctx context.Context, ing *v1alpha1.Ingress, gateway *v1alpha3.Gateway, existing []*istiov1alpha3.Server, desired []*istiov1alpha3.Server) error {
 	if equality.Semantic.DeepEqual(existing, desired) {
 		return nil
 	}

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -209,9 +209,13 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 			if err := r.reconcileIngressServers(ctx, ing, gw, desired); err != nil {
 				return err
 			}
-			desiredHTTPServer := resources.MakeHTTPServer(config.FromContext(ctx).Network.HTTPProtocol, []string{"*"})
-			if err := r.reconcileHTTPServer(ctx, ing, gw, desiredHTTPServer); err != nil {
-				return err
+			// HTTPProtocol should be effective only when Auto TLS is enabled
+			// per its definition.
+			if config.FromContext(ctx).Network.AutoTLS {
+				desiredHTTPServer := resources.MakeHTTPServer(config.FromContext(ctx).Network.HTTPProtocol, []string{"*"})
+				if err := r.reconcileHTTPServer(ctx, ing, gw, desiredHTTPServer); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -212,8 +212,7 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, ing *v1alpha1.Ingress
 		}
 	}
 
-	// HTTPProtocol should be effective only when Auto TLS is enabled
-	// per its definition.
+	// HTTPProtocol should be effective only when Auto TLS is enabled per its definition.
 	// TODO(zhiminx): figure out a better way to handle HTTP behavior.
 	// https://github.com/knative/serving/issues/6373
 	if config.FromContext(ctx).Network.AutoTLS {

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -694,14 +694,15 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
 			ingressWithFinalizers("reconciling-ingress", 1234, ingressTLS, []string{ingressFinalizer}, &deletionTime),
-			gateway(networking.KnativeIngressGateway, system.Namespace(), []*istiov1alpha3.Server{irrelevantServer, ingressTLSServer}),
+			// ingressHTTPRedirectServer should not be deleted when deleting ingress related TLS server..
+			gateway(networking.KnativeIngressGateway, system.Namespace(), []*istiov1alpha3.Server{irrelevantServer, ingressTLSServer, ingressHTTPRedirectServer}),
 		},
 		WantCreates: []runtime.Object{
 			// The creation of gateways are triggered when setting up the test.
-			gateway(networking.KnativeIngressGateway, system.Namespace(), []*istiov1alpha3.Server{irrelevantServer, ingressTLSServer}),
+			gateway(networking.KnativeIngressGateway, system.Namespace(), []*istiov1alpha3.Server{irrelevantServer, ingressTLSServer, ingressHTTPRedirectServer}),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: gateway(networking.KnativeIngressGateway, system.Namespace(), []*istiov1alpha3.Server{irrelevantServer}),
+			Object: gateway(networking.KnativeIngressGateway, system.Namespace(), []*istiov1alpha3.Server{ingressHTTPRedirectServer, irrelevantServer}),
 		}, {
 			// Finalizer should be removed.
 			Object: ingressWithFinalizers("reconciling-ingress", 1234, ingressTLS, []string{}, &deletionTime),
@@ -1037,6 +1038,7 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 					},
 					Network: &network.Config{
 						HTTPProtocol: network.HTTPDisabled,
+						AutoTLS:      true,
 					},
 				},
 			},

--- a/pkg/reconciler/ingress/resources/gateway_test.go
+++ b/pkg/reconciler/ingress/resources/gateway_test.go
@@ -501,13 +501,6 @@ func TestUpdateGateway(t *testing.T) {
 			},
 		},
 	}, {
-		name:            "Delete wildcard servers from gateway",
-		existingServers: []*istiov1alpha3.Server{},
-		newServers:      servers,
-		original:        gatewayWithDefaultWildcardTLSServer,
-		// The wildcard server should be deleted.
-		expected: gateway,
-	}, {
 		name:            "Do not delete modified wildcard servers from gateway",
 		existingServers: []*istiov1alpha3.Server{},
 		newServers: []*istiov1alpha3.Server{{


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #
https://github.com/knative/serving/issues/6934

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Make HTTPS server reconcilation independent with HTTP server reconcilation.
* Only reconcile HTTP server when Auto TLS is turned on.

This is a preparation for the work https://github.com/knative/serving/pull/6889

