### PR TITLE
Change metrics scraping based on TBC 

### DIFF
--- a/pkg/autoscaler/metrics/collector.go
+++ b/pkg/autoscaler/metrics/collector.go
@@ -195,7 +195,7 @@ func (c *MetricCollector) StableAndPanicConcurrency(key types.NamespacedName, no
 	}
 
 	s, p, noData := collection.stableAndPanicConcurrency(now)
-	if noData {
+	if noData && collection.currentMetric().Spec.ScrapeTarget != "" {
 		return 0, 0, ErrNoData
 	}
 	return s, p, nil
@@ -213,7 +213,7 @@ func (c *MetricCollector) StableAndPanicRPS(key types.NamespacedName, now time.T
 	}
 
 	s, p, noData := collection.stableAndPanicRPS(now)
-	if noData {
+	if noData && collection.currentMetric().Spec.ScrapeTarget != "" {
 		return 0, 0, ErrNoData
 	}
 	return s, p, nil

--- a/pkg/autoscaler/metrics/collector.go
+++ b/pkg/autoscaler/metrics/collector.go
@@ -279,11 +279,12 @@ func newCollection(metric *av1alpha1.Metric, scraper StatsScraper, tickFactory f
 				scrapeTicker.Stop()
 				return
 			case <-scrapeTicker.C:
-				if c.metric.Spec.ScrapeTarget == "" {
-					// don't scrape empty target service
+				currentMetric := c.currentMetric()
+				if currentMetric.Spec.ScrapeTarget == "" {
+					// Don't scrape empty target service.
 					continue
 				}
-				stat, err := c.getScraper().Scrape(c.currentMetric().Spec.StableWindow)
+				stat, err := c.getScraper().Scrape(currentMetric.Spec.StableWindow)
 				if err != nil {
 					copy := metric.DeepCopy()
 					switch {

--- a/pkg/autoscaler/metrics/collector.go
+++ b/pkg/autoscaler/metrics/collector.go
@@ -279,6 +279,10 @@ func newCollection(metric *av1alpha1.Metric, scraper StatsScraper, tickFactory f
 				scrapeTicker.Stop()
 				return
 			case <-scrapeTicker.C:
+				if c.metric.Spec.ScrapeTarget == "" {
+					// don't scrape empty target service
+					continue
+				}
 				stat, err := c.getScraper().Scrape(c.currentMetric().Spec.StableWindow)
 				if err != nil {
 					copy := metric.DeepCopy()

--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -253,12 +253,6 @@ func TestMetricCollectorNoScraper(t *testing.T) {
 	mtp.Channel <- now
 	mtp.Channel <- now
 
-	wait.PollImmediate(10*time.Millisecond, 100*time.Millisecond, func() (bool, error) {
-		_, _, errCon := coll.StableAndPanicConcurrency(metricKey, now)
-		_, _, errRPS := coll.StableAndPanicRPS(metricKey, now)
-		return errRPS == nil && errCon == nil, nil
-	})
-
 	gotConcurrency, panicConcurrency, errCon := coll.StableAndPanicConcurrency(metricKey, now)
 	gotRPS, panicRPS, errRPS := coll.StableAndPanicRPS(metricKey, now)
 	if errCon != nil {

--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -208,6 +208,72 @@ func TestMetricCollectorScraper(t *testing.T) {
 	}
 }
 
+func TestMetricCollectorNoScraper(t *testing.T) {
+	logger := TestLogger(t)
+
+	mtp := &fake.ManualTickProvider{
+		Channel: make(chan time.Time),
+	}
+	now := time.Now()
+	metricKey := types.NamespacedName{Namespace: defaultNamespace, Name: defaultName}
+	const (
+		reportConcurrency = 0.0
+		reportRPS         = 0.0
+		wantConcurrency   = 0.0
+		wantRPS           = 0.0
+		wantPConcurrency  = 0.0
+		wantPRPS          = 0.0
+	)
+	stat := Stat{
+		Time:                      now,
+		PodName:                   "testPod",
+		AverageConcurrentRequests: reportConcurrency,
+		RequestCount:              reportRPS,
+	}
+	scraper := &testScraper{
+		s: func() (Stat, error) {
+			return stat, nil
+		},
+	}
+	factory := scraperFactory(scraper, nil)
+
+	coll := NewMetricCollector(factory, logger)
+	coll.tickProvider = mtp.NewTicker // custom ticker.
+
+	noTargetMetric := defaultMetric
+	noTargetMetric.Spec.ScrapeTarget = ""
+	coll.CreateOrUpdate(&noTargetMetric)
+
+	// Tick three times.  Time doesn't matter since we use the time on the Stat.
+	mtp.Channel <- now
+	mtp.Channel <- now
+	mtp.Channel <- now
+
+	wait.PollImmediate(10*time.Millisecond, 100*time.Millisecond, func() (bool, error) {
+		_, _, errCon := coll.StableAndPanicConcurrency(metricKey, now)
+		_, _, errRPS := coll.StableAndPanicRPS(metricKey, now)
+		return errRPS == ErrNoData && errCon == errRPS, nil
+	})
+
+	gotConcurrency, panicConcurrency, _ := coll.StableAndPanicConcurrency(metricKey, now)
+	gotRPS, panicRPS, noData := coll.StableAndPanicRPS(metricKey, now)
+	if noData != ErrNoData {
+		t.Errorf("StableAndPanicRPS = %v", noData)
+	}
+	if panicConcurrency != wantPConcurrency {
+		t.Errorf("PanicConcurrency() = %v, want %v", panicConcurrency, wantPConcurrency)
+	}
+	if panicRPS != wantPRPS {
+		t.Errorf("PanicRPS() = %v, want %v", panicRPS, wantPRPS)
+	}
+	if gotConcurrency != wantConcurrency {
+		t.Errorf("StableConcurrency() = %v, want %v", gotConcurrency, wantConcurrency)
+	}
+	if gotRPS != wantRPS {
+		t.Errorf("StableRPS() = %v, want %v", gotRPS, wantRPS)
+	}
+}
+
 func TestMetricCollectorRecord(t *testing.T) {
 	logger := TestLogger(t)
 

--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -249,9 +249,9 @@ func TestMetricCollectorNoScraper(t *testing.T) {
 	})
 
 	gotConcurrency, panicConcurrency, _ := coll.StableAndPanicConcurrency(metricKey, now)
-	gotRPS, panicRPS, noData := coll.StableAndPanicRPS(metricKey, now)
-	if noData != ErrNoData {
-		t.Errorf("StableAndPanicRPS = %v", noData)
+	gotRPS, panicRPS, err := coll.StableAndPanicRPS(metricKey, now)
+	if err != nil {
+		t.Errorf("StableAndPanicRPS = %v", err)
 	}
 	if panicConcurrency != wantStat {
 		t.Errorf("PanicConcurrency() = %v, want %v", panicConcurrency, wantStat)
@@ -277,7 +277,7 @@ func TestMetricCollectorNoScraper(t *testing.T) {
 	coll.Record(metricKey, stat)
 
 	gotConcurrency, _, _ = coll.StableAndPanicConcurrency(metricKey, now)
-	gotRPS, _, err := coll.StableAndPanicRPS(metricKey, now)
+	gotRPS, _, err = coll.StableAndPanicRPS(metricKey, now)
 	if err != nil {
 		t.Errorf("StableAndPanicRPS = %v", err)
 	}

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -102,7 +102,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 		return fmt.Errorf("error reconciling Decider: %w", err)
 	}
 
-	if err := c.ReconcileMetric(ctx, pa, resolveScrapeTarget(ctx, pa, pa.Status.MetricsServiceName)); err != nil {
+	if err := c.ReconcileMetric(ctx, pa, resolveScrapeTarget(ctx, pa)); err != nil {
 		return fmt.Errorf("error reconciling Metric: %w", err)
 	}
 
@@ -280,13 +280,15 @@ func activeThreshold(pa *pav1alpha1.PodAutoscaler) int {
 
 // resolveScrapeTarget returns metric service name to be scraped based on TBC configuration
 // TBC == -1 => activator in path, don't scrape the service
-func resolveScrapeTarget(ctx context.Context, pa *pav1alpha1.PodAutoscaler, metricSN string) string {
-	tbc := config.FromContext(ctx).Autoscaler.TargetBurstCapacity
+func resolveScrapeTarget(ctx context.Context, pa *pav1alpha1.PodAutoscaler) string {
+	tbc := 0.
 	if v, ok := pa.TargetBC(); ok {
 		tbc = v
+	} else {
+		tbc = config.FromContext(ctx).Autoscaler.TargetBurstCapacity
 	}
 	if tbc == -1 {
 		return ""
 	}
-	return metricSN
+	return pa.Status.MetricsServiceName
 }

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1602,27 +1602,21 @@ func TestMetricsReporter(t *testing.T) {
 }
 
 func TestResolveScrapeTarget(t *testing.T) {
-	pa := kpa(testNamespace, testRevision)
+	pa := kpa(testNamespace, testRevision, WithPAMetricsService("echo"))
 	tc := &testConfigStore{config: defaultConfig()}
 
-	want := "echo"
-	got := resolveScrapeTarget(tc.ToContext(context.Background()), pa, "echo")
-	if got != want {
-		t.Errorf("reconcileMetricSN()= %v, want %v", got, want)
+	if got, want := resolveScrapeTarget(tc.ToContext(context.Background()), pa), "echo"; got != want {
+		t.Errorf("reconcileMetricSN()= %s, want %s", got, want)
 	}
-
+	
 	tc.config.Autoscaler.TargetBurstCapacity = -1
-	want = ""
-	got = resolveScrapeTarget(tc.ToContext(context.Background()), pa, "echo")
-	if got != want {
-		t.Errorf("reconcileMetricSN()= %v, want %v", got, want)
+	if got, want := resolveScrapeTarget(tc.ToContext(context.Background()), pa), ""; got != want {
+		t.Errorf("reconcileMetricSN()= %s, want %s", got, want)
 	}
-
+	
 	tc = &testConfigStore{config: defaultConfig()}
 	pa.Annotations["autoscaling.knative.dev/targetBurstCapacity"] = "-1"
-	want = ""
-	got = resolveScrapeTarget(tc.ToContext(context.Background()), pa, "echo")
-	if got != want {
-		t.Errorf("reconcileMetricSN()= %v, want %v", got, want)
+	if got, want := resolveScrapeTarget(tc.ToContext(context.Background()), pa), ""; got != want {
+		t.Errorf("reconcileMetricSN()= %s, want %s", got, want)
 	}
 }

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1600,3 +1600,29 @@ func TestMetricsReporter(t *testing.T) {
 	metricstest.CheckLastValueData(t, "pending_pods", wantTags, 1996)
 	metricstest.CheckLastValueData(t, "terminating_pods", wantTags, 1955)
 }
+
+func TestResolveScrapeTarget(t *testing.T) {
+	pa := kpa(testNamespace, testRevision)
+	tc := &testConfigStore{config: defaultConfig()}
+
+	want := "echo"
+	got := resolveScrapeTarget(tc.ToContext(context.Background()), pa, "echo")
+	if got != want {
+		t.Errorf("reconcileMetricSN()= %v, want %v", got, want)
+	}
+
+	tc.config.Autoscaler.TargetBurstCapacity = -1
+	want = ""
+	got = resolveScrapeTarget(tc.ToContext(context.Background()), pa, "echo")
+	if got != want {
+		t.Errorf("reconcileMetricSN()= %v, want %v", got, want)
+	}
+
+	tc = &testConfigStore{config: defaultConfig()}
+	pa.Annotations["autoscaling.knative.dev/targetBurstCapacity"] = "-1"
+	want = ""
+	got = resolveScrapeTarget(tc.ToContext(context.Background()), pa, "echo")
+	if got != want {
+		t.Errorf("reconcileMetricSN()= %v, want %v", got, want)
+	}
+}

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1608,12 +1608,12 @@ func TestResolveScrapeTarget(t *testing.T) {
 	if got, want := resolveScrapeTarget(tc.ToContext(context.Background()), pa), "echo"; got != want {
 		t.Errorf("reconcileMetricSN()= %s, want %s", got, want)
 	}
-	
+
 	tc.config.Autoscaler.TargetBurstCapacity = -1
 	if got, want := resolveScrapeTarget(tc.ToContext(context.Background()), pa), ""; got != want {
 		t.Errorf("reconcileMetricSN()= %s, want %s", got, want)
 	}
-	
+
 	tc = &testConfigStore{config: defaultConfig()}
 	pa.Annotations["autoscaling.knative.dev/targetBurstCapacity"] = "-1"
 	if got, want := resolveScrapeTarget(tc.ToContext(context.Background()), pa), ""; got != want {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Related to #7324 (partially fixes)

Implement the first case:

> 1. Never scrape if TBC=-1. The activator will always be in path in this case, so we never need to scrape really.


<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add `resolveScrapeTarget` function when reconciling metrics 
* Change metrics collector to skip on empty `ScrapeTarget`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Metrics are not scraped if activator is always in path (`TargetBurstCapacity == -1`)
```

/assign @markusthoemmes 