### PR TITLE
Remove some stray cluster ingress references.

### DIFF
--- a/pkg/apis/config/defaults.go
+++ b/pkg/apis/config/defaults.go
@@ -164,7 +164,7 @@ type Defaults struct {
 	EnableMultiContainer bool
 
 	RevisionTimeoutSeconds int64
-	// This is the timeout set for cluster ingress.
+	// This is the timeout set for ingress.
 	// RevisionTimeoutSeconds must be less than this value.
 	MaxRevisionTimeoutSeconds int64
 

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -748,7 +748,7 @@ func TestMakeIngressTLS(t *testing.T) {
 	}
 }
 
-func TestMakeClusterIngress_ACMEChallenges(t *testing.T) {
+func TestMakeIngress_ACMEChallenges(t *testing.T) {
 	targets := map[string]traffic.RevisionTargets{
 		traffic.DefaultTarget: {{
 			TrafficTarget: v1.TrafficTarget{

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -400,8 +400,7 @@ func TestReconcile(t *testing.T) {
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: Route("default", "ingress-create-failure", WithConfigTarget("config"),
 				WithRouteFinalizer,
-				// Populated by reconciliation when we fail to create
-				// the cluster ingress.
+				// Populated by reconciliation when we fail to create the ingress.
 				WithURL, WithAddress, WithInitRouteConditions,
 				MarkTrafficAssigned, WithStatusTraffic(
 					v1.TrafficTarget{
@@ -788,8 +787,8 @@ func TestReconcile(t *testing.T) {
 		}},
 		Key: "default/becomes-public",
 	}, {
-		Name: "failure updating cluster ingress",
-		// Starting from the new latest ready, induce a failure updating the cluster ingress.
+		Name: "failure updating ingress",
+		// Starting from the new latest ready, induce a failure updating the ingress.
 		WantErr: true,
 		WithReactors: []clientgotesting.ReactionFunc{
 			InduceFailure("update", "ingresses"),
@@ -1029,7 +1028,7 @@ func TestReconcile(t *testing.T) {
 		}},
 		Key: "default/external-name",
 	}, {
-		Name: "reconcile cluster ingress mutation",
+		Name: "reconcile ingress mutation",
 		Objects: []runtime.Object{
 			Route("default", "ingress-mutation", WithConfigTarget("config"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,
@@ -1633,7 +1632,7 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "default/stale-lastpinned",
 	}, {
-		Name: "check that we can find the cluster ingress with old naming",
+		Name: "check that we can find the ingress with old naming",
 		Objects: []runtime.Object{
 			Route("default", "old-naming", WithConfigTarget("config"), WithRouteFinalizer,
 				WithURL, WithAddress, WithInitRouteConditions,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Nobody wants to talk about cluster ingress anymore.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @tcnghia 
