### PR TITLE
Create a patch to generated k8s client to include CreateOptions header

### DIFF
--- a/hack/patches/README.md
+++ b/hack/patches/README.md
@@ -2,7 +2,8 @@
 
 These are applied after update-deps.sh pulls generated dependencies
 
--------
+---
+
 ## dryruncreate.patch
 
 - Adds CreateWithOptions function to the k8s client

--- a/hack/patches/README.md
+++ b/hack/patches/README.md
@@ -1,4 +1,5 @@
 # Patch file
+
 These are applied after update-deps.sh pulls generated dependencies
 
 -------

--- a/hack/patches/README.md
+++ b/hack/patches/README.md
@@ -5,6 +5,6 @@ These are applied after update-deps.sh pulls generated dependencies
 -------
 ## dryruncreate.patch
 
-* Adds CreateWithOptions function to the k8s client
-* [Commit added to upstream k8s](https://github.com/kubernetes/client-go/commit/e7a922c979d0f5cd6131039b2c86af97a164c7e4#diff-15cf3927b2b02b300f0305c68c6b244al)
-* [Patch removal tracking issue](https://github.com/knative/serving/issues/7143)
+- Adds CreateWithOptions function to the k8s client
+- [Commit added to upstream k8s](https://github.com/kubernetes/client-go/commit/e7a922c979d0f5cd6131039b2c86af97a164c7e4#diff-15cf3927b2b02b300f0305c68c6b244al)
+- [Patch removal tracking issue](https://github.com/knative/serving/issues/7143)

--- a/hack/patches/README.md
+++ b/hack/patches/README.md
@@ -1,0 +1,9 @@
+# Patch file
+These are applied after update-deps.sh pulls generated dependencies
+
+-------
+## dryruncreate.patch
+
+* Adds CreateWithOptions function to the k8s client
+* [Commit added to upstream k8s](https://github.com/kubernetes/client-go/commit/e7a922c979d0f5cd6131039b2c86af97a164c7e4#diff-15cf3927b2b02b300f0305c68c6b244al)
+* [Patch removal tracking issue](https://github.com/knative/serving/issues/7143)

--- a/hack/patches/dryruncreate.patch
+++ b/hack/patches/dryruncreate.patch
@@ -1,0 +1,107 @@
+From 82de2edabc5c4782573ebb0e74a08d2d3348bf7c Mon Sep 17 00:00:00 2001
+From: Weston Haught <whaught@google.com>
+Date: Thu, 20 Feb 2020 15:05:20 -0800
+Subject: [PATCH] Include the modified generated code
+
+---
+ .../kubernetes/typed/core/v1/fake/fake_pod.go     | 13 +++++++++++++
+ .../client-go/kubernetes/typed/core/v1/pod.go     | 15 +++++++++++++++
+ .../resourcesemantics/validation/validation.go    |  4 ++++
+ 3 files changed, 32 insertions(+)
+
+diff --git a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
+index ebd473ac7..39a03b0d5 100644
+--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
++++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
+@@ -19,6 +19,8 @@ limitations under the License.
+ package fake
+
+ import (
++	"context"
++
+ 	corev1 "k8s.io/api/core/v1"
+ 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	labels "k8s.io/apimachinery/pkg/labels"
+@@ -89,6 +91,17 @@ func (c *FakePods) Create(pod *corev1.Pod) (result *corev1.Pod, err error) {
+ 	return obj.(*corev1.Pod), err
+ }
+
++// Create takes the representation of a pod and creates it.  Returns the server's representation of the pod, and an error, if there is any.
++func (c *FakePods) CreateWithOptions(ctx context.Context, pod *corev1.Pod, opts v1.CreateOptions) (result *corev1.Pod, err error) {
++	obj, err := c.Fake.
++		Invokes(testing.NewCreateAction(podsResource, c.ns, pod), &corev1.Pod{})
++
++	if obj == nil {
++		return nil, err
++	}
++	return obj.(*corev1.Pod), err
++}
++
+ // Update takes the representation of a pod and updates it. Returns the server's representation of the pod, and an error, if there is any.
+ func (c *FakePods) Update(pod *corev1.Pod) (result *corev1.Pod, err error) {
+ 	obj, err := c.Fake.
+diff --git a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/pod.go b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+index feacd307f..6dee8fea8 100644
+--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
++++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+@@ -19,6 +19,7 @@ limitations under the License.
+ package v1
+
+ import (
++	"context"
+ 	"time"
+
+ 	v1 "k8s.io/api/core/v1"
+@@ -38,6 +39,7 @@ type PodsGetter interface {
+ // PodInterface has methods to work with Pod resources.
+ type PodInterface interface {
+ 	Create(*v1.Pod) (*v1.Pod, error)
++	CreateWithOptions(ctx context.Context, pod *v1.Pod, opts metav1.CreateOptions) (*v1.Pod, error)
+ 	Update(*v1.Pod) (*v1.Pod, error)
+ 	UpdateStatus(*v1.Pod) (*v1.Pod, error)
+ 	Delete(name string, options *metav1.DeleteOptions) error
+@@ -123,6 +125,19 @@ func (c *pods) Create(pod *v1.Pod) (result *v1.Pod, err error) {
+ 	return
+ }
+
++// Create takes the representation of a pod and creates it.  Returns the server's representation of the pod, and an error, if there is any.
++func (c *pods) CreateWithOptions(ctx context.Context, pod *v1.Pod, opts metav1.CreateOptions) (result *v1.Pod, err error) {
++	result = &v1.Pod{}
++	err = c.client.Post().
++		Namespace(c.ns).
++		Resource("pods").
++		VersionedParams(&opts, scheme.ParameterCodec).
++		Body(pod).
++		Do().
++		Into(result)
++	return
++}
++
+ // Update takes the representation of a pod and updates it. Returns the server's representation of the pod, and an error, if there is any.
+ func (c *pods) Update(pod *v1.Pod) (result *v1.Pod, err error) {
+ 	result = &v1.Pod{}
+diff --git a/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/validation.go b/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/validation.go
+index f394c3968..d6c810c4c 100644
+--- a/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/validation.go
++++ b/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/validation.go
+@@ -34,6 +34,7 @@ import (
+ 	admissionlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
+ 	corelisters "k8s.io/client-go/listers/core/v1"
+ 	"knative.dev/pkg/apis"
++	kubeclient "knative.dev/pkg/client/injection/kube/client"
+ 	"knative.dev/pkg/controller"
+ 	"knative.dev/pkg/kmp"
+ 	"knative.dev/pkg/logging"
+@@ -238,6 +239,9 @@ func (ac *reconciler) validate(ctx context.Context, req *admissionv1beta1.Admiss
+ 		return errMissingNewObject
+ 	}
+
++	// Copy the admission controller's client to the request's context.
++	ctx = context.WithValue(ctx, kubeclient.Key{}, ac.client)
++
+ 	if err := validate(ctx, newObj); err != nil {
+ 		logger.Errorw("Failed the resource specific validation", zap.Error(err))
+ 		// Return the error message as-is to give the validation callback
+--
+2.25.0.265.gbab2e86ba0-goog
+

--- a/hack/patches/dryruncreate.patch
+++ b/hack/patches/dryruncreate.patch
@@ -6,8 +6,7 @@ Subject: [PATCH] Include the modified generated code
 ---
  .../kubernetes/typed/core/v1/fake/fake_pod.go     | 13 +++++++++++++
  .../client-go/kubernetes/typed/core/v1/pod.go     | 15 +++++++++++++++
- .../resourcesemantics/validation/validation.go    |  4 ++++
- 3 files changed, 32 insertions(+)
+ 2 files changed, 28 insertions(+)
 
 diff --git a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
 index ebd473ac7..39a03b0d5 100644
@@ -80,28 +79,6 @@ index feacd307f..6dee8fea8 100644
  // Update takes the representation of a pod and updates it. Returns the server's representation of the pod, and an error, if there is any.
  func (c *pods) Update(pod *v1.Pod) (result *v1.Pod, err error) {
  	result = &v1.Pod{}
-diff --git a/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/validation.go b/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/validation.go
-index f394c3968..d6c810c4c 100644
---- a/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/validation.go
-+++ b/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/validation.go
-@@ -34,6 +34,7 @@ import (
- 	admissionlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
- 	corelisters "k8s.io/client-go/listers/core/v1"
- 	"knative.dev/pkg/apis"
-+	kubeclient "knative.dev/pkg/client/injection/kube/client"
- 	"knative.dev/pkg/controller"
- 	"knative.dev/pkg/kmp"
- 	"knative.dev/pkg/logging"
-@@ -238,6 +239,9 @@ func (ac *reconciler) validate(ctx context.Context, req *admissionv1beta1.Admiss
- 		return errMissingNewObject
- 	}
-
-+	// Copy the admission controller's client to the request's context.
-+	ctx = context.WithValue(ctx, kubeclient.Key{}, ac.client)
-+
- 	if err := validate(ctx, newObj); err != nil {
- 		logger.Errorw("Failed the resource specific validation", zap.Error(err))
- 		// Return the error message as-is to give the validation callback
 --
 2.25.0.265.gbab2e86ba0-goog
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -88,3 +88,7 @@ ${GOPATH}/bin/deepcopy-gen \
 
 # Make sure our dependencies are up-to-date
 ${REPO_ROOT_DIR}/hack/update-deps.sh
+
+# Apply Patches
+echo "Applying patches"
+git apply ${REPO_ROOT_DIR}/hack/patches/*.patch

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -88,7 +88,3 @@ ${GOPATH}/bin/deepcopy-gen \
 
 # Make sure our dependencies are up-to-date
 ${REPO_ROOT_DIR}/hack/update-deps.sh
-
-# Apply Patches
-echo "Applying patches"
-git apply ${REPO_ROOT_DIR}/hack/patches/*.patch

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -46,6 +46,10 @@ readonly DEP_FLAGS
 # Ensure we have everything we need under vendor/
 dep ensure ${DEP_FLAGS[@]}
 
+# Apply Patches
+echo "Applying patches"
+git apply ${REPO_ROOT_DIR}/hack/patches/*.patch
+
 rm -rf $(find vendor/ -name 'OWNERS')
 rm -rf $(find vendor/ -name '*_test.go')
 

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
@@ -19,6 +19,8 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
@@ -80,6 +82,17 @@ func (c *FakePods) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 // Create takes the representation of a pod and creates it.  Returns the server's representation of the pod, and an error, if there is any.
 func (c *FakePods) Create(pod *corev1.Pod) (result *corev1.Pod, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(podsResource, c.ns, pod), &corev1.Pod{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*corev1.Pod), err
+}
+
+// Create takes the representation of a pod and creates it.  Returns the server's representation of the pod, and an error, if there is any.
+func (c *FakePods) CreateWithOptions(ctx context.Context, pod *corev1.Pod, opts v1.CreateOptions) (result *corev1.Pod, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(podsResource, c.ns, pod), &corev1.Pod{})
 

--- a/vendor/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/vendor/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -38,6 +39,7 @@ type PodsGetter interface {
 // PodInterface has methods to work with Pod resources.
 type PodInterface interface {
 	Create(*v1.Pod) (*v1.Pod, error)
+	CreateWithOptions(ctx context.Context, pod *v1.Pod, opts metav1.CreateOptions) (*v1.Pod, error)
 	Update(*v1.Pod) (*v1.Pod, error)
 	UpdateStatus(*v1.Pod) (*v1.Pod, error)
 	Delete(name string, options *metav1.DeleteOptions) error
@@ -117,6 +119,19 @@ func (c *pods) Create(pod *v1.Pod) (result *v1.Pod, err error) {
 	err = c.client.Post().
 		Namespace(c.ns).
 		Resource("pods").
+		Body(pod).
+		Do().
+		Into(result)
+	return
+}
+
+// Create takes the representation of a pod and creates it.  Returns the server's representation of the pod, and an error, if there is any.
+func (c *pods) CreateWithOptions(ctx context.Context, pod *v1.Pod, opts metav1.CreateOptions) (result *v1.Pod, err error) {
+	result = &v1.Pod{}
+	err = c.client.Post().
+		Namespace(c.ns).
+		Resource("pods").
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(pod).
 		Do().
 		Into(result)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Issue  #3425

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adding a new Patch file that includes a CreateWithOptions function of the k8s client that allows for headers.
* Updating the codegen script to apply patches. This will apply the patch here and any future patches made in the hack/patches directory.

_Note: The latest version of the k8s client ([commit](https://github.com/kubernetes/client-go/commit/e7a922c979d0f5cd6131039b2c86af97a164c7e4#diff-15cf3927b2b02b300f0305c68c6b244al)) will include this option at which point the patch can be removed._

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
