### PR TITLE
Fix the data race in the auto tls test.

### DIFF
--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -101,7 +101,6 @@ func testAutoTLS(t *testing.T) {
 			return transport
 		}
 		prober := test.RunRouteProber(t.Logf, clients, objects.Service.Status.URL.URL(), transportOption)
-		defer test.AssertProberDefault(t, prober)
 
 		if _, err := v1test.UpdateServiceRouteSpec(t, clients, names, servingv1.RouteSpec{
 			Traffic: []servingv1.TrafficTarget{{
@@ -139,6 +138,7 @@ func testAutoTLS(t *testing.T) {
 		for _, traffic := range route.Status.Traffic {
 			testingress.RuntimeRequest(t, httpsClient, traffic.URL.String())
 		}
+		test.AssertProberDefault(t, prober)
 	})
 }
 

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -133,8 +133,7 @@ func CreateServiceReady(t pkgTest.T, clients *test.Clients, names *test.Resource
 func CreateService(t pkgTest.T, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.ServiceOption) (*v1.Service, error) {
 	service := Service(names, fopt...)
 	LogResourceObject(t, ResourceObjects{Service: service})
-	svc, err := clients.ServingClient.Services.Create(service)
-	return svc, err
+	return clients.ServingClient.Services.Create(service)
 }
 
 // PatchService patches the existing service passed in with the applied mutations.


### PR DESCRIPTION
When we try to verify probing for a test that exited by 'Fatal' calls in the body
we are having data races for logging after test terminated.
For example: https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1235870345278263296


/assign @ZhiminXiang 