### PR TITLE
Remove usages of md5, replace with sha256

### DIFF
--- a/pkg/network/ingress/ingress.go
+++ b/pkg/network/ingress/ingress.go
@@ -17,7 +17,7 @@ limitations under the License.
 package ingress
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -29,14 +29,14 @@ import (
 )
 
 // ComputeHash computes a hash of the Ingress Spec, Namespace and Name
-func ComputeHash(ing *v1alpha1.Ingress) ([16]byte, error) {
+func ComputeHash(ing *v1alpha1.Ingress) ([sha256.Size]byte, error) {
 	bytes, err := json.Marshal(ing.Spec)
 	if err != nil {
-		return [16]byte{}, fmt.Errorf("failed to serialize Ingress: %w", err)
+		return [sha256.Size]byte{}, fmt.Errorf("failed to serialize Ingress: %w", err)
 	}
 	bytes = append(bytes, []byte(ing.GetNamespace())...)
 	bytes = append(bytes, []byte(ing.GetName())...)
-	return md5.Sum(bytes), nil
+	return sha256.Sum256(bytes), nil
 }
 
 // InsertProbe adds a AppendHeader rule so that any request going through a Gateway is tagged with

--- a/pkg/network/ingress/ingress_test.go
+++ b/pkg/network/ingress/ingress_test.go
@@ -102,7 +102,7 @@ func TestInsertProbe(t *testing.T) {
 				}},
 			},
 		},
-		want: "b90f793b72c245476c6b4060967121ef",
+		want: "a25000a350642c8abef53078b329bd043e18758f6063c1172d53b04e14fcf5c1",
 	}, {
 		name: "with rules, with append header",
 		ingress: &v1alpha1.Ingress{
@@ -126,7 +126,7 @@ func TestInsertProbe(t *testing.T) {
 				}},
 			},
 		},
-		want: "061575cdf950105126a81d6da83cda8b",
+		want: "6b652c7abed871354affd4a9cb699d33816f24541fac942149b91ad872fe63ca",
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
/lint

Fixes # none

## Proposed Changes

* Remove usages of md5 in serving - From the Go library documentation, "MD5 is cryptographically broken and should not be used for secure applications." Replace all instances with sha256

**Release Note**

```release-note
NONE
```
