### PR TITLE
Update to KPA/HPA to set number of activators on SKS objects 

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -37,7 +37,7 @@ import (
 )
 
 // The minimum number of activators a revision will get.
-const minActivators = 2
+const MinActivators = 2
 
 // Autoscaler stores current state of an instance of an autoscaler.
 type Autoscaler struct {
@@ -137,7 +137,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount,
 	// If the error is NotFound, then presume 0.
 	if err != nil && !apierrors.IsNotFound(err) {
 		logger.Errorw("Failed to get Endpoints via K8S Lister", zap.Error(err))
-		return 0, 0, minActivators, false
+		return 0, 0, MinActivators, false
 	}
 	// Use 1 if there are zero current pods.
 	readyPodsCount := math.Max(1, float64(originalReadyPodsCount))
@@ -167,7 +167,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount,
 		} else {
 			logger.Errorw("Failed to obtain metrics", zap.Error(err))
 		}
-		return 0, 0, minActivators, false
+		return 0, 0, MinActivators, false
 	}
 
 	// Make sure we don't get stuck with the same number of pods, if the scale up rate
@@ -242,7 +242,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount,
 	//   With default target utilization of 0.7, we're overprovisioning number of needed activators
 	//   by rate of 1/0.7=1.42.
 	excessBCF := -1.
-	numAct = minActivators
+	numAct = MinActivators
 	switch {
 	case a.deciderSpec.TargetBurstCapacity == 0:
 		excessBCF = 0
@@ -251,10 +251,10 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) (desiredPodCount,
 		totCap := float64(originalReadyPodsCount) * a.deciderSpec.TotalValue
 		excessBCF = math.Floor(totCap - observedStableValue -
 			a.deciderSpec.TargetBurstCapacity)
-		numAct = int32(math.Max(minActivators,
+		numAct = int32(math.Max(MinActivators,
 			math.Ceil((totCap+a.deciderSpec.TargetBurstCapacity)/a.deciderSpec.ActivatorCapacity)))
 	case a.deciderSpec.TargetBurstCapacity == -1:
-		numAct = int32(math.Max(minActivators,
+		numAct = int32(math.Max(MinActivators,
 			math.Ceil(float64(originalReadyPodsCount)*a.deciderSpec.TotalValue/a.deciderSpec.ActivatorCapacity)))
 	}
 	logger.Debugf("PodCount=%v Total1PodCapacity=%v ObsStableValue=%v ObsPanicValue=%v TargetBC=%v ExcessBC=%v NumActivators=%d",

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -62,7 +62,7 @@ func TestAutoscalerNoDataNoAutoscale(t *testing.T) {
 	}
 
 	a := newTestAutoscaler(t, 10, 100, metrics)
-	a.expectScale(t, time.Now(), 0, 0, minActivators, false)
+	a.expectScale(t, time.Now(), 0, 0, MinActivators, false)
 }
 
 func expectedEBC(totCap, targetBC, recordedConcurrency, numPods float64) int32 {
@@ -70,7 +70,7 @@ func expectedEBC(totCap, targetBC, recordedConcurrency, numPods float64) int32 {
 }
 
 func expectedNA(a *Autoscaler, numP float64) int32 {
-	return int32(math.Max(minActivators,
+	return int32(math.Max(MinActivators,
 		math.Ceil(
 			(a.deciderSpec.TotalValue*numP+a.deciderSpec.TargetBurstCapacity)/a.deciderSpec.ActivatorCapacity)))
 }
@@ -382,12 +382,12 @@ func TestAutoscalerUseOnePodAsMinimumIfEndpointsNotFound(t *testing.T) {
 	fake.Endpoints(0, fake.TestService)
 	// 2*10 as the rate limited if we can get the actual pods number.
 	// 1*10 as the rate limited since no read pods are there from K8S API.
-	a.expectScale(t, time.Now(), 10, expectedEBC(10, 81, 1000, 0), minActivators, true)
+	a.expectScale(t, time.Now(), 10, expectedEBC(10, 81, 1000, 0), MinActivators, true)
 
 	eraseEndpoints()
 	// 2*10 as the rate limited if we can get the actual pods number.
 	// 1*10 as the rate limited since no Endpoints object is there from K8S API.
-	a.expectScale(t, time.Now(), 10, expectedEBC(10, 81, 1000, 0), minActivators, true)
+	a.expectScale(t, time.Now(), 10, expectedEBC(10, 81, 1000, 0), MinActivators, true)
 }
 
 func TestAutoscalerUpdateTarget(t *testing.T) {

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -30,7 +30,6 @@ import (
 	"knative.dev/serving/pkg/apis/autoscaling"
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	nv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
-	"knative.dev/serving/pkg/autoscaler/scaling"
 	pareconciler "knative.dev/serving/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler"
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
@@ -84,8 +83,8 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 		}
 	}
 
-	// TODO: determine real number of activators to use here.
-	sks, err := c.ReconcileSKS(ctx, pa, nv1alpha1.SKSOperationModeServe, scaling.MinActivators)
+	// 0 num activators will work as "all".
+	sks, err := c.ReconcileSKS(ctx, pa, nv1alpha1.SKSOperationModeServe, 0 /*numActivators*/)
 	if err != nil {
 		return fmt.Errorf("error reconciling SKS: %w", err)
 	}

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -84,7 +84,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 		}
 	}
 
-	// TODO: determine real number of activators here.
+	// TODO: determine real number of activators to use here.
 	sks, err := c.ReconcileSKS(ctx, pa, nv1alpha1.SKSOperationModeServe, scaling.MinActivators)
 	if err != nil {
 		return fmt.Errorf("error reconciling SKS: %w", err)

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -30,6 +30,7 @@ import (
 	"knative.dev/serving/pkg/apis/autoscaling"
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	nv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/autoscaler/scaling"
 	pareconciler "knative.dev/serving/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler"
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
@@ -83,7 +84,8 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 		}
 	}
 
-	sks, err := c.ReconcileSKS(ctx, pa, nv1alpha1.SKSOperationModeServe)
+	// TODO: determine real number of activators here.
+	sks, err := c.ReconcileSKS(ctx, pa, nv1alpha1.SKSOperationModeServe, scaling.MinActivators)
 	if err != nil {
 		return fmt.Errorf("error reconciling SKS: %w", err)
 	}

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -55,7 +55,6 @@ import (
 	nv1a1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
-	"knative.dev/serving/pkg/autoscaler/scaling"
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
 	"knative.dev/serving/pkg/reconciler/autoscaling/hpa/resources"
@@ -385,7 +384,7 @@ func TestReconcile(t *testing.T) {
 			pa(testNamespace, testRevision, WithHPAClass, WithTraffic, withScales(0, 0),
 				WithPAStatusService(testRevision), WithTargetAnnotation("1")),
 			hpa(pa(testNamespace, testRevision, WithHPAClass, WithMetricAnnotation("cpu"))),
-			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady, WithNumActivators(2)),
+			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady, WithNumActivators(0)),
 			deploy(testNamespace, testRevision),
 		},
 		Key: key(testNamespace, testRevision),
@@ -406,7 +405,7 @@ func TestReconcile(t *testing.T) {
 				WithPAStatusService(testRevision), WithPAMetricsService(privateSvc), WithTargetAnnotation("1")),
 			hpa(pa(testNamespace, testRevision, WithHPAClass, WithMetricAnnotation("cpu"))),
 			deploy(testNamespace, testRevision),
-			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady, WithNumActivators(2)),
+			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady, WithNumActivators(0)),
 		},
 		Key: key(testNamespace, testRevision),
 		WantUpdates: []ktesting.UpdateActionImpl{{
@@ -467,7 +466,7 @@ func TestReconcile(t *testing.T) {
 
 func sks(ns, n string, so ...SKSOption) *nv1a1.ServerlessService {
 	hpa := pa(ns, n, WithHPAClass)
-	s := aresources.MakeSKS(hpa, nv1a1.SKSOperationModeServe, scaling.MinActivators)
+	s := aresources.MakeSKS(hpa, nv1a1.SKSOperationModeServe, 0)
 	for _, opt := range so {
 		opt(s)
 	}

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -385,7 +385,7 @@ func TestReconcile(t *testing.T) {
 			pa(testNamespace, testRevision, WithHPAClass, WithTraffic, withScales(0, 0),
 				WithPAStatusService(testRevision), WithTargetAnnotation("1")),
 			hpa(pa(testNamespace, testRevision, WithHPAClass, WithMetricAnnotation("cpu"))),
-			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
+			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady, WithNumActivators(2)),
 			deploy(testNamespace, testRevision),
 		},
 		Key: key(testNamespace, testRevision),
@@ -406,7 +406,7 @@ func TestReconcile(t *testing.T) {
 				WithPAStatusService(testRevision), WithPAMetricsService(privateSvc), WithTargetAnnotation("1")),
 			hpa(pa(testNamespace, testRevision, WithHPAClass, WithMetricAnnotation("cpu"))),
 			deploy(testNamespace, testRevision),
-			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
+			sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady, WithNumActivators(2)),
 		},
 		Key: key(testNamespace, testRevision),
 		WantUpdates: []ktesting.UpdateActionImpl{{
@@ -486,7 +486,7 @@ func pa(namespace, name string, options ...PodAutoscalerOption) *asv1a1.PodAutos
 		},
 		Spec: asv1a1.PodAutoscalerSpec{
 			ScaleTargetRef: corev1.ObjectReference{
-				APIVersion: "apps/v2",
+				APIVersion: "apps/v1",
 				Kind:       "Deployment",
 				Name:       name + "-deployment",
 			},

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -55,6 +55,7 @@ import (
 	nv1a1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
+	"knative.dev/serving/pkg/autoscaler/scaling"
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
 	"knative.dev/serving/pkg/reconciler/autoscaling/hpa/resources"
@@ -466,7 +467,7 @@ func TestReconcile(t *testing.T) {
 
 func sks(ns, n string, so ...SKSOption) *nv1a1.ServerlessService {
 	hpa := pa(ns, n, WithHPAClass)
-	s := aresources.MakeSKS(hpa, nv1a1.SKSOperationModeServe)
+	s := aresources.MakeSKS(hpa, nv1a1.SKSOperationModeServe, scaling.MinActivators)
 	for _, opt := range so {
 		opt(s)
 	}
@@ -485,7 +486,7 @@ func pa(namespace, name string, options ...PodAutoscalerOption) *asv1a1.PodAutos
 		},
 		Spec: asv1a1.PodAutoscalerSpec{
 			ScaleTargetRef: corev1.ObjectReference{
-				APIVersion: "apps/v1",
+				APIVersion: "apps/v2",
 				Kind:       "Deployment",
 				Name:       name + "-deployment",
 			},

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -129,6 +129,11 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 		mode = nv1alpha1.SKSOperationModeProxy
 	}
 
+	// If we arrive here before first successful run of Scale has completed.
+	na := decider.Status.NumActivators
+	if na == 0 {
+		na = scaling.MinActivators
+	}
 	sks, err = c.ReconcileSKS(ctx, pa, mode, decider.Status.NumActivators)
 	if err != nil {
 		return fmt.Errorf("error reconciling SKS: %w", err)

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -129,6 +129,8 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 		mode = nv1alpha1.SKSOperationModeProxy
 	}
 
+	// If we have not successfully reconciled Decider yet, NumActivators will be 0 and
+	// we'll use all activators to back this revision.
 	sks, err = c.ReconcileSKS(ctx, pa, mode, decider.Status.NumActivators)
 	if err != nil {
 		return fmt.Errorf("error reconciling SKS: %w", err)

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -129,11 +129,6 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 		mode = nv1alpha1.SKSOperationModeProxy
 	}
 
-	// If we arrive here before first successful run of Scale has completed.
-	na := decider.Status.NumActivators
-	if na == 0 {
-		na = scaling.MinActivators
-	}
 	sks, err = c.ReconcileSKS(ctx, pa, mode, decider.Status.NumActivators)
 	if err != nil {
 		return fmt.Errorf("error reconciling SKS: %w", err)

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -92,7 +92,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 	if sks == nil || (sks != nil && sks.Status.PrivateServiceName == "") {
 		// Before we can reconcile decider and get real number of activators
 		// we start with default of 2.
-		if _, err = c.ReconcileSKS(ctx, pa, nv1alpha1.SKSOperationModeServe, scaling.MinActivators); err != nil {
+		if _, err = c.ReconcileSKS(ctx, pa, nv1alpha1.SKSOperationModeServe, 0 /*numActivators == all*/); err != nil {
 			return fmt.Errorf("error reconciling SKS: %w", err)
 		}
 		return computeStatus(pa, podCounts{want: scaleUnknown})

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -147,12 +147,6 @@ func metric(ns, n string, opts ...metricOption) *asv1a1.Metric {
 	return m
 }
 
-func withNumActivators(n int32) SKSOption {
-	return func(sks *nv1a1.ServerlessService) {
-		sks.Spec.NumActivators = n
-	}
-}
-
 func sks(ns, n string, so ...SKSOption) *nv1a1.ServerlessService {
 	kpa := kpa(ns, n)
 	s := aresources.MakeSKS(kpa, nv1a1.SKSOperationModeServe, scaling.MinActivators)
@@ -928,13 +922,13 @@ func TestReconcile(t *testing.T) {
 			kpa(testNamespace, testRevision, markActive, WithPAMetricsService(privateSvc),
 				withScales(1, defaultScale), WithPAStatusService(testRevision)),
 			sks(testNamespace, testRevision, WithDeployRef(deployName),
-				WithProxyMode, WithSKSReady, withNumActivators(4)),
+				WithProxyMode, WithSKSReady, WithNumActivators(4)),
 			metric(testNamespace, testRevision),
 			defaultDeployment, defaultEndpoints,
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: sks(testNamespace, testRevision, WithDeployRef(deployName),
-				WithProxyMode, WithSKSReady, withNumActivators(1982)),
+				WithProxyMode, WithSKSReady, WithNumActivators(1982)),
 		}},
 	}, {
 		Name: "traffic increased, no longer enough burst capacity",

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -917,7 +917,7 @@ func TestReconcile(t *testing.T) {
 		Key:  key,
 		Ctx: context.WithValue(context.Background(), deciderKey,
 			decider(testNamespace, testRevision, defaultScale, /* desiredScale */
-				-42 /* ebc */, 1982)),
+				-42 /* ebc */, 1982 /*numActivators*/)),
 		Objects: []runtime.Object{
 			kpa(testNamespace, testRevision, markActive, WithPAMetricsService(privateSvc),
 				withScales(1, defaultScale), WithPAStatusService(testRevision)),

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/logging"
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
@@ -74,7 +73,6 @@ func (c *Base) ReconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler,
 			want := sks.DeepCopy()
 			want.Spec = tmpl.Spec
 			logger.Infof("SKS %s changed; reconciling, want mode: %v", sksName, want.Spec.Mode)
-			logger.Debugf("Diff: %s", cmp.Diff(tmpl.Spec, sks.Spec))
 			if sks, err = c.Client.NetworkingV1alpha1().ServerlessServices(sks.Namespace).Update(want); err != nil {
 				return nil, fmt.Errorf("error updating SKS %s: %w", sksName, err)
 			}

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/go-cmp/cmp"
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/logging"
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
@@ -73,6 +74,7 @@ func (c *Base) ReconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler,
 			want := sks.DeepCopy()
 			want.Spec = tmpl.Spec
 			logger.Infof("SKS %s changed; reconciling, want mode: %v", sksName, want.Spec.Mode)
+			logger.Debugf("Diff: %s", cmp.Diff(tmpl.Spec, sks.Spec))
 			if sks, err = c.Client.NetworkingV1alpha1().ServerlessServices(sks.Namespace).Update(want); err != nil {
 				return nil, fmt.Errorf("error updating SKS %s: %w", sksName, err)
 			}

--- a/pkg/reconciler/autoscaling/resources/sks.go
+++ b/pkg/reconciler/autoscaling/resources/sks.go
@@ -26,7 +26,7 @@ import (
 )
 
 // MakeSKS makes an SKS resource from the PA and operation mode.
-func MakeSKS(pa *pav1alpha1.PodAutoscaler, mode nv1a1.ServerlessServiceOperationMode) *nv1a1.ServerlessService {
+func MakeSKS(pa *pav1alpha1.PodAutoscaler, mode nv1a1.ServerlessServiceOperationMode, numActivators int32) *nv1a1.ServerlessService {
 	return &nv1a1.ServerlessService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.SKS(pa.Name),
@@ -38,9 +38,10 @@ func MakeSKS(pa *pav1alpha1.PodAutoscaler, mode nv1a1.ServerlessServiceOperation
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(pa)},
 		},
 		Spec: nv1a1.ServerlessServiceSpec{
-			Mode:         mode,
-			ObjectRef:    pa.Spec.ScaleTargetRef,
-			ProtocolType: pa.Spec.ProtocolType,
+			Mode:          mode,
+			ObjectRef:     pa.Spec.ScaleTargetRef,
+			ProtocolType:  pa.Spec.ProtocolType,
+			NumActivators: numActivators,
 		},
 	}
 }

--- a/pkg/reconciler/autoscaling/resources/sks_test.go
+++ b/pkg/reconciler/autoscaling/resources/sks_test.go
@@ -56,6 +56,7 @@ func TestMakeSKS(t *testing.T) {
 	}
 
 	const mode = nv1a1.SKSOperationModeServe
+	const na = int32(42)
 
 	want := &nv1a1.ServerlessService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -79,8 +80,9 @@ func TestMakeSKS(t *testing.T) {
 			}},
 		},
 		Spec: nv1a1.ServerlessServiceSpec{
-			ProtocolType: networking.ProtocolHTTP1,
-			Mode:         nv1a1.SKSOperationModeServe,
+			ProtocolType:  networking.ProtocolHTTP1,
+			Mode:          nv1a1.SKSOperationModeServe,
+			NumActivators: 42,
 			ObjectRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
@@ -88,7 +90,7 @@ func TestMakeSKS(t *testing.T) {
 			},
 		},
 	}
-	if got, want := MakeSKS(pa, mode), want; !cmp.Equal(got, want) {
+	if got, want := MakeSKS(pa, mode, na), want; !cmp.Equal(got, want) {
 		t.Errorf("MakeSKS = %#v, want: %#v, diff: %s", got, want, cmp.Diff(got, want))
 	}
 }

--- a/pkg/reconciler/autoscaling/resources/sks_test.go
+++ b/pkg/reconciler/autoscaling/resources/sks_test.go
@@ -82,7 +82,7 @@ func TestMakeSKS(t *testing.T) {
 		Spec: nv1a1.ServerlessServiceSpec{
 			ProtocolType:  networking.ProtocolHTTP1,
 			Mode:          nv1a1.SKSOperationModeServe,
-			NumActivators: 42,
+			NumActivators: na,
 			ObjectRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -337,6 +337,14 @@ func WithSKSReady(sks *netv1alpha1.ServerlessService) {
 	sks.Status.MarkEndpointsReady()
 }
 
+// WithNumActivators sets the number of requested activators
+// on the SKS spec.
+func WithNumActivators(n int32) SKSOption {
+	return func(sks *netv1alpha1.ServerlessService) {
+		sks.Spec.NumActivators = n
+	}
+}
+
 // WithPrivateService annotates SKS status with the private service name.
 func WithPrivateService(sks *netv1alpha1.ServerlessService) {
 	sks.Status.PrivateServiceName = kmeta.ChildName(sks.Name, "-private")


### PR DESCRIPTION
This is mostly done in KPA, since HPA does not use deciders
There a default number of 2 is passed.
/lint
For #7022 

/assign mattmoor @markusthoemmes 