### PR TITLE
Contruct config by using NewConfigFromMap

### DIFF
--- a/pkg/apis/config/defaults_test.go
+++ b/pkg/apis/config/defaults_test.go
@@ -25,8 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
-	"knative.dev/pkg/system"
-
 	. "knative.dev/pkg/configmap/testing"
 	_ "knative.dev/pkg/system/testing"
 )
@@ -150,13 +148,7 @@ func TestDefaultsConfiguration(t *testing.T) {
 
 	for _, tt := range configTests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualDefaults, err := NewDefaultsConfigFromConfigMap(&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: system.Namespace(),
-					Name:      DefaultsConfigName,
-				},
-				Data: tt.data,
-			})
+			actualDefaults, err := NewDefaultsConfigFromMap(tt.data)
 
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("NewDefaultsConfigFromConfigMap() error = %v, WantErr %v", err, tt.wantErr)
@@ -186,15 +178,7 @@ func TestTemplating(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			def, err := NewDefaultsConfigFromConfigMap(&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: system.Namespace(),
-					Name:      DefaultsConfigName,
-				},
-				Data: map[string]string{
-					"container-name-template": test.template,
-				},
-			})
+			def, err := NewDefaultsConfigFromMap(map[string]string{"container-name-template": test.template})
 			if err != nil {
 				t.Errorf("Error parsing defaults: %v", err)
 			}

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -21,8 +21,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	corev1 "k8s.io/api/core/v1"
-
 	. "knative.dev/pkg/configmap/testing"
 )
 
@@ -246,9 +244,7 @@ func TestNewConfig(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := NewConfigFromConfigMap(&corev1.ConfigMap{
-				Data: test.input,
-			})
+			got, err := NewConfigFromMap(test.input)
 			t.Logf("Error = %v", err)
 			if (err != nil) != test.wantErr {
 				t.Errorf("NewConfig() = %v, want %v", err, test.wantErr)

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -191,14 +191,7 @@ func TestConfiguration(t *testing.T) {
 
 	for _, tt := range networkConfigTests {
 		t.Run(tt.name, func(t *testing.T) {
-			config := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: system.Namespace(),
-					Name:      ConfigName,
-				},
-				Data: tt.data,
-			}
-			actualConfig, err := NewConfigFromConfigMap(config)
+			actualConfig, err := NewConfigFromMap(tt.data)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Test: %q; NewConfigFromConfigMap() error = %v, WantErr %v",
 					tt.name, err, tt.wantErr)


### PR DESCRIPTION
Fixes: #7410

* Contructing config from a `map[string]string` by using `NewConfigFromMap`. It is much sample than contruct a configmap.