### PR TITLE
Change default-domain's restartPolicy to OnFailure

### DIFF
--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -50,7 +50,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-      restartPolicy: Never
+      restartPolicy: OnFailure
   backoffLimit: 10
 
 ---

--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -51,7 +51,6 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
       restartPolicy: OnFailure
-  backoffLimit: 10
 
 ---
 apiVersion: v1


### PR DESCRIPTION
## Proposed Changes

If pod's network is not initialized or has a temporary issue when
default-domain job starts, the default-domain job fails and will not
retry.

Hence this patch changes the default-domain's restartPolicy to OnFailure.

Fixes https://github.com/knative/serving/issues/7487

**Release Note**

```release-note
default-domain changed restartPolicy to OnFailure from Never.
```
