### PR TITLE
Remove unused ErrActivatorOverload

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -30,7 +30,6 @@ import (
 	tracingconfig "knative.dev/pkg/tracing/config"
 	"knative.dev/serving/pkg/activator"
 	activatorconfig "knative.dev/serving/pkg/activator/config"
-	activatornet "knative.dev/serving/pkg/activator/net"
 	"knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/queue"
@@ -92,7 +91,7 @@ func (a *activationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		logger.Errorw("Throttler try error", zap.Error(err))
 
 		switch err {
-		case activatornet.ErrActivatorOverload, context.DeadlineExceeded, queue.ErrRequestQueueFull:
+		case context.DeadlineExceeded, queue.ErrRequestQueueFull:
 			http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		default:
 			w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -39,12 +39,12 @@ import (
 	tracetesting "knative.dev/pkg/tracing/testing"
 	"knative.dev/serving/pkg/activator"
 	activatorconfig "knative.dev/serving/pkg/activator/config"
-	anet "knative.dev/serving/pkg/activator/net"
 	activatortest "knative.dev/serving/pkg/activator/testing"
 	"knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/network"
+	"knative.dev/serving/pkg/queue"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -101,10 +101,10 @@ func TestActivationHandler(t *testing.T) {
 		throttler: fakeThrottler{err: context.DeadlineExceeded},
 	}, {
 		name:      "overflow",
-		wantBody:  "activator overload\n",
+		wantBody:  "pending request queue full\n",
 		wantCode:  http.StatusServiceUnavailable,
 		wantErr:   nil,
-		throttler: fakeThrottler{err: anet.ErrActivatorOverload},
+		throttler: fakeThrottler{err: queue.ErrRequestQueueFull},
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -18,7 +18,6 @@ package net
 
 import (
 	"context"
-	"errors"
 	"math"
 	"math/rand"
 	"sort"
@@ -61,8 +60,6 @@ const (
 )
 
 var (
-	ErrActivatorOverload = errors.New("activator overload")
-
 	breakerParams = queue.BreakerParams{
 		QueueDepth:      breakerQueueDepth,
 		MaxConcurrency:  breakerMaxConcurrency,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Looks like throttler has now been directly returning `queue.ErrRequestQueueFull` or `context.DeadlineExceeded` [for a while](https://github.com/knative/serving/pull/5493) so remove unused variable and update test to match code for clarity about actual behaviour.