### PR TITLE
Set config in the context for validation admission controller

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -106,7 +106,7 @@ func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher
 	// Decorate contexts with the current state of the config.
 	store := defaultconfig.NewStore(logging.FromContext(ctx).Named("config-store"))
 	store.WatchConfigs(cmw)
-	
+
 	return validation.NewAdmissionController(ctx,
 
 		// Name of the resource webhook.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #6853 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Set config in the context for validation admission controller like default controller

