### PR TITLE
Add a span to show queue waiting on tracing

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -165,6 +165,7 @@ func proxyHandler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, tracingEn
 			}
 			if err := breaker.Maybe(r.Context(), func() {
 				cf()
+				next.ServeHTTP(w, r)
 			}); err != nil {
 				cf()
 				switch err {
@@ -173,10 +174,10 @@ func proxyHandler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, tracingEn
 				default:
 					w.WriteHeader(http.StatusInternalServerError)
 				}
-				return
 			}
+		} else {
+			next.ServeHTTP(w, r)
 		}
-		next.ServeHTTP(w, r)
 	}
 }
 

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -165,7 +165,6 @@ func proxyHandler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, tracingEn
 			}
 			if err := breaker.Maybe(r.Context(), func() {
 				cf()
-				next.ServeHTTP(w, r)
 			}); err != nil {
 				cf()
 				switch err {
@@ -174,10 +173,10 @@ func proxyHandler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, tracingEn
 				default:
 					w.WriteHeader(http.StatusInternalServerError)
 				}
+				return
 			}
-		} else {
-			next.ServeHTTP(w, r)
 		}
+		next.ServeHTTP(w, r)
 	}
 }
 

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -128,6 +128,8 @@ type config struct {
 	TracingConfigStackdriverProjectID string                    `split_words:"true"` // optional
 }
 
+func noop() {}
+
 // Make handler a closure for testing.
 func proxyHandler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, tracingEnabled bool, next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -155,21 +157,17 @@ func proxyHandler(reqChan chan queue.ReqEvent, breaker *queue.Breaker, tracingEn
 
 		// Enforce queuing and concurrency limits.
 		if breaker != nil {
-			var cf func()
+			cf := noop
 			if tracingEnabled {
 				ctx, waitSpan := trace.StartSpan(r.Context(), "queueWait")
 				r = r.WithContext(ctx)
 				cf = waitSpan.End
 			}
 			if err := breaker.Maybe(r.Context(), func() {
-				if cf != nil {
-					cf()
-				}
+				cf()
 				next.ServeHTTP(w, r)
 			}); err != nil {
-				if cf != nil {
-					cf()
-				}
+				cf()
 				switch err {
 				case context.DeadlineExceeded, queue.ErrRequestQueueFull:
 					http.Error(w, err.Error(), http.StatusServiceUnavailable)


### PR DESCRIPTION
It is quite useful to see the queue waiting in the trace
since right now they are munged together with the 'proxy', which
does not help to separate those two.


/lint
/assign mattmoor

![drzLVDEUzEi](https://user-images.githubusercontent.com/764767/79164693-69b11200-7d96-11ea-941a-611484e82208.png)
