### PR TITLE
Network config sanitization

### DIFF
--- a/pkg/apis/config/defaults.go
+++ b/pkg/apis/config/defaults.go
@@ -90,11 +90,11 @@ func NewDefaultsConfigFromMap(data map[string]string) (*Defaults, error) {
 		field: &nc.ContainerConcurrencyMaxLimit,
 	}} {
 		if raw, ok := data[i64.key]; ok {
-			if val, err := strconv.ParseInt(raw, 10, 64); err != nil {
+			val, err := strconv.ParseInt(raw, 10, 64)
+			if err != nil {
 				return nil, err
-			} else {
-				*i64.field = val
 			}
+			*i64.field = val
 		}
 	}
 


### PR DESCRIPTION
1. Use defaultConfig object to remove spread out defaulting
2. Update tests to use it.
3. Verify EXAMPLE stanza matches defaults.
4. remove redundancy in test declarations

/assign @tcnghia 


/lint
