### PR TITLE
Remove unused fields from PA base reconciler.

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/controller.go
+++ b/pkg/reconciler/autoscaling/hpa/controller.go
@@ -21,10 +21,8 @@ import (
 
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	hpainformer "knative.dev/pkg/client/injection/kube/informers/autoscaling/v2beta1/horizontalpodautoscaler"
-	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/logging"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
-	"knative.dev/serving/pkg/client/injection/ducks/autoscaling/v1alpha1/podscalable"
 	metricinformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/metric"
 	painformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler"
 	sksinformer "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/serverlessservice"
@@ -53,21 +51,19 @@ func NewController(
 	paInformer := painformer.Get(ctx)
 	sksInformer := sksinformer.Get(ctx)
 	hpaInformer := hpainformer.Get(ctx)
-	serviceInformer := serviceinformer.Get(ctx)
 	metricInformer := metricinformer.Get(ctx)
 
 	onlyHpaClass := pkgreconciler.AnnotationFilterFunc(autoscaling.ClassAnnotationKey, autoscaling.HPA, false)
 
 	c := &Reconciler{
 		Base: &areconciler.Base{
-			KubeClient:        kubeclient.Get(ctx),
-			Client:            servingclient.Get(ctx),
-			SKSLister:         sksInformer.Lister(),
-			ServiceLister:     serviceInformer.Lister(),
-			MetricLister:      metricInformer.Lister(),
-			PSInformerFactory: podscalable.Get(ctx),
+			Client:       servingclient.Get(ctx),
+			SKSLister:    sksInformer.Lister(),
+			MetricLister: metricInformer.Lister(),
 		},
-		hpaLister: hpaInformer.Lister(),
+
+		kubeClient: kubeclient.Get(ctx),
+		hpaLister:  hpaInformer.Lister(),
 	}
 	impl := pareconciler.NewImpl(ctx, c, autoscaling.HPA, func(impl *controller.Impl) controller.Options {
 		logger.Info("Setting up ConfigMap receivers")

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	autoscalingv2beta1listers "k8s.io/client-go/listers/autoscaling/v2beta1"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
@@ -39,7 +40,9 @@ import (
 // Reconciler implements the control loop for the HPA resources.
 type Reconciler struct {
 	*areconciler.Base
-	hpaLister autoscalingv2beta1listers.HorizontalPodAutoscalerLister
+
+	kubeClient kubernetes.Interface
+	hpaLister  autoscalingv2beta1listers.HorizontalPodAutoscalerLister
 }
 
 // Check that our Reconciler implements pareconciler.Interface
@@ -65,7 +68,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 	hpa, err := c.hpaLister.HorizontalPodAutoscalers(pa.Namespace).Get(desiredHpa.Name)
 	if errors.IsNotFound(err) {
 		logger.Infof("Creating HPA %q", desiredHpa.Name)
-		if hpa, err = c.KubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers(pa.Namespace).Create(desiredHpa); err != nil {
+		if hpa, err = c.kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers(pa.Namespace).Create(desiredHpa); err != nil {
 			pa.Status.MarkResourceFailedCreation("HorizontalPodAutoscaler", desiredHpa.Name)
 			return fmt.Errorf("failed to create HPA: %w", err)
 		}
@@ -78,7 +81,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 	}
 	if !equality.Semantic.DeepEqual(desiredHpa.Spec, hpa.Spec) {
 		logger.Infof("Updating HPA %q", desiredHpa.Name)
-		if _, err := c.KubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers(pa.Namespace).Update(desiredHpa); err != nil {
+		if _, err := c.kubeClient.AutoscalingV2beta1().HorizontalPodAutoscalers(pa.Namespace).Update(desiredHpa); err != nil {
 			return fmt.Errorf("failed to update HPA: %w", err)
 		}
 	}

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -447,14 +447,12 @@ func TestReconcile(t *testing.T) {
 
 		r := &Reconciler{
 			Base: &areconciler.Base{
-				KubeClient:        kubeclient.Get(ctx),
-				Client:            servingclient.Get(ctx),
-				SKSLister:         listers.GetServerlessServiceLister(),
-				MetricLister:      listers.GetMetricLister(),
-				ServiceLister:     listers.GetK8sServiceLister(),
-				PSInformerFactory: podscalable.Get(ctx),
+				Client:       servingclient.Get(ctx),
+				SKSLister:    listers.GetServerlessServiceLister(),
+				MetricLister: listers.GetMetricLister(),
 			},
-			hpaLister: listers.GetHorizontalPodAutoscalerLister(),
+			kubeClient: kubeclient.Get(ctx),
+			hpaLister:  listers.GetHorizontalPodAutoscalerLister(),
 		}
 		return pareconciler.NewReconciler(ctx, logging.FromContext(ctx), servingclient.Get(ctx),
 			listers.GetPodAutoscalerLister(), controller.GetEventRecorder(ctx), r, autoscaling.HPA,

--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -20,10 +20,8 @@ import (
 	"context"
 
 	"go.uber.org/zap"
-	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	podinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod"
-	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
@@ -60,7 +58,6 @@ func NewController(
 	logger := logging.FromContext(ctx)
 	paInformer := painformer.Get(ctx)
 	sksInformer := sksinformer.Get(ctx)
-	serviceInformer := serviceinformer.Get(ctx)
 	endpointsInformer := endpointsinformer.Get(ctx)
 	podsInformer := podinformer.Get(ctx)
 	metricInformer := metricinformer.Get(ctx)
@@ -71,12 +68,9 @@ func NewController(
 
 	c := &Reconciler{
 		Base: &areconciler.Base{
-			KubeClient:        kubeclient.Get(ctx),
-			Client:            servingclient.Get(ctx),
-			SKSLister:         sksInformer.Lister(),
-			ServiceLister:     serviceInformer.Lister(),
-			MetricLister:      metricInformer.Lister(),
-			PSInformerFactory: psInformerFactory,
+			Client:       servingclient.Get(ctx),
+			SKSLister:    sksInformer.Lister(),
+			MetricLister: metricInformer.Lister(),
 		},
 		endpointsLister: endpointsInformer.Lister(),
 		podsLister:      podsInformer.Lister(),

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	// These are the fake informers we want setup.
-	kubeclient "knative.dev/pkg/client/injection/kube/client"
+
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	fakeendpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
@@ -993,12 +993,9 @@ func TestReconcile(t *testing.T) {
 		scaler.activatorProbe = func(*asv1a1.PodAutoscaler, http.RoundTripper) (bool, error) { return true, nil }
 		r := &Reconciler{
 			Base: &areconciler.Base{
-				KubeClient:        kubeclient.Get(ctx),
-				Client:            servingclient.Get(ctx),
-				SKSLister:         listers.GetServerlessServiceLister(),
-				ServiceLister:     listers.GetK8sServiceLister(),
-				MetricLister:      listers.GetMetricLister(),
-				PSInformerFactory: psf,
+				Client:       servingclient.Get(ctx),
+				SKSLister:    listers.GetServerlessServiceLister(),
+				MetricLister: listers.GetMetricLister(),
 			},
 			endpointsLister: listers.GetEndpointsLister(),
 			podsLister:      listers.GetPodsLister(),

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/logging"
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	nv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
@@ -34,18 +33,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 // Base implements the core controller logic for autoscaling, given a Reconciler.
 type Base struct {
-	KubeClient        kubernetes.Interface
-	Client            clientset.Interface
-	ServiceLister     corev1listers.ServiceLister
-	SKSLister         nlisters.ServerlessServiceLister
-	MetricLister      listers.MetricLister
-	PSInformerFactory duck.InformerFactory
+	Client       clientset.Interface
+	SKSLister    nlisters.ServerlessServiceLister
+	MetricLister listers.MetricLister
 }
 
 // ReconcileSKS reconciles a ServerlessService based on the given PodAutoscaler.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Quite a few unused fields in the PodAutoscaler base reconciler that nothing uses. Let's remove them to avoid confusion.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
