### PR TITLE
Poke the KPA when the underlying scale changed.

### DIFF
--- a/pkg/autoscaler/scaling/multiscaler_test.go
+++ b/pkg/autoscaler/scaling/multiscaler_test.go
@@ -95,7 +95,7 @@ func TestMultiScalerScaling(t *testing.T) {
 	ms.tickProvider = mtp.NewTicker
 
 	decider := newDecider()
-	uniScaler.setScaleResult(1, 1, 2, true)
+	uniScaler.setScaleResult(1, 1, 1, 2, true)
 
 	// Before it exists, we should get a NotFound.
 	m, err := ms.Get(ctx, decider.Namespace, decider.Name)
@@ -113,6 +113,9 @@ func TestMultiScalerScaling(t *testing.T) {
 	d, err := ms.Get(ctx, decider.Namespace, decider.Name)
 	if err != nil {
 		t.Fatalf("Get() = %v", err)
+	}
+	if got, want := d.Status.ObservedScale, int32(0); got != want {
+		t.Errorf("Decider.Status.ObservedScale = %d, want: %d", got, want)
 	}
 	if got, want := d.Status.DesiredScale, int32(-1); got != want {
 		t.Errorf("Decider.Status.DesiredScale = %d, want: %d", got, want)
@@ -135,6 +138,9 @@ func TestMultiScalerScaling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get() = %v", err)
 	}
+	if got, want := d.Status.ObservedScale, int32(1); got != want {
+		t.Errorf("Decider.Status.ObservedScale = %d, want: %d", got, want)
+	}
 	if got, want := d.Status.DesiredScale, int32(1); got != want {
 		t.Errorf("Decider.Status.DesiredScale = %d, want: %d", got, want)
 	}
@@ -147,7 +153,7 @@ func TestMultiScalerScaling(t *testing.T) {
 
 	// Change number of activators, keeping the other data the same. E.g. CM
 	// value changed.
-	uniScaler.setScaleResult(1, 1, 3, true)
+	uniScaler.setScaleResult(1, 1, 1, 3, true)
 	mtp.Channel <- time.Now()
 	if err := verifyTick(errCh); err != nil {
 		t.Fatal(err)
@@ -157,6 +163,9 @@ func TestMultiScalerScaling(t *testing.T) {
 	d, err = ms.Get(ctx, decider.Namespace, decider.Name)
 	if err != nil {
 		t.Fatalf("Get() = %v", err)
+	}
+	if got, want := d.Status.ObservedScale, int32(1); got != want {
+		t.Errorf("Decider.Status.ObservedScale = %d, want: %d", got, want)
 	}
 	if got, want := d.Status.DesiredScale, int32(1); got != want {
 		t.Errorf("Decider.Status.DesiredScale = %d, want: %d", got, want)
@@ -251,7 +260,7 @@ func TestMultiScalerOnlyCapacityChange(t *testing.T) {
 	ms.tickProvider = mtp.NewTicker
 
 	decider := newDecider()
-	uniScaler.setScaleResult(1, 1, 2, true)
+	uniScaler.setScaleResult(1, 1, 1, 2, true)
 
 	errCh := make(chan error)
 	ms.Watch(watchFunc(ctx, ms, decider, 1, errCh))
@@ -268,7 +277,7 @@ func TestMultiScalerOnlyCapacityChange(t *testing.T) {
 	}
 
 	// Change the sign of the excess capacity.
-	uniScaler.setScaleResult(1, -1, 2, true)
+	uniScaler.setScaleResult(1, 1, -1, 2, true)
 
 	// Verify that the update is observed.
 	mtp.Channel <- time.Now()
@@ -294,7 +303,7 @@ func TestMultiScalerTickUpdate(t *testing.T) {
 
 	decider := newDecider()
 	decider.Spec.TickInterval = 10 * time.Second
-	uniScaler.setScaleResult(1, 1, 2, true)
+	uniScaler.setScaleResult(1, 1, 1, 2, true)
 
 	// Before it exists, we should get a NotFound.
 	m, err := ms.Get(ctx, decider.Namespace, decider.Name)
@@ -344,7 +353,7 @@ func TestMultiScalerScaleToZero(t *testing.T) {
 	ms.tickProvider = mtp.NewTicker
 
 	decider := newDecider()
-	uniScaler.setScaleResult(0, 1, 2, true)
+	uniScaler.setScaleResult(1, 0, 1, 2, true)
 
 	// Before it exists, we should get a NotFound.
 	m, err := ms.Get(ctx, decider.Namespace, decider.Name)
@@ -389,7 +398,7 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 
 	decider := newDecider()
 	decider.Spec.TickInterval = 60 * time.Second
-	uniScaler.setScaleResult(1, 1, 2, true)
+	uniScaler.setScaleResult(1, 1, 1, 2, true)
 
 	errCh := make(chan error)
 	ms.Watch(watchFunc(ctx, ms, decider, 1, errCh))
@@ -401,7 +410,7 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 	metricKey := types.NamespacedName{Namespace: decider.Namespace, Name: decider.Name}
 	if scaler, exists := ms.scalers[metricKey]; !exists {
 		t.Errorf("Failed to get scaler for metric %s", metricKey)
-	} else if !scaler.updateLatestScale(0, 10, 2) {
+	} else if !scaler.updateLatestScale(0, 0, 10, 2) {
 		t.Error("Failed to set scale for metric to 0")
 	}
 
@@ -433,7 +442,7 @@ func TestMultiScalerIgnoreNegativeScale(t *testing.T) {
 
 	decider := newDecider()
 
-	uniScaler.setScaleResult(-1, 10, 2, true)
+	uniScaler.setScaleResult(1, -1, 10, 2, true)
 
 	// Before it exists, we should get a NotFound.
 	m, err := ms.Get(ctx, decider.Namespace, decider.Name)
@@ -480,7 +489,7 @@ func TestMultiScalerUpdate(t *testing.T) {
 
 	decider := newDecider()
 	decider.Spec.TargetValue = 1.0
-	uniScaler.setScaleResult(0, 100, 2, true)
+	uniScaler.setScaleResult(1, 0, 100, 2, true)
 
 	// Create the decider and verify the Spec
 	_, err := ms.Create(ctx, decider)
@@ -520,6 +529,7 @@ func createMultiScaler(ctx context.Context, l *zap.SugaredLogger) (*MultiScaler,
 
 type fakeUniScaler struct {
 	mutex         sync.RWMutex
+	observed      int32
 	replicas      int32
 	surplus       int32
 	numActivators int32
@@ -531,11 +541,11 @@ func (u *fakeUniScaler) fakeUniScalerFactory(*Decider) (UniScaler, error) {
 	return u, nil
 }
 
-func (u *fakeUniScaler) Scale(context.Context, time.Time) (int32, int32, int32, bool) {
+func (u *fakeUniScaler) Scale(context.Context, time.Time) (int32, int32, int32, int32, bool) {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 	u.scaleCount++
-	return u.replicas, u.surplus, u.numActivators, u.scaled
+	return u.observed, u.replicas, u.surplus, u.numActivators, u.scaled
 }
 
 func (u *fakeUniScaler) getScaleCount() int {
@@ -544,10 +554,11 @@ func (u *fakeUniScaler) getScaleCount() int {
 	return u.scaleCount
 }
 
-func (u *fakeUniScaler) setScaleResult(replicas, surplus, na int32, scaled bool) {
+func (u *fakeUniScaler) setScaleResult(observed, replicas, surplus, na int32, scaled bool) {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 
+	u.observed = observed
 	u.surplus = surplus
 	u.replicas = replicas
 	u.scaled = scaled


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

There is currently a bug where the KPA doesn't notice that a revision's deployment is scaled to `minScale` even though the autoscaler clearly prints a ready pod count of 3. That is caused by no informer in the KPA actually firing and informing the KPA.

This change adds the "ObservedScale" to the decider's status and makes it poke the KPA whenever that changes too.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixed a bug where a revision would never become ready if it has a minScale setting > 1.
```

/assign @vagababov 
