### PR TITLE
Remove istio sidecar injection from default namespace

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -502,7 +502,6 @@ function test_setup() {
     kubectl label namespace serving-tests istio-injection=enabled
     kubectl label namespace serving-tests-alt istio-injection=enabled
     kubectl label namespace serving-tests-security istio-injection=enabled
-    kubectl label namespace default istio-injection=enabled
     ko apply ${KO_FLAGS} -f ${TEST_CONFIG_DIR}/security/ || return 1
   fi
 


### PR DESCRIPTION
## Proposed Changes

This patch removes istio sidecar injection from default namespace,
which should not be necessary.


**Release Note**

```release-note
NONE
```
