### PR TITLE
Use buffer to build strings for hashing to noticeably improve the time and memory.

### DIFF
--- a/pkg/reconciler/serverlessservice/subsetter.go
+++ b/pkg/reconciler/serverlessservice/subsetter.go
@@ -34,7 +34,7 @@ const (
 
 	// universe represents the possible range of angles [0, universe).
 	// We want to have universe divide total range evenly to reduce bias.
-	universe = (1 << 10)
+	universe = (1 << 11)
 )
 
 // computeAngle returns a uint64 number which represents
@@ -73,8 +73,7 @@ func (hd *hashData) nameForHIndex(hi int) string {
 
 func buildHashes(from []string, target string) *hashData {
 	// Any one changing this function must execute
-	// Remove the skip in the TestOverlay test and run
-	// `go test -run=TestOverlay -count=150`.
+	// `go test -run=TestOverlay -count=200`.
 	// This is to ensure there is no regression in the selection
 	// algorithm.
 	hasher := fnv.New64a()

--- a/pkg/reconciler/serverlessservice/subsetter_test.go
+++ b/pkg/reconciler/serverlessservice/subsetter_test.go
@@ -99,9 +99,9 @@ func TestCollisionHandling(t *testing.T) {
 	)
 	// Verify baseline, that they collide.
 	hasher := fnv.New64a()
-	h1 := computeHash(key1+target, hasher) % universe
+	h1 := computeHash([]byte(key1+target), hasher) % universe
 	hasher.Reset()
-	h2 := computeHash(key2+target, hasher) % universe
+	h2 := computeHash([]byte(key2+target), hasher) % universe
 	if h1 != h2 {
 		t.Fatalf("Baseline incorrect keys don't collide %d != %d", h1, h2)
 	}
@@ -109,7 +109,6 @@ func TestCollisionHandling(t *testing.T) {
 	if got, want := len(hd.nameLookup), 2; got != want {
 		t.Error("Did not resolve collision, only 1 key in the map")
 	}
-
 }
 
 func TestOverlay(t *testing.T) {


### PR DESCRIPTION
The number of allocs went 15x on the high end of the benchmark.
Also 40% speed up on the high end.

On the more realistic ~25 activators addresses: 50% speedup and 4x reduction in allocations.

/assign @markusthoemmes 