### PR TITLE
Restructure Conformance API tests to match Spec

### DIFF
--- a/test/conformance.go
+++ b/test/conformance.go
@@ -45,6 +45,11 @@ const (
 	PizzaPlanetText2 = "Re-energize yourself with a slice of pepperoni!"
 	HelloWorldText   = "Hello World! How about some tasty noodles?"
 
+	// The Failing image will always exit with an exit code of 5
+	ExitCodeReason = "ExitCode5"
+	// ... and will print "Crashed..." before it exits
+	ErrorLog = "Crashed..."
+
 	ConcurrentRequests = 50
 	// We expect to see 100% of requests succeed for traffic sent directly to revisions.
 	// This might be a bad assumption.

--- a/test/conformance/api/v1/resources_test.go
+++ b/test/conformance/api/v1/resources_test.go
@@ -19,99 +19,55 @@ limitations under the License.
 package v1
 
 import (
-	"fmt"
-	"net/http"
-	"net/url"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	pkgTest "knative.dev/pkg/test"
-	"knative.dev/pkg/test/spoof"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/test/logging"
 	"knative.dev/serving/test"
 	v1test "knative.dev/serving/test/v1"
 
 	rtesting "knative.dev/serving/pkg/testing/v1"
 )
 
-func TestCustomResourcesLimits(t *testing.T) {
-	t.Parallel()
-	clients := test.Setup(t)
+var resourceLimit resource.Quantity
 
-	t.Log("Creating a new Route and Configuration")
-	withResources := rtesting.WithResourceRequirements(corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("350Mi"),
-		},
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("350Mi"),
-		},
+func init() {
+	resourceLimit = resource.MustParse(test.ContainerMemoryLimit)
+}
+
+func TestMustSetCustomResourcesLimits(legacy *testing.T) {
+	t, cancel := logging.NewTLogger(legacy)
+	defer cancel()
+
+	clients, names, objects, cancel, err := v1test.CreateBasicServiceTest(t,
+		test.Autoscale,
+		rtesting.WithResourceRequirements(corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resourceLimit,
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resourceLimit,
+			},
+		}))
+	defer cancel()
+	t.FatalIfErr(err, "Failed to create initial Service", "name", names.Service)
+
+	t.Run("API", func(t *logging.TLogger) {
+		svc, err := clients.ServingClient.Revisions.Get(objects.Revision.Status.ServiceName, metav1.GetOptions{})
+		t.FatalIfErr(err, "Failed requesting information about Revision")
+
+		// TODO: need to not panic if any nil pointers/missing keys
+		resources := svc.Spec.Containers[0].Resources
+		limit := resources.Limits["memory"]
+		request := resources.Requests["memory"]
+
+		if limit.Cmp(resourceLimit) != 0 {
+			t.Error("Memory limit did not match", "want", resourceLimit, "got", limit)
+		}
+		if request.Cmp(resourceLimit) != 0 {
+			t.Error("Memory request did not match", "want", resourceLimit, "got", request)
+		}
 	})
-
-	names := test.ResourceNames{
-		Service: test.ObjectNameForTest(t),
-		Image:   test.Autoscale,
-	}
-
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
-
-	objects, err := v1test.CreateServiceReady(t, clients, &names, withResources)
-	if err != nil {
-		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
-	}
-	endpoint := objects.Route.Status.URL.URL()
-
-	_, err = pkgTest.WaitForEndpointState(
-		clients.KubeClient,
-		t.Logf,
-		endpoint,
-		v1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK)),
-		"ResourceTestServesText",
-		test.ServingFlags.ResolvableDomain)
-	if err != nil {
-		t.Fatalf("Error probing %s: %v", endpoint, err)
-	}
-
-	sendPostRequest := func(resolvableDomain bool, url *url.URL) (*spoof.Response, error) {
-		t.Logf("Request %s", url)
-		client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), resolvableDomain)
-		if err != nil {
-			return nil, err
-		}
-
-		req, err := http.NewRequest(http.MethodPost, url.String(), nil)
-		if err != nil {
-			return nil, err
-		}
-		return client.Do(req)
-	}
-
-	pokeCowForMB := func(mb int) error {
-		u, _ := url.Parse(endpoint.String())
-		q := u.Query()
-		q.Set("bloat", fmt.Sprintf("%d", mb))
-		u.RawQuery = q.Encode()
-		response, err := sendPostRequest(test.ServingFlags.ResolvableDomain, u)
-		if err != nil {
-			return err
-		}
-		if response.StatusCode != http.StatusOK {
-			return fmt.Errorf("StatusCode = %d, want %d", response.StatusCode, http.StatusOK)
-		}
-		return nil
-	}
-
-	t.Log("Querying the application to see if the memory limits are enforced.")
-	if err := pokeCowForMB(100); err != nil {
-		t.Fatalf("Didn't get a response from bloating cow with %d MBs of Memory: %v", 100, err)
-	}
-
-	if err := pokeCowForMB(200); err != nil {
-		t.Fatalf("Didn't get a response from bloating cow with %d MBs of Memory: %v", 200, err)
-	}
-
-	if err := pokeCowForMB(500); err == nil {
-		t.Fatalf("We shouldn't have got a response from bloating cow with %d MBs of Memory: %v", 500, err)
-	}
 }

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -41,7 +41,7 @@ import (
 
 // createService creates a service in namespace with the name names.Service
 // that uses the image specified by names.Image
-func createService(t *testing.T, clients *test.Clients, names test.ResourceNames, revisionTimeoutSeconds int64) (*v1.Service, error) {
+func createService(t pkgTest.T, clients *test.Clients, names test.ResourceNames, revisionTimeoutSeconds int64) (*v1.Service, error) {
 	service := v1test.Service(names, WithRevisionTimeoutSeconds(revisionTimeoutSeconds))
 	v1test.LogResourceObject(t, v1test.ResourceObjects{Service: service})
 	return clients.ServingClient.Services.Create(service)
@@ -62,7 +62,7 @@ func updateServiceWithTimeout(clients *test.Clients, names test.ResourceNames, r
 }
 
 // sendRequests send a request to "endpoint", returns error if unexpected response code, nil otherwise.
-func sendRequest(t *testing.T, kubeClient *pkgTest.KubeClient, endpoint *url.URL,
+func sendRequest(t pkgTest.TLegacy, kubeClient *pkgTest.KubeClient, endpoint *url.URL,
 	initialSleep, sleep time.Duration, expectedResponseCode int) error {
 	client, err := pkgTest.NewSpoofingClient(kubeClient, t.Logf, endpoint.Hostname(), test.ServingFlags.ResolvableDomain)
 	if err != nil {

--- a/test/e2e/resources_test.go
+++ b/test/e2e/resources_test.go
@@ -1,0 +1,122 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog"
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/logging"
+	"knative.dev/pkg/test/spoof"
+	"knative.dev/serving/test"
+	v1test "knative.dev/serving/test/v1"
+
+	rtesting "knative.dev/serving/pkg/testing/v1"
+)
+
+var resourceLimit resource.Quantity
+
+func init() {
+	resourceLimit = resource.MustParse(test.ContainerMemoryLimit)
+}
+
+func TestMustSetCustomResourcesLimits(legacy *testing.T) {
+	t, cancel := logging.NewTLogger(legacy)
+	defer cancel()
+
+	clients, names, objects, cancel, err := v1test.CreateBasicServiceTest(t,
+		test.Autoscale,
+		rtesting.WithResourceRequirements(corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resourceLimit,
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resourceLimit,
+			},
+		}))
+	defer cancel()
+	t.FatalIfErr(err, "Failed to create initial Service", "name", names.Service)
+
+	// This is in e2e, not conformance, because k8s does not require implementations to terminate
+	// See https://github.com/knative/serving/pull/6014#issuecomment-553714724
+	endpoint := objects.Route.Status.URL.URL()
+	_, err = pkgTest.WaitForEndpointState(
+		clients.KubeClient,
+		t.Logf,
+		endpoint,
+		v1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK)),
+		"ResourceTestServesText",
+		test.ServingFlags.ResolvableDomain)
+	t.FatalIfErr(err, "Error probing", "URL", endpoint)
+
+	sendPostRequest := func(resolvableDomain bool, url *url.URL) (*spoof.Response, error) {
+		client, err := pkgTest.NewSpoofingClient(clients.KubeClient, klog.V(4).Infof, url.Hostname(), resolvableDomain)
+		if err != nil {
+			return nil, err
+		}
+
+		req, err := http.NewRequest(http.MethodPost, url.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+		return client.Do(req)
+	}
+
+	bloatAndCheck := func(mb int, wantSuccess bool) {
+		expect := "failure"
+		if wantSuccess {
+			expect = "success"
+		}
+		t.V(2).Info("Bloating", "MB increase", mb, "want", expect)
+		u, _ := url.Parse(endpoint.String())
+		q := u.Query()
+		q.Set("bloat", fmt.Sprintf("%d", mb))
+		u.RawQuery = q.Encode()
+		response, err := sendPostRequest(test.ServingFlags.ResolvableDomain, u)
+		if err != nil {
+			t.V(5).Info("Received error from sendPostRequest (may be expected)", "error", err)
+			if wantSuccess {
+				t.Error("Didn't get a response from bloating RAM", "MB", mb)
+			}
+		} else if response.StatusCode == http.StatusOK {
+			if !wantSuccess {
+				t.Error("We shouldn't have got a response from bloating RAM", "MB", mb)
+			}
+		} else if response.StatusCode == http.StatusBadRequest {
+			t.Error("Test Issue: Received BadRequest from test app, which probably means the test & test image are not cooperating with each other.")
+		} else {
+			// Accept all other StatusCode as failure; different systems could return 404, 502, etc on failure
+			t.V(5).Info("Received non-OK http code from sendPostRequest; interpreting as failure of bloat", "StatusCode", response.StatusCode)
+			if wantSuccess {
+				t.Error("Didn't get a good response from bloating RAM", "MB", mb)
+			}
+		}
+	}
+
+	t.V(1).Info("Querying the application to see if the memory limits are enforced.")
+	bloatAndCheck(100, true)
+	bloatAndCheck(200, true)
+	bloatAndCheck(500, false)
+}

--- a/test/scenarios/container_failures.go
+++ b/test/scenarios/container_failures.go
@@ -31,8 +31,6 @@ import (
 	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 	v1test "knative.dev/serving/test/v1"
-
-	. "knative.dev/serving/pkg/testing/v1"
 )
 
 // ContainerError executes a test flow where the container returns an Error when it attempts to start.
@@ -60,7 +58,7 @@ func ContainerError(t *logging.TLogger, falseConfigurationValidator func(*loggin
 	// Specify an invalid image path
 	// A valid DockerRepo is still needed, otherwise will get UNAUTHORIZED instead of container missing error
 	t.V(2).Info("Creating a new Service", "service", names.Service)
-	svc, err := v1test.CreateService(t, clients, names, WithRevisionTimeoutSeconds(2))
+	svc, err := v1test.CreateService(t, clients, names, rtesting.WithRevisionTimeoutSeconds(2))
 	t.FatalIfErr(err, "Failed to create Service")
 
 	names.Config = serviceresourcenames.Configuration(svc)

--- a/test/scenarios/container_failures.go
+++ b/test/scenarios/container_failures.go
@@ -1,0 +1,198 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scenarios
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/logging"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
+	rtesting "knative.dev/serving/pkg/testing/v1"
+	"knative.dev/serving/test"
+	v1test "knative.dev/serving/test/v1"
+
+	. "knative.dev/serving/pkg/testing/v1"
+)
+
+func ContainerError(t *logging.TLogger, falseConfigurationValidator func(*logging.TLogger, *apis.Condition) (bool, error), revisionValidator func(*logging.TLogger, *apis.Condition) (bool, error)) {
+	if strings.HasSuffix(strings.Split(pkgTest.Flags.DockerRepo, "/")[0], ".local") {
+		t.V(0).Info("Skipping for local docker repo")
+		t.SkipNow()
+	}
+	t.Parallel()
+	clients := test.Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.InvalidHelloWorld,
+	}
+
+	defer test.TearDown(clients, names)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+
+	// Specify an invalid image path
+	// A valid DockerRepo is still needed, otherwise will get UNAUTHORIZED instead of container missing error
+	t.V(2).Info("Creating a new Service", "service", names.Service)
+	svc, err := v1test.CreateService(t, clients, names, WithRevisionTimeoutSeconds(2))
+	t.FatalIfErr(err, "Failed to create Service")
+
+	names.Config = serviceresourcenames.Configuration(svc)
+	names.Route = serviceresourcenames.Route(svc)
+
+	t.Run("API", func(ts *logging.TLogger) {
+		ts.V(1).Info("When the imagepath is invalid, the Configuration should have error status.")
+		ts.V(8).Info("Wait for ServiceState becomes NotReady. It also waits for the creation of Configuration.")
+		err = v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceNotReady, "ServiceIsNotReady")
+		ts.FatalIfErr(err, "The Service was unexpected state",
+			"service", names.Service)
+
+		ts.V(8).Info("Checking for 'Container image not present in repository' scenario defined in error condition spec.")
+		err = v1test.WaitForConfigurationState(clients.ServingClient, names.Config, func(r *v1.Configuration) (bool, error) {
+			cond := r.Status.GetCondition(v1.ConfigurationConditionReady)
+			ts.WithValues("configuration", names.Config, "condition", cond)
+			v1test.ValidateCondition(ts, cond)
+			if cond != nil && !cond.IsUnknown() {
+				if cond.IsFalse() {
+					return falseConfigurationValidator(ts, cond)
+				} else {
+					ts.Fatal("Configuration should not have become ready")
+				}
+			}
+			return false, nil
+		}, "ContainerImageNotPresent")
+
+		ts.FatalIfErr(err, "Failed to validate configuration state")
+
+		revisionName, err := getRevisionFromConfiguration(clients, names.Config)
+		ts.FatalIfErr(err, "Failed to get revision from configuration", "configuration", names.Config)
+
+		ts.V(1).Info("When the imagepath is invalid, the revision should have error status.")
+		err = v1test.WaitForRevisionState(clients.ServingClient, revisionName, func(r *v1.Revision) (bool, error) {
+			cond := r.Status.GetCondition(v1.RevisionConditionReady)
+			ts := ts.WithValues("revision", revisionName, "condition", cond)
+			v1test.ValidateCondition(ts, cond)
+			if cond != nil {
+				return revisionValidator(ts, cond)
+			}
+			return false, nil
+		}, "ImagePathInvalid")
+
+		ts.FatalIfErr(err, "Failed to validate revision state")
+
+		ts.V(1).Info("Checking to ensure Route is in desired state")
+		err = v1test.CheckRouteState(clients.ServingClient, names.Route, v1test.IsRouteNotReady)
+		ts.FatalIfErr(err, "The Route was not desired state", "route", names.Route)
+	})
+}
+
+func ContainerExiting(t *logging.TLogger, falseConfigurationValidator func(*logging.TLogger, *apis.Condition) (bool, error), revisionValidator func(*logging.TLogger, *apis.Condition) (bool, error)) {
+	t.Parallel()
+	tests := []struct {
+		Name           string
+		ReadinessProbe *corev1.Probe
+	}{{
+		Name: "http",
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{},
+			},
+		},
+	}, {
+		Name: "tcp",
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				TCPSocket: &corev1.TCPSocketAction{},
+			},
+		},
+	}}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.Name, func(t *logging.TLogger) {
+			t.Parallel()
+			clients := test.Setup(t)
+
+			names := test.ResourceNames{
+				Config: test.ObjectNameForTest(t),
+				Image:  test.Failing,
+			}
+
+			defer test.TearDown(clients, names)
+			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+
+			t.Run("API", func(ts *logging.TLogger) {
+				ts.V(2).Info("Creating a new Configuration", "configuration", names.Config)
+
+				_, err := v1test.CreateConfiguration(t, clients, names, rtesting.WithConfigReadinessProbe(tt.ReadinessProbe))
+				ts.FatalIfErr(err, "Failed to create Configuration", "configuration", names.Config)
+
+				ts.V(1).Info("When the containers keep crashing, the Configuration should have error status.")
+
+				err = v1test.WaitForConfigurationState(clients.ServingClient, names.Config, func(r *v1.Configuration) (bool, error) {
+					cond := r.Status.GetCondition(v1.ConfigurationConditionReady)
+					ts := ts.WithValues("configuration", names.Config, "condition", cond)
+					v1test.ValidateCondition(ts, cond)
+					if cond != nil && !cond.IsUnknown() {
+						if cond.IsFalse() {
+							return falseConfigurationValidator(ts, cond)
+						} else {
+							ts.Fatal("Configuration should not have become ready")
+						}
+					}
+					return false, nil
+				}, "ConfigContainersCrashing")
+
+				ts.FatalIfErr(err, "Failed to validate configuration state")
+
+				revisionName, err := getRevisionFromConfiguration(clients, names.Config)
+				ts.FatalIfErr(err, "Failed to get revision from configuration", "configuration", names.Config)
+
+				ts.V(1).Info("When the containers keep crashing, the revision should have error status.")
+				err = v1test.WaitForRevisionState(clients.ServingClient, revisionName, func(r *v1.Revision) (bool, error) {
+					cond := r.Status.GetCondition(v1.RevisionConditionReady)
+					ts := ts.WithValues("revision", revisionName, "condition", cond)
+					v1test.ValidateCondition(ts, cond)
+					if cond != nil {
+						return revisionValidator(ts, cond)
+					}
+					return false, nil
+				}, "RevisionContainersCrashing")
+
+				ts.FatalIfErr(err, "Failed to validate revision state")
+			})
+		})
+	}
+}
+
+// Get revision name from configuration.
+func getRevisionFromConfiguration(clients *test.Clients, configName string) (string, error) {
+	config, err := clients.ServingClient.Configs.Get(configName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if config.Status.LatestCreatedRevisionName != "" {
+		return config.Status.LatestCreatedRevisionName, nil
+	}
+	return "", logging.Error("No valid revision name found", "configuration", configName)
+}

--- a/test/scenarios/container_failures.go
+++ b/test/scenarios/container_failures.go
@@ -35,6 +35,12 @@ import (
 	. "knative.dev/serving/pkg/testing/v1"
 )
 
+// ContainerError executes a test flow where the container returns an Error when it attempts to start.
+// The caller can inject its testing at two points:
+// * falseConfigurationValidator: when the Configuration state becomes false, this function is called
+// * revisionValidator: when checking the Revision state
+// In both cases, the Condition has already been validated by ValidateCondition and relevant fields are
+// already included in the TLogger.
 func ContainerError(t *logging.TLogger, falseConfigurationValidator func(*logging.TLogger, *apis.Condition) (bool, error), revisionValidator func(*logging.TLogger, *apis.Condition) (bool, error)) {
 	if strings.HasSuffix(strings.Split(pkgTest.Flags.DockerRepo, "/")[0], ".local") {
 		t.V(0).Info("Skipping for local docker repo")
@@ -106,6 +112,12 @@ func ContainerError(t *logging.TLogger, falseConfigurationValidator func(*loggin
 	})
 }
 
+// ContainerError executes a test flow where the container exists shortly after successfully starting.
+// The caller can inject its testing at two points:
+// * falseConfigurationValidator: when the Configuration state becomes false, this function is called
+// * revisionValidator: when checking the Revision state
+// In both cases, the Condition has already been validated by ValidateCondition and relevant fields are
+// already included in the TLogger.
 func ContainerExiting(t *logging.TLogger, falseConfigurationValidator func(*logging.TLogger, *apis.Condition) (bool, error), revisionValidator func(*logging.TLogger, *apis.Condition) (bool, error)) {
 	t.Parallel()
 	tests := []struct {
@@ -156,9 +168,8 @@ func ContainerExiting(t *logging.TLogger, falseConfigurationValidator func(*logg
 					if cond != nil && !cond.IsUnknown() {
 						if cond.IsFalse() {
 							return falseConfigurationValidator(ts, cond)
-						} else {
-							ts.Fatal("Configuration should not have become ready")
 						}
+						ts.Fatal("Configuration should not have become ready")
 					}
 					return false, nil
 				}, "ConfigContainersCrashing")

--- a/test/v1/condition.go
+++ b/test/v1/condition.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"regexp"
+
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/test/logging"
+)
+
+var camelCaseRegex = regexp.MustCompile(`^[[:upper:]].*`)
+var camelCaseSingleWordRegex = regexp.MustCompile(`^[[:upper:]][^[\s]]+$`)
+
+func ValidateCondition(t *logging.TLogger, c *apis.Condition) {
+	if c == nil {
+		return
+	}
+	if c.Type == "" {
+		t.Error("A Condition.Type must not be an empty string")
+	} else if !camelCaseRegex.MatchString(string(c.Type)) {
+		t.Error("A Condition.Type must be CamelCase, so must start with an upper-case letter")
+	}
+	if c.Status != corev1.ConditionTrue && c.Status != corev1.ConditionFalse && c.Status != corev1.ConditionUnknown {
+		t.Error("A Condition.Status must be True, False, or Unknown")
+	}
+	if c.Reason != "" && !camelCaseRegex.MatchString(c.Reason) {
+		t.Error("A Condition.Reason, if given, must be a single-word CamelCase")
+	}
+	if c.Severity != apis.ConditionSeverityError && c.Severity != apis.ConditionSeverityWarning && c.Severity != apis.ConditionSeverityInfo {
+		t.Error("A Condition.Status must be '', Warning, or Info")
+	}
+}

--- a/test/v1/condition.go
+++ b/test/v1/condition.go
@@ -27,6 +27,8 @@ import (
 var camelCaseRegex = regexp.MustCompile(`^[[:upper:]].*`)
 var camelCaseSingleWordRegex = regexp.MustCompile(`^[[:upper:]][^[\s]]+$`)
 
+// ValidateCondition validates all fields of a Condition which are universal
+// across all Condition, as defined in the API Spec.
 func ValidateCondition(t *logging.TLogger, c *apis.Condition) {
 	if c == nil {
 		return

--- a/test/v1/constants.go
+++ b/test/v1/constants.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+const (
+	// TODO: shouldn't this be exported by the code so we can reuse it? It was in v1alpha1
+	ContainerMissing = "ContainerMissing"
+)

--- a/test/v1/constants.go
+++ b/test/v1/constants.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 const (
+	// ContainerMissing is the string returned when a container image cannot be found
 	// TODO: shouldn't this be exported by the code so we can reuse it? It was in v1alpha1
 	ContainerMissing = "ContainerMissing"
 )

--- a/test/v1/crd.go
+++ b/test/v1/crd.go
@@ -32,5 +32,5 @@ type ResourceObjects struct {
 
 // LogResourceObject logs the resource object with the resource name and value
 func LogResourceObject(t pkgTest.T, value ResourceObjects) {
-	t.Log("", "resource", spew.Sprint(value))
+	t.Log("", "resource", spew.Sdump(value))
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #6006 by making TestCustomResourceLimits to be a conformance
test and moving e2e parts out.
    
For #6226 fixes it for TestContainerErrorMsg and
TestContainerExitingMsg, though could be other tests checking errors
incorrectly.
    
Addresses #6264 though continuing work is needed.
    
Don't mix E2E and conformance:
Strip E2E portions of conformance out into tests in the test/e2e
directory. Commonality goes into test/scenarios or test/v1 depending
on specificity of the common functionality.
    
Rename to more align with runtime test naming (Must/Should).

```release-note
NONE
```

/cc @dgerd 