### PR TITLE
Enhance and stabilize parallel queue probe test.

### DIFF
--- a/pkg/queue/readiness/probe_test.go
+++ b/pkg/queue/readiness/probe_test.go
@@ -18,15 +18,17 @@ package readiness
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
@@ -222,7 +224,11 @@ func TestHTTPSuccess(t *testing.T) {
 func TestHTTPManyParallel(t *testing.T) {
 	cnt := int32(0)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&cnt, 1)
+		if atomic.AddInt32(&cnt, 1) == 1 {
+			// Add a small amount of work to allow the requests below to collapse into one.
+			// The second request can go through as quickly as possible.
+			time.Sleep(50 * time.Millisecond)
+		}
 	}))
 	defer ts.Close()
 
@@ -245,23 +251,25 @@ func TestHTTPManyParallel(t *testing.T) {
 		},
 	})
 
-	var wg sync.WaitGroup
-	wg.Add(5)
-	barrier := make(chan struct{})
+	var grp errgroup.Group
 	for i := 0; i < 5; i++ {
-		go func() {
-			wg.Done()
-			<-barrier
-			pb.ProbeContainer()
-		}()
+		grp.Go(func() error {
+			if !pb.ProbeContainer() {
+				return errors.New("failed to probe container")
+			}
+			return nil
+		})
 	}
-	wg.Wait()
-	close(barrier)
+	if err := grp.Wait(); err != nil {
+		t.Error("Probe failed. Expected success.")
+	}
+
+	// This should trigger a second probe now.
 	if !pb.ProbeContainer() {
 		t.Error("Probe failed. Expected success.")
 	}
-	if got, want := atomic.LoadInt32(&cnt), int32(1); got != want {
-		t.Errorf("Probe count = %d, want: 1", got)
+	if got, want := atomic.LoadInt32(&cnt), int32(2); got != want {
+		t.Errorf("Probe count = %d, want: 2", got)
 	}
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Test failed here https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1240340067323482112.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

- For very slow CPUs, the requests might not actually collapse, even though we're trying hard to guarantee that. Adding an explicit sleep to the actual HTTP request should make sure that the requests actually collapse regardless.
- Added error checking for the parallel probes.
- Added a check that makes sure that the probe running after actually triggers a new request again.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
