### PR TITLE
Bring back logstreams during tests.

### DIFF
--- a/test/apicoverage.sh
+++ b/test/apicoverage.sh
@@ -52,7 +52,7 @@ ko apply -f "${TMP_DIR}/test/apicoverage/image/apicoverage-webhook.yaml" || fail
 header "Running tests"
 # Run conformance tests and e2e tests
 go_test_e2e -timeout=30m ./test/conformance/api/v1alpha1 ./test/conformance/api/v1beta1 ./test/conformance/runtime ./test/e2e \
-  --systemNamespace=${E2E_SYSTEM_NAMESPACE} || fail_apicoverage_run "Failed in executing Tests"
+  --systemNamespace=${SYSTEM_NAMESPACE} || fail_apicoverage_run "Failed in executing Tests"
 
 header "Retrieving API Coverage values"
 go run "${APICOVERAGE_TOOL}/main.go" || fail_test "Failed retrieving API coverage values"

--- a/test/apicoverage.sh
+++ b/test/apicoverage.sh
@@ -52,7 +52,7 @@ ko apply -f "${TMP_DIR}/test/apicoverage/image/apicoverage-webhook.yaml" || fail
 header "Running tests"
 # Run conformance tests and e2e tests
 go_test_e2e -timeout=30m ./test/conformance/api/v1alpha1 ./test/conformance/api/v1beta1 ./test/conformance/runtime ./test/e2e \
-  --systemNamespace=${SYSTEM_NAMESPACE} || fail_apicoverage_run "Failed in executing Tests"
+  || fail_apicoverage_run "Failed in executing Tests"
 
 header "Retrieving API Coverage values"
 go run "${APICOVERAGE_TOOL}/main.go" || fail_test "Failed retrieving API coverage values"

--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -173,22 +173,19 @@ add_trap "cleanup_auto_tls_common" EXIT SIGKILL SIGTERM SIGQUIT
 
 subheader "Auto TLS test for per-ksvc certificate provision using self-signed CA"
 setup_selfsigned_per_ksvc_auto_tls
-go_test_e2e -timeout=10m \
-  ./test/e2e/autotls/ --systemNamespace=${SYSTEM_NAMESPACE} || failed=1
+go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
 kubectl delete -f ./test/config/autotls/certmanager/selfsigned/
 
 subheader "Auto TLS test for per-namespace certificate provision using self-signed CA"
 setup_selfsigned_per_namespace_auto_tls
 add_trap "cleanup_per_selfsigned_namespace_auto_tls" SIGKILL SIGTERM SIGQUIT
-go_test_e2e -timeout=10m \
-  ./test/e2e/autotls/ --systemNamespace=${SYSTEM_NAMESPACE} || failed=1
+go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
 cleanup_per_selfsigned_namespace_auto_tls
 
 subheader "Auto TLS test for per-ksvc certificate provision using HTTP01 challenge"
 setup_http01_auto_tls
 add_trap "delete_dns_record" SIGKILL SIGTERM SIGQUIT
-go_test_e2e -timeout=10m \
-  ./test/e2e/autotls/ --systemNamespace=${SYSTEM_NAMESPACE} || failed=1
+go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
 kubectl delete -f ./test/config/autotls/certmanager/http01/
 delete_dns_record
 

--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -51,7 +51,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-domain
-  namespace: ${E2E_SYSTEM_NAMESPACE}
+  namespace: ${SYSTEM_NAMESPACE}
   labels:
     serving.knative.dev/release: devel
 data:
@@ -60,7 +60,7 @@ EOF
 }
 
 function cleanup_custom_domain() {
-  kubectl delete ConfigMap config-domain -n ${E2E_SYSTEM_NAMESPACE}
+  kubectl delete ConfigMap config-domain -n ${SYSTEM_NAMESPACE}
 }
 
 function setup_auto_tls_common() {
@@ -131,7 +131,7 @@ function setup_selfsigned_per_namespace_auto_tls() {
     exit 1
   fi
   local YAML_NAME=${TMP_DIR}/${SERVING_NSCERT_YAML##*/}
-  sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${SERVING_NSCERT_YAML} > ${YAML_NAME}
+  sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${SERVING_NSCERT_YAML} > ${YAML_NAME}
   kubectl apply -f ${YAML_NAME}
 }
 
@@ -174,21 +174,21 @@ add_trap "cleanup_auto_tls_common" EXIT SIGKILL SIGTERM SIGQUIT
 subheader "Auto TLS test for per-ksvc certificate provision using self-signed CA"
 setup_selfsigned_per_ksvc_auto_tls
 go_test_e2e -timeout=10m \
-  ./test/e2e/autotls/ --systemNamespace=${E2E_SYSTEM_NAMESPACE} || failed=1
+  ./test/e2e/autotls/ --systemNamespace=${SYSTEM_NAMESPACE} || failed=1
 kubectl delete -f ./test/config/autotls/certmanager/selfsigned/
 
 subheader "Auto TLS test for per-namespace certificate provision using self-signed CA"
 setup_selfsigned_per_namespace_auto_tls
 add_trap "cleanup_per_selfsigned_namespace_auto_tls" SIGKILL SIGTERM SIGQUIT
 go_test_e2e -timeout=10m \
-  ./test/e2e/autotls/ --systemNamespace=${E2E_SYSTEM_NAMESPACE} || failed=1
+  ./test/e2e/autotls/ --systemNamespace=${SYSTEM_NAMESPACE} || failed=1
 cleanup_per_selfsigned_namespace_auto_tls
 
 subheader "Auto TLS test for per-ksvc certificate provision using HTTP01 challenge"
 setup_http01_auto_tls
 add_trap "delete_dns_record" SIGKILL SIGTERM SIGQUIT
 go_test_e2e -timeout=10m \
-  ./test/e2e/autotls/ --systemNamespace=${E2E_SYSTEM_NAMESPACE} || failed=1
+  ./test/e2e/autotls/ --systemNamespace=${SYSTEM_NAMESPACE} || failed=1
 kubectl delete -f ./test/config/autotls/certmanager/http01/
 delete_dns_record
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -123,7 +123,7 @@ function parse_flags() {
       ;;
     --system-namespace)
       [[ -z "$2" ]] || [[ $2 = --* ]] && fail_test "Missing argument to --system-namespace"
-      readonly SYSTEM_NAMESPACE=$2
+      export SYSTEM_NAMESPACE=$2
       return 2
       ;;
   esac

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -47,6 +47,7 @@ TMP_DIR=$(mktemp -d -t ci-$(date +%Y-%m-%d-%H-%M-%S)-XXXXXXXXXX)
 readonly TMP_DIR
 readonly KNATIVE_DEFAULT_NAMESPACE="knative-serving"
 # This the namespace used to install Knative Serving. Use generated UUID as namespace.
+export SYSTEM_NAMESPACE
 SYSTEM_NAMESPACE=$(uuidgen | tr 'A-Z' 'a-z')
 
 # Parse our custom flags.

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -47,7 +47,7 @@ TMP_DIR=$(mktemp -d -t ci-$(date +%Y-%m-%d-%H-%M-%S)-XXXXXXXXXX)
 readonly TMP_DIR
 readonly KNATIVE_DEFAULT_NAMESPACE="knative-serving"
 # This the namespace used to install Knative Serving. Use generated UUID as namespace.
-E2E_SYSTEM_NAMESPACE=$(uuidgen | tr 'A-Z' 'a-z')
+SYSTEM_NAMESPACE=$(uuidgen | tr 'A-Z' 'a-z')
 
 # Parse our custom flags.
 function parse_flags() {
@@ -122,7 +122,7 @@ function parse_flags() {
       ;;
     --system-namespace)
       [[ -z "$2" ]] || [[ $2 = --* ]] && fail_test "Missing argument to --system-namespace"
-      readonly E2E_SYSTEM_NAMESPACE=$2
+      readonly SYSTEM_NAMESPACE=$2
       return 2
       ;;
   esac
@@ -163,7 +163,7 @@ function install_knative_serving() {
   echo "Custom YAML files: ${INSTALL_CUSTOM_YAMLS}"
   for yaml in ${INSTALL_CUSTOM_YAMLS}; do
     local YAML_NAME=${TMP_DIR}/${yaml##*/}
-    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${yaml} > ${YAML_NAME}
+    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${yaml} > ${YAML_NAME}
     echo "Installing '${YAML_NAME}'"
     kubectl create -f "${YAML_NAME}" || return 1
   done
@@ -205,7 +205,7 @@ function install_istio() {
     # bundle then the whole bundle it passed here.  We use ko because it has
     # better filtering support for CRDs.
     local YAML_NAME=${TMP_DIR}/${1##*/}
-    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${1} > ${YAML_NAME}
+    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${1} > ${YAML_NAME}
     ko apply -f "${YAML_NAME}" --selector=networking.knative.dev/ingress-provider=istio || return 1
     UNINSTALL_LIST+=( "${YAML_NAME}" )
   fi
@@ -272,7 +272,7 @@ function install_contour() {
   UNINSTALL_LIST+=( "${INSTALL_CONTOUR_YAML}" )
 
   local NET_CONTOUR_YAML_NAME=${TMP_DIR}/${INSTALL_NET_CONTOUR_YAML##*/}
-  sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${INSTALL_NET_CONTOUR_YAML} > ${NET_CONTOUR_YAML_NAME}
+  sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${INSTALL_NET_CONTOUR_YAML} > ${NET_CONTOUR_YAML_NAME}
   echo ">> Bringing up net-contour"
   kubectl apply -f ${NET_CONTOUR_YAML_NAME} || return 1
 
@@ -286,13 +286,13 @@ function install_contour() {
 function install_knative_serving_standard() {
   readonly INSTALL_CERT_MANAGER_YAML="./third_party/cert-manager-${CERT_MANAGER_VERSION}/cert-manager.yaml"
 
-  echo ">> Creating ${E2E_SYSTEM_NAMESPACE} namespace if it does not exist"
-  kubectl get ns ${E2E_SYSTEM_NAMESPACE} || kubectl create namespace ${E2E_SYSTEM_NAMESPACE}
+  echo ">> Creating ${SYSTEM_NAMESPACE} namespace if it does not exist"
+  kubectl get ns ${SYSTEM_NAMESPACE} || kubectl create namespace ${SYSTEM_NAMESPACE}
   if (( MESH )); then
-    kubectl label namespace ${E2E_SYSTEM_NAMESPACE} istio-injection=enabled
+    kubectl label namespace ${SYSTEM_NAMESPACE} istio-injection=enabled
   fi
   # Delete the test namespace
-  add_trap "kubectl delete namespace ${E2E_SYSTEM_NAMESPACE} --ignore-not-found=true" SIGKILL SIGTERM SIGQUIT
+  add_trap "kubectl delete namespace ${SYSTEM_NAMESPACE} --ignore-not-found=true" SIGKILL SIGTERM SIGQUIT
 
   echo ">> Installing Knative CRD"
   if [[ -z "$1" ]]; then
@@ -304,7 +304,7 @@ function install_knative_serving_standard() {
     UNINSTALL_LIST+=( "${SERVING_CRD_YAML}" )
   else
     local YAML_NAME=${TMP_DIR}/${1##*/}
-    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${1} > ${YAML_NAME}
+    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${1} > ${YAML_NAME}
     echo "Knative YAML: ${YAML_NAME}"
     ko apply -f "${YAML_NAME}" --selector=knative.dev/crd-install=true || return 1
     UNINSTALL_LIST+=( "${YAML_NAME}" )
@@ -331,9 +331,9 @@ function install_knative_serving_standard() {
   echo ">> Installing Knative serving"
   if [[ -z "$1" ]]; then
     local CORE_YAML_NAME=${TMP_DIR}/${SERVING_CORE_YAML##*/}
-    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${SERVING_CORE_YAML} > ${CORE_YAML_NAME}
+    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${SERVING_CORE_YAML} > ${CORE_YAML_NAME}
     local HPA_YAML_NAME=${TMP_DIR}/${SERVING_HPA_YAML##*/}
-    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${SERVING_HPA_YAML} > ${HPA_YAML_NAME}
+    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${SERVING_HPA_YAML} > ${HPA_YAML_NAME}
     echo "Knative YAML: ${CORE_YAML_NAME} and ${HPA_YAML_NAME}"
     kubectl apply \
 	    -f "${CORE_YAML_NAME}" \
@@ -343,7 +343,7 @@ function install_knative_serving_standard() {
     # ${SERVING_CERT_MANAGER_YAML} is set when calling
     # build_knative_from_source
     local CERT_YAML_NAME=${TMP_DIR}/${SERVING_CERT_MANAGER_YAML##*/}
-    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${SERVING_CERT_MANAGER_YAML} > ${CERT_YAML_NAME}
+    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${SERVING_CERT_MANAGER_YAML} > ${CERT_YAML_NAME}
     echo "Knative TLS YAML: ${CERT_YAML_NAME}"
     kubectl apply \
       -f "${CERT_YAML_NAME}" || return 1
@@ -360,7 +360,7 @@ function install_knative_serving_standard() {
     # and if we choose to install istio below, then pass the whole file as the rest.
     # We use ko because it has better filtering support for CRDs.
     local YAML_NAME=${TMP_DIR}/${1##*/}
-    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${E2E_SYSTEM_NAMESPACE}/g" ${1} > ${YAML_NAME}
+    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${1} > ${YAML_NAME}
     ko apply -f "${YAML_NAME}" --selector=networking.knative.dev/ingress-provider!=istio || return 1
     UNINSTALL_LIST+=( "${YAML_NAME}" )
 
@@ -378,7 +378,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-network
-  namespace: ${E2E_SYSTEM_NAMESPACE}
+  namespace: ${SYSTEM_NAMESPACE}
   labels:
     serving.knative.dev/release: devel
 data:
@@ -391,14 +391,14 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-observability
-  namespace: ${E2E_SYSTEM_NAMESPACE}
+  namespace: ${SYSTEM_NAMESPACE}
 data:
   profiling.enable: "true"
 EOF
 
   echo ">> Patching activator HPA"
   # We set min replicas to 2 for testing multiple activator pods.
-  kubectl -n ${E2E_SYSTEM_NAMESPACE} patch hpa activator --patch '{"spec":{"minReplicas":2}}' || return 1
+  kubectl -n ${SYSTEM_NAMESPACE} patch hpa activator --patch '{"spec":{"minReplicas":2}}' || return 1
 }
 
 # Check if we should use --resolvabledomain.  In case the ingress only has
@@ -469,7 +469,7 @@ function test_setup() {
   local TEST_DIR=${TMP_DIR}/test
   mkdir -p ${TEST_DIR}
   cp -r test/* ${TEST_DIR}
-  find ${TEST_DIR} -type f -name "*.yaml" -exec sed -i "s/${KNATIVE_DEFAULT_NAMESPACE}/${E2E_SYSTEM_NAMESPACE}/g" {} +
+  find ${TEST_DIR} -type f -name "*.yaml" -exec sed -i "s/${KNATIVE_DEFAULT_NAMESPACE}/${SYSTEM_NAMESPACE}/g" {} +
 
   echo ">> Setting up logging..."
 
@@ -498,7 +498,7 @@ function test_setup() {
   ${REPO_ROOT_DIR}/test/upload-test-images.sh || return 1
 
   echo ">> Waiting for Serving components to be running..."
-  wait_until_pods_running ${E2E_SYSTEM_NAMESPACE} || return 1
+  wait_until_pods_running ${SYSTEM_NAMESPACE} || return 1
 
   echo ">> Waiting for Cert Manager components to be running..."
   wait_until_pods_running cert-manager || return 1
@@ -580,9 +580,9 @@ function dump_extra_cluster_state() {
 }
 
 function turn_on_auto_tls() {
-  kubectl patch configmap config-network -n ${E2E_SYSTEM_NAMESPACE} -p '{"data":{"autoTLS":"Enabled"}}'
+  kubectl patch configmap config-network -n ${SYSTEM_NAMESPACE} -p '{"data":{"autoTLS":"Enabled"}}'
 }
 
 function turn_off_auto_tls() {
-  kubectl patch configmap config-network -n ${E2E_SYSTEM_NAMESPACE} -p '{"data":{"autoTLS":"Disabled"}}'
+  kubectl patch configmap config-network -n ${SYSTEM_NAMESPACE} -p '{"data":{"autoTLS":"Disabled"}}'
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -68,7 +68,6 @@ go_test_e2e -timeout=30m \
   $(go list ./test/conformance/... | grep -v certificate) \
   ./test/e2e \
   ${parallelism} \
-  "--systemNamespace=${SYSTEM_NAMESPACE}" \
   "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 
 if (( HTTPS )); then
@@ -80,27 +79,20 @@ fi
 # because they need cert-manager specific configurations.
 kubectl apply -f ${TMP_DIR}/test/config/autotls/certmanager/selfsigned/
 add_trap "kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/selfsigned/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
-go_test_e2e -timeout=10m \
-  ./test/conformance/certificate/nonhttp01 "$(certificate_class)" --systemNamespace=${SYSTEM_NAMESPACE} || failed=1
+go_test_e2e -timeout=10m ./test/conformance/certificate/nonhttp01 "$(certificate_class)" || failed=1
 kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/selfsigned/
 
 kubectl apply -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
 add_trap "kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
-go_test_e2e -timeout=10m \
-  ./test/conformance/certificate/http01 "$(certificate_class)" --systemNamespace=${SYSTEM_NAMESPACE} || failed=1
+go_test_e2e -timeout=10m ./test/conformance/certificate/http01 "$(certificate_class)" || failed=1
 kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
 
 # Run scale tests.
-go_test_e2e -timeout=10m \
-  ${parallelism} \
-  ./test/scale "--systemNamespace=${SYSTEM_NAMESPACE}" || failed=1
+go_test_e2e -timeout=10m ${parallelism} ./test/scale || failed=1
 
 # Istio E2E tests mutate the cluster and must be ran separately
 if [[ -n "${ISTIO_VERSION}" ]]; then
-  go_test_e2e -timeout=10m \
-    ./test/e2e/istio \
-    "--systemNamespace=${SYSTEM_NAMESPACE}" \
-    "--resolvabledomain=$(use_resolvable_domain)" || failed=1
+  go_test_e2e -timeout=10m ./test/e2e/istio "--resolvabledomain=$(use_resolvable_domain)" || failed=1
 fi
 
 # Run HA tests separately as they're stopping core Knative Serving pods
@@ -114,7 +106,7 @@ for deployment in controller autoscaler-hpa activator; do
   kubectl -n "${SYSTEM_NAMESPACE}" patch deployment "$deployment" --patch '{"spec":{"replicas":2}}'
 done
 # Define short -spoofinterval to ensure frequent probing while stopping pods
-go_test_e2e -timeout=10m -parallel=1 ./test/ha "--systemNamespace=${SYSTEM_NAMESPACE}" -spoofinterval="10ms" || failed=1
+go_test_e2e -timeout=10m -parallel=1 ./test/ha -spoofinterval="10ms" || failed=1
 kubectl get cm config-leader-election -n "${SYSTEM_NAMESPACE}" -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -
 
 # Dump cluster state in case of failure

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -68,7 +68,7 @@ go_test_e2e -timeout=30m \
   $(go list ./test/conformance/... | grep -v certificate) \
   ./test/e2e \
   ${parallelism} \
-  "--systemNamespace=${E2E_SYSTEM_NAMESPACE}" \
+  "--systemNamespace=${SYSTEM_NAMESPACE}" \
   "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 
 if (( HTTPS )); then
@@ -81,41 +81,41 @@ fi
 kubectl apply -f ${TMP_DIR}/test/config/autotls/certmanager/selfsigned/
 add_trap "kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/selfsigned/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
 go_test_e2e -timeout=10m \
-  ./test/conformance/certificate/nonhttp01 "$(certificate_class)" --systemNamespace=${E2E_SYSTEM_NAMESPACE} || failed=1
+  ./test/conformance/certificate/nonhttp01 "$(certificate_class)" --systemNamespace=${SYSTEM_NAMESPACE} || failed=1
 kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/selfsigned/
 
 kubectl apply -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
 add_trap "kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
 go_test_e2e -timeout=10m \
-  ./test/conformance/certificate/http01 "$(certificate_class)" --systemNamespace=${E2E_SYSTEM_NAMESPACE} || failed=1
+  ./test/conformance/certificate/http01 "$(certificate_class)" --systemNamespace=${SYSTEM_NAMESPACE} || failed=1
 kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
 
 # Run scale tests.
 go_test_e2e -timeout=10m \
   ${parallelism} \
-  ./test/scale "--systemNamespace=${E2E_SYSTEM_NAMESPACE}" || failed=1
+  ./test/scale "--systemNamespace=${SYSTEM_NAMESPACE}" || failed=1
 
 # Istio E2E tests mutate the cluster and must be ran separately
 if [[ -n "${ISTIO_VERSION}" ]]; then
   go_test_e2e -timeout=10m \
     ./test/e2e/istio \
-    "--systemNamespace=${E2E_SYSTEM_NAMESPACE}" \
+    "--systemNamespace=${SYSTEM_NAMESPACE}" \
     "--resolvabledomain=$(use_resolvable_domain)" || failed=1
 fi
 
 # Run HA tests separately as they're stopping core Knative Serving pods
-kubectl -n "${E2E_SYSTEM_NAMESPACE}" patch configmap/config-leader-election --type=merge \
+kubectl -n "${SYSTEM_NAMESPACE}" patch configmap/config-leader-election --type=merge \
   --patch='{"data":{"enabledComponents":"controller,hpaautoscaler"}}'
-add_trap "kubectl get cm config-leader-election -n ${E2E_SYSTEM_NAMESPACE} -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -" SIGKILL SIGTERM SIGQUIT
+add_trap "kubectl get cm config-leader-election -n ${SYSTEM_NAMESPACE} -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -" SIGKILL SIGTERM SIGQUIT
 # Delete HPA to stabilize HA tests
-kubectl -n "${E2E_SYSTEM_NAMESPACE}" delete hpa activator
+kubectl -n "${SYSTEM_NAMESPACE}" delete hpa activator
 # Scale up components for HA tests
 for deployment in controller autoscaler-hpa activator; do
-  kubectl -n "${E2E_SYSTEM_NAMESPACE}" patch deployment "$deployment" --patch '{"spec":{"replicas":2}}'
+  kubectl -n "${SYSTEM_NAMESPACE}" patch deployment "$deployment" --patch '{"spec":{"replicas":2}}'
 done
 # Define short -spoofinterval to ensure frequent probing while stopping pods
-go_test_e2e -timeout=10m -parallel=1 ./test/ha "--systemNamespace=${E2E_SYSTEM_NAMESPACE}" -spoofinterval="10ms" || failed=1
-kubectl get cm config-leader-election -n "${E2E_SYSTEM_NAMESPACE}" -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -
+go_test_e2e -timeout=10m -parallel=1 ./test/ha "--systemNamespace=${SYSTEM_NAMESPACE}" -spoofinterval="10ms" || failed=1
+kubectl get cm config-leader-election -n "${SYSTEM_NAMESPACE}" -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -
 
 # Dump cluster state in case of failure
 (( failed )) && dump_cluster_state

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -69,7 +69,7 @@ TIMEOUT=10m
 header "Running preupgrade tests"
 
 go_test_e2e -tags=preupgrade -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${SYSTEM_NAMESPACE} || fail_test
+  --resolvabledomain=$(use_resolvable_domain) || fail_test
 
 header "Starting prober test"
 
@@ -77,7 +77,7 @@ header "Starting prober test"
 rm -f /tmp/prober-signal
 
 go_test_e2e -tags=probe -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${SYSTEM_NAMESPACE} &
+  --resolvabledomain=$(use_resolvable_domain) &
 PROBER_PID=$!
 echo "Prober PID is ${PROBER_PID}"
 
@@ -85,13 +85,13 @@ install_head
 
 header "Running postupgrade tests"
 go_test_e2e -tags=postupgrade -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${SYSTEM_NAMESPACE} || fail_test
+  --resolvabledomain=$(use_resolvable_domain) || fail_test
 
 install_latest_release
 
 header "Running postdowngrade tests"
 go_test_e2e -tags=postdowngrade -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${SYSTEM_NAMESPACE} || fail_test
+  --resolvabledomain=$(use_resolvable_domain) || fail_test
 
 # The prober is blocking on /tmp/prober-signal to know when it should exit.
 #

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -46,13 +46,13 @@ function install_latest_release() {
 
   install_knative_serving "${RELEASE_YAML}" \
       || fail_test "Knative latest release installation failed"
-  wait_until_pods_running ${E2E_SYSTEM_NAMESPACE}
+  wait_until_pods_running ${SYSTEM_NAMESPACE}
 }
 
 function install_head() {
   header "Installing Knative head release"
   install_knative_serving || fail_test "Knative head release installation failed"
-  wait_until_pods_running ${E2E_SYSTEM_NAMESPACE}
+  wait_until_pods_running ${SYSTEM_NAMESPACE}
 }
 
 function knative_setup() {
@@ -69,7 +69,7 @@ TIMEOUT=10m
 header "Running preupgrade tests"
 
 go_test_e2e -tags=preupgrade -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${E2E_SYSTEM_NAMESPACE} || fail_test
+  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${SYSTEM_NAMESPACE} || fail_test
 
 header "Starting prober test"
 
@@ -77,7 +77,7 @@ header "Starting prober test"
 rm -f /tmp/prober-signal
 
 go_test_e2e -tags=probe -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${E2E_SYSTEM_NAMESPACE} &
+  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${SYSTEM_NAMESPACE} &
 PROBER_PID=$!
 echo "Prober PID is ${PROBER_PID}"
 
@@ -85,13 +85,13 @@ install_head
 
 header "Running postupgrade tests"
 go_test_e2e -tags=postupgrade -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${E2E_SYSTEM_NAMESPACE} || fail_test
+  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${SYSTEM_NAMESPACE} || fail_test
 
 install_latest_release
 
 header "Running postdowngrade tests"
 go_test_e2e -tags=postdowngrade -timeout=${TIMEOUT} ./test/upgrade \
-  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${E2E_SYSTEM_NAMESPACE} || fail_test
+  --resolvabledomain=$(use_resolvable_domain) --systemNamespace=${SYSTEM_NAMESPACE} || fail_test
 
 # The prober is blocking on /tmp/prober-signal to know when it should exit.
 #

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
+	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/logstream"
@@ -645,7 +646,7 @@ func TestTargetBurstCapacityMinusOne(t *testing.T) {
 		t.Fatalf("Error retrieving autoscaler configmap: %v", err)
 	}
 	aeps, err := ctx.clients.KubeClient.Kube.CoreV1().Endpoints(
-		test.ServingFlags.SystemNamespace).Get(networking.ActivatorServiceName, metav1.GetOptions{})
+		system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error getting activator endpoints: %v", err)
 	}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -32,6 +32,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/networking"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
@@ -72,7 +73,7 @@ func SetupWithNamespace(t *testing.T, namespace string) *test.Clients {
 // autoscalerCM returns the current autoscaler config map deployed to the
 // test cluster.
 func autoscalerCM(clients *test.Clients) (*autoscalerconfig.Config, error) {
-	autoscalerCM, err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingFlags.SystemNamespace).Get(
+	autoscalerCM, err := clients.KubeClient.Kube.CoreV1().ConfigMaps(system.Namespace()).Get(
 		autoscalerconfig.ConfigName,
 		metav1.GetOptions{})
 	if err != nil {
@@ -83,14 +84,14 @@ func autoscalerCM(clients *test.Clients) (*autoscalerconfig.Config, error) {
 
 // rawCM returns the raw knative config map for the given name
 func rawCM(clients *test.Clients, name string) (*corev1.ConfigMap, error) {
-	return clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingFlags.SystemNamespace).Get(
+	return clients.KubeClient.Kube.CoreV1().ConfigMaps(system.Namespace()).Get(
 		name,
 		metav1.GetOptions{})
 }
 
 // patchCM updates the existing config map with the supplied value.
 func patchCM(clients *test.Clients, cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	return clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingFlags.SystemNamespace).Update(cm)
+	return clients.KubeClient.Kube.CoreV1().ConfigMaps(system.Namespace()).Update(cm)
 }
 
 // WaitForScaleToZero will wait for the specified deployment to scale to 0 replicas.
@@ -121,7 +122,7 @@ func waitForActivatorEndpoints(resources *v1test.ResourceObjects, clients *test.
 	return wait.Poll(250*time.Millisecond, time.Minute, func() (bool, error) {
 		// We need to fetch the activator endpoints at every check, since it can change.
 		aeps, err := clients.KubeClient.Kube.CoreV1().Endpoints(
-			test.ServingFlags.SystemNamespace).Get(networking.ActivatorServiceName, metav1.GetOptions{})
+			system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
 		if err != nil {
 			return false, nil
 		}

--- a/test/e2e/istio/probing_test.go
+++ b/test/e2e/istio/probing_test.go
@@ -43,6 +43,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	istiov1alpha3 "istio.io/api/networking/v1alpha3"
+	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/pkg/test/spoof"
@@ -57,7 +58,7 @@ func TestIstioProbing(t *testing.T) {
 	defer cancel()
 
 	clients := e2e.Setup(t)
-	namespace := test.ServingFlags.SystemNamespace
+	namespace := system.Namespace()
 	// Save the current Gateway to restore it after the test
 	oldGateway, err := clients.IstioClient.NetworkingV1alpha3().Gateways(namespace).Get(networking.KnativeIngressGateway, metav1.GetOptions{})
 	if err != nil {

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -50,8 +50,6 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 		"Set this flag to the ingress class to test against.")
 	flag.StringVar(&f.CertificateClass, "certificateClass", network.CertManagerCertificateClassName,
 		"Set this flag to the certificate class to test against.")
-	flag.StringVar(&f.SystemNamespace, "systemNamespace", "knative-serving",
-		"Set this flag to the namespace for Knative Serving.")
 
 	return &f
 }

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -23,6 +23,8 @@ import (
 	"sort"
 	"testing"
 
+	"knative.dev/pkg/system"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/ptr"
 	pkgTest "knative.dev/pkg/test"
@@ -90,7 +92,7 @@ func TestActivatorHA(t *testing.T) {
 		t.Fatal("Error creating spoofing client:", err)
 	}
 
-	pods, err := clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).List(metav1.ListOptions{
+	pods, err := clients.KubeClient.Kube.CoreV1().Pods(system.Namespace()).List(metav1.ListOptions{
 		LabelSelector: activatorLabel,
 	})
 	if err != nil {
@@ -103,7 +105,7 @@ func TestActivatorHA(t *testing.T) {
 		t.Fatalf("Unable to get public endpoints for revision %s: %v", resourcesScaleToZero.Revision.Name, err)
 	}
 
-	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(activatorPod, &metav1.DeleteOptions{
+	clients.KubeClient.Kube.CoreV1().Pods(system.Namespace()).Delete(activatorPod, &metav1.DeleteOptions{
 		GracePeriodSeconds: ptr.Int64(0),
 	})
 
@@ -122,7 +124,7 @@ func TestActivatorHA(t *testing.T) {
 		t.Fatalf("Deployment %s failed to scale up: %v", activatorDeploymentName, err)
 	}
 
-	pods, err = clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).List(metav1.ListOptions{
+	pods, err = clients.KubeClient.Kube.CoreV1().Pods(system.Namespace()).List(metav1.ListOptions{
 		LabelSelector: activatorLabel,
 	})
 	if err != nil {
@@ -140,7 +142,7 @@ func TestActivatorHA(t *testing.T) {
 		t.Fatalf("Unable to get public endpoints for revision %s: %v", resourcesScaleToZero.Revision.Name, err)
 	}
 
-	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(activatorPod, &metav1.DeleteOptions{
+	clients.KubeClient.Kube.CoreV1().Pods(system.Namespace()).Delete(activatorPod, &metav1.DeleteOptions{
 		GracePeriodSeconds: ptr.Int64(0),
 	})
 

--- a/test/ha/autoscalerhpa_test.go
+++ b/test/ha/autoscalerhpa_test.go
@@ -57,16 +57,7 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-<<<<<<< HEAD
-	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(leaderController, &metav1.DeleteOptions{})
-=======
-	leaderController, err := getLeader(t, clients, autoscalerHPALease)
-	if err != nil {
-		t.Fatalf("Failed to get leader: %v", err)
-	}
-
 	clients.KubeClient.Kube.CoreV1().Pods(system.Namespace()).Delete(leaderController, &metav1.DeleteOptions{})
->>>>>>> e4621c5c3... Remove namespace flag and replace with exported env var.
 
 	if err := waitForPodDeleted(t, clients, leaderController); err != nil {
 		t.Fatalf("Did not observe %s to actually be deleted: %v", leaderController, err)

--- a/test/ha/autoscalerhpa_test.go
+++ b/test/ha/autoscalerhpa_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	rtesting "knative.dev/serving/pkg/testing/v1"
@@ -56,7 +57,16 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
+<<<<<<< HEAD
 	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(leaderController, &metav1.DeleteOptions{})
+=======
+	leaderController, err := getLeader(t, clients, autoscalerHPALease)
+	if err != nil {
+		t.Fatalf("Failed to get leader: %v", err)
+	}
+
+	clients.KubeClient.Kube.CoreV1().Pods(system.Namespace()).Delete(leaderController, &metav1.DeleteOptions{})
+>>>>>>> e4621c5c3... Remove namespace flag and replace with exported env var.
 
 	if err := waitForPodDeleted(t, clients, leaderController); err != nil {
 		t.Fatalf("Did not observe %s to actually be deleted: %v", leaderController, err)

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -43,15 +43,11 @@ func TestControllerHA(t *testing.T) {
 		t.Fatalf("Failed to get leader: %v", err)
 	}
 
-<<<<<<< HEAD
 	service1Names, resources := createPizzaPlanetService(t)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, service1Names) })
 	defer test.TearDown(clients, service1Names)
 
-	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(leaderController, &metav1.DeleteOptions{})
-=======
 	clients.KubeClient.Kube.CoreV1().Pods(system.Namespace()).Delete(leaderController, &metav1.DeleteOptions{})
->>>>>>> e4621c5c3... Remove namespace flag and replace with exported env var.
 
 	if err := waitForPodDeleted(t, clients, leaderController); err != nil {
 		t.Fatalf("Did not observe %s to actually be deleted: %v", leaderController, err)

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/system"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"
 )
@@ -42,11 +43,15 @@ func TestControllerHA(t *testing.T) {
 		t.Fatalf("Failed to get leader: %v", err)
 	}
 
+<<<<<<< HEAD
 	service1Names, resources := createPizzaPlanetService(t)
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, service1Names) })
 	defer test.TearDown(clients, service1Names)
 
 	clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Delete(leaderController, &metav1.DeleteOptions{})
+=======
+	clients.KubeClient.Kube.CoreV1().Pods(system.Namespace()).Delete(leaderController, &metav1.DeleteOptions{})
+>>>>>>> e4621c5c3... Remove namespace flag and replace with exported env var.
 
 	if err := waitForPodDeleted(t, clients, leaderController); err != nil {
 		t.Fatalf("Did not observe %s to actually be deleted: %v", leaderController, err)

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -99,25 +99,7 @@ func podExists(clients *test.Clients, podName string) (bool, error) {
 	return true, nil
 }
 
-<<<<<<< HEAD
 func waitForDeploymentScale(clients *test.Clients, name string, scale int) error {
-=======
-func scaleUpDeployment(clients *test.Clients, name string) error {
-	return scaleDeployment(clients, name, haReplicas)
-}
-
-func scaleDownDeployment(clients *test.Clients, name string) error {
-	return scaleDeployment(clients, name, 1 /*target number of replicas*/)
-}
-
-func scaleDeployment(clients *test.Clients, name string, replicas int) error {
-	scaleRequest := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: int32(replicas)}}
-	scaleRequest.Name = name
-	scaleRequest.Namespace = system.Namespace()
-	if _, err := clients.KubeClient.Kube.AppsV1().Deployments(system.Namespace()).UpdateScale(name, scaleRequest); err != nil {
-		return fmt.Errorf("error scaling: %w", err)
-	}
->>>>>>> e4621c5c3... Remove namespace flag and replace with exported env var.
 	return pkgTest.WaitForDeploymentState(
 		clients.KubeClient,
 		name,

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -29,6 +29,7 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/pkg/apis/networking"
@@ -46,7 +47,7 @@ const (
 func getLeader(t *testing.T, clients *test.Clients, lease string) (string, error) {
 	var leader string
 	err := wait.PollImmediate(test.PollInterval, time.Minute, func() (bool, error) {
-		lease, err := clients.KubeClient.Kube.CoordinationV1().Leases(test.ServingFlags.SystemNamespace).Get(lease, metav1.GetOptions{})
+		lease, err := clients.KubeClient.Kube.CoordinationV1().Leases(system.Namespace()).Get(lease, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("error getting lease %s: %w", lease, err)
 		}
@@ -89,7 +90,7 @@ func waitForChangedPublicEndpoints(t *testing.T, clients *test.Clients, revision
 }
 
 func podExists(clients *test.Clients, podName string) (bool, error) {
-	if _, err := clients.KubeClient.Kube.CoreV1().Pods(test.ServingFlags.SystemNamespace).Get(podName, metav1.GetOptions{}); err != nil {
+	if _, err := clients.KubeClient.Kube.CoreV1().Pods(system.Namespace()).Get(podName, metav1.GetOptions{}); err != nil {
 		if apierrs.IsNotFound(err) {
 			return false, nil
 		}
@@ -98,7 +99,25 @@ func podExists(clients *test.Clients, podName string) (bool, error) {
 	return true, nil
 }
 
+<<<<<<< HEAD
 func waitForDeploymentScale(clients *test.Clients, name string, scale int) error {
+=======
+func scaleUpDeployment(clients *test.Clients, name string) error {
+	return scaleDeployment(clients, name, haReplicas)
+}
+
+func scaleDownDeployment(clients *test.Clients, name string) error {
+	return scaleDeployment(clients, name, 1 /*target number of replicas*/)
+}
+
+func scaleDeployment(clients *test.Clients, name string, replicas int) error {
+	scaleRequest := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: int32(replicas)}}
+	scaleRequest.Name = name
+	scaleRequest.Namespace = system.Namespace()
+	if _, err := clients.KubeClient.Kube.AppsV1().Deployments(system.Namespace()).UpdateScale(name, scaleRequest); err != nil {
+		return fmt.Errorf("error scaling: %w", err)
+	}
+>>>>>>> e4621c5c3... Remove namespace flag and replace with exported env var.
 	return pkgTest.WaitForDeploymentState(
 		clients.KubeClient,
 		name,
@@ -106,7 +125,7 @@ func waitForDeploymentScale(clients *test.Clients, name string, scale int) error
 			return d.Status.ReadyReplicas == int32(scale), nil
 		},
 		"DeploymentIsScaled",
-		test.ServingFlags.SystemNamespace,
+		system.Namespace(),
 		time.Minute,
 	)
 }

--- a/test/performance/benchmarks/dataplane-probe/continuous/main.go
+++ b/test/performance/benchmarks/dataplane-probe/continuous/main.go
@@ -25,8 +25,8 @@ import (
 	vegeta "github.com/tsenart/vegeta/lib"
 
 	"knative.dev/pkg/signals"
+	"knative.dev/pkg/system"
 	"knative.dev/pkg/test/mako"
-	"knative.dev/serving/test"
 	"knative.dev/serving/test/performance"
 	"knative.dev/serving/test/performance/metrics"
 )
@@ -97,7 +97,7 @@ func main() {
 
 	// Start the attack!
 	results := attacker.Attack(targeter, rate, *duration, "load-test")
-	deploymentStatus := metrics.FetchDeploymentStatus(ctx, test.ServingFlags.SystemNamespace, "activator", time.Second)
+	deploymentStatus := metrics.FetchDeploymentStatus(ctx, system.Namespace(), "activator", time.Second)
 LOOP:
 	for {
 		select {

--- a/test/system.go
+++ b/test/system.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"os"
+
+	"knative.dev/pkg/system"
+)
+
+func init() {
+	if ns := os.Getenv(system.NamespaceEnvKey); ns != "" {
+		return
+	}
+	os.Setenv(system.NamespaceEnvKey, "knative-serving")
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Our logstreams have been broken since https://github.com/knative/serving/commit/c43a7e76db13c21d4bb49e89b597f4c943e24b8a because we dropped the connection via the `SYSTEM_NAMESPACE` variable. This brings it back,

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor @houshengbo 
