### PR TITLE
Clarify the usage of the map vs constant 1

### DIFF
--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -78,6 +78,32 @@ func TestStats(t *testing.T) {
 				PodName:                   "activator",
 			}},
 		}}, {
+		// NB: this test should start failing when #6991 is fixed
+		// and must be updated.
+		name: "in'n out",
+		ops: []reqOp{{
+			op:  requestOpStart,
+			key: rev1,
+		}, {
+			op:  requestOpEnd,
+			key: rev1,
+		}, {
+			op:  requestOpStart,
+			key: rev1,
+		}, {
+			op:  requestOpEnd,
+			key: rev1,
+		}, {
+			op: requestOpTick, // This won't result in reporting anything at all.
+		}},
+		expectedStats: []metrics.StatMessage{{
+			Key: rev1,
+			Stat: metrics.Stat{
+				AverageConcurrentRequests: 1,
+				RequestCount:              1,
+				PodName:                   "activator",
+			}},
+		}}, {
 		name: "Scale to two",
 		ops: []reqOp{{
 			op:  requestOpStart,


### PR DESCRIPTION
Performed the analysis and documented, why 1 is a valid choice in the reporting,
which is better than previous misleading notion of map[key] value, which indicated
that a different from  value is possible.
As currently code is written it is impossible.
In the process I found another bug and documented it with a unit test that will start
failing when the #6991 is fixed.

Fixes #6988 
/assign mattmoor @markusthoemmes 
