### PR TITLE
Add common probe path in autoscaler, networking and activator

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -69,7 +69,7 @@ type dests struct {
 const (
 	probeTimeout          time.Duration = 300 * time.Millisecond
 	defaultProbeFrequency time.Duration = 200 * time.Millisecond
-	probePath                           = "/_internal/knative/activator/probe"
+	probePath                           = "/healthz"
 )
 
 // revisionWatcher watches the podIPs and ClusterIP of the service for a revision. It implements the logic

--- a/pkg/network/status/status.go
+++ b/pkg/network/status/status.go
@@ -45,6 +45,7 @@ const (
 	probeConcurrency = 15
 	//probeTimeout defines the maximum amount of time a request will wait
 	probeTimeout = 1 * time.Second
+	probePath = "/_internal/knative/networking/probe"
 )
 
 var dialContext = (&net.Dialer{Timeout: probeTimeout}).DialContext
@@ -356,10 +357,13 @@ func (m *Prober) processWorkItem() bool {
 			return dialContext(ctx, network, net.JoinHostPort(item.podIP, item.podPort))
 		}}
 
+	probeUrl := *item.url
+	probeUrl.Path = probePath
+
 	ok, err := prober.Do(
 		item.context,
 		transport,
-		item.url.String(),
+		probeUrl.String(),
 		prober.WithHeader(network.UserAgentKey, network.IngressReadinessUserAgent),
 		prober.WithHeader(network.ProbeHeaderName, network.ProbeHeaderValue),
 		m.probeVerifier(item))

--- a/pkg/network/status/status.go
+++ b/pkg/network/status/status.go
@@ -433,7 +433,7 @@ func (m *Prober) probeVerifier(item *workItem) prober.Verifier {
 	}
 }
 
-// Deep copies a URL into a new one
+// deepCopy copies a URL into a new one
 func deepCopy(in *url.URL) *url.URL {
 	// Safe to ignore the error since this is a deep copy
 	newURL, _ := url.Parse(in.String())

--- a/pkg/network/status/status.go
+++ b/pkg/network/status/status.go
@@ -44,8 +44,8 @@ const (
 	// probeConcurrency defines how many probing calls can be issued simultaneously
 	probeConcurrency = 15
 	//probeTimeout defines the maximum amount of time a request will wait
-	probeTimeout = 1 * time.Second
-	probePath = "/_internal/knative/networking/probe"
+	probeTimeout     = 1 * time.Second
+	probePath        = "/_internal/knative/networking/probe"
 )
 
 var dialContext = (&net.Dialer{Timeout: probeTimeout}).DialContext
@@ -357,7 +357,7 @@ func (m *Prober) processWorkItem() bool {
 			return dialContext(ctx, network, net.JoinHostPort(item.podIP, item.podPort))
 		}}
 
-	probeUrl := *item.url
+	probeUrl, _ := url.Parse(item.url.String())
 	probeUrl.Path = probePath
 
 	ok, err := prober.Do(

--- a/pkg/network/status/status.go
+++ b/pkg/network/status/status.go
@@ -358,13 +358,13 @@ func (m *Prober) processWorkItem() bool {
 			return dialContext(ctx, network, net.JoinHostPort(item.podIP, item.podPort))
 		}}
 
-	probeUrl := deepCopy(item.url)
-	probeUrl.Path = path.Join(probeUrl.Path, probePath)
+	probeURL := deepCopy(item.url)
+	probeURL.Path = path.Join(probeURL.Path, probePath)
 
 	ok, err := prober.Do(
 		item.context,
 		transport,
-		probeUrl.String(),
+		probeURL.String(),
 		prober.WithHeader(network.UserAgentKey, network.IngressReadinessUserAgent),
 		prober.WithHeader(network.ProbeHeaderName, network.ProbeHeaderValue),
 		m.probeVerifier(item))
@@ -433,8 +433,9 @@ func (m *Prober) probeVerifier(item *workItem) prober.Verifier {
 	}
 }
 
+// Deep copies a URL into a new one
 func deepCopy(in *url.URL) *url.URL {
 	// Safe to ignore the error since this is a deep copy
-	newUrl, _ := url.Parse(in.String())
-	return newUrl
+	newURL, _ := url.Parse(in.String())
+	return newURL
 }

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -123,7 +123,7 @@ func paToProbeTarget(pa *pav1alpha1.PodAutoscaler) string {
 
 	// Safe to ignore error since we know the string is a valid URL
 	httpDest, _ := url.Parse(fmt.Sprintf("http://%s:%d/", svc, port))
-    httpDest.Path = path.Join(httpDest.Path, probePath)
+	httpDest.Path = path.Join(httpDest.Path, probePath)
 
 	return httpDest.String()
 }

--- a/test/config/security/policy.yaml
+++ b/test/config/security/policy.yaml
@@ -46,4 +46,6 @@ spec:
       - excludedPaths:
         - prefix: /metrics
         - prefix: /_internal/knative/activator/probe
+        - prefix: /_internal/knative/autoscaler/probe
+        - prefix: /_internal/knative/networking/probe
   principalBinding: USE_ORIGIN

--- a/test/config/security/policy.yaml
+++ b/test/config/security/policy.yaml
@@ -45,7 +45,5 @@ spec:
       triggerRules:
       - excludedPaths:
         - prefix: /metrics
-        - prefix: /_internal/knative/activator/probe
-        - prefix: /_internal/knative/autoscaler/probe
-        - prefix: /_internal/knative/networking/probe
+        - prefix: /healthz
   principalBinding: USE_ORIGIN


### PR DESCRIPTION
Fixes #[5918](https://github.com/knative/serving/issues/5918)

* In [PR 6505](https://github.com/knative/serving/pull/6505), a new probe path was added in activator code which can be whitelisted
* This PR adds a common probe path '/healthz' in networking, autoscaler and activator (modifies previous custom path) to be whitelisted