### PR TITLE
Preparing for v0.13 release, point pkg to release-0.13.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1809,7 +1809,7 @@
   revision = "926e84e7b96b27a339e76f321bedd156104000e5"
 
 [[projects]]
-  branch = "master"
+  branch = "release-0.13"
   digest = "1:efd99f16d7b5337b1cce9ac8576e2f65c2c2f7b759f64cd235b82f42e0f86f09"
   name = "knative.dev/pkg"
   packages = [

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,7 +30,7 @@ required = [
 
 [[override]]
   name = "knative.dev/pkg"
-  branch = "master"
+  branch = "release-0.13"
 
 [[constraint]]
   name = "knative.dev/caching"


### PR DESCRIPTION
<!---->
<!--Preparing for v0.13 release, point pkg to release-0.13.-->
## Proposed Changes

- Prepping for `v0.13` release.
- Point `knative.dev/pkg` to branch `release-0.13`.

**Release Note**

```release-note
NONE
```

/cc @mattmoor
