### PR TITLE
Revert "Adopt the new `// +genreconciler:class` style for ingress reconciler"

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -25,7 +25,7 @@ import (
 )
 
 // +genclient
-// +genreconciler:class=networking.knative.dev/ingress.class
+// +genreconciler
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Ingress is a collection of rules that allow inbound connections to reach the endpoints defined

--- a/pkg/client/injection/reconciler/networking/v1alpha1/ingress/controller.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/ingress/controller.go
@@ -38,14 +38,13 @@ const (
 	defaultControllerAgentName = "ingress-controller"
 	defaultFinalizerName       = "ingresses.networking.internal.knative.dev"
 	defaultQueueName           = "ingresses"
-	classAnnotationKey         = "networking.knative.dev/ingress.class"
 )
 
 // NewImpl returns a controller.Impl that handles queuing and feeding work from
 // the queue through an implementation of controller.Reconciler, delegating to
 // the provided Interface and optional Finalizer methods. OptionsFn is used to return
 // controller.Options to be used but the internal reconciler.
-func NewImpl(ctx context.Context, r Interface, classValue string, optionsFns ...controller.OptionsFn) *controller.Impl {
+func NewImpl(ctx context.Context, r Interface, optionsFns ...controller.OptionsFn) *controller.Impl {
 	logger := logging.FromContext(ctx)
 
 	// Check the options function input. It should be 0 or 1.
@@ -79,7 +78,6 @@ func NewImpl(ctx context.Context, r Interface, classValue string, optionsFns ...
 		Lister:     ingressInformer.Lister(),
 		Recorder:   recorder,
 		reconciler: r,
-		classValue: classValue,
 	}
 	impl := controller.NewImpl(rec, logger, defaultQueueName)
 

--- a/pkg/client/injection/reconciler/networking/v1alpha1/ingress/reconciler.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/ingress/reconciler.go
@@ -81,15 +81,12 @@ type reconcilerImpl struct {
 
 	// reconciler is the implementation of the business logic of the resource.
 	reconciler Interface
-
-	// classValue is the resource annotation[networking.knative.dev/ingress.class] instance value this reconciler instance filters on.
-	classValue string
 }
 
 // Check that our Reconciler implements controller.Reconciler
 var _ controller.Reconciler = (*reconcilerImpl)(nil)
 
-func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister networkingv1alpha1.IngressLister, recorder record.EventRecorder, r Interface, classValue string, options ...controller.Options) controller.Reconciler {
+func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versioned.Interface, lister networkingv1alpha1.IngressLister, recorder record.EventRecorder, r Interface, options ...controller.Options) controller.Reconciler {
 	// Check the options function input. It should be 0 or 1.
 	if len(options) > 1 {
 		logger.Fatalf("up to one options struct is supported, found %d", len(options))
@@ -100,7 +97,6 @@ func NewReconciler(ctx context.Context, logger *zap.SugaredLogger, client versio
 		Lister:     lister,
 		Recorder:   recorder,
 		reconciler: r,
-		classValue: classValue,
 	}
 
 	for _, opts := range options {
@@ -139,13 +135,6 @@ func (r *reconcilerImpl) Reconcile(ctx context.Context, key string) error {
 		return nil
 	} else if err != nil {
 		return err
-	}
-
-	if classValue, found := original.GetAnnotations()[classAnnotationKey]; !found || classValue != r.classValue {
-		logger.Debugw("Skip reconciling resource, class annotation value does not match reconciler instance value.",
-			zap.String("classKey", classAnnotationKey),
-			zap.String("issue", classValue+"!="+r.classValue))
-		return nil
 	}
 
 	// Don't modify the informers copy.

--- a/pkg/client/injection/reconciler/networking/v1alpha1/ingress/stub/controller.go
+++ b/pkg/client/injection/reconciler/networking/v1alpha1/ingress/stub/controller.go
@@ -40,10 +40,9 @@ func NewController(
 	ingressInformer := ingress.Get(ctx)
 
 	// TODO: setup additional informers here.
-	// TODO: pass in the expected value for the class annotation filter.
 
 	r := &Reconciler{}
-	impl := v1alpha1ingress.NewImpl(ctx, r, "default")
+	impl := v1alpha1ingress.NewImpl(ctx, r)
 
 	logger.Info("Setting up event handlers.")
 

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -76,7 +76,7 @@ func newControllerWithOptions(
 	}
 	myFilterFunc := reconciler.AnnotationFilterFunc(networking.IngressClassAnnotationKey, network.IstioIngressClassName, true)
 
-	impl := ingressreconciler.NewImpl(ctx, c, network.IstioIngressClassName, func(impl *controller.Impl) controller.Options {
+	impl := ingressreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
 		logger.Info("Setting up ConfigMap receivers")
 		configsToResync := []interface{}{
 			&config.Istio{},


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This reverts commit d37bb7adcd2d2ded8ec1b86562f6515758211187. It was pointed out in the relevant PR https://github.com/knative/serving/pull/6993#issuecomment-590588446 that this breaks functionality. I don't think we should accept that breakage and instead work on our class-based reconciler implementation to allow it to implement the lost functionality.

Since we're close to release, I'd propose to revert this until we have a better answer.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @shashwathi @mattmoor @n3wscott 
