### PR TITLE
Use default install flow for smoke tests

### DIFF
--- a/test/e2e-smoke-tests.sh
+++ b/test/e2e-smoke-tests.sh
@@ -28,15 +28,12 @@
 source $(dirname $0)/e2e-common.sh
 
 function knative_setup() {
-  # Build serving, create $SERVING_YAML
-  build_knative_from_source
-  start_knative_serving "${SERVING_YAML}"
-  start_knative_monitoring "${MONITORING_YAML}"
+  install_knative_serving
 }
 
 # Script entry point.
 
-initialize $@
+initialize $@ --install-monitoring
 
 # Ensure Knative Serving can be uninstalled/reinstalled cleanly
 subheader "Uninstalling Knative Serving"


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes continuous runs

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* There's logic to wait for cert-manager to be running that's common in all the test setup. This unblocks the failing smoke test by installing cert-manager

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
