### PR TITLE
Fix minscale on deploy

### DIFF
--- a/pkg/reconciler/labeler/labeler_test.go
+++ b/pkg/reconciler/labeler/labeler_test.go
@@ -77,7 +77,7 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "label pinned revision",
 		Objects: []runtime.Object{
-			simpleRoute("default", "pinned-revision", "the-revision"),
+			pinnedRoute("default", "pinned-revision", "the-revision"),
 			simpleConfig("default", "the-config"),
 			rev("default", "the-config"),
 			rev("default", "the-config", WithRevName("the-revision")),
@@ -103,6 +103,43 @@ func TestReconcile(t *testing.T) {
 				WithRevisionLabel("serving.knative.dev/route", "steady-state")),
 		},
 		Key: "default/steady-state",
+	}, {
+		Name: "no ready revision",
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "no-ready-revision", "the-config", WithStatusTraffic()),
+			simpleConfig("default", "the-config", WithLatestReady("")),
+			rev("default", "the-config"),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddFinalizerAction("default", "no-ready-revision"),
+			patchAddLabel("default", rev("default", "the-config").Name,
+				"serving.knative.dev/route", "no-ready-revision"),
+			patchAddLabel("default", "the-config",
+				"serving.knative.dev/route", "no-ready-revision"),
+		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", "no-ready-revision"),
+		},
+		Key: "default/no-ready-revision",
+	}, {
+		Name: "transitioning route",
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "transitioning-route", "old", WithRouteFinalizer,
+				WithSpecTraffic(configTraffic("new"))),
+			simpleConfig("default", "old",
+				WithConfigLabel("serving.knative.dev/route", "transitioning-route")),
+			rev("default", "old",
+				WithRevisionLabel("serving.knative.dev/route", "transitioning-route")),
+			simpleConfig("default", "new"),
+			rev("default", "new"),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddLabel("default", rev("default", "new").Name,
+				"serving.knative.dev/route", "transitioning-route"),
+			patchAddLabel("default", "new",
+				"serving.knative.dev/route", "transitioning-route"),
+		},
+		Key: "default/transitioning-route",
 	}, {
 		Name: "failure adding label (revision)",
 		// Induce a failure during patching
@@ -278,23 +315,38 @@ func TestReconcile(t *testing.T) {
 	}))
 }
 
-func routeWithTraffic(namespace, name string, traffic v1.TrafficTarget, opts ...RouteOption) *v1.Route {
-	return Route(namespace, name, append(opts, WithStatusTraffic(traffic))...)
+func configTraffic(name string) v1.TrafficTarget {
+	return v1.TrafficTarget{
+		ConfigurationName: name,
+		Percent:           ptr.Int64(100),
+		LatestRevision:    ptr.Bool(true),
+	}
+}
+
+func revTraffic(name string, latest bool) v1.TrafficTarget {
+	return v1.TrafficTarget{
+		RevisionName:   name,
+		Percent:        ptr.Int64(100),
+		LatestRevision: ptr.Bool(latest),
+	}
+}
+
+func routeWithTraffic(namespace, name string, spec, status v1.TrafficTarget, opts ...RouteOption) *v1.Route {
+	return Route(namespace, name,
+		append([]RouteOption{WithSpecTraffic(spec), WithStatusTraffic(status)}, opts...)...)
 }
 
 func simpleRunLatest(namespace, name, config string, opts ...RouteOption) *v1.Route {
-	return routeWithTraffic(namespace, name, v1.TrafficTarget{
-		RevisionName:   config + "-dbnfd",
-		Percent:        ptr.Int64(100),
-		LatestRevision: ptr.Bool(true),
-	}, opts...)
+	return routeWithTraffic(namespace, name,
+		configTraffic(config),
+		revTraffic(config+"-dbnfd", true),
+		opts...)
 }
 
-func simpleRoute(namespace, name, revision string, opts ...RouteOption) *v1.Route {
-	return routeWithTraffic(namespace, name, v1.TrafficTarget{
-		RevisionName: revision,
-		Percent:      ptr.Int64(100),
-	}, opts...)
+func pinnedRoute(namespace, name, revision string, opts ...RouteOption) *v1.Route {
+	traffic := revTraffic(revision, false)
+
+	return routeWithTraffic(namespace, name, traffic, traffic, opts...)
 }
 
 func simpleConfig(namespace, name string, opts ...ConfigOption) *v1.Configuration {

--- a/pkg/reconciler/labeler/labels.go
+++ b/pkg/reconciler/labeler/labels.go
@@ -45,28 +45,40 @@ func (c *Reconciler) syncLabels(ctx context.Context, r *v1.Route) error {
 	revisions := sets.NewString()
 	configs := sets.NewString()
 
-	// Walk the revisions in Route's .status.traffic and build a list
-	// of Configurations to label from their OwnerReferences.
-	for _, tt := range r.Status.Traffic {
-		rev, err := c.revisionLister.Revisions(r.Namespace).Get(tt.RevisionName)
-		if err != nil {
-			return err
+	// Walk the Route's .status.traffic and .spec.traffic and build a list
+	// of revisions and configurations to label
+	for _, tt := range append(r.Status.Traffic, r.Spec.Traffic...) {
+		revName := tt.RevisionName
+		configName := tt.ConfigurationName
+
+		latest := tt.LatestRevision != nil && *tt.LatestRevision
+
+		if revName != "" {
+			rev, err := c.revisionLister.Revisions(r.Namespace).Get(revName)
+			if err != nil {
+				return err
+			}
+
+			revisions.Insert(revName)
+
+			// If the owner reference is a configuration, treat it like a configuration target
+			owner := metav1.GetControllerOf(rev)
+			if owner != nil && owner.Kind == "Configuration" {
+				configName = owner.Name
+			}
 		}
-		revisions.Insert(tt.RevisionName)
 
-		// If the owner reference is a configuration, add it to the list of configurations
-		owner := metav1.GetControllerOf(rev)
-		if owner != nil && owner.Kind == "Configuration" {
-			configs.Insert(owner.Name)
+		if configName != "" {
+			config, err := c.configurationLister.Configurations(r.Namespace).Get(configName)
+			if err != nil {
+				return err
+			}
 
-			// If we are tracking the latest revision, add the latest created revision as well
+			configs.Insert(configName)
+
+			// If the target is for the latest revision, add the latest created revision to the list
 			// so that there is a smooth transition when the new revision becomes ready.
-			if tt.LatestRevision != nil && *tt.LatestRevision {
-				config, err := c.configurationLister.Configurations(r.Namespace).Get(owner.Name)
-				if err != nil {
-					return err
-				}
-
+			if latest && config.Status.LatestCreatedRevisionName != "" {
 				revisions.Insert(config.Status.LatestCreatedRevisionName)
 			}
 		}

--- a/pkg/reconciler/labeler/labels.go
+++ b/pkg/reconciler/labeler/labels.go
@@ -51,8 +51,6 @@ func (c *Reconciler) syncLabels(ctx context.Context, r *v1.Route) error {
 		revName := tt.RevisionName
 		configName := tt.ConfigurationName
 
-		latest := tt.LatestRevision != nil && *tt.LatestRevision
-
 		if revName != "" {
 			rev, err := c.revisionLister.Revisions(r.Namespace).Get(revName)
 			if err != nil {
@@ -78,7 +76,7 @@ func (c *Reconciler) syncLabels(ctx context.Context, r *v1.Route) error {
 
 			// If the target is for the latest revision, add the latest created revision to the list
 			// so that there is a smooth transition when the new revision becomes ready.
-			if latest && config.Status.LatestCreatedRevisionName != "" {
+			if config.Status.LatestCreatedRevisionName != "" && tt.LatestRevision != nil && *tt.LatestRevision {
 				revisions.Insert(config.Status.LatestCreatedRevisionName)
 			}
 		}

--- a/pkg/reconciler/labeler/labels.go
+++ b/pkg/reconciler/labeler/labels.go
@@ -60,8 +60,7 @@ func (c *Reconciler) syncLabels(ctx context.Context, r *v1.Route) error {
 			revisions.Insert(revName)
 
 			// If the owner reference is a configuration, treat it like a configuration target
-			owner := metav1.GetControllerOf(rev)
-			if owner != nil && owner.Kind == "Configuration" {
+			if owner := metav1.GetControllerOf(rev); owner != nil && owner.Kind == "Configuration" {
 				configName = owner.Name
 			}
 		}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #6935 

Same root cause as #6733, but for brand new routes which do not have a `status.traffic` yet.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add route labels to all revisions and configurations listen in *both* the `.spec.traffic` and `.status.traffic` of a Route. 


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixes bug with new minScale revisions, where containers are created, then destroyed, then created again.
```
