### PR TITLE
Set INGRESS_CLASS to istio if it's not set

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -309,6 +309,9 @@ function install_knative_serving_standard() {
     install_contour || return 1
   else
     install_istio "${SERVING_ISTIO_YAML}" || return 1
+    if [[ -z "${INGRESS_CLASS}" ]]; then
+      readonly INGRESS_CLASS="istio.ingress.networking.knative.dev"
+    fi
   fi
 
   echo ">> Installing Cert-Manager"


### PR DESCRIPTION
Fixes #6942

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
Set INGRESS_CLASS to istio if it's not set.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
