### PR TITLE
[RELEASE 0.13] Update to latest pkg 0.13

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1812,7 +1812,7 @@
 
 [[projects]]
   branch = "release-0.13"
-  digest = "1:77db7d7e7364e6acb7fe627ddb377f94e5199b020be96aa0e8654cd864db2d7a"
+  digest = "1:333539485c96ddf9d1ac20c5141a27044890c7d5b7f5de85f28a9267120acb4c"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -1920,7 +1920,7 @@
     "websocket",
   ]
   pruneopts = "T"
-  revision = "2006e107e39eb0e661e4437ba76b16465162689e"
+  revision = "a56a6ea3fa56b9c9c2482a5bda0005dd2364d183"
 
 [[projects]]
   branch = "master"

--- a/vendor/knative.dev/pkg/injection/sharedmain/main.go
+++ b/vendor/knative.dev/pkg/injection/sharedmain/main.go
@@ -106,7 +106,7 @@ func GetLeaderElectionConfig(ctx context.Context) (*kle.Config, error) {
 	leaderElectionConfigMap, err := kubeclient.Get(ctx).CoreV1().ConfigMaps(system.Namespace()).Get(kle.ConfigMapName(), metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return kle.NewConfigFromMap(nil)
+			return kle.NewConfigFromConfigMap(nil)
 		}
 
 		return nil, err

--- a/vendor/knative.dev/pkg/metrics/exporter.go
+++ b/vendor/knative.dev/pkg/metrics/exporter.go
@@ -16,6 +16,7 @@ package metrics
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"go.opencensus.io/stats/view"
@@ -74,7 +75,7 @@ func UpdateExporterFromConfigMap(component string, logger *zap.SugaredLogger) fu
 	return func(configMap *corev1.ConfigMap) {
 		UpdateExporter(ExporterOptions{
 			Domain:    domain,
-			Component: component,
+			Component: strings.ReplaceAll(component, "-", "_"),
 			ConfigMap: configMap.Data,
 		}, logger)
 	}


### PR DESCRIPTION
Brings in knative/pkg#1142 and knative/pkg#1145:

- correct behavior when leader election config doesn't exist
- fix problem with invalid prometheus metrics names with some controllers

**Release Note**

```release-note
- correct behavior when leader election config doesn't exist
- fix problem with invalid prometheus metrics names with some controller names
```
