### PR TITLE
Do not append port to IngressEndpoint in ingress conformance test

### DIFF
--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -832,7 +832,7 @@ func CreateDialContext(t *testing.T, ing *v1alpha1.Ingress, clients *test.Client
 		// Allow "ingressendpoint" flag to override the discovered ingress IP/hostname,
 		// this is required in minikube-like environments.
 		if pkgTest.Flags.IngressEndpoint != "" {
-			return net.Dial("tcp", pkgTest.Flags.IngressEndpoint+":"+port)
+			return net.Dial("tcp", pkgTest.Flags.IngressEndpoint)
 		}
 		if ingress.IP != "" {
 			return net.Dial("tcp", ingress.IP+":"+port)


### PR DESCRIPTION
## Proposed Changes

`--ingressendpoint` option should specify both IP and Port like
[`--ingressendpoint "$(minikube ip):31380"`](https://github.com/knative/serving/blob/efe814de9d42e7358da82f78022be79abe3a8ed6/test/README.md#using-a-custom-ingress-endpoint).
So, this patch removes unnecessary appending port in the code.

/lint

**Release Note**

```release-note
NONE
```
