### PR TITLE
Demote ForEachBucket to a helper test method.

### DIFF
--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -144,8 +144,7 @@ func (t *TimedFloat64Buckets) Record(now time.Time, value float64) {
 			// Thus we need to clean not only the current index, but also
 			// all the ones from the last write. This is slower than the loop above
 			// due to possible wrap-around, so they are not merged together.
-			oldIdx := t.timeToIndex(t.lastWrite)
-			for i := oldIdx + 1; i <= writeIdx; i++ {
+			for i := t.timeToIndex(t.lastWrite) + 1; i <= writeIdx; i++ {
 				idx := i % len(t.buckets)
 				t.windowTotal -= t.buckets[idx]
 				t.buckets[idx] = 0
@@ -156,34 +155,6 @@ func (t *TimedFloat64Buckets) Record(now time.Time, value float64) {
 	}
 	t.buckets[writeIdx%len(t.buckets)] += value
 	t.windowTotal += value
-}
-
-// ForEachBucket calls the given Accumulator function for each bucket.
-// Returns true if any data was recorded.
-func (t *TimedFloat64Buckets) ForEachBucket(now time.Time, accs ...func(time time.Time, bucket float64)) bool {
-	now = now.Truncate(t.granularity)
-	t.bucketsMutex.RLock()
-	defer t.bucketsMutex.RUnlock()
-
-	if now.Sub(t.lastWrite) >= t.window {
-		return false
-	}
-
-	// So number of buckets we can process is len(buckets)-(now-lastWrite)/granularity.
-	// Since empty check above failed, we know this is at least 1 bucket.
-	numBuckets := len(t.buckets) - int(now.Sub(t.lastWrite)/t.granularity)
-	bucketTime := t.lastWrite // Always aligned with granularity.
-	si := t.timeToIndex(bucketTime)
-	for i := 0; i < numBuckets; i++ {
-		tIdx := si % len(t.buckets)
-		for _, acc := range accs {
-			acc(bucketTime, t.buckets[tIdx])
-		}
-		si--
-		bucketTime = bucketTime.Add(-t.granularity)
-	}
-
-	return true
 }
 
 func min(a, b int) int {

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -88,7 +88,7 @@ func TestTimedFloat64BucketsSimple(t *testing.T) {
 
 			got := make(map[time.Time]float64)
 			// Less time in future than our window is (2mins above), but more than any of the tests report.
-			buckets.ForEachBucket(trunc1.Add(time.Minute), func(t time.Time, b float64) {
+			buckets.forEachBucket(trunc1.Add(time.Minute), func(t time.Time, b float64) {
 				// Since we're storing 0s when there's no data, we need to exclude those
 				// for this test.
 				if b > 0 {
@@ -120,10 +120,10 @@ func TestTimedFloat64BucketsManyReps(t *testing.T) {
 	//                  = 100
 	const want = 100.
 	sum1, sum2 := 0., 0.
-	buckets.ForEachBucket(trunc1, func(_ time.Time, b float64) {
+	buckets.forEachBucket(trunc1, func(_ time.Time, b float64) {
 		sum1 += b
 	})
-	buckets.ForEachBucket(trunc1, func(_ time.Time, b float64) {
+	buckets.forEachBucket(trunc1, func(_ time.Time, b float64) {
 		sum2 += b
 	})
 	if got, want := sum1, want; got != want {
@@ -190,13 +190,11 @@ func TestTimedFloat64BucketsHoles(t *testing.T) {
 
 	sum := 0.
 
-	if !buckets.ForEachBucket(now.Add(4*time.Second),
+	buckets.forEachBucket(now.Add(4*time.Second),
 		func(_ time.Time, b float64) {
 			sum += b
-		},
-	) {
-		t.Fatal("ForEachBucket unexpectedly returned empty result")
-	}
+		})
+
 	if got, want := sum, 15.; got != want {
 		t.Errorf("Sum = %v, want: %v", got, want)
 	}
@@ -209,49 +207,12 @@ func TestTimedFloat64BucketsHoles(t *testing.T) {
 	// So now we have [3] = 2, [4] = 5 and sum should be 7.
 	sum = 0.
 
-	if !buckets.ForEachBucket(now.Add(8*time.Second),
+	buckets.forEachBucket(now.Add(8*time.Second),
 		func(_ time.Time, b float64) {
 			sum += b
-		},
-	) {
-		t.Fatal("ForEachBucket unexpectedly returned empty result")
-	}
+		})
 	if got, want := sum, 7.; got != want {
 		t.Errorf("Sum = %v, want: %v", got, want)
-	}
-}
-
-func TestTimedFloat64BucketsForEachBucket(t *testing.T) {
-	now := time.Now()
-	buckets := NewTimedFloat64Buckets(2*time.Minute, granularity)
-
-	// Since we recorded 0 data, even in this implementation no iteration must occur.
-	if buckets.ForEachBucket(now, func(time time.Time, bucket float64) {}) {
-		t.Fatalf("ForEachBucket unexpectedly returned non-empty result")
-	}
-
-	buckets.Record(now, 10.0)
-	buckets.Record(now.Add(1*time.Second), 10.0)
-	buckets.Record(now.Add(2*time.Second), 5.0)
-	buckets.Record(now.Add(3*time.Second), 5.0)
-
-	acc1 := 0
-	acc2 := 0
-
-	if !buckets.ForEachBucket(now.Add(4*time.Second),
-		func(_ time.Time, b float64) {
-			// We need to exclude the 0s for this test.
-			if b > 0 {
-				acc1++
-			}
-		},
-		func(_ time.Time, b float64) {
-			if b > 0 {
-				acc2++
-			}
-		},
-	) {
-		t.Fatal("ForEachBucket unexpectedly returned empty result")
 	}
 }
 
@@ -269,7 +230,7 @@ func TestTimedFloat64BucketsWindowUpdate(t *testing.T) {
 	now := startTime.Add(5 * time.Second)
 
 	sum := 0.
-	buckets.ForEachBucket(now, func(t time.Time, b float64) {
+	buckets.forEachBucket(now, func(t time.Time, b float64) {
 		sum += b
 	})
 	const wantInitial = 2. + 3 + 4 + 5 + 6
@@ -291,7 +252,7 @@ func TestTimedFloat64BucketsWindowUpdate(t *testing.T) {
 
 	// Verify values were properly copied.
 	sum = 0.
-	buckets.ForEachBucket(now, func(t time.Time, b float64) {
+	buckets.forEachBucket(now, func(t time.Time, b float64) {
 		sum += b
 	})
 	if got, want := sum, wantInitial; got != want {
@@ -307,7 +268,7 @@ func TestTimedFloat64BucketsWindowUpdate(t *testing.T) {
 	buckets.Record(now, 7)
 	const wantWithUpdate = wantInitial + 7
 	sum = 0.
-	buckets.ForEachBucket(now, func(t time.Time, b float64) {
+	buckets.forEachBucket(now, func(t time.Time, b float64) {
 		sum += b
 	})
 	if got, want := sum, wantWithUpdate; got != want {
@@ -326,7 +287,7 @@ func TestTimedFloat64BucketsWindowUpdate(t *testing.T) {
 	// Just last 4 buckets should have remained (so 2 oldest are expunged).
 	const wantWithShrink = wantWithUpdate - 2 - 3
 	sum = 0.
-	buckets.ForEachBucket(now, func(t time.Time, b float64) {
+	buckets.forEachBucket(now, func(t time.Time, b float64) {
 		sum += b
 	})
 	if got, want := sum, wantWithShrink; got != want {
@@ -363,7 +324,7 @@ func TestTimedFloat64BucketsWindowUpdate3sGranularity(t *testing.T) {
 	buckets.Record(trunc1.Add(5*time.Second), 6)
 	buckets.Record(trunc1.Add(6*time.Second), 7) // This overrides the initial 15 (10+2+3)
 	sum := 0.
-	buckets.ForEachBucket(trunc1.Add(6*time.Second), func(t time.Time, b float64) {
+	buckets.forEachBucket(trunc1.Add(6*time.Second), func(t time.Time, b float64) {
 		sum += b
 	})
 	want := (4. + 5 + 6) + 7
@@ -382,7 +343,7 @@ func TestTimedFloat64BucketsWindowUpdate3sGranularity(t *testing.T) {
 
 	// Verify values were properly copied.
 	sum = 0
-	buckets.ForEachBucket(trunc1.Add(6*time.Second), func(t time.Time, b float64) {
+	buckets.forEachBucket(trunc1.Add(6*time.Second), func(t time.Time, b float64) {
 		sum += b
 	})
 	if got, want := sum, want; got != want {
@@ -392,7 +353,7 @@ func TestTimedFloat64BucketsWindowUpdate3sGranularity(t *testing.T) {
 	// Add one more. Make sure all the data is preserved, since window is longer.
 	buckets.Record(trunc1.Add(9*time.Second+300*time.Millisecond), 42)
 	sum = 0
-	buckets.ForEachBucket(trunc1.Add(9*time.Second), func(t time.Time, b float64) {
+	buckets.forEachBucket(trunc1.Add(9*time.Second), func(t time.Time, b float64) {
 		sum += b
 	})
 	want += 42
@@ -411,7 +372,7 @@ func TestTimedFloat64BucketsWindowUpdate3sGranularity(t *testing.T) {
 	// Just last 4 buckets should have remained.
 	sum = 0.
 	want = 42 + 7 // we drop oldest bucket and the one not yet utilized)
-	buckets.ForEachBucket(trunc1.Add(9*time.Second), func(t time.Time, b float64) {
+	buckets.forEachBucket(trunc1.Add(9*time.Second), func(t time.Time, b float64) {
 		sum += b
 	})
 	if got, want := sum, want; got != want {
@@ -474,4 +435,22 @@ func TestRoundToNDigits(t *testing.T) {
 		t.Errorf("Rounding = %v, want: %v", got, want)
 	}
 
+}
+
+func (t *TimedFloat64Buckets) forEachBucket(now time.Time, acc func(time time.Time, bucket float64)) {
+	now = now.Truncate(t.granularity)
+	t.bucketsMutex.RLock()
+	defer t.bucketsMutex.RUnlock()
+
+	// So number of buckets we can process is len(buckets)-(now-lastWrite)/granularity.
+	// Since empty check above failed, we know this is at least 1 bucket.
+	numBuckets := len(t.buckets) - int(now.Sub(t.lastWrite)/t.granularity)
+	bucketTime := t.lastWrite // Always aligned with granularity.
+	si := t.timeToIndex(bucketTime)
+	for i := 0; i < numBuckets; i++ {
+		tIdx := si % len(t.buckets)
+		acc(bucketTime, t.buckets[tIdx])
+		si--
+		bucketTime = bucketTime.Add(-t.granularity)
+	}
 }


### PR DESCRIPTION
This is no longer used on any public call and we have no plans for it to be used
in the future, so demote it, move it to the test file (so it does not matter for coverage),
simplify it.

/assign mattmoor @markusthoemmes 