### PR TITLE
Revert PR 6161

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,4 +3,6 @@
 approvers:
 - evankanderson
 - mattmoor
+- mdemirhan
+- vaikas-google
 - vaikas

--- a/OWNERS
+++ b/OWNERS
@@ -4,5 +4,4 @@ approvers:
 - evankanderson
 - mattmoor
 - mdemirhan
-- vaikas-google
 - vaikas

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,9 +27,11 @@ aliases:
 
   autoscaling-approvers:
   - markusthoemmes
+  - mdemirhan
   - vagababov
   autoscaling-reviewers:
   - markusthoemmes
+  - mdemirhan
   - taragu
   - vagababov
   - yanweiguo


### PR DESCRIPTION
Based on a unanimous vote from the steering committee, we are temporarily reverting #6161 and reinstating approver permissions for @mdemirhan while we clarify the process through which approver permissions can be removed by the community.