### PR TITLE
Add init scale to zero operator config

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -137,3 +137,10 @@ data:
     # that should be used if none is specified. If omitted, the Knative
     # Horizontal Pod Autoscaler (KPA) is used by default.
     pod-autoscaler-class: "kpa.autoscaling.knative.dev"
+
+    # Scale to zero on deploy indicates whether new services will scale to
+    # 0 pods at the time of deployment. If minScale is set to > 0, new
+    # services will respect minScale and create the desired number of
+    # instances. If user provides readiness probe, readiness probe will
+    # still run and new services will not scale to 0.
+    scale-to-zero-on-deploy: "false"

--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -138,9 +138,11 @@ data:
     # Horizontal Pod Autoscaler (KPA) is used by default.
     pod-autoscaler-class: "kpa.autoscaling.knative.dev"
 
-    # Scale to zero on deploy indicates whether new services will scale to
-    # 0 pods at the time of deployment. If minScale is set to > 0, new
-    # services will respect minScale and create the desired number of
-    # instances. If user provides readiness probe, readiness probe will
-    # still run and new services will not scale to 0.
+    # scale-to-zero-on-deploy creates new revisions with zero initial
+    # replicas.  With this setting enabled the user container is not
+    # activated, nor are readinessProbes evaluated before the new
+    # Revision is declared Ready.  This setting should only be enabled
+    # with extreme caution as it may cause traffic to shift to unverified
+    # Revisions.  This behavior is overridden when the minScale
+    # annotation is specified.
     scale-to-zero-on-deploy: "false"

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -90,22 +90,19 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		key          string
 		field        *bool
 		defaultValue bool
-	}{
-		{
-			key:          "enable-scale-to-zero",
-			field:        &lc.EnableScaleToZero,
-			defaultValue: true,
-		},
-		{
-			key:          "enable-graceful-scaledown",
-			field:        &lc.EnableGracefulScaledown,
-			defaultValue: false,
-		},
-		{
-			key:          "scale-to-zero-on-deploy",
-			field:        &lc.ScaleToZeroOnDeploy,
-			defaultValue: false,
-		}} {
+	}{{
+		key:          "enable-scale-to-zero",
+		field:        &lc.EnableScaleToZero,
+		defaultValue: true,
+	}, {
+		key:          "enable-graceful-scaledown",
+		field:        &lc.EnableGracefulScaledown,
+		defaultValue: false,
+	}, {
+		key:          "scale-to-zero-on-deploy",
+		field:        &lc.ScaleToZeroOnDeploy,
+		defaultValue: false,
+	}} {
 		if raw, ok := data[b.key]; !ok {
 			*b.field = b.defaultValue
 		} else {

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -48,6 +48,10 @@ type Config struct {
 	// Enable connection-aware pod scaledown
 	EnableGracefulScaledown bool
 
+	// ScaleToZeroOnDeploy indicates whether default readiness probe will run on deploy.
+	// If this is set to true, services will be scaled to 0 on deploy.
+	ScaleToZeroOnDeploy bool
+
 	// Target concurrency knobs for different container concurrency configurations.
 	ContainerConcurrencyTargetFraction float64
 	ContainerConcurrencyTargetDefault  float64
@@ -95,6 +99,11 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		{
 			key:          "enable-graceful-scaledown",
 			field:        &lc.EnableGracefulScaledown,
+			defaultValue: false,
+		},
+		{
+			key:          "scale-to-zero-on-deploy",
+			field:        &lc.ScaleToZeroOnDeploy,
 			defaultValue: false,
 		}} {
 		if raw, ok := data[b.key]; !ok {

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -30,6 +30,7 @@ import (
 var defaultConfig = Config{
 	EnableScaleToZero:                  true,
 	EnableGracefulScaledown:            false,
+	ScaleToZeroOnDeploy:                false,
 	ContainerConcurrencyTargetFraction: 0.7,
 	ContainerConcurrencyTargetDefault:  100,
 	RPSTargetDefault:                   200,
@@ -98,6 +99,7 @@ func TestNewConfig(t *testing.T) {
 		input: map[string]string{
 			"enable-scale-to-zero":                    "true",
 			"enable-graceful-scaledown":               "false",
+			"scale-to-zero-on-deploy":                 "false",
 			"max-scale-down-rate":                     "3.0",
 			"max-scale-up-rate":                       "1.01",
 			"container-concurrency-target-percentage": "0.71",
@@ -137,6 +139,21 @@ func TestNewConfig(t *testing.T) {
 		want: func(c Config) *Config {
 			c.EnableScaleToZero = false
 			c.EnableGracefulScaledown = true
+			return &c
+		}(defaultConfig),
+	}, {
+		name: "with scale to zero on deploy toggle on strange casing",
+		input: map[string]string{
+			"scale-to-zero-on-deploy": "FALSE",
+		},
+		want: &defaultConfig,
+	}, {
+		name: "with scale to zero on deploy toggle explicitly off",
+		input: map[string]string{
+			"scale-to-zero-on-deploy": "true",
+		},
+		want: func(c Config) *Config {
+			c.ScaleToZeroOnDeploy = true
 			return &c
 		}(defaultConfig),
 	}, {

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
@@ -265,6 +265,7 @@ func withMetric(m autoscalingv2beta1.MetricSpec) hpaOption {
 
 var config = &autoscalerconfig.Config{
 	EnableScaleToZero:                  true,
+	ScaleToZeroOnDeploy:                false,
 	ContainerConcurrencyTargetFraction: 1.0,
 	ContainerConcurrencyTargetDefault:  100.0,
 	RPSTargetDefault:                   200.0,

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -93,7 +93,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 		if _, err = c.ReconcileSKS(ctx, pa, nv1alpha1.SKSOperationModeServe); err != nil {
 			return fmt.Errorf("error reconciling SKS: %w", err)
 		}
-		return computeStatus(pa, podCounts{want: scaleUnknown})
+		return computeStatus(ctx, pa, podCounts{want: scaleUnknown})
 	}
 
 	pa.Status.MetricsServiceName = sks.Status.PrivateServiceName
@@ -174,7 +174,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 		terminating: terminating,
 	}
 	logger.Infof("Observed pod counts=%#v", pc)
-	return computeStatus(pa, pc)
+	return computeStatus(ctx, pa, pc)
 }
 
 func (c *Reconciler) reconcileDecider(ctx context.Context, pa *pav1alpha1.PodAutoscaler, k8sSvc string) (*scaling.Decider, error) {
@@ -200,14 +200,14 @@ func (c *Reconciler) reconcileDecider(ctx context.Context, pa *pav1alpha1.PodAut
 	return decider, nil
 }
 
-func computeStatus(pa *pav1alpha1.PodAutoscaler, pc podCounts) error {
+func computeStatus(ctx context.Context, pa *pav1alpha1.PodAutoscaler, pc podCounts) error {
 	pa.Status.DesiredScale, pa.Status.ActualScale = ptr.Int32(int32(pc.want)), ptr.Int32(int32(pc.ready))
 
 	if err := reportMetrics(pa, pc); err != nil {
 		return fmt.Errorf("error reporting metrics: %w", err)
 	}
 
-	computeActiveCondition(pa, pc)
+	computeActiveCondition(ctx, pa, pc)
 
 	pa.Status.ObservedGeneration = pa.Generation
 	return nil
@@ -247,8 +247,8 @@ func reportMetrics(pa *pav1alpha1.PodAutoscaler, pc podCounts) error {
 //    | -1   | >= min | inactive   | inactive   |
 //    | -1   | >= min | activating | active     |
 //    | -1   | >= min | active     | active     |
-func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, pc podCounts) {
-	minReady := activeThreshold(pa)
+func computeActiveCondition(ctx context.Context, pa *pav1alpha1.PodAutoscaler, pc podCounts) {
+	minReady := activeThreshold(ctx, pa)
 
 	switch {
 	case pc.want == 0:
@@ -274,11 +274,12 @@ func computeActiveCondition(pa *pav1alpha1.PodAutoscaler, pc podCounts) {
 }
 
 // activeThreshold returns the scale required for the pa to be marked Active
-func activeThreshold(pa *pav1alpha1.PodAutoscaler) int {
+func activeThreshold(ctx context.Context, pa *pav1alpha1.PodAutoscaler) int {
+	clusterScaleToZeroOnDeploy := config.FromContext(ctx).Autoscaler.ScaleToZeroOnDeploy
+
 	min, _ := pa.ScaleBounds()
-	if min < 1 {
+	if min < 1 && !clusterScaleToZeroOnDeploy {
 		min = 1
 	}
-
 	return int(min)
 }

--- a/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
@@ -263,6 +263,7 @@ func withPanicThresholdPercentageAnnotation(percentage string) deciderOption {
 
 var config = &autoscalerconfig.Config{
 	EnableScaleToZero:                  true,
+	ScaleToZeroOnDeploy:                false,
 	ContainerConcurrencyTargetFraction: 1.0,
 	ContainerConcurrencyTargetDefault:  100.0,
 	TargetBurstCapacity:                211.0,

--- a/pkg/reconciler/autoscaling/resources/metric_test.go
+++ b/pkg/reconciler/autoscaling/resources/metric_test.go
@@ -172,6 +172,7 @@ func pa(options ...PodAutoscalerOption) *v1alpha1.PodAutoscaler {
 
 var config = &autoscalerconfig.Config{
 	EnableScaleToZero:                  true,
+	ScaleToZeroOnDeploy:                false,
 	ContainerConcurrencyTargetFraction: 1.0,
 	ContainerConcurrencyTargetDefault:  100.0,
 	RPSTargetDefault:                   200.0,

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -243,6 +243,11 @@ func MakeDeployment(rev *v1.Revision,
 		return nil, fmt.Errorf("failed to create PodSpec: %w", err)
 	}
 
+	replicaCount := ptr.Int32(1)
+	if autoscalerConfig.ScaleToZeroOnDeploy {
+		replicaCount = ptr.Int32(0)
+	}
+
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.Deployment(rev),
@@ -255,7 +260,7 @@ func MakeDeployment(rev *v1.Revision,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(rev)},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas:                ptr.Int32(1),
+			Replicas:                replicaCount,
 			Selector:                makeSelector(rev),
 			ProgressDeadlineSeconds: ptr.Int32(ProgressDeadlineSeconds),
 			Template: corev1.PodTemplateSpec{

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -550,7 +550,7 @@ func TestReconcile(t *testing.T) {
 		Key: "foo/image-pull-secrets",
 	}, {
 		Name: "scale to zero on deploy true",
-		Ctx:  context.WithValue(context.Background(), scaleToZeroKey, ptr.Bool(true)),
+		Ctx:  context.WithValue(context.Background(), scaleToZeroKey, true),
 		Objects: []runtime.Object{
 			rev("foo", "scale-to-zero-on-deploy-true"),
 			pa("foo", "scale-to-zero-on-deploy-true"),
@@ -568,7 +568,7 @@ func TestReconcile(t *testing.T) {
 		Key: "foo/scale-to-zero-on-deploy-true",
 	}, {
 		Name: "scale to zero on deploy false",
-		Ctx:  context.WithValue(context.Background(), scaleToZeroKey, ptr.Bool(false)),
+		Ctx:  context.WithValue(context.Background(), scaleToZeroKey, false),
 		Objects: []runtime.Object{
 			rev("foo", "scale-to-zero-on-deploy-false"),
 			pa("foo", "scale-to-zero-on-deploy-false"),
@@ -588,8 +588,8 @@ func TestReconcile(t *testing.T) {
 
 	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
 		testConfigs := ReconcilerTestConfig()
-		if scaleToZeroVal := ctx.Value(scaleToZeroKey); scaleToZeroVal != nil {
-			testConfigs.Autoscaler.ScaleToZeroOnDeploy = *(scaleToZeroVal.(*bool))
+		if ctx.Value(scaleToZeroKey) != nil && ctx.Value(scaleToZeroKey).(bool) {
+			testConfigs.Autoscaler.ScaleToZeroOnDeploy = true
 		}
 		r := &Reconciler{
 			kubeclient:    kubeclient.Get(ctx),

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -73,7 +73,7 @@ func TestReconcile(t *testing.T) {
 		Name: "first revision reconciliation",
 		// Test the simplest successful reconciliation flow.
 		// We feed in a well formed Revision where none of its sub-resources exist,
-		// and we exect it to create them and initialize the Revision's status.
+		// and we expect it to create them and initialize the Revision's status.
 		Objects: []runtime.Object{
 			rev("foo", "first-reconcile"),
 		},

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -86,6 +86,10 @@ if [[ -n "${ISTIO_VERSION}" ]]; then
     "--resolvabledomain=$(use_resolvable_domain)" || failed=1
 fi
 
+# Run init scale zero tests separately because they mutate the autoscaler config
+go_test_e2e -timeout=10m \
+  ./test/e2e/initscalezero || failed=1
+
 # Dump cluster state in case of failure
 (( failed )) && dump_cluster_state
 (( failed )) && fail_test

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -443,16 +443,16 @@ func TestGracefulScaledown(t *testing.T) {
 		}))
 	defer test.TearDown(ctx.clients, ctx.names)
 
-	autoscalerConfigMap, err := rawCM(ctx.clients, autoscalerconfig.ConfigName)
+	autoscalerConfigMap, err := RawCM(ctx.clients, autoscalerconfig.ConfigName)
 	if err != nil {
 		t.Errorf("Error retrieving autoscaler configmap: %v", err)
 	}
 
 	patchedAutoscalerConfigMap := autoscalerConfigMap.DeepCopy()
 	patchedAutoscalerConfigMap.Data["enable-graceful-scaledown"] = "true"
-	patchCM(ctx.clients, patchedAutoscalerConfigMap)
-	defer patchCM(ctx.clients, autoscalerConfigMap)
-	test.CleanupOnInterrupt(func() { patchCM(ctx.clients, autoscalerConfigMap) })
+	PatchCM(ctx.clients, patchedAutoscalerConfigMap)
+	defer PatchCM(ctx.clients, autoscalerConfigMap)
+	test.CleanupOnInterrupt(func() { PatchCM(ctx.clients, autoscalerConfigMap) })
 
 	if err = assertGracefulScaledown(t, ctx, 4 /* desired pods */); err != nil {
 		t.Errorf("Failed: %v", err)

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -82,15 +82,15 @@ func autoscalerCM(clients *test.Clients) (*autoscalerconfig.Config, error) {
 	return autoscalerconfig.NewConfigFromMap(autoscalerCM.Data)
 }
 
-// rawCM returns the raw knative config map for the given name
-func rawCM(clients *test.Clients, name string) (*corev1.ConfigMap, error) {
+// RawCM returns the raw knative config map for the given name
+func RawCM(clients *test.Clients, name string) (*corev1.ConfigMap, error) {
 	return clients.KubeClient.Kube.CoreV1().ConfigMaps("knative-serving").Get(
 		name,
 		metav1.GetOptions{})
 }
 
-// patchCM updates the existing config map with the supplied value.
-func patchCM(clients *test.Clients, cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+// PatchCM updates the existing config map with the supplied value.
+func PatchCM(clients *test.Clients, cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 	return clients.KubeClient.Kube.CoreV1().ConfigMaps("knative-serving").Update(cm)
 }
 

--- a/test/e2e/init_scale_zero_test.go
+++ b/test/e2e/init_scale_zero_test.go
@@ -1,0 +1,139 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/test/logstream"
+	"knative.dev/serving/pkg/apis/autoscaling"
+	"knative.dev/serving/pkg/apis/serving"
+	v1a1testing "knative.dev/serving/pkg/testing/v1alpha1"
+	"knative.dev/serving/test"
+	v1a1test "knative.dev/serving/test/v1alpha1"
+)
+
+func TestInitScaleZeroClusterLevel(t *testing.T) {
+	cancel := logstream.Start(t)
+	defer cancel()
+
+	clients := Setup(t)
+	tests := []struct {
+		name string
+		// configAutoscalerFlag indicates if the scale to zero on deploy flag is set to true
+		// or false in the config-autoscaler config map.
+		configAutoscalerFlag bool
+	}{{
+		name:                 "config-autoscaler true",
+		configAutoscalerFlag: true,
+	}, {
+		name:                 "config-autoscaler false",
+		configAutoscalerFlag: false,
+	}}
+	for _, tc := range tests {
+		func() {
+			t.Logf("Setting flag to %v on config-autoscaler ConfigMap.", tc.configAutoscalerFlag)
+			if tc.configAutoscalerFlag {
+				updatedConfigAutoscalerCM := setScaleToZeroOnDeployOnCluster(t, clients, "config-autoscaler")
+				defer restoreCM(t, clients, updatedConfigAutoscalerCM)
+			}
+			names := test.ResourceNames{
+				Service: test.ObjectNameForTest(t),
+				Image:   "helloworld",
+			}
+			defer test.TearDown(clients, names)
+			t.Logf("Creating a new Service and verifying that scale to zero is %v.", tc.configAutoscalerFlag)
+			createServiceAndCheckPods(t, clients, &names, tc.configAutoscalerFlag /* scaledToZero */)
+		}()
+	}
+}
+
+// TestInitScaleZeroMinScaleClusterLevel tests setting of scaleToZeroOnDeploy on
+// config-autoscaler with minScale > 0
+func TestInitScaleZeroMinScaleClusterLevel(t *testing.T) {
+	cancel := logstream.Start(t)
+	defer cancel()
+
+	clients := Setup(t)
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "helloworld",
+	}
+	defer test.TearDown(clients, names)
+
+	updatedConfigAutoscalerCM := setScaleToZeroOnDeployOnCluster(t, clients, "config-autoscaler")
+	defer restoreCM(t, clients, updatedConfigAutoscalerCM)
+
+	t.Log("Creating a new Service with minScale greater than 0 and verifying that pods are created.")
+	createServiceAndCheckPods(t, clients, &names, false,
+		v1a1testing.WithConfigAnnotations(map[string]string{
+			autoscaling.MinScaleAnnotationKey: "1",
+		}))
+}
+
+func restoreCM(t *testing.T, clients *test.Clients, oldCM *v1.ConfigMap) {
+	if _, err := patchCM(clients, oldCM); err != nil {
+		t.Fatalf("Error restoring ConfigMap %q: %v", oldCM.Name, err)
+	}
+	t.Logf("Successfully restored ConfigMap %s", oldCM.Name)
+}
+
+func setScaleToZeroOnDeployOnCluster(t *testing.T, clients *test.Clients, configMapName string) *v1.ConfigMap {
+	t.Logf("Fetch %s ConfigMap", configMapName)
+	original, err := rawCM(clients, configMapName)
+	if err != nil || original == nil {
+		t.Fatalf("Error fetching %s: %v", configMapName, err)
+	}
+	var newCM *v1.ConfigMap
+	original.Data["scale-to-zero-on-deploy"] = "true"
+	if newCM, err = patchCM(clients, original); err != nil {
+		t.Fatalf("Failed to update %s: %v", configMapName, err)
+	}
+	t.Logf("Successfully updated %s configMap.", configMapName)
+
+	newCM.Data["scale-to-zero-on-deploy"] = "false"
+	test.CleanupOnInterrupt(func() { restoreCM(t, clients, newCM) })
+	return newCM
+}
+
+// Returns true if no pods are created; false if otherwise.
+func createServiceAndCheckPods(t *testing.T, clients *test.Clients, names *test.ResourceNames, scaledToZero bool, fopt ...v1a1testing.ServiceOption) {
+	t.Helper()
+	test.CleanupOnInterrupt(func() {
+		test.TearDown(clients, *names)
+	})
+	objects, _, err := v1a1test.CreateRunLatestServiceReady(t, clients, names, test.ServingFlags.Https, fopt...)
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	pods := clients.KubeClient.Kube.CoreV1().Pods(test.ServingNamespace)
+	podList, err := pods.List(metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", serving.RevisionLabelKey, objects.Revision.Name),
+	})
+	if err != nil {
+		t.Fatalf("Failed to list all pods: %v: %v", names.Service, err)
+	}
+	if gotPods := len(podList.Items); scaledToZero != (gotPods == 0) {
+		t.Fatalf("Expect scaledToZero to be %v, but got %d pods.", scaledToZero, gotPods)
+	}
+}

--- a/test/e2e/initscalezero/init_scale_zero_test.go
+++ b/test/e2e/initscalezero/init_scale_zero_test.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package initscalezero
 
 import (
 	"fmt"
@@ -29,6 +29,7 @@ import (
 	"knative.dev/serving/pkg/apis/serving"
 	v1a1testing "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
+	"knative.dev/serving/test/e2e"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
 
@@ -36,7 +37,7 @@ func TestInitScaleZeroClusterLevel(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
 
-	clients := Setup(t)
+	clients := e2e.Setup(t)
 	tests := []struct {
 		name string
 		// configAutoscalerFlag indicates if the scale to zero on deploy flag is set to true
@@ -73,7 +74,7 @@ func TestInitScaleZeroMinScaleClusterLevel(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
 
-	clients := Setup(t)
+	clients := e2e.Setup(t)
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),
 		Image:   "helloworld",
@@ -91,7 +92,7 @@ func TestInitScaleZeroMinScaleClusterLevel(t *testing.T) {
 }
 
 func restoreCM(t *testing.T, clients *test.Clients, oldCM *v1.ConfigMap) {
-	if _, err := patchCM(clients, oldCM); err != nil {
+	if _, err := e2e.PatchCM(clients, oldCM); err != nil {
 		t.Fatalf("Error restoring ConfigMap %q: %v", oldCM.Name, err)
 	}
 	t.Logf("Successfully restored ConfigMap %s", oldCM.Name)
@@ -99,13 +100,13 @@ func restoreCM(t *testing.T, clients *test.Clients, oldCM *v1.ConfigMap) {
 
 func setScaleToZeroOnDeployOnCluster(t *testing.T, clients *test.Clients, configMapName string) *v1.ConfigMap {
 	t.Logf("Fetch %s ConfigMap", configMapName)
-	original, err := rawCM(clients, configMapName)
+	original, err := e2e.RawCM(clients, configMapName)
 	if err != nil || original == nil {
 		t.Fatalf("Error fetching %s: %v", configMapName, err)
 	}
 	var newCM *v1.ConfigMap
 	original.Data["scale-to-zero-on-deploy"] = "true"
-	if newCM, err = patchCM(clients, original); err != nil {
+	if newCM, err = e2e.PatchCM(clients, original); err != nil {
 		t.Fatalf("Failed to update %s: %v", configMapName, err)
 	}
 	t.Logf("Successfully updated %s configMap.", configMapName)


### PR DESCRIPTION
/lint

Fixes #4098

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
Add config-autoscaler operator config `scale-to-zero-on-deploy`. The config will be overridden if user sets minScale.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add config-autoscaler operator config `scale-to-zero-on-deploy` (default to false). When this flag is set to true, new Knative services created will have zero instance. The config will be overridden if user sets minScale.
```

/cc @dprotaso @mattmoor @vagababov @markusthoemmes @duglin 
