### PR TITLE
Update 0 to be All

### DIFF
--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -258,7 +258,7 @@ func TestStats(t *testing.T) {
 				case x := <-s.statChan:
 					stats = append(stats, x...)
 				case <-time.After(time.Second):
-					t.Fatal("Timedout waiting for the event")
+					t.Fatal("Timed out waiting for the event")
 				}
 			}
 

--- a/pkg/apis/networking/v1alpha1/serverlessservice_types.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_types.go
@@ -104,6 +104,7 @@ type ServerlessServiceSpec struct {
 
 	// NumActivators contains number of Activators that this revision should be
 	// assigned.
+	// O means — assign all.
 	NumActivators int32 `json:"numActivators,omitempty"`
 }
 

--- a/pkg/apis/networking/v1alpha1/serverlessservice_validation.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_validation.go
@@ -46,12 +46,8 @@ func (spec *ServerlessServiceSpec) Validate(ctx context.Context) *apis.FieldErro
 		all = all.Also(apis.ErrInvalidValue(spec.Mode, "mode"))
 	}
 
-	switch {
-	case spec.NumActivators < 0:
+	if spec.NumActivators < 0 {
 		all = all.Also(apis.ErrInvalidValue(spec.NumActivators, "numActivators"))
-	case spec.NumActivators == 0:
-		// TODO(vagababov): stop permitting after 0.16, since this is needed only for upgrades.
-		break
 	}
 
 	all = all.Also(serving.ValidateNamespacedObjectReference(&spec.ObjectRef).ViaField("objectRef"))


### PR DESCRIPTION
After some more thinking and discussion with @markusthoemmes, we need to update
the Spec for the SKS to speficy that NumActivators 0 is a valid entry
and means 'all'.

For #7022.