### PR TITLE
Update DEVELOPMENT.md to point to v1 types

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -253,7 +253,7 @@ of:
   [`./hack/update-codegen.sh`](./hack/update-codegen.sh). Inputs include:
 
   - API type definitions in
-    [pkg/apis/serving/v1alpha1/](./pkg/apis/serving/v1alpha1/.),
+    [pkg/apis/serving/v1/](./pkg/apis/serving/v1/.),
   - Types definitions annotated with `// +k8s:deepcopy-gen=true`.
 
 - **If you change a package's deps** (including adding external dep), then you


### PR DESCRIPTION
Point to v1 types

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/6035

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Point documentation to v1 types

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Switch Controllers to use v1 API types
```
