### PR TITLE
Include a job to help operators migrate their storage version

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -199,8 +199,8 @@ ko apply -f config/
 
 # Run post-install job to setup nice XIP.IO domain name.  This only works
 # if your Kubernetes LoadBalancer has an IPv4 address.
-ko delete -f config/post-install --ignore-not-found
-ko apply -f config/post-install
+ko delete -f config/post-install/default-domain.yaml --ignore-not-found
+ko apply -f config/post-install/default-domain.yaml
 ```
 
 The above step is equivalent to applying the `serving.yaml` for released

--- a/config/core/roles/clusterrole.yaml
+++ b/config/core/roles/clusterrole.yaml
@@ -33,7 +33,7 @@ rules:
     resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
+    resources: ["customresourcedefinitions", "customresourcedefinitions/status"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["autoscaling"]
     resources: ["horizontalpodautoscalers"]

--- a/config/post-install/storage-version-migration.yaml
+++ b/config/post-install/storage-version-migration.yaml
@@ -1,0 +1,44 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: storage-version-migration
+  namespace: knative-serving
+  labels:
+    app: "storage-version-migration"
+    serving.knative.dev/release: devel
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app: "storage-version-migration"
+        serving.knative.dev/release: devel
+    spec:
+      serviceAccountName: controller
+      restartPolicy: OnFailure
+      containers:
+      - name: migrate
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: ko://knative.dev/serving/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate
+        args:
+          - "services.serving.knative.dev"
+          - "configurations.serving.knative.dev"
+          - "revisions.serving.knative.dev"
+          - "routes.serving.knative.dev"
+

--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -51,6 +51,7 @@ rm -fr ${YAML_OUTPUT_DIR}/*.yaml
 readonly SERVING_YAML=${YAML_OUTPUT_DIR}/serving.yaml
 readonly SERVING_CORE_YAML=${YAML_OUTPUT_DIR}/serving-core.yaml
 readonly SERVING_DEFAULT_DOMAIN_YAML=${YAML_OUTPUT_DIR}/serving-default-domain.yaml
+readonly SERVING_STORAGE_VERSION_MIGRATE_YAML=${YAML_OUTPUT_DIR}/serving-storage-version-migration.yaml
 readonly SERVING_HPA_YAML=${YAML_OUTPUT_DIR}/serving-hpa.yaml
 readonly SERVING_CRD_YAML=${YAML_OUTPUT_DIR}/serving-crds.yaml
 readonly SERVING_CERT_MANAGER_YAML=${YAML_OUTPUT_DIR}/serving-cert-manager.yaml
@@ -85,7 +86,9 @@ cd "${YAML_REPO_ROOT}"
 echo "Building Knative Serving"
 ko resolve ${KO_YAML_FLAGS} -R -f config/300-imagecache.yaml -f config/core/ | "${LABEL_YAML_CMD[@]}" > "${SERVING_CORE_YAML}"
 
-ko resolve ${KO_YAML_FLAGS} -f config/post-install/ | "${LABEL_YAML_CMD[@]}" > "${SERVING_DEFAULT_DOMAIN_YAML}"
+ko resolve ${KO_YAML_FLAGS} -f config/post-install/default-domain.yaml | "${LABEL_YAML_CMD[@]}" > "${SERVING_DEFAULT_DOMAIN_YAML}"
+
+ko resolve ${KO_YAML_FLAGS} -f config/post-install/storage-version-migration.yaml | "${LABEL_YAML_CMD[@]}" > "${SERVING_STORAGE_VERSION_MIGRATE_YAML}"
 
 # These don't have images, but ko will concatenate them for us.
 ko resolve ${KO_YAML_FLAGS} -f config/core/resources/ -f config/300-imagecache.yaml | "${LABEL_YAML_CMD[@]}" > "${SERVING_CRD_YAML}"
@@ -152,6 +155,7 @@ cat << EOF > ${YAML_LIST_FILE}
 ${SERVING_YAML}
 ${SERVING_CORE_YAML}
 ${SERVING_DEFAULT_DOMAIN_YAML}
+${SERVING_STORAGE_VERSION_MIGRATE_YAML}
 ${SERVING_HPA_YAML}
 ${SERVING_CRD_YAML}
 ${SERVING_CERT_MANAGER_YAML}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #6726
Depended on https://github.com/knative/pkg/pull/1197 to merge

The [sigs.k8s.io/kube-storage-version-migrator](https://github.com/kubernetes-sigs/kube-storage-version-migrator) seems to migrate all K8s resources/CRDs and it does it at a specific intervals. One thing it doesn't do is drop older storage versions from the CRD's status block. That's still a manual process - but this is necessary for us to drop older versions in our spec.  Additionally, the tool performs full PUTs which I don't believe is necessary (issue here: https://github.com/kubernetes-sigs/kube-storage-version-migrator/issues/65)

Thus I felt it would simpler to write a custom job to perform the storage migration specific to serving's resources (service, revision, configuration, route)

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Include a K8s Job to help migrate Service, Configuration, Revision, Route resources between storage versions



**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Include a K8s Job to help migrate Service, Configuration, Revision, Route resources between storage versions
```
