### PR TITLE
[RELEASE 0.13] Backport fixes to minScale behavior.

### DIFF
--- a/pkg/reconciler/labeler/controller.go
+++ b/pkg/reconciler/labeler/controller.go
@@ -19,16 +19,20 @@ package labeler
 import (
 	"context"
 
+	"k8s.io/client-go/tools/cache"
+
+	"knative.dev/serving/pkg/apis/serving"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 	routeinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/route"
 	routereconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/route"
+	servingreconciler "knative.dev/serving/pkg/reconciler"
 
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
-	servingreconciler "knative.dev/serving/pkg/reconciler"
+	pkgreconciler "knative.dev/pkg/reconciler"
 )
 
 const controllerAgentName = "labeler-controller"
@@ -55,6 +59,11 @@ func NewController(
 
 	logger.Info("Setting up event handlers")
 	routeInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+
+	configInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: pkgreconciler.LabelExistsFilterFunc(serving.RouteLabelKey),
+		Handler:    controller.HandleAll(impl.EnqueueLabelOfNamespaceScopedResource("", serving.RouteLabelKey)),
+	})
 
 	return impl
 }

--- a/pkg/reconciler/labeler/labeler_test.go
+++ b/pkg/reconciler/labeler/labeler_test.go
@@ -77,7 +77,7 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "label pinned revision",
 		Objects: []runtime.Object{
-			simpleRoute("default", "pinned-revision", "the-revision"),
+			pinnedRoute("default", "pinned-revision", "the-revision"),
 			simpleConfig("default", "the-config"),
 			rev("default", "the-config"),
 			rev("default", "the-config", WithRevName("the-revision")),
@@ -103,6 +103,43 @@ func TestReconcile(t *testing.T) {
 				WithRevisionLabel("serving.knative.dev/route", "steady-state")),
 		},
 		Key: "default/steady-state",
+	}, {
+		Name: "no ready revision",
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "no-ready-revision", "the-config", WithStatusTraffic()),
+			simpleConfig("default", "the-config", WithLatestReady("")),
+			rev("default", "the-config"),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddFinalizerAction("default", "no-ready-revision"),
+			patchAddLabel("default", rev("default", "the-config").Name,
+				"serving.knative.dev/route", "no-ready-revision"),
+			patchAddLabel("default", "the-config",
+				"serving.knative.dev/route", "no-ready-revision"),
+		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", "no-ready-revision"),
+		},
+		Key: "default/no-ready-revision",
+	}, {
+		Name: "transitioning route",
+		Objects: []runtime.Object{
+			simpleRunLatest("default", "transitioning-route", "old", WithRouteFinalizer,
+				WithSpecTraffic(configTraffic("new"))),
+			simpleConfig("default", "old",
+				WithConfigLabel("serving.knative.dev/route", "transitioning-route")),
+			rev("default", "old",
+				WithRevisionLabel("serving.knative.dev/route", "transitioning-route")),
+			simpleConfig("default", "new"),
+			rev("default", "new"),
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			patchAddLabel("default", rev("default", "new").Name,
+				"serving.knative.dev/route", "transitioning-route"),
+			patchAddLabel("default", "new",
+				"serving.knative.dev/route", "transitioning-route"),
+		},
+		Key: "default/transitioning-route",
 	}, {
 		Name: "failure adding label (revision)",
 		// Induce a failure during patching
@@ -278,23 +315,38 @@ func TestReconcile(t *testing.T) {
 	}))
 }
 
-func routeWithTraffic(namespace, name string, traffic v1.TrafficTarget, opts ...RouteOption) *v1.Route {
-	return Route(namespace, name, append(opts, WithStatusTraffic(traffic))...)
+func configTraffic(name string) v1.TrafficTarget {
+	return v1.TrafficTarget{
+		ConfigurationName: name,
+		Percent:           ptr.Int64(100),
+		LatestRevision:    ptr.Bool(true),
+	}
+}
+
+func revTraffic(name string, latest bool) v1.TrafficTarget {
+	return v1.TrafficTarget{
+		RevisionName:   name,
+		Percent:        ptr.Int64(100),
+		LatestRevision: ptr.Bool(latest),
+	}
+}
+
+func routeWithTraffic(namespace, name string, spec, status v1.TrafficTarget, opts ...RouteOption) *v1.Route {
+	return Route(namespace, name,
+		append([]RouteOption{WithSpecTraffic(spec), WithStatusTraffic(status)}, opts...)...)
 }
 
 func simpleRunLatest(namespace, name, config string, opts ...RouteOption) *v1.Route {
-	return routeWithTraffic(namespace, name, v1.TrafficTarget{
-		RevisionName:   config + "-dbnfd",
-		Percent:        ptr.Int64(100),
-		LatestRevision: ptr.Bool(true),
-	}, opts...)
+	return routeWithTraffic(namespace, name,
+		configTraffic(config),
+		revTraffic(config+"-dbnfd", true),
+		opts...)
 }
 
-func simpleRoute(namespace, name, revision string, opts ...RouteOption) *v1.Route {
-	return routeWithTraffic(namespace, name, v1.TrafficTarget{
-		RevisionName: revision,
-		Percent:      ptr.Int64(100),
-	}, opts...)
+func pinnedRoute(namespace, name, revision string, opts ...RouteOption) *v1.Route {
+	traffic := revTraffic(revision, false)
+
+	return routeWithTraffic(namespace, name, traffic, traffic, opts...)
 }
 
 func simpleConfig(namespace, name string, opts ...ConfigOption) *v1.Configuration {

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -61,11 +61,11 @@ func TestMinScale(t *testing.T) {
 	}
 
 	revName := latestRevisionName(t, clients, names.Config, "")
-	serviceName := serverlessServicesName(t, clients, revName)
+	serviceName := privateServiceName(t, clients, revName)
 
 	// Before becoming ready, observe minScale
 	t.Log("Waiting for revision to scale to minScale before becoming ready")
-	if err := waitForDesiredScale(t, clients, serviceName, gte(minScale)); err != nil {
+	if err := waitForDesiredScale(clients, serviceName, gte(minScale)); err != nil {
 		t.Fatalf("The revision %q did not scale >= %d before becoming ready: %v", revName, minScale, err)
 	}
 
@@ -79,7 +79,7 @@ func TestMinScale(t *testing.T) {
 
 	// Without a route, ignore minScale
 	t.Log("Waiting for revision to scale below minScale after becoming ready")
-	if err := waitForDesiredScale(t, clients, serviceName, lt(minScale)); err != nil {
+	if err := waitForDesiredScale(clients, serviceName, lt(minScale)); err != nil {
 		t.Fatalf("The revision %q did not scale < minScale after becoming ready: %v", revName, err)
 	}
 
@@ -99,7 +99,7 @@ func TestMinScale(t *testing.T) {
 
 	// With a route, observe minScale
 	t.Log("Waiting for revision to scale to minScale after creating route")
-	if err := waitForDesiredScale(t, clients, serviceName, gte(minScale)); err != nil {
+	if err := waitForDesiredScale(clients, serviceName, gte(minScale)); err != nil {
 		t.Fatalf("The revision %q did not scale >= %d after creating route: %v", revName, minScale, err)
 	}
 
@@ -109,11 +109,11 @@ func TestMinScale(t *testing.T) {
 	}
 
 	newRevName := latestRevisionName(t, clients, names.Config, revName)
-	newServiceName := serverlessServicesName(t, clients, newRevName)
+	newServiceName := privateServiceName(t, clients, newRevName)
 
 	// After update, observe minScale in new revision
 	t.Log("Waiting for latest revision to scale to minScale after update")
-	if err := waitForDesiredScale(t, clients, newServiceName, gte(minScale)); err != nil {
+	if err := waitForDesiredScale(clients, newServiceName, gte(minScale)); err != nil {
 		t.Fatalf("The revision %q did not scale >= %d after creating route: %v", newRevName, minScale, err)
 	}
 
@@ -127,13 +127,13 @@ func TestMinScale(t *testing.T) {
 
 	// After update, ensure new revision holds minScale
 	t.Log("Hold minScale after update")
-	if err := ensureDesiredScale(t, clients, newServiceName, gte(minScale)); err != nil {
+	if err := ensureDesiredScale(clients, newServiceName, gte(minScale)); err != nil {
 		t.Fatalf("The revision %q did not stay at scale >= %d after creating route: %v", newRevName, minScale, err)
 	}
 
 	// After update, ensure old revision ignores minScale
 	t.Log("Waiting for old revision to scale below minScale after being replaced")
-	if err := waitForDesiredScale(t, clients, serviceName, lt(minScale)); err != nil {
+	if err := waitForDesiredScale(clients, serviceName, lt(minScale)); err != nil {
 		t.Fatalf("The revision %q did not scale < minScale after being replaced: %v", revName, err)
 	}
 }
@@ -184,7 +184,7 @@ func latestRevisionName(t *testing.T, clients *test.Clients, configName, oldRevN
 	return config.Status.LatestCreatedRevisionName
 }
 
-func serverlessServicesName(t *testing.T, clients *test.Clients, revisionName string) string {
+func privateServiceName(t *testing.T, clients *test.Clients, revisionName string) string {
 	var privateServiceName string
 
 	if err := wait.PollImmediate(time.Second, 1*time.Minute, func() (bool, error) {
@@ -193,10 +193,7 @@ func serverlessServicesName(t *testing.T, clients *test.Clients, revisionName st
 			return false, nil
 		}
 		privateServiceName = sks.Status.PrivateServiceName
-		if privateServiceName == "" {
-			return false, nil
-		}
-		return true, nil
+		return privateServiceName != "", nil
 	}); err != nil {
 		t.Fatalf("Error retrieving sks %q: %v", revisionName, err)
 	}
@@ -204,7 +201,7 @@ func serverlessServicesName(t *testing.T, clients *test.Clients, revisionName st
 	return privateServiceName
 }
 
-func waitForDesiredScale(t *testing.T, clients *test.Clients, serviceName string, cond func(int) bool) error {
+func waitForDesiredScale(clients *test.Clients, serviceName string, cond func(int) bool) error {
 	endpoints := clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace)
 
 	return wait.PollImmediate(250*time.Millisecond, 1*time.Minute, func() (bool, error) {
@@ -217,10 +214,10 @@ func waitForDesiredScale(t *testing.T, clients *test.Clients, serviceName string
 
 }
 
-func ensureDesiredScale(t *testing.T, clients *test.Clients, serviceName string, cond func(int) bool) error {
+func ensureDesiredScale(clients *test.Clients, serviceName string, cond func(int) bool) error {
 	endpoints := clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace)
 
-	err := wait.PollImmediate(250*time.Millisecond, 5*time.Second, func() (bool, error) {
+	if err := wait.PollImmediate(250*time.Millisecond, 5*time.Second, func() (bool, error) {
 		endpoint, err := endpoints.Get(serviceName, metav1.GetOptions{})
 		if err != nil {
 			return false, nil
@@ -231,9 +228,7 @@ func ensureDesiredScale(t *testing.T, clients *test.Clients, serviceName string,
 		}
 
 		return false, nil
-	})
-
-	if err != wait.ErrWaitTimeout {
+	}); err != wait.ErrWaitTimeout {
 		return err
 	}
 

--- a/test/v1alpha1/configuration.go
+++ b/test/v1alpha1/configuration.go
@@ -44,6 +44,22 @@ func CreateConfiguration(t pkgTest.T, clients *test.Clients, names test.Resource
 	return clients.ServingAlphaClient.Configs.Create(config)
 }
 
+// PatchConfig patches the existing config with the provided options. Returns the latest Configuration object
+func PatchConfig(clients *test.Clients, cfg *v1alpha1.Configuration, fopt ...v1alpha1testing.ConfigOption) (*v1alpha1.Configuration, error) {
+	newCfg := cfg.DeepCopy()
+
+	for _, opt := range fopt {
+		opt(newCfg)
+	}
+
+	patchBytes, err := duck.CreateBytePatch(cfg, newCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return clients.ServingAlphaClient.Configs.Patch(cfg.ObjectMeta.Name, types.JSONPatchType, patchBytes, "")
+}
+
 // PatchConfigImage patches the existing config passed in with a new imagePath. Returns the latest Configuration object
 func PatchConfigImage(clients *test.Clients, cfg *v1alpha1.Configuration, imagePath string) (*v1alpha1.Configuration, error) {
 	newCfg := cfg.DeepCopy()


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes for #6733 to be backported onto 0.13.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixes a bug where a revision would be scaled down to 0 even if it has minScale applied to it.
```

/assign @mattmoor 
