### PR TITLE
Expand the comment for grace time to scale to 0

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -140,6 +140,13 @@ data:
 
     # Scale to zero grace period is the time an inactive revision is left
     # running before it is scaled to zero (min: 6s).
+    # This is the upper limit and is provided not to enforce timeout after
+    # the revision stopped receiving requests for stable window, but to
+    # ensure network reprogramming to put activator in the path has completed.
+    # If the system determines that a shorter period is satisfactory,
+    # then the system will only wait that amount of time before scaling to 0.
+    # NOTE: this period might actually be 0, if activator has been
+    # in the request path sufficiently long.
     scale-to-zero-grace-period: "30s"
 
     # Enable graceful scaledown feature flag.


### PR DESCRIPTION
It seems that this parameter has been miused to actually wait for Xseconds before scaling to 0,
rather than its initial purpose of ensuring network reprogramming.
So comment to that effect.

Also we might actually _need_ that kind of knob, but not sure.


/assign @markusthoemmes mattmoor