### PR TITLE
Simplify activator inferring and make it more efficient.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -172,12 +172,7 @@ func main() {
 	defer close(reqCh)
 
 	// Start throttler.
-	throttler := activatornet.NewThrottler(ctx,
-		// We need a separator at the end of the Activator IP, not to do incorrect prefix matches,
-		// but also so that we can match with IP address of the public service
-		// endpoints, which might be ports 8012 or 8013.
-		// e.g. `10.10.10.1` will prefix match `10.10.10.10`, but `10.10.10.1:` won't.
-		env.PodIP+":")
+	throttler := activatornet.NewThrottler(ctx, env.PodIP)
 	go throttler.Run(ctx)
 
 	oct := tracing.NewOpenCensusTracer(tracing.WithExporter(networking.ActivatorServiceName, logger))

--- a/pkg/activator/net/helpers.go
+++ b/pkg/activator/net/helpers.go
@@ -37,6 +37,7 @@ func healthyAddressesWithPort(endpoints *corev1.Endpoints, portName string) sets
 				for _, addr := range es.Addresses {
 					ready.Insert(addr.IP)
 				}
+				break
 			}
 		}
 	}
@@ -62,6 +63,7 @@ func endpointsToDests(endpoints *corev1.Endpoints, portName string) (sets.String
 					// Prefer IP as we can avoid a DNS lookup this way.
 					notReady.Insert(net.JoinHostPort(addr.IP, portStr))
 				}
+				break
 			}
 		}
 	}

--- a/pkg/activator/net/helpers.go
+++ b/pkg/activator/net/helpers.go
@@ -26,6 +26,24 @@ import (
 	"knative.dev/serving/pkg/apis/networking"
 )
 
+// healthyEndpointsWithPort takes an endpoints object and a port name and return the set
+// of addresses that implement this port.
+func healthyAddressesWithPort(endpoints *corev1.Endpoints, portName string) sets.String {
+	ready := sets.NewString()
+
+	for _, es := range endpoints.Subsets {
+		for _, port := range es.Ports {
+			if port.Name == portName {
+				for _, addr := range es.Addresses {
+					ready.Insert(addr.IP)
+				}
+			}
+		}
+	}
+
+	return ready
+}
+
 // endpointsToDests takes an endpoints object and a port name and returns two sets of
 // ready and non-ready l4 dests in the endpoints object which have that port.
 func endpointsToDests(endpoints *corev1.Endpoints, portName string) (sets.String, sets.String) {

--- a/pkg/activator/net/helpers.go
+++ b/pkg/activator/net/helpers.go
@@ -26,7 +26,7 @@ import (
 	"knative.dev/serving/pkg/apis/networking"
 )
 
-// healthyEndpoints takes an endpoints object and a port name and return the set
+// healthyAddresses takes an endpoints object and a port name and return the set
 // of addresses that implement this port.
 func healthyAddresses(endpoints *corev1.Endpoints, portName string) sets.String {
 	ready := sets.NewString()

--- a/pkg/activator/net/helpers.go
+++ b/pkg/activator/net/helpers.go
@@ -26,9 +26,9 @@ import (
 	"knative.dev/serving/pkg/apis/networking"
 )
 
-// healthyEndpointsWithPort takes an endpoints object and a port name and return the set
+// healthyEndpoints takes an endpoints object and a port name and return the set
 // of addresses that implement this port.
-func healthyAddressesWithPort(endpoints *corev1.Endpoints, portName string) sets.String {
+func healthyAddresses(endpoints *corev1.Endpoints, portName string) sets.String {
 	ready := sets.NewString()
 
 	for _, es := range endpoints.Subsets {

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -588,7 +588,7 @@ func (t *Throttler) handlePubEpsUpdate(eps *corev1.Endpoints) {
 
 func (rt *revisionThrottler) handlePubEpsUpdate(eps *corev1.Endpoints, selfIP string) {
 	// NB: this is guaranteed to be executed on a single thread.
-	epSet := healthyAddressesWithPort(eps, rt.protocol)
+	epSet := healthyAddresses(eps, rt.protocol)
 	if !epSet.Has(selfIP) {
 		// No need to do anything, this activator is not in path.
 		return

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -68,7 +68,7 @@ func newTestThrottler(ctx context.Context) (*Throttler, func()) {
 	bp := breakerParams
 	breakerParams = defaultParams
 
-	throttler := NewThrottler(ctx, "10.10.10.10:8012")
+	throttler := NewThrottler(ctx, "10.10.10.10")
 	return throttler, func() {
 		breakerParams = bp
 	}
@@ -400,7 +400,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 			updateCh := make(chan revisionDestsUpdate)
 			defer close(updateCh)
 
-			throttler := NewThrottler(ctx, "130.0.0.2:8012")
+			throttler := NewThrottler(ctx, "130.0.0.2")
 			go throttler.run(updateCh)
 
 			for _, update := range tc.initUpdates {
@@ -597,7 +597,7 @@ func TestActivatorsIndexUpdate(t *testing.T) {
 	updateCh := make(chan revisionDestsUpdate)
 	defer close(updateCh)
 
-	throttler := NewThrottler(ctx, "130.0.0.2:")
+	throttler := NewThrottler(ctx, "130.0.0.2")
 	go throttler.run(updateCh)
 
 	possibleDests := sets.NewString("128.0.0.1:1234", "128.0.0.2:1234", "128.0.0.23:1234")
@@ -681,7 +681,7 @@ func TestMultipleActivators(t *testing.T) {
 	updateCh := make(chan revisionDestsUpdate)
 	defer close(updateCh)
 
-	throttler := NewThrottler(ctx, "130.0.0.2:8012")
+	throttler := NewThrottler(ctx, "130.0.0.2")
 	go throttler.run(updateCh)
 
 	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
@@ -844,7 +844,7 @@ func TestInfiniteBreaker(t *testing.T) {
 }
 
 func TestInferIndex(t *testing.T) {
-	const myIP = "10.10.10.3:1234"
+	const myIP = "10.10.10.3"
 	tests := []struct {
 		label string
 		ips   []string
@@ -855,19 +855,19 @@ func TestInferIndex(t *testing.T) {
 		-1,
 	}, {
 		"missing",
-		[]string{"11.11.11.11:1234", "11.11.11.12:1234"},
+		[]string{"11.11.11.11", "11.11.11.12"},
 		-1,
 	}, {
 		"first",
-		[]string{"10.10.10.3:1234,11.11.11.11:1234"},
+		[]string{"10.10.10.3", "11.11.11.11"},
 		0,
 	}, {
 		"middle",
-		[]string{"10.10.10.1:1212", "10.10.10.2:1234", "10.10.10.3:1234", "11.11.11.11:1234"},
+		[]string{"10.10.10.1", "10.10.10.2", "10.10.10.3", "11.11.11.11"},
 		2,
 	}, {
 		"last",
-		[]string{"10.10.10.1:1234", "10.10.10.2:1234", "10.10.10.3:1234"},
+		[]string{"10.10.10.1", "10.10.10.2", "10.10.10.3"},
 		2,
 	}}
 	for _, test := range tests {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Searching the activator IP worked because of the search algorithm being a binary search and that matches prefixes quite nicely.

This changes the logic to be solely based on straight IPs, which allows us to short-circuit computations based on the absence of a certain IP efficiently.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
