### PR TITLE
Move test constants to their own file

### DIFF
--- a/test/e2e_constants.go
+++ b/test/e2e_constants.go
@@ -32,6 +32,7 @@ const (
 	ServingNamespaceforSecurityTesting = "serving-tests-security"
 
 	// Environment propagation conformance test objects
+
 	// ConformanceConfigMap is the name of the configmap to propagate env variables from
 	ConformanceConfigMap = "conformance-test-configmap"
 
@@ -44,6 +45,6 @@ const (
 	// EnvValue is the configmap/secret test value to match env variable with
 	EnvValue = "testValue"
 
-	// ContainerMemoryLimit
+	// ContainerMemoryLimit is used in any test which needs a default memory resource limit
 	ContainerMemoryLimit = "350Mi"
 )

--- a/test/e2e_constants.go
+++ b/test/e2e_constants.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// All test-affecting constants should be placed in this file
+// At some point it may make sense to be able to modify them
+// via a configuration mechanism (see https://github.com/knative/serving/issues/6109)
+
+package test
+
+const (
+	// ServingNamespace is the default namespace for serving e2e tests
+	ServingNamespace = "serving-tests"
+
+	// AlternativeServingNamespace is a different namepace to run cross-
+	// namespace tests in.
+	AlternativeServingNamespace = "serving-tests-alt"
+
+	// ServingNamespaceforSecurityTesting is the namespace for security tests.
+	ServingNamespaceforSecurityTesting = "serving-tests-security"
+
+	// Environment propagation conformance test objects
+	// ConformanceConfigMap is the name of the configmap to propagate env variables from
+	ConformanceConfigMap = "conformance-test-configmap"
+
+	// ConformanceSecret is the name of the secret to propagate env variables from
+	ConformanceSecret = "conformance-test-secret"
+
+	// EnvKey is the configmap/secret key which contains test value
+	EnvKey = "testKey"
+
+	// EnvValue is the configmap/secret test value to match env variable with
+	EnvValue = "testValue"
+
+	// ContainerMemoryLimit
+	ContainerMemoryLimit = "350Mi"
+)

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -25,28 +25,6 @@ import (
 	"knative.dev/serving/pkg/network"
 )
 
-const (
-	// ServingNamespace is the default namespace for serving e2e tests
-	ServingNamespace = "serving-tests"
-
-	// AlternativeServingNamespace is a different namepace to run cross-
-	// namespace tests in.
-	AlternativeServingNamespace = "serving-tests-alt"
-
-	// ServingNamespaceforSecurityTesting is the namespace for security tests.
-	ServingNamespaceforSecurityTesting = "serving-tests-security"
-	// Environment propagation conformance test objects
-
-	// ConformanceConfigMap is the name of the configmap to propagate env variables from
-	ConformanceConfigMap = "conformance-test-configmap"
-	// ConformanceSecret is the name of the secret to propagate env variables from
-	ConformanceSecret = "conformance-test-secret"
-	// EnvKey is the configmap/secret key which contains test value
-	EnvKey = "testKey"
-	// EnvValue is the configmap/secret test value to match env variable with
-	EnvValue = "testValue"
-)
-
 // ServingFlags holds the flags or defaults for knative/serving settings in the user's environment.
 var ServingFlags = initializeServingFlags()
 


### PR DESCRIPTION
See discussion in #6109 why this solution was chosen. At the very least, it provides one location for a true configuration system to interface.

Fixes #6109
Fixes #3892

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


```release-note
NONE
```
