### PR TITLE
Fix connection refused for testvisibility and testvisibilitysplit

### DIFF
--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -35,7 +35,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
-	nurl "net/url"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -930,7 +930,7 @@ func StatusCodeExpectation(statusCodes sets.Int) ResponseExpectation {
 }
 
 func IsDialError(err error) bool {
-	if err, ok := err.(*nurl.Error); ok {
+	if err, ok := err.(*url.Error); ok {
 		err, ok := err.Err.(*net.OpError)
 		return ok && err.Op == "dial"
 	}

--- a/test/conformance/ingress/visibility_test.go
+++ b/test/conformance/ingress/visibility_test.go
@@ -148,6 +148,9 @@ func TestVisibilitySplit(t *testing.T) {
 	})
 	defer cancel()
 
+	// Ensure we can't connect to the private resources
+	RuntimeRequestWithExpectations(t, client, "http://"+privateHostName, []ResponseExpectation{StatusCodeExpectation(sets.NewInt(http.StatusNotFound))}, true)
+
 	loadbalancerAddress := localIngress.Status.PrivateLoadBalancer.Ingress[0].DomainInternal
 	proxyName, proxyPort, cancel := CreateProxyService(t, clients, privateHostName, loadbalancerAddress)
 	defer cancel()
@@ -171,9 +174,6 @@ func TestVisibilitySplit(t *testing.T) {
 		}},
 	})
 	defer cancel()
-
-	// Ensure we can't connect to the private resources
-	RuntimeRequestWithExpectations(t, client, "http://"+privateHostName, []ResponseExpectation{StatusCodeExpectation(sets.NewInt(http.StatusNotFound))}, true)
 
 	// Create a large enough population of requests that we can reasonably assess how
 	// well the Ingress respected the percentage split.

--- a/test/conformance/ingress/visibility_test.go
+++ b/test/conformance/ingress/visibility_test.go
@@ -61,11 +61,10 @@ func TestVisibility(t *testing.T) {
 	defer cancel()
 
 	// Ensure the service is not publicly accessible
-	expectations := []Expectation{
-		AllowDialErrorConnectionExpectation,
-		StatusCodeExpectation(sets.NewInt(http.StatusNotFound)),
-	}
-	RuntimeRequestWithStatus(t, client, "http://"+privateHostName, expectations)
+	RuntimeRequestWithStatus(t, client, "http://"+privateHostName,
+		[]ResponseExpectation{AllowStatusCodeExpectation(sets.NewInt(http.StatusNotFound))},
+		[]ErrorExpectation{AllowDialErrorConnectionExpectation},
+	)
 
 	loadbalancerAddress := ingress.Status.PrivateLoadBalancer.Ingress[0].DomainInternal
 	proxyName, proxyPort, cancel := CreateProxyService(t, clients, privateHostName, loadbalancerAddress)
@@ -177,11 +176,10 @@ func TestVisibilitySplit(t *testing.T) {
 	defer cancel()
 
 	// Ensure we can't connect to the private resources
-	expectations := []Expectation{
-		AllowDialErrorConnectionExpectation,
-		StatusCodeExpectation(sets.NewInt(http.StatusNotFound)),
-	}
-	RuntimeRequestWithStatus(t, client, "http://"+privateHostName, expectations)
+	RuntimeRequestWithStatus(t, client, "http://"+privateHostName,
+		[]ResponseExpectation{AllowStatusCodeExpectation(sets.NewInt(http.StatusNotFound))},
+		[]ErrorExpectation{AllowDialErrorConnectionExpectation},
+	)
 
 	// Create a large enough population of requests that we can reasonably assess how
 	// well the Ingress respected the percentage split.

--- a/test/conformance/ingress/visibility_test.go
+++ b/test/conformance/ingress/visibility_test.go
@@ -61,10 +61,7 @@ func TestVisibility(t *testing.T) {
 	defer cancel()
 
 	// Ensure the service is not publicly accessible
-	RuntimeRequestWithStatus(t, client, "http://"+privateHostName,
-		[]ResponseExpectation{AllowStatusCodeExpectation(sets.NewInt(http.StatusNotFound))},
-		[]ErrorExpectation{AllowDialErrorConnectionExpectation},
-	)
+	RuntimeRequestWithExpectations(t, client, "http://"+privateHostName, []ResponseExpectation{StatusCodeExpectation(sets.NewInt(http.StatusNotFound))}, true)
 
 	loadbalancerAddress := ingress.Status.PrivateLoadBalancer.Ingress[0].DomainInternal
 	proxyName, proxyPort, cancel := CreateProxyService(t, clients, privateHostName, loadbalancerAddress)
@@ -176,10 +173,7 @@ func TestVisibilitySplit(t *testing.T) {
 	defer cancel()
 
 	// Ensure we can't connect to the private resources
-	RuntimeRequestWithStatus(t, client, "http://"+privateHostName,
-		[]ResponseExpectation{AllowStatusCodeExpectation(sets.NewInt(http.StatusNotFound))},
-		[]ErrorExpectation{AllowDialErrorConnectionExpectation},
-	)
+	RuntimeRequestWithExpectations(t, client, "http://"+privateHostName, []ResponseExpectation{StatusCodeExpectation(sets.NewInt(http.StatusNotFound))}, true)
 
 	// Create a large enough population of requests that we can reasonably assess how
 	// well the Ingress respected the percentage split.

--- a/test/conformance/ingress/visibility_test.go
+++ b/test/conformance/ingress/visibility_test.go
@@ -61,9 +61,9 @@ func TestVisibility(t *testing.T) {
 	defer cancel()
 
 	// Ensure the service is not publicly accessible
-	expectations := Expectations{
-		HTTPResponseStatuses: sets.NewInt(http.StatusNotFound),
-		AllowDialError:       true,
+	expectations := []Expectation{
+		AllowDialErrorConnectionExpectation,
+		StatusCodeExpectation(sets.NewInt(http.StatusNotFound)),
 	}
 	RuntimeRequestWithStatus(t, client, "http://"+privateHostName, expectations)
 
@@ -177,9 +177,9 @@ func TestVisibilitySplit(t *testing.T) {
 	defer cancel()
 
 	// Ensure we can't connect to the private resources
-	expectations := Expectations{
-		HTTPResponseStatuses: sets.NewInt(http.StatusNotFound),
-		AllowDialError:       true,
+	expectations := []Expectation{
+		AllowDialErrorConnectionExpectation,
+		StatusCodeExpectation(sets.NewInt(http.StatusNotFound)),
 	}
 	RuntimeRequestWithStatus(t, client, "http://"+privateHostName, expectations)
 

--- a/test/conformance/ingress/visibility_test.go
+++ b/test/conformance/ingress/visibility_test.go
@@ -60,9 +60,6 @@ func TestVisibility(t *testing.T) {
 	})
 	defer cancel()
 
-	// Ensure the service is not publicly accessible
-	RuntimeRequestWithStatus(t, client, "http://"+privateHostName, sets.NewInt(http.StatusNotFound))
-
 	loadbalancerAddress := ingress.Status.PrivateLoadBalancer.Ingress[0].DomainInternal
 	proxyName, proxyPort, cancel := CreateProxyService(t, clients, privateHostName, loadbalancerAddress)
 	defer cancel()
@@ -86,6 +83,9 @@ func TestVisibility(t *testing.T) {
 		}},
 	})
 	defer cancel()
+
+	// Ensure the service is not publicly accessible
+	RuntimeRequestWithStatus(t, client, "http://"+privateHostName, sets.NewInt(http.StatusNotFound))
 
 	// Ensure the service is accessible from within the cluster.
 	RuntimeRequest(t, client, "http://"+publicHostName)
@@ -148,9 +148,6 @@ func TestVisibilitySplit(t *testing.T) {
 	})
 	defer cancel()
 
-	// Ensure we can't connect to the private resources
-	RuntimeRequestWithStatus(t, client, "http://"+privateHostName, sets.NewInt(http.StatusNotFound))
-
 	loadbalancerAddress := localIngress.Status.PrivateLoadBalancer.Ingress[0].DomainInternal
 	proxyName, proxyPort, cancel := CreateProxyService(t, clients, privateHostName, loadbalancerAddress)
 	defer cancel()
@@ -174,6 +171,9 @@ func TestVisibilitySplit(t *testing.T) {
 		}},
 	})
 	defer cancel()
+
+	// Ensure we can't connect to the private resources
+	RuntimeRequestWithStatus(t, client, "http://"+privateHostName, sets.NewInt(http.StatusNotFound))
 
 	// Create a large enough population of requests that we can reasonably assess how
 	// well the Ingress respected the percentage split.


### PR DESCRIPTION
Issue: https://github.com/knative/net-contour/issues/70

When using contour, if there are no publicly facing services (kingress)
connections to port 80 of the public ingress will fail with a connection
refused.

We didn't dig into why contour is doing this, but this change is to
ensure that the public facing service is ready before we test if the
private services are truly private.

When the ingress conformance suite is ran it has a chance that a public service is available so it passes sometimes.

/cc @shashwathi 
/assign @mattmoor
/assign @tcnghia 