### PR TITLE
Point test-infra to release-0.14 in prep for 0.14 release

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1956,15 +1956,15 @@
   revision = "2a1db869228ceaca9df34790b49cdf4893a5d39d"
 
 [[projects]]
-  branch = "master"
-  digest = "1:dc73d65f40ea05b1d0db96ae5491b6ebc162bb59b3ac5a252cdf87848bc7a4b7"
+  branch = "release-0.14"
+  digest = "1:50482e6fd500cf50c4a29d640cda026206145c6716dff72e4368a5e57fdb7095"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "74b24ca44778c3a69ecc193250cdddb5d0e64b88"
+  revision = "9fa5882b65c5fe7e177bb74874e9a5ac87b84e98"
 
 [[projects]]
   digest = "1:92b88da51692abe195601cb17d35bbb9b6bc2011237a2f234fedba7411ed8122"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,6 +30,10 @@ required = [
   name = "knative.dev/pkg"
   branch = "release-0.14"
 
+[[override]]
+  name = "knative.dev/test-infra"
+  branch = "release-0.14"
+
 [[constraint]]
   name = "knative.dev/caching"
   branch = "master"

--- a/vendor/knative.dev/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/knative.dev/test-infra/scripts/presubmit-tests.sh
@@ -129,7 +129,7 @@ function markdown_build_tests() {
   (( DISABLE_MD_LINTING && DISABLE_MD_LINK_CHECK )) && return 0
   # Get changed markdown files (ignore /vendor, github templates, and deleted files)
   local mdfiles=""
-  for file in $(echo "${CHANGED_FILES}" | grep \\.md$ | grep -v ^vendor/ | grep -v ^.github/); do
+  for file in $(echo "${CHANGED_FILES}" | grep \.md$ | grep -v ^vendor/ | grep -v ^.github/); do
     [[ -f "${file}" ]] && mdfiles="${mdfiles} ${file}"
   done
   [[ -z "${mdfiles}" ]] && return 0


### PR DESCRIPTION
Related to https://github.com/knative/test-infra/issues/1900

In future releases, we should coordinate this with the 1-week-early pkg release branch switchover.

## Proposed Changes

- Update test-infra dependency to release-0.14 branch in prep for 0.14 release