### PR TITLE
[DO NOT REVIEW] Collect log from e2e https failure

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -155,6 +155,8 @@ function delete_dns_record() {
 
 # Script entry point.
 
+exit 0
+
 # Skip installing istio as an add-on
 initialize $@ --skip-istio-addon
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -50,6 +50,7 @@ use_https=""
 
 if (( HTTPS )); then
   use_https="--https"
+  parallelism="-parallel 1"
   turn_on_auto_tls
   kubectl apply -f ./test/config/autotls/certmanager/caissuer/
   add_trap "kubectl delete -f ./test/config/autotls/certmanager/caissuer/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT

--- a/third_party/net-istio.yaml
+++ b/third_party/net-istio.yaml
@@ -311,9 +311,9 @@ spec:
           requests:
             cpu: 30m
             memory: 40Mi
-          limits:
-            cpu: 300m
-            memory: 400Mi
+#          limits:
+#            cpu: 300m
+#            memory: 400Mi
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -383,9 +383,9 @@ spec:
           requests:
             cpu: 20m
             memory: 20Mi
-          limits:
-            cpu: 200m
-            memory: 200Mi
+#          limits:
+#            cpu: 200m
+#            memory: 200Mi
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/third_party/net-istio.yaml
+++ b/third_party/net-istio.yaml
@@ -311,9 +311,9 @@ spec:
           requests:
             cpu: 30m
             memory: 40Mi
-#          limits:
-#            cpu: 300m
-#            memory: 400Mi
+          limits:
+            cpu: 300m
+            memory: 400Mi
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -383,9 +383,9 @@ spec:
           requests:
             cpu: 20m
             memory: 20Mi
-#          limits:
-#            cpu: 200m
-#            memory: 200Mi
+          limits:
+            cpu: 200m
+            memory: 200Mi
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:


### PR DESCRIPTION
Current e2e test's log is only from e2e-auto-tls-tests.sh,
not e2e-test.sh due to https://github.com/knative/test-infra/issues/1859.

This PR is to collect http2 failure logs.

/hold
