### PR TITLE
Fix the default CM as well.

### DIFF
--- a/pkg/apis/config/defaults.go
+++ b/pkg/apis/config/defaults.go
@@ -136,9 +136,7 @@ func NewDefaultsConfigFromMap(data map[string]string) (*Defaults, error) {
 		}
 	}
 
-	if raw, ok := data["container-name-template"]; !ok {
-		nc.UserContainerNameTemplate = DefaultUserContainerName
-	} else {
+	if raw, ok := data["container-name-template"]; ok {
 		tmpl, err := template.New("user-container").Parse(raw)
 		if err != nil {
 			return nil, err

--- a/pkg/leaderelection/config.go
+++ b/pkg/leaderelection/config.go
@@ -41,7 +41,7 @@ func ValidateConfig(configMap *corev1.ConfigMap) (*kle.Config, error) {
 		return nil, err
 	}
 
-	for _, component := range config.EnabledComponents.List() {
+	for component := range config.EnabledComponents {
 		if !validComponents.Has(component) {
 			return nil, fmt.Errorf("invalid enabledComponent %q: valid values are %q", component, validComponents.List())
 		}


### PR DESCRIPTION
This one is tricky, since we showcase how to set requests/limits on the revision,
but we default to nil, in order to inherit k8s defaults.
Thus, we need to explicitly clear those out :/.

Also various small test and code fixes .

Fixes #3492

/assign mattmoor, @dprotaso 