### PR TITLE
Deflake the kpa test by waiting for KPA to propagate.

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -47,6 +47,7 @@ import (
 	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
 	pareconciler "knative.dev/serving/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -1154,6 +1155,18 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 	sks := sks(testNamespace, testRevision, WithDeployRef(kpa.Spec.ScaleTargetRef.Name),
 		WithSKSReady)
 	fakeservingclient.Get(ctx).NetworkingV1alpha1().ServerlessServices(testNamespace).Create(sks)
+
+	sksl := fakesksinformer.Get(ctx).Lister()
+	if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
+		l, err := sksl.List(labels.Everything())
+		if err != nil {
+			return false, err
+		}
+		// We only create a single SKS object.
+		return len(l) > 0, nil
+	}); err != nil {
+		t.Fatalf("Failed to see SKS propagation: %v", err)
+	}
 
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
 


### PR DESCRIPTION
https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1233454607657603073

It shows as a flake and it can be seen in the logs
that the reason for that is because of the SKS creation race.
By waiting for SKS to show up in the informer we resolve the flake.
See #7099

```
>rt -count=10 -run=TestControllerSy
PASS
ok      knative.dev/serving/pkg/reconciler/autoscaling/kpa      1.955s
```

/assign mattmoor @markusthoemmes 