### PR TITLE
Adopt the new `// +genreconciler:class` style for ingress reconciler

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -25,7 +25,7 @@ import (
 )
 
 // +genclient
-// +genreconciler
+// +genreconciler:class=networking.knative.dev/ingress.class
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Ingress is a collection of rules that allow inbound connections to reach the endpoints defined

--- a/pkg/client/injection/reconciler/networking/v1alpha1/ingress/controller.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/ingress/controller.go
@@ -38,13 +38,14 @@ const (
 	defaultControllerAgentName = "ingress-controller"
 	defaultFinalizerName       = "ingresses.networking.internal.knative.dev"
 	defaultQueueName           = "ingresses"
+	classAnnotationKey         = "networking.knative.dev/ingress.class"
 )
 
 // NewImpl returns a controller.Impl that handles queuing and feeding work from
 // the queue through an implementation of controller.Reconciler, delegating to
 // the provided Interface and optional Finalizer methods. OptionsFn is used to return
 // controller.Options to be used but the internal reconciler.
-func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsFn) *controller.Impl {
+func NewImpl(ctx context.Context, r Interface, classValue string, optionsFns ...controller.OptionsFn) *controller.Impl {
 	logger := logging.FromContext(ctx)
 
 	// Check the options function input. It should be 0 or 1.
@@ -78,6 +79,7 @@ func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsF
 		Lister:     ingressInformer.Lister(),
 		Recorder:   recorder,
 		reconciler: r,
+		classValue: classValue,
 	}
 	impl := controller.NewImpl(rec, logger, defaultQueueName)
 

--- a/pkg/client/injection/reconciler/networking/v1alpha1/ingress/reconciler.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/ingress/reconciler.go
@@ -81,12 +81,15 @@ type reconcilerImpl struct {
 
 	// reconciler is the implementation of the business logic of the resource.
 	reconciler Interface
+
+	// classValue is the resource annotation[networking.knative.dev/ingress.class] instance value this reconciler instance filters on.
+	classValue string
 }
 
 // Check that our Reconciler implements controller.Reconciler
 var _ controller.Reconciler = (*reconcilerImpl)(nil)
 
-func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister networkingv1alpha1.IngressLister, recorder record.EventRecorder, r Interface, options ...controller.Options) controller.Reconciler {
+func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister networkingv1alpha1.IngressLister, recorder record.EventRecorder, r Interface, classValue string, options ...controller.Options) controller.Reconciler {
 	// Check the options function input. It should be 0 or 1.
 	if len(options) > 1 {
 		logger.Fatalf("up to one options struct is supported, found %d", len(options))
@@ -97,6 +100,7 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versio
 		Lister:     lister,
 		Recorder:   recorder,
 		reconciler: r,
+		classValue: classValue,
 	}
 
 	for _, opts := range options {
@@ -135,6 +139,13 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		return nil
 	} else if err != nil {
 		return err
+	}
+
+	if classValue, found := original.GetAnnotations()[classAnnotationKey]; !found || classValue != r.classValue {
+		logger.Debugw("Skip reconciling resource, class annotation value does not match reconciler instance value.",
+			zap.String("classKey", classAnnotationKey),
+			zap.String("issue", classValue+"!="+r.classValue))
+		return nil
 	}
 
 	// Don't modify the informers copy.

--- a/pkg/client/injection/reconciler/networking/v1alpha1/ingress/stub/controller.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/ingress/stub/controller.go
@@ -40,9 +40,10 @@ func NewController(
 	ingressInformer := ingress.Get(ctx)
 
 	// TODO: setup additional informers here.
+	// TODO: pass in the expected value for the class annotation filter.
 
 	r := &Reconciler{}
-	impl := v1alpha1ingress.NewImpl(ctx, r)
+	impl := v1alpha1ingress.NewImpl(ctx, r, "default")
 
 	logger.Info("Setting up event handlers.")
 

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -80,7 +80,7 @@ func newControllerWithOptions(
 	}
 	myFilterFunc := reconciler.AnnotationFilterFunc(networking.IngressClassAnnotationKey, network.IstioIngressClassName, true)
 
-	impl := ingressreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
+	impl := ingressreconciler.NewImpl(ctx, c, network.IstioIngressClassName, func(impl *controller.Impl) controller.Options {
 		logger.Info("Setting up ConfigMap receivers")
 		configsToResync := []interface{}{
 			&config.Istio{},

--- a/pkg/reconciler/ingress/ingress_test.go
+++ b/pkg/reconciler/ingress/ingress_test.go
@@ -473,113 +473,6 @@ func TestReconcile(t *testing.T) {
 			patchAddFinalizerAction("reconcile-virtualservice", "ingresses.networking.internal.knative.dev"),
 		},
 		Key: "test-ns/reconcile-virtualservice",
-	}, {
-		Name: "clean up VirtualServices when ingress class annotation is not istio",
-		Objects: []runtime.Object{
-			gateway("knative-ingress-gateway", system.Namespace(), []*istiov1alpha3.Server{irrelevantServer1}),
-			gateway("knative-test-gateway", system.Namespace(), []*istiov1alpha3.Server{irrelevantServer1}),
-			&v1alpha1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "reconcile-virtualservice",
-					Namespace: testNS,
-					Labels: map[string]string{
-						serving.RouteLabelKey:          "test-route",
-						serving.RouteNamespaceLabelKey: testNS,
-					},
-					Annotations:     map[string]string{networking.IngressClassAnnotationKey: "some-other-ingress"},
-					ResourceVersion: "v1",
-					Finalizers:      []string{"ingresses.networking.internal.knative.dev"},
-				},
-				Spec: v1alpha1.IngressSpec{
-					DeprecatedGeneration: 1234,
-					Rules:                ingressRules,
-					// Deprecated, needed because of DeepCopy behavior
-					Visibility: v1alpha1.IngressVisibilityExternalIP,
-				},
-			},
-
-			&v1alpha3.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "reconcile-virtualservice",
-					Namespace: testNS,
-					Labels: map[string]string{
-						networking.IngressLabelKey: "reconcile-virtualservice",
-					},
-					Annotations:     map[string]string{networking.IngressClassAnnotationKey: network.IstioIngressClassName},
-					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconcile-virtualservice", 1234))},
-				},
-				Spec: istiov1alpha3.VirtualService{},
-			},
-			&v1alpha3.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "reconcile-virtualservice-extra",
-					Namespace: testNS,
-					Labels: map[string]string{
-						networking.IngressLabelKey: "reconcile-virtualservice",
-					},
-					Annotations:     map[string]string{networking.IngressClassAnnotationKey: network.IstioIngressClassName},
-					OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ing("reconcile-virtualservice", 1234))},
-				},
-				Spec: istiov1alpha3.VirtualService{},
-			},
-		},
-		WantDeletes: []clientgotesting.DeleteActionImpl{
-			{
-				ActionImpl: clientgotesting.ActionImpl{
-					Namespace: testNS,
-					Verb:      "delete",
-				},
-				Name: "reconcile-virtualservice",
-			},
-			{
-				ActionImpl: clientgotesting.ActionImpl{
-					Namespace: testNS,
-					Verb:      "delete",
-				},
-				Name: "reconcile-virtualservice-extra",
-			},
-		},
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: addAnnotations(ingressWithFinalizersAndStatus("reconcile-virtualservice", 1234,
-				[]string{"ingresses.networking.internal.knative.dev"},
-				v1alpha1.IngressStatus{
-					LoadBalancer: &v1alpha1.LoadBalancerStatus{
-						Ingress: []v1alpha1.LoadBalancerIngressStatus{
-							{DomainInternal: pkgnet.GetServiceHostname("test-ingressgateway", "istio-system")},
-						},
-					},
-					PublicLoadBalancer: &v1alpha1.LoadBalancerStatus{
-						Ingress: []v1alpha1.LoadBalancerIngressStatus{
-							{DomainInternal: pkgnet.GetServiceHostname("test-ingressgateway", "istio-system")},
-						},
-					},
-					PrivateLoadBalancer: &v1alpha1.LoadBalancerStatus{
-						Ingress: []v1alpha1.LoadBalancerIngressStatus{
-							{MeshOnly: true},
-						},
-					},
-					Status: duckv1.Status{
-						Conditions: duckv1.Conditions{{
-							Type:     v1alpha1.IngressConditionLoadBalancerReady,
-							Status:   corev1.ConditionTrue,
-							Severity: apis.ConditionSeverityError,
-						}, {
-							Type:     v1alpha1.IngressConditionNetworkConfigured,
-							Status:   corev1.ConditionTrue,
-							Severity: apis.ConditionSeverityError,
-						}, {
-							Type:     v1alpha1.IngressConditionReady,
-							Status:   corev1.ConditionTrue,
-							Severity: apis.ConditionSeverityError,
-						}},
-					},
-				},
-			), map[string]string{networking.IngressClassAnnotationKey: "some-other-ingress"}),
-		}},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "IngressTypeReconciled", `IngressType reconciled: "test-ns/reconcile-virtualservice"`),
-		},
-		Key: "test-ns/reconcile-virtualservice",
 	}}
 
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
@@ -598,7 +491,8 @@ func TestReconcile(t *testing.T) {
 		}
 
 		return ingressreconciler.NewReconciler(ctx, logging.FromContext(ctx), servingclient.Get(ctx),
-			listers.GetIngressLister(), controller.GetEventRecorder(ctx), r, controller.Options{
+			listers.GetIngressLister(), controller.GetEventRecorder(ctx), r, network.IstioIngressClassName,
+			controller.Options{
 				ConfigStore: &testConfigStore{
 					config: ReconcilerTestConfig(),
 				}})
@@ -1011,7 +905,8 @@ func TestReconcile_EnableAutoTLS(t *testing.T) {
 		}
 
 		return ingressreconciler.NewReconciler(ctx, logging.FromContext(ctx), servingclient.Get(ctx),
-			listers.GetIngressLister(), controller.GetEventRecorder(ctx), r, controller.Options{
+			listers.GetIngressLister(), controller.GetEventRecorder(ctx), r, network.IstioIngressClassName,
+			controller.Options{
 				ConfigStore: &testConfigStore{
 					// Enable reconciling gateway.
 					config: &config.Config{


### PR DESCRIPTION
Signed-off-by: Andrew Su <asu@pivotal.io>
cc @andrew-su 

/lint

Fixes https://github.com/knative/serving/issues/6970

## Proposed Changes

* Ingress reconciler uses generate reconciler.

/assign @mattmoor 
