### PR TITLE
HPA Autoscaling uses v1 APIs

### DIFF
--- a/pkg/autoscaler/metrics/metrics_provider.go
+++ b/pkg/autoscaler/metrics/metrics_provider.go
@@ -32,8 +32,6 @@ import (
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
-type getMetric func(MetricClient, types.NamespacedName, time.Time) (float64, float64, error)
-
 var (
 	concurrencyMetricInfo = provider.CustomMetricInfo{
 		GroupResource: v1.Resource("revisions"),

--- a/pkg/autoscaler/metrics/metrics_provider.go
+++ b/pkg/autoscaler/metrics/metrics_provider.go
@@ -29,17 +29,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	cmetrics "k8s.io/metrics/pkg/apis/custom_metrics"
 	"knative.dev/serving/pkg/apis/autoscaling"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 var (
 	concurrencyMetricInfo = provider.CustomMetricInfo{
-		GroupResource: v1alpha1.Resource("revisions"),
+		GroupResource: v1.Resource("revisions"),
 		Namespaced:    true,
 		Metric:        autoscaling.Concurrency,
 	}
 	rpsMetricInfo = provider.CustomMetricInfo{
-		GroupResource: v1alpha1.Resource("revisions"),
+		GroupResource: v1.Resource("revisions"),
 		Namespaced:    true,
 		Metric:        autoscaling.RPS,
 	}

--- a/pkg/autoscaler/metrics/metrics_provider_test.go
+++ b/pkg/autoscaler/metrics/metrics_provider_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
-	"knative.dev/pkg/kmp"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler/fake"
@@ -112,20 +112,18 @@ func TestGetMetricBySelector(t *testing.T) {
 }
 
 func TestListAllMetrics(t *testing.T) {
-	provider := NewMetricProvider(staticMetrics(10.0, 14))
-	gotConcurrency := provider.ListAllMetrics()[0]
-
-	if equal, err := kmp.SafeEqual(gotConcurrency, concurrencyMetricInfo); err != nil {
-		t.Errorf("Got error comparing output, err = %v", err)
-	} else if !equal {
-		t.Errorf("ListAllMetrics() = %v, want %v", gotConcurrency, concurrencyMetricInfo)
+	want := []provider.CustomMetricInfo{
+		deprecatedConcurrencyMetricInfo,
+		deprecatedRpsMetricsInfo,
+		concurrencyMetricInfo,
+		rpsMetricInfo,
 	}
 
-	gotRPS := provider.ListAllMetrics()[1]
-	if equal, err := kmp.SafeEqual(gotRPS, rpsMetricInfo); err != nil {
-		t.Errorf("Got error comparing output, err = %v", err)
-	} else if !equal {
-		t.Errorf("ListAllMetrics() = %v, want %v", gotRPS, rpsMetricInfo)
+	p := NewMetricProvider(staticMetrics(10.0, 14))
+	got := p.ListAllMetrics()
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("ListAllMetrics() returned unexpected list (-want, +got): %s", diff)
 	}
 }
 

--- a/pkg/autoscaler/metrics/metrics_provider_test.go
+++ b/pkg/autoscaler/metrics/metrics_provider_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/kubernetes-incubator/custom-metrics-apiserver/pkg/provider"
 	"knative.dev/pkg/kmp"
 	"knative.dev/serving/pkg/apis/autoscaling"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler/fake"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -65,7 +65,7 @@ func TestGetMetricByName(t *testing.T) {
 		args: args{
 			name: types.NamespacedName{Namespace: existingNamespace, Name: "test"},
 			info: provider.CustomMetricInfo{
-				GroupResource: v1alpha1.Resource("services"),
+				GroupResource: v1.Resource("services"),
 				Namespaced:    true,
 				Metric:        autoscaling.Concurrency,
 			},

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -54,7 +54,7 @@ import (
 	asv1a1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/networking"
 	nv1a1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
@@ -62,7 +62,7 @@ import (
 	aresources "knative.dev/serving/pkg/reconciler/autoscaling/resources"
 
 	. "knative.dev/pkg/reconciler/testing"
-	. "knative.dev/serving/pkg/reconciler/testing/v1alpha1"
+	. "knative.dev/serving/pkg/reconciler/testing/v1"
 	. "knative.dev/serving/pkg/testing"
 )
 
@@ -143,7 +143,7 @@ func TestReconcile(t *testing.T) {
 					return false, nil, nil
 				}
 				retryAttempted = true
-				return true, nil, apierrs.NewConflict(v1alpha1.Resource("foo"), "bar", errors.New("foo"))
+				return true, nil, apierrs.NewConflict(v1.Resource("foo"), "bar", errors.New("foo"))
 			},
 		},
 		WantCreates: []runtime.Object{

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -27,7 +27,7 @@ import (
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
-	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	aresources "knative.dev/serving/pkg/reconciler/autoscaling/resources"
 )
@@ -77,7 +77,7 @@ func MakeHPA(pa *v1alpha1.PodAutoscaler, config *autoscalerconfig.Config) *autos
 			Type: autoscalingv2beta1.ObjectMetricSourceType,
 			Object: &autoscalingv2beta1.ObjectMetricSource{
 				Target: autoscalingv2beta1.CrossVersionObjectReference{
-					APIVersion: servingv1alpha1.SchemeGroupVersion.String(),
+					APIVersion: servingv1.SchemeGroupVersion.String(),
 					Kind:       "revision",
 					Name:       pa.Name,
 				},

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
@@ -26,7 +26,7 @@ import (
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
-	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
@@ -94,7 +94,7 @@ func TestMakeHPA(t *testing.T) {
 				Type: autoscalingv2beta1.ObjectMetricSourceType,
 				Object: &autoscalingv2beta1.ObjectMetricSource{
 					Target: autoscalingv2beta1.CrossVersionObjectReference{
-						APIVersion: servingv1alpha1.SchemeGroupVersion.String(),
+						APIVersion: servingv1.SchemeGroupVersion.String(),
 						Kind:       "revision",
 						Name:       testName,
 					},
@@ -113,7 +113,7 @@ func TestMakeHPA(t *testing.T) {
 				Type: autoscalingv2beta1.ObjectMetricSourceType,
 				Object: &autoscalingv2beta1.ObjectMetricSource{
 					Target: autoscalingv2beta1.CrossVersionObjectReference{
-						APIVersion: servingv1alpha1.SchemeGroupVersion.String(),
+						APIVersion: servingv1.SchemeGroupVersion.String(),
 						Kind:       "revision",
 						Name:       testName,
 					},
@@ -131,7 +131,7 @@ func TestMakeHPA(t *testing.T) {
 				Type: autoscalingv2beta1.ObjectMetricSourceType,
 				Object: &autoscalingv2beta1.ObjectMetricSource{
 					Target: autoscalingv2beta1.CrossVersionObjectReference{
-						APIVersion: servingv1alpha1.SchemeGroupVersion.String(),
+						APIVersion: servingv1.SchemeGroupVersion.String(),
 						Kind:       "revision",
 						Name:       testName,
 					},
@@ -150,7 +150,7 @@ func TestMakeHPA(t *testing.T) {
 				Type: autoscalingv2beta1.ObjectMetricSourceType,
 				Object: &autoscalingv2beta1.ObjectMetricSource{
 					Target: autoscalingv2beta1.CrossVersionObjectReference{
-						APIVersion: servingv1alpha1.SchemeGroupVersion.String(),
+						APIVersion: servingv1.SchemeGroupVersion.String(),
 						Kind:       "revision",
 						Name:       testName,
 					},


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Contributes to #6035

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Metric Provider now supports v1 in addition to v1alpha1
* HPA autoscaling now uses v1 resource version for revisions

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
