### PR TITLE
Append script name to k8s.log.txt

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -453,7 +453,7 @@ function test_setup() {
   fi
 
   # Capture all logs.
-  kail > ${ARTIFACTS}/k8s.log-${E2E_SCRIPT}.txt &
+  kail > ${ARTIFACTS}/k8s.log-$(basename ${E2E_SCRIPT}).txt &
   local kail_pid=$!
   # Clean up kail so it doesn't interfere with job shutting down
   add_trap "kill $kail_pid || true" EXIT

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -453,7 +453,7 @@ function test_setup() {
   fi
 
   # Capture all logs.
-  kail > ${ARTIFACTS}/k8s.log.txt &
+  kail > ${ARTIFACTS}/k8s.log-${E2E_SCRIPT}.txt &
   local kail_pid=$!
   # Clean up kail so it doesn't interfere with job shutting down
   add_trap "kill $kail_pid || true" EXIT


### PR DESCRIPTION
## Proposed Changes

This patch appends script name to k8s.log.txt like
`k8s.log-e2e-test.sh.txt`.
When two e2e test scripts (e.g e2e-test.sh and e2e-auto-tls-tests.sh)
ran, one of test script overwrites another log.

To avoid it, this patch adds the script name to the log file.

Part of https://github.com/knative/test-infra/issues/1859

**Release Note**

```release-note
NONE
```
