### PR TITLE
Fix race condition in concurrency metrics test.

### DIFF
--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -302,6 +302,8 @@ func TestMetricsReported(t *testing.T) {
 	s.reqChan <- ReqEvent{Key: rev1, EventType: ReqIn}
 	s.reqChan <- ReqEvent{Key: rev1, EventType: ReqIn}
 	s.reportBiChan <- time.Time{}
+	<-s.statChan // The scale from 0 quick-report
+	<-s.statChan // The actual report we want to see
 
 	wantTags := map[string]string{
 		metricskey.LabelRevisionName:      rev1.Name,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #7112 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Once the reporter is kicked through the report-channel there is no guarantee that the metric has actually been written. Instead, we need to await the stats being written to the stat-channel (which happens after the metrics are written), to guarantee that we'll always see the published metrics. We need to wait for two stats as the first one is eagerly written to make scale-from-0 as quick as possible.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
