### PR TITLE
Actually verify the contents of resource.Quantity.

### DIFF
--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -841,8 +840,8 @@ func TestMakeDeployment(t *testing.T) {
 			if err != nil {
 				t.Fatalf("got unexpected error: %v", err)
 			}
-			if diff := cmp.Diff(test.want, got, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" {
-				t.Errorf("MakeDeployment (-want, +got) = %v", diff)
+			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(resource.Quantity{})); diff != "" {
+				t.Error("MakeDeployment (-want, +got) =", diff)
 			}
 		})
 	}

--- a/pkg/reconciler/revision/resources/pa_test.go
+++ b/pkg/reconciler/revision/resources/pa_test.go
@@ -20,9 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/ptr"
@@ -316,8 +314,8 @@ func TestMakePA(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			got := MakePA(test.rev)
-			if diff := cmp.Diff(test.want, got, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" {
-				t.Errorf("MakeK8sService (-want, +got) = %v", diff)
+			if !cmp.Equal(got, test.want) {
+				t.Error("MakeK8sService (-want, +got) =", cmp.Diff(test.want, got))
 			}
 		})
 	}

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
 
 	corev1 "k8s.io/api/core/v1"
@@ -278,8 +277,8 @@ func TestMakeQueueContainer(t *testing.T) {
 			})
 			sortEnv(got.Env)
 			sortEnv(test.want.Env)
-			if diff := cmp.Diff(test.want, *got, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" {
-				t.Errorf("makeQueueContainer (-want, +got) = %v", diff)
+			if diff := cmp.Diff(test.want, *got, cmp.AllowUnexported(resource.Quantity{})); diff != "" {
+				t.Error("makeQueueContainer (-want, +got) =", diff)
 			}
 		})
 	}
@@ -419,8 +418,8 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 			})
 			sortEnv(got.Env)
 			sortEnv(test.want.Env)
-			if diff := cmp.Diff(test.want, *got, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" {
-				t.Errorf("makeQueueContainerWithPercentageAnnotation (-want, +got) = %v", diff)
+			if diff := cmp.Diff(test.want, *got, cmp.AllowUnexported(resource.Quantity{})); diff != "" {
+				t.Error("makeQueueContainerWithPercentageAnnotation (-want, +got) =", diff)
 			}
 			if test.want.Resources.Limits.Memory().Cmp(*got.Resources.Limits.Memory()) != 0 {
 				t.Errorf("Resources.Limits.Memory = %v, want: %v", got.Resources.Limits.Memory(), test.want.Resources.Limits.Memory())
@@ -504,8 +503,8 @@ func TestProbeGenerationHTTPDefaults(t *testing.T) {
 		t.Fatal("makeQueueContainer returned error")
 	}
 	sortEnv(got.Env)
-	if diff := cmp.Diff(want, *got, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" {
-		t.Errorf("makeQueueContainer(-want, +got) = %v", diff)
+	if diff := cmp.Diff(want, *got, cmp.AllowUnexported(resource.Quantity{})); diff != "" {
+		t.Error("makeQueueContainer(-want, +got) =", diff)
 	}
 }
 
@@ -579,8 +578,8 @@ func TestProbeGenerationHTTP(t *testing.T) {
 		t.Fatal("makeQueueContainer returned error")
 	}
 	sortEnv(got.Env)
-	if diff := cmp.Diff(want, *got, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" {
-		t.Errorf("makeQueueContainer(-want, +got) = %v", diff)
+	if diff := cmp.Diff(want, *got, cmp.AllowUnexported(resource.Quantity{})); diff != "" {
+		t.Error("makeQueueContainer(-want, +got) =", diff)
 	}
 }
 
@@ -756,8 +755,8 @@ func TestTCPProbeGeneration(t *testing.T) {
 			}
 			sortEnv(got.Env)
 			sortEnv(test.want.Env)
-			if diff := cmp.Diff(test.want, *got, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" {
-				t.Errorf("makeQueueContainer (-want, +got) = %v", diff)
+			if diff := cmp.Diff(test.want, *got, cmp.AllowUnexported(resource.Quantity{})); diff != "" {
+				t.Error("makeQueueContainer (-want, +got) =", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Currently we basically ignored the quantity numerical values.
No reaon to do that.


/lint
/assign @dprotaso mattmoor @taragu 