### PR TITLE
Fix wrong var HTTP to HTTPS in e2e-test.sh

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -48,7 +48,7 @@ parallelism=""
 use_https=""
 (( MESH )) && parallelism="-parallel 1"
 
-if (( HTTP )); then
+if (( HTTPS )); then
   parallelism="-parallel 1"
   use_https="--https"
 fi


### PR DESCRIPTION
## Proposed Changes

In [e2e-common.sh](https://github.com/knative/serving/blob/7b1931a9b860a145c13241c744cc09c6d1640d80/test/e2e-common.sh#L76), there are no `HTTP` value is defined, but HTTPS is.
This patch corrects the value to HTTPS.

/lint

**Release Note**

```release-note
NONE
```
