### PR TITLE
Best effort Istio probing

### DIFF
--- a/pkg/network/status/status_test.go
+++ b/pkg/network/status/status_test.go
@@ -534,6 +534,85 @@ func TestCancelIngressProbing(t *testing.T) {
 	}
 }
 
+func TestProbeVerifier(t *testing.T) {
+	const hash = "Hi! I am hash!"
+	prober := NewProber(zaptest.NewLogger(t).Sugar(), nil, nil)
+	verifier := prober.probeVerifier(&workItem{
+		ingressState: &ingressState{
+			hash:         hash,
+		},
+		podState:     nil,
+		context:      nil,
+		url:          nil,
+		podIP:        "",
+		podPort:      "",
+	})
+	cases := []struct {
+		name string
+		resp *http.Response
+		want bool
+	}{{
+		name: "HTTP 200 matching hash",
+		resp: &http.Response{
+			StatusCode:       http.StatusOK,
+			Header:           http.Header{network.HashHeaderName: []string{hash}},
+		},
+		want: true,
+	},{
+		name: "HTTP 200 mismatching hash",
+		resp: &http.Response{
+			StatusCode:       http.StatusOK,
+			Header:           http.Header{network.HashHeaderName: []string{"nope"}},
+		},
+		want: false,
+	},{
+		name: "HTTP 200 missing header",
+		resp: &http.Response{
+			StatusCode:       http.StatusOK,
+		},
+		want: true,
+	},{
+		name: "HTTP 404",
+		resp: &http.Response{
+			StatusCode:       http.StatusNotFound,
+		},
+		want: false,
+	}, {
+		name: "HTTP 503",
+		resp: &http.Response{
+			StatusCode:       http.StatusServiceUnavailable,
+		},
+		want: false,
+	}, {
+		name: "HTTP 403",
+		resp: &http.Response{
+			StatusCode:       http.StatusForbidden,
+		},
+		want: true,
+	}, {
+		name: "HTTP 503",
+		resp: &http.Response{
+			StatusCode:       http.StatusServiceUnavailable,
+		},
+		want: false,
+	}, {
+		name: "HTTP 302",
+		resp: &http.Response{
+			StatusCode:       http.StatusFound,
+		},
+		want: true,
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, _ := verifier(c.resp, nil)
+			if got != c.want {
+				t.Errorf("got: %v, want: %v", got, c.want)
+			}
+		})
+	}
+}
+
 type fakeProbeTargetLister []ProbeTarget
 
 func (l fakeProbeTargetLister) ListProbeTargets(ctx context.Context, ing *v1alpha1.Ingress) ([]ProbeTarget, error) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Addresses https://github.com/knative/serving/issues/6829

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
Any scenario where probing would fail forever with the current implementation is now treated as a successful probing. The idea is too make probing more best effort. It is already best effort regarding protocols today (if the protocol is not HTTP, HTTP2 or HTTPS probing is skipped today).

See the comments in the code for more details.
