### PR TITLE
Replate test config with link to real one and update defaulting.

### DIFF
--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -80,31 +80,46 @@ type Config struct {
 	PodAutoscalerClass string
 }
 
+func defaultConfig() *Config {
+	return &Config{
+		EnableScaleToZero:                  true,
+		EnableGracefulScaledown:            false,
+		ContainerConcurrencyTargetFraction: defaultTargetUtilization,
+		ContainerConcurrencyTargetDefault:  100,
+		// TODO(#1956): Tune target usage based on empirical data.
+		TargetUtilization:        defaultTargetUtilization,
+		RPSTargetDefault:         200,
+		MaxScaleUpRate:           1000,
+		MaxScaleDownRate:         2,
+		TargetBurstCapacity:      200,
+		PanicWindowPercentage:    10,
+		ActivatorCapacity:        100,
+		PanicThresholdPercentage: 200,
+		StableWindow:             60 * time.Second,
+		ScaleToZeroGracePeriod:   30 * time.Second,
+		TickInterval:             2 * time.Second,
+		PodAutoscalerClass:       autoscaling.KPA,
+	}
+}
+
 // NewConfigFromMap creates a Config from the supplied map
 func NewConfigFromMap(data map[string]string) (*Config, error) {
-	lc := &Config{
-		TargetUtilization: defaultTargetUtilization,
-	}
+	lc := defaultConfig()
 
 	// Process bool fields.
 	for _, b := range []struct {
-		key          string
-		field        *bool
-		defaultValue bool
+		key   string
+		field *bool
 	}{
 		{
-			key:          "enable-scale-to-zero",
-			field:        &lc.EnableScaleToZero,
-			defaultValue: true,
+			key:   "enable-scale-to-zero",
+			field: &lc.EnableScaleToZero,
 		},
 		{
-			key:          "enable-graceful-scaledown",
-			field:        &lc.EnableGracefulScaledown,
-			defaultValue: false,
+			key:   "enable-graceful-scaledown",
+			field: &lc.EnableGracefulScaledown,
 		}} {
-		if raw, ok := data[b.key]; !ok {
-			*b.field = b.defaultValue
-		} else {
+		if raw, ok := data[b.key]; ok {
 			*b.field = strings.EqualFold(raw, "true")
 		}
 	}
@@ -113,52 +128,40 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 	for _, f64 := range []struct {
 		key   string
 		field *float64
-		// specified exactly when optional
-		defaultValue float64
 	}{{
-		key:          "max-scale-up-rate",
-		field:        &lc.MaxScaleUpRate,
-		defaultValue: 1000.0,
+		key:   "max-scale-up-rate",
+		field: &lc.MaxScaleUpRate,
 	}, {
-		key:          "max-scale-down-rate",
-		field:        &lc.MaxScaleDownRate,
-		defaultValue: 2.0,
+		key:   "max-scale-down-rate",
+		field: &lc.MaxScaleDownRate,
 	}, {
 		key:   "container-concurrency-target-percentage",
 		field: &lc.ContainerConcurrencyTargetFraction,
-		// TODO(#1956): Tune target usage based on empirical data.
-		defaultValue: defaultTargetUtilization,
 	}, {
-		key:          "container-concurrency-target-default",
-		field:        &lc.ContainerConcurrencyTargetDefault,
-		defaultValue: 100.0,
+		key:   "container-concurrency-target-default",
+		field: &lc.ContainerConcurrencyTargetDefault,
 	}, {
-		key:          "requests-per-second-target-default",
-		field:        &lc.RPSTargetDefault,
-		defaultValue: 200.0,
+		key:   "requests-per-second-target-default",
+		field: &lc.RPSTargetDefault,
 	}, {
-		key:          "target-burst-capacity",
-		field:        &lc.TargetBurstCapacity,
-		defaultValue: 200,
+		key:   "target-burst-capacity",
+		field: &lc.TargetBurstCapacity,
 	}, {
-		key:          "panic-window-percentage",
-		field:        &lc.PanicWindowPercentage,
-		defaultValue: 10.0,
+		key:   "panic-window-percentage",
+		field: &lc.PanicWindowPercentage,
 	}, {
-		key:          "activator-capacity",
-		field:        &lc.ActivatorCapacity,
-		defaultValue: 100.0,
+		key:   "activator-capacity",
+		field: &lc.ActivatorCapacity,
 	}, {
-		key:          "panic-threshold-percentage",
-		field:        &lc.PanicThresholdPercentage,
-		defaultValue: 200.0,
+		key:   "panic-threshold-percentage",
+		field: &lc.PanicThresholdPercentage,
 	}} {
-		if raw, ok := data[f64.key]; !ok {
-			*f64.field = f64.defaultValue
-		} else if val, err := strconv.ParseFloat(raw, 64); err != nil {
-			return nil, err
-		} else {
-			*f64.field = val
+		if raw, ok := data[f64.key]; ok {
+			if val, err := strconv.ParseFloat(raw, 64); err != nil {
+				return nil, err
+			} else {
+				*f64.field = val
+			}
 		}
 	}
 
@@ -172,32 +175,27 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 
 	// Process Duration fields
 	for _, dur := range []struct {
-		key          string
-		field        *time.Duration
-		defaultValue time.Duration
+		key   string
+		field *time.Duration
 	}{{
-		key:          "stable-window",
-		field:        &lc.StableWindow,
-		defaultValue: 60 * time.Second,
+		key:   "stable-window",
+		field: &lc.StableWindow,
 	}, {
-		key:          "scale-to-zero-grace-period",
-		field:        &lc.ScaleToZeroGracePeriod,
-		defaultValue: 30 * time.Second,
+		key:   "scale-to-zero-grace-period",
+		field: &lc.ScaleToZeroGracePeriod,
 	}, {
-		key:          "tick-interval",
-		field:        &lc.TickInterval,
-		defaultValue: 2 * time.Second,
+		key:   "tick-interval",
+		field: &lc.TickInterval,
 	}} {
-		if raw, ok := data[dur.key]; !ok {
-			*dur.field = dur.defaultValue
-		} else if val, err := time.ParseDuration(raw); err != nil {
-			return nil, err
-		} else {
-			*dur.field = val
+		if raw, ok := data[dur.key]; ok {
+			if val, err := time.ParseDuration(raw); err != nil {
+				return nil, err
+			} else {
+				*dur.field = val
+			}
 		}
 	}
 
-	lc.PodAutoscalerClass = autoscaling.KPA
 	if pac, ok := data["pod-autoscaler-class"]; ok {
 		lc.PodAutoscalerClass = pac
 	}

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -157,11 +157,11 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		field: &lc.PanicThresholdPercentage,
 	}} {
 		if raw, ok := data[f64.key]; ok {
-			if val, err := strconv.ParseFloat(raw, 64); err != nil {
+			val, err := strconv.ParseFloat(raw, 64)
+			if err != nil {
 				return nil, err
-			} else {
-				*f64.field = val
 			}
+			*f64.field = val
 		}
 	}
 
@@ -188,11 +188,11 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		field: &lc.TickInterval,
 	}} {
 		if raw, ok := data[dur.key]; ok {
-			if val, err := time.ParseDuration(raw); err != nil {
+			val, err := time.ParseDuration(raw)
+			if err != nil {
 				return nil, err
-			} else {
-				*dur.field = val
 			}
+			*dur.field = val
 		}
 	}
 

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -24,27 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	. "knative.dev/pkg/configmap/testing"
-	"knative.dev/serving/pkg/apis/autoscaling"
 )
-
-var defaultConfig = Config{
-	EnableScaleToZero:                  true,
-	EnableGracefulScaledown:            false,
-	ContainerConcurrencyTargetFraction: 0.7,
-	ContainerConcurrencyTargetDefault:  100,
-	RPSTargetDefault:                   200,
-	ActivatorCapacity:                  100,
-	TargetUtilization:                  0.7,
-	TargetBurstCapacity:                200,
-	MaxScaleUpRate:                     1000,
-	MaxScaleDownRate:                   2,
-	StableWindow:                       time.Minute,
-	ScaleToZeroGracePeriod:             30 * time.Second,
-	TickInterval:                       2 * time.Second,
-	PanicWindowPercentage:              10.0,
-	PanicThresholdPercentage:           200.0,
-	PodAutoscalerClass:                 autoscaling.KPA,
-}
 
 func TestNewConfig(t *testing.T) {
 	tests := []struct {
@@ -55,7 +35,7 @@ func TestNewConfig(t *testing.T) {
 	}{{
 		name:  "default",
 		input: map[string]string{},
-		want:  &defaultConfig,
+		want:  defaultConfig(),
 	}, {
 		name: "minimum",
 		input: map[string]string{
@@ -69,33 +49,36 @@ func TestNewConfig(t *testing.T) {
 			"panic-threshold-percentage":              "200",
 			"activator-capacity":                      "1",
 		},
-		want: func(c Config) *Config {
+		want: func() *Config {
+			c := defaultConfig()
 			c.ContainerConcurrencyTargetFraction = 0.5
 			c.ContainerConcurrencyTargetDefault = 10
 			c.MaxScaleUpRate = 1.001
 			c.TargetBurstCapacity = 0
 			c.StableWindow = 5 * time.Minute
 			c.ActivatorCapacity = 1
-			return &c
-		}(defaultConfig),
+			return c
+		}(),
 	}, {
 		name: "concurrencty target percentage as percent",
 		input: map[string]string{
 			"container-concurrency-target-percentage": "55",
 		},
-		want: func(c Config) *Config {
+		want: func() *Config {
+			c := defaultConfig()
 			c.ContainerConcurrencyTargetFraction = 0.55
-			return &c
-		}(defaultConfig),
+			return c
+		}(),
 	}, {
 		name: "with -1 tbc",
 		input: map[string]string{
 			"target-burst-capacity": "-1",
 		},
-		want: func(c Config) *Config {
+		want: func() *Config {
+			c := defaultConfig()
 			c.TargetBurstCapacity = -1
-			return &c
-		}(defaultConfig),
+			return c
+		}(),
 	}, {
 		name: "with default toggles set",
 		input: map[string]string{
@@ -114,7 +97,8 @@ func TestNewConfig(t *testing.T) {
 			"pod-autoscaler-class":                    "some.class",
 			"activator-capacity":                      "905",
 		},
-		want: func(c Config) *Config {
+		want: func() *Config {
+			c := defaultConfig()
 			c.TargetBurstCapacity = 12345
 			c.ContainerConcurrencyTargetDefault = 10.5
 			c.ContainerConcurrencyTargetFraction = 0.71
@@ -124,37 +108,39 @@ func TestNewConfig(t *testing.T) {
 			c.StableWindow = 5 * time.Minute
 			c.ActivatorCapacity = 905
 			c.PodAutoscalerClass = "some.class"
-			return &c
-		}(defaultConfig),
+			return c
+		}(),
 	}, {
 		name: "with toggles on strange casing",
 		input: map[string]string{
 			"enable-scale-to-zero":      "TRUE",
 			"enable-graceful-scaledown": "FALSE",
 		},
-		want: &defaultConfig,
+		want: defaultConfig(),
 	}, {
 		name: "with toggles explicitly flipped",
 		input: map[string]string{
 			"enable-scale-to-zero":      "false",
 			"enable-graceful-scaledown": "true",
 		},
-		want: func(c Config) *Config {
+		want: func() *Config {
+			c := defaultConfig()
 			c.EnableScaleToZero = false
 			c.EnableGracefulScaledown = true
-			return &c
-		}(defaultConfig),
+			return c
+		}(),
 	}, {
 		name: "with explicit grace period",
 		input: map[string]string{
 			"enable-scale-to-zero":       "false",
 			"scale-to-zero-grace-period": "33s",
 		},
-		want: func(c Config) *Config {
+		want: func() *Config {
+			c := defaultConfig()
 			c.EnableScaleToZero = false
 			c.ScaleToZeroGracePeriod = 33 * time.Second
-			return &c
-		}(defaultConfig),
+			return c
+		}(),
 	}, {
 		name: "malformed float",
 		input: map[string]string{
@@ -279,7 +265,11 @@ func TestOurConfig(t *testing.T) {
 	if _, err := NewConfigFromConfigMap(cm); err != nil {
 		t.Errorf("NewConfigFromConfigMap(actual) = %v", err)
 	}
-	if _, err := NewConfigFromConfigMap(example); err != nil {
+	if cm, err := NewConfigFromConfigMap(example); err != nil {
 		t.Errorf("NewConfigFromConfigMap(example) = %v", err)
+	} else if got, want := cm, defaultConfig(); !cmp.Equal(want, got) {
+		t.Errorf("ExampleConfig is not equal to defaults (-want, +got) = %s",
+			cmp.Diff(want, got))
 	}
+
 }


### PR DESCRIPTION
1. Use the replaced test config with link to the real one, as designed:
   - this way we can validate the example to match the defaults!
   - add the test to verify that example yields the default config
2. Re-do how we do defaulting
   - return a default prebuilt object
   - stop using the defaults in the parse loop
   - update the UTs accordingly.

For #3492
/lint

/assign mattmoor @markusthoemmes 