### PR TITLE
Remove unused code in ingress reconciler

### DIFF
--- a/pkg/reconciler/ingress/ingress.go
+++ b/pkg/reconciler/ingress/ingress.go
@@ -32,7 +32,6 @@ import (
 
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
-	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/network/status"
 	"knative.dev/serving/pkg/reconciler/ingress/config"
 	"knative.dev/serving/pkg/reconciler/ingress/resources"
@@ -211,11 +210,6 @@ func (r *Reconciler) reconcileVirtualServices(ctx context.Context, ing *v1alpha1
 	// First, create all needed VirtualServices.
 	kept := sets.NewString()
 	for _, d := range desired {
-		if d.GetAnnotations()[networking.IngressClassAnnotationKey] != network.IstioIngressClassName {
-			// We do not create resources that do not have istio ingress class annotation.
-			// As a result, obsoleted resources will be cleaned up.
-			continue
-		}
 		if _, err := istioaccessor.ReconcileVirtualService(ctx, ing, d, r); err != nil {
 			if kaccessor.IsNotOwned(err) {
 				ing.Status.MarkResourceNotOwned("VirtualService", d.Name)


### PR DESCRIPTION
/lint

Why: Ingress reconciler wont pick up non-istio class name objects anymore. This code path wont be used.

/assign @tcnghia 