### PR TITLE
drop v1alpha1 support from the metric provider

### DIFF
--- a/pkg/autoscaler/metrics/metrics_provider.go
+++ b/pkg/autoscaler/metrics/metrics_provider.go
@@ -29,7 +29,6 @@ import (
 	cmetrics "k8s.io/metrics/pkg/apis/custom_metrics"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
 var (
@@ -47,20 +46,6 @@ var (
 
 	errMetricNotSupported = errors.New("metric not supported")
 	errNotImplemented     = errors.New("not implemented")
-
-	//TODO(markusthoemmes) remove once 0.13 cuts
-	deprecatedConcurrencyMetricInfo = provider.CustomMetricInfo{
-		GroupResource: v1alpha1.Resource("revisions"),
-		Namespaced:    true,
-		Metric:        autoscaling.Concurrency,
-	}
-
-	//TODO(markusthoemmes) remove once 0.13 cuts
-	deprecatedRpsMetricsInfo = provider.CustomMetricInfo{
-		GroupResource: v1alpha1.Resource("revisions"),
-		Namespaced:    true,
-		Metric:        autoscaling.RPS,
-	}
 )
 
 // MetricProvider is a provider to back a custom-metrics API implementation.
@@ -86,9 +71,9 @@ func (p *MetricProvider) GetMetricByName(name types.NamespacedName, info provide
 	var err error
 
 	switch info {
-	case concurrencyMetricInfo, deprecatedConcurrencyMetricInfo:
+	case concurrencyMetricInfo:
 		data, _, err = p.metricClient.StableAndPanicConcurrency(name, now)
-	case rpsMetricInfo, deprecatedRpsMetricsInfo:
+	case rpsMetricInfo:
 		data, _, err = p.metricClient.StableAndPanicRPS(name, now)
 	default:
 		return nil, errMetricNotSupported
@@ -115,8 +100,6 @@ func (p *MetricProvider) GetMetricBySelector(string, labels.Selector, provider.C
 // ListAllMetrics implements the interface.
 func (p *MetricProvider) ListAllMetrics() []provider.CustomMetricInfo {
 	return []provider.CustomMetricInfo{
-		deprecatedConcurrencyMetricInfo,
-		deprecatedRpsMetricsInfo,
 		concurrencyMetricInfo,
 		rpsMetricInfo,
 	}

--- a/pkg/autoscaler/metrics/metrics_provider_test.go
+++ b/pkg/autoscaler/metrics/metrics_provider_test.go
@@ -113,8 +113,6 @@ func TestGetMetricBySelector(t *testing.T) {
 
 func TestListAllMetrics(t *testing.T) {
 	want := []provider.CustomMetricInfo{
-		deprecatedConcurrencyMetricInfo,
-		deprecatedRpsMetricsInfo,
 		concurrencyMetricInfo,
 		rpsMetricInfo,
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Revision Metrics Provider only supports v1 APIs

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
HPA auto scaling using Revision metrics (concurrency & requests per second) now requires using the v1 APIs
```
