### PR TITLE
Make sure all probing goroutines are finished on calling Stop().

### DIFF
--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -101,6 +101,7 @@ func testAutoTLS(t *testing.T) {
 			return transport
 		}
 		prober := test.RunRouteProber(t.Logf, clients, objects.Service.Status.URL.URL(), transportOption)
+		defer test.AssertProberDefault(t, prober)
 
 		if _, err := v1test.UpdateServiceRouteSpec(t, clients, names, servingv1.RouteSpec{
 			Traffic: []servingv1.TrafficTarget{{
@@ -138,7 +139,6 @@ func testAutoTLS(t *testing.T) {
 		for _, traffic := range route.Status.Traffic {
 			testingress.RuntimeRequest(t, httpsClient, traffic.URL.String())
 		}
-		test.AssertProberDefault(t, prober)
 	})
 }
 

--- a/test/prober.go
+++ b/test/prober.go
@@ -27,6 +27,7 @@ import (
 	"sync/atomic"
 
 	"golang.org/x/sync/errgroup"
+	"knative.dev/pkg/ptr"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/spoof"
@@ -149,6 +150,9 @@ func (m *manager) Spawn(url *url.URL) Prober {
 		logf:          m.logf,
 		url:           url,
 		minimumProbes: m.minProbes,
+
+		requests: ptr.Int64(0),
+		failures: ptr.Int64(0),
 
 		minDoneCh: make(chan struct{}),
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #7030

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Some of our tests use a managed prober, which essentially polls forever until instructed to stop. We're not really checking that they are actually done after Stop() returns, which causes racy behavior especially around loggers.

This changes that and makes sure that we've received a done signal from all goroutines before we continue.

This also switches our abuse of the spoofing client's `Poll` function to a more explicit usage of an infinite loop to make clear what's going on.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
