### PR TITLE
Add enable-certificate-owner-ref option to cert-manager's controller

### DIFF
--- a/third_party/cert-manager-0.12.0/cert-manager.yaml
+++ b/third_party/cert-manager-0.12.0/cert-manager.yaml
@@ -6206,6 +6206,7 @@ spec:
           - --webhook-ca-secret=cert-manager-webhook-ca
           - --webhook-serving-secret=cert-manager-webhook-tls
           - --webhook-dns-names=cert-manager-webhook,cert-manager-webhook.cert-manager,cert-manager-webhook.cert-manager.svc
+          - --enable-certificate-owner-ref
           ports:
           - containerPort: 9402
             protocol: TCP

--- a/third_party/cert-manager-0.12.0/download-cert-manager.sh
+++ b/third_party/cert-manager-0.12.0/download-cert-manager.sh
@@ -38,3 +38,7 @@ wget $YAML_URL
 # Clean up.
 rm -rf cert-manager-${CERT_MANAGER_VERSION}
 rm v${CERT_MANAGER_VERSION}.tar.gz
+
+# Add enable-certificate-owner-ref option to cert-manager's controller.
+# The option is to cleans up secret(certificate) by adding ownerref.
+patch -l cert-manager.yaml owner-ref.patch

--- a/third_party/cert-manager-0.12.0/owner-ref.patch
+++ b/third_party/cert-manager-0.12.0/owner-ref.patch
@@ -1,0 +1,13 @@
+6206@6207,1
+diff --git a/third_party/cert-manager-0.12.0/cert-manager.yaml b/third_party/cert-manager-0.12.0/cert-manager.yaml
+index 1ee179c02..0a96ed86b 100644
+--- a/third_party/cert-manager-0.12.0/cert-manager.yaml
++++ b/third_party/cert-manager-0.12.0/cert-manager.yaml
+@@ -6206,6 +6206,7 @@ spec:
+           - --webhook-ca-secret=cert-manager-webhook-ca
+           - --webhook-serving-secret=cert-manager-webhook-tls
+           - --webhook-dns-names=cert-manager-webhook,cert-manager-webhook.cert-manager,cert-manager-webhook.cert-manager.svc
++          - --enable-certificate-owner-ref
+           ports:
+           - containerPort: 9402
+             protocol: TCP


### PR DESCRIPTION
## Proposed Changes

When running autoTLS and cert-manager, the secrets created by
cert-manager is not cleaned up. Due to this, switching issuer during
tests like from selfsigned to http01 could mess up the secret(certificate).

By using this option, the secret has ownerref to certificate so it
will be cleaned up when deleting certificate.

**Release Note**

```release-note
NONE
```
