### PR TITLE
Fix AutoTLS flakes

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -30,7 +30,9 @@ function setup_auto_tls_env_variables() {
   # The service account credential file used to access the DNS server.
   export CLOUD_DNS_SERVICE_ACCOUNT_KEY_FILE="${GOOGLE_APPLICATION_CREDENTIALS}"
 
-  export CUSTOM_DOMAIN_SUFFIX="$(($RANDOM % 10000)).${E2E_PROJECT_ID}.kn-e2e.dev"
+  export DOMAIN_NAME="kn-e2e.dev"
+
+  export CUSTOM_DOMAIN_SUFFIX="$(($RANDOM % 10000)).${E2E_PROJECT_ID}.${DOMAIN_NAME}"
 
   local INGRESS_NAMESPACE=${GATEWAY_NAMESPACE}
   if [[ -z "${GATEWAY_NAMESPACE}" ]]; then

--- a/test/e2e/autotls/config/dnssetup/main.go
+++ b/test/e2e/autotls/config/dnssetup/main.go
@@ -17,9 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -50,7 +52,7 @@ func setupDNSRecord() error {
 	if err := createDNSRecord(dnsRecord); err != nil {
 		return err
 	}
-	if err := waitForDNSRecordVisibleLocally(dnsRecord); err != nil {
+	if err := waitForDNSRecordVisible(dnsRecord); err != nil {
 		config.DeleteDNSRecord(dnsRecord, env.CloudDNSServiceAccountKeyFile, env.CloudDNSProject, env.DNSZone)
 		return err
 	}
@@ -77,14 +79,47 @@ func createDNSRecord(dnsRecord *config.DNSRecord) error {
 	return config.ChangeDNSRecord(addition, svc, env.CloudDNSProject, env.DNSZone)
 }
 
-func waitForDNSRecordVisibleLocally(record *config.DNSRecord) error {
+func waitForDNSRecordVisible(record *config.DNSRecord) error {
+	nameservers, err := net.LookupNS(env.DomainName)
+	if err != nil {
+		return fmt.Errorf("failed to lookup NS records for domain: %v", err)
+	}
+
 	return wait.PollImmediate(10*time.Second, 300*time.Second, func() (bool, error) {
-		ips, _ := net.LookupHost(record.Domain)
-		for _, ip := range ips {
-			if ip == record.IP {
-				return true, nil
+		for _, ns := range nameservers {
+			nsIP, err := net.LookupHost(ns.Host)
+			if err != nil {
+				return true, err
+			}
+			r := &net.Resolver{
+				PreferGo: true,
+				Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+					d := net.Dialer{}
+					return d.DialContext(ctx, "udp", nsIP[0]+":53")
+				},
+			}
+			if !validateRecord(r, record) {
+				return false, nil
 			}
 		}
-		return false, nil
+		return true, nil
 	})
+}
+
+func validateRecord(resolver *net.Resolver, record *config.DNSRecord) bool {
+	ips, _ := resolver.LookupHost(context.Background(), replaceWildcard(record.Domain))
+	for _, ip := range ips {
+		if ip == record.IP {
+			return true
+		}
+	}
+	return false
+}
+
+func replaceWildcard(domain string) string {
+	if !strings.HasPrefix(domain, "*") {
+		return domain
+	}
+
+	return strings.Replace(domain, "*", "star", 1)
 }

--- a/test/e2e/autotls/config/util.go
+++ b/test/e2e/autotls/config/util.go
@@ -28,6 +28,7 @@ import (
 
 type EnvConfig struct {
 	FullHostName                  string `envconfig:"full_host_name" required: "true"`
+	DomainName                    string `envconfig:"domain_name" required: "true"`
 	DNSZone                       string `envconfig:"dns_zone" required:"true"`
 	CloudDNSServiceAccountKeyFile string `envconfig:"cloud_dns_service_account_key_file" required:"true"`
 	CloudDNSProject               string `envconfig:"cloud_dns_project" required:"true"`


### PR DESCRIPTION
This changes the DNS setup for the test to check that the record is present in all of the domain's nameservers.

The failed AutoTLS tests I looked at failed in the same way (couldn't solve http01 challenge) with two different root causes:
- Let's Encrypt failed to find the A record for the requested hostname.
- The record existed but contained no IP addresses.

It seems that LE queries the domain's authoritative servers directly and doesn't cache anything so by waiting until all of those nameservers have the record we just created with the correct value we can hopefully avoid both failure scenarios.

