### PR TITLE
Activator HA test

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -103,8 +103,9 @@ fi
 kubectl -n ${E2E_SYSTEM_NAMESPACE} patch configmap/config-leader-election --type=merge \
   --patch='{"data":{"enabledComponents":"controller,hpaautoscaler,certcontroller,istiocontroller,nscontroller"}}'
 add_trap "kubectl get cm config-leader-election -n ${E2E_SYSTEM_NAMESPACE} -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -" SIGKILL SIGTERM SIGQUIT
-go_test_e2e -timeout=10m -parallel=1 ./test/ha "--systemNamespace=${E2E_SYSTEM_NAMESPACE}" || failed=1
-kubectl get cm config-leader-election -n ${E2E_SYSTEM_NAMESPACE} -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -
+# Define short -spoofinterval to ensure frequent probing while stopping pods
+go_test_e2e -timeout=10m -parallel=1 ./test/ha "--systemNamespace=${E2E_SYSTEM_NAMESPACE}" -spoofinterval="10ms" || failed=1
+kubectl get cm config-leader-election -n "${E2E_SYSTEM_NAMESPACE}" -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -
 
 # Dump cluster state in case of failure
 (( failed )) && dump_cluster_state

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -447,16 +447,16 @@ func TestGracefulScaledown(t *testing.T) {
 		}))
 	defer test.TearDown(ctx.clients, ctx.names)
 
-	autoscalerConfigMap, err := RawCM(ctx.clients, autoscalerconfig.ConfigName)
+	autoscalerConfigMap, err := rawCM(ctx.clients, autoscalerconfig.ConfigName)
 	if err != nil {
 		t.Errorf("Error retrieving autoscaler configmap: %v", err)
 	}
 
 	patchedAutoscalerConfigMap := autoscalerConfigMap.DeepCopy()
 	patchedAutoscalerConfigMap.Data["enable-graceful-scaledown"] = "true"
-	PatchCM(ctx.clients, patchedAutoscalerConfigMap)
-	defer PatchCM(ctx.clients, autoscalerConfigMap)
-	test.CleanupOnInterrupt(func() { PatchCM(ctx.clients, autoscalerConfigMap) })
+	patchCM(ctx.clients, patchedAutoscalerConfigMap)
+	defer patchCM(ctx.clients, autoscalerConfigMap)
+	test.CleanupOnInterrupt(func() { patchCM(ctx.clients, autoscalerConfigMap) })
 
 	if err = assertGracefulScaledown(t, ctx, 4 /* desired pods */); err != nil {
 		t.Errorf("Failed: %v", err)

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -447,16 +447,16 @@ func TestGracefulScaledown(t *testing.T) {
 		}))
 	defer test.TearDown(ctx.clients, ctx.names)
 
-	autoscalerConfigMap, err := rawCM(ctx.clients, autoscalerconfig.ConfigName)
+	autoscalerConfigMap, err := RawCM(ctx.clients, autoscalerconfig.ConfigName)
 	if err != nil {
 		t.Errorf("Error retrieving autoscaler configmap: %v", err)
 	}
 
 	patchedAutoscalerConfigMap := autoscalerConfigMap.DeepCopy()
 	patchedAutoscalerConfigMap.Data["enable-graceful-scaledown"] = "true"
-	patchCM(ctx.clients, patchedAutoscalerConfigMap)
-	defer patchCM(ctx.clients, autoscalerConfigMap)
-	test.CleanupOnInterrupt(func() { patchCM(ctx.clients, autoscalerConfigMap) })
+	PatchCM(ctx.clients, patchedAutoscalerConfigMap)
+	defer PatchCM(ctx.clients, autoscalerConfigMap)
+	test.CleanupOnInterrupt(func() { PatchCM(ctx.clients, autoscalerConfigMap) })
 
 	if err = assertGracefulScaledown(t, ctx, 4 /* desired pods */); err != nil {
 		t.Errorf("Failed: %v", err)

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -1,0 +1,110 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ha
+
+import (
+	"log"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/serving/pkg/apis/autoscaling"
+	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
+	rtesting "knative.dev/serving/pkg/testing/v1"
+	"knative.dev/serving/test"
+	"knative.dev/serving/test/e2e"
+)
+
+const (
+	activatorDeploymentName = "activator"
+	activatorLabel          = "app=activator"
+)
+
+// Activator is managed by the activator HPA and does not have leader election enabled.
+// The test ensures that stopping one of the activator pods doesn't affect user applications.
+func TestActivatorHA(t *testing.T) {
+	clients := e2e.Setup(t)
+
+	autoscalerConfigMap, err := e2e.RawCM(clients, autoscalerconfig.ConfigName)
+	if err != nil {
+		t.Errorf("Error retrieving autoscaler configmap: %v", err)
+	}
+	patchedAutoscalerConfigMap := autoscalerConfigMap.DeepCopy()
+	// make sure all requests go through the activator
+	patchedAutoscalerConfigMap.Data["target-burst-capacity"] = "-1"
+	e2e.PatchCM(clients, patchedAutoscalerConfigMap)
+	defer e2e.PatchCM(clients, autoscalerConfigMap)
+	test.CleanupOnInterrupt(func() { e2e.PatchCM(clients, autoscalerConfigMap) })
+
+	names, resources := createPizzaPlanetService(t,
+		rtesting.WithConfigAnnotations(map[string]string{
+			autoscaling.MinScaleAnnotationKey: "1", //make sure we don't scale to zero during the test
+		}),
+	)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
+
+	namesScaleToZero, resourcesScaleToZero := createPizzaPlanetService(t,
+		rtesting.WithConfigAnnotations(map[string]string{
+			autoscaling.WindowAnnotationKey: autoscaling.WindowMin.String(), //make sure we scale to zero quickly
+		}),
+	)
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, namesScaleToZero) })
+	defer test.TearDown(clients, namesScaleToZero)
+
+	if err := e2e.WaitForScaleToZero(t, revisionresourcenames.Deployment(resourcesScaleToZero.Revision), clients); err != nil {
+		t.Fatalf("Failed to scale to zero: %v", err)
+	}
+
+	prober := test.RunRouteProber(log.Printf, clients, resources.Service.Status.URL.URL())
+	defer test.AssertProberDefault(t, prober)
+
+	pods, err := clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).List(metav1.ListOptions{
+		LabelSelector: activatorLabel,
+	})
+	if err != nil {
+		t.Fatalf("Failed to get activator pods: %v", err)
+	}
+	if len(pods.Items) != haReplicas {
+		t.Fatalf("The test requires %d activator pods", haReplicas)
+	}
+	activatorPod := pods.Items[0].Name // stop the first activator pod
+
+	clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).Delete(activatorPod, &metav1.DeleteOptions{})
+
+	if err := waitForPodDeleted(t, clients, activatorPod); err != nil {
+		t.Fatalf("Did not observe %s to actually be deleted: %v", activatorPod, err)
+	}
+
+	if err := waitForDeploymentScale(clients, activatorDeploymentName, haReplicas); err != nil {
+		t.Fatalf("Deployment %s failed to scale up: %v", activatorDeploymentName, err)
+	}
+
+	activatorPod = pods.Items[1].Name // now stop the other activator pod
+
+	clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).Delete(activatorPod, &metav1.DeleteOptions{})
+	if err := waitForPodDeleted(t, clients, activatorPod); err != nil {
+		t.Fatalf("Did not observe %s to actually be deleted: %v", activatorPod, err)
+	}
+
+	if err := waitForDeploymentScale(clients, activatorDeploymentName, haReplicas); err != nil {
+		t.Fatalf("Deployment %s failed to scale up: %v", activatorDeploymentName, err)
+	}
+
+	assertServiceWorks(t, clients, namesScaleToZero, resourcesScaleToZero.Service.Status.URL.URL(), test.PizzaPlanetText1)
+}

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -99,8 +99,7 @@ func TestActivatorHA(t *testing.T) {
 	})
 
 	// Wait for the killed activator to disappear from the knative service's endpoints.
-	if err := waitForPublicEndpointAddresses(t, clients, resourcesScaleToZero.Revision.Name,
-		1 /* expected number of public endpoint addresses */); err != nil {
+	if err := waitForChangedPublicEndpoints(t, clients, resourcesScaleToZero.Revision.Name); err != nil {
 		t.Fatal("Failed to wait for the service to use only the remaining activator")
 	}
 
@@ -129,8 +128,7 @@ func TestActivatorHA(t *testing.T) {
 	})
 
 	// Wait for the killed activator to disappear from the knative service's endpoints.
-	if err := waitForPublicEndpointAddresses(t, clients, resourcesScaleToZero.Revision.Name,
-		1 /* expected number of public endpoint addresses */); err != nil {
+	if err := waitForChangedPublicEndpoints(t, clients, resourcesScaleToZero.Revision.Name); err != nil {
 		t.Fatalf("Failed to wait for the service to use only the remaining activator")
 	}
 
@@ -138,8 +136,7 @@ func TestActivatorHA(t *testing.T) {
 	assertServiceWorksNow(t, clients, spoofingClient, namesScaleToZero, scaleToZeroURL, test.PizzaPlanetText1)
 
 	// Wait until activators are scaled up again and the service can use both of them.
-	if err := waitForPublicEndpointAddresses(t, clients, resourcesScaleToZero.Revision.Name,
-		2 /* expected number of public endpoint addresses */); err != nil {
+	if err := waitForChangedPublicEndpoints(t, clients, resourcesScaleToZero.Revision.Name); err != nil {
 		t.Fatalf("Failed to wait for the service to use two activators again")
 	}
 

--- a/test/ha/autoscalerhpa_test.go
+++ b/test/ha/autoscalerhpa_test.go
@@ -70,7 +70,7 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 	}
 
 	url := resources.Service.Status.URL.URL()
-	assertServiceWorks(t, clients, names, url, test.PizzaPlanetText1)
+	assertServiceEventuallyWorks(t, clients, names, url, test.PizzaPlanetText1)
 
 	t.Log("Updating the Service after selecting new leader controller in order to generate a new revision")
 	names.Image = test.PizzaPlanet2
@@ -85,5 +85,5 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 		t.Fatalf("New image not reflected in Service: %v", err)
 	}
 
-	assertServiceWorks(t, clients, names, url, test.PizzaPlanetText2)
+	assertServiceEventuallyWorks(t, clients, names, url, test.PizzaPlanetText2)
 }

--- a/test/ha/autoscalerhpa_test.go
+++ b/test/ha/autoscalerhpa_test.go
@@ -38,11 +38,9 @@ const (
 func TestAutoscalerHPAHANewRevision(t *testing.T) {
 	clients := e2e.Setup(t)
 
-	if err := scaleUpDeployment(clients, autoscalerHPADeploymentName); err != nil {
-		t.Fatalf("Failed to scale deployment: %v", err)
+	if err := waitForDeploymentScale(clients, autoscalerHPADeploymentName, haReplicas); err != nil {
+		t.Fatalf("Deployment %s not scaled to %d: %v", autoscalerHPADeploymentName, haReplicas, err)
 	}
-	defer scaleDownDeployment(clients, autoscalerHPADeploymentName)
-	test.CleanupOnInterrupt(func() { scaleDownDeployment(clients, autoscalerHPADeploymentName) })
 
 	leaderController, err := getLeader(t, clients, autoscalerHPALease)
 	if err != nil {

--- a/test/ha/autoscalerhpa_test.go
+++ b/test/ha/autoscalerhpa_test.go
@@ -47,7 +47,7 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 		t.Fatalf("Failed to get leader: %v", err)
 	}
 
-	names, resources := createPizzaPlanetService(t, "pizzaplanet-service",
+	names, resources := createPizzaPlanetService(t,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.ClassAnnotationKey:  autoscaling.HPA,
 			autoscaling.MetricAnnotationKey: autoscaling.CPU,

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -42,7 +42,7 @@ func TestControllerHA(t *testing.T) {
 		t.Fatalf("Failed to get leader: %v", err)
 	}
 
-	service1Names, resources := createPizzaPlanetService(t, "pizzaplanet-service1")
+	service1Names, resources := createPizzaPlanetService(t)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, service1Names) })
 	defer test.TearDown(clients, service1Names)
 

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -33,11 +33,9 @@ const (
 func TestControllerHA(t *testing.T) {
 	clients := e2e.Setup(t)
 
-	if err := scaleUpDeployment(clients, controllerDeploymentName); err != nil {
-		t.Fatalf("Failed to scale deployment: %v", err)
+	if err := waitForDeploymentScale(clients, controllerDeploymentName, haReplicas); err != nil {
+		t.Fatalf("Deployment %s not scaled to %d: %v", controllerDeploymentName, haReplicas, err)
 	}
-	defer scaleDownDeployment(clients, controllerDeploymentName)
-	test.CleanupOnInterrupt(func() { scaleDownDeployment(clients, controllerDeploymentName) })
 
 	leaderController, err := getLeader(t, clients, controllerDeploymentName)
 	if err != nil {

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -59,7 +59,7 @@ func TestControllerHA(t *testing.T) {
 		t.Fatalf("Failed to find new leader: %v", err)
 	}
 
-	assertServiceWorks(t, clients, service1Names, resources.Service.Status.URL.URL(), test.PizzaPlanetText1)
+	assertServiceEventuallyWorks(t, clients, service1Names, resources.Service.Status.URL.URL(), test.PizzaPlanetText1)
 
 	// Verify that after changing the leader we can still create a new kservice
 	service2Names, _ := createPizzaPlanetService(t)

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -62,7 +62,7 @@ func TestControllerHA(t *testing.T) {
 	assertServiceWorks(t, clients, service1Names, resources.Service.Status.URL.URL(), test.PizzaPlanetText1)
 
 	// Verify that after changing the leader we can still create a new kservice
-	service2Names, _ := createPizzaPlanetService(t, "pizzaplanet-service2")
+	service2Names, _ := createPizzaPlanetService(t)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, service2Names) })
 	test.TearDown(clients, service2Names)
 }

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -81,11 +81,7 @@ func getPublicEndpoints(t *testing.T, clients *test.Clients, revision string) ([
 	return hosts, nil
 }
 
-func waitForChangedPublicEndpoints(t *testing.T, clients *test.Clients, revision string) error {
-	origEndpoints, err := getPublicEndpoints(t, clients, revision)
-	if err != nil {
-		return err
-	}
+func waitForChangedPublicEndpoints(t *testing.T, clients *test.Clients, revision string, origEndpoints []string) error {
 	return wait.PollImmediate(100*time.Millisecond, time.Minute, func() (bool, error) {
 		newEndpoints, err := getPublicEndpoints(t, clients, revision)
 		return !reflect.DeepEqual(origEndpoints, newEndpoints), err

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -84,7 +84,7 @@ func getPublicEndpoints(t *testing.T, clients *test.Clients, revision string) ([
 func waitForChangedPublicEndpoints(t *testing.T, clients *test.Clients, revision string, origEndpoints []string) error {
 	return wait.PollImmediate(100*time.Millisecond, time.Minute, func() (bool, error) {
 		newEndpoints, err := getPublicEndpoints(t, clients, revision)
-		return !reflect.DeepEqual(origEndpoints, newEndpoints), err
+		return !cmp.Equal(origEndpoints, newEndpoints), err
 	})
 }
 


### PR DESCRIPTION
The activator doesn't have leader election but it runs with at least two pods in the E2E testsuite and this test verifies that:
* stopping one activator pod doesn't break the application and it continues to work
* it's possible to scale from zero after we stop one or the other activator pod

This is a follow up on https://github.com/knative/serving/pull/7325
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
