### PR TITLE
Make default ingress class consistent in e2e tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -26,12 +26,13 @@ E2E_CLUSTER_MACHINE=${E2E_CLUSTER_MACHINE:-e2-standard-8}
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
 
 CERT_MANAGER_VERSION="0.12.0"
+# Since default is istio, make default ingress as istio
+INGRESS_CLASS=${INGRESS_CLASS:-istio.ingress.networking.knative.dev}
 ISTIO_VERSION=""
 GLOO_VERSION=""
 KOURIER_VERSION=""
 AMBASSADOR_VERSION=""
 CONTOUR_VERSION=""
-INGRESS_CLASS=""
 CERTIFICATE_CLASS=""
 
 HTTPS=0


### PR DESCRIPTION
`INGRESS_CLASS` is initialized as empty string, and the value is only supplied when an explicit ingress flag is given. When running test with default ingress it fails this line: https://github.com/knative/serving/blob/2651015189828309464b1eece0b12e7c9cbc323b/test/e2e-common.sh#L355

/assign @mattmoor 