### PR TITLE
Microfixes to autoscale.go

### DIFF
--- a/test/test_images/autoscale/autoscale.go
+++ b/test/test_images/autoscale/autoscale.go
@@ -171,7 +171,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if max <= 0 {
+	if hasMax && max <= 0 {
 		http.Error(w, "Non-positive query params are not supported", http.StatusBadRequest)
 		return
 	}
@@ -180,7 +180,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if mb <= 0 {
+	if hasMb && mb <= 0 {
 		http.Error(w, "Non-positive durations are not supported", http.StatusBadRequest)
 		return
 	}

--- a/test/test_images/autoscale/autoscale.go
+++ b/test/test_images/autoscale/autoscale.go
@@ -157,12 +157,12 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Negative query params are not supported", http.StatusBadRequest)
 		return
 	}
-	mssd, hasMssd, err := parseIntParam(r, "sleep-stddev")
+	msSD, hasMsSD, err := parseIntParam(r, "sleep-stddev")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if mssd < 0 {
+	if msSD < 0 {
 		http.Error(w, "Negative query params are not supported", http.StatusBadRequest)
 		return
 	}
@@ -171,8 +171,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if max < 0 {
-		http.Error(w, "Negative query params are not supported", http.StatusBadRequest)
+	if max <= 0 {
+		http.Error(w, "Non-positive query params are not supported", http.StatusBadRequest)
 		return
 	}
 	mb, hasMb, err := parseIntParam(r, "bloat")
@@ -180,35 +180,35 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if mb < 0 {
-		http.Error(w, "Negative durations are not supported", http.StatusBadRequest)
+	if mb <= 0 {
+		http.Error(w, "Non-positive durations are not supported", http.StatusBadRequest)
 		return
 	}
 	// Consume time, cpu and memory in parallel.
 	var wg sync.WaitGroup
 	defer wg.Wait()
-	if hasMs && !hasMssd && ms > 0 {
+	if hasMs && !hasMsSD {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			fmt.Fprint(w, sleep(ms))
 		}()
 	}
-	if hasMs && hasMssd && ms > 0 && mssd > 0 {
+	if hasMs && hasMsSD {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			fmt.Fprint(w, randSleep(ms, mssd))
+			fmt.Fprint(w, randSleep(ms, msSD))
 		}()
 	}
-	if hasMax && max > 0 {
+	if hasMax {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			fmt.Fprint(w, prime(max))
 		}()
 	}
-	if hasMb && mb > 0 {
+	if hasMb {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
- Stop permitting 0 mb/prime since this is errorneous input.
- Stop checking 0 for delays, since it's not error, in general, but just
  useless.

/assign @markusthoemmes mattmoor