### PR TITLE
Clean up configmap lister in revision

### DIFF
--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -87,7 +87,6 @@ func newControllerWithOptions(
 		imageLister:         imageInformer.Lister(),
 		deploymentLister:    deploymentInformer.Lister(),
 		serviceLister:       serviceInformer.Lister(),
-		configMapLister:     configMapInformer.Lister(),
 		resolver: &digestResolver{
 			client:    kubeclient.Get(ctx),
 			transport: transport,

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -55,7 +55,6 @@ type Reconciler struct {
 	imageLister         cachinglisters.ImageLister
 	deploymentLister    appsv1listers.DeploymentLister
 	serviceLister       corev1listers.ServiceLister
-	configMapLister     corev1listers.ConfigMapLister
 
 	resolver resolver
 }

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -559,7 +559,6 @@ func TestReconcile(t *testing.T) {
 			imageLister:         listers.GetImageLister(),
 			deploymentLister:    listers.GetDeploymentLister(),
 			serviceLister:       listers.GetK8sServiceLister(),
-			configMapLister:     listers.GetConfigMapLister(),
 			resolver:            &nopResolver{},
 		}
 


### PR DESCRIPTION

/lint

## Proposed Changes

* After generate reconcilers config map lister is not used .

/assign @mattmoor 

