### PR TITLE
Add logging to see the bad cert

### DIFF
--- a/test/conformance/certificate/nonhttp01/certificate_test.go
+++ b/test/conformance/certificate/nonhttp01/certificate_test.go
@@ -33,8 +33,8 @@ func TestSecret(t *testing.T) {
 	cert, cancel := utils.CreateCertificate(t, clients, []string{certName})
 	defer cancel()
 
-	err := utils.WaitForCertificateSecret(clients, cert, t.Name())
+	err := utils.WaitForCertificateSecret(t, clients, cert, t.Name())
 	if err != nil {
-		t.Fatalf("failed to wait for secret: %v", err)
+		t.Errorf("Failed to wait for secret: %v", err)
 	}
 }

--- a/test/conformance/certificate/utils.go
+++ b/test/conformance/certificate/utils.go
@@ -72,7 +72,7 @@ func CreateCertificate(t *testing.T, clients *test.Clients, dnsNames []string) (
 
 // WaitForCertificateSecret polls the status of the Secret for the provided Certificate
 // until it exists or the timeout is exceeded. It then validates its contents
-func WaitForCertificateSecret(client *test.Clients, cert *v1alpha1.Certificate, desc string) error {
+func WaitForCertificateSecret(t *testing.T, client *test.Clients, cert *v1alpha1.Certificate, desc string) error {
 	span := logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForCertificateSecret/%s/%s", cert.Spec.SecretName, desc))
 	defer span.End()
 
@@ -87,6 +87,8 @@ func WaitForCertificateSecret(client *test.Clients, cert *v1alpha1.Certificate, 
 
 		block, _ := pem.Decode(secret.Data[corev1.TLSCertKey])
 		if block == nil {
+			// PEM files are text, so just dump it here.
+			t.Logf("Bad PEM file:\n%s", secret.Data[corev1.TLSCertKey])
 			return true, errors.New("failed to decode PEM data")
 		}
 


### PR DESCRIPTION
See the failure here: https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/7395/pull-knative-serving-integration-tests/1243265042716037120
Impossible to debug without knowing what was the returned cert

/assign mattmoor, @tcnghia 