### PR TITLE
switch e2e tests to use v1 APIs

### DIFF
--- a/pkg/testing/v1/configuration.go
+++ b/pkg/testing/v1/configuration.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -109,4 +110,18 @@ func WithConfigLabel(key, value string) ConfigOption {
 // WithConfigOwnersRemoved clears the owner references of this Configuration.
 func WithConfigOwnersRemoved(cfg *v1.Configuration) {
 	cfg.OwnerReferences = nil
+}
+
+// WithConfigEnv configures the Service to use the provided environment variables.
+func WithConfigEnv(evs ...corev1.EnvVar) ConfigOption {
+	return func(c *v1.Configuration) {
+		c.Spec.Template.Spec.Containers[0].Env = evs
+	}
+}
+
+// WithConfigRevisionTimeoutSeconds sets revision timeout.
+func WithConfigRevisionTimeoutSeconds(revisionTimeoutSeconds int64) ConfigOption {
+	return func(cfg *v1.Configuration) {
+		cfg.Spec.Template.Spec.TimeoutSeconds = ptr.Int64(revisionTimeoutSeconds)
+	}
 }

--- a/pkg/testing/v1/service.go
+++ b/pkg/testing/v1/service.go
@@ -390,6 +390,14 @@ func WithServiceLatestReadyRevision(lrr string) ServiceOption {
 	}
 }
 
+// WithReadinessProbe sets the provided probe to be the readiness
+// probe on the service.
+func WithReadinessProbe(p *corev1.Probe) ServiceOption {
+	return func(s *v1.Service) {
+		s.Spec.Template.Spec.Containers[0].ReadinessProbe = p
+	}
+}
+
 // MarkConfigurationNotReconciled calls the function of the same name on the Service's status.
 func MarkConfigurationNotReconciled(service *v1.Service) {
 	service.Status.MarkConfigurationNotReconciled()

--- a/test/cleanup.go
+++ b/test/cleanup.go
@@ -38,8 +38,8 @@ func CleanupOnInterrupt(cleanup func()) {
 
 // TearDown will delete created names using clients.
 func TearDown(clients *Clients, names ResourceNames) {
-	if clients != nil && clients.ServingBetaClient != nil {
-		clients.ServingAlphaClient.Delete(
+	if clients != nil && clients.ServingClient != nil {
+		clients.ServingClient.Delete(
 			[]string{names.Route},
 			[]string{names.Config},
 			[]string{names.Service},

--- a/test/clients.go
+++ b/test/clients.go
@@ -201,7 +201,7 @@ func newServingClients(cfg *rest.Config, namespace string) (*ServingClients, err
 
 // Delete will delete all Routes and Configs with the names routes and configs, if clients
 // has been successfully initialized.
-func (clients *ServingAlphaClients) Delete(routes []string, configs []string, services []string) error {
+func (clients *ServingClients) Delete(routes []string, configs []string, services []string) error {
 	deletions := []struct {
 		client interface {
 			Delete(name string, options *v1.DeleteOptions) error

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -26,11 +26,12 @@ import (
 
 	"knative.dev/pkg/ptr"
 	pkgTest "knative.dev/pkg/test"
+	pkgtest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logstream"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	rnames "knative.dev/serving/pkg/reconciler/revision/resources/names"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 // TestActivatorOverload makes sure that activator can handle the load when scaling from 0.
@@ -59,10 +60,10 @@ func TestActivatorOverload(t *testing.T) {
 	t.Log("Creating a service with run latest configuration.")
 	// Create a service with concurrency 1 that sleeps for N ms.
 	// Limit its maxScale to 10 containers, wait for the service to scale down and hit it with concurrent requests.
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		func(service *v1alpha1.Service) {
-			service.Spec.ConfigurationSpec.Template.Spec.ContainerConcurrency = ptr.Int64(1)
-			service.Spec.ConfigurationSpec.Template.Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}
+	resources, err := v1test.CreateServiceReady(t, clients, &names,
+		func(service *v1.Service) {
+			service.Spec.Template.Spec.ContainerConcurrency = ptr.Int64(1)
+			service.Spec.Template.Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}
 		})
 	if err != nil {
 		t.Fatalf("Unable to create resources: %v", err)
@@ -73,7 +74,7 @@ func TestActivatorOverload(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		resources.Route.Status.URL.URL(),
-		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
+		v1test.RetryingRouteInconsistency(pkgtest.IsStatusOK),
 		"WaitForSuccessfulResponse",
 		test.ServingFlags.ResolvableDomain,
 		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https),

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -29,6 +29,12 @@ import (
 
 	vegeta "github.com/tsenart/vegeta/lib"
 	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	ingress "knative.dev/pkg/test/ingress"
@@ -39,16 +45,9 @@ import (
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	resourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
 	"knative.dev/serving/pkg/resources"
-	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
+	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
+	v1test "knative.dev/serving/test/v1"
 )
 
 const (
@@ -67,7 +66,7 @@ type testContext struct {
 	t                 *testing.T
 	clients           *test.Clients
 	names             test.ResourceNames
-	resources         *v1a1test.ResourceObjects
+	resources         *v1test.ResourceObjects
 	targetUtilization float64
 	targetValue       float64
 	metric            string
@@ -174,7 +173,7 @@ func validateEndpoint(t *testing.T, clients *test.Clients, names test.ResourceNa
 		clients.KubeClient,
 		t.Logf,
 		names.URL,
-		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK)),
+		v1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK)),
 		"CheckingEndpointAfterUpdating",
 		test.ServingFlags.ResolvableDomain,
 		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https),
@@ -197,7 +196,7 @@ func setup(t *testing.T, class, metric string, target, targetUtilization float64
 		Image:   image,
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+	resources, err := v1test.CreateServiceReady(t, clients, &names,
 		append([]rtesting.ServiceOption{
 			rtesting.WithConfigAnnotations(map[string]string{
 				autoscaling.ClassAnnotationKey:             class,
@@ -263,7 +262,7 @@ func assertScaleDown(ctx *testContext) {
 	}
 
 	ctx.t.Log("The Revision should remain ready after scaling to zero.")
-	if err := v1a1test.CheckRevisionState(ctx.clients.ServingAlphaClient, ctx.names.Revision, v1a1test.IsRevisionReady); err != nil {
+	if err := v1test.CheckRevisionState(ctx.clients.ServingClient, ctx.names.Revision, v1test.IsRevisionReady); err != nil {
 		ctx.t.Fatalf("The Revision %s did not stay Ready after scaling down to zero: %v", ctx.names.Revision, err)
 	}
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -37,7 +37,7 @@ import (
 	"knative.dev/serving/pkg/apis/networking"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 // Setup creates the client objects needed in the e2e tests.
@@ -118,7 +118,7 @@ func WaitForScaleToZero(t *testing.T, deploymentName string, clients *test.Clien
 }
 
 // waitForActivatorEndpoints waits for the Service endpoints to match that of activator.
-func waitForActivatorEndpoints(resources *v1a1test.ResourceObjects, clients *test.Clients) error {
+func waitForActivatorEndpoints(resources *v1test.ResourceObjects, clients *test.Clients) error {
 	return wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
 		// We need to fetch the activator endpoints at every check, since it can change.
 		aeps, err := clients.KubeClient.Kube.CoreV1().Endpoints(

--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -21,12 +21,12 @@ package e2e
 import (
 	"testing"
 
-	pkgTest "knative.dev/pkg/test"
-	v1a1opts "knative.dev/serving/pkg/testing/v1alpha1"
-	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
-
 	corev1 "k8s.io/api/core/v1"
+	pkgTest "knative.dev/pkg/test"
+	rtesting "knative.dev/serving/pkg/testing/v1"
+	"knative.dev/serving/test"
+	v1 "knative.dev/serving/test/v1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 const (
@@ -45,11 +45,12 @@ func TestEgressTraffic(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	service, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		v1a1opts.WithEnv(corev1.EnvVar{
+	service, err := v1.CreateServiceReady(t, clients, &names,
+		rtesting.WithEnv(corev1.EnvVar{
 			Name:  targetHostEnvName,
 			Value: targetHostDomain,
 		}))
+
 	if err != nil {
 		t.Fatalf("Failed to create a service: %v", err)
 	}
@@ -63,7 +64,7 @@ func TestEgressTraffic(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		url,
-		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
+		v1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"HTTPProxy",
 		test.ServingFlags.ResolvableDomain,
 		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https),

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -36,10 +36,10 @@ import (
 	"knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/pkg/apis/autoscaling"
-	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
+	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 	ping "knative.dev/serving/test/test_images/grpc-ping/proto"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 const (
@@ -47,7 +47,7 @@ const (
 	grpcMinScale             = 3
 )
 
-type grpcTest func(*testing.T, *v1a1test.ResourceObjects, *test.Clients, test.ResourceNames, string, string)
+type grpcTest func(*testing.T, *v1test.ResourceObjects, *test.Clients, test.ResourceNames, string, string)
 
 // hasPort checks if a URL contains a port number
 func hasPort(u string) bool {
@@ -84,7 +84,7 @@ func dial(host, domain string) (*grpc.ClientConn, error) {
 	)
 }
 
-func unaryTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
+func unaryTest(t *testing.T, resources *v1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
 	t.Helper()
 	t.Logf("Connecting to grpc-ping using host %q and authority %q", host, domain)
 	const want = "Hello!"
@@ -97,7 +97,7 @@ func unaryTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.
 	}
 }
 
-func autoscaleTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
+func autoscaleTest(t *testing.T, resources *v1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
 	t.Helper()
 	t.Logf("Connecting to grpc-ping using host %q and authority %q", host, domain)
 
@@ -113,7 +113,7 @@ func autoscaleTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *t
 	assertGRPCAutoscaleUpToNumPods(ctx, 0, 2, 60*time.Second, host, domain)
 }
 
-func loadBalancingTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
+func loadBalancingTest(t *testing.T, resources *v1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
 	t.Helper()
 	t.Logf("Connecting to grpc-ping using host %q and authority %q", host, domain)
 
@@ -269,7 +269,7 @@ func assertGRPCAutoscaleUpToNumPods(ctx *testContext, curPods, targetPods float6
 	}
 }
 
-func streamTest(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
+func streamTest(t *testing.T, resources *v1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
 	t.Helper()
 	t.Logf("Connecting to grpc-ping using host %q and authority %q", host, domain)
 	conn, err := dial(host, domain)
@@ -340,8 +340,7 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		fopts...)
+	resources, err := v1test.CreateServiceReady(t, clients, &names, fopts...)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -351,7 +350,7 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 		clients.KubeClient,
 		t.Logf,
 		url,
-		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
+		v1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"gRPCPingReadyToServe",
 		test.ServingFlags.ResolvableDomain,
 		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https),
@@ -383,7 +382,7 @@ func TestGRPCStreamingPing(t *testing.T) {
 
 func TestGRPCUnaryPingViaActivator(t *testing.T) {
 	testGRPC(t,
-		func(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
+		func(t *testing.T, resources *v1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
 			if err := waitForActivatorEndpoints(resources, clients); err != nil {
 				t.Fatalf("Never got Activator endpoints in the service: %v", err)
 			}
@@ -397,7 +396,7 @@ func TestGRPCUnaryPingViaActivator(t *testing.T) {
 
 func TestGRPCStreamingPingViaActivator(t *testing.T) {
 	testGRPC(t,
-		func(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
+		func(t *testing.T, resources *v1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
 			if err := waitForActivatorEndpoints(resources, clients); err != nil {
 				t.Fatalf("Never got Activator endpoints in the service: %v", err)
 			}
@@ -411,7 +410,7 @@ func TestGRPCStreamingPingViaActivator(t *testing.T) {
 
 func TestGRPCAutoscaleUpDownUp(t *testing.T) {
 	testGRPC(t,
-		func(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
+		func(t *testing.T, resources *v1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
 			autoscaleTest(t, resources, clients, names, host, domain)
 		},
 		rtesting.WithConfigAnnotations(map[string]string{
@@ -429,7 +428,7 @@ func TestGRPCAutoscaleUpDownUp(t *testing.T) {
 
 func TestGRPCLoadBalancing(t *testing.T) {
 	testGRPC(t,
-		func(t *testing.T, resources *v1a1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
+		func(t *testing.T, resources *v1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
 			loadBalancingTest(t, resources, clients, names, host, domain)
 		},
 		rtesting.WithConfigAnnotations(map[string]string{

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -29,9 +29,9 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/pkg/apis/serving"
-	v1a1opts "knative.dev/serving/pkg/testing/v1alpha1"
+	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 func TestHelloWorld(t *testing.T) {
@@ -50,7 +50,8 @@ func TestHelloWorld(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	t.Log("Creating a new Service")
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)
+
+	resources, err := v1test.CreateServiceReady(t, clients, &names)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -60,7 +61,7 @@ func TestHelloWorld(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		url,
-		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloWorldText))),
+		v1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloWorldText))),
 		"HelloWorldServesText",
 		test.ServingFlags.ResolvableDomain,
 		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https),
@@ -101,8 +102,8 @@ func TestQueueSideCarResourceLimit(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	t.Log("Creating a new Service")
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		v1a1opts.WithResourceRequirements(corev1.ResourceRequirements{
+	resources, err := v1test.CreateServiceReady(t, clients, &names,
+		rtesting.WithResourceRequirements(corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceName("cpu"):    resource.MustParse("50m"),
 				corev1.ResourceName("memory"): resource.MustParse("128Mi"),
@@ -111,7 +112,7 @@ func TestQueueSideCarResourceLimit(t *testing.T) {
 				corev1.ResourceName("cpu"):    resource.MustParse("100m"),
 				corev1.ResourceName("memory"): resource.MustParse("258Mi"),
 			},
-		}), v1a1opts.WithConfigAnnotations(map[string]string{
+		}), rtesting.WithConfigAnnotations(map[string]string{
 			serving.QueueSideCarResourcePercentageAnnotation: "0.2",
 		}))
 	if err != nil {
@@ -123,7 +124,7 @@ func TestQueueSideCarResourceLimit(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		url,
-		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloWorldText))),
+		v1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloWorldText))),
 		"HelloWorldServesText",
 		test.ServingFlags.ResolvableDomain,
 		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https),

--- a/test/e2e/image_pull_error_test.go
+++ b/test/e2e/image_pull_error_test.go
@@ -22,11 +22,11 @@ import (
 	"testing"
 
 	"knative.dev/pkg/test/logstream"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
-	v1alpha1testing "knative.dev/serving/pkg/testing/v1alpha1"
+	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 func TestImagePullError(t *testing.T) {
@@ -46,7 +46,7 @@ func TestImagePullError(t *testing.T) {
 
 	t.Logf("Creating a new Service %s", names.Image)
 	var (
-		svc *v1alpha1.Service
+		svc *v1.Service
 		err error
 	)
 	if svc, err = createLatestService(t, clients, names); err != nil {
@@ -55,8 +55,8 @@ func TestImagePullError(t *testing.T) {
 
 	names.Config = serviceresourcenames.Configuration(svc)
 
-	err = v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, func(r *v1alpha1.Service) (bool, error) {
-		cond := r.Status.GetCondition(v1alpha1.ServiceConditionConfigurationsReady)
+	err = v1test.WaitForServiceState(clients.ServingClient, names.Service, func(r *v1.Service) (bool, error) {
+		cond := r.Status.GetCondition(v1.ServiceConditionConfigurationsReady)
 		if cond != nil && !cond.IsUnknown() {
 			if cond.IsFalse() {
 				if cond.Reason == "RevisionFailed" {
@@ -80,8 +80,8 @@ func TestImagePullError(t *testing.T) {
 	}
 
 	t.Log("When the images are not pulled, the revision should have error status.")
-	err = v1a1test.CheckRevisionState(clients.ServingAlphaClient, revisionName, func(r *v1alpha1.Revision) (bool, error) {
-		cond := r.Status.GetCondition(v1alpha1.RevisionConditionReady)
+	err = v1test.CheckRevisionState(clients.ServingClient, revisionName, func(r *v1.Revision) (bool, error) {
+		cond := r.Status.GetCondition(v1.RevisionConditionReady)
 		if cond != nil {
 			if cond.Reason == "ImagePullBackOff" || cond.Reason == "ErrImagePull" {
 				return true, nil
@@ -99,9 +99,9 @@ func TestImagePullError(t *testing.T) {
 
 // Wrote our own thing so that we can pass in an image by digest.
 // knative/pkg/test.ImagePath currently assumes there's a tag, which fails to parse.
-func createLatestService(t *testing.T, clients *test.Clients, names test.ResourceNames) (*v1alpha1.Service, error) {
-	opt := v1alpha1testing.WithInlineConfigSpec(*v1a1test.ConfigurationSpec(names.Image))
-	service := v1alpha1testing.ServiceWithoutNamespace(names.Service, opt)
-	v1a1test.LogResourceObject(t, v1a1test.ResourceObjects{Service: service})
-	return clients.ServingAlphaClient.Services.Create(service)
+func createLatestService(t *testing.T, clients *test.Clients, names test.ResourceNames) (*v1.Service, error) {
+	opt := rtesting.WithConfigSpec(*v1test.ConfigurationSpec(names.Image))
+	service := rtesting.ServiceWithoutNamespace(names.Service, opt)
+	v1test.LogResourceObject(t, v1test.ResourceObjects{Service: service})
+	return clients.ServingClient.Services.Create(service)
 }

--- a/test/e2e/istio/probing_test.go
+++ b/test/e2e/istio/probing_test.go
@@ -49,7 +49,7 @@ import (
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 var (
@@ -89,7 +89,7 @@ func TestIstioProbing(t *testing.T) {
 		}
 		test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 		defer test.TearDown(clients, names)
-		objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)
+		objects, err := v1test.CreateServiceReady(t, clients, &names)
 		if err != nil {
 			t.Fatalf("Failed to create Service %s: %v", names.Service, err)
 		}
@@ -264,7 +264,7 @@ func TestIstioProbing(t *testing.T) {
 			// Create the service and wait for it to be ready
 			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 			defer test.TearDown(clients, names)
-			_, err = v1a1test.CreateRunLatestServiceReady(t, clients, &names)
+			_, err = v1test.CreateServiceReady(t, clients, &names)
 			if err != nil {
 				t.Fatalf("Failed to create Service %s: %v", names.Service, err)
 			}
@@ -282,7 +282,7 @@ func TestIstioProbing(t *testing.T) {
 						clients.KubeClient,
 						t.Logf,
 						u,
-						v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloWorldText))),
+						v1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloWorldText))),
 						"HelloWorldServesText",
 						test.ServingFlags.ResolvableDomain,
 						1*time.Minute,

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -29,11 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/pkg/apis/autoscaling"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/resources"
-	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
+	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 func TestMinScale(t *testing.T) {
@@ -56,12 +56,12 @@ func TestMinScale(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	t.Log("Creating route")
-	if _, err := v1a1test.CreateRoute(t, clients, names); err != nil {
+	if _, err := v1test.CreateRoute(t, clients, names); err != nil {
 		t.Fatalf("Failed to create Route: %v", err)
 	}
 
 	t.Log("Creating configuration")
-	cfg, err := v1a1test.CreateConfiguration(t, clients, names, withMinScale(minScale))
+	cfg, err := v1test.CreateConfiguration(t, clients, names, withMinScale(minScale))
 	if err != nil {
 		t.Fatalf("Failed to create Configuration: %v", err)
 	}
@@ -75,8 +75,8 @@ func TestMinScale(t *testing.T) {
 	}
 
 	t.Log("Waiting for revision to become ready")
-	if err := v1a1test.WaitForRevisionState(
-		clients.ServingAlphaClient, revName, v1a1test.IsRevisionReady, "RevisionIsReady",
+	if err := v1test.WaitForRevisionState(
+		clients.ServingClient, revName, v1test.IsRevisionReady, "RevisionIsReady",
 	); err != nil {
 		t.Fatalf("The Revision %q did not become ready: %v", revName, err)
 	}
@@ -87,7 +87,7 @@ func TestMinScale(t *testing.T) {
 	}
 
 	t.Log("Updating configuration")
-	if _, err := v1a1test.PatchConfig(clients, cfg, rtesting.WithConfigEnv(corev1.EnvVar{Name: "FOO", Value: "BAR"})); err != nil {
+	if _, err := v1test.PatchConfig(t, clients, cfg, rtesting.WithConfigEnv(corev1.EnvVar{Name: "FOO", Value: "BAR"})); err != nil {
 		t.Fatalf("Failed to update Configuration: %v", err)
 	}
 
@@ -100,8 +100,8 @@ func TestMinScale(t *testing.T) {
 	}
 
 	t.Log("Waiting for new revision to become ready")
-	if err := v1a1test.WaitForRevisionState(
-		clients.ServingAlphaClient, newRevName, v1a1test.IsRevisionReady, "RevisionIsReady",
+	if err := v1test.WaitForRevisionState(
+		clients.ServingClient, newRevName, v1test.IsRevisionReady, "RevisionIsReady",
 	); err != nil {
 		t.Fatalf("The Revision %q did not become ready: %v", newRevName, err)
 	}
@@ -117,7 +117,7 @@ func TestMinScale(t *testing.T) {
 	}
 
 	t.Log("Deleting route")
-	if err := clients.ServingAlphaClient.Routes.Delete(names.Route, &metav1.DeleteOptions{}); err != nil {
+	if err := clients.ServingClient.Routes.Delete(names.Route, &metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Failed to delete route %q: %v", names.Route, err)
 	}
 
@@ -139,8 +139,8 @@ func lt(m int) func(int) bool {
 	}
 }
 
-func withMinScale(minScale int) func(cfg *v1alpha1.Configuration) {
-	return func(cfg *v1alpha1.Configuration) {
+func withMinScale(minScale int) func(cfg *v1.Configuration) {
+	return func(cfg *v1.Configuration) {
 		if cfg.Spec.Template.Annotations == nil {
 			cfg.Spec.Template.Annotations = make(map[string]string)
 		}
@@ -150,16 +150,16 @@ func withMinScale(minScale int) func(cfg *v1alpha1.Configuration) {
 
 func latestRevisionName(t *testing.T, clients *test.Clients, configName, oldRevName string) string {
 	// Wait for the Config have a LatestCreatedRevisionName
-	if err := v1a1test.WaitForConfigurationState(
-		clients.ServingAlphaClient, configName,
-		func(c *v1alpha1.Configuration) (bool, error) {
+	if err := v1test.WaitForConfigurationState(
+		clients.ServingClient, configName,
+		func(c *v1.Configuration) (bool, error) {
 			return c.Status.LatestCreatedRevisionName != oldRevName, nil
 		}, "ConfigurationHasUpdatedCreatedRevision",
 	); err != nil {
 		t.Fatalf("The Configuration %q has not updated LatestCreatedRevisionName from %q: %v", configName, oldRevName, err)
 	}
 
-	config, err := clients.ServingAlphaClient.Configs.Get(configName, metav1.GetOptions{})
+	config, err := clients.ServingClient.Configs.Get(configName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get Configuration after it was seen to be live: %v", err)
 	}

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -25,7 +25,7 @@ import (
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +36,7 @@ func checkResponse(t *testing.T, clients *test.Clients, names test.ResourceNames
 		clients.KubeClient,
 		t.Logf,
 		names.URL,
-		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
+		v1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
 		test.ServingFlags.ResolvableDomain,
 		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https),
@@ -64,7 +64,7 @@ func TestMultipleNamespace(t *testing.T) {
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(defaultClients, defaultResources) })
 	defer test.TearDown(defaultClients, defaultResources)
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, defaultClients, &defaultResources); err != nil {
+	if _, err := v1test.CreateServiceReady(t, defaultClients, &defaultResources); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", defaultResources.Service, test.ServingNamespace, err)
 	}
 
@@ -74,7 +74,7 @@ func TestMultipleNamespace(t *testing.T) {
 	}
 	test.CleanupOnInterrupt(func() { test.TearDown(altClients, altResources) })
 	defer test.TearDown(altClients, altResources)
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, altClients, &altResources); err != nil {
+	if _, err := v1test.CreateServiceReady(t, altClients, &altResources); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", altResources.Service, test.AlternativeServingNamespace, err)
 	}
 
@@ -126,7 +126,7 @@ func TestConflictingRouteService(t *testing.T) {
 
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names); err != nil {
+	if _, err := v1test.CreateServiceReady(t, clients, &names); err != nil {
 		t.Errorf("Failed to create Service %v in namespace %v: %v", names.Service, test.ServingNamespace, err)
 	}
 }

--- a/test/e2e/pod_schedule_error_test.go
+++ b/test/e2e/pod_schedule_error_test.go
@@ -26,11 +26,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/test/logstream"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
-	v1a1opts "knative.dev/serving/pkg/testing/v1alpha1"
+	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 func TestPodScheduleError(t *testing.T) {
@@ -62,17 +62,17 @@ func TestPodScheduleError(t *testing.T) {
 		},
 	}
 	var (
-		svc *v1alpha1.Service
+		svc *v1.Service
 		err error
 	)
-	if svc, err = v1a1test.CreateLatestService(t, clients, names, v1a1opts.WithResourceRequirements(resources)); err != nil {
+	if svc, err = v1test.CreateService(t, clients, names, rtesting.WithResourceRequirements(resources)); err != nil {
 		t.Fatalf("Failed to create Service %s: %v", names.Service, err)
 	}
 
 	names.Config = serviceresourcenames.Configuration(svc)
 
-	err = v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, func(r *v1alpha1.Service) (bool, error) {
-		cond := r.Status.GetCondition(v1alpha1.ServiceConditionConfigurationsReady)
+	err = v1test.WaitForServiceState(clients.ServingClient, names.Service, func(r *v1.Service) (bool, error) {
+		cond := r.Status.GetCondition(v1.ServiceConditionConfigurationsReady)
 		if cond != nil && !cond.IsUnknown() {
 			if strings.Contains(cond.Message, errorMsg) && cond.IsFalse() {
 				return true, nil
@@ -94,8 +94,8 @@ func TestPodScheduleError(t *testing.T) {
 	}
 
 	t.Log("When the containers are not scheduled, the revision should have error status.")
-	err = v1a1test.WaitForRevisionState(clients.ServingAlphaClient, revisionName, func(r *v1alpha1.Revision) (bool, error) {
-		cond := r.Status.GetCondition(v1alpha1.RevisionConditionReady)
+	err = v1test.WaitForRevisionState(clients.ServingClient, revisionName, func(r *v1.Revision) (bool, error) {
+		cond := r.Status.GetCondition(v1.RevisionConditionReady)
 		if cond != nil {
 			if cond.Reason == revisionReason && strings.Contains(cond.Message, errorMsg) {
 				return true, nil
@@ -113,7 +113,7 @@ func TestPodScheduleError(t *testing.T) {
 
 // Get revision name from configuration.
 func revisionFromConfiguration(clients *test.Clients, configName string) (string, error) {
-	config, err := clients.ServingAlphaClient.Configs.Get(configName, metav1.GetOptions{})
+	config, err := clients.ServingClient.Configs.Get(configName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/probe_whitelist_test.go
+++ b/test/e2e/probe_whitelist_test.go
@@ -25,7 +25,7 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 //This test checks if the activator can probe
@@ -51,7 +51,7 @@ func TestProbeWhitelist(t *testing.T) {
 	defer test.TearDown(clients, names)
 
 	t.Log("Creating a new Service")
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)
+	resources, err := v1test.CreateServiceReady(t, clients, &names)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -61,7 +61,7 @@ func TestProbeWhitelist(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		url,
-		v1a1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsOneOfStatusCodes(http.StatusUnauthorized))),
+		v1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsOneOfStatusCodes(http.StatusUnauthorized))),
 		"HelloWorldServesAuthFailed",
 		test.ServingFlags.ResolvableDomain,
 		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https),

--- a/test/e2e/rollback_byo_test.go
+++ b/test/e2e/rollback_byo_test.go
@@ -24,10 +24,9 @@ import (
 	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/test/logstream"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	. "knative.dev/serving/pkg/testing/v1alpha1"
+	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 func TestRollbackBYOName(t *testing.T) {
@@ -48,26 +47,23 @@ func TestRollbackBYOName(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	withTrafficSpecOld := WithInlineRouteSpec(v1alpha1.RouteSpec{
-		Traffic: []v1alpha1.TrafficTarget{{
-			TrafficTarget: v1.TrafficTarget{
-				RevisionName: byoNameOld,
-				Percent:      ptr.Int64(100),
-			},
+	withTrafficSpecOld := rtesting.WithRouteSpec(v1.RouteSpec{
+		Traffic: []v1.TrafficTarget{{
+			RevisionName: byoNameOld,
+			Percent:      ptr.Int64(100),
 		}},
 	})
-	withTrafficSpecNew := WithInlineRouteSpec(v1alpha1.RouteSpec{
-		Traffic: []v1alpha1.TrafficTarget{{
-			TrafficTarget: v1.TrafficTarget{
-				RevisionName: byoNameNew,
-				Percent:      ptr.Int64(100),
-			},
+	withTrafficSpecNew := rtesting.WithRouteSpec(v1.RouteSpec{
+		Traffic: []v1.TrafficTarget{{
+			RevisionName: byoNameNew,
+			Percent:      ptr.Int64(100),
 		}},
 	})
 
 	t.Logf("Creating a new Service with byo config name %q.", byoNameOld)
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		withTrafficSpecOld, func(svc *v1alpha1.Service) {
+	resources, err := v1test.CreateServiceReady(t, clients, &names,
+		withTrafficSpecOld,
+		func(svc *v1.Service) {
 			svc.Spec.ConfigurationSpec.Template.ObjectMeta.Name = byoNameOld
 		})
 	if err != nil {
@@ -81,17 +77,17 @@ func TestRollbackBYOName(t *testing.T) {
 
 	// Update service to use a new byo name
 	t.Logf("Updating the Service to a new revision with a new byo name %q.", byoNameNew)
-	newSvc := resources.Service.DeepCopy()
-	newSvc.Spec.ConfigurationSpec.Template.ObjectMeta.Name = byoNameNew
-	withTrafficSpecNew(newSvc)
-	svc, err := v1a1test.PatchService(t, clients, resources.Service, newSvc)
+	svc, err := v1test.PatchService(t, clients, resources.Service, func(s *v1.Service) {
+		s.Spec.Template.Name = byoNameNew
+		withTrafficSpecNew(s)
+	})
 	resources.Service = svc
 	if err != nil {
 		t.Fatalf("Patch update for Service (new byo name %q) failed: %v", byoNameNew, err)
 	}
 
 	t.Log("Since the Service was updated a new Revision will be created and the Service will be updated")
-	newRevision, err := v1a1test.WaitForServiceLatestRevision(clients, names)
+	newRevision, err := v1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
 		t.Fatalf("Service %s was not updated with the Revision for new byo name %s: %v", names.Service, byoNameNew, err)
 	}
@@ -100,9 +96,9 @@ func TestRollbackBYOName(t *testing.T) {
 	}
 
 	// Now, rollback to the first RevisionSpec
-	rollbackSvc := resources.Service.DeepCopy()
-	rollbackSvc.Spec = originalServiceSpec
-	svc, err = v1a1test.PatchService(t, clients, resources.Service, rollbackSvc)
+	svc, err = v1test.PatchService(t, clients, resources.Service, func(s *v1.Service) {
+		s.Spec = originalServiceSpec
+	})
 	resources.Service = svc
 	if err != nil {
 		t.Fatalf("Patch update for Service (rollback to byo name %q) failed: %v", byoNameOld, err)
@@ -111,7 +107,7 @@ func TestRollbackBYOName(t *testing.T) {
 	t.Logf("We are rolling back to the previous revision (byoNameOld %q).", byoNameOld)
 	// Wait for the route to become ready, and check that the traffic split between the byoNameOld
 	// and byoNameNew is 100 and 0, respectively
-	err = v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
+	err = v1test.WaitForServiceState(clients.ServingClient, names.Service, func(s *v1.Service) (bool, error) {
 		for _, tr := range s.Status.Traffic {
 			if tr.RevisionName != byoNameOld {
 				return false, nil
@@ -128,7 +124,7 @@ func TestRollbackBYOName(t *testing.T) {
 
 	// Verify that the latest ready revision and latest created revision are both byoNameNew,
 	// which means no new revision is created in the rollback
-	err = v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
+	err = v1test.WaitForServiceState(clients.ServingClient, names.Service, func(s *v1.Service) (bool, error) {
 		return (s.Status.LatestReadyRevisionName == byoNameOld && s.Status.LatestCreatedRevisionName == byoNameOld), nil
 	}, "ServiceNoNewRevisionCreated")
 	if err != nil {

--- a/test/e2e/route_service_test.go
+++ b/test/e2e/route_service_test.go
@@ -26,11 +26,10 @@ import (
 	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/test/logstream"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
-	. "knative.dev/serving/pkg/testing/v1alpha1"
+	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 // TestRoutesNotReady tests the scenario that when Route's status is
@@ -51,37 +50,35 @@ func TestRoutesNotReady(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	withTrafficSpec := WithInlineRouteSpec(v1alpha1.RouteSpec{
-		Traffic: []v1alpha1.TrafficTarget{
+	withTrafficSpec := rtesting.WithRouteSpec(v1.RouteSpec{
+		Traffic: []v1.TrafficTarget{
 			{
-				TrafficTarget: v1.TrafficTarget{
-					RevisionName: "foobar", // Invalid revision name. This allows Revision creation to succeed and Route configuration to fail
-					Percent:      ptr.Int64(100),
-				},
+				RevisionName: "foobar", // Invalid revision name. This allows Revision creation to succeed and Route configuration to fail
+				Percent:      ptr.Int64(100),
 			},
 		},
 	})
 
 	t.Log("Creating a new Service with an invalid traffic target.")
-	svc, err := v1a1test.CreateLatestService(t, clients, names, withTrafficSpec)
+	svc, err := v1test.CreateService(t, clients, names, withTrafficSpec)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service %q: %#v", names.Service, err)
 	}
 
 	t.Logf("Waiting for Service %q ObservedGeneration to match Generation, and status transition to Ready == False.", names.Service)
-	if err := v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, v1a1test.IsServiceNotReady, "ServiceIsNotReady"); err != nil {
+	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceNotReady, "ServiceIsNotReady"); err != nil {
 		t.Fatalf("Failed waiting for Service %q to transition to Ready == False: %#v", names.Service, err)
 	}
 
 	t.Logf("Validating Route %q has reconciled to Ready == False.", serviceresourcenames.Route(svc))
 	// Check Route is not ready
-	if err = v1a1test.CheckRouteState(clients.ServingAlphaClient, serviceresourcenames.Route(svc), v1a1test.IsRouteNotReady); err != nil {
+	if err = v1test.CheckRouteState(clients.ServingClient, serviceresourcenames.Route(svc), v1test.IsRouteNotReady); err != nil {
 		t.Fatalf("The Route %q was marked as Ready to serve traffic but it should not be: %#v", serviceresourcenames.Route(svc), err)
 	}
 
 	// Wait for RoutesReady to become False
 	t.Logf("Validating Service %q has reconciled to RoutesReady == False.", names.Service)
-	if err = v1a1test.CheckServiceState(clients.ServingAlphaClient, names.Service, v1a1test.IsServiceRoutesNotReady); err != nil {
+	if err = v1test.CheckServiceState(clients.ServingClient, names.Service, v1test.IsServiceRoutesNotReady); err != nil {
 		t.Fatalf("Service %q was not marked RoutesReady  == False: %#v", names.Service, err)
 	}
 }
@@ -89,58 +86,50 @@ func TestRoutesNotReady(t *testing.T) {
 func TestRouteVisibilityChanges(t *testing.T) {
 	testCases := []struct {
 		name            string
-		withTrafficSpec ServiceOption
+		withTrafficSpec rtesting.ServiceOption
 	}{
 		{
 			name: "Route visibility changes from public to private with single traffic",
-			withTrafficSpec: WithInlineRouteSpec(v1alpha1.RouteSpec{
-				Traffic: []v1alpha1.TrafficTarget{
+			withTrafficSpec: rtesting.WithRouteSpec(v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{
 					{
-						TrafficTarget: v1.TrafficTarget{
-							Percent: ptr.Int64(100),
-						},
+						Percent: ptr.Int64(100),
 					},
 				},
 			}),
 		},
 		{
 			name: "Route visibility changes from public to private with tag only",
-			withTrafficSpec: WithInlineRouteSpec(v1alpha1.RouteSpec{
-				Traffic: []v1alpha1.TrafficTarget{
+			withTrafficSpec: rtesting.WithRouteSpec(v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{
 					{
-						TrafficTarget: v1.TrafficTarget{
-							Percent: ptr.Int64(100),
-							Tag:     "cow",
-						},
+						Percent: ptr.Int64(100),
+						Tag:     "cow",
 					},
 				},
 			}),
 		},
 		{
 			name: "Route visibility changes from public to private with both tagged and non-tagged traffic",
-			withTrafficSpec: WithInlineRouteSpec(v1alpha1.RouteSpec{
-				Traffic: []v1alpha1.TrafficTarget{
+			withTrafficSpec: rtesting.WithRouteSpec(v1.RouteSpec{
+				Traffic: []v1.TrafficTarget{
 					{
-						TrafficTarget: v1.TrafficTarget{
-							Percent: ptr.Int64(60),
-						},
+						Percent: ptr.Int64(60),
 					},
 					{
-						TrafficTarget: v1.TrafficTarget{
-							Percent: ptr.Int64(40),
-							Tag:     "cow",
-						},
+						Percent: ptr.Int64(40),
+						Tag:     "cow",
 					},
 				},
 			}),
 		},
 	}
 
-	hasPublicRoute := func(r *v1alpha1.Route) (b bool, e error) {
+	hasPublicRoute := func(r *v1.Route) (b bool, e error) {
 		return !strings.HasSuffix(r.Status.URL.Host, network.GetClusterDomainName()), nil
 	}
 
-	hasPrivateRoute := func(r *v1alpha1.Route) (b bool, e error) {
+	hasPrivateRoute := func(r *v1.Route) (b bool, e error) {
 		return strings.HasSuffix(r.Status.URL.Host, network.GetClusterDomainName()), nil
 	}
 
@@ -162,36 +151,36 @@ func TestRouteVisibilityChanges(t *testing.T) {
 			defer test.TearDown(clients, names)
 
 			st.Log("Creating a new Service")
-			svc, err := v1a1test.CreateLatestService(st, clients, names, testCase.withTrafficSpec)
+			svc, err := v1test.CreateService(st, clients, names, testCase.withTrafficSpec)
 			if err != nil {
 				st.Fatalf("Failed to create initial Service %q: %#v", names.Service, err)
 			}
 
 			st.Logf("Waiting for Service %q ObservedGeneration to match Generation, and status transition to Ready == True", names.Service)
-			if err := v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, v1a1test.IsServiceReady, "ServiceIsReady"); err != nil {
+			if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
 				st.Fatalf("Failed waiting for Service %q to transition to Ready == True: %#v", names.Service, err)
 			}
 
 			st.Logf("Validating Route %q has non cluster-local address", serviceresourcenames.Route(svc))
 			// Check Route is not ready
 
-			if err = v1a1test.CheckRouteState(clients.ServingAlphaClient, serviceresourcenames.Route(svc), hasPublicRoute); err != nil {
+			if err = v1test.CheckRouteState(clients.ServingClient, serviceresourcenames.Route(svc), hasPublicRoute); err != nil {
 				st.Fatalf("The Route %q should be publicly visible but it was not: %#v", serviceresourcenames.Route(svc), err)
 			}
 
-			newSvc := svc.DeepCopy()
-			newSvc.SetLabels(map[string]string{"serving.knative.dev/visibility": "cluster-local"})
-			v1a1test.PatchService(st, clients, svc, newSvc)
+			v1test.PatchService(st, clients, svc, func(s *v1.Service) {
+				s.SetLabels(map[string]string{"serving.knative.dev/visibility": "cluster-local"})
+			})
 
 			st.Logf("Waiting for Service %q ObservedGeneration to match Generation, and status transition to Ready == True", names.Service)
-			if err := v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, v1a1test.IsServiceReady, "ServiceIsReady"); err != nil {
+			if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
 				st.Fatalf("Failed waiting for Service %q to transition to Ready == True: %#v", names.Service, err)
 			}
 
 			st.Logf("Validating Route %q has cluster-local address", serviceresourcenames.Route(svc))
 			// Check Route is not ready
 
-			if err = v1a1test.WaitForRouteState(clients.ServingAlphaClient, serviceresourcenames.Route(svc), hasPrivateRoute, "RouteIsClusterLocal"); err != nil {
+			if err = v1test.WaitForRouteState(clients.ServingClient, serviceresourcenames.Route(svc), hasPrivateRoute, "RouteIsClusterLocal"); err != nil {
 				st.Fatalf("The Route %q should be privately visible but it was not: %#v", serviceresourcenames.Route(svc), err)
 			}
 		})

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -24,17 +24,16 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	pkgTest "knative.dev/pkg/test"
 	ingress "knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/serving"
-	v1alph1testing "knative.dev/serving/pkg/testing/v1alpha1"
+	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
-
-	corev1 "k8s.io/api/core/v1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 const (
@@ -118,9 +117,9 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		v1alph1testing.WithEnv(envVars...),
-		v1alph1testing.WithConfigAnnotations(map[string]string{
+	resources, err := v1test.CreateServiceReady(t, clients, &names,
+		rtesting.WithEnv(envVars...),
+		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
 			"sidecar.istio.io/inject":       strconv.FormatBool(inject),
 		}))
@@ -133,7 +132,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 		clients.KubeClient,
 		t.Logf,
 		url,
-		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
+		v1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"HTTPProxy",
 		test.ServingFlags.ResolvableDomain,
 		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https),
@@ -195,11 +194,11 @@ func TestServiceToServiceCall(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	withInternalVisibility := v1alph1testing.WithServiceLabel(
+	withInternalVisibility := rtesting.WithServiceLabel(
 		serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+	resources, err := v1test.CreateServiceReady(t, clients, &names,
 		withInternalVisibility,
-		v1alph1testing.WithConfigAnnotations(map[string]string{
+		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
 		}))
 	if err != nil {
@@ -241,14 +240,14 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 		Image:   "helloworld",
 	}
 
-	withInternalVisibility := v1alph1testing.WithServiceLabel(
+	withInternalVisibility := rtesting.WithServiceLabel(
 		serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
 
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, testNames) })
 	defer test.TearDown(clients, testNames)
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &testNames,
-		v1alph1testing.WithConfigAnnotations(map[string]string{
+	resources, err := v1test.CreateServiceReady(t, clients, &testNames,
+		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 			"sidecar.istio.io/inject":          strconv.FormatBool(injectB),
 		}), withInternalVisibility)
@@ -302,8 +301,8 @@ func TestCallToPublicService(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		v1alph1testing.WithConfigAnnotations(map[string]string{
+	resources, err := v1test.CreateServiceReady(t, clients, &names,
+		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
 		}))
 	if err != nil {

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -32,12 +32,10 @@ import (
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/pkg/reconciler/route/resources/labels"
+	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
-
-	. "knative.dev/serving/pkg/testing/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 // In this test, we set up two apps: helloworld and httpproxy.
@@ -64,20 +62,17 @@ func TestSubrouteLocalSTS(t *testing.T) { // We can't use a longer more descript
 
 	tag := "current"
 
-	withInternalVisibility := WithServiceLabel(serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
-	withTrafficSpec := WithInlineRouteSpec(v1alpha1.RouteSpec{
-		Traffic: []v1alpha1.TrafficTarget{
+	withInternalVisibility := rtesting.WithServiceLabel(serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
+	withTrafficSpec := rtesting.WithRouteSpec(v1.RouteSpec{
+		Traffic: []v1.TrafficTarget{
 			{
-				TrafficTarget: v1.TrafficTarget{
-					Tag:     tag,
-					Percent: ptr.Int64(100),
-				},
+				Tag:     tag,
+				Percent: ptr.Int64(100),
 			},
 		},
 	})
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		withInternalVisibility, withTrafficSpec)
+	resources, err := v1test.CreateServiceReady(t, clients, &names, withInternalVisibility, withTrafficSpec)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -114,16 +109,13 @@ func TestSubrouteVisibilityPublicToPrivate(t *testing.T) {
 	subrouteTag1 := "my-tag"
 	subrouteTag2 := "my-tag2"
 
-	withTrafficSpec := WithInlineRouteSpec(v1alpha1.RouteSpec{
-		Traffic: []v1alpha1.TrafficTarget{{
-			TrafficTarget: v1.TrafficTarget{
-				Tag:     subrouteTag1,
-				Percent: ptr.Int64(100),
-			},
+	withTrafficSpec := rtesting.WithRouteSpec(v1.RouteSpec{
+		Traffic: []v1.TrafficTarget{{
+			Tag:     subrouteTag1,
+			Percent: ptr.Int64(100),
 		}},
 	})
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		withTrafficSpec)
+	resources, err := v1test.CreateServiceReady(t, clients, &names, withTrafficSpec)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -160,18 +152,16 @@ func TestSubrouteVisibilityPublicToPrivate(t *testing.T) {
 	//Create subroute2 in kservice.
 	ksvcCopy := resources.Service.DeepCopy()
 	ksvcCopyRouteTraffic := append(ksvcCopy.Spec.Traffic,
-		v1alpha1.TrafficTarget{
-			TrafficTarget: v1.TrafficTarget{
-				Tag:            subrouteTag2,
-				LatestRevision: ptr.Bool(true),
-			},
+		v1.TrafficTarget{
+			Tag:            subrouteTag2,
+			LatestRevision: ptr.Bool(true),
 		})
 
-	if _, err = v1a1test.UpdateServiceRouteSpec(t, clients, names, v1alpha1.RouteSpec{Traffic: ksvcCopyRouteTraffic}); err != nil {
+	if _, err = v1test.UpdateServiceRouteSpec(t, clients, names, v1.RouteSpec{Traffic: ksvcCopyRouteTraffic}); err != nil {
 		t.Fatalf("Failed to patch service: %v", err)
 	}
 
-	if err = v1a1test.WaitForRouteState(clients.ServingAlphaClient, resources.Route.Name, func(r *v1alpha1.Route) (bool, error) {
+	if err = v1test.WaitForRouteState(clients.ServingClient, resources.Route.Name, func(r *v1.Route) (bool, error) {
 		//Check subroute1 is not cluster-local
 		if isClusterLocal, err := isTrafficClusterLocal(r.Status.Traffic, subrouteTag1); err != nil {
 			return false, err
@@ -190,19 +180,19 @@ func TestSubrouteVisibilityPublicToPrivate(t *testing.T) {
 	}
 
 	//Update route to private.
-	ksvclabelCopy := resources.Service.DeepCopy()
-	labels.SetVisibility(&ksvclabelCopy.ObjectMeta, true)
-	if _, err = v1a1test.PatchService(t, clients, resources.Service, ksvclabelCopy); err != nil {
+	if _, err = v1test.PatchService(t, clients, resources.Service, func(s *v1.Service) {
+		labels.SetVisibility(&s.ObjectMeta, true)
+	}); err != nil {
 		t.Fatalf("Failed to patch service: %s", err.Error())
 	}
 
-	if err = v1a1test.WaitForRouteState(clients.ServingAlphaClient, resources.Route.Name, func(r *v1alpha1.Route) (bool, error) {
+	if err = v1test.WaitForRouteState(clients.ServingClient, resources.Route.Name, func(r *v1.Route) (bool, error) {
 		return isRouteClusterLocal(r.Status), nil
 	}, "Route is cluster local"); err != nil {
 		t.Fatalf("Route did not become cluster local: %s", err.Error())
 	}
 
-	clusterLocalRoute, err := clients.ServingAlphaClient.Routes.Get(resources.Route.Name, metav1.GetOptions{})
+	clusterLocalRoute, err := clients.ServingClient.Routes.Get(resources.Route.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -235,25 +225,20 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 	subrouteTag1 := "my-tag"
 	subrouteTag2 := "my-tag2"
 
-	withInternalVisibility := WithServiceLabel(serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
-	withTrafficSpec := WithInlineRouteSpec(v1alpha1.RouteSpec{
-		Traffic: []v1alpha1.TrafficTarget{
+	withInternalVisibility := rtesting.WithServiceLabel(serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
+	withTrafficSpec := rtesting.WithRouteSpec(v1.RouteSpec{
+		Traffic: []v1.TrafficTarget{
 			{
-				TrafficTarget: v1.TrafficTarget{
-					Tag:     subrouteTag1,
-					Percent: ptr.Int64(50),
-				},
+				Tag:     subrouteTag1,
+				Percent: ptr.Int64(50),
 			},
 			{
-				TrafficTarget: v1.TrafficTarget{
-					Tag:     subrouteTag2,
-					Percent: ptr.Int64(50),
-				},
+				Tag:     subrouteTag2,
+				Percent: ptr.Int64(50),
 			},
 		},
 	})
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		withTrafficSpec, withInternalVisibility)
+	resources, err := v1test.CreateServiceReady(t, clients, &names, withTrafficSpec, withInternalVisibility)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -292,7 +277,7 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 	afterCh := time.After(5 * time.Second)
 
 	// check subroutes are private
-	if err = v1a1test.WaitForRouteState(clients.ServingAlphaClient, resources.Route.Name, func(r *v1alpha1.Route) (bool, error) {
+	if err = v1test.WaitForRouteState(clients.ServingClient, resources.Route.Name, func(r *v1.Route) (bool, error) {
 		for _, tag := range []string{subrouteTag1, subrouteTag2} {
 			if isClusterLocal, err := isTrafficClusterLocal(r.Status.Traffic, tag); err != nil {
 				return false, err
@@ -318,19 +303,19 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 
 	// change route - public (Updating ksvc as it will reconcile the route)
 	// check route = public
-	ksvclabelCopy := resources.Service.DeepCopy()
-	labels.SetVisibility(&ksvclabelCopy.ObjectMeta, false)
-	if _, err = v1a1test.PatchService(t, clients, resources.Service, ksvclabelCopy); err != nil {
+	if _, err = v1test.PatchService(t, clients, resources.Service, func(s *v1.Service) {
+		labels.SetVisibility(&s.ObjectMeta, false)
+	}); err != nil {
 		t.Fatalf("Failed to patch service: %s", err.Error())
 	}
 
-	if err = v1a1test.WaitForRouteState(clients.ServingAlphaClient, resources.Route.Name, func(r *v1alpha1.Route) (b bool, e error) {
+	if err = v1test.WaitForRouteState(clients.ServingClient, resources.Route.Name, func(r *v1.Route) (b bool, e error) {
 		return !isRouteClusterLocal(r.Status), nil
 	}, "Route is public"); err != nil {
 		t.Fatalf("Route is not public: %s", err.Error())
 	}
 
-	publicRoute, err := clients.ServingAlphaClient.Routes.Get(resources.Route.Name, metav1.GetOptions{})
+	publicRoute, err := clients.ServingClient.Routes.Get(resources.Route.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -368,7 +353,7 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 		t.Fatalf("Failed to patch service: %v", err)
 	}
 
-	if err = v1a1test.WaitForRouteState(clients.ServingAlphaClient, resources.Route.Name, v1a1test.IsRouteReady, "Route is ready"); err != nil {
+	if err = v1test.WaitForRouteState(clients.ServingClient, resources.Route.Name, v1test.IsRouteReady, "Route is ready"); err != nil {
 		t.Fatalf("Route did not become ready: %v", err)
 	}
 
@@ -380,16 +365,16 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 }
 
 // Function check whether traffic with tag is cluster local or
-func isTrafficClusterLocal(tt []v1alpha1.TrafficTarget, tag string) (bool, error) {
+func isTrafficClusterLocal(tt []v1.TrafficTarget, tag string) (bool, error) {
 	for _, traffic := range tt {
 		if traffic.Tag == tag {
-			return strings.HasSuffix(traffic.TrafficTarget.URL.Host, network.GetClusterDomainName()), nil
+			return strings.HasSuffix(traffic.URL.Host, network.GetClusterDomainName()), nil
 		}
 	}
 	return false, fmt.Errorf("Unable to find traffic target with tag %s", tag)
 }
 
-func isRouteClusterLocal(rs v1alpha1.RouteStatus) bool {
+func isRouteClusterLocal(rs v1.RouteStatus) bool {
 	return strings.HasSuffix(rs.URL.Host, network.GetClusterDomainName())
 }
 

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -30,10 +30,9 @@ import (
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	rtesting "knative.dev/serving/pkg/testing/v1alpha1"
+	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 const (
@@ -135,7 +134,7 @@ func TestWebSocket(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	if _, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names); err != nil {
+	if _, err := v1test.CreateServiceReady(t, clients, &names); err != nil {
 		t.Fatalf("Failed to create WebSocket server: %v", err)
 	}
 
@@ -162,7 +161,7 @@ func TestWebSocketViaActivator(t *testing.T) {
 	defer test.TearDown(clients, names)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
-	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+	resources, err := v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 		}),
@@ -195,7 +194,7 @@ func TestWebSocketBlueGreenRoute(t *testing.T) {
 
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
+	objects, err := v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithEnv(corev1.EnvVar{
 			Name:  "SUFFIX",
 			Value: "Blue",
@@ -209,8 +208,9 @@ func TestWebSocketBlueGreenRoute(t *testing.T) {
 
 	t.Log("Updating the Service to use a different suffix")
 	greenSvc := objects.Service.DeepCopy()
-	greenSvc.Spec.ConfigurationSpec.Template.Spec.Containers[0].Env[0].Value = "Green"
-	greenSvc, err = v1a1test.PatchService(t, clients, objects.Service, greenSvc)
+	greenSvc, err = v1test.PatchService(t, clients, objects.Service, func(s *v1.Service) {
+		s.Spec.Template.Spec.Containers[0].Env[0].Value = "Green"
+	})
 	if err != nil {
 		t.Fatalf("Patch update for Service %s with new env var failed: %v", names.Service, err)
 	}
@@ -219,36 +219,32 @@ func TestWebSocketBlueGreenRoute(t *testing.T) {
 	green.TrafficTarget = "green"
 
 	t.Log("Since the Service was updated a new Revision will be created and the Service will be updated")
-	green.Revision, err = v1a1test.WaitForServiceLatestRevision(clients, names)
+	green.Revision, err = v1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
 		t.Fatalf("Service %s was not updated with the new Revision: %v", names.Service, err)
 	}
 
 	t.Log("Updating RouteSpec")
-	if _, err := v1a1test.UpdateServiceRouteSpec(t, clients, names, v1alpha1.RouteSpec{
-		Traffic: []v1alpha1.TrafficTarget{{
-			TrafficTarget: v1.TrafficTarget{
-				Tag:          blue.TrafficTarget,
-				RevisionName: blue.Revision,
-				Percent:      ptr.Int64(50),
-			},
+	if _, err := v1test.UpdateServiceRouteSpec(t, clients, names, v1.RouteSpec{
+		Traffic: []v1.TrafficTarget{{
+			Tag:          blue.TrafficTarget,
+			RevisionName: blue.Revision,
+			Percent:      ptr.Int64(50),
 		}, {
-			TrafficTarget: v1.TrafficTarget{
-				Tag:          green.TrafficTarget,
-				RevisionName: green.Revision,
-				Percent:      ptr.Int64(50),
-			},
+			Tag:          green.TrafficTarget,
+			RevisionName: green.Revision,
+			Percent:      ptr.Int64(50),
 		}},
 	}); err != nil {
 		t.Fatalf("Failed to update Service route spec: %v", err)
 	}
 
 	t.Log("Wait for the service domains to be ready")
-	if err := v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, v1a1test.IsServiceReady, "ServiceIsReady"); err != nil {
+	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
 		t.Fatalf("The Service %s was not marked as Ready to serve traffic: %v", names.Service, err)
 	}
 
-	service, err := clients.ServingAlphaClient.Services.Get(names.Service, metav1.GetOptions{})
+	service, err := clients.ServingClient.Services.Get(names.Service, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
 	}

--- a/test/v1/configuration.go
+++ b/test/v1/configuration.go
@@ -21,15 +21,13 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"knative.dev/pkg/apis/duck"
-	"knative.dev/pkg/test/logging"
-	v1 "knative.dev/serving/pkg/apis/serving/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-
+	"knative.dev/pkg/apis/duck"
 	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/logging"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 )

--- a/test/v1/route.go
+++ b/test/v1/route.go
@@ -23,11 +23,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/ptr"
+	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/spoof"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-
-	pkgTest "knative.dev/pkg/test"
 	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 )

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -23,14 +23,15 @@ import (
 
 	"github.com/mattbaird/jsonpatch"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-
 	"knative.dev/pkg/apis/duck"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
 	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
@@ -253,4 +254,10 @@ func IsServiceReady(s *v1.Service) (bool, error) {
 // not ready.
 func IsServiceNotReady(s *v1.Service) (bool, error) {
 	return s.Generation == s.Status.ObservedGeneration && !s.Status.IsReady(), nil
+}
+
+// IsServiceRoutesNotReady checks the RoutesReady status of the service and returns true only if RoutesReady is set to False.
+func IsServiceRoutesNotReady(s *v1.Service) (bool, error) {
+	result := s.Status.GetCondition(v1alpha1.ServiceConditionRoutesReady)
+	return s.Generation == s.Status.ObservedGeneration && result != nil && result.Status == corev1.ConditionFalse, nil
 }

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -31,7 +31,6 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
 	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
@@ -253,11 +252,12 @@ func IsServiceReady(s *v1.Service) (bool, error) {
 // IsServiceNotReady will check the status conditions of the service and return true if the service is
 // not ready.
 func IsServiceNotReady(s *v1.Service) (bool, error) {
-	return s.Generation == s.Status.ObservedGeneration && !s.Status.IsReady(), nil
+	result := s.Status.GetCondition(v1.ServiceConditionReady)
+	return s.Generation == s.Status.ObservedGeneration && result != nil && result.Status == corev1.ConditionFalse, nil
 }
 
 // IsServiceRoutesNotReady checks the RoutesReady status of the service and returns true only if RoutesReady is set to False.
 func IsServiceRoutesNotReady(s *v1.Service) (bool, error) {
-	result := s.Status.GetCondition(v1alpha1.ServiceConditionRoutesReady)
+	result := s.Status.GetCondition(v1.ServiceConditionRoutesReady)
 	return s.Generation == s.Status.ObservedGeneration && result != nil && result.Status == corev1.ConditionFalse, nil
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Contributes to https://github.com/knative/serving/issues/6816

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Have e2e tests use v1 APIs

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
