### PR TITLE
Add tests that validate actual and example config for the leaderelection

### DIFF
--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -20,11 +20,6 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 data:
-  # An inactive but valid configuration follows; see example.
-  resourceLock: "leases"
-  leaseDuration: "15s"
-  renewDeadline: "10s"
-  retryPeriod: "2s"
   _example: |
     ################################
     #                              #

--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -20,6 +20,11 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 data:
+  # An inactive but valid configuration follows; see example.
+  resourceLock: "leases"
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
   _example: |
     ################################
     #                              #

--- a/pkg/leaderelection/config_test.go
+++ b/pkg/leaderelection/config_test.go
@@ -22,8 +22,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	. "knative.dev/pkg/configmap/testing"
 	kle "knative.dev/pkg/leaderelection"
 )
 
@@ -56,35 +60,76 @@ func TestValidateConfig(t *testing.T) {
 		data     map[string]string
 		expected *kle.Config
 		err      error
-	}{
-		{
-			name:     "OK",
-			data:     okData(),
-			expected: okConfig(),
-		},
-		{
-			name: "invalid component",
-			data: func() map[string]string {
-				data := okData()
-				data["enabledComponents"] = "controller,frobulator"
-				return data
-			}(),
-			err: errors.New(`invalid enabledComponent "frobulator": valid values are ["certcontroller" "controller" "hpaautoscaler" "istiocontroller" "nscontroller"]`),
-		},
+	}{{
+		name:     "OK",
+		data:     okData(),
+		expected: okConfig(),
+	}, {
+		name: "bad time",
+		data: func() map[string]string {
+			data := okData()
+			data["renewDeadline"] = "not a duration"
+			return data
+		}(),
+		err: errors.New(`renewDeadline: invalid duration: "not a duration"`),
+	}, {
+		name: "invalid component",
+		data: func() map[string]string {
+			data := okData()
+			data["enabledComponents"] = "controller,frobulator"
+			return data
+		}(),
+		err: errors.New(`invalid enabledComponent "frobulator": valid values are ["certcontroller" "controller" "hpaautoscaler" "istiocontroller" "nscontroller"]`),
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualConfig, actualErr := ValidateConfig(&corev1.ConfigMap{Data: tc.data})
+			if !reflect.DeepEqual(tc.err, actualErr) {
+				t.Fatalf("%v: expected error %v, got %v", tc.name, tc.err, actualErr)
+			}
+
+			if got, want := actualConfig, tc.expected; !cmp.Equal(got, want) {
+				t.Errorf("Config = %v, want: %v, diff(-want,+got):\n%s", got, want, cmp.Diff(want, got))
+			}
+		})
 	}
-
-	for i := range cases {
-		tc := cases[i]
-		actualConfig, actualErr := ValidateConfig(&corev1.ConfigMap{Data: tc.data})
-		if !reflect.DeepEqual(tc.err, actualErr) {
-			t.Errorf("%v: expected error %v, got %v", tc.name, tc.err, actualErr)
-			continue
-		}
-
-		if !reflect.DeepEqual(tc.expected, actualConfig) {
-			t.Errorf("%v: expected config:\n%+v\ngot:\n%+v", tc.name, tc.expected, actualConfig)
-			continue
-		}
+}
+func TestServingConfig(t *testing.T) {
+	actual, example := ConfigMapsFromTestFile(t, "config-leader-election",
+		"resourceLock", "leaseDuration", "renewDeadline", "retryPeriod")
+	for _, test := range []struct {
+		name string
+		data *corev1.ConfigMap
+		want *kle.Config
+	}{{
+		name: "Default config",
+		want: &kle.Config{
+			ResourceLock:  "leases",
+			LeaseDuration: 15 * time.Second,
+			RenewDeadline: 10 * time.Second,
+			RetryPeriod:   2 * time.Second,
+		},
+		data: actual,
+	}, {
+		name: "Example config",
+		want: &kle.Config{
+			ResourceLock:      "leases",
+			LeaseDuration:     15 * time.Second,
+			RenewDeadline:     10 * time.Second,
+			RetryPeriod:       2 * time.Second,
+			EnabledComponents: validComponents,
+		},
+		data: example,
+	}} {
+		t.Run(test.name, func(t *testing.T) {
+			cm, err := ValidateConfig(test.data)
+			if err != nil {
+				t.Fatalf("Error parsing config = %v", err)
+			}
+			if got, want := cm, test.want; !cmp.Equal(got, want) {
+				t.Errorf("Config mismatch: (-want,+got):\n%s", cmp.Diff(want, got))
+			}
+		})
 	}
-
 }

--- a/pkg/leaderelection/config_test.go
+++ b/pkg/leaderelection/config_test.go
@@ -96,8 +96,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 }
 func TestServingConfig(t *testing.T) {
-	actual, example := ConfigMapsFromTestFile(t, "config-leader-election",
-		"resourceLock", "leaseDuration", "renewDeadline", "retryPeriod")
+	actual, example := ConfigMapsFromTestFile(t, "config-leader-election")
 	for _, test := range []struct {
 		name string
 		data *corev1.ConfigMap

--- a/pkg/leaderelection/config_test.go
+++ b/pkg/leaderelection/config_test.go
@@ -96,7 +96,8 @@ func TestValidateConfig(t *testing.T) {
 	}
 }
 func TestServingConfig(t *testing.T) {
-	actual, example := ConfigMapsFromTestFile(t, "config-leader-election")
+	actual, example := ConfigMapsFromTestFile(t, "config-leader-election",
+		"resourceLock", "leaseDuration", "renewDeadline", "retryPeriod")
 	for _, test := range []struct {
 		name string
 		data *corev1.ConfigMap

--- a/pkg/leaderelection/testdata/config-leader-election.yaml
+++ b/pkg/leaderelection/testdata/config-leader-election.yaml
@@ -1,0 +1,1 @@
+../../../config/core/configmaps/leader-election.yaml


### PR DESCRIPTION
Add parsing for the actual and example config, verify they make sense.
Unfortunately the way parsing in pkg is setup we can't use empty leader
election config, but that's ok... just I had to list the keys in the
test loader.
Cleanup the test itself a bit as well.

/lint
/assign @markusthoemmes @pmorie mattmoor