### PR TITLE
Make WaitForConfigLatestRevision more robust

### DIFF
--- a/test/conformance/api/v1/generatename_test.go
+++ b/test/conformance/api/v1/generatename_test.go
@@ -167,7 +167,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 
 	// Ensure the associated revision is created. This also checks that the configuration becomes ready.
 	t.Log("The configuration will be updated with the name of the associated Revision once it is created.")
-	names.Revision, err = v1test.WaitForConfigLatestRevision(clients, names)
+	names.Revision, err = v1test.WaitForConfigLatestUnpinnedRevision(clients, names)
 	if err != nil {
 		t.Fatalf("Configuration %s was not updated with the new revision: %v", names.Config, err)
 	}

--- a/test/conformance/api/v1/route_test.go
+++ b/test/conformance/api/v1/route_test.go
@@ -124,7 +124,7 @@ func TestRouteCreation(t *testing.T) {
 	objects.Route = route
 
 	t.Log("The Configuration will be updated with the name of the Revision")
-	names.Revision, err = v1test.WaitForConfigLatestRevision(clients, names)
+	names.Revision, err = v1test.WaitForConfigLatestPinnedRevision(clients, names)
 	if err != nil {
 		t.Fatalf("Configuration %s was not updated with the new revision: %v", names.Config, err)
 	}
@@ -148,7 +148,7 @@ func TestRouteCreation(t *testing.T) {
 	}
 
 	t.Log("Since the Configuration was updated a new Revision will be created and the Configuration will be updated")
-	names.Revision, err = v1test.WaitForConfigLatestRevision(clients, names)
+	names.Revision, err = v1test.WaitForConfigLatestPinnedRevision(clients, names)
 	if err != nil {
 		t.Fatalf("Configuration %s was not updated with the Revision for image %s: %v", names.Config, test.PizzaPlanet2, err)
 	}

--- a/test/conformance/api/v1/route_test.go
+++ b/test/conformance/api/v1/route_test.go
@@ -69,8 +69,7 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clien
 		t.Fatalf("The Configuration %s was not updated indicating that the Revision %s was ready: %v", names.Config, names.Revision, err)
 	}
 	t.Log("Updates the Route to route traffic to the Revision")
-	err = v1test.CheckRouteState(clients.ServingClient, names.Route, v1test.AllRouteTrafficAtRevision(names))
-	if err != nil {
+	if err := v1test.WaitForRouteState(clients.ServingClient, names.Route, v1test.AllRouteTrafficAtRevision(names), "AllRouteTrafficAtRevision"); err != nil {
 		t.Fatalf("The Route %s was not updated to route traffic to the Revision %s: %v", names.Route, names.Revision, err)
 	}
 }

--- a/test/conformance/api/v1alpha1/generatename_test.go
+++ b/test/conformance/api/v1alpha1/generatename_test.go
@@ -169,7 +169,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 
 	// Ensure the associated revision is created. This also checks that the configuration becomes ready.
 	t.Log("The configuration will be updated with the name of the associated Revision once it is created.")
-	names.Revision, err = v1a1test.WaitForConfigLatestRevision(clients, names)
+	names.Revision, err = v1a1test.WaitForConfigLatestUnpinnedRevision(clients, names)
 	if err != nil {
 		t.Fatalf("Configuration %s was not updated with the new revision: %v", names.Config, err)
 	}

--- a/test/conformance/api/v1alpha1/route_test.go
+++ b/test/conformance/api/v1alpha1/route_test.go
@@ -67,8 +67,7 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clien
 		t.Fatalf("The Configuration %s was not updated indicating that the Revision %s was ready: %v", names.Config, names.Revision, err)
 	}
 	t.Log("Updates the Route to route traffic to the Revision")
-	err = v1a1test.CheckRouteState(clients.ServingAlphaClient, names.Route, v1a1test.AllRouteTrafficAtRevision(names))
-	if err != nil {
+	if err := v1a1test.WaitForRouteState(clients.ServingAlphaClient, names.Route, v1a1test.AllRouteTrafficAtRevision(names), "AllRouteTrafficAtRevision"); err != nil {
 		t.Fatalf("The Route %s was not updated to route traffic to the Revision %s: %v", names.Route, names.Revision, err)
 	}
 }

--- a/test/conformance/api/v1alpha1/route_test.go
+++ b/test/conformance/api/v1alpha1/route_test.go
@@ -121,7 +121,7 @@ func TestRouteCreation(t *testing.T) {
 	objects.Route = route
 
 	t.Log("The Configuration will be updated with the name of the Revision")
-	names.Revision, err = v1a1test.WaitForConfigLatestRevision(clients, names)
+	names.Revision, err = v1a1test.WaitForConfigLatestPinnedRevision(clients, names)
 	if err != nil {
 		t.Fatalf("Configuration %s was not updated with the new revision: %v", names.Config, err)
 	}
@@ -145,7 +145,7 @@ func TestRouteCreation(t *testing.T) {
 	}
 
 	t.Log("Since the Configuration was updated a new Revision will be created and the Configuration will be updated")
-	names.Revision, err = v1a1test.WaitForConfigLatestRevision(clients, names)
+	names.Revision, err = v1a1test.WaitForConfigLatestPinnedRevision(clients, names)
 	if err != nil {
 		t.Fatalf("Configuration %s was not updated with the Revision for image %s: %v", names.Config, test.PizzaPlanet2, err)
 	}

--- a/test/conformance/api/v1beta1/generatename_test.go
+++ b/test/conformance/api/v1beta1/generatename_test.go
@@ -167,7 +167,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 
 	// Ensure the associated revision is created. This also checks that the configuration becomes ready.
 	t.Log("The configuration will be updated with the name of the associated Revision once it is created.")
-	names.Revision, err = v1b1test.WaitForConfigLatestRevision(clients, names)
+	names.Revision, err = v1b1test.WaitForConfigLatestUnpinnedRevision(clients, names)
 	if err != nil {
 		t.Fatalf("Configuration %s was not updated with the new revision: %v", names.Config, err)
 	}

--- a/test/conformance/api/v1beta1/route_test.go
+++ b/test/conformance/api/v1beta1/route_test.go
@@ -124,7 +124,7 @@ func TestRouteCreation(t *testing.T) {
 	objects.Route = route
 
 	t.Log("The Configuration will be updated with the name of the Revision")
-	names.Revision, err = v1b1test.WaitForConfigLatestRevision(clients, names)
+	names.Revision, err = v1b1test.WaitForConfigLatestPinnedRevision(clients, names)
 	if err != nil {
 		t.Fatalf("Configuration %s was not updated with the new revision: %v", names.Config, err)
 	}
@@ -148,7 +148,7 @@ func TestRouteCreation(t *testing.T) {
 	}
 
 	t.Log("Since the Configuration was updated a new Revision will be created and the Configuration will be updated")
-	names.Revision, err = v1b1test.WaitForConfigLatestRevision(clients, names)
+	names.Revision, err = v1b1test.WaitForConfigLatestPinnedRevision(clients, names)
 	if err != nil {
 		t.Fatalf("Configuration %s was not updated with the Revision for image %s: %v", names.Config, test.PizzaPlanet2, err)
 	}

--- a/test/conformance/api/v1beta1/route_test.go
+++ b/test/conformance/api/v1beta1/route_test.go
@@ -69,8 +69,7 @@ func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clien
 		t.Fatalf("The Configuration %s was not updated indicating that the Revision %s was ready: %v", names.Config, names.Revision, err)
 	}
 	t.Log("Updates the Route to route traffic to the Revision")
-	err = v1b1test.CheckRouteState(clients.ServingBetaClient, names.Route, v1b1test.AllRouteTrafficAtRevision(names))
-	if err != nil {
+	if err := v1b1test.WaitForRouteState(clients.ServingBetaClient, names.Route, v1b1test.AllRouteTrafficAtRevision(names), "AllRouteTrafficAtRevision"); err != nil {
 		t.Fatalf("The Route %s was not updated to route traffic to the Revision %s: %v", names.Route, names.Revision, err)
 	}
 }

--- a/test/v1/configuration.go
+++ b/test/v1/configuration.go
@@ -57,19 +57,31 @@ func PatchConfig(t pkgTest.T, clients *test.Clients, svc *v1.Configuration, fopt
 	return clients.ServingClient.Configs.Patch(svc.ObjectMeta.Name, types.JSONPatchType, patchBytes, "")
 }
 
+// WaitForConfigLatestPinnedRevision enables the check for pinned revision in WaitForConfigLatestRevision.
+func WaitForConfigLatestPinnedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
+	return WaitForConfigLatestRevision(clients, names, true)
+}
+
+// WaitForConfigLatestUnpinnedRevision disables the check for pinned revision in WaitForConfigLatestRevision.
+func WaitForConfigLatestUnpinnedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
+	return WaitForConfigLatestRevision(clients, names, false)
+}
+
 // WaitForConfigLatestRevision takes a revision in through names and compares it to the current state of LatestCreatedRevisionName in Configuration.
 // Once an update is detected in the LatestCreatedRevisionName, the function waits for the created revision to be set in LatestReadyRevisionName
 // before returning the name of the revision.
-func WaitForConfigLatestRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
+// Make sure to enable ensurePinned flag if the revision has an associated Route.
+func WaitForConfigLatestRevision(clients *test.Clients, names test.ResourceNames, ensurePinned bool) (string, error) {
 	var revisionName string
 	err := WaitForConfigurationState(clients.ServingClient, names.Config, func(c *v1.Configuration) (bool, error) {
 		if c.Status.LatestCreatedRevisionName != names.Revision {
 			revisionName = c.Status.LatestCreatedRevisionName
-			// We also check that the revision is pinned, meaning it's not a stale revision.
-			// Without this it might happen that the latest created revision is later overridden by a newer one
-			// and the following check for LatestReadyRevisionName would fail.
-			if revErr := CheckRevisionState(clients.ServingClient, revisionName, IsRevisionPinned); revErr != nil {
-				return false, nil
+			if ensurePinned {
+				// Without this it might happen that the latest created revision is later overridden by a newer one
+				// that is pinned and the following check for LatestReadyRevisionName would fail.
+				if revErr := CheckRevisionState(clients.ServingClient, revisionName, IsRevisionPinned); revErr != nil {
+					return false, nil
+				}
 			}
 			return true, nil
 		}

--- a/test/v1/configuration.go
+++ b/test/v1/configuration.go
@@ -59,12 +59,12 @@ func PatchConfig(t pkgTest.T, clients *test.Clients, svc *v1.Configuration, fopt
 
 // WaitForConfigLatestPinnedRevision enables the check for pinned revision in WaitForConfigLatestRevision.
 func WaitForConfigLatestPinnedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
-	return WaitForConfigLatestRevision(clients, names, true)
+	return WaitForConfigLatestRevision(clients, names, true /*wait for pinned revision*/)
 }
 
 // WaitForConfigLatestUnpinnedRevision disables the check for pinned revision in WaitForConfigLatestRevision.
 func WaitForConfigLatestUnpinnedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
-	return WaitForConfigLatestRevision(clients, names, false)
+	return WaitForConfigLatestRevision(clients, names, false /*wait for unpinned revision*/)
 }
 
 // WaitForConfigLatestRevision takes a revision in through names and compares it to the current state of LatestCreatedRevisionName in Configuration.
@@ -79,9 +79,7 @@ func WaitForConfigLatestRevision(clients *test.Clients, names test.ResourceNames
 			if ensurePinned {
 				// Without this it might happen that the latest created revision is later overridden by a newer one
 				// that is pinned and the following check for LatestReadyRevisionName would fail.
-				if revErr := CheckRevisionState(clients.ServingClient, revisionName, IsRevisionPinned); revErr != nil {
-					return false, nil
-				}
+				return CheckRevisionState(clients.ServingClient, revisionName, IsRevisionPinned) == nil, nil
 			}
 			return true, nil
 		}

--- a/test/v1/route.go
+++ b/test/v1/route.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/ptr"
@@ -128,15 +127,7 @@ func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.Response
 func AllRouteTrafficAtRevision(names test.ResourceNames) func(r *v1.Route) (bool, error) {
 	return func(r *v1.Route) (bool, error) {
 		for _, tt := range r.Status.Traffic {
-			if tt.Percent != nil && *tt.Percent == 100 {
-				if tt.RevisionName != names.Revision {
-					return true, fmt.Errorf("expected traffic revision name to be %s but actually is %s: %s", names.Revision, tt.RevisionName, spew.Sprint(r))
-				}
-
-				if tt.Tag != names.TrafficTarget {
-					return true, fmt.Errorf("expected traffic target name to be %s but actually is %s: %s", names.TrafficTarget, tt.Tag, spew.Sprint(r))
-				}
-
+			if tt.Percent != nil && *tt.Percent == 100 && tt.RevisionName == names.Revision && tt.Tag == names.TrafficTarget {
 				return true, nil
 			}
 		}

--- a/test/v1alpha1/configuration.go
+++ b/test/v1alpha1/configuration.go
@@ -57,12 +57,12 @@ func PatchConfigImage(clients *test.Clients, cfg *v1alpha1.Configuration, imageP
 
 // WaitForConfigLatestPinnedRevision enables the check for pinned revision in WaitForConfigLatestRevision.
 func WaitForConfigLatestPinnedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
-	return WaitForConfigLatestRevision(clients, names, true)
+	return WaitForConfigLatestRevision(clients, names, true /*wait for pinned revision*/)
 }
 
 // WaitForConfigLatestUnpinnedRevision disables the check for pinned revision in WaitForConfigLatestRevision.
 func WaitForConfigLatestUnpinnedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
-	return WaitForConfigLatestRevision(clients, names, false)
+	return WaitForConfigLatestRevision(clients, names, false /*wait for unpinned revision*/)
 }
 
 // WaitForConfigLatestRevision takes a revision in through names and compares it to the current state of LatestCreatedRevisionName in Configuration.
@@ -77,9 +77,7 @@ func WaitForConfigLatestRevision(clients *test.Clients, names test.ResourceNames
 			if ensurePinned {
 				// Without this it might happen that the latest created revision is later overridden by a newer one
 				// that is pinned and the following check for LatestReadyRevisionName would fail.
-				if revErr := CheckRevisionState(clients.ServingAlphaClient, revisionName, IsRevisionPinned); revErr != nil {
-					return false, nil
-				}
+				return CheckRevisionState(clients.ServingAlphaClient, revisionName, IsRevisionPinned) == nil, nil
 			}
 			return true, nil
 		}

--- a/test/v1alpha1/configuration.go
+++ b/test/v1alpha1/configuration.go
@@ -63,18 +63,26 @@ func WaitForConfigLatestRevision(clients *test.Clients, names test.ResourceNames
 	err := WaitForConfigurationState(clients.ServingAlphaClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
 		if c.Status.LatestCreatedRevisionName != names.Revision {
 			revisionName = c.Status.LatestCreatedRevisionName
+			// We also check that the revision is pinned, meaning it's not a stale revision.
+			// Without this it might happen that the latest created revision is later overridden by a newer one
+			// and the following check for LatestReadyRevisionName would fail.
+			if revErr := CheckRevisionState(clients.ServingAlphaClient, revisionName, IsRevisionPinned); revErr != nil {
+				return false, nil
+			}
 			return true, nil
 		}
 		return false, nil
 	}, "ConfigurationUpdatedWithRevision")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("LatestCreatedRevisionName not updated: %w", err)
 	}
-	err = WaitForConfigurationState(clients.ServingAlphaClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
+	if err = WaitForConfigurationState(clients.ServingAlphaClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
 		return (c.Status.LatestReadyRevisionName == revisionName), nil
-	}, "ConfigurationReadyWithRevision")
+	}, "ConfigurationReadyWithRevision"); err != nil {
+		return "", fmt.Errorf("LatestReadyRevisionName not updated with %s: %w", revisionName, err)
+	}
 
-	return revisionName, err
+	return revisionName, nil
 }
 
 // ConfigurationSpec returns the spec of a configuration to be used throughout different

--- a/test/v1alpha1/configuration.go
+++ b/test/v1alpha1/configuration.go
@@ -55,19 +55,31 @@ func PatchConfigImage(clients *test.Clients, cfg *v1alpha1.Configuration, imageP
 	return clients.ServingAlphaClient.Configs.Patch(cfg.ObjectMeta.Name, types.JSONPatchType, patchBytes, "")
 }
 
+// WaitForConfigLatestPinnedRevision enables the check for pinned revision in WaitForConfigLatestRevision.
+func WaitForConfigLatestPinnedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
+	return WaitForConfigLatestRevision(clients, names, true)
+}
+
+// WaitForConfigLatestUnpinnedRevision disables the check for pinned revision in WaitForConfigLatestRevision.
+func WaitForConfigLatestUnpinnedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
+	return WaitForConfigLatestRevision(clients, names, false)
+}
+
 // WaitForConfigLatestRevision takes a revision in through names and compares it to the current state of LatestCreatedRevisionName in Configuration.
 // Once an update is detected in the LatestCreatedRevisionName, the function waits for the created revision to be set in LatestReadyRevisionName
 // before returning the name of the revision.
-func WaitForConfigLatestRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
+// Make sure to enable ensurePinned flag if the revision has an associated Route.
+func WaitForConfigLatestRevision(clients *test.Clients, names test.ResourceNames, ensurePinned bool) (string, error) {
 	var revisionName string
 	err := WaitForConfigurationState(clients.ServingAlphaClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
 		if c.Status.LatestCreatedRevisionName != names.Revision {
 			revisionName = c.Status.LatestCreatedRevisionName
-			// We also check that the revision is pinned, meaning it's not a stale revision.
-			// Without this it might happen that the latest created revision is later overridden by a newer one
-			// and the following check for LatestReadyRevisionName would fail.
-			if revErr := CheckRevisionState(clients.ServingAlphaClient, revisionName, IsRevisionPinned); revErr != nil {
-				return false, nil
+			if ensurePinned {
+				// Without this it might happen that the latest created revision is later overridden by a newer one
+				// that is pinned and the following check for LatestReadyRevisionName would fail.
+				if revErr := CheckRevisionState(clients.ServingAlphaClient, revisionName, IsRevisionPinned); revErr != nil {
+					return false, nil
+				}
 			}
 			return true, nil
 		}

--- a/test/v1alpha1/route.go
+++ b/test/v1alpha1/route.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/ptr"
@@ -116,15 +115,7 @@ func IsRouteNotReady(r *v1alpha1.Route) (bool, error) {
 func AllRouteTrafficAtRevision(names test.ResourceNames) func(r *v1alpha1.Route) (bool, error) {
 	return func(r *v1alpha1.Route) (bool, error) {
 		for _, tt := range r.Status.Traffic {
-			if tt.Percent != nil && *tt.Percent == 100 {
-				if tt.RevisionName != names.Revision {
-					return true, fmt.Errorf("expected traffic revision name to be %s but actually is %s: %s", names.Revision, tt.RevisionName, spew.Sprint(r))
-				}
-
-				if tt.Tag != names.TrafficTarget {
-					return true, fmt.Errorf("expected traffic target name to be %s but actually is %s: %s", names.TrafficTarget, tt.Tag, spew.Sprint(r))
-				}
-
+			if tt.Percent != nil && *tt.Percent == 100 && tt.RevisionName == names.Revision && tt.Tag == names.TrafficTarget {
 				return true, nil
 			}
 		}

--- a/test/v1beta1/configuration.go
+++ b/test/v1beta1/configuration.go
@@ -60,12 +60,12 @@ func PatchConfig(t pkgTest.T, clients *test.Clients, svc *v1beta1.Configuration,
 
 // WaitForConfigLatestPinnedRevision enables the check for pinned revision in WaitForConfigLatestRevision.
 func WaitForConfigLatestPinnedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
-	return WaitForConfigLatestRevision(clients, names, true)
+	return WaitForConfigLatestRevision(clients, names, true /*wait for pinned revision*/)
 }
 
 // WaitForConfigLatestUnpinnedRevision disables the check for pinned revision in WaitForConfigLatestRevision.
 func WaitForConfigLatestUnpinnedRevision(clients *test.Clients, names test.ResourceNames) (string, error) {
-	return WaitForConfigLatestRevision(clients, names, false)
+	return WaitForConfigLatestRevision(clients, names, false /*wait for unpinned revision*/)
 }
 
 // WaitForConfigLatestRevision takes a revision in through names and compares it to the current state of LatestCreatedRevisionName in Configuration.
@@ -80,9 +80,7 @@ func WaitForConfigLatestRevision(clients *test.Clients, names test.ResourceNames
 			if ensurePinned {
 				// Without this it might happen that the latest created revision is later overridden by a newer one
 				// that is pinned and the following check for LatestReadyRevisionName would fail.
-				if revErr := CheckRevisionState(clients.ServingBetaClient, revisionName, IsRevisionPinned); revErr != nil {
-					return false, nil
-				}
+				return CheckRevisionState(clients.ServingBetaClient, revisionName, IsRevisionPinned) == nil, nil
 			}
 			return true, nil
 		}

--- a/test/v1beta1/configuration.go
+++ b/test/v1beta1/configuration.go
@@ -66,18 +66,26 @@ func WaitForConfigLatestRevision(clients *test.Clients, names test.ResourceNames
 	err := WaitForConfigurationState(clients.ServingBetaClient, names.Config, func(c *v1beta1.Configuration) (bool, error) {
 		if c.Status.LatestCreatedRevisionName != names.Revision {
 			revisionName = c.Status.LatestCreatedRevisionName
+			// We also check that the revision is pinned, meaning it's not a stale revision.
+			// Without this it might happen that the latest created revision is later overridden by a newer one
+			// and the following check for LatestReadyRevisionName would fail.
+			if revErr := CheckRevisionState(clients.ServingBetaClient, revisionName, IsRevisionPinned); revErr != nil {
+				return false, nil
+			}
 			return true, nil
 		}
 		return false, nil
 	}, "ConfigurationUpdatedWithRevision")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("LatestCreatedRevisionName not updated: %w", err)
 	}
-	err = WaitForConfigurationState(clients.ServingBetaClient, names.Config, func(c *v1beta1.Configuration) (bool, error) {
+	if err = WaitForConfigurationState(clients.ServingBetaClient, names.Config, func(c *v1beta1.Configuration) (bool, error) {
 		return (c.Status.LatestReadyRevisionName == revisionName), nil
-	}, "ConfigurationReadyWithRevision")
+	}, "ConfigurationReadyWithRevision"); err != nil {
+		return "", fmt.Errorf("LatestReadyRevisionName not updated with %s: %w", revisionName, err)
+	}
 
-	return revisionName, err
+	return revisionName, nil
 }
 
 // ConfigurationSpec returns the spec of a configuration to be used throughout different

--- a/test/v1beta1/route.go
+++ b/test/v1beta1/route.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -130,15 +128,7 @@ func RetryingRouteInconsistency(innerCheck spoof.ResponseChecker) spoof.Response
 func AllRouteTrafficAtRevision(names test.ResourceNames) func(r *v1beta1.Route) (bool, error) {
 	return func(r *v1beta1.Route) (bool, error) {
 		for _, tt := range r.Status.Traffic {
-			if tt.Percent != nil && *tt.Percent == 100 {
-				if tt.RevisionName != names.Revision {
-					return true, fmt.Errorf("expected traffic revision name to be %s but actually is %s: %s", names.Revision, tt.RevisionName, spew.Sprint(r))
-				}
-
-				if tt.Tag != names.TrafficTarget {
-					return true, fmt.Errorf("expected traffic target name to be %s but actually is %s: %s", names.TrafficTarget, tt.Tag, spew.Sprint(r))
-				}
-
+			if tt.Percent != nil && *tt.Percent == 100 && tt.RevisionName == names.Revision && tt.Tag == names.TrafficTarget {
 				return true, nil
 			}
 		}


### PR DESCRIPTION
* This should make TestRouteCreate test more stable
* Similar to what was done in the commit "More robust
WaitForServiceLatestRevision function for rolling upgrades"

The test error looks like this:
```
route_test.go:126: Configuration route-creation-jzxjlpgr was not updated with the new revision: configuration "route-creation-jzxjlpgr" is not in desired state, got: &{TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:route-creation-jzxjlpgr GenerateName: Namespace:serving-tests SelfLink:/apis/serving.knative.dev/v1alpha1/namespaces/serving-tests/configurations/route-creation-jzxjlpgr UID:50e0e908-3909-49eb-bf9d-ab41501124a7 ResourceVersion:36246 Generation:1 CreationTimestamp:2020-02-13 10:30:28 -0500 EST DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[serving.knative.dev/route:route-creation-jzxjlpgr] Annotations:map[serving.knative.dev/creator:kube:admin serving.knative.dev/lastModifier:kube:admin] OwnerReferences:[] Initializers:nil Finalizers:[] ClusterName: ManagedFields:[]} Spec:{DeprecatedGeneration:0 DeprecatedBuild:nil DeprecatedRevisionTemplate:<nil> Template:&ObjectMeta{Name:,GenerateName:,Namespace:,SelfLink:,UID:,ResourceVersion:,Generation:0,CreationTimestamp:0001-01-01 00:00:00 +0000 UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{},Annotations:map[string]string{},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,ManagedFields:[],}} Status:{Status:{ObservedGeneration:1 Conditions:[{Type:Ready Status:True Severity: LastTransitionTime:{Inner:2020-02-13 10:30:52 -0500 EST} Reason: Message:}]} ConfigurationStatusFields:{LatestReadyRevisionName:route-creation-jzxjlpgr-hsrrq LatestCreatedRevisionName:route-creation-jzxjlpgr-hsrrq}}}: timed out waiting for the condition
```

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Also Fixes https://github.com/knative/serving/issues/6752


<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
