### PR TITLE
HA tests - wait for the service to be ready before sending requests

### DIFF
--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -142,6 +142,11 @@ func assertServiceWorksNow(t *testing.T, clients *test.Clients, spoofingClient *
 
 func assertServiceEventuallyWorks(t *testing.T, clients *test.Clients, names test.ResourceNames, url *url.URL, expectedText string) {
 	t.Helper()
+	// Wait for the Service to be ready.
+	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
+		t.Fatal("Service not ready: ", err)
+	}
+	// Wait for the Service to serve the expected text.
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,


### PR DESCRIPTION
* this might be required when Controller is killed and a new leader is
elected, in this case it might take the new controller a few seconds to
reconcile the existing knative services which are unavailable in the
mean time

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/7421 (the failure from 2020-04-15)

The failure looks like this:
```
controller_test.go:61: The endpoint for Route controller-h-a-pkpezmvj at http://controller-h-a-pkpezmvj.serving-tests.example.com didn't serve the expected text "What a spaceport!": response: <nil> did not pass checks: Get http://controller-h-a-pkpezmvj.serving-tests.example.com: dial tcp 35.238.33.221:80: connect: no route to host
```
The problem is that the knative service is being reconciled while we send a request to it and we get an error. We need to wait for the service to be ready before proceeding.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
