### PR TITLE
Removes write access to the internal resources from aggregated cluserroles

### DIFF
--- a/config/core/roles/clusterrole-namespaced.yaml
+++ b/config/core/roles/clusterrole-namespaced.yaml
@@ -20,9 +20,12 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     serving.knative.dev/release: devel
 rules:
-  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+  - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
     verbs: ["*"]
+  - apiGroups: ["networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -32,9 +35,12 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     serving.knative.dev/release: devel
 rules:
-  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+  - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
     verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: ["networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Proposed Changes

This patch removes power to create/edit "internal" resources from
namespaced users.

The internal resources should be created/edit by controller only.
Users should not create them manually.

Fixes https://github.com/knative/serving/issues/7599

**Release Note**

```release-note
serving-core.yaml removes write access to the internal resources from aggregated cluserroles such as aggregate-to-admin and aggregate-to-edit 
```
