### PR TITLE
Improve logging for the pod tracker.

### DIFF
--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -69,6 +69,10 @@ type podTracker struct {
 	b    breaker
 }
 
+func (p *podTracker) String() string {
+	return p.dest
+}
+
 func (p *podTracker) Capacity() int {
 	if p.b == nil {
 		return 1


### PR DESCRIPTION
 We've been logging pointers and it's useless.
Now we'll log destination instead :-)

/assign @markusthoemmes mattmoor