### PR TITLE
Add route label to `LatestCreatedRevision`

### DIFF
--- a/pkg/reconciler/labeler/controller.go
+++ b/pkg/reconciler/labeler/controller.go
@@ -19,16 +19,18 @@ package labeler
 import (
 	"context"
 
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 	routeinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/route"
 	routereconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/route"
+	servingreconciler "knative.dev/serving/pkg/reconciler"
 
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
-	servingreconciler "knative.dev/serving/pkg/reconciler"
+	"knative.dev/pkg/tracker"
 )
 
 const controllerAgentName = "labeler-controller"
@@ -55,6 +57,18 @@ func NewController(
 
 	logger.Info("Setting up event handlers")
 	routeInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+
+	c.tracker = tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx))
+
+	configInformer.Informer().AddEventHandler(controller.HandleAll(
+		// Call the tracker's OnChanged method, but we've seen the objects
+		// coming through this path missing TypeMeta, so ensure it is properly
+		// populated.
+		controller.EnsureTypeMeta(
+			c.tracker.OnChanged,
+			v1.SchemeGroupVersion.WithKind("Configuration"),
+		),
+	))
 
 	return impl
 }

--- a/pkg/reconciler/labeler/labeler.go
+++ b/pkg/reconciler/labeler/labeler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	pkgreconciler "knative.dev/pkg/reconciler"
+	"knative.dev/pkg/tracker"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
 	routereconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/route"
@@ -33,6 +34,7 @@ type Reconciler struct {
 	// Listers index properties about resources
 	configurationLister listers.ConfigurationLister
 	revisionLister      listers.RevisionLister
+	tracker             tracker.Interface
 }
 
 // Check that our Reconciler implements routereconciler.Interface

--- a/pkg/reconciler/labeler/labeler.go
+++ b/pkg/reconciler/labeler/labeler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	pkgreconciler "knative.dev/pkg/reconciler"
-	"knative.dev/pkg/tracker"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
 	routereconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/route"
@@ -34,7 +33,6 @@ type Reconciler struct {
 	// Listers index properties about resources
 	configurationLister listers.ConfigurationLister
 	revisionLister      listers.RevisionLister
-	tracker             tracker.Interface
 }
 
 // Check that our Reconciler implements routereconciler.Interface

--- a/pkg/reconciler/labeler/labeler_test.go
+++ b/pkg/reconciler/labeler/labeler_test.go
@@ -78,14 +78,15 @@ func TestReconcile(t *testing.T) {
 		Name: "label pinned revision",
 		Objects: []runtime.Object{
 			simpleRoute("default", "pinned-revision", "the-revision"),
-			simpleConfig("default", "red-herring", WithLatestCreated("red-herring-ecoge")),
-			rev("default", "red-herring"),
-			rev("default", "red-herring", WithRevName("red-herring-ecoge")),
-			rev("default", "red-herring", WithRevName("the-revision")),
+			simpleConfig("default", "the-config"),
+			rev("default", "the-config"),
+			rev("default", "the-config", WithRevName("the-revision")),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizerAction("default", "pinned-revision"),
 			patchAddLabel("default", "the-revision",
+				"serving.knative.dev/route", "pinned-revision"),
+			patchAddLabel("default", "the-config",
 				"serving.knative.dev/route", "pinned-revision"),
 		},
 		WantEvents: []string{

--- a/pkg/reconciler/labeler/labeler_test.go
+++ b/pkg/reconciler/labeler/labeler_test.go
@@ -252,7 +252,6 @@ func TestReconcile(t *testing.T) {
 			client:              servingclient.Get(ctx),
 			configurationLister: listers.GetConfigurationLister(),
 			revisionLister:      listers.GetRevisionLister(),
-			tracker:             &NullTracker{},
 		}
 
 		return routereconciler.NewReconciler(ctx, logging.FromContext(ctx), servingclient.Get(ctx),

--- a/pkg/reconciler/labeler/labels.go
+++ b/pkg/reconciler/labeler/labels.go
@@ -46,7 +46,7 @@ func (c *Reconciler) syncLabels(ctx context.Context, r *v1.Route) error {
 	configs := sets.NewString()
 
 	// Walk the revisions in Route's .status.traffic and build a list
-	// of Configurations to label from their OwnerReferences.
+	// of RunLatest Configurations to label from their OwnerReferences.
 	for _, tt := range r.Status.Traffic {
 		rev, err := c.revisionLister.Revisions(r.Namespace).Get(tt.RevisionName)
 		if err != nil {
@@ -54,10 +54,10 @@ func (c *Reconciler) syncLabels(ctx context.Context, r *v1.Route) error {
 		}
 		revisions.Insert(tt.RevisionName)
 
-		// If the owner reference is a configuration, add it to the list of configurations
-		// and add its LatestCreatedRevision to the list of revisions
+		// If the .traffic is a RunLatest and the revision's owner is a configuration,
+		// add the configuration to the list along with its LatestCreatedRevisionName
 		owner := metav1.GetControllerOf(rev)
-		if owner != nil && owner.Kind == "Configuration" {
+		if owner != nil && owner.Kind == "Configuration" && tt.LatestRevision != nil && *tt.LatestRevision {
 			configs.Insert(owner.Name)
 
 			config, err := c.configurationLister.Configurations(r.Namespace).Get(owner.Name)

--- a/pkg/reconciler/labeler/labels.go
+++ b/pkg/reconciler/labeler/labels.go
@@ -65,10 +65,10 @@ func (c *Reconciler) syncLabels(ctx context.Context, r *v1.Route) error {
 				return err
 			}
 
+			// If the configuration is being updated, the route's .status.traffic will
+			// only incude the latest ready revision. We need to label the latest created revision
+			// as well so that there is a smooth transition when the new revision becomes ready.
 			revisions.Insert(config.Status.LatestCreatedRevisionName)
-
-			// Track future changes to the configuration
-			c.tracker.Track(kmeta.ObjectReference(config), r)
 		}
 	}
 

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -19,10 +19,12 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
 	"strconv"
 	"testing"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/test/logstream"
@@ -54,18 +56,18 @@ func TestMinScale(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	t.Log("Creating configuration")
-	if _, err := v1a1test.CreateConfiguration(t, clients, names, withMinScale(minScale)); err != nil {
+	cfg, err := v1a1test.CreateConfiguration(t, clients, names, withMinScale(minScale))
+	if err != nil {
 		t.Fatalf("Failed to create Configuration: %v", err)
 	}
 
-	revName := latestRevisionName(t, clients, names.Config)
-	deploymentName := revName + "-deployment"
-	privateServiceName := serverlessServicesName(t, clients, revName)
+	revName := latestRevisionName(t, clients, names.Config, "")
+	serviceName := serverlessServicesName(t, clients, revName)
 
 	// Before becoming ready, observe minScale
 	t.Log("Waiting for revision to scale to minScale before becoming ready")
-	if err := waitForDesiredScale(t, clients, privateServiceName, gte(minScale)); err != nil {
-		t.Fatalf("The deployment %q did not scale >= %d before becoming ready: %v", deploymentName, minScale, err)
+	if err := waitForDesiredScale(t, clients, serviceName, gte(minScale)); err != nil {
+		t.Fatalf("The revision %q did not scale >= %d before becoming ready: %v", revName, minScale, err)
 	}
 
 	// Revision becomes ready
@@ -78,8 +80,8 @@ func TestMinScale(t *testing.T) {
 
 	// Without a route, ignore minScale
 	t.Log("Waiting for revision to scale below minScale after becoming ready")
-	if err := waitForDesiredScale(t, clients, privateServiceName, lt(minScale)); err != nil {
-		t.Fatalf("The deployment %q did not scale < minScale after becoming ready: %v", deploymentName, err)
+	if err := waitForDesiredScale(t, clients, serviceName, lt(minScale)); err != nil {
+		t.Fatalf("The revision %q did not scale < minScale after becoming ready: %v", revName, err)
 	}
 
 	// Create route
@@ -98,8 +100,42 @@ func TestMinScale(t *testing.T) {
 
 	// With a route, observe minScale
 	t.Log("Waiting for revision to scale to minScale after creating route")
-	if err := waitForDesiredScale(t, clients, privateServiceName, gte(minScale)); err != nil {
-		t.Fatalf("The deployment %q did not scale >= %d after creating route: %v", deploymentName, minScale, err)
+	if err := waitForDesiredScale(t, clients, serviceName, gte(minScale)); err != nil {
+		t.Fatalf("The revision %q did not scale >= %d after creating route: %v", revName, minScale, err)
+	}
+
+	t.Log("Updating configuration")
+	if _, err := v1a1test.PatchConfig(clients, cfg, withEnv("FOO", "BAR")); err != nil {
+		t.Fatalf("Failed to update Configuration: %v", err)
+	}
+
+	newRevName := latestRevisionName(t, clients, names.Config, revName)
+	newServiceName := serverlessServicesName(t, clients, newRevName)
+
+	// After update, observe minScale in new revision
+	t.Log("Waiting for latest revision to scale to minScale after update")
+	if err := waitForDesiredScale(t, clients, newServiceName, gte(minScale)); err != nil {
+		t.Fatalf("The revision %q did not scale >= %d after creating route: %v", newRevName, minScale, err)
+	}
+
+	// Revision becomes ready
+	t.Log("Waiting for revision to become ready")
+	if err := v1a1test.WaitForRevisionState(
+		clients.ServingAlphaClient, newRevName, v1a1test.IsRevisionReady, "RevisionIsReady",
+	); err != nil {
+		t.Fatalf("The Revision %q did not become ready: %v", newRevName, err)
+	}
+
+	// After update, ensure new revision holds minScale
+	t.Log("Hold minScale after update")
+	if err := ensureDesiredScale(t, clients, newServiceName, gte(minScale)); err != nil {
+		t.Fatalf("The revision %q did not stay at scale >= %d after creating route: %v", newRevName, minScale, err)
+	}
+
+	// After update, ensure old revision ignores minScale
+	t.Log("Waiting for old revision to scale below minScale after being replaced")
+	if err := waitForDesiredScale(t, clients, serviceName, lt(minScale)); err != nil {
+		t.Fatalf("The revision %q did not scale < minScale after being replaced: %v", revName, err)
 	}
 }
 
@@ -115,6 +151,12 @@ func lt(m int) func(int) bool {
 	}
 }
 
+func withEnv(name, value string) func(cfg *v1alpha1.Configuration) {
+	return func(cfg *v1alpha1.Configuration) {
+		cfg.Spec.GetTemplate().Spec.GetContainer().Env = []v1.EnvVar{{Name: name, Value: value}}
+	}
+}
+
 func withMinScale(minScale int) func(cfg *v1alpha1.Configuration) {
 	return func(cfg *v1alpha1.Configuration) {
 		if cfg.Spec.Template.Annotations == nil {
@@ -124,13 +166,19 @@ func withMinScale(minScale int) func(cfg *v1alpha1.Configuration) {
 	}
 }
 
-func latestRevisionName(t *testing.T, clients *test.Clients, configName string) string {
+func lrcChanged(oldName string) func(c *v1alpha1.Configuration) (bool, error) {
+	return func(c *v1alpha1.Configuration) (bool, error) {
+		return c.Status.LatestCreatedRevisionName != oldName, nil
+	}
+}
+
+func latestRevisionName(t *testing.T, clients *test.Clients, configName, oldRevName string) string {
 	// Wait for the Config have a LatestCreatedRevisionName
 	if err := v1a1test.WaitForConfigurationState(
 		clients.ServingAlphaClient, configName,
-		v1a1test.ConfigurationHasCreatedRevision, "ConfigurationHasCreatedRevision",
+		lrcChanged(oldRevName), "ConfigurationHasUpdatedCreatedRevision",
 	); err != nil {
-		t.Fatalf("The Configuration %q does not have a LatestCreatedRevisionName: %v", configName, err)
+		t.Fatalf("The Configuration %q has not updated LatestCreatedRevisionName from %q: %v", configName, oldRevName, err)
 	}
 
 	config, err := clients.ServingAlphaClient.Configs.Get(configName, metav1.GetOptions{})
@@ -143,6 +191,7 @@ func latestRevisionName(t *testing.T, clients *test.Clients, configName string) 
 
 func serverlessServicesName(t *testing.T, clients *test.Clients, revisionName string) string {
 	var privateServiceName string
+
 	if err := wait.PollImmediate(time.Second, 1*time.Minute, func() (bool, error) {
 		sks, err := clients.NetworkingClient.ServerlessServices.Get(revisionName, metav1.GetOptions{})
 		if err != nil {
@@ -156,17 +205,42 @@ func serverlessServicesName(t *testing.T, clients *test.Clients, revisionName st
 	}); err != nil {
 		t.Fatalf("Error retrieving sks %q: %v", revisionName, err)
 	}
+
 	return privateServiceName
 }
 
-func waitForDesiredScale(t *testing.T, clients *test.Clients, privateServiceName string, cond func(int) bool) error {
+func waitForDesiredScale(t *testing.T, clients *test.Clients, serviceName string, cond func(int) bool) error {
 	endpoints := clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace)
 
 	return wait.PollImmediate(time.Second, 1*time.Minute, func() (bool, error) {
-		endpoint, err := endpoints.Get(privateServiceName, metav1.GetOptions{})
+		endpoint, err := endpoints.Get(serviceName, metav1.GetOptions{})
 		if err != nil {
 			return false, nil
 		}
 		return cond(resources.ReadyAddressCount(endpoint)), nil
 	})
+
+}
+
+func ensureDesiredScale(t *testing.T, clients *test.Clients, serviceName string, cond func(int) bool) error {
+	endpoints := clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace)
+
+	err := wait.PollImmediate(time.Second, 5*time.Second, func() (bool, error) {
+		endpoint, err := endpoints.Get(serviceName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		if scale := resources.ReadyAddressCount(endpoint); !cond(scale) {
+			return false, fmt.Errorf("scaled to %d", scale)
+		}
+
+		return false, nil
+	})
+
+	if err != wait.ErrWaitTimeout {
+		return err
+	}
+
+	return nil
 }

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -44,11 +44,10 @@ func TestMinScale(t *testing.T) {
 
 	clients := Setup(t)
 
-	name := test.ObjectNameForTest(t)
-
 	names := test.ResourceNames{
-		Config: name,
-		Route:  name,
+		// Config and Route have different names to avoid false positives
+		Config: test.ObjectNameForTest(t),
+		Route:  test.ObjectNameForTest(t),
 		Image:  "helloworld",
 	}
 

--- a/test/v1alpha1/configuration.go
+++ b/test/v1alpha1/configuration.go
@@ -44,6 +44,22 @@ func CreateConfiguration(t pkgTest.T, clients *test.Clients, names test.Resource
 	return clients.ServingAlphaClient.Configs.Create(config)
 }
 
+// PatchConfig patches the existing config with the provided options. Returns the latest Configuration object
+func PatchConfig(clients *test.Clients, cfg *v1alpha1.Configuration, fopt ...v1alpha1testing.ConfigOption) (*v1alpha1.Configuration, error) {
+	newCfg := cfg.DeepCopy()
+
+	for _, opt := range fopt {
+		opt(newCfg)
+	}
+
+	patchBytes, err := duck.CreateBytePatch(cfg, newCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return clients.ServingAlphaClient.Configs.Patch(cfg.ObjectMeta.Name, types.JSONPatchType, patchBytes, "")
+}
+
 // PatchConfigImage patches the existing config passed in with a new imagePath. Returns the latest Configuration object
 func PatchConfigImage(clients *test.Clients, cfg *v1alpha1.Configuration, imagePath string) (*v1alpha1.Configuration, error) {
 	newCfg := cfg.DeepCopy()


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #6733 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add additional scenarios to the `MinScale` e2e tests to check `minScale` during the update of a configuration.
* Add a route label to the `LatestCreatedRevision`. This ensures continuity of a `reachable` revision when a configuration is updated.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The `LatestCreatedRevision` of a Configuration will now have a route label. Fixes issue where a Revision's pods are temporarily scaled below `minScale` after the Revision becomes ready.
```
