### PR TITLE
Return cumulative errors when deleting test resources

### DIFF
--- a/test/clients.go
+++ b/test/clients.go
@@ -201,7 +201,7 @@ func newServingClients(cfg *rest.Config, namespace string) (*ServingClients, err
 
 // Delete will delete all Routes and Configs with the names routes and configs, if clients
 // has been successfully initialized.
-func (clients *ServingClients) Delete(routes []string, configs []string, services []string) error {
+func (clients *ServingClients) Delete(routes []string, configs []string, services []string) []error {
 	deletions := []struct {
 		client interface {
 			Delete(name string, options *v1.DeleteOptions) error
@@ -218,6 +218,7 @@ func (clients *ServingClients) Delete(routes []string, configs []string, service
 		PropagationPolicy: &propPolicy,
 	}
 
+	var errs []error
 	for _, deletion := range deletions {
 		if deletion.client == nil {
 			continue
@@ -229,12 +230,12 @@ func (clients *ServingClients) Delete(routes []string, configs []string, service
 			}
 
 			if err := deletion.client.Delete(item, dopt); err != nil {
-				return err
+				errs = append(errs, err)
 			}
 		}
 	}
 
-	return nil
+	return errs
 }
 
 // BuildClientConfig builds client config for testing.

--- a/test/clients.go
+++ b/test/clients.go
@@ -19,7 +19,6 @@ limitations under the License.
 package test
 
 import (
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -230,9 +229,7 @@ func (clients *ServingClients) Delete(routes []string, configs []string, service
 			}
 
 			if err := deletion.client.Delete(item, dopt); err != nil {
-				if !apierrs.IsNotFound(err) {
-					return err
-				}
+				return err
 			}
 		}
 	}

--- a/test/clients.go
+++ b/test/clients.go
@@ -19,6 +19,7 @@ limitations under the License.
 package test
 
 import (
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -229,7 +230,9 @@ func (clients *ServingClients) Delete(routes []string, configs []string, service
 			}
 
 			if err := deletion.client.Delete(item, dopt); err != nil {
-				return err
+				if !apierrs.IsNotFound(err) {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed Changes

When running TestMinScale, knative config created by TestMinScale
always remains. This is because TestMinScale's defer tries to remove Route but
Route is [already removed during the test](https://github.com/knative/serving/blob/08ede7f985220d126ca0ccef2ec1609b2ea9877d/test/e2e/minscale_readiness_test.go#L119-L122) and so delete process failed
due to Route not found error.

To fix it, this patch changes to ignore NotFound error during
the deletion.

/lint

**Release Note**

```release-note
NONE
```
