### PR TITLE
Have the activator use v1 APIs

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -36,7 +36,7 @@ import (
 	// Injection related imports.
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/injection"
-	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
+	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 

--- a/cmd/activator/request_log.go
+++ b/cmd/activator/request_log.go
@@ -23,7 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/serving"
-	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1alpha1"
+	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
 	pkghttp "knative.dev/serving/pkg/http"
 )
 

--- a/cmd/activator/request_log_test.go
+++ b/cmd/activator/request_log_test.go
@@ -28,10 +28,10 @@ import (
 	rtesting "knative.dev/pkg/reconciler/testing"
 	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/serving"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
-	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision/fake"
-	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1alpha1"
+	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
+	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
 	pkghttp "knative.dev/serving/pkg/http"
 
 	corev1 "k8s.io/api/core/v1"
@@ -179,7 +179,7 @@ func TestRequestLogTemplateInputGetter(t *testing.T) {
 }
 
 func revisionLister(t *testing.T, addLabels bool) servinglisters.RevisionLister {
-	rev := &v1alpha1.Revision{}
+	rev := &v1.Revision{}
 	rev.Name = testRevisionName
 	rev.Namespace = testNamespaceName
 	if addLabels {
@@ -190,7 +190,7 @@ func revisionLister(t *testing.T, addLabels bool) servinglisters.RevisionLister 
 	}
 
 	ctx, _ := rtesting.SetupFakeContext(t)
-	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespaceName).Create(rev)
+	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespaceName).Create(rev)
 	ri := fakerevisioninformer.Get(ctx)
 	ri.Informer().GetIndexer().Add(rev)
 	return ri.Lister()

--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -29,8 +29,8 @@ import (
 	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/serving"
 	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
-	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
-	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1alpha1"
+	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
+	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
 	"knative.dev/serving/pkg/metrics"
 )
 

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -27,10 +27,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	rtesting "knative.dev/pkg/reconciler/testing"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler/metrics"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
-	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision/fake"
+	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
 )
 
 const (
@@ -255,12 +255,12 @@ func newTestStats(t *testing.T) (*testStats, *ConcurrencyReporter, context.Conte
 	return ts, cr, ctx, cancel
 }
 
-func revisionInformer(ctx context.Context, revs ...*v1alpha1.Revision) {
+func revisionInformer(ctx context.Context, revs ...*v1.Revision) {
 	fake := fakeservingclient.Get(ctx)
 	revisions := fakerevisioninformer.Get(ctx)
 
 	for _, rev := range revs {
-		fake.ServingV1alpha1().Revisions(rev.Namespace).Create(rev)
+		fake.ServingV1().Revisions(rev.Namespace).Create(rev)
 		revisions.Informer().GetIndexer().Add(rev)
 	}
 }

--- a/pkg/activator/handler/context_handler.go
+++ b/pkg/activator/handler/context_handler.go
@@ -28,8 +28,8 @@ import (
 	"knative.dev/pkg/logging/logkey"
 	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/activator/util"
-	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
-	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1alpha1"
+	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
+	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
 )
 
 // NewContextHandler creates a handler that extracts the necessary context from the request

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -44,7 +44,6 @@ import (
 	"knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/network"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -285,8 +284,8 @@ func sendRequest(namespace, revName string, handler *activationHandler, store *a
 	return resp
 }
 
-func revision(namespace, name string) *v1alpha1.Revision {
-	return &v1alpha1.Revision{
+func revision(namespace, name string) *v1.Revision {
+	return &v1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
@@ -295,10 +294,8 @@ func revision(namespace, name string) *v1alpha1.Revision {
 				serving.ServiceLabelKey:       "service-" + testRevName,
 			},
 		},
-		Spec: v1alpha1.RevisionSpec{
-			RevisionSpec: v1.RevisionSpec{
-				ContainerConcurrency: ptr.Int64(1),
-			},
+		Spec: v1.RevisionSpec{
+			ContainerConcurrency: ptr.Int64(1),
 		},
 	}
 }

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -24,11 +24,10 @@ import (
 	"strconv"
 	"testing"
 
-	"knative.dev/serving/pkg/activator"
-
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/pkg/metrics/metricstest"
+	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/apis/serving"
 )

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -45,8 +45,8 @@ import (
 	"knative.dev/pkg/reconciler"
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
-	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
-	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1alpha1"
+	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
+	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/queue"
 )

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -41,9 +41,9 @@ import (
 	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/apis/networking"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
-	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
+	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
 	"knative.dev/serving/pkg/queue"
 	"knative.dev/serving/pkg/resources"
 )
@@ -488,7 +488,7 @@ func (t *Throttler) getOrCreateRevisionThrottler(revID types.NamespacedName) (*r
 // revisionUpdated is used to ensure we have a backlog set up for a revision as soon as it is created
 // rather than erroring with revision not found until a networking probe succeeds
 func (t *Throttler) revisionUpdated(obj interface{}) {
-	rev := obj.(*v1alpha1.Revision)
+	rev := obj.(*v1.Revision)
 	revID := types.NamespacedName{Namespace: rev.Namespace, Name: rev.Name}
 	logger := t.logger.With(zap.String(logkey.Key, revID.String()))
 
@@ -502,7 +502,7 @@ func (t *Throttler) revisionUpdated(obj interface{}) {
 // revisionDeleted is to clean up revision throttlers after a revision is deleted to prevent unbounded
 // memory growth
 func (t *Throttler) revisionDeleted(obj interface{}) {
-	rev := obj.(*v1alpha1.Revision)
+	rev := obj.(*v1.Revision)
 	revID := types.NamespacedName{Namespace: rev.Namespace, Name: rev.Name}
 	logger := t.logger.With(zap.String(logkey.Key, revID.String()))
 

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -43,10 +43,10 @@ import (
 	_ "knative.dev/pkg/system/testing"
 	"knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/apis/networking"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
-	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
-	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/revision/fake"
+	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
+	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
 	"knative.dev/serving/pkg/queue"
 )
 
@@ -214,7 +214,7 @@ func TestThrottlerErrorNoRevision(t *testing.T) {
 	// Add the revision we're testing.
 	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
 	revision := revisionCC1(revID, networking.ProtocolHTTP1)
-	servfake.ServingV1alpha1().Revisions(revision.Namespace).Create(revision)
+	servfake.ServingV1().Revisions(revision.Namespace).Create(revision)
 	revisions.Informer().GetIndexer().Add(revision)
 
 	throttler := newTestThrottler(ctx, 1)
@@ -235,7 +235,7 @@ func TestThrottlerErrorNoRevision(t *testing.T) {
 		t.Fatalf("Try() = %v, want %v", err, innerError)
 	}
 
-	servfake.ServingV1alpha1().Revisions(revision.Namespace).Delete(revision.Name, nil)
+	servfake.ServingV1().Revisions(revision.Namespace).Delete(revision.Name, nil)
 	revisions.Informer().GetIndexer().Delete(revID)
 
 	// Eventually it should now fail.
@@ -265,7 +265,7 @@ func TestThrottlerErrorOneTimesOut(t *testing.T) {
 	// Add the revision we're testing.
 	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
 	revision := revisionCC1(revID, networking.ProtocolHTTP1)
-	servfake.ServingV1alpha1().Revisions(revision.Namespace).Create(revision)
+	servfake.ServingV1().Revisions(revision.Namespace).Create(revision)
 	revisions.Informer().GetIndexer().Add(revision)
 
 	throttler := newTestThrottler(ctx, 1)
@@ -301,7 +301,7 @@ func TestThrottlerErrorOneTimesOut(t *testing.T) {
 func TestThrottlerSuccesses(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
-		revision    *v1alpha1.Revision
+		revision    *v1.Revision
 		initUpdates []revisionDestsUpdate
 		requests    int
 		wantDests   sets.String
@@ -391,7 +391,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 			}()
 
 			// Add the revision were testing.
-			servfake.ServingV1alpha1().Revisions(tc.revision.Namespace).Create(tc.revision)
+			servfake.ServingV1().Revisions(tc.revision.Namespace).Create(tc.revision)
 			revisions.Informer().GetIndexer().Add(tc.revision)
 
 			throttler := newTestThrottler(ctx, 1)
@@ -547,7 +547,7 @@ func TestMultipleActivators(t *testing.T) {
 
 	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1)
 	// Add the revision we're testing.
-	servfake.ServingV1alpha1().Revisions(rev.Namespace).Create(rev)
+	servfake.ServingV1().Revisions(rev.Namespace).Create(rev)
 	revisions.Informer().GetIndexer().Add(rev)
 
 	throttler := NewThrottler(ctx, defaultParams, "130.0.0.2:8012")

--- a/pkg/activator/util/context.go
+++ b/pkg/activator/util/context.go
@@ -25,20 +25,20 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 type revisionKey struct{}
 type revIDKey struct{}
 
 // WithRevision attaches the Revision object to the context.
-func WithRevision(ctx context.Context, rev *v1alpha1.Revision) context.Context {
+func WithRevision(ctx context.Context, rev *v1.Revision) context.Context {
 	return context.WithValue(ctx, revisionKey{}, rev)
 }
 
 // RevisionFrom retrieves the Revision object from the context.
-func RevisionFrom(ctx context.Context) *v1alpha1.Revision {
-	return ctx.Value(revisionKey{}).(*v1alpha1.Revision)
+func RevisionFrom(ctx context.Context) *v1.Revision {
+	return ctx.Value(revisionKey{}).(*v1.Revision)
 }
 
 // WithRevID attaches the the revisionID to the context.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Contributes to #6035

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Activator will now use Serving v1 APIs

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
