### PR TITLE
Add new field ImageDigests to Revision status for multi container support

### DIFF
--- a/pkg/apis/config/defaults.go
+++ b/pkg/apis/config/defaults.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"math"
 	"strconv"
+	"strings"
 	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
@@ -67,6 +68,18 @@ func defaultConfig() *Defaults {
 // NewDefaultsConfigFromMap creates a Defaults from the supplied Map
 func NewDefaultsConfigFromMap(data map[string]string) (*Defaults, error) {
 	nc := defaultConfig()
+
+	// Process bool fields.
+	b := struct {
+		key          string
+		field        *bool
+		defaultValue bool
+	}{
+		key:          "enable-multi-container",
+		field:        &nc.EnableMultiContainer,
+		defaultValue: false,
+	}
+	nc.EnableMultiContainer = strings.EqualFold(data[b.key], "true")
 
 	// Process int64 fields
 	for _, i64 := range []struct {
@@ -158,6 +171,9 @@ func NewDefaultsConfigFromConfigMap(config *corev1.ConfigMap) (*Defaults, error)
 
 // Defaults includes the default values to be populated by the webhook.
 type Defaults struct {
+	// Feature flag to enable multi container support
+	EnableMultiContainer bool
+
 	RevisionTimeoutSeconds int64
 	// This is the timeout set for cluster ingress.
 	// RevisionTimeoutSeconds must be less than this value.

--- a/pkg/apis/serving/v1/revision_types.go
+++ b/pkg/apis/serving/v1/revision_types.go
@@ -136,6 +136,12 @@ type RevisionStatus struct {
 	// may be empty if the image comes from a registry listed to skip resolution.
 	// +optional
 	ImageDigest string `json:"imageDigest,omitempty"`
+	// ImageDigests holds the resolved digest for the image specified
+	// within .Spec.Container.Image. The digest is resolved during the creation
+	// of Revision. ImageDigests holds the digest for all the .Spec.Container.Image both serving and non serving.
+	// ref: http://bit.ly/image-digests
+	// +optional
+	ImageDigests map[string]string `json:"imageDigests,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/serving/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/serving/v1/zz_generated.deepcopy.go
@@ -230,6 +230,13 @@ func (in *RevisionSpec) DeepCopy() *RevisionSpec {
 func (in *RevisionStatus) DeepCopyInto(out *RevisionStatus) {
 	*out = *in
 	in.Status.DeepCopyInto(&out.Status)
+	if in.ImageDigests != nil {
+		in, out := &in.ImageDigests, &out.ImageDigests
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/serving/v1alpha1/revision_conversion.go
+++ b/pkg/apis/serving/v1alpha1/revision_conversion.go
@@ -62,10 +62,8 @@ func (source *RevisionSpec) ConvertTo(ctx context.Context, sink *v1.RevisionSpec
 			Volumes:            source.Volumes,
 			ImagePullSecrets:   source.ImagePullSecrets,
 		}
-	case len(source.Containers) == 1:
+	case len(source.Containers) != 0:
 		sink.PodSpec = source.PodSpec
-	case len(source.Containers) > 1:
-		return apis.ErrMultipleOneOf("containers")
 	default:
 		return apis.ErrMissingOneOf("container", "containers")
 	}
@@ -82,6 +80,7 @@ func (source *RevisionStatus) ConvertTo(ctx context.Context, sink *v1.RevisionSt
 	sink.ServiceName = source.ServiceName
 	sink.LogURL = source.LogURL
 	sink.ImageDigest = source.ImageDigest
+	sink.ImageDigests = source.ImageDigests
 }
 
 // ConvertFrom implements apis.Convertible
@@ -114,4 +113,5 @@ func (sink *RevisionStatus) ConvertFrom(ctx context.Context, source v1.RevisionS
 	sink.ServiceName = source.ServiceName
 	sink.LogURL = source.LogURL
 	sink.ImageDigest = source.ImageDigest
+	sink.ImageDigests = source.ImageDigests
 }

--- a/pkg/apis/serving/v1alpha1/revision_conversion_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_conversion_test.go
@@ -231,6 +231,9 @@ func TestRevisionConversionError(t *testing.T) {
 					TimeoutSeconds:       ptr.Int64(18),
 					ContainerConcurrency: ptr.Int64(53),
 				},
+				DeprecatedContainer: &corev1.Container{
+					Image: "busybox",
+				},
 			},
 			Status: RevisionStatus{
 				Status: duckv1.Status{
@@ -244,7 +247,7 @@ func TestRevisionConversionError(t *testing.T) {
 				LogURL:      "http://logger.io",
 			},
 		},
-		want: apis.ErrMultipleOneOf("containers"),
+		want: apis.ErrMultipleOneOf("container, containers"),
 	}, {
 		name: "no containers in podspec",
 		in: &Revision{

--- a/pkg/apis/serving/v1alpha1/revision_types.go
+++ b/pkg/apis/serving/v1alpha1/revision_types.go
@@ -192,6 +192,12 @@ type RevisionStatus struct {
 	// may be empty if the image comes from a registry listed to skip resolution.
 	// +optional
 	ImageDigest string `json:"imageDigest,omitempty"`
+	// ImageDigests holds the resolved digest for the image specified
+	// within .Spec.Container.Image. The digest is resolved during the creation
+	// of Revision. ImageDigests holds the digest for all the .Spec.Container.Image both serving and non serving.
+	// ref: http://bit.ly/image-digests
+	// +optional
+	ImageDigests map[string]string `json:"imageDigests,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
@@ -316,6 +316,13 @@ func (in *RevisionSpec) DeepCopy() *RevisionSpec {
 func (in *RevisionStatus) DeepCopyInto(out *RevisionStatus) {
 	*out = *in
 	in.Status.DeepCopyInto(&out.Status)
+	if in.ImageDigests != nil {
+		in, out := &in.ImageDigests, &out.ImageDigests
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/reconciler/revision/queueing_test.go
+++ b/pkg/reconciler/revision/queueing_test.go
@@ -110,9 +110,32 @@ func testRevision() *v1.Revision {
 	rev.SetDefaults(context.Background())
 	return rev
 }
+func testRevisionForMultipleContainer() *v1.Revision {
+	return &v1.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rev-multi-container",
+			Namespace: testNamespace,
+		},
+		Spec: v1.RevisionSpec{
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Image: "gcr.io/repo/image",
+				}, {
+					Image: "docker.io/repo/image",
+				}},
+			},
+		},
+	}
+}
 
 func getTestDeploymentConfig() *deployment.Config {
 	c, _ := deployment.NewConfigFromConfigMap(getTestDeploymentConfigMap())
+	// ignoring error as test controller is generated
+	return c
+}
+
+func getTestDefaultConfig() *config.Defaults {
+	c, _ := config.NewDefaultsConfigFromConfigMap(getTestDefaultsConfigMap())
 	// ignoring error as test controller is generated
 	return c
 }

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -747,5 +747,6 @@ func ReconcilerTestConfig() *config.Config {
 		Logging:    &logging.Config{},
 		Tracing:    &tracingconfig.Config{},
 		Autoscaler: &autoscalerconfig.Config{},
+		Defaults:   getTestDefaultConfig(),
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

**Fixes:**
Parts of #5822 #3384

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Divided [PR](https://github.com/knative/serving/pull/6739) to multiple parts in order to cover all the functionality with sub PR's

### Part 1: [PR](https://github.com/knative/serving/pull/7167)
### Part  2:
* Add imageDigests field to revision status in order to maintain digests for all the containers

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Need to update ImageDigests along with ImageDigest for Revision status
```

**Dependency:**
This PR has dependency with [PR](https://github.com/knative/serving/pull/7167) so once that is merged will update this PR.
