### PR TITLE
Finish the validation of the max container concurrency

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -36,8 +36,9 @@ func (pa *PodAutoscalerSpec) Validate(ctx context.Context) *apis.FieldError {
 	}
 	return serving.ValidateNamespacedObjectReference(&pa.ScaleTargetRef).
 		ViaField("scaleTargetRef").Also(
-		serving.ValidateContainerConcurrency(ctx, &pa.ContainerConcurrency).
-			ViaField("containerConcurrency")).Also(validateSKSFields(ctx, pa))
+		serving.ValidateContainerConcurrency(
+			ctx, &pa.ContainerConcurrency).ViaField("containerConcurrency")).Also(
+		validateSKSFields(ctx, pa))
 }
 
 func validateSKSFields(ctx context.Context, rs *PodAutoscalerSpec) (errs *apis.FieldError) {

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -34,7 +34,10 @@ func (pa *PodAutoscalerSpec) Validate(ctx context.Context) *apis.FieldError {
 	if equality.Semantic.DeepEqual(pa, &PodAutoscalerSpec{}) {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
-	return serving.ValidateNamespacedObjectReference(&pa.ScaleTargetRef).ViaField("scaleTargetRef").Also(serving.ValidateContainerConcurrency(&pa.ContainerConcurrency).ViaField("containerConcurrency")).Also(validateSKSFields(ctx, pa))
+	return serving.ValidateNamespacedObjectReference(&pa.ScaleTargetRef).
+		ViaField("scaleTargetRef").Also(
+		serving.ValidateContainerConcurrency(ctx, &pa.ContainerConcurrency).
+			ViaField("containerConcurrency")).Also(validateSKSFields(ctx, pa))
 }
 
 func validateSKSFields(ctx context.Context, rs *PodAutoscalerSpec) (errs *apis.FieldError) {

--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -91,11 +91,12 @@ func ValidateTimeoutSeconds(ctx context.Context, timeoutSeconds int64) *apis.Fie
 
 // ValidateContainerConcurrency function validates the ContainerConcurrency field
 // TODO(#5007): Move this to autoscaling.
-func ValidateContainerConcurrency(containerConcurrency *int64) *apis.FieldError {
+func ValidateContainerConcurrency(ctx context.Context, containerConcurrency *int64) *apis.FieldError {
 	if containerConcurrency != nil {
-		if *containerConcurrency < 0 || *containerConcurrency > config.DefaultMaxRevisionContainerConcurrency {
+		cfg := config.FromContextOrDefaults(ctx).Defaults
+		if *containerConcurrency < 0 || *containerConcurrency > cfg.ContainerConcurrencyMaxLimit {
 			return apis.ErrOutOfBoundsValue(
-				*containerConcurrency, 0, config.DefaultMaxRevisionContainerConcurrency, apis.CurrentField)
+				*containerConcurrency, 0, cfg.ContainerConcurrencyMaxLimit, apis.CurrentField)
 		}
 	}
 	return nil

--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -103,7 +103,7 @@ func (rs *RevisionSpec) Validate(ctx context.Context) *apis.FieldError {
 	}
 
 	if rs.ContainerConcurrency != nil {
-		errs = errs.Also(serving.ValidateContainerConcurrency(rs.ContainerConcurrency).ViaField("containerConcurrency"))
+		errs = errs.Also(serving.ValidateContainerConcurrency(ctx, rs.ContainerConcurrency).ViaField("containerConcurrency"))
 	}
 
 	return errs

--- a/pkg/apis/serving/v1/revision_validation_test.go
+++ b/pkg/apis/serving/v1/revision_validation_test.go
@@ -274,7 +274,7 @@ func TestContainerConcurrencyValidation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := serving.ValidateContainerConcurrency(&test.cc)
+			got := serving.ValidateContainerConcurrency(context.Background(), &test.cc)
 			if got, want := got.Error(), test.want.Error(); !cmp.Equal(got, want) {
 				t.Errorf("Validate (-want, +got) = %v", cmp.Diff(want, got))
 			}

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -126,7 +126,7 @@ func (rs *RevisionSpec) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(err)
 	} else {
 		if rs.ContainerConcurrency != nil {
-			errs = errs.Also(serving.ValidateContainerConcurrency(rs.ContainerConcurrency).ViaField("containerConcurrency"))
+			errs = errs.Also(serving.ValidateContainerConcurrency(ctx, rs.ContainerConcurrency).ViaField("containerConcurrency"))
 		}
 	}
 

--- a/pkg/apis/serving/v1beta1/revision_validation_test.go
+++ b/pkg/apis/serving/v1beta1/revision_validation_test.go
@@ -276,7 +276,7 @@ func TestContainerConcurrencyValidation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := serving.ValidateContainerConcurrency(&test.cc)
+			got := serving.ValidateContainerConcurrency(context.Background(), &test.cc)
 			if got, want := got.Error(), test.want.Error(); !cmp.Equal(got, want) {
 				t.Errorf("Validate (-want, +got) = %v", cmp.Diff(want, got))
 			}


### PR DESCRIPTION
Validation will now use the Defaults config map
from the context in order to validate the maximim permitted container
concurrency.

This is for #7121


/lint
/assign mattmoor @dprotaso 