### PR TITLE
Add the operator limits for the #7121

### DIFF
--- a/config/core/configmaps/defaults.yaml
+++ b/config/core/configmaps/defaults.yaml
@@ -81,3 +81,11 @@ data:
     # disables this throttling and lets through as many requests as
     # the pod receives.
     container-concurrency: "0"
+
+    # The container concurrency max limit is an operator setting ensuring that
+    # the individual revisions cannot have arbitrary large concurrency
+    # values, or autoscaling targets. `container-concurrency` default setting
+    # must be at or below this value.
+    # If the value is `0`, no limit is enforced.
+    # Must be greater than 1.
+    container-concurrency-max-limit: "1000"

--- a/config/core/configmaps/defaults.yaml
+++ b/config/core/configmaps/defaults.yaml
@@ -86,6 +86,5 @@ data:
     # the individual revisions cannot have arbitrary large concurrency
     # values, or autoscaling targets. `container-concurrency` default setting
     # must be at or below this value.
-    # If the value is `0`, no limit is enforced.
     # Must be greater than 1.
     container-concurrency-max-limit: "1000"


### PR DESCRIPTION
As described in the issue #7121 we need to be able to permit operators to restrict
developers from shooting themselves in the foot, should they decide so.
Add a default off settings for target/cc and target utilization.

Actual validation in the next PRs


/lint


For #7121
/assign mattmoor @markusthoemmes 