### PR TITLE
net-istio now has a webhook that defaults some istio specific revision labels

### DIFF
--- a/cmd/networking/istio/revision.go
+++ b/cmd/networking/istio/revision.go
@@ -43,7 +43,22 @@ func (r *RevisionStub) SetDefaults(context.Context) {
 		r.Labels = make(map[string]string)
 	}
 
-	service, ok := r.Labels[serving.ServiceLabelKey]
+	var (
+		parent string
+		ok     bool
+
+		parentKeys = []string{
+			serving.ServiceLabelKey,
+			serving.ConfigurationLabelKey,
+		}
+	)
+
+	for _, parentKey := range parentKeys {
+		parent, ok = r.Labels[parentKey]
+		if ok {
+			break
+		}
+	}
 
 	// Shouldn't happen but you never know
 	if !ok {
@@ -51,7 +66,7 @@ func (r *RevisionStub) SetDefaults(context.Context) {
 	}
 
 	r.Labels["service.istio.io/canonical-revision"] = r.Name
-	r.Labels["service.istio.io/canonical-service"] = service
+	r.Labels["service.istio.io/canonical-service"] = parent
 }
 
 // Validate sadly performs no validation

--- a/cmd/networking/istio/revision.go
+++ b/cmd/networking/istio/revision.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
+	"knative.dev/serving/pkg/apis/serving"
+)
+
+// RevisionStub is stub for the versioned types for the purposes
+// of defaulting
+type RevisionStub struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// TODO - add a general solution that captures
+	// top level properties in addition to spec & status
+	Spec   runtime.RawExtension `json:"spec"`
+	Status runtime.RawExtension `json:"status"`
+}
+
+// SetDefaults will apply istio specific defaults to the RevisionStub
+func (r *RevisionStub) SetDefaults(context.Context) {
+	if r.Labels == nil {
+		r.Labels = make(map[string]string)
+	}
+
+	service, ok := r.Labels[serving.ServiceLabelKey]
+
+	// Shouldn't happen but you never know
+	if !ok {
+		return
+	}
+
+	r.Labels["service.istio.io/canonical-revision"] = r.Name
+	r.Labels["service.istio.io/canonical-service"] = service
+}
+
+// Validate sadly performs no validation
+func (r *RevisionStub) Validate(context.Context) *apis.FieldError {
+	return nil
+}
+
+// DeepCopyObject returns a deep copy of this object
+func (r *RevisionStub) DeepCopyObject() runtime.Object {
+	if r == nil {
+		return nil
+	}
+
+	out := &RevisionStub{
+		TypeMeta: r.TypeMeta, //simple struct
+	}
+
+	r.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	r.Spec.DeepCopyInto(&out.Spec)
+	r.Status.DeepCopyInto(&out.Status)
+
+	return out
+}

--- a/config/istio-ingress/controller.yaml
+++ b/config/istio-ingress/controller.yaml
@@ -73,6 +73,31 @@ spec:
           containerPort: 9090
         - name: profiling
           containerPort: 8008
-
-# Unlike other controllers, this doesn't need a Service defined for metrics and
+# Unlike other controllers, this didn't need a Service defined for metrics and
 # profiling because it opts out of the mesh (see annotation above).
+#
+# Though we added a service since it's a target for the istio webhook
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-webhook
+  namespace: knative-serving
+  labels:
+    role: webhook
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
+spec:
+  ports:
+  # Define metrics and profiling for them to be accessible within service meshes.
+  - name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  - name: https-webhook
+    port: 443
+    targetPort: 8443
+  selector:
+    app: networking-istio

--- a/config/istio-ingress/webhook.yaml
+++ b/config/istio-ingress/webhook.yaml
@@ -1,0 +1,40 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: webhook.istio.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: istio-webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: webhook.istio.networking.internal.knative.dev
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: istio-webhook-certs
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+    networking.knative.dev/ingress-provider: istio

--- a/test/e2e/istio/label_test.go
+++ b/test/e2e/istio/label_test.go
@@ -1,0 +1,103 @@
+// +build e2e istio
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	"knative.dev/serving/test"
+	"knative.dev/serving/test/e2e"
+	v1test "knative.dev/serving/test/v1"
+)
+
+func TestIstioRevisionLabel_Service(t *testing.T) {
+	clients := e2e.Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "helloworld",
+	}
+
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
+
+	objects, _, err := v1test.CreateServiceReady(t, clients, &names)
+
+	if err != nil {
+		t.Fatalf("Failed to create Service %s: %v", names.Service, err)
+	}
+
+	r := objects.Revision
+	revisionLabel := r.Labels["service.istio.io/canonical-revision"]
+
+	if revisionLabel != r.Name {
+		t.Errorf("canonical-revision label set incorrected - got: %q want %q",
+			revisionLabel,
+			r.Name,
+		)
+	}
+
+	s := objects.Service
+	serviceLabel := r.Labels["service.istio.io/canonical-service"]
+
+	if serviceLabel != s.Name {
+		t.Errorf("canonical-service label set incorrected - got: %q want %q",
+			serviceLabel,
+			s.Name,
+		)
+	}
+}
+
+func TestIstioRevisionLabel_Configuration(t *testing.T) {
+	clients := e2e.Setup(t)
+
+	names := test.ResourceNames{
+		Config: test.ObjectNameForTest(t),
+		Image:  "helloworld",
+	}
+
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
+
+	objects, err := v1test.CreateConfigurationReady(t, clients, &names)
+
+	if err != nil {
+		t.Fatalf("Failed to create Configuration %s: %v", names.Service, err)
+	}
+
+	r := objects.Revision
+	revisionLabel := r.Labels["service.istio.io/canonical-revision"]
+
+	if revisionLabel != r.Name {
+		t.Errorf("canonical-revision label set incorrected - got: %q want %q",
+			revisionLabel,
+			r.Name,
+		)
+	}
+
+	c := objects.Configuration
+	serviceLabel := r.Labels["service.istio.io/canonical-service"]
+
+	if serviceLabel != c.Name {
+		t.Errorf("canonical-service label set incorrected - got: %q want %q",
+			serviceLabel,
+			c.Name,
+		)
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #6832

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Introduces a defaulting webhook in the `cmd/networking/istio` main
* Webhook will place istio specific labels on revisions

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
