### PR TITLE
Runtime conformance tests now use serving v1 APIs

### DIFF
--- a/test/apicoverage/image/common/common.go
+++ b/test/apicoverage/image/common/common.go
@@ -20,15 +20,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook/resourcesemantics"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 var (
 	ResourceMap = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
-		v1alpha1.SchemeGroupVersion.WithKind("Revision"):      &v1alpha1.Revision{},
-		v1alpha1.SchemeGroupVersion.WithKind("Configuration"): &v1alpha1.Configuration{},
-		v1alpha1.SchemeGroupVersion.WithKind("Route"):         &v1alpha1.Route{},
-		v1alpha1.SchemeGroupVersion.WithKind("Service"):       &v1alpha1.Service{},
+		v1.SchemeGroupVersion.WithKind("Revision"):      &v1.Revision{},
+		v1.SchemeGroupVersion.WithKind("Configuration"): &v1.Configuration{},
+		v1.SchemeGroupVersion.WithKind("Route"):         &v1.Route{},
+		v1.SchemeGroupVersion.WithKind("Service"):       &v1.Service{},
 	}
 	WebhookNamespace = system.Namespace()
 )

--- a/test/conformance/runtime/cgroup_test.go
+++ b/test/conformance/runtime/cgroup_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"knative.dev/serving/test"
 
-	. "knative.dev/serving/pkg/testing/v1alpha1"
+	. "knative.dev/serving/pkg/testing/v1"
 )
 
 const (

--- a/test/conformance/runtime/cmd_args_test.go
+++ b/test/conformance/runtime/cmd_args_test.go
@@ -22,13 +22,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	v1a1options "knative.dev/serving/pkg/testing/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	v1options "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 )
 
-func withCmdArgs(cmds []string, args []string) v1a1options.ServiceOption {
-	return func(s *v1alpha1.Service) {
+func withCmdArgs(cmds []string, args []string) v1options.ServiceOption {
+	return func(s *v1.Service) {
 		c := &s.Spec.Template.Spec.Containers[0]
 		c.Command = cmds
 		c.Args = args

--- a/test/conformance/runtime/container_test.go
+++ b/test/conformance/runtime/container_test.go
@@ -25,9 +25,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/pkg/ptr"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	testv1 "knative.dev/serving/test/v1"
 )
 
 // TestMustNotContainerContraints tests that attempting to set unsupported fields or invalid values as
@@ -38,17 +38,17 @@ func TestMustNotContainerConstraints(t *testing.T) {
 
 	testCases := []struct {
 		name    string
-		options func(s *v1alpha1.Service)
+		options func(s *v1.Service)
 	}{{
 		name: "TestArbitraryPortName",
-		options: func(s *v1alpha1.Service) {
+		options: func(s *v1.Service) {
 			s.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{{
 				Name: "arbitrary",
 			}}
 		},
 	}, {
 		name: "TestMountPropagation",
-		options: func(s *v1alpha1.Service) {
+		options: func(s *v1.Service) {
 			propagationMode := corev1.MountPropagationHostToContainer
 			s.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{
 				Name:             "VolumeMount",
@@ -58,7 +58,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 		},
 	}, {
 		name: "TestReadinessHTTPProbePort",
-		options: func(s *v1alpha1.Service) {
+		options: func(s *v1.Service) {
 			s.Spec.Template.Spec.Containers[0].ReadinessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
@@ -70,7 +70,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 		},
 	}, {
 		name: "TestLivenessHTTPProbePort",
-		options: func(s *v1alpha1.Service) {
+		options: func(s *v1.Service) {
 			s.Spec.Template.Spec.Containers[0].LivenessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
@@ -82,7 +82,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 		},
 	}, {
 		name: "TestReadinessTCPProbePort",
-		options: func(s *v1alpha1.Service) {
+		options: func(s *v1.Service) {
 			s.Spec.Template.Spec.Containers[0].ReadinessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(8888)},
@@ -91,7 +91,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 		},
 	}, {
 		name: "TestLivenessTCPProbePort",
-		options: func(s *v1alpha1.Service) {
+		options: func(s *v1.Service) {
 			s.Spec.Template.Spec.Containers[0].LivenessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(8888)},
@@ -108,7 +108,7 @@ func TestMustNotContainerConstraints(t *testing.T) {
 				Service: test.ObjectNameForTest(t),
 				Image:   test.Runtime,
 			}
-			if svc, err := v1a1test.CreateLatestService(t, clients, names, tc.options); err == nil {
+			if svc, err := testv1.CreateService(t, clients, names, tc.options); err == nil {
 				t.Errorf("CreateService = %v, want: error", spew.Sdump(svc))
 			}
 		})
@@ -123,10 +123,10 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 
 	testCases := []struct {
 		name    string
-		options func(s *v1alpha1.Service)
+		options func(s *v1.Service)
 	}{{
 		name: "TestPoststartHook",
-		options: func(s *v1alpha1.Service) {
+		options: func(s *v1.Service) {
 			lifecycleHandler := &corev1.ExecAction{
 				Command: []string{"/bin/sh", "-c", "echo Hello from the post start handler > /usr/share/message"},
 			}
@@ -136,7 +136,7 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 		},
 	}, {
 		name: "TestPrestopHook",
-		options: func(s *v1alpha1.Service) {
+		options: func(s *v1.Service) {
 			lifecycleHandler := &corev1.ExecAction{
 				Command: []string{"/bin/sh", "-c", "echo Hello from the pre stop handler > /usr/share/message"},
 			}
@@ -146,7 +146,7 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 		},
 	}, {
 		name: "TestMultiplePorts",
-		options: func(s *v1alpha1.Service) {
+		options: func(s *v1.Service) {
 			s.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
 				{ContainerPort: 80},
 				{ContainerPort: 81},
@@ -154,29 +154,29 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 		},
 	}, {
 		name: "TestHostPort",
-		options: func(s *v1alpha1.Service) {
+		options: func(s *v1.Service) {
 			s.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{{
 				HostPort: 80,
 			}}
 		},
 	}, {
 		name: "TestStdin",
-		options: func(s *v1alpha1.Service) {
+		options: func(s *v1.Service) {
 			s.Spec.Template.Spec.Containers[0].Stdin = true
 		},
 	}, {
 		name: "TestStdinOnce",
-		options: func(s *v1alpha1.Service) {
+		options: func(s *v1.Service) {
 			s.Spec.Template.Spec.Containers[0].StdinOnce = true
 		},
 	}, {
 		name: "TestTTY",
-		options: func(s *v1alpha1.Service) {
+		options: func(s *v1.Service) {
 			s.Spec.Template.Spec.Containers[0].TTY = true
 		},
 	}, {
 		name: "TestInvalidUID",
-		options: func(s *v1alpha1.Service) {
+		options: func(s *v1.Service) {
 			s.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
 				RunAsUser: ptr.Int64(-10),
 			}
@@ -191,7 +191,7 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 				Service: test.ObjectNameForTest(t),
 				Image:   test.Runtime,
 			}
-			if svc, err := v1a1test.CreateLatestService(t, clients, names, tc.options); err == nil {
+			if svc, err := testv1.CreateService(t, clients, names, tc.options); err == nil {
 				t.Errorf("CreateLatestService = %v, want: error", spew.Sdump(svc))
 			}
 		})

--- a/test/conformance/runtime/envpropagation_test.go
+++ b/test/conformance/runtime/envpropagation_test.go
@@ -25,7 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/serving/test"
 
-	. "knative.dev/serving/pkg/testing/v1alpha1"
+	. "knative.dev/serving/pkg/testing/v1"
 )
 
 // TestSecretsViaEnv verifies propagation of Secrets through environment variables.

--- a/test/conformance/runtime/envvars_test.go
+++ b/test/conformance/runtime/envvars_test.go
@@ -26,7 +26,7 @@ import (
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/types"
 
-	. "knative.dev/serving/pkg/testing/v1alpha1"
+	. "knative.dev/serving/pkg/testing/v1"
 )
 
 // TestShouldEnvVars verifies environment variables that are declared as "SHOULD be set" in runtime-contract

--- a/test/conformance/runtime/protocol_test.go
+++ b/test/conformance/runtime/protocol_test.go
@@ -22,13 +22,13 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	v1a1options "knative.dev/serving/pkg/testing/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	testingv1 "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 )
 
-func withPort(name string) v1a1options.ServiceOption {
-	return func(s *v1alpha1.Service) {
+func withPort(name string) testingv1.ServiceOption {
+	return func(s *v1.Service) {
 		if name != "" {
 			s.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{{Name: name}}
 		}

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -24,10 +24,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/test/logstream"
 	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
-	v1a1opts "knative.dev/serving/pkg/testing/v1alpha1"
+	v1opts "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 func TestProbeRuntime(t *testing.T) {
@@ -77,8 +77,8 @@ func TestProbeRuntime(t *testing.T) {
 			defer test.TearDown(clients, names)
 
 			t.Log("Creating a new Service")
-			resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-				v1a1opts.WithReadinessProbe(
+			resources, err := v1test.CreateServiceReady(t, clients, &names,
+				v1opts.WithReadinessProbe(
 					&corev1.Probe{
 						Handler: tc.handler,
 					}))

--- a/test/conformance/runtime/user_test.go
+++ b/test/conformance/runtime/user_test.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/serving/test"
 
-	. "knative.dev/serving/pkg/testing/v1alpha1"
+	. "knative.dev/serving/pkg/testing/v1"
 )
 
 const (

--- a/test/conformance/runtime/util.go
+++ b/test/conformance/runtime/util.go
@@ -22,12 +22,12 @@ import (
 	"testing"
 
 	pkgTest "knative.dev/pkg/test"
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/types"
-	v1a1test "knative.dev/serving/test/v1alpha1"
 
-	v1alpha1testing "knative.dev/serving/pkg/testing/v1alpha1"
+	v1testing "knative.dev/serving/pkg/testing/v1"
+	v1test "knative.dev/serving/test/v1"
 )
 
 // fetchRuntimeInfo creates a Service that uses the 'runtime' test image, and extracts the returned output into the
@@ -49,12 +49,12 @@ func fetchRuntimeInfo(
 		return nil, nil, err
 	}
 
-	serviceOpts = append(serviceOpts, func(svc *v1alpha1.Service) {
+	serviceOpts = append(serviceOpts, func(svc *v1.Service) {
 		// Always fetch the latest runtime image.
 		svc.Spec.Template.Spec.Containers[0].ImagePullPolicy = "Always"
 	})
 
-	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, names,
+	objects, err := v1test.CreateServiceReady(t, clients, names,
 		serviceOpts...)
 	if err != nil {
 		return nil, nil, err
@@ -64,7 +64,7 @@ func fetchRuntimeInfo(
 		clients.KubeClient,
 		t.Logf,
 		objects.Service.Status.URL.URL(),
-		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
+		v1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"RuntimeInfo",
 		test.ServingFlags.ResolvableDomain,
 		append(reqOpts, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))...)
@@ -77,13 +77,13 @@ func fetchRuntimeInfo(
 	return names, &ri, err
 }
 
-func splitOpts(opts ...interface{}) ([]v1alpha1testing.ServiceOption, []interface{}, error) {
-	serviceOpts := []v1alpha1testing.ServiceOption{}
+func splitOpts(opts ...interface{}) ([]v1testing.ServiceOption, []interface{}, error) {
+	serviceOpts := []v1testing.ServiceOption{}
 	reqOpts := []interface{}{}
 	for _, opt := range opts {
 		switch t := opt.(type) {
-		case v1alpha1testing.ServiceOption:
-			serviceOpts = append(serviceOpts, opt.(v1alpha1testing.ServiceOption))
+		case v1testing.ServiceOption:
+			serviceOpts = append(serviceOpts, opt.(v1testing.ServiceOption))
 		case pkgTest.RequestOption:
 			reqOpts = append(reqOpts, opt.(pkgTest.RequestOption))
 		default:

--- a/test/conformance/runtime/workingdir_test.go
+++ b/test/conformance/runtime/workingdir_test.go
@@ -21,13 +21,13 @@ package runtime
 import (
 	"testing"
 
-	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	v1a1options "knative.dev/serving/pkg/testing/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	testingv1 "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 )
 
-func withWorkingDir(wd string) v1a1options.ServiceOption {
-	return func(svc *v1alpha1.Service) {
+func withWorkingDir(wd string) testingv1.ServiceOption {
+	return func(svc *v1.Service) {
 		svc.Spec.Template.Spec.Containers[0].WorkingDir = wd
 	}
 }

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -33,9 +33,9 @@ import (
 	"golang.org/x/sync/errgroup"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
-	v1a1opts "knative.dev/serving/pkg/testing/v1alpha1"
+	v1opts "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
-	v1a1test "knative.dev/serving/test/v1alpha1"
+	v1test "knative.dev/serving/test/v1"
 	"knative.dev/test-infra/pkg/junit"
 	perf "knative.dev/test-infra/pkg/performance"
 	"knative.dev/test-infra/pkg/testgrid"
@@ -152,14 +152,14 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 	test.CleanupOnInterrupt(func() { TearDown(perfClients, names, t.Logf) })
 
 	t.Log("Creating a new Service")
-	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
-		v1a1opts.WithResourceRequirements(corev1.ResourceRequirements{
+	objs, err := v1test.CreateServiceReady(t, clients, &names,
+		v1opts.WithResourceRequirements(corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("20Mi"),
 			},
 		}),
-		v1a1opts.WithContainerConcurrency(1))
+		v1opts.WithContainerConcurrency(1))
 	if err != nil {
 		t.Fatalf("Failed to create Service: %v", err)
 	}
@@ -171,7 +171,7 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 		clients.KubeClient,
 		t.Logf,
 		baseURL,
-		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
+		v1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
 		"ObservedConcurrency",
 		test.ServingFlags.ResolvableDomain); err != nil {
 		t.Fatalf("Error probing %s: %v", baseURL, err)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Contributes to #6816

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Runtime conformance tests now use serving v1 APIs

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Runtime conformance tests now use serving v1 APIs
```
