### PR TITLE
Allow auto tls test scripts taking parameters

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-
 source $(dirname $0)/e2e-common.sh
 
 function knative_setup() {


### PR DESCRIPTION
Auto tls test script failed to accept any parameter, and removing `set -e` on top makes it run successfully. Seems that none of the e2e test scripts under https://github.com/knative/serving/tree/master/test have `set -e`, so just remove it from auto tls test script

This is blocking https://github.com/knative/test-infra/pull/1783

/assign @ZhiminXiang @chizhg 