### PR TITLE
A controller by any other name would smell as sweet

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/controller.go
+++ b/pkg/reconciler/autoscaling/hpa/controller.go
@@ -36,15 +36,19 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
+	servingreconciler "knative.dev/serving/pkg/reconciler"
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
 )
+
+const controllerAgentName = "hpa-class-podautoscaler-controller"
 
 // NewController returns a new HPA reconcile controller.
 func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+	ctx = servingreconciler.AnnotateLoggerWithName(ctx, controllerAgentName)
 	logger := logging.FromContext(ctx)
 	paInformer := painformer.Get(ctx)
 	sksInformer := sksinformer.Get(ctx)

--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -39,10 +39,13 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
+	servingreconciler "knative.dev/serving/pkg/reconciler"
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
 	"knative.dev/serving/pkg/reconciler/autoscaling/kpa/resources"
 )
+
+const controllerAgentName = "kpa-class-podautoscaler-controller"
 
 // NewController returns a new KPA reconcile controller.
 // TODO(mattmoor): Fix the signature to adhere to the injection type.
@@ -51,6 +54,7 @@ func NewController(
 	cmw configmap.Watcher,
 	deciders resources.Deciders,
 ) *controller.Impl {
+	ctx = servingreconciler.AnnotateLoggerWithName(ctx, controllerAgentName)
 	logger := logging.FromContext(ctx)
 	paInformer := painformer.Get(ctx)
 	sksInformer := sksinformer.Get(ctx)

--- a/pkg/reconciler/certificate/controller.go
+++ b/pkg/reconciler/certificate/controller.go
@@ -36,8 +36,11 @@ import (
 	kcertinformer "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/certificate"
 	certreconciler "knative.dev/serving/pkg/client/injection/reconciler/networking/v1alpha1/certificate"
 	"knative.dev/serving/pkg/network"
+	servingreconciler "knative.dev/serving/pkg/reconciler"
 	"knative.dev/serving/pkg/reconciler/certificate/config"
 )
+
+const controllerAgentName = "certificate-controller"
 
 // NewController initializes the controller and is called by the generated code
 // Registers eventhandlers to enqueue events.
@@ -45,6 +48,7 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+	ctx = servingreconciler.AnnotateLoggerWithName(ctx, controllerAgentName)
 	logger := logging.FromContext(ctx)
 	knCertificateInformer := kcertinformer.Get(ctx)
 	cmCertificateInformer := cmcertinformer.Get(ctx)

--- a/pkg/reconciler/configuration/controller.go
+++ b/pkg/reconciler/configuration/controller.go
@@ -28,13 +28,17 @@ import (
 	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 	configreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/configuration"
+	servingreconciler "knative.dev/serving/pkg/reconciler"
 )
+
+const controllerAgentName = "configuration-controller"
 
 // NewController creates a new Configuration controller
 func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+	ctx = servingreconciler.AnnotateLoggerWithName(ctx, controllerAgentName)
 	logger := logging.FromContext(ctx)
 	configurationInformer := configurationinformer.Get(ctx)
 	revisionInformer := revisioninformer.Get(ctx)

--- a/pkg/reconciler/gc/controller.go
+++ b/pkg/reconciler/gc/controller.go
@@ -29,14 +29,19 @@ import (
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 	configreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/configuration"
 	gcconfig "knative.dev/serving/pkg/gc"
+	servingreconciler "knative.dev/serving/pkg/reconciler"
 	configns "knative.dev/serving/pkg/reconciler/gc/config"
 )
+
+const controllerAgentName = "revision-gc-controller"
 
 // NewController creates a new Garbage Collection controller
 func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+	ctx = servingreconciler.AnnotateLoggerWithName(ctx, controllerAgentName)
+	logger := logging.FromContext(ctx)
 	configurationInformer := configurationinformer.Get(ctx)
 	revisionInformer := revisioninformer.Get(ctx)
 
@@ -45,7 +50,6 @@ func NewController(
 		revisionLister: revisionInformer.Lister(),
 	}
 	return configreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
-		logger := logging.FromContext(ctx)
 		logger.Info("Setting up event handlers")
 
 		// Since the gc controller came from the configuration controller, having event handlers

--- a/pkg/reconciler/ingress/controller.go
+++ b/pkg/reconciler/ingress/controller.go
@@ -38,12 +38,15 @@ import (
 	virtualserviceinformer "knative.dev/serving/pkg/client/istio/injection/informers/networking/v1alpha3/virtualservice"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/network/status"
+	servingreconciler "knative.dev/serving/pkg/reconciler"
 	"knative.dev/serving/pkg/reconciler/ingress/config"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 )
+
+const controllerAgentName = "istio-ingress-controller"
 
 type ingressOption func(*Reconciler)
 
@@ -60,6 +63,8 @@ func newControllerWithOptions(
 	cmw configmap.Watcher,
 	opts ...ingressOption,
 ) *controller.Impl {
+
+	ctx = servingreconciler.AnnotateLoggerWithName(ctx, controllerAgentName)
 	logger := logging.FromContext(ctx)
 	virtualServiceInformer := virtualserviceinformer.Get(ctx)
 	gatewayInformer := gatewayinformer.Get(ctx)

--- a/pkg/reconciler/labeler/controller.go
+++ b/pkg/reconciler/labeler/controller.go
@@ -28,7 +28,10 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	servingreconciler "knative.dev/serving/pkg/reconciler"
 )
+
+const controllerAgentName = "labeler-controller"
 
 // NewController wraps a new instance of the labeler that labels
 // Configurations with Routes in a controller.
@@ -36,6 +39,8 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+
+	ctx = servingreconciler.AnnotateLoggerWithName(ctx, controllerAgentName)
 	logger := logging.FromContext(ctx)
 	routeInformer := routeinformer.Get(ctx)
 	configInformer := configurationinformer.Get(ctx)

--- a/pkg/reconciler/logger.go
+++ b/pkg/reconciler/logger.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/logging/logkey"
+)
+
+// AnnotateLoggerWithName names the logger in the context with the supplied name
+//
+// Deprecated - this is a stop gap until the generated reconcilers can do
+// this automatically for you
+func AnnotateLoggerWithName(ctx context.Context, name string) context.Context {
+	logger := logging.FromContext(ctx).
+		Named(name).
+		With(zap.String(logkey.ControllerType, name))
+
+	return logging.WithLogger(ctx, logger)
+
+}

--- a/pkg/reconciler/metric/controller.go
+++ b/pkg/reconciler/metric/controller.go
@@ -29,7 +29,10 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
+	servingreconciler "knative.dev/serving/pkg/reconciler"
 )
+
+const controllerAgentName = "metric-controller"
 
 // NewController initializes the controller and is called by the generated code.
 // Registers eventhandlers to enqueue events.
@@ -38,6 +41,7 @@ func NewController(
 	cmw configmap.Watcher,
 	collector metrics.Collector,
 ) *controller.Impl {
+	ctx = servingreconciler.AnnotateLoggerWithName(ctx, controllerAgentName)
 	logger := logging.FromContext(ctx)
 	metricInformer := metricinformer.Get(ctx)
 

--- a/pkg/reconciler/nscert/controller.go
+++ b/pkg/reconciler/nscert/controller.go
@@ -37,6 +37,7 @@ import (
 
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/serving/pkg/network"
+	servingreconciler "knative.dev/serving/pkg/reconciler"
 	"knative.dev/serving/pkg/reconciler/nscert/config"
 )
 
@@ -47,6 +48,7 @@ const (
 // NewController initializes the controller and is called by the generated code
 // Registers eventhandlers to enqueue events.
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	ctx = servingreconciler.AnnotateLoggerWithName(ctx, controllerAgentName)
 	logger := logging.FromContext(ctx)
 	nsInformer := nsinformer.Get(ctx)
 	knCertificateInformer := kcertinformer.Get(ctx)

--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -40,8 +40,11 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
+	servingreconciler "knative.dev/serving/pkg/reconciler"
 	"knative.dev/serving/pkg/reconciler/revision/config"
 )
+
+const controllerAgentName = "revision-controller"
 
 // NewController initializes the controller and is called by the generated code
 // Registers eventhandlers to enqueue events
@@ -66,6 +69,7 @@ func newControllerWithOptions(
 		transport = rt
 	}
 
+	ctx = servingreconciler.AnnotateLoggerWithName(ctx, controllerAgentName)
 	logger := logging.FromContext(ctx)
 	deploymentInformer := deploymentinformer.Get(ctx)
 	serviceInformer := serviceinformer.Get(ctx)

--- a/pkg/reconciler/route/controller.go
+++ b/pkg/reconciler/route/controller.go
@@ -37,8 +37,11 @@ import (
 	"knative.dev/pkg/tracker"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/network"
+	servingreconciler "knative.dev/serving/pkg/reconciler"
 	"knative.dev/serving/pkg/reconciler/route/config"
 )
+
+const controllerAgentName = "route-controller"
 
 // NewController initializes the controller and is called by the generated code
 // Registers eventhandlers to enqueue events
@@ -57,6 +60,7 @@ func newControllerWithClock(
 	clock system.Clock,
 	opts ...reconcilerOption,
 ) *controller.Impl {
+	ctx = servingreconciler.AnnotateLoggerWithName(ctx, controllerAgentName)
 	logger := logging.FromContext(ctx)
 	serviceInformer := serviceinformer.Get(ctx)
 	routeInformer := routeinformer.Get(ctx)

--- a/pkg/reconciler/serverlessservice/controller.go
+++ b/pkg/reconciler/serverlessservice/controller.go
@@ -34,7 +34,10 @@ import (
 	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/apis/networking"
 	netv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	servingreconciler "knative.dev/serving/pkg/reconciler"
 )
+
+const controllerAgentName = "serverlessservice-controller"
 
 // NewController initializes the controller and is called by the generated code.
 // Registers eventhandlers to enqueue events.
@@ -42,6 +45,8 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+
+	ctx = servingreconciler.AnnotateLoggerWithName(ctx, controllerAgentName)
 	logger := logging.FromContext(ctx)
 	serviceInformer := serviceinformer.Get(ctx)
 	endpointsInformer := endpointsinformer.Get(ctx)

--- a/pkg/reconciler/service/controller.go
+++ b/pkg/reconciler/service/controller.go
@@ -31,7 +31,10 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	servingreconciler "knative.dev/serving/pkg/reconciler"
 )
+
+const controllerAgentName = "service-controller"
 
 // NewController initializes the controller and is called by the generated code
 // Registers eventhandlers to enqueue events
@@ -39,6 +42,7 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
+	ctx = servingreconciler.AnnotateLoggerWithName(ctx, controllerAgentName)
 	logger := logging.FromContext(ctx)
 	serviceInformer := kserviceinformer.Get(ctx)
 	routeInformer := routeinformer.Get(ctx)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->



<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Instrument the controller loggers with the name/type to help disambiguate them in the logs
* `ingress-controller` renamed to `istio-ingress-controller`

This preserves the logger tag logic from 0.12 release (with the exception of the istio ingress controller). This is a stop gap until https://github.com/knative/pkg/issues/1129 is sorted out

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
`ingress-controller` log key renamed to `istio-ingress-controller`
```
