### PR TITLE
Migrate service reconciler to use v1 APIs

### DIFF
--- a/pkg/apis/serving/v1/service_lifecycle.go
+++ b/pkg/apis/serving/v1/service_lifecycle.go
@@ -17,9 +17,18 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+const (
+	trafficNotMigratedReason  = "TrafficNotMigrated"
+	trafficNotMigratedMessage = "Traffic is not yet migrated to the latest revision."
 )
 
 var serviceCondSet = apis.NewLivingConditionSet(
@@ -40,4 +49,89 @@ func (ss *ServiceStatus) IsReady() bool {
 // InitializeConditions sets the initial values to the conditions.
 func (ss *ServiceStatus) InitializeConditions() {
 	serviceCondSet.Manage(ss).InitializeConditions()
+}
+
+// MarkConfigurationNotOwned surfaces a failure via the ConfigurationsReady
+// status noting that the Configuration with the name we want has already
+// been created and we do not own it.
+func (ss *ServiceStatus) MarkConfigurationNotOwned(name string) {
+	serviceCondSet.Manage(ss).MarkFalse(ServiceConditionConfigurationsReady, "NotOwned",
+		fmt.Sprintf("There is an existing Configuration %q that we do not own.", name))
+}
+
+// MarkRouteNotOwned surfaces a failure via the RoutesReady status noting that the Route
+// with the name we want has already been created and we do not own it.
+func (ss *ServiceStatus) MarkRouteNotOwned(name string) {
+	serviceCondSet.Manage(ss).MarkFalse(ServiceConditionRoutesReady, "NotOwned",
+		fmt.Sprintf("There is an existing Route %q that we do not own.", name))
+}
+
+// MarkConfigurationNotReconciled notes that the Configuration controller has not yet
+// caught up to the desired changes we have specified.
+func (ss *ServiceStatus) MarkConfigurationNotReconciled() {
+	serviceCondSet.Manage(ss).MarkUnknown(ServiceConditionConfigurationsReady,
+		"OutOfDate", "The Configuration is still working to reflect the latest desired specification.")
+}
+
+// PropagateConfigurationStatus takes the Configuration status and applies its values
+// to the Service status.
+func (ss *ServiceStatus) PropagateConfigurationStatus(cs *ConfigurationStatus) {
+	ss.ConfigurationStatusFields = cs.ConfigurationStatusFields
+
+	cc := cs.GetCondition(ConfigurationConditionReady)
+	if cc == nil {
+		return
+	}
+	switch {
+	case cc.Status == corev1.ConditionUnknown:
+		serviceCondSet.Manage(ss).MarkUnknown(ServiceConditionConfigurationsReady, cc.Reason, cc.Message)
+	case cc.Status == corev1.ConditionTrue:
+		serviceCondSet.Manage(ss).MarkTrue(ServiceConditionConfigurationsReady)
+	case cc.Status == corev1.ConditionFalse:
+		serviceCondSet.Manage(ss).MarkFalse(ServiceConditionConfigurationsReady, cc.Reason, cc.Message)
+	}
+}
+
+// MarkRevisionNameTaken notes that the Route has not been programmed because the revision name is taken by a
+// conflicting revision definition.
+func (ss *ServiceStatus) MarkRevisionNameTaken(name string) {
+	serviceCondSet.Manage(ss).MarkFalse(ServiceConditionRoutesReady, "RevisionNameTaken",
+		"The revision name %q is taken by a conflicting Revision, so traffic will not be migrated", name)
+}
+
+// MarkRouteNotYetReady marks the service `RouteReady` condition to the `Unknown` state.
+// See: #2430, for details.
+func (ss *ServiceStatus) MarkRouteNotYetReady() {
+	serviceCondSet.Manage(ss).MarkUnknown(ServiceConditionRoutesReady, trafficNotMigratedReason, trafficNotMigratedMessage)
+}
+
+// MarkRouteNotReconciled notes that the Route controller has not yet
+// caught up to the desired changes we have specified.
+func (ss *ServiceStatus) MarkRouteNotReconciled() {
+	serviceCondSet.Manage(ss).MarkUnknown(ServiceConditionRoutesReady,
+		"OutOfDate", "The Route is still working to reflect the latest desired specification.")
+}
+
+// PropagateRouteStatus propagates route's status to the service's status.
+func (ss *ServiceStatus) PropagateRouteStatus(rs *RouteStatus) {
+	ss.RouteStatusFields = rs.RouteStatusFields
+
+	rc := rs.GetCondition(RouteConditionReady)
+	if rc == nil {
+		return
+	}
+
+	m := serviceCondSet.Manage(ss)
+	switch rc.Status {
+	case corev1.ConditionTrue:
+		m.MarkTrue(ServiceConditionRoutesReady)
+	case corev1.ConditionFalse:
+		m.MarkFalse(ServiceConditionRoutesReady, rc.Reason, rc.Message)
+	case corev1.ConditionUnknown:
+		m.MarkUnknown(ServiceConditionRoutesReady, rc.Reason, rc.Message)
+	}
+}
+
+func (ss *ServiceStatus) duck() *duckv1.Status {
+	return &ss.Status
 }

--- a/pkg/apis/serving/v1/service_lifecycle_test.go
+++ b/pkg/apis/serving/v1/service_lifecycle_test.go
@@ -18,11 +18,14 @@ package v1
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	apitestv1 "knative.dev/pkg/apis/testing/v1"
+	"knative.dev/pkg/ptr"
 )
 
 func TestServiceDuckTypes(t *testing.T) {
@@ -57,55 +60,572 @@ func TestServiceGetGroupVersionKind(t *testing.T) {
 }
 
 func TestServiceIsReady(t *testing.T) {
-	tests := []struct {
-		name     string
-		ss       *ServiceStatus
-		expected bool
+	cases := []struct {
+		name    string
+		status  ServiceStatus
+		isReady bool
 	}{{
-		name:     "Ready undefined",
-		ss:       &ServiceStatus{},
-		expected: false,
+		name:    "empty status should not be ready",
+		status:  ServiceStatus{},
+		isReady: false,
 	}, {
-		name: "Ready=False",
-		ss: &ServiceStatus{
+		name: "Different condition type should not be ready",
+		status: ServiceStatus{
 			Status: duckv1.Status{
 				Conditions: duckv1.Conditions{{
-					Type:   apis.ConditionReady,
-					Status: corev1.ConditionFalse,
-				}},
-			},
-		},
-		expected: false,
-	}, {
-		name: "Ready=Unknown",
-		ss: &ServiceStatus{
-			Status: duckv1.Status{
-				Conditions: duckv1.Conditions{{
-					Type:   apis.ConditionReady,
-					Status: corev1.ConditionUnknown,
-				}},
-			},
-		},
-		expected: false,
-	}, {
-		name: "Ready=True",
-		ss: &ServiceStatus{
-			Status: duckv1.Status{
-				Conditions: duckv1.Conditions{{
-					Type:   apis.ConditionReady,
+					Type:   "Foo",
 					Status: corev1.ConditionTrue,
 				}},
 			},
 		},
-		expected: true,
+		isReady: false,
+	}, {
+		name: "False condition status should not be ready",
+		status: ServiceStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   ServiceConditionReady,
+					Status: corev1.ConditionFalse,
+				}},
+			},
+		},
+		isReady: false,
+	}, {
+		name: "Unknown condition status should not be ready",
+		status: ServiceStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   ServiceConditionReady,
+					Status: corev1.ConditionUnknown,
+				}},
+			},
+		},
+		isReady: false,
+	}, {
+		name: "Missing condition status should not be ready",
+		status: ServiceStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type: ServiceConditionReady,
+				}},
+			},
+		},
+		isReady: false,
+	}, {
+		name: "True condition status should be ready",
+		status: ServiceStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   ServiceConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+		},
+		isReady: true,
+	}, {
+		name: "Multiple conditions with ready status should be ready",
+		status: ServiceStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   "Foo",
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   ServiceConditionReady,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+		},
+		isReady: true,
+	}, {
+		name: "Multiple conditions with ready status false should not be ready",
+		status: ServiceStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
+					Type:   "Foo",
+					Status: corev1.ConditionTrue,
+				}, {
+					Type:   ServiceConditionReady,
+					Status: corev1.ConditionFalse,
+				}},
+			},
+		},
+		isReady: false,
 	}}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			ready := test.ss.IsReady()
-			if ready != test.expected {
-				t.Errorf("IsReady() = %t; expected %t", ready, test.expected)
-			}
-		})
+	for _, tc := range cases {
+		if e, a := tc.isReady, tc.status.IsReady(); e != a {
+			t.Errorf("%q expected: %v got: %v", tc.name, e, a)
+		}
+	}
+}
+
+func TestServiceHappyPath(t *testing.T) {
+	svc := &ServiceStatus{}
+	svc.InitializeConditions()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Nothing from Configuration is nothing to us.
+	svc.PropagateConfigurationStatus(&ConfigurationStatus{})
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Nothing from Route is nothing to us.
+	svc.PropagateRouteStatus(&RouteStatus{})
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Done from Configuration moves our ConfigurationsReady condition
+	svc.PropagateConfigurationStatus(&ConfigurationStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	})
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Done from Route moves our RoutesReady condition, which triggers us to be Ready.
+	svc.PropagateRouteStatus(&RouteStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   RouteConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	})
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Check idempotency.
+	svc.PropagateRouteStatus(&RouteStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   RouteConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	})
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+}
+
+func TestMarkRouteNotYetReady(t *testing.T) {
+	svc := &ServiceStatus{}
+	svc.InitializeConditions()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	svc.MarkRouteNotYetReady()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	dt := svc.GetCondition(ServiceConditionReady)
+	if got, want := dt.Reason, trafficNotMigratedReason; got != want {
+		t.Errorf("Condition Reason: got: %s, want: %s", got, want)
+	}
+	if got, want := dt.Message, trafficNotMigratedMessage; got != want {
+		t.Errorf("Condition Message: got: %s, want: %s", got, want)
+	}
+}
+
+func TestMarkRouteNotReconciled(t *testing.T) {
+	svc := &ServiceStatus{}
+	svc.InitializeConditions()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	svc.MarkRouteNotReconciled()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	dt := svc.GetCondition(ServiceConditionReady)
+	if got, want := dt.Reason, "OutOfDate"; got != want {
+		t.Errorf("Condition Reason: got: %s, want: %s", got, want)
+	}
+}
+
+func TestMarkRevisionNameTaken(t *testing.T) {
+	svc := &ServiceStatus{}
+	svc.InitializeConditions()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	svc.MarkRevisionNameTaken("revision-name")
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	dt := svc.GetCondition(ServiceConditionReady)
+	if got, want := dt.Reason, "RevisionNameTaken"; got != want {
+		t.Errorf("Condition Reason: got: %s, want: %s", got, want)
+	}
+}
+
+func TestMarkConfigurationNotReconciled(t *testing.T) {
+	svc := &ServiceStatus{}
+	svc.InitializeConditions()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	svc.MarkConfigurationNotReconciled()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	dt := svc.GetCondition(ServiceConditionReady)
+	if got, want := dt.Reason, "OutOfDate"; got != want {
+		t.Errorf("Condition Reason: got: %s, want: %s", got, want)
+	}
+}
+
+func TestFailureRecovery(t *testing.T) {
+	svc := &ServiceStatus{}
+	svc.InitializeConditions()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Config failure causes us to become unready immediately (route still ok).
+	svc.PropagateConfigurationStatus(&ConfigurationStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	})
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Route failure causes route to become failed (config and service still failed).
+	svc.PropagateRouteStatus(&RouteStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   RouteConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	})
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Fix Configuration moves our ConfigurationsReady condition (route and service still failed).
+	svc.PropagateConfigurationStatus(&ConfigurationStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	})
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Fix route, should make everything ready.
+	svc.PropagateRouteStatus(&RouteStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   RouteConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	})
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+}
+
+func TestConfigurationFailurePropagation(t *testing.T) {
+	svc := &ServiceStatus{}
+	svc.InitializeConditions()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Failure causes us to become unready immediately.
+	svc.PropagateConfigurationStatus(&ConfigurationStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	})
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+}
+
+func TestConfigurationFailureRecovery(t *testing.T) {
+	svc := &ServiceStatus{}
+	svc.InitializeConditions()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Done from Route moves our RoutesReady condition
+	svc.PropagateRouteStatus(&RouteStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   RouteConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	})
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Failure causes us to become unready immediately (route still ok).
+	svc.PropagateConfigurationStatus(&ConfigurationStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	})
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Fixed the glitch.
+	svc.PropagateConfigurationStatus(&ConfigurationStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	})
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+}
+
+func TestConfigurationUnknownPropagation(t *testing.T) {
+	svc := &ServiceStatus{}
+	svc.InitializeConditions()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Configuration and Route become ready, making us ready.
+	svc.PropagateConfigurationStatus(&ConfigurationStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	})
+	svc.PropagateRouteStatus(&RouteStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   RouteConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	})
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Configuration flipping back to Unknown causes us to become ongoing immediately
+	svc.PropagateConfigurationStatus(&ConfigurationStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionUnknown,
+			}},
+		},
+	})
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	// Route is unaffected.
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+}
+
+func TestConfigurationStatusPropagation(t *testing.T) {
+	svc := &Service{}
+
+	csf := ConfigurationStatusFields{
+		LatestReadyRevisionName:   "foo",
+		LatestCreatedRevisionName: "bar",
+	}
+	svc.Status.PropagateConfigurationStatus(&ConfigurationStatus{
+		ConfigurationStatusFields: csf,
+	})
+
+	want := ServiceStatus{
+		ConfigurationStatusFields: csf,
+	}
+
+	if diff := cmp.Diff(want, svc.Status); diff != "" {
+		t.Errorf("unexpected ServiceStatus (-want +got): %s", diff)
+	}
+}
+
+func TestRouteFailurePropagation(t *testing.T) {
+	svc := &ServiceStatus{}
+	svc.InitializeConditions()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Failure causes us to become unready immediately
+	svc.PropagateRouteStatus(&RouteStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   RouteConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	})
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionRoutesReady, t)
+}
+
+func TestRouteFailureRecovery(t *testing.T) {
+	svc := &ServiceStatus{}
+	svc.InitializeConditions()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Done from Configuration moves our ConfigurationsReady condition
+	svc.PropagateConfigurationStatus(&ConfigurationStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	})
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Failure causes us to become unready immediately (config still ok).
+	svc.PropagateRouteStatus(&RouteStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   RouteConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	})
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Fixed the glitch.
+	svc.PropagateRouteStatus(&RouteStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   RouteConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	})
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+}
+
+func TestRouteUnknownPropagation(t *testing.T) {
+	svc := &ServiceStatus{}
+	svc.InitializeConditions()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Configuration and Route become ready, making us ready.
+	svc.PropagateConfigurationStatus(&ConfigurationStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   ConfigurationConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	})
+	svc.PropagateRouteStatus(&RouteStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   RouteConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	})
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionRoutesReady, t)
+
+	// Route flipping back to Unknown causes us to become ongoing immediately.
+	svc.PropagateRouteStatus(&RouteStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   RouteConditionReady,
+				Status: corev1.ConditionUnknown,
+			}},
+		},
+	})
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+	// Configuration is unaffected.
+	apitestv1.CheckConditionSucceeded(svc.duck(), ServiceConditionConfigurationsReady, t)
+}
+
+func TestServiceNotOwnedStuff(t *testing.T) {
+	svc := &ServiceStatus{}
+	svc.InitializeConditions()
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionOngoing(svc.duck(), ServiceConditionRoutesReady, t)
+
+	svc.MarkRouteNotOwned("mark")
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionRoutesReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+
+	svc.MarkConfigurationNotOwned("jon")
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionConfigurationsReady, t)
+	apitestv1.CheckConditionFailed(svc.duck(), ServiceConditionReady, t)
+}
+
+func TestRouteStatusPropagation(t *testing.T) {
+	svc := &Service{}
+
+	rsf := RouteStatusFields{
+		URL: &apis.URL{
+			Scheme: "http",
+			Host:   "route.namespace.example.com",
+		},
+		Traffic: []TrafficTarget{{
+			Percent:      ptr.Int64(100),
+			RevisionName: "newstuff",
+		}, {
+			Percent:      nil,
+			RevisionName: "oldstuff",
+		}},
+	}
+
+	svc.Status.PropagateRouteStatus(&RouteStatus{
+		RouteStatusFields: rsf,
+	})
+
+	want := ServiceStatus{
+		RouteStatusFields: rsf,
+	}
+
+	if diff := cmp.Diff(want, svc.Status); diff != "" {
+		t.Errorf("unexpected ServiceStatus (-want +got): %s", diff)
 	}
 }

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -21,9 +21,6 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -43,14 +40,6 @@ import (
 	"knative.dev/pkg/logging/logkey"
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
 	servingScheme "knative.dev/serving/pkg/client/clientset/versioned/scheme"
-)
-
-const (
-	ForceUpgradePatch = `[{
-  "op":"add",
-  "path":"/metadata/annotations/serving.knative.dev~1forceUpgrade",
-  "value":"true"
-}]`
 )
 
 // Base implements the core controller logic, given a Reconciler.
@@ -123,13 +112,6 @@ func NewBase(ctx context.Context, controllerAgentName string, cmw configmap.Watc
 	}
 
 	return base
-}
-
-func (b *Base) MarkNeedsUpgrade(gvr schema.GroupVersionResource, namespace, name string) error {
-	// Add the annotation serving.knative.dev/forceUpgrade=true to trigger webhook-based defaulting.
-	_, err := b.DynamicClientSet.Resource(gvr).Namespace(namespace).Patch(name, types.JSONPatchType,
-		[]byte(ForceUpgradePatch), metav1.PatchOptions{})
-	return err
 }
 
 func init() {

--- a/pkg/reconciler/service/controller.go
+++ b/pkg/reconciler/service/controller.go
@@ -19,15 +19,15 @@ package service
 import (
 	"context"
 
-	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/configuration"
-	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
-	routeinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/route"
-	kserviceinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/service"
+	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration"
+	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
+	routeinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/route"
+	kserviceinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/service"
 
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler"
 )
 
@@ -59,12 +59,12 @@ func NewController(
 	serviceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	configurationInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Service")),
+		FilterFunc: controller.FilterGroupKind(v1.Kind("Service")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
 	routeInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Service")),
+		FilterFunc: controller.FilterGroupKind(v1.Kind("Service")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -22,14 +22,14 @@ import (
 
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler/service/resources/names"
 	"knative.dev/serving/pkg/resources"
 )
 
 // MakeConfiguration creates a Configuration from a Service object.
-func MakeConfiguration(service *v1alpha1.Service) (*v1alpha1.Configuration, error) {
-	return &v1alpha1.Configuration{
+func MakeConfiguration(service *v1.Service) (*v1.Configuration, error) {
+	return &v1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.Configuration(service),
 			Namespace: service.Namespace,

--- a/pkg/reconciler/service/resources/configuration_test.go
+++ b/pkg/reconciler/service/resources/configuration_test.go
@@ -17,107 +17,23 @@ limitations under the License.
 package resources
 
 import (
-	"context"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"knative.dev/serving/pkg/apis/serving"
-	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
-func makeConfiguration(service *v1alpha1.Service) (*v1alpha1.Configuration, error) {
-	// We do this prior to reconciliation, so test with it enabled.
-	service.SetDefaults(v1.WithUpgradeViaDefaulting(context.Background()))
-	return MakeConfiguration(service)
-}
-
-func TestRunLatest(t *testing.T) {
-	s := createServiceWithRunLatest()
-	c, _ := makeConfiguration(s)
+func TestConfigurationSpec(t *testing.T) {
+	s := createService()
+	c, _ := MakeConfiguration(s)
 	if got, want := c.Name, testServiceName; got != want {
 		t.Errorf("expected %q for service name got %q", want, got)
 	}
 	if got, want := c.Namespace, testServiceNamespace; got != want {
 		t.Errorf("expected %q for service namespace got %q", want, got)
 	}
-	if got, want := c.Spec.GetTemplate().Spec.GetContainer().Name, testContainerNameRunLatest; got != want {
-		t.Errorf("expected %q for container name got %q", want, got)
-	}
-	expectOwnerReferencesSetCorrectly(t, c.OwnerReferences)
-
-	if got, want := len(c.Labels), 3; got != want {
-		t.Errorf("expected %d labels got %d", want, got)
-	}
-	if got, want := c.Labels[testLabelKey], testLabelValueRunLatest; got != want {
-		t.Errorf("expected %q labels got %q", want, got)
-	}
-	if got, want := c.Labels[serving.ServiceLabelKey], testServiceName; got != want {
-		t.Errorf("expected %q labels got %q", want, got)
-	}
-}
-
-func TestPinned(t *testing.T) {
-	s := createServiceWithPinned()
-	c, _ := makeConfiguration(s)
-	if got, want := c.Name, testServiceName; got != want {
-		t.Errorf("expected %q for service name got %q", want, got)
-	}
-	if got, want := c.Namespace, testServiceNamespace; got != want {
-		t.Errorf("expected %q for service namespace got %q", want, got)
-	}
-	if got, want := c.Spec.GetTemplate().Spec.GetContainer().Name, testContainerNamePinned; got != want {
-		t.Errorf("expected %q for container name got %q", want, got)
-	}
-	expectOwnerReferencesSetCorrectly(t, c.OwnerReferences)
-
-	if got, want := len(c.Labels), 3; got != want {
-		t.Errorf("expected %d labels got %d", want, got)
-	}
-	if got, want := c.Labels[testLabelKey], testLabelValuePinned; got != want {
-		t.Errorf("expected %q labels got %q", want, got)
-	}
-	if got, want := c.Labels[serving.ServiceLabelKey], testServiceName; got != want {
-		t.Errorf("expected %q labels got %q", want, got)
-	}
-}
-
-func TestRelease(t *testing.T) {
-	s := createServiceWithRelease(1, 0)
-	c, _ := makeConfiguration(s)
-	if got, want := c.Name, testServiceName; got != want {
-		t.Errorf("expected %q for service name got %q", want, got)
-	}
-	if got, want := c.Namespace, testServiceNamespace; got != want {
-		t.Errorf("expected %q for service namespace got %q", want, got)
-	}
-	if got, want := c.Spec.GetTemplate().Spec.GetContainer().Name, testContainerNameRelease; got != want {
-		t.Errorf("expected %q for container name got %q", want, got)
-	}
-	expectOwnerReferencesSetCorrectly(t, c.OwnerReferences)
-
-	if got, want := len(c.Labels), 3; got != want {
-		t.Errorf("expected %d labels got %d", want, got)
-	}
-	if got, want := c.Labels[testLabelKey], testLabelValueRelease; got != want {
-		t.Errorf("expected %q labels got %q", want, got)
-	}
-	if got, want := c.Labels[serving.ServiceLabelKey], testServiceName; got != want {
-		t.Errorf("expected %q labels got %q", want, got)
-	}
-}
-
-func TestInlineConfigurationSpec(t *testing.T) {
-	s := createServiceInline()
-	c, _ := makeConfiguration(s)
-	if got, want := c.Name, testServiceName; got != want {
-		t.Errorf("expected %q for service name got %q", want, got)
-	}
-	if got, want := c.Namespace, testServiceNamespace; got != want {
-		t.Errorf("expected %q for service namespace got %q", want, got)
-	}
-	if got, want := c.Spec.GetTemplate().Spec.GetContainer().Name, testContainerNameInline; got != want {
+	if got, want := c.Spec.GetTemplate().Spec.GetContainer().Name, testContainerName; got != want {
 		t.Errorf("expected %q for container name got %q", want, got)
 	}
 	expectOwnerReferencesSetCorrectly(t, c.OwnerReferences)
@@ -132,7 +48,7 @@ func TestInlineConfigurationSpec(t *testing.T) {
 
 func TestConfigurationHasNoKubectlAnnotation(t *testing.T) {
 	s := createServiceWithKubectlAnnotation()
-	c, err := makeConfiguration(s)
+	c, err := MakeConfiguration(s)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/reconciler/service/resources/names/names_test.go
+++ b/pkg/reconciler/service/resources/names/names_test.go
@@ -22,18 +22,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/kmeta"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 func TestNamer(t *testing.T) {
 	tests := []struct {
 		name    string
-		service *v1alpha1.Service
+		service *v1.Service
 		f       func(kmeta.Accessor) string
 		want    string
 	}{{
 		name: "Configuration",
-		service: &v1alpha1.Service{
+		service: &v1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
 				Namespace: "default",
@@ -43,7 +43,7 @@ func TestNamer(t *testing.T) {
 		want: "foo",
 	}, {
 		name: "Route",
-		service: &v1alpha1.Service{
+		service: &v1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "bar",
 				Namespace: "default",

--- a/pkg/reconciler/service/resources/route.go
+++ b/pkg/reconciler/service/resources/route.go
@@ -22,14 +22,14 @@ import (
 
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler/service/resources/names"
 	"knative.dev/serving/pkg/resources"
 )
 
 // MakeRoute creates a Route from a Service object.
-func MakeRoute(service *v1alpha1.Service) (*v1alpha1.Route, error) {
-	c := &v1alpha1.Route{
+func MakeRoute(service *v1.Service) (*v1.Route, error) {
+	c := &v1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.Route(service),
 			Namespace: service.Namespace,

--- a/pkg/reconciler/service/resources/route_test.go
+++ b/pkg/reconciler/service/resources/route_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -26,20 +25,13 @@ import (
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/reconciler/service/resources/names"
 )
 
-func makeRoute(service *v1alpha1.Service) (*v1alpha1.Route, error) {
-	// We do this prior to reconciliation, so test with it enabled.
-	service.SetDefaults(v1.WithUpgradeViaDefaulting(context.Background()))
-	return MakeRoute(service)
-}
-
-func TestRouteRunLatest(t *testing.T) {
-	s := createServiceWithRunLatest()
+func TestRouteSpec(t *testing.T) {
+	s := createService()
 	testConfigName := names.Configuration(s)
-	r, err := makeRoute(s)
+	r, err := MakeRoute(s)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -52,333 +44,10 @@ func TestRouteRunLatest(t *testing.T) {
 	if got, want := len(r.Spec.Traffic), 1; got != want {
 		t.Fatalf("Expected %d traffic targets got %d", want, got)
 	}
-	wantT := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			Percent:           ptr.Int64(100),
-			ConfigurationName: testConfigName,
-			LatestRevision:    ptr.Bool(true),
-		},
-	}}
-	if got, want := r.Spec.Traffic, wantT; !cmp.Equal(got, want) {
-		t.Errorf("Traffic mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
-	}
-	expectOwnerReferencesSetCorrectly(t, r.OwnerReferences)
-
-	wantL := map[string]string{
-		testLabelKey:            testLabelValueRunLatest,
-		serving.ServiceLabelKey: testServiceName,
-	}
-	if got, want := r.Labels, wantL; !cmp.Equal(got, want) {
-		t.Errorf("Labels mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
-	}
-
-	wantA := map[string]string{
-		testAnnotationKey: testAnnotationValue,
-	}
-	if got, want := r.Annotations, wantA; !cmp.Equal(got, want) {
-		t.Errorf("Annotations mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
-	}
-}
-
-func TestRoutePinned(t *testing.T) {
-	s := createServiceWithPinned()
-	r, err := makeRoute(s)
-	if err != nil {
-		t.Errorf("Expected nil for err got %q", err)
-	}
-	if got, want := r.Name, testServiceName; got != want {
-		t.Errorf("Expected %q for service name got %q", want, got)
-	}
-	if got, want := r.Namespace, testServiceNamespace; got != want {
-		t.Errorf("Expected %q for service namespace got %q", want, got)
-	}
-	if got, want := len(r.Spec.Traffic), 1; got != want {
-		t.Fatalf("Expected %d traffic targets, got %d", want, got)
-	}
-	wantT := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			Percent:        ptr.Int64(100),
-			RevisionName:   testRevisionName,
-			LatestRevision: ptr.Bool(false),
-		},
-	}}
-	if got, want := r.Spec.Traffic, wantT; !cmp.Equal(got, want) {
-		t.Errorf("Traffic mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
-	}
-	expectOwnerReferencesSetCorrectly(t, r.OwnerReferences)
-
-	wantL := map[string]string{
-		testLabelKey:            testLabelValuePinned,
-		serving.ServiceLabelKey: testServiceName,
-	}
-	if got, want := r.Labels, wantL; !cmp.Equal(got, want) {
-		t.Errorf("Labels mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
-	}
-}
-
-func TestRouteReleaseSingleRevision(t *testing.T) {
-	const numRevisions = 1
-	s := createServiceWithRelease(numRevisions, 0 /*no rollout*/)
-	testConfigName := names.Configuration(s)
-	r, err := makeRoute(s)
-	if err != nil {
-		t.Errorf("Expected nil for err got %q", err)
-	}
-	if got, want := r.Name, testServiceName; got != want {
-		t.Errorf("Expected %q for service name got %q", want, got)
-	}
-	if got, want := r.Namespace, testServiceNamespace; got != want {
-		t.Errorf("Expected %q for service namespace got %q", want, got)
-	}
-	wantT := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			Tag:            v1alpha1.CurrentTrafficTarget,
-			Percent:        ptr.Int64(100),
-			RevisionName:   testRevisionName,
-			LatestRevision: ptr.Bool(false),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			Tag:               v1alpha1.LatestTrafficTarget,
-			ConfigurationName: testConfigName,
-			LatestRevision:    ptr.Bool(true),
-		},
-	}}
-	if got, want := r.Spec.Traffic, wantT; !cmp.Equal(got, want) {
-		t.Errorf("Traffic mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
-	}
-	expectOwnerReferencesSetCorrectly(t, r.OwnerReferences)
-	wantL := map[string]string{
-		testLabelKey:            testLabelValueRelease,
-		serving.ServiceLabelKey: testServiceName,
-	}
-	if got, want := r.Labels, wantL; !cmp.Equal(got, want) {
-		t.Errorf("Labels mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
-	}
-}
-
-func TestRouteLatestRevisionSplit(t *testing.T) {
-	const (
-		rolloutPercent = 42
-		currentPercent = 100 - rolloutPercent
-	)
-	s := createServiceWithRelease(2 /*num revisions*/, rolloutPercent)
-	s.Spec.DeprecatedRelease.Revisions = []string{v1alpha1.ReleaseLatestRevisionKeyword, "juicy-revision"}
-	testConfigName := names.Configuration(s)
-	r, err := makeRoute(s)
-	if err != nil {
-		t.Errorf("Expected nil for err got %q", err)
-	}
-	if got, want := r.Name, testServiceName; got != want {
-		t.Errorf("Expected %q for service name got %q", want, got)
-	}
-	if got, want := r.Namespace, testServiceNamespace; got != want {
-		t.Errorf("Expected %q for service namespace got %q", want, got)
-	}
-	wantT := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			Tag:               v1alpha1.CurrentTrafficTarget,
-			Percent:           ptr.Int64(currentPercent),
-			ConfigurationName: testConfigName,
-			LatestRevision:    ptr.Bool(true),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			Tag:            v1alpha1.CandidateTrafficTarget,
-			Percent:        ptr.Int64(rolloutPercent),
-			RevisionName:   "juicy-revision",
-			LatestRevision: ptr.Bool(false),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			Tag:               v1alpha1.LatestTrafficTarget,
-			ConfigurationName: testConfigName,
-			LatestRevision:    ptr.Bool(true),
-		},
-	}}
-	if got, want := r.Spec.Traffic, wantT; !cmp.Equal(got, want) {
-		t.Errorf("Traffic mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
-	}
-	expectOwnerReferencesSetCorrectly(t, r.OwnerReferences)
-
-	wantL := map[string]string{
-		testLabelKey:            testLabelValueRelease,
-		serving.ServiceLabelKey: testServiceName,
-	}
-	if got, want := r.Labels, wantL; !cmp.Equal(got, want) {
-		t.Errorf("Labels mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
-	}
-}
-func TestRouteLatestRevisionSplitCandidate(t *testing.T) {
-	const (
-		rolloutPercent = 42
-		currentPercent = 100 - rolloutPercent
-	)
-	s := createServiceWithRelease(2 /*num revisions*/, rolloutPercent)
-	s.Spec.DeprecatedRelease.Revisions = []string{"squishy-revision", v1alpha1.ReleaseLatestRevisionKeyword}
-	testConfigName := names.Configuration(s)
-	r, err := makeRoute(s)
-	if err != nil {
-		t.Errorf("Expected nil for err got %q", err)
-	}
-	if got, want := r.Name, testServiceName; got != want {
-		t.Errorf("Expected %q for service name got %q", want, got)
-	}
-	if got, want := r.Namespace, testServiceNamespace; got != want {
-		t.Errorf("Expected %q for service namespace got %q", want, got)
-	}
-	wantT := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			Tag:            v1alpha1.CurrentTrafficTarget,
-			Percent:        ptr.Int64(currentPercent),
-			RevisionName:   "squishy-revision",
-			LatestRevision: ptr.Bool(false),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			Tag:               v1alpha1.CandidateTrafficTarget,
-			Percent:           ptr.Int64(rolloutPercent),
-			ConfigurationName: testConfigName,
-			LatestRevision:    ptr.Bool(true),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			Tag:               v1alpha1.LatestTrafficTarget,
-			ConfigurationName: testConfigName,
-			LatestRevision:    ptr.Bool(true),
-		},
-	}}
-	if got, want := r.Spec.Traffic, wantT; !cmp.Equal(got, want) {
-		t.Errorf("Traffic mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
-	}
-	expectOwnerReferencesSetCorrectly(t, r.OwnerReferences)
-
-	wantL := map[string]string{
-		testLabelKey:            testLabelValueRelease,
-		serving.ServiceLabelKey: testServiceName,
-	}
-	if got, want := r.Labels, wantL; !cmp.Equal(got, want) {
-		t.Errorf("Labels mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
-	}
-}
-func TestRouteLatestRevisionNoSplit(t *testing.T) {
-	s := createServiceWithRelease(1 /*num revisions*/, 0 /*unused*/)
-	s.Spec.DeprecatedRelease.Revisions = []string{v1alpha1.ReleaseLatestRevisionKeyword}
-	testConfigName := names.Configuration(s)
-	r, err := makeRoute(s)
-
-	if err != nil {
-		t.Errorf("Expected nil for err got %q", err)
-	}
-	if got, want := r.Name, testServiceName; got != want {
-		t.Errorf("Expected %q for service name got %q", want, got)
-	}
-	if got, want := r.Namespace, testServiceNamespace; got != want {
-		t.Errorf("Expected %q for service namespace got %q", want, got)
-	}
-	// Should have 2 named traffic targets (current, latest)
-	wantT := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			Tag:               v1alpha1.CurrentTrafficTarget,
-			Percent:           ptr.Int64(100),
-			ConfigurationName: testConfigName,
-			LatestRevision:    ptr.Bool(true),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			Tag:               v1alpha1.LatestTrafficTarget,
-			ConfigurationName: testConfigName,
-			LatestRevision:    ptr.Bool(true),
-		},
-	}}
-	if got, want := r.Spec.Traffic, wantT; !cmp.Equal(got, want) {
-		t.Errorf("Traffic mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
-	}
-	expectOwnerReferencesSetCorrectly(t, r.OwnerReferences)
-
-	wantL := map[string]string{
-		testLabelKey:            testLabelValueRelease,
-		serving.ServiceLabelKey: testServiceName,
-	}
-	if got, want := r.Labels, wantL; !cmp.Equal(got, want) {
-		t.Errorf("Labels mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
-	}
-}
-
-func TestRouteReleaseTwoRevisions(t *testing.T) {
-	const (
-		currentPercent = 52
-		numRevisions   = 2
-	)
-	s := createServiceWithRelease(numRevisions, 100-currentPercent)
-	testConfigName := names.Configuration(s)
-	r, err := makeRoute(s)
-	if err != nil {
-		t.Errorf("Expected nil for err got %q", err)
-	}
-	if got, want := r.Name, testServiceName; got != want {
-		t.Errorf("Expected %q for service name got %q", want, got)
-	}
-	if got, want := r.Namespace, testServiceNamespace; got != want {
-		t.Errorf("Expected %q for service namespace got %q", want, got)
-	}
-	// Should have 3 named traffic targets (current, candidate, latest)
-	wantT := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			Tag:            v1alpha1.CurrentTrafficTarget,
-			Percent:        ptr.Int64(currentPercent),
-			RevisionName:   testRevisionName,
-			LatestRevision: ptr.Bool(false),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			Tag:            v1alpha1.CandidateTrafficTarget,
-			Percent:        ptr.Int64(100 - currentPercent),
-			RevisionName:   testCandidateRevisionName,
-			LatestRevision: ptr.Bool(false),
-		},
-	}, {
-		TrafficTarget: v1.TrafficTarget{
-			Tag:               v1alpha1.LatestTrafficTarget,
-			ConfigurationName: testConfigName,
-			LatestRevision:    ptr.Bool(true),
-		},
-	}}
-	if got, want := r.Spec.Traffic, wantT; !cmp.Equal(got, want) {
-		t.Errorf("Traffic mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
-	}
-	expectOwnerReferencesSetCorrectly(t, r.OwnerReferences)
-	wantL := map[string]string{
-		testLabelKey:            testLabelValueRelease,
-		serving.ServiceLabelKey: testServiceName,
-	}
-	if got, want := r.Labels, wantL; !cmp.Equal(got, want) {
-		t.Errorf("Labels mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
-	}
-}
-
-func TestInlineRouteSpec(t *testing.T) {
-	s := createServiceInline()
-	testConfigName := names.Configuration(s)
-	r, err := makeRoute(s)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if got, want := r.Name, testServiceName; got != want {
-		t.Errorf("Expected %q for service name got %q", want, got)
-	}
-	if got, want := r.Namespace, testServiceNamespace; got != want {
-		t.Errorf("Expected %q for service namespace got %q", want, got)
-	}
-	if got, want := len(r.Spec.Traffic), 1; got != want {
-		t.Fatalf("Expected %d traffic targets got %d", want, got)
-	}
-	wantT := []v1alpha1.TrafficTarget{{
-		TrafficTarget: v1.TrafficTarget{
-			Percent:           ptr.Int64(100),
-			ConfigurationName: testConfigName,
-			LatestRevision:    ptr.Bool(true),
-		},
+	wantT := []v1.TrafficTarget{{
+		Percent:           ptr.Int64(100),
+		ConfigurationName: testConfigName,
+		LatestRevision:    ptr.Bool(true),
 	}}
 	if got, want := r.Spec.Traffic, wantT; !cmp.Equal(got, want) {
 		t.Errorf("Traffic mismatch: diff (-got, +want): %s", cmp.Diff(got, want))
@@ -395,7 +64,7 @@ func TestInlineRouteSpec(t *testing.T) {
 
 func TestRouteHasNoKubectlAnnotation(t *testing.T) {
 	s := createServiceWithKubectlAnnotation()
-	r, err := makeRoute(s)
+	r, err := MakeRoute(s)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/testing/v1/configuration.go
+++ b/pkg/testing/v1/configuration.go
@@ -105,3 +105,8 @@ func WithConfigLabel(key, value string) ConfigOption {
 		config.Labels[key] = value
 	}
 }
+
+// WithConfigOwnersRemoved clears the owner references of this Configuration.
+func WithConfigOwnersRemoved(cfg *v1.Configuration) {
+	cfg.OwnerReferences = nil
+}

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -199,7 +199,7 @@ func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 // that uses the image specified by names.Image.
 func Service(names test.ResourceNames, fopt ...rtesting.ServiceOption) *v1.Service {
 	a := append([]rtesting.ServiceOption{
-		rtesting.WithInlineConfigSpec(*ConfigurationSpec(pkgTest.ImagePath(names.Image))),
+		rtesting.WithConfigSpec(*ConfigurationSpec(pkgTest.ImagePath(names.Image))),
 	}, fopt...)
 	return rtesting.ServiceWithoutNamespace(names.Service, a...)
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Contributes to #6035

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Service controller now uses v1 API types

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
