### PR TITLE
Fix the problem with target being at least 1.

### DIFF
--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -60,9 +60,11 @@ const (
 	//   autoscaling.knative.dev/metric: cpu
 	//   autoscaling.knative.dev/target: "75"   # target 75% cpu utilization
 	TargetAnnotationKey = GroupName + "/target"
-	// TargetMin is the minimum allowable target. Values less than
-	// zero don't make sense.
-	TargetMin = 1
+	// TargetMin is the minimum allowable target.
+	// This can be less than 1 due to the fact that with small container
+	// concurrencies and small target utilization values this can get
+	// below 1.
+	TargetMin = 0.01
 
 	// WindowAnnotationKey is the annotation to specify the time
 	// interval over which to calculate the average metric.  Larger

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -202,7 +202,7 @@ func validate(lc *Config) (*Config, error) {
 	}
 
 	if x := lc.ContainerConcurrencyTargetFraction * lc.ContainerConcurrencyTargetDefault; x < autoscaling.TargetMin {
-		return nil, fmt.Errorf("container-concurrency-target-percentage and container-concurrency-target-default yield target concurrency of %f, can't be less than 1", x)
+		return nil, fmt.Errorf("container-concurrency-target-percentage and container-concurrency-target-default yield target concurrency of %v, can't be less than %v", x, autoscaling.TargetMin)
 	}
 
 	if lc.RPSTargetDefault < autoscaling.TargetMin {

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -183,13 +183,6 @@ func TestNewConfig(t *testing.T) {
 		},
 		wantErr: true,
 	}, {
-		name: "target capacity less than 1",
-		input: map[string]string{
-			"container-concurrency-target-percentage": "30.0",
-			"container-concurrency-target-default":    "2",
-		},
-		wantErr: true,
-	}, {
 		name: "max scale up rate 1.0",
 		input: map[string]string{
 			"max-scale-up-rate": "1",
@@ -235,10 +228,10 @@ func TestNewConfig(t *testing.T) {
 		},
 		wantErr: true,
 	}, {
-		name: "TU*CC < 1",
+		name: "TU*CC < 0.01",
 		input: map[string]string{
-			"container-concurrency-target-percentage": "5",
-			"container-concurrency-target-default":    "10.0",
+			"container-concurrency-target-percentage": "1",
+			"container-concurrency-target-default":    "0.001",
 		},
 		wantErr: true,
 	}, {

--- a/pkg/reconciler/autoscaling/resources/target.go
+++ b/pkg/reconciler/autoscaling/resources/target.go
@@ -21,14 +21,14 @@ import (
 
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
-	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
+	asconfig "knative.dev/serving/pkg/autoscaler/config"
 )
 
 // ResolveMetricTarget takes scaling metric knobs from multiple locations
 // and resolves them to the final value to be used by the autoscaler.
 // `target` is the target value of scaling metric that we autoscaler will aim for;
 // `total` is the maximum possible value of scaling metric that is permitted on the pod.
-func ResolveMetricTarget(pa *v1alpha1.PodAutoscaler, config *autoscalerconfig.Config) (target float64, total float64) {
+func ResolveMetricTarget(pa *v1alpha1.PodAutoscaler, config *asconfig.Config) (target float64, total float64) {
 	var tu float64
 
 	switch pa.Metric() {
@@ -59,7 +59,7 @@ func ResolveMetricTarget(pa *v1alpha1.PodAutoscaler, config *autoscalerconfig.Co
 	if v, ok := pa.TargetUtilization(); ok {
 		tu = v
 	}
-	target = math.Max(1, total*tu)
+	target = math.Max(autoscaling.TargetMin, total*tu)
 
 	return target, total
 }

--- a/pkg/reconciler/autoscaling/resources/target_test.go
+++ b/pkg/reconciler/autoscaling/resources/target_test.go
@@ -55,7 +55,7 @@ func TestResolveMetricTarget(t *testing.T) {
 			c.ContainerConcurrencyTargetDefault = 2
 			return &c
 		},
-		wantTgt: 1,
+		wantTgt: 0.6,
 		wantTot: 2,
 	}, {
 		name: "with container concurrency 12 and TU=80%, but TU annotation 75%",
@@ -82,7 +82,7 @@ func TestResolveMetricTarget(t *testing.T) {
 			c.ContainerConcurrencyTargetFraction = 0.8
 			return &c
 		},
-		wantTgt: 1, // Not permitting less than 1.
+		wantTgt: 0.8,
 		wantTot: 1,
 	}, {
 		name:    "with container concurrency 1",
@@ -109,13 +109,22 @@ func TestResolveMetricTarget(t *testing.T) {
 		wantTgt: 1,
 		wantTot: 1,
 	}, {
+		name: "with target annotation 1 and TU=0.1%",
+		pa:   pa(WithTargetAnnotation("1")),
+		cfgOpt: func(c autoscalerconfig.Config) *autoscalerconfig.Config {
+			c.ContainerConcurrencyTargetFraction = 0.001
+			return &c
+		},
+		wantTgt: autoscaling.TargetMin,
+		wantTot: 1,
+	}, {
 		name: "with target annotation 1 and TU=75%",
 		pa:   pa(WithTargetAnnotation("1")),
 		cfgOpt: func(c autoscalerconfig.Config) *autoscalerconfig.Config {
 			c.ContainerConcurrencyTargetFraction = 0.75
 			return &c
 		},
-		wantTgt: 1,
+		wantTgt: 0.75,
 		wantTot: 1,
 	}, {
 		name: "with target annotation 10 and TU=75%",
@@ -149,7 +158,7 @@ func TestResolveMetricTarget(t *testing.T) {
 	}, {
 		name:    "RPS: with target annotation 1",
 		pa:      pa(WithMetricAnnotation(autoscaling.RPS), WithTargetAnnotation("1")),
-		wantTgt: 1,
+		wantTgt: 0.7,
 		wantTot: 1,
 	}, {
 		name:    "RPS: with TU annotation 75%",
@@ -171,7 +180,7 @@ func TestResolveMetricTarget(t *testing.T) {
 			}
 			gotTgt, gotTot := ResolveMetricTarget(tc.pa, cfg)
 			if gotTgt != tc.wantTgt || gotTot != tc.wantTot {
-				t.Errorf("ResolveMetricTarget(%v, %v) = (%v, %v), want (%v, %v)",
+				t.Errorf("ResolveMetricTarget(%#v, %#v) = (%#v, %#v), want (%#v, %#v)",
 					tc.pa, config, gotTgt, gotTot, tc.wantTgt, tc.wantTot)
 			}
 		})

--- a/pkg/reconciler/autoscaling/resources/target_test.go
+++ b/pkg/reconciler/autoscaling/resources/target_test.go
@@ -180,7 +180,7 @@ func TestResolveMetricTarget(t *testing.T) {
 			}
 			gotTgt, gotTot := ResolveMetricTarget(tc.pa, cfg)
 			if gotTgt != tc.wantTgt || gotTot != tc.wantTot {
-				t.Errorf("ResolveMetricTarget(%#v, %#v) = (%#v, %#v), want (%#v, %#v)",
+				t.Errorf("ResolveMetricTarget(%#v, %#v) = (%v, %v), want (%v, %v)",
 					tc.pa, config, gotTgt, gotTot, tc.wantTgt, tc.wantTot)
 			}
 		})

--- a/pkg/reconciler/autoscaling/resources/target_test.go
+++ b/pkg/reconciler/autoscaling/resources/target_test.go
@@ -28,16 +28,16 @@ import (
 
 func TestResolveMetricTarget(t *testing.T) {
 	cases := []struct {
-		name    string
-		pa      *v1alpha1.PodAutoscaler
-		cfgOpt  func(autoscalerconfig.Config) *autoscalerconfig.Config
-		wantTgt float64
-		wantTot float64
+		name       string
+		pa         *v1alpha1.PodAutoscaler
+		cfgOpt     func(autoscalerconfig.Config) *autoscalerconfig.Config
+		wantTarget float64
+		wantTotal  float64
 	}{{
-		name:    "defaults",
-		pa:      pa(),
-		wantTgt: 100,
-		wantTot: 100,
+		name:       "defaults",
+		pa:         pa(),
+		wantTarget: 100,
+		wantTotal:  100,
 	}, {
 		name: "default CC + 80% TU",
 		pa:   pa(),
@@ -45,8 +45,8 @@ func TestResolveMetricTarget(t *testing.T) {
 			c.ContainerConcurrencyTargetFraction = 0.8
 			return &c
 		},
-		wantTgt: 80,
-		wantTot: 100,
+		wantTarget: 80,
+		wantTotal:  100,
 	}, {
 		name: "non-default CC and TU",
 		pa:   pa(),
@@ -55,8 +55,8 @@ func TestResolveMetricTarget(t *testing.T) {
 			c.ContainerConcurrencyTargetDefault = 2
 			return &c
 		},
-		wantTgt: 0.6,
-		wantTot: 2,
+		wantTarget: 0.6,
+		wantTotal:  2,
 	}, {
 		name: "with container concurrency 12 and TU=80%, but TU annotation 75%",
 		pa:   pa(WithPAContainerConcurrency(12), WithTUAnnotation("75")),
@@ -64,8 +64,8 @@ func TestResolveMetricTarget(t *testing.T) {
 			c.ContainerConcurrencyTargetFraction = 0.8
 			return &c
 		},
-		wantTgt: 9,
-		wantTot: 12,
+		wantTarget: 9,
+		wantTotal:  12,
 	}, {
 		name: "with container concurrency 10 and TU=80%",
 		pa:   pa(WithPAContainerConcurrency(10)),
@@ -73,8 +73,8 @@ func TestResolveMetricTarget(t *testing.T) {
 			c.ContainerConcurrencyTargetFraction = 0.8
 			return &c
 		},
-		wantTgt: 8,
-		wantTot: 10,
+		wantTarget: 8,
+		wantTotal:  10,
 	}, {
 		name: "with container concurrency 1 and TU=80%",
 		pa:   pa(WithPAContainerConcurrency(1)),
@@ -82,13 +82,13 @@ func TestResolveMetricTarget(t *testing.T) {
 			c.ContainerConcurrencyTargetFraction = 0.8
 			return &c
 		},
-		wantTgt: 0.8,
-		wantTot: 1,
+		wantTarget: 0.8,
+		wantTotal:  1,
 	}, {
-		name:    "with container concurrency 1",
-		pa:      pa(WithPAContainerConcurrency(1)),
-		wantTgt: 1,
-		wantTot: 1,
+		name:       "with container concurrency 1",
+		pa:         pa(WithPAContainerConcurrency(1)),
+		wantTarget: 1,
+		wantTotal:  1,
 	}, {
 		name: "with container concurrency 10 and TU=80%",
 		pa:   pa(WithPAContainerConcurrency(10)),
@@ -96,18 +96,18 @@ func TestResolveMetricTarget(t *testing.T) {
 			c.ContainerConcurrencyTargetFraction = 0.8
 			return &c
 		},
-		wantTgt: 8,
-		wantTot: 10,
+		wantTarget: 8,
+		wantTotal:  10,
 	}, {
-		name:    "with container concurrency 10",
-		pa:      pa(WithPAContainerConcurrency(10)),
-		wantTgt: 10,
-		wantTot: 10,
+		name:       "with container concurrency 10",
+		pa:         pa(WithPAContainerConcurrency(10)),
+		wantTarget: 10,
+		wantTotal:  10,
 	}, {
-		name:    "with target annotation 1",
-		pa:      pa(WithTargetAnnotation("1")),
-		wantTgt: 1,
-		wantTot: 1,
+		name:       "with target annotation 1",
+		pa:         pa(WithTargetAnnotation("1")),
+		wantTarget: 1,
+		wantTotal:  1,
 	}, {
 		name: "with target annotation 1 and TU=0.1%",
 		pa:   pa(WithTargetAnnotation("1")),
@@ -115,8 +115,8 @@ func TestResolveMetricTarget(t *testing.T) {
 			c.ContainerConcurrencyTargetFraction = 0.001
 			return &c
 		},
-		wantTgt: autoscaling.TargetMin,
-		wantTot: 1,
+		wantTarget: autoscaling.TargetMin,
+		wantTotal:  1,
 	}, {
 		name: "with target annotation 1 and TU=75%",
 		pa:   pa(WithTargetAnnotation("1")),
@@ -124,8 +124,8 @@ func TestResolveMetricTarget(t *testing.T) {
 			c.ContainerConcurrencyTargetFraction = 0.75
 			return &c
 		},
-		wantTgt: 0.75,
-		wantTot: 1,
+		wantTarget: 0.75,
+		wantTotal:  1,
 	}, {
 		name: "with target annotation 10 and TU=75%",
 		pa:   pa(WithTargetAnnotation("10")),
@@ -133,43 +133,43 @@ func TestResolveMetricTarget(t *testing.T) {
 			c.ContainerConcurrencyTargetFraction = 0.75
 			return &c
 		},
-		wantTgt: 7.5,
-		wantTot: 10,
+		wantTarget: 7.5,
+		wantTotal:  10,
 	}, {
-		name:    "with container concurrency greater than target annotation (ok)",
-		pa:      pa(WithPAContainerConcurrency(10), WithTargetAnnotation("1")),
-		wantTgt: 1,
-		wantTot: 1,
+		name:       "with container concurrency greater than target annotation (ok)",
+		pa:         pa(WithPAContainerConcurrency(10), WithTargetAnnotation("1")),
+		wantTarget: 1,
+		wantTotal:  1,
 	}, {
-		name:    "with target annotation greater than default (ok)",
-		pa:      pa(WithTargetAnnotation("500")),
-		wantTgt: 500,
-		wantTot: 500,
+		name:       "with target annotation greater than default (ok)",
+		pa:         pa(WithTargetAnnotation("500")),
+		wantTarget: 500,
+		wantTotal:  500,
 	}, {
-		name:    "with target annotation greater than container concurrency (ignore annotation for safety)",
-		pa:      pa(WithPAContainerConcurrency(1), WithTargetAnnotation("10")),
-		wantTgt: 1,
-		wantTot: 1,
+		name:       "with target annotation greater than container concurrency (ignore annotation for safety)",
+		pa:         pa(WithPAContainerConcurrency(1), WithTargetAnnotation("10")),
+		wantTarget: 1,
+		wantTotal:  1,
 	}, {
-		name:    "RPS: defaults",
-		pa:      pa(WithMetricAnnotation(autoscaling.RPS), WithPAContainerConcurrency(1)),
-		wantTgt: 140,
-		wantTot: 200,
+		name:       "RPS: defaults",
+		pa:         pa(WithMetricAnnotation(autoscaling.RPS), WithPAContainerConcurrency(1)),
+		wantTarget: 140,
+		wantTotal:  200,
 	}, {
-		name:    "RPS: with target annotation 1",
-		pa:      pa(WithMetricAnnotation(autoscaling.RPS), WithTargetAnnotation("1")),
-		wantTgt: 0.7,
-		wantTot: 1,
+		name:       "RPS: with target annotation 1",
+		pa:         pa(WithMetricAnnotation(autoscaling.RPS), WithTargetAnnotation("1")),
+		wantTarget: 0.7,
+		wantTotal:  1,
 	}, {
-		name:    "RPS: with TU annotation 75%",
-		pa:      pa(WithMetricAnnotation(autoscaling.RPS), WithTUAnnotation("75")),
-		wantTgt: 150,
-		wantTot: 200,
+		name:       "RPS: with TU annotation 75%",
+		pa:         pa(WithMetricAnnotation(autoscaling.RPS), WithTUAnnotation("75")),
+		wantTarget: 150,
+		wantTotal:  200,
 	}, {
-		name:    "RPS: with target annotation greater than default",
-		pa:      pa(WithMetricAnnotation(autoscaling.RPS), WithTargetAnnotation("300")),
-		wantTgt: 210,
-		wantTot: 300,
+		name:       "RPS: with target annotation greater than default",
+		pa:         pa(WithMetricAnnotation(autoscaling.RPS), WithTargetAnnotation("300")),
+		wantTarget: 210,
+		wantTotal:  300,
 	}}
 
 	for _, tc := range cases {
@@ -179,9 +179,9 @@ func TestResolveMetricTarget(t *testing.T) {
 				cfg = tc.cfgOpt(*cfg)
 			}
 			gotTgt, gotTot := ResolveMetricTarget(tc.pa, cfg)
-			if gotTgt != tc.wantTgt || gotTot != tc.wantTot {
+			if gotTgt != tc.wantTarget || gotTot != tc.wantTotal {
 				t.Errorf("ResolveMetricTarget(%#v, %#v) = (%v, %v), want (%v, %v)",
-					tc.pa, config, gotTgt, gotTot, tc.wantTgt, tc.wantTot)
+					tc.pa, config, gotTgt, gotTot, tc.wantTarget, tc.wantTotal)
 			}
 		})
 	}


### PR DESCRIPTION
The situation that we had here violated out target utilization promise, wherein with CC=1 and TU=0.7, we'd
still target 1 and basically would never overprovision for cases of 1 and underprovision for small cc's.


/lint
/assign mattmoor @markusthoemmes 