### PR TITLE
Add K_NAMESPACE env var to user-container

### DIFF
--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -56,6 +56,7 @@ var (
 		"K_SERVICE",
 		"K_CONFIGURATION",
 		"K_REVISION",
+		"K_NAMESPACE",
 	)
 
 	// The port is named "user-port" on the deployment, but a user cannot set an arbitrary name on the port

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -762,6 +762,19 @@ func TestContainerValidation(t *testing.T) {
 			Paths:   []string{"env[0].name"},
 		},
 	}, {
+		name: "reserved K_NAMESPACE env var",
+		c: corev1.Container{
+			Image: "foo",
+			Env: []corev1.EnvVar{{
+				Name:  "K_NAMESPACE",
+				Value: "Foo",
+			}},
+		},
+		want: &apis.FieldError{
+			Message: `"K_NAMESPACE" is a reserved environment variable`,
+			Paths:   []string{"env[0].name"},
+		},
+	}, {
 		name: "disallowed envvarsource",
 		c: corev1.Container{
 			Image: "foo",

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -66,6 +66,9 @@ var (
 		}, {
 			Name:  "K_SERVICE",
 			Value: "svc",
+		}, {
+			Name:  "K_NAMESPACE",
+			Value: "foo",
 		}},
 	}
 

--- a/pkg/reconciler/revision/resources/env_var.go
+++ b/pkg/reconciler/revision/resources/env_var.go
@@ -26,6 +26,7 @@ const (
 	knativeRevisionEnvVariableKey      = "K_REVISION"
 	knativeConfigurationEnvVariableKey = "K_CONFIGURATION"
 	knativeServiceEnvVariableKey       = "K_SERVICE"
+	knativeNamespaceEnvVariableKey     = "K_NAMESPACE"
 )
 
 func getKnativeEnvVar(rev *v1.Revision) []corev1.EnvVar {
@@ -38,5 +39,8 @@ func getKnativeEnvVar(rev *v1.Revision) []corev1.EnvVar {
 	}, {
 		Name:  knativeServiceEnvVariableKey,
 		Value: rev.Labels[serving.ServiceLabelKey],
+	}, {
+		Name:  knativeNamespaceEnvVariableKey,
+		Value: rev.Namespace,
 	}}
 }

--- a/pkg/reconciler/revision/resources/env_var_test.go
+++ b/pkg/reconciler/revision/resources/env_var_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"knative.dev/serving/pkg/apis/serving"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+)
+
+func TestEnvVar(t *testing.T) {
+	tests := []struct {
+		name string
+		rev  *v1.Revision
+		want []corev1.EnvVar
+	}{{
+		name: "revisions without objectMeta and labels",
+		rev:  &v1.Revision{},
+		want: []corev1.EnvVar{{
+			Name: knativeRevisionEnvVariableKey,
+		}, {
+			Name: knativeConfigurationEnvVariableKey,
+		}, {
+			Name: knativeServiceEnvVariableKey,
+		}, {
+			Name: knativeNamespaceEnvVariableKey,
+		}},
+	}, {
+		name: "revision without labels",
+		rev: &v1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar-rev",
+				Namespace: "foo",
+			},
+		},
+		want: []corev1.EnvVar{{
+			Name:  knativeRevisionEnvVariableKey,
+			Value: "bar-rev",
+		}, {
+			Name: knativeConfigurationEnvVariableKey,
+		}, {
+			Name: knativeServiceEnvVariableKey,
+		}, {
+			Name:  knativeNamespaceEnvVariableKey,
+			Value: "foo",
+		}},
+	}, {
+		name: "revision with objectMeta and labels",
+		rev: &v1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar-rev",
+				Namespace: "foo",
+				Labels: map[string]string{
+					serving.ConfigurationLabelKey: "bar",
+					serving.ServiceLabelKey:       "bar",
+				},
+			},
+		},
+		want: []corev1.EnvVar{{
+			Name:  knativeRevisionEnvVariableKey,
+			Value: "bar-rev",
+		}, {
+			Name:  knativeConfigurationEnvVariableKey,
+			Value: "bar",
+		}, {
+			Name:  knativeServiceEnvVariableKey,
+			Value: "bar",
+		}, {
+			Name:  knativeNamespaceEnvVariableKey,
+			Value: "foo",
+		}},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if diff := cmp.Diff(test.want, getKnativeEnvVar(test.rev)); diff != "" {
+				t.Errorf("environment variable (-want, +got) = %v", diff)
+			}
+		})
+	}
+}

--- a/test/crd.go
+++ b/test/crd.go
@@ -32,6 +32,7 @@ type ResourceNames struct {
 	Route         string
 	Revision      string
 	Service       string
+	Namespace     string
 	TrafficTarget string
 	URL           *url.URL
 	Image         string

--- a/test/types/runtime.go
+++ b/test/types/runtime.go
@@ -33,6 +33,7 @@ var ShouldEnvVars = map[string]string{
 	"K_SERVICE":       "Service",
 	"K_CONFIGURATION": "Config",
 	"K_REVISION":      "Revision",
+	"K_NAMESPACE":     "Namespace",
 }
 
 // MustFiles specifies the file paths and expected permissions that MUST be set as specified in the runtime contract.

--- a/test/v1alpha1/service.go
+++ b/test/v1alpha1/service.go
@@ -141,6 +141,9 @@ func CreateRunLatestServiceReady(t pkgTest.TLegacy, clients *test.Clients, names
 		names.Service = svc.Name
 	}
 
+	if names.Namespace == "" {
+		names.Namespace = svc.Namespace
+	}
 	t.Log("Waiting for Service to transition to Ready.", "service", names.Service)
 	if err = WaitForServiceState(clients.ServingAlphaClient, names.Service, IsServiceReady, "ServiceIsReady"); err != nil {
 		return nil, nil, err


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #6947

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add K_NAMESPACE env to user-container

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```
