### PR TITLE
Add loglevel overrides examples and enable debug level for test

### DIFF
--- a/config/core/configmaps/logging.yaml
+++ b/config/core/configmaps/logging.yaml
@@ -69,3 +69,7 @@ data:
     loglevel.queueproxy: "info"
     loglevel.webhook: "info"
     loglevel.activator: "info"
+    loglevel.hpaautoscaler: "info"
+    loglevel.certcontroller: "info"
+    loglevel.istiocontroller: "info"
+    loglevel.nscontroller: "info"

--- a/pkg/logging/config_test.go
+++ b/pkg/logging/config_test.go
@@ -124,8 +124,13 @@ func TestLogLevelTestConfig(t *testing.T) {
 		"queueproxy",
 		"webhook",
 		"activator",
+		"hpaautoscaler",
+		"certcontroller",
+		"istiocontroller",
+		"nscontroller",
 	}
-	cm, _ := ConfigMapsFromTestFile(t, testConfigFileName, "loglevel.autoscaler", "loglevel.controller", "loglevel.queueproxy", "loglevel.webhook", "loglevel.activator", "zap-logger-config")
+	cm, _ := ConfigMapsFromTestFile(t, testConfigFileName, "loglevel.autoscaler", "loglevel.controller", "loglevel.queueproxy", "loglevel.webhook",
+		"loglevel.activator", "loglevel.hpaautoscaler", "loglevel.certcontroller", "loglevel.istiocontroller", "loglevel.nscontroller", "zap-logger-config")
 	cfg, err := logging.NewConfigFromConfigMap(cm)
 
 	if err != nil {

--- a/test/config/config-logging.yaml
+++ b/test/config/config-logging.yaml
@@ -69,6 +69,10 @@ data:
     loglevel.queueproxy: "info"
     loglevel.webhook: "info"
     loglevel.activator: "info"
+    loglevel.hpaautoscaler: "info"
+    loglevel.certcontroller: "info"
+    loglevel.istiocontroller: "info"
+    loglevel.nscontroller: "info"
 
   zap-logger-config: |
     {
@@ -101,3 +105,7 @@ data:
   loglevel.queueproxy: "debug"
   loglevel.webhook: "debug"
   loglevel.activator: "debug"
+  loglevel.hpaautoscaler: "debug"
+  loglevel.certcontroller: "debug"
+  loglevel.istiocontroller: "debug"
+  loglevel.nscontroller: "debug"


### PR DESCRIPTION
## Proposed Changes

This patch adds loglevel overrides examples
`hpaautoscaler`,`certcontroller`,`istiocontroller` and `nscontroller`.

These names are different from deployment so it is difficult to find
the component name without code search.

/lint

**Release Note**

```release-note
NONE
```
