### PR TITLE
Fix the panic in the test for go 1.14

### DIFF
--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -991,10 +990,9 @@ func TestPickIndices(t *testing.T) {
 }
 
 func TestAssignSlice(t *testing.T) {
-	opts := []cmp.Option{
-		cmpopts.IgnoreUnexported(queue.Breaker{}),
-		cmp.AllowUnexported(podTracker{}),
-	}
+	opt := cmp.Comparer(func(a *podTracker, b *podTracker) bool {
+		return a.dest == b.dest
+	})
 	trackers := []*podTracker{{
 		dest: "2",
 	}, {
@@ -1003,32 +1001,32 @@ func TestAssignSlice(t *testing.T) {
 		dest: "3",
 	}}
 	t.Run("notrackers", func(t *testing.T) {
-		got := assignSlice([]*podTracker{}, 0, 1, 0)
-		if !cmp.Equal(got, []*podTracker{}, opts...) {
+		got := assignSlice([]*podTracker{}, 0 /*selfIdx*/, 1 /*numAct*/, 0 /*cc*/)
+		if !cmp.Equal(got, []*podTracker{}, opt) {
 			t.Errorf("Got=%v, want: %v, diff: %s", got, trackers,
-				cmp.Diff([]*podTracker{}, got, opts...))
+				cmp.Diff([]*podTracker{}, got, opt))
 		}
 	})
 	t.Run("idx=-1", func(t *testing.T) {
 		got := assignSlice(trackers, -1, 1, 0)
-		if !cmp.Equal(got, trackers, opts...) {
+		if !cmp.Equal(got, trackers, opt) {
 			t.Errorf("Got=%v, want: %v, diff: %s", got, trackers,
-				cmp.Diff(trackers, got, opts...))
+				cmp.Diff(trackers, got, opt))
 		}
 	})
 	t.Run("idx=1", func(t *testing.T) {
 		cp := append(trackers[:0:0], trackers...)
 		got := assignSlice(cp, 1, 3, 0)
-		if !cmp.Equal(got, trackers[0:1], opts...) {
+		if !cmp.Equal(got, trackers[0:1], opt) {
 			t.Errorf("Got=%v, want: %v; diff: %s", got, trackers[0:1],
-				cmp.Diff(trackers[0:1], got, opts...))
+				cmp.Diff(trackers[0:1], got, opt))
 		}
 	})
 	t.Run("len=1", func(t *testing.T) {
 		got := assignSlice(trackers[0:1], 1, 3, 0)
-		if !cmp.Equal(got, trackers[0:1], opts...) {
+		if !cmp.Equal(got, trackers[0:1], opt) {
 			t.Errorf("Got=%v, want: %v; diff: %s", got, trackers[0:1],
-				cmp.Diff(trackers[0:1], got, opts...))
+				cmp.Diff(trackers[0:1], got, opt))
 		}
 	})
 
@@ -1046,9 +1044,9 @@ func TestAssignSlice(t *testing.T) {
 		cp := append(trackers[:0:0], trackers...)
 		got := assignSlice(cp, 1, 2, 5)
 		want := append(trackers[0:1], trackers[2:]...)
-		if !cmp.Equal(got, want, opts...) {
+		if !cmp.Equal(got, want, opt) {
 			t.Errorf("Got=%v, want: %v; diff: %s", got, want,
-				cmp.Diff(trackers[0:1], got, opts...))
+				cmp.Diff(trackers[0:1], got, opt))
 		}
 		if got, want := got[1].b.Capacity(), 5/2+1; got != want {
 			t.Errorf("Capacity for the tail pod = %d, want: %d", got, want)
@@ -1068,9 +1066,9 @@ func TestAssignSlice(t *testing.T) {
 		cp := append(trackers[:0:0], trackers...)
 		got := assignSlice(cp, 1, 2, 6)
 		want := append(trackers[0:1], trackers[2:]...)
-		if !cmp.Equal(got, want, opts...) {
+		if !cmp.Equal(got, want, opt) {
 			t.Errorf("Got=%v, want: %v; diff: %s", got, want,
-				cmp.Diff(trackers[0:1], got, opts...))
+				cmp.Diff(trackers[0:1], got, opt))
 		}
 		if got, want := got[1].b.Capacity(), 3; got != want {
 			t.Errorf("Capacity for the tail pod = %d, want: %d", got, want)


### PR DESCRIPTION
Go 1.14 changed some thing and cmp is panicing when running with --race.
The panic is:
fatal error: checkptr: unsafe pointer arithmetic

goroutine 683 [running]:
runtime.throw(0x256f365, 0x23)
        /usr/lib/google-golang/src/runtime/panic.go:1118 +0x72 fp=0xc0005c2e48 sp=0xc0005c2e18 pc=0x58a3d2
runtime.checkptrArithmetic(0xc0007606a0, 0x0, 0x0, 0x0)
        /usr/lib/google-golang/src/runtime/checkptr.go:41 +0xb5 fp=0xc0005c2e78 sp=0xc0005c2e48 pc=0x55ae75

I think final code is much better even if not for panic.

/assign @markusthoemmes mattmoor