### PR TITLE
HA tests - create services after electing the leader

### DIFF
--- a/test/ha/autoscalerhpa_test.go
+++ b/test/ha/autoscalerhpa_test.go
@@ -44,6 +44,11 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 	defer scaleDownDeployment(clients, autoscalerHPADeploymentName)
 	test.CleanupOnInterrupt(func() { scaleDownDeployment(clients, autoscalerHPADeploymentName) })
 
+	leaderController, err := getLeader(t, clients, autoscalerHPALease)
+	if err != nil {
+		t.Fatalf("Failed to get leader: %v", err)
+	}
+
 	names, resources := createPizzaPlanetService(t, "pizzaplanet-service",
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.ClassAnnotationKey:  autoscaling.HPA,
@@ -52,11 +57,6 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 		}))
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
-
-	leaderController, err := getLeader(t, clients, autoscalerHPALease)
-	if err != nil {
-		t.Fatalf("Failed to get leader: %v", err)
-	}
 
 	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(leaderController, &metav1.DeleteOptions{})
 

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -39,14 +39,14 @@ func TestControllerHA(t *testing.T) {
 	defer scaleDownDeployment(clients, controllerDeploymentName)
 	test.CleanupOnInterrupt(func() { scaleDownDeployment(clients, controllerDeploymentName) })
 
-	service1Names, resources := createPizzaPlanetService(t, "pizzaplanet-service1")
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, service1Names) })
-	defer test.TearDown(clients, service1Names)
-
 	leaderController, err := getLeader(t, clients, controllerDeploymentName)
 	if err != nil {
 		t.Fatalf("Failed to get leader: %v", err)
 	}
+
+	service1Names, resources := createPizzaPlanetService(t, "pizzaplanet-service1")
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, service1Names) })
+	defer test.TearDown(clients, service1Names)
 
 	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(leaderController, &metav1.DeleteOptions{})
 


### PR DESCRIPTION
This makes the test more stable. We should wait for the leader before creating services to prevent race conditions. Hopefully, it will fix one flake from https://github.com/knative/serving/issues/7421

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
