### PR TITLE
Avoid unnecessarily sending empty messages from concurrency reporter.

### DIFF
--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -151,7 +151,9 @@ func (cr *ConcurrencyReporter) run(stopCh <-chan struct{}, reportCh <-chan time.
 				}
 				cr.reportToMetricsBackend(key, concurrency)
 			}
-			cr.statCh <- messages
+			if len(messages) > 0 {
+				cr.statCh <- messages
+			}
 
 			incomingRequestsPerKey = make(map[types.NamespacedName]float64)
 			reportedFirstRequest = make(map[types.NamespacedName]int64)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #7008

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

The failing test intermittently got a stray message which was just an empty array. We probably shouldn't send empty arrays anyway so this gets rid of that.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
