### PR TITLE
Add more debugging information to the latest revision checks.

### DIFF
--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -241,10 +241,12 @@ func validateControlPlane(t pkgTest.T, clients *test.Clients, names test.Resourc
 	t.Log("Checking to ensure Configuration is in desired state.")
 	err = v1test.CheckConfigurationState(clients.ServingClient, names.Config, func(c *v1.Configuration) (bool, error) {
 		if c.Status.LatestCreatedRevisionName != names.Revision {
-			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was created: %w", names.Config, names.Revision, err)
+			return false, fmt.Errorf("Configuration(%q).LatestCreatedRevisionName = %q, want %q",
+				names.Config, c.Status.LatestCreatedRevisionName, names.Revision)
 		}
 		if c.Status.LatestReadyRevisionName != names.Revision {
-			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was ready: %w", names.Config, names.Revision, err)
+			return false, fmt.Errorf("Configuration(%q).LatestReadyRevisionName = %q, want %q",
+				names.Config, c.Status.LatestReadyRevisionName, names.Revision)
 		}
 		return true, nil
 	})

--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -241,11 +241,11 @@ func validateControlPlane(t pkgTest.T, clients *test.Clients, names test.Resourc
 	t.Log("Checking to ensure Configuration is in desired state.")
 	err = v1test.CheckConfigurationState(clients.ServingClient, names.Config, func(c *v1.Configuration) (bool, error) {
 		if c.Status.LatestCreatedRevisionName != names.Revision {
-			return false, fmt.Errorf("Configuration(%q).LatestCreatedRevisionName = %q, want %q",
+			return false, fmt.Errorf("Configuration(%s).LatestCreatedRevisionName = %q, want %q",
 				names.Config, c.Status.LatestCreatedRevisionName, names.Revision)
 		}
 		if c.Status.LatestReadyRevisionName != names.Revision {
-			return false, fmt.Errorf("Configuration(%q).LatestReadyRevisionName = %q, want %q",
+			return false, fmt.Errorf("Configuration(%s).LatestReadyRevisionName = %q, want %q",
 				names.Config, c.Status.LatestReadyRevisionName, names.Revision)
 		}
 		return true, nil

--- a/test/conformance/api/v1alpha1/util.go
+++ b/test/conformance/api/v1alpha1/util.go
@@ -241,11 +241,11 @@ func validateRunLatestControlPlane(t pkgTest.T, clients *test.Clients, names tes
 	t.Log("Checking to ensure Configuration is in desired state.")
 	err = v1a1test.CheckConfigurationState(clients.ServingAlphaClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
 		if c.Status.LatestCreatedRevisionName != names.Revision {
-			return false, fmt.Errorf("Configuration(%q).LatestCreatedRevisionName = %q, want %q",
+			return false, fmt.Errorf("Configuration(%s).LatestCreatedRevisionName = %q, want %q",
 				names.Config, c.Status.LatestCreatedRevisionName, names.Revision)
 		}
 		if c.Status.LatestReadyRevisionName != names.Revision {
-			return false, fmt.Errorf("Configuration(%q).LatestReadyRevisionName = %q, want %q",
+			return false, fmt.Errorf("Configuration(%s).LatestReadyRevisionName = %q, want %q",
 				names.Config, c.Status.LatestReadyRevisionName, names.Revision)
 		}
 		return true, nil

--- a/test/conformance/api/v1alpha1/util.go
+++ b/test/conformance/api/v1alpha1/util.go
@@ -241,10 +241,12 @@ func validateRunLatestControlPlane(t pkgTest.T, clients *test.Clients, names tes
 	t.Log("Checking to ensure Configuration is in desired state.")
 	err = v1a1test.CheckConfigurationState(clients.ServingAlphaClient, names.Config, func(c *v1alpha1.Configuration) (bool, error) {
 		if c.Status.LatestCreatedRevisionName != names.Revision {
-			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was created: %w", names.Config, names.Revision, err)
+			return false, fmt.Errorf("Configuration(%q).LatestCreatedRevisionName = %q, want %q",
+				names.Config, c.Status.LatestCreatedRevisionName, names.Revision)
 		}
 		if c.Status.LatestReadyRevisionName != names.Revision {
-			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was ready: %w", names.Config, names.Revision, err)
+			return false, fmt.Errorf("Configuration(%q).LatestReadyRevisionName = %q, want %q",
+				names.Config, c.Status.LatestReadyRevisionName, names.Revision)
 		}
 		return true, nil
 	})

--- a/test/conformance/api/v1beta1/util.go
+++ b/test/conformance/api/v1beta1/util.go
@@ -241,10 +241,12 @@ func validateControlPlane(t pkgTest.T, clients *test.Clients, names test.Resourc
 	t.Log("Checking to ensure Configuration is in desired state.")
 	err = v1b1test.CheckConfigurationState(clients.ServingBetaClient, names.Config, func(c *v1beta1.Configuration) (bool, error) {
 		if c.Status.LatestCreatedRevisionName != names.Revision {
-			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was created: %w", names.Config, names.Revision, err)
+			return false, fmt.Errorf("Configuration(%q).LatestCreatedRevisionName = %q, want %q",
+				names.Config, c.Status.LatestCreatedRevisionName, names.Revision)
 		}
 		if c.Status.LatestReadyRevisionName != names.Revision {
-			return false, fmt.Errorf("the Configuration %s was not updated indicating that the Revision %s was ready: %w", names.Config, names.Revision, err)
+			return false, fmt.Errorf("Configuration(%q).LatestReadyRevisionName = %q, want %q",
+				names.Config, c.Status.LatestReadyRevisionName, names.Revision)
 		}
 		return true, nil
 	})

--- a/test/conformance/api/v1beta1/util.go
+++ b/test/conformance/api/v1beta1/util.go
@@ -241,11 +241,11 @@ func validateControlPlane(t pkgTest.T, clients *test.Clients, names test.Resourc
 	t.Log("Checking to ensure Configuration is in desired state.")
 	err = v1b1test.CheckConfigurationState(clients.ServingBetaClient, names.Config, func(c *v1beta1.Configuration) (bool, error) {
 		if c.Status.LatestCreatedRevisionName != names.Revision {
-			return false, fmt.Errorf("Configuration(%q).LatestCreatedRevisionName = %q, want %q",
+			return false, fmt.Errorf("Configuration(%s).LatestCreatedRevisionName = %q, want %q",
 				names.Config, c.Status.LatestCreatedRevisionName, names.Revision)
 		}
 		if c.Status.LatestReadyRevisionName != names.Revision {
-			return false, fmt.Errorf("Configuration(%q).LatestReadyRevisionName = %q, want %q",
+			return false, fmt.Errorf("Configuration(%s).LatestReadyRevisionName = %q, want %q",
 				names.Config, c.Status.LatestReadyRevisionName, names.Revision)
 		}
 		return true, nil


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

The output here is not helpful if the test actually fails here (which I've seen [downstream](https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/215/pull-ci-openshift-knative-serverless-operator-master-4.3-e2e-aws-ocp-43/633))

It looks like we're wrongly stamping out more than one revision. Going to hunt that more but this would've been helpful to tell for sure.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
