### PR TITLE
Print the SKS num activators field in kubectl

### DIFF
--- a/config/core/resources/serverlessservice.yaml
+++ b/config/core/resources/serverlessservice.yaml
@@ -41,6 +41,9 @@ spec:
   - name: Mode
     type: string
     JSONPath: ".spec.mode"
+  - name: NumActivators
+    type: integer
+    JSONPath: ".spec.numActivators"
   - name: ServiceName
     type: string
     JSONPath: ".status.serviceName"

--- a/config/core/resources/serverlessservice.yaml
+++ b/config/core/resources/serverlessservice.yaml
@@ -41,7 +41,7 @@ spec:
   - name: Mode
     type: string
     JSONPath: ".spec.mode"
-  - name: NumActivators
+  - name: Activators
     type: integer
     JSONPath: ".spec.numActivators"
   - name: ServiceName


### PR DESCRIPTION
This is quite useful when debugging the state of sks

/assign mattmoor @markusthoemmes 