### PR TITLE
HA tests - give it more time to elect the leader

### DIFF
--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -41,7 +41,7 @@ const (
 
 func getLeader(t *testing.T, clients *test.Clients, lease string) (string, error) {
 	var leader string
-	err := wait.PollImmediate(test.PollInterval, time.Minute, func() (bool, error) {
+	err := wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
 		lease, err := clients.KubeClient.Kube.CoordinationV1().Leases(test.ServingFlags.SystemNamespace).Get(lease, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("error getting lease %s: %w", lease, err)


### PR DESCRIPTION
* increase from 1 minute to 10 minutes

Attempt to fix the autoscaler-hpa HA test that failed in https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/7426/pull-knative-serving-integration-tests/1244497426811719684

Looking at the failure from the run: the leader pod was killed at 6:00:53 (autoscaler-hpa-8d8945b87-bzh86) but the Lease object from the dump shows the acquireTime: "2020-03-30T06:00:47.607744Z" (which is earlier) and it was for the bzh86 pod, it doesn't get any update after killing the pod; and I can also see that the only Lease event was generated for the hpa autoscaler at 6:00:47 ; this means that either the new leader was not elected at all after killing the first pod or the leader was elected but the Event was lost.
In either case the only thing I can do is give it more time to elect the leader. This PR does that.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
