### PR TITLE
Fix the issue with overcounting for request counts as well

### DIFF
--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -108,7 +108,7 @@ func TestStats(t *testing.T) {
 			Key: rev1,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 0,
-				RequestCount:              2,
+				RequestCount:              1,
 				PodName:                   activatorPodName,
 			}},
 		}}, {
@@ -134,7 +134,7 @@ func TestStats(t *testing.T) {
 			Key: rev1,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 1, // We subtract the one concurrent request we already reported.
-				RequestCount:              2,
+				RequestCount:              1,
 				PodName:                   activatorPodName,
 			}}, {
 			Key: rev1,
@@ -167,7 +167,7 @@ func TestStats(t *testing.T) {
 			Key: rev1,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 0,
-				RequestCount:              1,
+				RequestCount:              0,
 				PodName:                   activatorPodName,
 			}}, {
 			Key: rev1,
@@ -212,19 +212,19 @@ func TestStats(t *testing.T) {
 			Key: rev1,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 0,
-				RequestCount:              1,
+				RequestCount:              0,
 				PodName:                   activatorPodName,
 			}}, {
 			Key: rev2,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 0,
-				RequestCount:              1,
+				RequestCount:              0,
 				PodName:                   activatorPodName,
 			}}, {
 			Key: rev3,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 0,
-				RequestCount:              1,
+				RequestCount:              0,
 				PodName:                   activatorPodName,
 			}},
 		}},


### PR DESCRIPTION
Upon reflection, though less important, I think we should correct number of requests
the same way we do for the concurrent requests, since _that_ requests has already been counted.

For simplification also make all the maps float64, I think the number of casts reduces this way.

/assign mattmoor @markusthoemmes 