### PR TITLE
More explicit fail in AutoscaleTest

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package e2e
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -320,7 +319,7 @@ func checkPodScale(ctx *testContext, targetPods, minPods, maxPods float64, durat
 			ctx.t.Log(mes)
 			// verify that the number of pods doesn't go down while we are scaling up.
 			if got < minPods {
-				return errors.New(mes)
+				return fmt.Errorf("interim scale didn't fulfill constraints: %s", mes)
 			}
 			// A quick test succeeds when the number of pods scales up to `targetPods`
 			// (and, for sanity check, no more than `maxPods`).
@@ -338,13 +337,13 @@ func checkPodScale(ctx *testContext, targetPods, minPods, maxPods float64, durat
 			// (with a little room for de-flakiness).
 			got, err := numberOfReadyPods(ctx)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to fetch number of ready pods: %w", err)
 			}
 			mes := fmt.Sprintf("got %v replicas, expected between [%v, %v] replicas for revision %s",
 				got, targetPods-1, maxPods, ctx.resources.Revision.Name)
 			ctx.t.Log(mes)
 			if got < targetPods-1 || got > maxPods {
-				return errors.New(mes)
+				return fmt.Errorf("final scale didn't fulfill constraints: %s", mes)
 			}
 			return nil
 		}
@@ -381,7 +380,7 @@ func assertAutoscaleUpToNumPods(ctx *testContext, curPods, targetPods float64, d
 	})
 
 	if err := grp.Wait(); err != nil {
-		ctx.t.Error(err)
+		ctx.t.Errorf("Error: %v", err)
 	}
 }
 


### PR DESCRIPTION
* the problem is that when the error message is returned to the errgroup
it then logs it and marks the test as failing but the test runs futher;
it is then not clear why the test failed unless you have detailed
knowledge of the test
* this PR makes the failures explicit and also helps Prow highlight the
given section of the test because it detects "FAIL" in the string

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


