### PR TITLE
API for activator count to pass to SKS

### DIFF
--- a/pkg/apis/networking/v1alpha1/serverlessservice_types.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_types.go
@@ -101,6 +101,10 @@ type ServerlessServiceSpec struct {
 	// The application-layer protocol. Matches `RevisionProtocolType` set on the owning pa/revision.
 	// serving imports networking, so just use string.
 	ProtocolType networking.ProtocolType
+
+	// NumActivators contines number of Activators that this revision should be
+	// assigned.
+	NumActivators int32 `json:"numActivators,omitempty"`
 }
 
 // ServerlessServiceStatus describes the current state of the ServerlessService.

--- a/pkg/apis/networking/v1alpha1/serverlessservice_types.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_types.go
@@ -102,7 +102,7 @@ type ServerlessServiceSpec struct {
 	// serving imports networking, so just use string.
 	ProtocolType networking.ProtocolType
 
-	// NumActivators contines number of Activators that this revision should be
+	// NumActivators contains number of Activators that this revision should be
 	// assigned.
 	NumActivators int32 `json:"numActivators,omitempty"`
 }

--- a/pkg/apis/networking/v1alpha1/serverlessservice_validation.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_validation.go
@@ -50,7 +50,7 @@ func (spec *ServerlessServiceSpec) Validate(ctx context.Context) *apis.FieldErro
 	case spec.NumActivators < 0:
 		all = all.Also(apis.ErrInvalidValue(spec.NumActivators, "numActivators"))
 	case spec.NumActivators == 0:
-		// TODP(vagababov): stop permitting after 0.16, since this is needed only for upgrades.
+		// TODO(vagababov): stop permitting after 0.16, since this is needed only for upgrades.
 		break
 	}
 

--- a/pkg/apis/networking/v1alpha1/serverlessservice_validation.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_validation.go
@@ -46,6 +46,14 @@ func (spec *ServerlessServiceSpec) Validate(ctx context.Context) *apis.FieldErro
 		all = all.Also(apis.ErrInvalidValue(spec.Mode, "mode"))
 	}
 
+	switch {
+	case spec.NumActivators < 0:
+		all = all.Also(apis.ErrInvalidValue(spec.NumActivators, "numActivators"))
+	case spec.NumActivators == 0:
+		// TODP(vagababov): stop permitting after 0.16, since this is needed only for upgrades.
+		break
+	}
+
 	all = all.Also(serving.ValidateNamespacedObjectReference(&spec.ObjectRef).ViaField("objectRef"))
 
 	return all.Also(spec.ProtocolType.Validate(ctx).ViaField("protocolType"))

--- a/pkg/apis/networking/v1alpha1/serverlessservice_validation_test.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_validation_test.go
@@ -52,9 +52,36 @@ func TestServerlessServiceSpecValidation(t *testing.T) {
 				Kind:       "Deployment",
 				Name:       "foo",
 			},
-			ProtocolType: networking.ProtocolH2C,
+			ProtocolType:  networking.ProtocolH2C,
+			NumActivators: 311,
 		},
 		want: nil,
+	}, {
+		name: "num act == 0",
+		skss: &ServerlessServiceSpec{
+			Mode: SKSOperationModeServe,
+			ObjectRef: corev1.ObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "destiny",
+			},
+			ProtocolType:  networking.ProtocolH2C,
+			NumActivators: 0,
+		},
+		want: nil,
+	}, {
+		name: "num act invalid",
+		skss: &ServerlessServiceSpec{
+			Mode: SKSOperationModeServe,
+			ObjectRef: corev1.ObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "destiny",
+			},
+			ProtocolType:  networking.ProtocolH2C,
+			NumActivators: -1,
+		},
+		want: apis.ErrInvalidValue("-1", "numActivators"),
 	}, {
 		name: "invalid protocol",
 		skss: &ServerlessServiceSpec{


### PR DESCRIPTION
The API changes to pass along the # of activators to the SKS.


/lint

Part of #7022 