### PR TITLE
Infinitely wait for a pod to have reserve capacity.

### DIFF
--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -60,11 +60,15 @@ const (
 	breakerMaxConcurrency = 1000
 )
 
-var breakerParams = queue.BreakerParams{
-	QueueDepth:      breakerQueueDepth,
-	MaxConcurrency:  breakerMaxConcurrency,
-	InitialCapacity: 0,
-}
+var (
+	ErrActivatorOverload = errors.New("activator overload")
+
+	breakerParams = queue.BreakerParams{
+		QueueDepth:      breakerQueueDepth,
+		MaxConcurrency:  breakerMaxConcurrency,
+		InitialCapacity: 0,
+	}
+)
 
 type podTracker struct {
 	dest string
@@ -102,8 +106,6 @@ type breaker interface {
 	UpdateConcurrency(int) error
 	Reserve(ctx context.Context) (func(), bool)
 }
-
-var ErrActivatorOverload = errors.New("activator overload")
 
 type revisionThrottler struct {
 	revID                types.NamespacedName
@@ -176,17 +178,13 @@ func pickPod(ctx context.Context, tgs []*podTracker, cc int) (func(), *podTracke
 	if cc == 0 {
 		return noop, tgs[rand.Intn(len(tgs))]
 	}
-	// Us reaching here means we will eventually find a pod
-	// with available capacity, because we passed the outer
-	// semaphore. We can safely retry infinitely as request
-	// might still race to the actual pods.
-	for {
-		for _, t := range tgs {
-			if cb, ok := t.Reserve(ctx); ok {
-				return cb, t
-			}
+
+	for _, t := range tgs {
+		if cb, ok := t.Reserve(ctx); ok {
+			return cb, t
 		}
 	}
+	return noop, nil
 }
 
 // Returns a dest that at the moment of choosing had an open slot
@@ -204,13 +202,26 @@ func (rt *revisionThrottler) acquireDest(ctx context.Context) (func(), *podTrack
 func (rt *revisionThrottler) try(ctx context.Context, function func(string) error) error {
 	var ret error
 
-	if err := rt.breaker.Maybe(ctx, func() {
-		cb, tracker := rt.acquireDest(ctx)
-		defer cb()
-		// We already reserved a guaranteed spot. So just execute the passed functor.
-		ret = function(tracker.dest)
-	}); err != nil {
-		return err
+	// Retrying infinitely as long as we receive no dest. Outer semaphore and inner
+	// pod capacity are not changed atomically, hence they can race each other. We
+	// "reenqueue" requests should that happen.
+	reenqueue := true
+	for reenqueue {
+		reenqueue = false
+		if err := rt.breaker.Maybe(ctx, func() {
+			cb, tracker := rt.acquireDest(ctx)
+			if tracker == nil {
+				// This can happen if individual requests raced each other or if pod
+				// capacity was decreased after passing the outer semaphore.
+				reenqueue = true
+				return
+			}
+			defer cb()
+			// We already reserved a guaranteed spot. So just execute the passed functor.
+			ret = function(tracker.dest)
+		}); err != nil {
+			return err
+		}
 	}
 	return ret
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

---

By the moment we reach the `pickPod` function, we already passed the outer semaphore and thus know that capacity is available. Individual requests still race to the respective pods so it's possible to iterate over the entire pod list and not find a pod with capacity even though we passed the outer semaphore.

We can infinitely retry to reconcile that. This also statically proves the encoded comment.

---

On top of individual requests racing themselves, we could also race between outer semaphore and inner semaphore availability as their updates are non-atomic. Reenqueuing in this case puts the request through the entire path again to eventually be able to acquire a destination safely.

---

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
