### PR TITLE
Revert PR#7302

### DIFF
--- a/test/apicoverage.sh
+++ b/test/apicoverage.sh
@@ -51,8 +51,7 @@ ko apply -f "${APICOVERAGE_IMAGE}/apicoverage-webhook.yaml" || fail_apicoverage_
 
 header "Running tests"
 # Run conformance tests and e2e tests
-go_test_e2e -timeout=30m ./test/conformance/api/v1alpha1 ./test/conformance/api/v1beta1 ./test/conformance/runtime ./test/e2e \
-  --systemNamespace=${E2E_SYSTEM_NAMESPACE} || fail_apicoverage_run "Failed in executing Tests"
+go_test_e2e -timeout=30m ./test/conformance/api/v1alpha1 ./test/conformance/api/v1beta1 ./test/conformance/runtime ./test/e2e || fail_apicoverage_run "Failed in executing Tests"
 
 header "Retrieving API Coverage values"
 go run "${APICOVERAGE_TOOL}/main.go" || fail_test "Failed retrieving API coverage values"

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -43,9 +43,6 @@ INSTALL_MONITORING=0
 INSTALL_CUSTOM_YAMLS=""
 
 UNINSTALL_LIST=()
-readonly KNATIVE_DEFAULT_NAMESPACE="knative-serving"
-# This the namespace used to install Knative Serving. Use generated UUID as namespace.
-E2E_SYSTEM_NAMESPACE=$(uuidgen | tr 'A-Z' 'a-z')
 
 # Parse our custom flags.
 function parse_flags() {
@@ -118,11 +115,6 @@ function parse_flags() {
       readonly INGRESS_CLASS="contour.ingress.networking.knative.dev"
       return 2
       ;;
-    --system-namespace)
-      [[ -z "$2" ]] || [[ $2 = --* ]] && fail_test "Missing argument to --system-namespace"
-      readonly E2E_SYSTEM_NAMESPACE=$2
-      return 2
-      ;;
   esac
   return 0
 }
@@ -160,7 +152,6 @@ function install_knative_serving() {
   echo ">> Installing Knative serving from custom YAMLs"
   echo "Custom YAML files: ${INSTALL_CUSTOM_YAMLS}"
   for yaml in ${INSTALL_CUSTOM_YAMLS}; do
-    sed -i "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${yaml}
     echo "Installing '${yaml}'"
     kubectl create -f "${yaml}" || return 1
   done
@@ -212,7 +203,6 @@ function install_istio() {
     # We apply a filter here because when we're installing from a pre-built
     # bundle then the whole bundle it passed here.  We use ko because it has
     # better filtering support for CRDs.
-    sed -i "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${1}
     ko apply -f "${1}" --selector=networking.knative.dev/ingress-provider=istio || return 1
     UNINSTALL_LIST+=( "${1}" )
   fi
@@ -291,10 +281,8 @@ function install_contour() {
 function install_knative_serving_standard() {
   readonly INSTALL_CERT_MANAGER_YAML="./third_party/cert-manager-${CERT_MANAGER_VERSION}/cert-manager.yaml"
 
-  echo ">> Creating ${E2E_SYSTEM_NAMESPACE} namespace if it does not exist"
-  kubectl get ns ${E2E_SYSTEM_NAMESPACE} || kubectl create namespace ${E2E_SYSTEM_NAMESPACE}
-  # Delete the test namespace
-  add_trap "kubectl delete namespace ${E2E_SYSTEM_NAMESPACE} --ignore-not-found=true" SIGKILL SIGTERM SIGQUIT
+  echo ">> Creating knative-serving namespace if it does not exist"
+  kubectl get ns knative-serving || kubectl create namespace knative-serving
 
   echo ">> Installing Knative CRD"
   if [[ -z "$1" ]]; then
@@ -305,7 +293,6 @@ function install_knative_serving_standard() {
     kubectl apply -f "${SERVING_CRD_YAML}" || return 1
     UNINSTALL_LIST+=( "${SERVING_CRD_YAML}" )
   else
-    sed -i "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${1}
     echo "Knative YAML: ${1}"
     ko apply -f "${1}" --selector=knative.dev/crd-install=true || return 1
     UNINSTALL_LIST+=( "${1}" )
@@ -325,15 +312,12 @@ function install_knative_serving_standard() {
   fi
 
   echo ">> Installing Cert-Manager"
-  sed -i "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${INSTALL_CERT_MANAGER_YAML}
   echo "Cert Manager YAML: ${INSTALL_CERT_MANAGER_YAML}"
   kubectl apply -f "${INSTALL_CERT_MANAGER_YAML}" --validate=false || return 1
   UNINSTALL_LIST+=( "${INSTALL_CERT_MANAGER_YAML}" )
 
   echo ">> Installing Knative serving"
   if [[ -z "$1" ]]; then
-    sed -i "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${SERVING_CORE_YAML}
-    sed -i "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${SERVING_HPA_YAML}
     echo "Knative YAML: ${SERVING_CORE_YAML} and ${SERVING_HPA_YAML}"
     kubectl apply \
 	    -f "${SERVING_CORE_YAML}" \
@@ -342,14 +326,12 @@ function install_knative_serving_standard() {
 
     # ${SERVING_CERT_MANAGER_YAML} is set when calling
     # build_knative_from_source
-    sed -i "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${SERVING_CERT_MANAGER_YAML}
     echo "Knative TLS YAML: ${SERVING_CERT_MANAGER_YAML}"
     kubectl apply \
       -f "${SERVING_CERT_MANAGER_YAML}" || return 1
 
     if (( INSTALL_MONITORING )); then
 	echo ">> Installing Monitoring"
-	sed -i "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${MONITORING_YAML}
 	echo "Knative Monitoring YAML: ${MONITORING_YAML}"
 	kubectl apply -f "${MONITORING_YAML}" || return 1
 	UNINSTALL_LIST+=( "${MONITORING_YAML}" )
@@ -359,13 +341,11 @@ function install_knative_serving_standard() {
     # If we are installing from provided yaml, then only install non-istio bits here,
     # and if we choose to install istio below, then pass the whole file as the rest.
     # We use ko because it has better filtering support for CRDs.
-    sed -i "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${1}
     ko apply -f "${1}" --selector=networking.knative.dev/ingress-provider!=istio || return 1
     UNINSTALL_LIST+=( "${1}" )
 
     if (( INSTALL_MONITORING )); then
       echo ">> Installing Monitoring"
-      sed -i "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${2}
       echo "Knative Monitoring YAML: ${2}"
       kubectl apply -f "${2}" || return 1
       UNINSTALL_LIST+=( "${2}" )
@@ -378,7 +358,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-network
-  namespace: ${E2E_SYSTEM_NAMESPACE}
+  namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
 data:
@@ -391,14 +371,14 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-observability
-  namespace: ${E2E_SYSTEM_NAMESPACE}
+  namespace: knative-serving
 data:
   profiling.enable: "true"
 EOF
 
   echo ">> Patching activator HPA"
   # We set min replicas to 2 for testing multiple activator pods.
-  kubectl -n ${E2E_SYSTEM_NAMESPACE} patch hpa activator --patch '{"spec":{"minReplicas":2}}' || return 1
+  kubectl -n knative-serving patch hpa activator --patch '{"spec":{"minReplicas":2}}' || return 1
 }
 
 # Check if we should use --resolvabledomain.  In case the ingress only has
@@ -465,9 +445,6 @@ function add_trap() {
 
 # Create test resources and images
 function test_setup() {
-  echo ">> Replacing ${KNATIVE_DEFAULT_NAMESPACE} with the actual namespace for Knative Serving..."
-  find test -type f -name "*.yaml" -exec sed -i "s/${KNATIVE_DEFAULT_NAMESPACE}/${E2E_SYSTEM_NAMESPACE}/g" {} +
-
   echo ">> Setting up logging..."
 
   # Install kail if needed.
@@ -494,7 +471,7 @@ function test_setup() {
   ${REPO_ROOT_DIR}/test/upload-test-images.sh || return 1
 
   echo ">> Waiting for Serving components to be running..."
-  wait_until_pods_running ${E2E_SYSTEM_NAMESPACE} || return 1
+  wait_until_pods_running knative-serving || return 1
 
   echo ">> Waiting for Cert Manager components to be running..."
   wait_until_pods_running cert-manager || return 1
@@ -575,9 +552,9 @@ function dump_extra_cluster_state() {
 }
 
 function turn_on_auto_tls() {
-  kubectl patch configmap config-network -n ${E2E_SYSTEM_NAMESPACE} -p '{"data":{"autoTLS":"Enabled"}}'
+  kubectl patch configmap config-network -n knative-serving -p '{"data":{"autoTLS":"Enabled"}}'
 }
 
 function turn_off_auto_tls() {
-  kubectl patch configmap config-network -n ${E2E_SYSTEM_NAMESPACE} -p '{"data":{"autoTLS":"Disabled"}}'
+  kubectl patch configmap config-network -n knative-serving -p '{"data":{"autoTLS":"Disabled"}}'
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -62,7 +62,6 @@ go_test_e2e -timeout=30m \
   $(go list ./test/conformance/... | grep -v certificate) \
   ./test/e2e \
   ${parallelism} \
-  "--systemNamespace=${E2E_SYSTEM_NAMESPACE}" \
   "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 
 if (( HTTPS )); then
@@ -75,34 +74,33 @@ fi
 kubectl apply -f ./test/config/autotls/certmanager/selfsigned/
 add_trap "kubectl delete -f ./test/config/autotls/certmanager/selfsigned/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
 go_test_e2e -timeout=10m \
-  ./test/conformance/certificate/nonhttp01 "$(certificate_class)" --systemNamespace=${E2E_SYSTEM_NAMESPACE} || failed=1
+  ./test/conformance/certificate/nonhttp01 "$(certificate_class)" || failed=1
 kubectl delete -f ./test/config/autotls/certmanager/selfsigned/
 
 kubectl apply -f ./test/config/autotls/certmanager/http01/
 add_trap "kubectl delete -f ./test/config/autotls/certmanager/http01/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
 go_test_e2e -timeout=10m \
-  ./test/conformance/certificate/http01 "$(certificate_class)" --systemNamespace=${E2E_SYSTEM_NAMESPACE} || failed=1
+  ./test/conformance/certificate/http01 "$(certificate_class)" || failed=1
 kubectl delete -f ./test/config/autotls/certmanager/http01/
 
 # Run scale tests.
 go_test_e2e -timeout=10m \
   ${parallelism} \
-  ./test/scale "--systemNamespace=${E2E_SYSTEM_NAMESPACE}" || failed=1
+  ./test/scale || failed=1
 
 # Istio E2E tests mutate the cluster and must be ran separately
 if [[ -n "${ISTIO_VERSION}" ]]; then
   go_test_e2e -timeout=10m \
     ./test/e2e/istio \
-    "--systemNamespace=${E2E_SYSTEM_NAMESPACE}" \
     "--resolvabledomain=$(use_resolvable_domain)" || failed=1
 fi
 
 # Run HA tests separately as they're stopping core Knative Serving pods
-kubectl -n ${E2E_SYSTEM_NAMESPACE} patch configmap/config-leader-election --type=merge \
+kubectl -n knative-serving patch configmap/config-leader-election --type=merge \
   --patch='{"data":{"enabledComponents":"controller,hpaautoscaler,certcontroller,istiocontroller,nscontroller"}}'
-add_trap "kubectl get cm config-leader-election -n ${E2E_SYSTEM_NAMESPACE} -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -" SIGKILL SIGTERM SIGQUIT
-go_test_e2e -timeout=10m -parallel=1 ./test/ha "--systemNamespace=${E2E_SYSTEM_NAMESPACE}" || failed=1
-kubectl get cm config-leader-election -n ${E2E_SYSTEM_NAMESPACE} -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -
+add_trap "kubectl get cm config-leader-election -n knative-serving -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -" SIGKILL SIGTERM SIGQUIT
+go_test_e2e -timeout=10m -parallel=1 ./test/ha || failed=1
+kubectl get cm config-leader-election -n knative-serving -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -
 
 # Dump cluster state in case of failure
 (( failed )) && dump_cluster_state

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -46,16 +46,19 @@ function install_latest_release() {
 
   install_knative_serving "${RELEASE_YAML}" \
       || fail_test "Knative latest release installation failed"
-  wait_until_pods_running ${E2E_SYSTEM_NAMESPACE}
+  wait_until_pods_running knative-serving
 }
 
 function install_head() {
   header "Installing Knative head release"
   install_knative_serving || fail_test "Knative head release installation failed"
-  wait_until_pods_running ${E2E_SYSTEM_NAMESPACE}
+  wait_until_pods_running knative-serving
 }
 
 function knative_setup() {
+  # Build Knative to generate Istio manifests from HEAD for install_latest_release
+  # We do it here because it's a one-time setup
+  build_knative_from_source
   install_latest_release
 }
 
@@ -69,7 +72,7 @@ TIMEOUT=10m
 header "Running preupgrade tests"
 
 go_test_e2e -tags=preupgrade -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${E2E_SYSTEM_NAMESPACE} || fail_test
+  --resolvabledomain=$(use_resolvable_domain) || fail_test
 
 header "Starting prober test"
 
@@ -77,7 +80,7 @@ header "Starting prober test"
 rm -f /tmp/prober-signal
 
 go_test_e2e -tags=probe -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${E2E_SYSTEM_NAMESPACE} &
+  --resolvabledomain=$(use_resolvable_domain) &
 PROBER_PID=$!
 echo "Prober PID is ${PROBER_PID}"
 
@@ -85,13 +88,13 @@ install_head
 
 header "Running postupgrade tests"
 go_test_e2e -tags=postupgrade -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${E2E_SYSTEM_NAMESPACE} || fail_test
+  --resolvabledomain=$(use_resolvable_domain) || fail_test
 
 install_latest_release
 
 header "Running postdowngrade tests"
 go_test_e2e -tags=postdowngrade -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${E2E_SYSTEM_NAMESPACE} || fail_test
+  --resolvabledomain=$(use_resolvable_domain) || fail_test
 
 # The prober is blocking on /tmp/prober-signal to know when it should exit.
 #

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -29,8 +29,9 @@ import (
 
 	vegeta "github.com/tsenart/vegeta/lib"
 	"golang.org/x/sync/errgroup"
+	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
-	"knative.dev/pkg/test/ingress"
+	ingress "knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/networking"
@@ -641,7 +642,7 @@ func TestTargetBurstCapacityMinusOne(t *testing.T) {
 		t.Fatalf("Error retrieving autoscaler configmap: %v", err)
 	}
 	aeps, err := ctx.clients.KubeClient.Kube.CoreV1().Endpoints(
-		test.ServingFlags.SystemNamespace).Get(networking.ActivatorServiceName, metav1.GetOptions{})
+		system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error getting activator endpoints: %v", err)
 	}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/networking"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
@@ -72,7 +73,7 @@ func SetupWithNamespace(t *testing.T, namespace string) *test.Clients {
 // autoscalerCM returns the current autoscaler config map deployed to the
 // test cluster.
 func autoscalerCM(clients *test.Clients) (*autoscalerconfig.Config, error) {
-	autoscalerCM, err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingFlags.SystemNamespace).Get(
+	autoscalerCM, err := clients.KubeClient.Kube.CoreV1().ConfigMaps("knative-serving").Get(
 		autoscalerconfig.ConfigName,
 		metav1.GetOptions{})
 	if err != nil {
@@ -83,14 +84,14 @@ func autoscalerCM(clients *test.Clients) (*autoscalerconfig.Config, error) {
 
 // rawCM returns the raw knative config map for the given name
 func rawCM(clients *test.Clients, name string) (*corev1.ConfigMap, error) {
-	return clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingFlags.SystemNamespace).Get(
+	return clients.KubeClient.Kube.CoreV1().ConfigMaps("knative-serving").Get(
 		name,
 		metav1.GetOptions{})
 }
 
 // patchCM updates the existing config map with the supplied value.
 func patchCM(clients *test.Clients, cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	return clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingFlags.SystemNamespace).Update(cm)
+	return clients.KubeClient.Kube.CoreV1().ConfigMaps("knative-serving").Update(cm)
 }
 
 // WaitForScaleToZero will wait for the specified deployment to scale to 0 replicas.
@@ -121,7 +122,7 @@ func waitForActivatorEndpoints(resources *v1a1test.ResourceObjects, clients *tes
 	return wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
 		// We need to fetch the activator endpoints at every check, since it can change.
 		aeps, err := clients.KubeClient.Kube.CoreV1().Endpoints(
-			test.ServingFlags.SystemNamespace).Get(networking.ActivatorServiceName, metav1.GetOptions{})
+			system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
 		if err != nil {
 			return false, nil
 		}

--- a/test/e2e/istio/probing_test.go
+++ b/test/e2e/istio/probing_test.go
@@ -52,12 +52,16 @@ import (
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
 
+var (
+	namespace = "knative-serving"
+)
+
 func TestIstioProbing(t *testing.T) {
 	cancel := logstream.Start(t)
 	defer cancel()
 
 	clients := e2e.Setup(t)
-	namespace := test.ServingFlags.SystemNamespace
+
 	// Save the current Gateway to restore it after the test
 	oldGateway, err := clients.IstioClient.NetworkingV1alpha3().Gateways(namespace).Get(networking.KnativeIngressGateway, metav1.GetOptions{})
 	if err != nil {
@@ -255,7 +259,7 @@ func TestIstioProbing(t *testing.T) {
 				transportOptions = append(transportOptions, setupHTTPS(t, clients.KubeClient, []string{names.Service + "." + domain}))
 			}
 
-			setupGateway(t, clients, names, domain, namespace, c.servers)
+			setupGateway(t, clients, names, domain, c.servers)
 
 			// Create the service and wait for it to be ready
 			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
@@ -306,8 +310,7 @@ func hasHTTPS(servers []*istiov1alpha3.Server) bool {
 }
 
 // setupGateway updates the ingress Gateway to the provided Servers and waits until all Envoy pods have been updated.
-func setupGateway(t *testing.T, clients *test.Clients, names test.ResourceNames, domain string,
-	namespace string, servers []*istiov1alpha3.Server) {
+func setupGateway(t *testing.T, clients *test.Clients, names test.ResourceNames, domain string, servers []*istiov1alpha3.Server) {
 	// Get the current Gateway
 	curGateway, err := clients.IstioClient.NetworkingV1alpha3().Gateways(namespace).Get(networking.KnativeIngressGateway, metav1.GetOptions{})
 	if err != nil {

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -34,7 +34,6 @@ type ServingEnvironmentFlags struct {
 	Https            bool   // Indicates where the test service will be created with https
 	IngressClass     string // Indicates the class of Ingress provider to test.
 	CertificateClass string // Indicates the class of Certificate provider to test.
-	SystemNamespace  string // Indicates the system namespace, in which Knative Serving is installed.
 }
 
 func initializeServingFlags() *ServingEnvironmentFlags {
@@ -50,8 +49,6 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 		"Set this flag to the ingress class to test against.")
 	flag.StringVar(&f.CertificateClass, "certificateClass", network.CertManagerCertificateClassName,
 		"Set this flag to the certificate class to test against.")
-	flag.StringVar(&f.SystemNamespace, "systemNamespace", "knative-serving",
-		"Set this flag to the namespace for Knative Serving.")
 
 	return &f
 }

--- a/test/ha/autoscalerhpa_test.go
+++ b/test/ha/autoscalerhpa_test.go
@@ -58,7 +58,7 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 		t.Fatalf("Failed to get leader: %v", err)
 	}
 
-	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(leaderController, &metav1.DeleteOptions{})
+	clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).Delete(leaderController, &metav1.DeleteOptions{})
 
 	if err := waitForPodDeleted(t, clients, leaderController); err != nil {
 		t.Fatalf("Did not observe %s to actually be deleted: %v", leaderController, err)

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -48,7 +48,7 @@ func TestControllerHA(t *testing.T) {
 		t.Fatalf("Failed to get leader: %v", err)
 	}
 
-	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(leaderController, &metav1.DeleteOptions{})
+	clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).Delete(leaderController, &metav1.DeleteOptions{})
 
 	if err := waitForPodDeleted(t, clients, leaderController); err != nil {
 		t.Fatalf("Did not observe %s to actually be deleted: %v", leaderController, err)

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -36,13 +36,14 @@ import (
 )
 
 const (
-	haReplicas = 2
+	servingNamespace = "knative-serving"
+	haReplicas       = 2
 )
 
 func getLeader(t *testing.T, clients *test.Clients, lease string) (string, error) {
 	var leader string
 	err := wait.PollImmediate(test.PollInterval, time.Minute, func() (bool, error) {
-		lease, err := clients.KubeClient.Kube.CoordinationV1().Leases(test.ServingFlags.SystemNamespace).Get(lease, metav1.GetOptions{})
+		lease, err := clients.KubeClient.Kube.CoordinationV1().Leases(servingNamespace).Get(lease, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("error getting lease %s: %w", lease, err)
 		}
@@ -61,7 +62,7 @@ func waitForPodDeleted(t *testing.T, clients *test.Clients, podName string) erro
 }
 
 func podExists(clients *test.Clients, podName string) (bool, error) {
-	if _, err := clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Get(podName, metav1.GetOptions{}); err != nil {
+	if _, err := clients.KubeClient.Kube.CoreV1().Pods(servingNamespace).Get(podName, metav1.GetOptions{}); err != nil {
 		if apierrs.IsNotFound(err) {
 			return false, nil
 		}
@@ -81,8 +82,8 @@ func scaleDownDeployment(clients *test.Clients, name string) error {
 func scaleDeployment(clients *test.Clients, name string, replicas int) error {
 	scaleRequest := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: int32(replicas)}}
 	scaleRequest.Name = name
-	scaleRequest.Namespace = test.ServingFlags.SystemNamespace
-	if _, err := clients.KubeClient.Kube.AppsV1().Deployments(test.ServingFlags.SystemNamespace).UpdateScale(name, scaleRequest); err != nil {
+	scaleRequest.Namespace = servingNamespace
+	if _, err := clients.KubeClient.Kube.AppsV1().Deployments(servingNamespace).UpdateScale(name, scaleRequest); err != nil {
 		return fmt.Errorf("error scaling: %w", err)
 	}
 	return pkgTest.WaitForDeploymentState(
@@ -92,7 +93,7 @@ func scaleDeployment(clients *test.Clients, name string, replicas int) error {
 			return d.Status.ReadyReplicas == int32(replicas), nil
 		},
 		"DeploymentIsScaled",
-		test.ServingFlags.SystemNamespace,
+		servingNamespace,
 		time.Minute,
 	)
 }

--- a/test/performance/benchmarks/dataplane-probe/continuous/main.go
+++ b/test/performance/benchmarks/dataplane-probe/continuous/main.go
@@ -25,8 +25,8 @@ import (
 	vegeta "github.com/tsenart/vegeta/lib"
 
 	"knative.dev/pkg/signals"
+	"knative.dev/pkg/system"
 	"knative.dev/pkg/test/mako"
-	"knative.dev/serving/test"
 	"knative.dev/serving/test/performance"
 	"knative.dev/serving/test/performance/metrics"
 )
@@ -97,7 +97,7 @@ func main() {
 
 	// Start the attack!
 	results := attacker.Attack(targeter, rate, *duration, "load-test")
-	deploymentStatus := metrics.FetchDeploymentStatus(ctx, test.ServingFlags.SystemNamespace, "activator", time.Second)
+	deploymentStatus := metrics.FetchDeploymentStatus(ctx, system.Namespace(), "activator", time.Second)
 LOOP:
 	for {
 		select {

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -22,7 +22,6 @@
 export BENCHMARK_ROOT_PATH="$GOPATH/src/knative.dev/serving/test/performance/benchmarks"
 
 source vendor/knative.dev/test-infra/scripts/performance-tests.sh
-source $(dirname $0)/../e2e-common.sh
 
 function update_knative() {
   local istio_version="istio-1.4-latest"
@@ -59,11 +58,11 @@ function update_knative() {
   popd
 
   # Update the activator hpa minReplicas to 10
-  kubectl patch hpa -n ${E2E_SYSTEM_NAMESPACE} activator \
+  kubectl patch hpa -n knative-serving activator \
     --patch '{"spec": {"minReplicas": 10}}'
   # Update the scale-to-zero grace period to 10s
   kubectl patch configmap/config-autoscaler \
-    -n ${E2E_SYSTEM_NAMESPACE} \
+    -n knative-serving \
     --type merge \
     -p '{"data":{"scale-to-zero-grace-period":"10s"}}'
 

--- a/test/system.go
+++ b/test/system.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"os"
+
+	"knative.dev/pkg/system"
+)
+
+func init() {
+	os.Setenv(system.NamespaceEnvKey, "knative-serving")
+}


### PR DESCRIPTION
This reverts commit da2199a988baa87a11658768ec8b95fff90e73ec.

Currently all CI are broken like no-mesh, mesh, https, - e.g. https://testgrid.knative.dev/serving#istio-1.4-mesh

Even istio-1.4-no-mesh reports `Knative setup failed` in the [test log](https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-istio-1.4-no-mesh/1243061199587774464). 
It seems that no-mesh tests fail to run TestAutoTLS* tests.
