### PR TITLE
Update Serving WG leads in OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,16 +14,16 @@ aliases:
   - tcnghia
   - vagababov
 
-  # WG leads + TOC.
+  # TOC + WG leads
   serving-wg-leads:
-  - dgerd
-  - evankanderson
-  - markusthoemmes
-  - mattmoor
-  - tcnghia
-  - vagababov
-  - vaikas
-
+  - evankanderson  # TOC
+  - mattmoor       # TOC/Serving
+  - vaikas         # TOC
+  - dprotaso       # Serving
+  - markusthoemmes # Scaling
+  - mdemirhan      # Networking
+  - tcnghia        # Networking
+  - vagababov      # Scaling
 
   autoscaling-approvers:
   - markusthoemmes
@@ -35,8 +35,10 @@ aliases:
   - yanweiguo
 
   monitoring-approvers:
+  - mdemirhan
   - yanweiguo
   monitoring-reviewers:
+  - mdemirhan
   - yanweiguo
 
   productivity-approvers:

--- a/pkg/apis/OWNERS
+++ b/pkg/apis/OWNERS
@@ -7,7 +7,7 @@ approvers:
 - vaikas-google
 - vaikas
 # Serving WG Leads
-- dgerd
+- dprotaso
 
 labels:
 - area/API


### PR DESCRIPTION
This should reflect the current state of the WG leads in knative/community.