### PR TITLE
Remove parallel 1 option from e2e with https option

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -49,11 +49,11 @@ use_https=""
 (( MESH )) && parallelism="-parallel 1"
 
 if (( HTTPS )); then
-  parallelism="-parallel 1"
   use_https="--https"
   turn_on_auto_tls
   kubectl apply -f ./test/config/autotls/certmanager/caissuer/
   add_trap "kubectl delete -f ./test/config/autotls/certmanager/caissuer/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
+  add_trap "turn_off_auto_tls" SIGKILL SIGTERM SIGQUIT
 fi
 
 # Run conformance and e2e tests.


### PR DESCRIPTION
## Proposed Changes

Previously e2e with https option needed single `-parallel 1` option as
it updated Istio Gateway. Now, the test does not need to use the
Gateway update, so e2e can run without `-parallel 1` option.

/lint

**Release Note**

```release-note
NONE
```
