### PR TITLE
Pull in the GGCR update that caches the K8s keyring.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -408,7 +408,7 @@
   version = "v0.4.0"
 
 [[projects]]
-  digest = "1:01504b3636ebed2a77278bb497de8a4f36f7af1a1de973f5713fc39984ad781b"
+  digest = "1:dbb3e0b020b97ef9fa4aac07fab3c0040ff8f9b149e91de14d1059489fffc08e"
   name = "github.com/google/go-containerregistry"
   packages = [
     "pkg/authn",
@@ -430,7 +430,7 @@
     "pkg/v1/v1util",
   ]
   pruneopts = "NUT"
-  revision = "955bf358a3d8d1ebfa6204338ef3fe364255cd85"
+  revision = "3d03ed9b1ca2ad5d78d43832e8e46adc31d2b961"
 
 [[projects]]
   digest = "1:91099c6f78b1e7bdf9ed06eb4cb7f017174293a3689d76b995a06f4c8d64a7f0"
@@ -575,7 +575,7 @@
   revision = "bf2b5ad3c0a925c44a0d2842c5d8182113cd248e"
 
 [[projects]]
-  digest = "1:1e59759b895f57302df03c5632dc6bbedcdf6782a2b6259246ff653dd214ac45"
+  digest = "0:"
   name = "github.com/jetstack/cert-manager"
   packages = [
     "pkg/apis/acme",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -136,8 +136,8 @@ required = [
 # The dependencies below are required for go-containrregistry.
 [[constraint]]
   name = "github.com/google/go-containerregistry"
-  # HEAD as of 2020-03-13
-  revision = "955bf358a3d8d1ebfa6204338ef3fe364255cd85"
+  # HEAD as of 2020-03-31
+  revision = "3d03ed9b1ca2ad5d78d43832e8e46adc31d2b961"
 
 [[override]]
   name = "github.com/vdemeester/k8s-pkg-credentialprovider"

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/tarball/image.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/tarball/image.go
@@ -162,6 +162,10 @@ func (i *image) loadTarDescriptorAndConfig() error {
 		return err
 	}
 
+	if i.manifest == nil {
+		return errors.New("no valid manifest.json in tarball")
+	}
+
 	i.imgDescriptor, err = i.manifest.findDescriptor(i.tag)
 	if err != nil {
 		return err


### PR DESCRIPTION
This should alleviate recent problems where the AWS keyring entry slows down reconciles.

If this works, we can cherrypick to 0.13.

/cc @markusthoemmes @duglin 