### PR TITLE
Prevent timeoutWriter.Flush after TimeoutAndWriteError

### DIFF
--- a/pkg/queue/timeout.go
+++ b/pkg/queue/timeout.go
@@ -113,6 +113,9 @@ var _ http.Flusher = (*timeoutWriter)(nil)
 var _ http.ResponseWriter = (*timeoutWriter)(nil)
 
 func (tw *timeoutWriter) Flush() {
+	// The inner handler of timeoutHandler can call Flush at any time including after
+	// timeoutHandler.ServeHTTP has returned. Forwarding this call to the inner
+	// http.ResponseWriter would lead to a panic in HTTP2. See http2/server.go line 2556.
 	tw.mu.Lock()
 	defer tw.mu.Unlock()
 	if tw.timedOut {

--- a/pkg/queue/timeout.go
+++ b/pkg/queue/timeout.go
@@ -113,6 +113,12 @@ var _ http.Flusher = (*timeoutWriter)(nil)
 var _ http.ResponseWriter = (*timeoutWriter)(nil)
 
 func (tw *timeoutWriter) Flush() {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	if tw.timedOut {
+		return
+	}
+
 	tw.w.(http.Flusher).Flush()
 }
 

--- a/pkg/queue/timeout_test.go
+++ b/pkg/queue/timeout_test.go
@@ -153,3 +153,16 @@ func TestTimeoutWriterAllowsForAdditionalWrites(t *testing.T) {
 		t.Errorf("recorder.Body = %s, want %s", got, want)
 	}
 }
+
+func TestTimeoutWriterDoesntFlushAfterTimeout(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	handler := &timeoutWriter{
+		w: recorder,
+	}
+
+	handler.TimeoutAndWriteError("error")
+	handler.Flush()
+	if got, want := recorder.Flushed, false; got != want {
+		t.Errorf("recorder.Flushed = %t, want %t", got, want)
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

What was observed in the wild in `queue-proxy`
```
{"level":"error","ts":"2020-02-28T20:29:03.151Z","logger":"queueproxy","caller":"network/error_handler.go:31","msg":"error reverse proxying request; sockstat: sockets: used 271\nTCP: inuse 25 orphan 0 tw 205 alloc 1106 mem 139\nUDP: inuse 0 mem 23\nUDPLITE: inuse 0\nRAW: inuse 0\nFRAG: inuse 0 memory 0\n","knative.dev/key":"XXX","knative.dev/pod":"XXX","error":"context canceled","stacktrace":"gke-internal/knative/cloudrun/vendor/knative.dev/serving/pkg/network.ErrorHandler.func1\n\t/workspace/go/src/gke-internal/knative/cloudrun/vendor/knative.dev/serving/pkg/network/error_handler.go:31\nnet/http/httputil.(*ReverseProxy).ServeHTTP\n\t/usr/local/go/src/net/http/httputil/reverseproxy.go:251\ngke-internal/knative/cloudrun/vendor/knative.dev/serving/pkg/queue.(*requestMetricHandler).ServeHTTP\n\t/workspace/go/src/gke-internal/knative/cloudrun/vendor/knative.dev/serving/pkg/queue/request_metric.go:71\nmain.handler.func1\n\t/workspace/go/src/gke-internal/knative/cloudrun/vendor/knative.dev/serving/cmd/queue/main.go:197\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2007\ngke-internal/knative/cloudrun/vendor/knative.dev/serving/pkg/queue.ForwardedShimHandler.func1\n\t/workspace/go/src/gke-internal/knative/cloudrun/vendor/knative.dev/serving/pkg/queue/forwarded_shim.go:100\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2007\ngke-internal/knative/cloudrun/vendor/knative.dev/serving/pkg/queue.(*timeoutHandler).ServeHTTP.func1\n\t/workspace/go/src/gke-internal/knative/cloudrun/vendor/knative.dev/serving/pkg/queue/timeout.go:80"}

panic: Header called after Handler finished [recovered]

panic: Header called after Handler finished [recovered]

panic: send on closed channel
```


<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* The `panic: send on closed channel` bug has been fixed in https://github.com/knative/serving/pull/7138
* Prevent calls to the inner `ResponseWriter.Flush` when `timeoutWriter` has already timed out (see https://github.com/golang/net/blob/master/http2/server.go#L2556)

/assign @vagababov 