### PR TITLE
Add parallel 1 option back in https tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -50,6 +50,8 @@ use_https=""
 
 if (( HTTPS )); then
   use_https="--https"
+  # TODO: parallel 1 is necessary until https://github.com/knative/serving/issues/7406 is solved.
+  parallelism="-parallel 1"
   turn_on_auto_tls
   kubectl apply -f ./test/config/autotls/certmanager/caissuer/
   add_trap "kubectl delete -f ./test/config/autotls/certmanager/caissuer/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT


### PR DESCRIPTION
## Proposed Changes

Although https://github.com/knative/serving/pull/7368 removed the option,
https tests became [flaky](https://testgrid.knative.dev/serving#https) after removing it.

This patch adds the option to https tests again. 
(opened the issue to track to enable it again https://github.com/knative/serving/issues/7406)

**Release Note**

```release-note
NONE
```
