### PR TITLE
Support disable wildcard cert label without 'internal'

### DIFF
--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -79,7 +79,7 @@ const (
 
 	// DisableWildcardCertLabelKey is the label key attached to a namespace to indicate that
 	// a wildcard certificate should be not created for it.
-	DisableWildcardCertLabelKey = "networking.knative.dev" + "/disableWildcardCert"
+	DisableWildcardCertLabelKey = "networking.knative.dev/disableWildcardCert"
 
 	// WildcardCertDomainLabelKey is the label key attached to a certificate to indicate the
 	// domain for which it was issued.

--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -73,9 +73,9 @@ const (
 	// ActivatorServiceName is the name of the activator Kubernetes service.
 	ActivatorServiceName = "activator-service"
 
-	// DisableInternalWildcardCertLabelKey is the label key attached to a namespace to indicate that
+	// DeprecatedDisableWildcardCertLabelKey is the deprecated label key attached to a namespace to indicate that
 	// a wildcard certificate should be not created for it.
-	DisableInternalWildcardCertLabelKey = GroupName + "/disableWildcardCert"
+	DeprecatedDisableWildcardCertLabelKey = GroupName + "/disableWildcardCert"
 
 	// DisableWildcardCertLabelKey is the label key attached to a namespace to indicate that
 	// a wildcard certificate should be not created for it.

--- a/pkg/apis/networking/register.go
+++ b/pkg/apis/networking/register.go
@@ -73,9 +73,13 @@ const (
 	// ActivatorServiceName is the name of the activator Kubernetes service.
 	ActivatorServiceName = "activator-service"
 
+	// DisableInternalWildcardCertLabelKey is the label key attached to a namespace to indicate that
+	// a wildcard certificate should be not created for it.
+	DisableInternalWildcardCertLabelKey = GroupName + "/disableWildcardCert"
+
 	// DisableWildcardCertLabelKey is the label key attached to a namespace to indicate that
 	// a wildcard certificate should be not created for it.
-	DisableWildcardCertLabelKey = GroupName + "/disableWildcardCert"
+	DisableWildcardCertLabelKey = "networking.knative.dev" + "/disableWildcardCert"
 
 	// WildcardCertDomainLabelKey is the label key attached to a certificate to indicate the
 	// domain for which it was issued.

--- a/pkg/reconciler/nscert/controller.go
+++ b/pkg/reconciler/nscert/controller.go
@@ -26,12 +26,10 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
-	"knative.dev/serving/pkg/apis/networking"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	kcertinformer "knative.dev/serving/pkg/client/injection/informers/networking/v1alpha1/certificate"
 	routecfg "knative.dev/serving/pkg/reconciler/route/config"
 
-	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/serving/pkg/network"
 	servingreconciler "knative.dev/serving/pkg/reconciler"
 	"knative.dev/serving/pkg/reconciler/nscert/config"
@@ -56,15 +54,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	impl := namespacereconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
 		logger.Info("Setting up event handlers")
-		nsInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-			FilterFunc: pkgreconciler.ChainFilterFuncs(
-				pkgreconciler.Not(pkgreconciler.LabelFilterFunc(
-					networking.DisableWildcardCertLabelKey, "true", false)),
-				pkgreconciler.Not(pkgreconciler.LabelFilterFunc(
-					networking.DisableInternalWildcardCertLabelKey, "true", false)),
-			),
-			Handler: controller.HandleAll(impl.Enqueue),
-		})
+		nsInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 		knCertificateInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 			FilterFunc: controller.FilterGroupVersionKind(

--- a/pkg/reconciler/nscert/controller.go
+++ b/pkg/reconciler/nscert/controller.go
@@ -57,8 +57,12 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	impl := namespacereconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
 		logger.Info("Setting up event handlers")
 		nsInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-			FilterFunc: pkgreconciler.Not(pkgreconciler.LabelFilterFunc(
-				networking.DisableWildcardCertLabelKey, "true", false)),
+			FilterFunc: pkgreconciler.ChainFilterFuncs(
+				pkgreconciler.Not(pkgreconciler.LabelFilterFunc(
+					networking.DisableWildcardCertLabelKey, "true", false)),
+				pkgreconciler.Not(pkgreconciler.LabelFilterFunc(
+					networking.DisableInternalWildcardCertLabelKey, "true", false)),
+			),
 			Handler: controller.HandleAll(impl.Enqueue),
 		})
 

--- a/pkg/reconciler/nscert/nscert.go
+++ b/pkg/reconciler/nscert/nscert.go
@@ -78,8 +78,15 @@ func (c *reconciler) ReconcileKind(ctx context.Context, ns *corev1.Namespace) pk
 		return fmt.Errorf("failed to list certificates: %w", err)
 	}
 
-	if strings.EqualFold(ns.Labels[networking.DisableWildcardCertLabelKey], "true") ||
-		strings.EqualFold(ns.Labels[networking.DeprecatedDisableWildcardCertLabelKey], "true") {
+	disabledWildcardCertValue, hasDisabledWildcardCertValue := ns.Labels[networking.DisableWildcardCertLabelKey]
+	deprecatedDisabledWildcardCertValue, hasDeprecatedDisabledWildcardCertValue := ns.Labels[networking.DeprecatedDisableWildcardCertLabelKey]
+
+	if hasDisabledWildcardCertValue && hasDeprecatedDisabledWildcardCertValue && !strings.EqualFold(disabledWildcardCertValue, deprecatedDisabledWildcardCertValue) {
+		return fmt.Errorf("both %s and %s are specified but values do not match", networking.DisableWildcardCertLabelKey, networking.DeprecatedDisableWildcardCertLabelKey)
+	}
+
+	if strings.EqualFold(disabledWildcardCertValue, "true") ||
+		strings.EqualFold(deprecatedDisabledWildcardCertValue, "true") {
 		return c.deleteNamespaceCerts(ctx, ns, existingCerts)
 	}
 

--- a/pkg/reconciler/nscert/nscert.go
+++ b/pkg/reconciler/nscert/nscert.go
@@ -77,7 +77,7 @@ func (c *reconciler) ReconcileKind(ctx context.Context, ns *corev1.Namespace) pk
 		return fmt.Errorf("failed to list certificates: %w", err)
 	}
 
-	if ns.Labels[networking.DisableWildcardCertLabelKey] == "true" {
+	if ns.Labels[networking.DisableWildcardCertLabelKey] == "true" || ns.Labels[networking.DisableInternalWildcardCertLabelKey] == "true" {
 		return c.deleteNamespaceCerts(ctx, ns, existingCerts)
 	}
 

--- a/pkg/reconciler/nscert/nscert.go
+++ b/pkg/reconciler/nscert/nscert.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
@@ -77,7 +78,8 @@ func (c *reconciler) ReconcileKind(ctx context.Context, ns *corev1.Namespace) pk
 		return fmt.Errorf("failed to list certificates: %w", err)
 	}
 
-	if ns.Labels[networking.DisableWildcardCertLabelKey] == "true" || ns.Labels[networking.DisableInternalWildcardCertLabelKey] == "true" {
+	if strings.EqualFold(ns.Labels[networking.DisableWildcardCertLabelKey], "true") ||
+		strings.EqualFold(ns.Labels[networking.DeprecatedDisableWildcardCertLabelKey], "true") {
 		return c.deleteNamespaceCerts(ctx, ns, existingCerts)
 	}
 

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -182,7 +182,7 @@ func TestReconcile(t *testing.T) {
 		Name:                    "create Knative certificate for namespace with explicitly enabled",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
-			kubeNamespaceWithDisableLabelValue("foo", "false"),
+			kubeNamespaceWithLabelValue("foo", map[string]string{networking.DisableWildcardCertLabelKey: "false"}),
 		},
 		WantCreates: []runtime.Object{
 			knCert(kubeNamespace("foo")),
@@ -195,7 +195,7 @@ func TestReconcile(t *testing.T) {
 		Name:                    "create Knative certificate for namespace with explicitly enabled for internal label",
 		SkipNamespaceValidation: true,
 		Objects: []runtime.Object{
-			kubeNamespaceWithDisableInternalLabelValue("foo", "false"),
+			kubeNamespaceWithLabelValue("foo", map[string]string{networking.DisableWildcardCertLabelKey: "false"}),
 		},
 		WantCreates: []runtime.Object{
 			knCert(kubeNamespace("foo")),
@@ -208,13 +208,35 @@ func TestReconcile(t *testing.T) {
 		Name: "certificate not created for excluded namespace with internal label",
 		Key:  "foo",
 		Objects: []runtime.Object{
-			kubeNamespaceWithDisableLabelValue("foo", "true"),
+			kubeNamespaceWithLabelValue("foo", map[string]string{networking.DisableWildcardCertLabelKey: "true"}),
 		},
 	}, {
-		Name: "certificate not created for excluded namespace",
+		Name: "certificate not created for excluded namespace with external label",
 		Key:  "foo",
 		Objects: []runtime.Object{
-			kubeNamespaceWithDisableInternalLabelValue("foo", "true"),
+			kubeNamespaceWithLabelValue("foo", map[string]string{networking.DeprecatedDisableWildcardCertLabelKey: "true"}),
+		},
+	}, {
+		Name: "certificate not created for excluded namespace when both internal and external labels are present",
+		Key:  "foo",
+		Objects: []runtime.Object{
+			kubeNamespaceWithLabelValue("foo", map[string]string{
+				networking.DeprecatedDisableWildcardCertLabelKey: "true",
+				networking.DisableWildcardCertLabelKey:           "true",
+			}),
+		},
+	}, {
+		Name: "certificate not created for different wildcard cert label",
+		Key:  "foo",
+		Objects: []runtime.Object{
+			kubeNamespaceWithLabelValue("foo", map[string]string{
+				networking.DeprecatedDisableWildcardCertLabelKey: "true",
+				networking.DisableWildcardCertLabelKey:           "false",
+			}),
+		},
+		WantErr: true,
+		WantEvents: []string{
+			Eventf(corev1.EventTypeWarning, "InternalError", "both networking.knative.dev/disableWildcardCert and networking.internal.knative.dev/disableWildcardCert are specified but values do not match"),
 		},
 	}, {
 		Name:                    "certificate creation failed",
@@ -238,7 +260,7 @@ func TestReconcile(t *testing.T) {
 		Name: "disabling namespace cert feature deletes the cert",
 		Key:  "foo",
 		Objects: []runtime.Object{
-			kubeNamespaceWithDisableLabelValue("foo", "true"),
+			kubeNamespaceWithLabelValue("foo", map[string]string{networking.DisableWildcardCertLabelKey: "true"}),
 			knCert(kubeNamespace("foo")),
 		},
 		SkipNamespaceValidation: true,
@@ -530,24 +552,11 @@ func kubeNamespace(name string) *corev1.Namespace {
 	}
 }
 
-func kubeNamespaceWithDisableLabelValue(name, value string) *corev1.Namespace {
+func kubeNamespaceWithLabelValue(name string, labels map[string]string) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				networking.DisableWildcardCertLabelKey: value,
-			},
-		},
-	}
-}
-
-func kubeNamespaceWithDisableInternalLabelValue(name, value string) *corev1.Namespace {
-	return &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				networking.DeprecatedDisableWildcardCertLabelKey: value,
-			},
+			Name:   name,
+			Labels: labels,
 		},
 	}
 }

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -205,7 +205,7 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "foo",
 	}, {
-		Name: "certificate not created for excluded namespace with intenal label",
+		Name: "certificate not created for excluded namespace with internal label",
 		Key:  "foo",
 		Objects: []runtime.Object{
 			kubeNamespaceWithDisableLabelValue("foo", "true"),
@@ -546,7 +546,7 @@ func kubeNamespaceWithDisableInternalLabelValue(name, value string) *corev1.Name
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				networking.DisableInternalWildcardCertLabelKey: value,
+				networking.DeprecatedDisableWildcardCertLabelKey: value,
 			},
 		},
 	}

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -192,10 +192,29 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "foo",
 	}, {
-		Name: "certificate not created for excluded namespace",
+		Name:                    "create Knative certificate for namespace with explicitly enabled for internal label",
+		SkipNamespaceValidation: true,
+		Objects: []runtime.Object{
+			kubeNamespaceWithDisableInternalLabelValue("foo", "false"),
+		},
+		WantCreates: []runtime.Object{
+			knCert(kubeNamespace("foo")),
+		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Created", "Created Knative Certificate %s/%s", "foo", defaultCertName),
+		},
+		Key: "foo",
+	}, {
+		Name: "certificate not created for excluded namespace with intenal label",
 		Key:  "foo",
 		Objects: []runtime.Object{
 			kubeNamespaceWithDisableLabelValue("foo", "true"),
+		},
+	}, {
+		Name: "certificate not created for excluded namespace",
+		Key:  "foo",
+		Objects: []runtime.Object{
+			kubeNamespaceWithDisableInternalLabelValue("foo", "true"),
 		},
 	}, {
 		Name:                    "certificate creation failed",
@@ -517,6 +536,17 @@ func kubeNamespaceWithDisableLabelValue(name, value string) *corev1.Namespace {
 			Name: name,
 			Labels: map[string]string{
 				networking.DisableWildcardCertLabelKey: value,
+			},
+		},
+	}
+}
+
+func kubeNamespaceWithDisableInternalLabelValue(name, value string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				networking.DisableInternalWildcardCertLabelKey: value,
 			},
 		},
 	}

--- a/test/e2e/autotls/config/disablenscert/main.go
+++ b/test/e2e/autotls/config/disablenscert/main.go
@@ -68,7 +68,7 @@ func disableNamespaceCertWithWhiteList(clients *test.Clients, whiteLists sets.St
 		}
 		if whiteLists.Has(ns.Name) {
 			delete(ns.Labels, networking.DisableWildcardCertLabelKey)
-			delete(ns.Labels, networking.DisableInternalWildcardCertLabelKey)
+			delete(ns.Labels, networking.DeprecatedDisableWildcardCertLabelKey)
 		} else {
 			ns.Labels[networking.DisableWildcardCertLabelKey] = "true"
 		}

--- a/test/e2e/autotls/config/disablenscert/main.go
+++ b/test/e2e/autotls/config/disablenscert/main.go
@@ -68,6 +68,7 @@ func disableNamespaceCertWithWhiteList(clients *test.Clients, whiteLists sets.St
 		}
 		if whiteLists.Has(ns.Name) {
 			delete(ns.Labels, networking.DisableWildcardCertLabelKey)
+			delete(ns.Labels, networking.DisableInternalWildcardCertLabelKey)
 		} else {
 			ns.Labels[networking.DisableWildcardCertLabelKey] = "true"
 		}


### PR DESCRIPTION

Fixes https://github.com/knative/serving/issues/7498

## Proposed Changes

* users can use label `networking.internal.knative.dev/disableWildcardCert` or `networking.knative.dev/disableWildcardCert` onto namespace to disable namespace certificate provision. 

**Release Note**

```release-note
Users can use label `networking.knative.dev/disableWildcardCert` onto namespace to disable namespace certificate provision. To maintain backwards compatibility `networking.internal.knative.dev/disableWildcardCert` label is supported as well
```

/assign @ZhiminXiang 
cc @andrew-su 