### PR TITLE
Use the general constant for the field names

### DIFF
--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -310,8 +310,8 @@ func TestMetricsReported(t *testing.T) {
 		metricskey.LabelNamespaceName:     rev1.Namespace,
 		metricskey.LabelServiceName:       "service-" + rev1.Name,
 		metricskey.LabelConfigurationName: "config-" + rev1.Name,
-		"pod_name":                        "the-best-activator",
-		"container_name":                  "activator",
+		metricskey.PodName:                "the-best-activator",
+		metricskey.ContainerName:          "activator",
 	}
 	metricstest.CheckLastValueData(t, "request_concurrency", wantTags, 4)
 }

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -93,8 +93,8 @@ func TestRequestMetricHandler(t *testing.T) {
 				}
 
 				wantTags := map[string]string{
-					"pod_name":                        testPod,
-					"container_name":                  activator.Name,
+					metricskey.PodName:                testPod,
+					metricskey.ContainerName:          activator.Name,
 					metricskey.LabelNamespaceName:     rev.Namespace,
 					metricskey.LabelServiceName:       rev.Labels[serving.ServiceLabelKey],
 					metricskey.LabelConfigurationName: rev.Labels[serving.ConfigurationLabelKey],

--- a/pkg/metrics/key.go
+++ b/pkg/metrics/key.go
@@ -31,8 +31,8 @@ var (
 	ServiceTagKey        = tag.MustNewKey(metricskey.LabelServiceName)
 	ConfigTagKey         = tag.MustNewKey(metricskey.LabelConfigurationName)
 	RevisionTagKey       = tag.MustNewKey(metricskey.LabelRevisionName)
-	PodTagKey            = tag.MustNewKey("pod_name")
-	ContainerTagKey      = tag.MustNewKey("container_name")
+	PodTagKey            = tag.MustNewKey(metricskey.PodName)
+	ContainerTagKey      = tag.MustNewKey(metricskey.ContainerName)
 	ResponseCodeKey      = tag.MustNewKey(metricskey.LabelResponseCode)
 	ResponseCodeClassKey = tag.MustNewKey(metricskey.LabelResponseCodeClass)
 

--- a/pkg/metrics/tags_test.go
+++ b/pkg/metrics/tags_test.go
@@ -83,8 +83,8 @@ func TestContexts(t *testing.T) {
 			return PodContext("testpod", "testcontainer")
 		}),
 		wantTags: map[string]string{
-			"pod_name":       "testpod",
-			"container_name": "testcontainer",
+			metricskey.PodName:       "testpod",
+			metricskey.ContainerName: "testcontainer",
 		},
 	}, {
 		name: "revision context",
@@ -114,8 +114,8 @@ func TestContexts(t *testing.T) {
 			return PodRevisionContext("testpod", "testcontainer", "testns", "testsvc", "testcfg", "testrev")
 		}),
 		wantTags: map[string]string{
-			"pod_name":                        "testpod",
-			"container_name":                  "testcontainer",
+			metricskey.PodName:                "testpod",
+			metricskey.ContainerName:          "testcontainer",
 			metricskey.LabelNamespaceName:     "testns",
 			metricskey.LabelServiceName:       "testsvc",
 			metricskey.LabelConfigurationName: "testcfg",
@@ -127,8 +127,8 @@ func TestContexts(t *testing.T) {
 			return PodRevisionContext("testpod", "testcontainer", "testns", "", "testcfg", "testrev")
 		}),
 		wantTags: map[string]string{
-			"pod_name":                        "testpod",
-			"container_name":                  "testcontainer",
+			metricskey.PodName:                "testpod",
+			metricskey.ContainerName:          "testcontainer",
 			metricskey.LabelNamespaceName:     "testns",
 			metricskey.LabelServiceName:       metricskey.ValueUnknown,
 			metricskey.LabelConfigurationName: "testcfg",
@@ -140,8 +140,8 @@ func TestContexts(t *testing.T) {
 			return PodRevisionContext("testpod", "testcontainer", "testns", "", "testcfg", "testrev")
 		}),
 		wantTags: map[string]string{
-			"pod_name":                        "testpod",
-			"container_name":                  "testcontainer",
+			metricskey.PodName:                "testpod",
+			metricskey.ContainerName:          "testcontainer",
 			metricskey.LabelNamespaceName:     "testns",
 			metricskey.LabelServiceName:       metricskey.ValueUnknown,
 			metricskey.LabelConfigurationName: "testcfg",
@@ -157,8 +157,8 @@ func TestContexts(t *testing.T) {
 			return AugmentWithRevision(ctx, "testns", "testsvc", "testcfg", "testrev")
 		}),
 		wantTags: map[string]string{
-			"pod_name":                        "testpod",
-			"container_name":                  "testcontainer",
+			metricskey.PodName:                "testpod",
+			metricskey.ContainerName:          "testcontainer",
 			metricskey.LabelNamespaceName:     "testns",
 			metricskey.LabelServiceName:       "testsvc",
 			metricskey.LabelConfigurationName: "testcfg",
@@ -171,8 +171,8 @@ func TestContexts(t *testing.T) {
 			return AugmentWithResponse(ctx, 200), err
 		}),
 		wantTags: map[string]string{
-			"pod_name":                        "testpod",
-			"container_name":                  "testcontainer",
+			metricskey.PodName:                "testpod",
+			metricskey.ContainerName:          "testcontainer",
 			metricskey.LabelNamespaceName:     "testns",
 			metricskey.LabelServiceName:       metricskey.ValueUnknown,
 			metricskey.LabelConfigurationName: "testcfg",

--- a/pkg/queue/request_metric_test.go
+++ b/pkg/queue/request_metric_test.go
@@ -52,8 +52,8 @@ func TestRequestMetricsHandler(t *testing.T) {
 		metricskey.LabelRevisionName:      "rev",
 		metricskey.LabelServiceName:       "svc",
 		metricskey.LabelConfigurationName: "cfg",
-		"pod_name":                        "pod",
-		"container_name":                  "queue-proxy",
+		metricskey.PodName:                "pod",
+		metricskey.ContainerName:          "queue-proxy",
 		metricskey.LabelResponseCode:      "200",
 		metricskey.LabelResponseCodeClass: "2xx",
 	}
@@ -96,8 +96,8 @@ func TestRequestMetricsHandlerPanickingHandler(t *testing.T) {
 			metricskey.LabelRevisionName:      "rev",
 			metricskey.LabelServiceName:       "svc",
 			metricskey.LabelConfigurationName: "cfg",
-			"pod_name":                        "pod",
-			"container_name":                  "queue-proxy",
+			metricskey.PodName:                "pod",
+			metricskey.ContainerName:          "queue-proxy",
 			metricskey.LabelResponseCode:      "500",
 			metricskey.LabelResponseCodeClass: "5xx",
 		}
@@ -158,8 +158,8 @@ func TestAppRequestMetricsHandlerPanickingHandler(t *testing.T) {
 			metricskey.LabelRevisionName:      "rev",
 			metricskey.LabelServiceName:       "svc",
 			metricskey.LabelConfigurationName: "cfg",
-			"pod_name":                        "pod",
-			"container_name":                  "queue-proxy",
+			metricskey.PodName:                "pod",
+			metricskey.ContainerName:          "queue-proxy",
 			metricskey.LabelResponseCode:      "500",
 			metricskey.LabelResponseCodeClass: "5xx",
 		}
@@ -188,8 +188,8 @@ func TestAppRequestMetricsHandler(t *testing.T) {
 		metricskey.LabelRevisionName:      "rev",
 		metricskey.LabelServiceName:       "svc",
 		metricskey.LabelConfigurationName: "cfg",
-		"pod_name":                        "pod",
-		"container_name":                  "queue-proxy",
+		metricskey.PodName:                "pod",
+		metricskey.ContainerName:          "queue-proxy",
 		metricskey.LabelResponseCode:      "200",
 		metricskey.LabelResponseCodeClass: "2xx",
 	}


### PR DESCRIPTION
Rather than using the hardcoded ones.

/assign @yanweiguo @markusthoemmes 