### PR TITLE
Miscellaneous refactorings in autoscaler.Scale()

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -184,8 +184,8 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 		dspc, dppc, originalReadyPodsCount, maxScaleUp, maxScaleDown)
 
 	// We want to keep desired pod count in the  [maxScaleDown, maxScaleUp] range.
-	desiredStablePodCount := int32(math.Min(math.Max(dspc, maxScaleDown), maxScaleUp))
-	desiredPanicPodCount := int32(math.Min(math.Max(dppc, maxScaleDown), maxScaleUp))
+	desiredStablePodCount := int32(clampInclusiveRange(dspc, maxScaleDown, maxScaleUp))
+	desiredPanicPodCount := int32(clampInclusiveRange(dppc, maxScaleDown, maxScaleUp))
 
 	logger.With(zap.String("mode", "stable")).Debugf("Observed average scaling metric value: %0.3f, targeting %0.3f.",
 		observedStableValue, spec.TargetValue)
@@ -242,6 +242,10 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 		desiredPodCountM.M(int64(desiredPodCount)))
 
 	return desiredPodCount, int32(excessBCF), true
+}
+
+func clampInclusiveRange(valueToClamp float64, lowerBound float64, upperBound float64) float64 {
+	return math.Min(math.Max(valueToClamp, lowerBound), upperBound)
 }
 
 // Query functions

--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -199,7 +199,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	defer a.stateMux.Unlock()
 	if isOverPanicThreshold && a.currentlyStable() {
 		a.startPanicking(now, logger)
-	} else if isBelowPanicThreshold && a.currentlyPanicking() && a.stableWindowHasElapsed(spec, now) {
+	} else if isBelowPanicThreshold && a.currentlyPanicking() && a.hasElapsed(now, spec.StableWindow) {
 		a.stopPanicking(logger)
 	}
 
@@ -257,8 +257,8 @@ func (a *Autoscaler) currentlyPanicking() bool {
 	return !a.currentlyStable()
 }
 
-func (a *Autoscaler) stableWindowHasElapsed(spec *DeciderSpec, now time.Time) bool {
-	return a.panicTime.Add(spec.StableWindow).Before(now)
+func (a *Autoscaler) hasElapsed(now time.Time, duration time.Duration) bool {
+	return a.panicTime.Add(duration).Before(now)
 }
 
 func (a *Autoscaler) currentSpecAndPC() (*DeciderSpec, resources.EndpointsCounter) {

--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -142,8 +142,9 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	metricKey := types.NamespacedName{Namespace: a.namespace, Name: a.revision}
 
 	metricName := spec.ScalingMetric
+
 	var observedStableValue, observedPanicValue float64
-	switch spec.ScalingMetric {
+	switch metricName {
 	case autoscaling.RPS:
 		observedStableValue, observedPanicValue, err = a.metricClient.StableAndPanicRPS(metricKey, now)
 		pkgmetrics.RecordBatch(a.reporterCtx, stableRPSM.M(observedStableValue), panicRPSM.M(observedStableValue),

--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -153,7 +153,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 		pkgmetrics.RecordBatch(a.reporterCtx, stableRPSM.M(observedStableValue), panicRPSM.M(observedStableValue),
 			targetRPSM.M(spec.TargetValue))
 	default:
-		logger.Errorf("Expected metricName to be one of '%s' or '%s', but got '%s'", autoscaling.Concurrency, autoscaling.RPS, metricName)
+		logger.Errorf("Expected metricName to be one of %q or %q, but got %q", autoscaling.Concurrency, autoscaling.RPS, metricName)
 		return 0, 0, false
 	}
 
@@ -244,7 +244,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount 
 	return desiredPodCount, int32(excessBCF), true
 }
 
-func clampInclusiveRange(valueToClamp float64, lowerBound float64, upperBound float64) float64 {
+func clampInclusiveRange(valueToClamp, lowerBound, upperBound float64) float64 {
 	return math.Min(math.Max(valueToClamp, lowerBound), upperBound)
 }
 
@@ -274,19 +274,13 @@ func (a *Autoscaler) updatePanic(panicTime time.Time, maxPanicPods int32) {
 }
 
 func (a *Autoscaler) startPanicking(now time.Time, logger *zap.SugaredLogger) {
-	// Begin panicking when we cross the threshold in the panic window.
 	logger.Info("PANICKING.")
-
 	a.updatePanic(now, 0)
-
 	pkgmetrics.Record(a.reporterCtx, panicM.M(1))
 }
 
 func (a *Autoscaler) stopPanicking(logger *zap.SugaredLogger) {
-	// Stop panicking after the surge has made its way into the stable metric.
 	logger.Info("Un-panicking.")
-
 	a.updatePanic(time.Time{}, 0)
-
 	pkgmetrics.Record(a.reporterCtx, panicM.M(0))
 }

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -372,13 +372,13 @@ func TestAutoscalerUpdateTarget(t *testing.T) {
 }
 
 func TestRejectUnknownScalingMetric(t *testing.T) {
-	metrics := &autoscalerfake.MetricClient{StableConcurrency:100}
+	metrics := &autoscalerfake.MetricClient{StableConcurrency: 100}
 	a := newTestAutoscalerWithScalingMetric(t, 10, 10, metrics, "KABOOM!!!!", false)
 	a.expectScale(t, time.Now(), 0, 0, false)
 }
 
 func TestRejectEmptyScalingMetric(t *testing.T) {
-	metrics := &autoscalerfake.MetricClient{StableConcurrency:100}
+	metrics := &autoscalerfake.MetricClient{StableConcurrency: 100}
 	a := newTestAutoscalerWithScalingMetric(t, 10, 10, metrics, "", false)
 	a.expectScale(t, time.Now(), 0, 0, false)
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

These changes are primarily cosmetic/stylistic, developed while I hand-traced through the autoscaler code in order to better understand the exact algorithm behaviour. Mostly these are function or variable extractions, though in one or two cases I have reordered `if` or `switch` blocks in order to put common cases first.

There is one notable behaviour-changing modification, which is that empty or unknown `spec.ScalingMetric` values are made into an error condition. Previously these were treated as being "concurrency".

**Release Note**

```release-note
NONE
```
