### PR TITLE
Add imagecache CRD to core config

### DIFF
--- a/config/core/300-imagecache.yaml
+++ b/config/core/300-imagecache.yaml
@@ -1,0 +1,35 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: images.caching.internal.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
+spec:
+  group: caching.internal.knative.dev
+  version: v1alpha1
+  names:
+    kind: Image
+    plural: images
+    singular: image
+    categories:
+    - knative-internal
+    - caching
+    shortNames:
+    - img
+  scope: Namespaced
+  subresources:
+    status: {}


### PR DESCRIPTION
**Issue:** 
applying `ko apply -f config/core` failed to create CRD for `caching.internal.knative.dev` which intern leads to issue in controller pod
```
Failed to list *v1alpha1.Image: the server could not find the requested resource (get images.caching.internal.knative.dev)
```
and also leads to knative service creation failure
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add CRD for imagecache to config/core

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
