### PR TITLE
Add validation check to tag name

### DIFF
--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -62,7 +62,11 @@ func validateTrafficList(ctx context.Context, traffic []TrafficTarget) *apis.Fie
 		if tt.Tag == "" {
 			continue
 		}
-
+		if msgs := validation.IsDNS1035Label(tt.Tag); len(msgs) > 0 {
+			errs = errs.Also(apis.ErrInvalidArrayValue(
+				fmt.Sprintf("not a DNS 1035 label: %v", msgs),
+				"tag", i))
+		}
 		if idx, ok := trafficMap[tt.Tag]; ok {
 			// We want only single definition of the route, even if it points
 			// to the same config or revision.

--- a/pkg/apis/serving/v1/route_validation_test.go
+++ b/pkg/apis/serving/v1/route_validation_test.go
@@ -491,8 +491,25 @@ func TestRouteValidation(t *testing.T) {
 			Message: "not a DNS 1035 label: [must be no more than 63 characters]",
 			Paths:   []string{"metadata.name"},
 		},
+	}, {
+		name: "invalid tag name",
+		r: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+			},
+			Spec: RouteSpec{
+				Traffic: []TrafficTarget{{
+					Tag:          "foo@",
+					RevisionName: "bar",
+					Percent:      ptr.Int64(100),
+				}},
+			},
+		},
+		want: &apis.FieldError{
+			Message: "invalid value: not a DNS 1035 label: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]",
+			Paths:   []string{"spec.traffic.tag[0]"},
+		},
 	}}
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.r.Validate(context.Background())


### PR DESCRIPTION
## Proposed Changes

`tag` name is used for sub route's domain URL, but we can modify it to
any value like "foo@" or "foo.bar" currently.

This patch adds validation check to the tag name which is same
validation with Revision name.

ERROR AFTER THIS PATCH:

```
$ kubectl edit ksvc hello-example
error: services.serving.knative.dev "hello-example" could not be patched: admission webhook "validation.webhook.serving.knative.dev" denied the request: validation failed: invalid value: not a DNS 1035 label: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]: spec.traffic.tag[0]
You can run `kubectl replace -f /tmp/kubectl-edit-bm06i.yaml` to try this update again.
```

/lint

**Release Note**

```release-note
The tag name specified in spec.traffic.tag must meet requirements of RFC 1035
```
