### PR TITLE
Implement subsetting function in SKS

### DIFF
--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -129,12 +129,13 @@ func (r *reconciler) reconcilePublicService(ctx context.Context, sks *netv1alpha
 // input with the irrelevant endpoints and empty subsets filtered out, if the input
 // size is larger than `n`,
 // Otherwise the input is returned as is.
+// `target` is the revision name for which we are computing a subset.
 func subsetEndpoints(eps *corev1.Endpoints, target string, n int) *corev1.Endpoints {
 	if len(eps.Subsets) == 0 {
 		return eps
 	}
 
-	addrs := make([]string, 0, 1)
+	addrs := make([]string, 0, n)
 	for _, ss := range eps.Subsets {
 		for _, addr := range ss.Addresses {
 			addrs = append(addrs, addr.IP)
@@ -173,6 +174,11 @@ func subsetEndpoints(eps *corev1.Endpoints, target string, n int) *corev1.Endpoi
 		}
 		r++
 	}
+	// We are guaranteed here to have w > 0, because
+	// 0. There's at least one subset (checked above).
+	// 1. A subset cannot be empty (k8s validation).
+	// 2. len(addrs) is at least as big as n
+	// Thus there's at least 1 non empty subset (and for all intents and purposes we'll have 1 always).
 	neps.Subsets = neps.Subsets[:w]
 	return neps
 }

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -240,7 +240,7 @@ func WithK8sSvcOwnersRemoved(svc *corev1.Service) {
 // EndpointsOption enables further configuration of the Kubernetes Endpoints.
 type EndpointsOption func(*corev1.Endpoints)
 
-// WithSubsets adds subsets to the body of a Revision, enabling us to refer readiness.
+// WithSubsets adds subsets to the body of an Endpoints object.
 func WithSubsets(ep *corev1.Endpoints) {
 	ep.Subsets = []corev1.EndpointSubset{{
 		Addresses: []corev1.EndpointAddress{{IP: "127.0.0.1"}},


### PR DESCRIPTION
This has some non trivial bits to implement linear filtering, vs quadric,
so I've pulled that into a separate PR.

The current implementation preserves the order of IP addresses and subsets
in the endpoints object, but with slightly more complexity we can implement
slightly more effective solution.

I'll leave it as an exercise for future, since it is not going to give us much benefit right now, because the objects are not pointers, but rather values, which means swapping from tail would incur a copy.
So I don't want to introduce additional complexity without writing additional benchmarks.

/assign mattmoor @markusthoemmes 


/lint

#7022 