### PR TITLE
Propagate the webhook k8s client to validatable

### DIFF
--- a/pkg/apis/serving/v1/revision_validation_test.go
+++ b/pkg/apis/serving/v1/revision_validation_test.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2019 The Knative Authors
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,6 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"knative.dev/pkg/apis"
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/autoscaling"
@@ -77,10 +75,10 @@ func TestRevisionValidation(t *testing.T) {
 	}}
 
 	// TODO(dangerd): PodSpec validation failures.
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.r.Validate(context.Background())
+			ctx, _ := fakekubeclient.With(context.Background())
+			got := test.r.Validate(ctx)
 			if !cmp.Equal(test.want.Error(), got.Error()) {
 				t.Errorf("Validate (-want, +got) = %v",
 					cmp.Diff(test.want.Error(), got.Error()))
@@ -233,9 +231,11 @@ func TestRevisionLabelAnnotationValidation(t *testing.T) {
 		},
 		want: apis.ErrInvalidKeyName("serving.knative.dev/testlabel", "metadata.labels"),
 	}}
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.r.Validate(context.Background())
+			ctx, _ := fakekubeclient.With(context.Background())
+			got := test.r.Validate(ctx)
 			if got, want := got.Error(), test.want.Error(); !cmp.Equal(got, want) {
 				t.Errorf("Validate (-want, +got) = %s", cmp.Diff(want, got))
 			}
@@ -438,7 +438,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx, _ := fakekubeclient.With(context.Background())
 			if test.wc != nil {
 				ctx = test.wc(ctx)
 			}
@@ -896,7 +896,8 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := apis.WithinParent(context.Background(), metav1.ObjectMeta{
+			ctx, _ := fakekubeclient.With(context.Background())
+			ctx = apis.WithinParent(ctx, metav1.ObjectMeta{
 				Name: "parent",
 			})
 

--- a/pkg/reconciler/testing/v1/factory.go
+++ b/pkg/reconciler/testing/v1/factory.go
@@ -116,11 +116,13 @@ func MakeFactory(ctor Ctor) rtesting.Factory {
 		// Validate all Create operations through the serving client.
 		client.PrependReactor("create", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			// TODO(n3wscott): context.Background is the best we can do at the moment, but it should be set-able.
-			return rtesting.ValidateCreates(context.Background(), action)
+			validateContext, _ := fakekubeclient.With(context.Background())
+			return rtesting.ValidateCreates(validateContext, action)
 		})
 		client.PrependReactor("update", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			// TODO(n3wscott): context.Background is the best we can do at the moment, but it should be set-able.
-			return rtesting.ValidateUpdates(context.Background(), action)
+			validateContext, _ := fakekubeclient.With(context.Background())
+			return rtesting.ValidateCreates(validateContext, action)
 		})
 
 		actionRecorderList := rtesting.ActionRecorderList{istioClient, dynamicClient, client, kubeClient, cachingClient, certManagerClient}

--- a/vendor/knative.dev/pkg/apis/contexts.go
+++ b/vendor/knative.dev/pkg/apis/contexts.go
@@ -21,6 +21,8 @@ import (
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 )
 
 // This is attached to contexts passed to webhook interfaces when
@@ -197,4 +199,10 @@ func AllowDifferentNamespace(ctx context.Context) context.Context {
 // namespace is allowed from the encapsulating object.
 func IsDifferentNamespaceAllowed(ctx context.Context) bool {
 	return ctx.Value(allowDifferentNamespace{}) != nil
+}
+
+// WithKubeClient is used to attach a kubernetes go client to context. This is used
+// to allow k8s validation within Validatable.
+func WithKubeClient(ctx context.Context, client *kubernetes.Interface) context.Context {
+	return context.WithValue(ctx, kubeclient.Key{}, client)
 }

--- a/vendor/knative.dev/pkg/apis/contexts.go
+++ b/vendor/knative.dev/pkg/apis/contexts.go
@@ -203,6 +203,6 @@ func IsDifferentNamespaceAllowed(ctx context.Context) bool {
 
 // WithKubeClient is used to attach a kubernetes go client to context. This is used
 // to allow k8s validation within Validatable.
-func WithKubeClient(ctx context.Context, client *kubernetes.Interface) context.Context {
+func WithKubeClient(ctx context.Context, client kubernetes.Interface) context.Context {
 	return context.WithValue(ctx, kubeclient.Key{}, client)
 }

--- a/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/validation.go
+++ b/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/validation.go
@@ -34,6 +34,7 @@ import (
 	admissionlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"knative.dev/pkg/apis"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
@@ -237,6 +238,9 @@ func (ac *reconciler) validate(ctx context.Context, req *admissionv1beta1.Admiss
 	if newObj == nil {
 		return errMissingNewObject
 	}
+
+	// Copy the admission controller's client to the request's context.
+	ctx = context.WithValue(ctx, kubeclient.Key{}, ac.client)
 
 	if err := validate(ctx, newObj); err != nil {
 		logger.Errorw("Failed the resource specific validation", zap.Error(err))

--- a/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/validation.go
+++ b/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/validation.go
@@ -34,7 +34,6 @@ import (
 	admissionlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"knative.dev/pkg/apis"
-	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
@@ -240,7 +239,7 @@ func (ac *reconciler) validate(ctx context.Context, req *admissionv1beta1.Admiss
 	}
 
 	// Copy the admission controller's client to the request's context.
-	ctx = context.WithValue(ctx, kubeclient.Key{}, ac.client)
+	ctx = apis.WithKubeClient(ctx, &ac.client)
 
 	if err := validate(ctx, newObj); err != nil {
 		logger.Errorw("Failed the resource specific validation", zap.Error(err))

--- a/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/validation.go
+++ b/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/validation.go
@@ -239,7 +239,7 @@ func (ac *reconciler) validate(ctx context.Context, req *admissionv1beta1.Admiss
 	}
 
 	// Copy the admission controller's client to the request's context.
-	ctx = apis.WithKubeClient(ctx, &ac.client)
+	ctx = apis.WithKubeClient(ctx, ac.client)
 
 	if err := validate(ctx, newObj); err != nil {
 		logger.Errorw("Failed the resource specific validation", zap.Error(err))


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Issue #3425

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Copies the kubeclient from the Webhook controller to the request context. This allows
   for future use of the client during validation.
* No behavioral change.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
