### PR TITLE
Propagate Metric status changes to the API.

### DIFF
--- a/pkg/autoscaler/metrics/collector.go
+++ b/pkg/autoscaler/metrics/collector.go
@@ -89,7 +89,8 @@ type Collector interface {
 	Record(key types.NamespacedName, stat Stat)
 	// Delete deletes a Metric and halts collection.
 	Delete(string, string) error
-	// Watch registers a singleton function to call when collector status changes.
+	// Watch registers a singleton function to call when a specific collector's status changes.
+	// The passed name is the namespace/name of the metric owned by the respective collector.
 	Watch(func(types.NamespacedName))
 }
 
@@ -353,7 +354,8 @@ func (c *collection) currentMetric() *av1alpha1.Metric {
 	return c.metric
 }
 
-// updateLastError updates the last error returned from the scraper.
+// updateLastError updates the last error returned from the scraper
+// and returns true if the error or error state changed.
 func (c *collection) updateLastError(err error) bool {
 	c.errMutex.Lock()
 	defer c.errMutex.Unlock()

--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -447,9 +447,9 @@ func TestMetricCollectorError(t *testing.T) {
 				t.Fatalf("Event = %v, want %v", event, key)
 			}
 
-			// Simulate a reconcile.
+			// Make sure the error is surfaced via 'CreateOrUpdate', which is called in the reconciler.
 			if err := coll.CreateOrUpdate(testMetric); err != test.expectedError {
-				t.Fatalf("lastError = %v, want %v", err, test.expectedError)
+				t.Fatalf("CreateOrUpdate = %v, want %v", err, test.expectedError)
 			}
 
 			coll.Delete(testMetric.Namespace, testMetric.Name)

--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -23,12 +23,9 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	. "knative.dev/pkg/logging/testing"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -387,11 +384,25 @@ func TestMetricCollectorRecord(t *testing.T) {
 }
 
 func TestMetricCollectorError(t *testing.T) {
+	testMetric := &av1alpha1.Metric{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: fake.TestNamespace,
+			Name:      fake.TestRevision,
+			Labels: map[string]string{
+				serving.RevisionLabelKey: fake.TestRevision,
+			},
+		},
+		Spec: av1alpha1.MetricSpec{
+			ScrapeTarget: fake.TestRevision + "-zhudex",
+		},
+	}
+
+	errOther := errors.New("foo")
+
 	testCases := []struct {
-		name                 string
-		scraper              *testScraper
-		metric               *av1alpha1.Metric
-		expectedMetricStatus duckv1.Status
+		name          string
+		scraper       *testScraper
+		expectedError error
 	}{{
 		name: "Failed to get endpoints scraper error",
 		scraper: &testScraper{
@@ -399,26 +410,7 @@ func TestMetricCollectorError(t *testing.T) {
 				return emptyStat, ErrFailedGetEndpoints
 			},
 		},
-		metric: &av1alpha1.Metric{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: fake.TestNamespace,
-				Name:      fake.TestRevision,
-				Labels: map[string]string{
-					serving.RevisionLabelKey: fake.TestRevision,
-				},
-			},
-			Spec: av1alpha1.MetricSpec{
-				ScrapeTarget: fake.TestRevision + "-zhudex",
-			},
-		},
-		expectedMetricStatus: duckv1.Status{
-			Conditions: duckv1.Conditions{{
-				Type:    av1alpha1.MetricConditionReady,
-				Status:  corev1.ConditionUnknown,
-				Reason:  "NoEndpoints",
-				Message: ErrFailedGetEndpoints.Error(),
-			}},
-		},
+		expectedError: ErrFailedGetEndpoints,
 	}, {
 		name: "Did not receive stat scraper error",
 		scraper: &testScraper{
@@ -426,53 +418,15 @@ func TestMetricCollectorError(t *testing.T) {
 				return emptyStat, ErrDidNotReceiveStat
 			},
 		},
-		metric: &av1alpha1.Metric{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: fake.TestNamespace,
-				Name:      fake.TestRevision,
-				Labels: map[string]string{
-					serving.RevisionLabelKey: fake.TestRevision,
-				},
-			},
-			Spec: av1alpha1.MetricSpec{
-				ScrapeTarget: fake.TestRevision + "-zhudex",
-			},
-		},
-		expectedMetricStatus: duckv1.Status{
-			Conditions: duckv1.Conditions{{
-				Type:    av1alpha1.MetricConditionReady,
-				Status:  corev1.ConditionFalse,
-				Reason:  "DidNotReceiveStat",
-				Message: ErrDidNotReceiveStat.Error(),
-			}},
-		},
+		expectedError: ErrDidNotReceiveStat,
 	}, {
 		name: "Other scraper error",
 		scraper: &testScraper{
 			s: func() (Stat, error) {
-				return emptyStat, errors.New("foo")
+				return emptyStat, errOther
 			},
 		},
-		metric: &av1alpha1.Metric{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: fake.TestNamespace,
-				Name:      fake.TestRevision,
-				Labels: map[string]string{
-					serving.RevisionLabelKey: fake.TestRevision,
-				},
-			},
-			Spec: av1alpha1.MetricSpec{
-				ScrapeTarget: fake.TestRevision + "-zhudex",
-			},
-		},
-		expectedMetricStatus: duckv1.Status{
-			Conditions: duckv1.Conditions{{
-				Type:    av1alpha1.MetricConditionReady,
-				Status:  corev1.ConditionUnknown,
-				Reason:  "CreateOrUpdateFailed",
-				Message: "Collector has failed.",
-			}},
-		},
+		expectedError: errOther,
 	}}
 
 	logger := TestLogger(t)
@@ -480,22 +434,23 @@ func TestMetricCollectorError(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			factory := scraperFactory(test.scraper, nil)
 			coll := NewMetricCollector(factory, logger)
-			coll.CreateOrUpdate(test.metric)
-			key := types.NamespacedName{Namespace: test.metric.Namespace, Name: test.metric.Name}
+			coll.CreateOrUpdate(testMetric)
+			key := types.NamespacedName{Namespace: testMetric.Namespace, Name: testMetric.Name}
 
-			var got duckv1.Status
 			wait.PollImmediate(10*time.Millisecond, 2*time.Second, func() (bool, error) {
 				collection, ok := coll.collections[key]
-				if ok {
-					got = collection.currentMetric().Status.Status
-					return equality.Semantic.DeepEqual(got, test.expectedMetricStatus), nil
+				if !ok {
+					return false, nil
 				}
-				return false, nil
+				return collection.lastError() == test.expectedError, nil
 			})
-			if !equality.Semantic.DeepEqual(got, test.expectedMetricStatus) {
-				t.Errorf("Got = %#v, want: %#v, diff:\n%q", got, test.expectedMetricStatus, cmp.Diff(got, test.expectedMetricStatus))
+
+			// Simulate a reconcile.
+			if err := coll.CreateOrUpdate(testMetric); err != test.expectedError {
+				t.Fatalf("lastError = %v, want %v", err, test.expectedError)
 			}
-			coll.Delete(test.metric.Namespace, test.metric.Name)
+
+			coll.Delete(testMetric.Namespace, testMetric.Name)
 		})
 	}
 }

--- a/pkg/reconciler/metric/controller.go
+++ b/pkg/reconciler/metric/controller.go
@@ -66,5 +66,7 @@ func NewController(
 		},
 	})
 
+	collector.Watch(impl.EnqueueKey)
+
 	return impl
 }

--- a/pkg/reconciler/metric/metric.go
+++ b/pkg/reconciler/metric/metric.go
@@ -45,7 +45,8 @@ func (r *reconciler) ReconcileKind(ctx context.Context, metric *v1alpha1.Metric)
 		case metrics.ErrDidNotReceiveStat:
 			metric.Status.MarkMetricFailed("DidNotReceiveStat", err.Error())
 		default:
-			metric.Status.MarkMetricFailed("CollectionFailed", "Failed to reconcile metric collection: "+err.Error())
+			metric.Status.MarkMetricFailed("CollectionFailed",
+				"Failed to reconcile metric collection: "+err.Error())
 		}
 
 		// We don't return an error because retrying is of no use. We'll be poked by collector on a change.

--- a/pkg/reconciler/metric/metric.go
+++ b/pkg/reconciler/metric/metric.go
@@ -18,7 +18,6 @@ package metric
 
 import (
 	"context"
-	"fmt"
 
 	"knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler/metrics"
@@ -40,9 +39,17 @@ func (r *reconciler) ReconcileKind(ctx context.Context, metric *v1alpha1.Metric)
 	metric.Status.InitializeConditions()
 
 	if err := r.collector.CreateOrUpdate(metric); err != nil {
-		// If create or update fails, we won't be able to collect at all.
-		metric.Status.MarkMetricFailed("CollectionFailed", "Failed to reconcile metric collection")
-		return fmt.Errorf("failed to initiate or update scraping: %w", err)
+		switch err {
+		case metrics.ErrFailedGetEndpoints:
+			metric.Status.MarkMetricNotReady("NoEndpoints", err.Error())
+		case metrics.ErrDidNotReceiveStat:
+			metric.Status.MarkMetricFailed("DidNotReceiveStat", err.Error())
+		default:
+			metric.Status.MarkMetricFailed("CollectionFailed", "Failed to reconcile metric collection: "+err.Error())
+		}
+
+		// We don't return an error because retrying is of no use. We'll be poked by collector on a change.
+		return nil
 	}
 
 	metric.Status.MarkMetricReady()

--- a/pkg/reconciler/metric/metric_test.go
+++ b/pkg/reconciler/metric/metric_test.go
@@ -285,3 +285,5 @@ func (c *testCollector) Delete(namespace, name string) error {
 	}
 	return c.deleteError
 }
+
+func (c *testCollector) Watch(func(types.NamespacedName)) {}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

The Metric status changes have never been reflected to the API itself, which make them not very useful. This does a few things:

1. Move status determination into the reconciler.
2. Connect the collector with the reconciler to be able to inform it about changes of status. The mechanism is the same as for the Multiscaler/KPA reconciler.
3. Actually set a status that is reflected into the API.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Metric status is now reflected in the API.
```

/assign @taragu @vagababov 