### PR TITLE
switch to v1 types as the storage version

### DIFF
--- a/config/core/resources/configuration.yaml
+++ b/config/core/resources/configuration.yaml
@@ -34,13 +34,13 @@ spec:
   versions:
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
   - name: v1beta1
     served: true
     storage: false
   - name: v1
     served: true
-    storage: false
+    storage: true
   names:
     kind: Configuration
     plural: configurations

--- a/config/core/resources/revision.yaml
+++ b/config/core/resources/revision.yaml
@@ -33,13 +33,13 @@ spec:
   versions:
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
   - name: v1beta1
     served: true
     storage: false
   - name: v1
     served: true
-    storage: false
+    storage: true
   names:
     kind: Revision
     plural: revisions

--- a/config/core/resources/route.yaml
+++ b/config/core/resources/route.yaml
@@ -34,13 +34,13 @@ spec:
   versions:
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
   - name: v1beta1
     served: true
     storage: false
   - name: v1
     served: true
-    storage: false
+    storage: true
   names:
     kind: Route
     plural: routes

--- a/config/core/resources/service.yaml
+++ b/config/core/resources/service.yaml
@@ -35,13 +35,13 @@ spec:
   versions:
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
   - name: v1beta1
     served: true
     storage: false
   - name: v1
     served: true
-    storage: false
+    storage: true
   names:
     kind: Service
     plural: services


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Contributes to https://github.com/knative/serving/issues/6726

Will close off that issue once migration docs are written

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Changes the storage version of Service, Route, Revision, Configuration to v1

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Changes the storage version of Service, Route, Revision, Configuration to v1
```
