### PR TITLE
Stabilize Activator HA tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -33,6 +33,22 @@ function knative_setup() {
   install_knative_serving
 }
 
+function wait_for_leader_controller() {
+  echo -n "Waiting for a leader Controller"
+  for i in {1..150}; do  # timeout after 5 minutes
+    local leader=$(kubectl get lease controller -n "${SYSTEM_NAMESPACE}" -ojsonpath='{.spec.holderIdentity}' | cut -d"_" -f1)
+    # Make sure the leader pod exists.
+    if [ -n "${leader}" ] && kubectl get pod "${leader}" -n "${SYSTEM_NAMESPACE}"  >/dev/null 2>&1; then
+      echo -e "\nNew leader Controller has been elected"
+      return 0
+    fi
+    echo -n "."
+    sleep 2
+  done
+  echo -e "\n\nERROR: timeout waiting for leader controller"
+  return 1
+}
+
 # Script entry point.
 
 # Skip installing istio as an add-on
@@ -105,6 +121,8 @@ kubectl -n "${SYSTEM_NAMESPACE}" delete hpa activator
 for deployment in controller autoscaler-hpa activator; do
   kubectl -n "${SYSTEM_NAMESPACE}" patch deployment "$deployment" --patch '{"spec":{"replicas":2}}'
 done
+# Wait for a new leader Controller to prevent race conditions during service reconciliation
+wait_for_leader_controller || failed=1
 # Define short -spoofinterval to ensure frequent probing while stopping pods
 go_test_e2e -timeout=15m -failfast -parallel=1 ./test/ha -spoofinterval="10ms" || failed=1
 kubectl get cm config-leader-election -n "${SYSTEM_NAMESPACE}" -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -119,7 +119,7 @@ add_trap "kubectl get cm config-leader-election -n ${SYSTEM_NAMESPACE} -oyaml | 
 kubectl -n "${SYSTEM_NAMESPACE}" delete hpa activator
 # Scale up components for HA tests
 for deployment in controller autoscaler-hpa activator; do
-  kubectl -n "${SYSTEM_NAMESPACE}" patch deployment "$deployment" --patch '{"spec":{"replicas":2}}'
+  kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "$deployment" --replicas=2
 done
 # Wait for a new leader Controller to prevent race conditions during service reconciliation
 wait_for_leader_controller || failed=1

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -106,7 +106,7 @@ for deployment in controller autoscaler-hpa activator; do
   kubectl -n "${SYSTEM_NAMESPACE}" patch deployment "$deployment" --patch '{"spec":{"replicas":2}}'
 done
 # Define short -spoofinterval to ensure frequent probing while stopping pods
-go_test_e2e -timeout=10m -parallel=1 ./test/ha -spoofinterval="10ms" || failed=1
+go_test_e2e -timeout=15m -failfast -parallel=1 ./test/ha -spoofinterval="10ms" || failed=1
 kubectl get cm config-leader-election -n "${SYSTEM_NAMESPACE}" -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -
 
 # Dump cluster state in case of failure

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -53,6 +53,11 @@ func TestActivatorHA(t *testing.T) {
 		t.Fatalf("Deployment %s not scaled to %d: %v", activatorDeploymentName, haReplicas, err)
 	}
 
+	// Wait for Controller to elect a new leader to prevent race conditions.
+	if _, err := getLeader(t, clients, controllerDeploymentName); err != nil {
+		t.Fatalf("Failed get leader: %v", err)
+	}
+
 	// Create first service that we will continually probe during activator restart.
 	names, resources := createPizzaPlanetService(t,
 		rtesting.WithConfigAnnotations(map[string]string{

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -53,11 +53,6 @@ func TestActivatorHA(t *testing.T) {
 		t.Fatalf("Deployment %s not scaled to %d: %v", activatorDeploymentName, haReplicas, err)
 	}
 
-	// Wait for Controller to elect a new leader to prevent race conditions.
-	if _, err := getLeader(t, clients, controllerDeploymentName); err != nil {
-		t.Fatalf("Failed get leader: %v", err)
-	}
-
 	// Create first service that we will continually probe during activator restart.
 	names, resources := createPizzaPlanetService(t,
 		rtesting.WithConfigAnnotations(map[string]string{

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -38,6 +38,7 @@ import (
 const (
 	activatorDeploymentName = "activator"
 	activatorLabel          = "app=activator"
+	minProbes               = 100  // We want to send at least 100 requests.
 	SLO                     = 0.99 // We permit 0.01 of requests to fail due to killing the Activator.
 )
 
@@ -77,7 +78,8 @@ func TestActivatorHA(t *testing.T) {
 		t.Fatal("Failed to scale to zero:", err)
 	}
 
-	prober := test.RunRouteProber(log.Printf, clients, resources.Service.Status.URL.URL())
+	prober := test.NewProberManager(log.Printf, clients, minProbes)
+	prober.Spawn(resources.Service.Status.URL.URL())
 	defer assertSLO(t, prober)
 
 	scaleToZeroURL := resourcesScaleToZero.Service.Status.URL.URL()

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -18,7 +18,6 @@ package ha
 
 import (
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 	"testing"
@@ -31,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
-	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
 	rtesting "knative.dev/serving/pkg/testing/v1"
@@ -126,18 +124,6 @@ func createPizzaPlanetService(t *testing.T, fopt ...rtesting.ServiceOption) (tes
 
 	assertServiceEventuallyWorks(t, clients, names, resources.Service.Status.URL.URL(), test.PizzaPlanetText1)
 	return names, resources
-}
-
-func assertServiceWorksNow(t *testing.T, clients *test.Clients, spoofingClient *spoof.SpoofingClient, names test.ResourceNames, url *url.URL, expectedText string) {
-	t.Helper()
-	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
-	if err != nil {
-		t.Fatalf("Failed to create request: %v", err)
-	}
-	resp, err := spoofingClient.Do(req)
-	if err != nil || !strings.Contains(string(resp.Body), expectedText) {
-		t.Fatalf("Failed to verify service works. Response body: %s, Error: %v", string(resp.Body), err)
-	}
 }
 
 func assertServiceEventuallyWorks(t *testing.T, clients *test.Clients, names test.ResourceNames, url *url.URL, expectedText string) {


### PR DESCRIPTION
* at the moment we sometimes hit test suite timeout

This is to prevent those timeouts which should help stabilize  https://github.com/knative/serving/issues/7579

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/7579 (partially)

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* increase the timeout to 15 minutes so that we allow at least one test to pass/fail 
* use -failfast to stop immediately after the failure and create a dump of services
* make sure we wait for the Leader controller even in the ActivatorHA test. Even though it doesn't have leader election enabled we need to wait for Controller's leader. (see the commit message for more details)
* send at least 100 requests to make sure we hit the SLO (see commit message) 


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
