### PR TITLE
Add the tests to cover metric reporting in ConcurrReporter

### DIFF
--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -67,7 +67,7 @@ func (cr *ConcurrencyReporter) reportToMetricsBackend(key types.NamespacedName, 
 	revName := key.Name
 	revision, err := cr.rl.Revisions(ns).Get(revName)
 	if err != nil {
-		cr.logger.With(zap.Any("revID", key)).Errorw("Error while getting revision", zap.Error(err))
+		cr.logger.Errorw("Error while getting revision", zap.Any("revID", key), zap.Error(err))
 		return
 	}
 	configurationName := revision.Labels[serving.ConfigurationLabelKey]

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -26,6 +26,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
+	"knative.dev/pkg/metrics/metricskey"
+	"knative.dev/pkg/metrics/metricstest"
 	rtesting "knative.dev/pkg/reconciler/testing"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler/metrics"
@@ -38,6 +40,8 @@ const (
 	requestOpStart
 	requestOpEnd
 )
+
+const activatorPodName = "the-best-activator"
 
 var (
 	rev1 = types.NamespacedName{Namespace: "test", Name: "rev1"}
@@ -69,13 +73,13 @@ func TestStats(t *testing.T) {
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
-				PodName:                   "activator",
+				PodName:                   activatorPodName,
 			}}, {
 			Key: rev2,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
-				PodName:                   "activator",
+				PodName:                   activatorPodName,
 			}},
 		}}, {
 		// NB: this test should start failing when #6991 is fixed
@@ -101,7 +105,7 @@ func TestStats(t *testing.T) {
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
-				PodName:                   "activator",
+				PodName:                   activatorPodName,
 			}},
 		}}, {
 		name: "Scale to two",
@@ -121,19 +125,19 @@ func TestStats(t *testing.T) {
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
-				PodName:                   "activator",
+				PodName:                   activatorPodName,
 			}}, {
 			Key: rev1,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 1, // We subtract the one concurrent request we already reported.
 				RequestCount:              2,
-				PodName:                   "activator",
+				PodName:                   activatorPodName,
 			}}, {
 			Key: rev1,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 2, // Next reporting period, report both requests in flight.
 				RequestCount:              0, // No new requests have appeared.
-				PodName:                   "activator",
+				PodName:                   activatorPodName,
 			}},
 		}}, {
 		name: "Scale-from-zero after tick sends stat",
@@ -154,13 +158,13 @@ func TestStats(t *testing.T) {
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
-				PodName:                   "activator",
+				PodName:                   activatorPodName,
 			}}, {
 			Key: rev1,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
-				PodName:                   "activator",
+				PodName:                   activatorPodName,
 			}},
 		}}, {
 		name: "Multiple revisions tick",
@@ -181,37 +185,37 @@ func TestStats(t *testing.T) {
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
-				PodName:                   "activator",
+				PodName:                   activatorPodName,
 			}}, {
 			Key: rev2,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
-				PodName:                   "activator",
+				PodName:                   activatorPodName,
 			}}, {
 			Key: rev3,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
-				PodName:                   "activator",
+				PodName:                   activatorPodName,
 			}}, {
 			Key: rev1,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 0,
 				RequestCount:              1,
-				PodName:                   "activator",
+				PodName:                   activatorPodName,
 			}}, {
 			Key: rev2,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 0,
 				RequestCount:              1,
-				PodName:                   "activator",
+				PodName:                   activatorPodName,
 			}}, {
 			Key: rev3,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 0,
 				RequestCount:              1,
-				PodName:                   "activator",
+				PodName:                   activatorPodName,
 			}},
 		}},
 	}
@@ -274,6 +278,32 @@ func TestStats(t *testing.T) {
 	}
 }
 
+func TestMetricsReported(t *testing.T) {
+	reset()
+	s, cr, ctx, cancel := newTestStats(t)
+	defer cancel()
+	go func() {
+		cr.run(ctx.Done(), s.reportBiChan)
+		close(s.reportBiChan)
+	}()
+
+	s.reqChan <- ReqEvent{Key: rev1, EventType: ReqIn}
+	s.reqChan <- ReqEvent{Key: rev1, EventType: ReqIn}
+	s.reqChan <- ReqEvent{Key: rev1, EventType: ReqIn}
+	s.reqChan <- ReqEvent{Key: rev1, EventType: ReqIn}
+	s.reportBiChan <- time.Time{}
+
+	wantTags := map[string]string{
+		metricskey.LabelRevisionName:      rev1.Name,
+		metricskey.LabelNamespaceName:     rev1.Namespace,
+		metricskey.LabelServiceName:       "service-" + rev1.Name,
+		metricskey.LabelConfigurationName: "config-" + rev1.Name,
+		"pod_name":                        "the-best-activator",
+		"container_name":                  "activator",
+	}
+	metricstest.CheckLastValueData(t, "request_concurrency", wantTags, 4)
+}
+
 // Test type to hold the bi-directional time channels
 type testStats struct {
 	reqChan      chan ReqEvent
@@ -294,7 +324,8 @@ func newTestStats(t *testing.T) (*testStats, *ConcurrencyReporter, context.Conte
 	revisionInformer(ctx, revision(rev1.Namespace, rev1.Name),
 		revision(rev2.Namespace, rev2.Name), revision(rev3.Namespace, rev3.Name))
 
-	return ts, NewConcurrencyReporter(ctx, "activator", ts.reqChan, ts.statChan), ctx, cancel
+	return ts, NewConcurrencyReporter(ctx, activatorPodName,
+		ts.reqChan, ts.statChan), ctx, cancel
 }
 
 func revisionInformer(ctx context.Context, revs ...*v1.Revision) {

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -290,8 +290,8 @@ func revision(namespace, name string) *v1.Revision {
 			Namespace: namespace,
 			Name:      name,
 			Labels: map[string]string{
-				serving.ConfigurationLabelKey: "config-" + testRevName,
-				serving.ServiceLabelKey:       "service-" + testRevName,
+				serving.ConfigurationLabelKey: "config-" + name,
+				serving.ServiceLabelKey:       "service-" + name,
 			},
 		},
 		Spec: v1.RevisionSpec{


### PR DESCRIPTION
We had whole wherein we did not verify whether metrics were correctly reported
by the concurrency reporter.
Now we do!

Also randomize the constants here and there.

/assign @markusthoemmes 