### PR TITLE
Improve the Scale API

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -23,13 +23,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
 	. "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/pkg/metrics/metricstest"
 	"knative.dev/serving/pkg/autoscaler/fake"
-	autoscalerfake "knative.dev/serving/pkg/autoscaler/fake"
 	"knative.dev/serving/pkg/autoscaler/metrics"
 	smetrics "knative.dev/serving/pkg/metrics"
 )
@@ -41,28 +43,28 @@ const (
 )
 
 func TestNewErrorWhenGivenNilReadyPodCounter(t *testing.T) {
-	if _, err := New(fake.TestNamespace, fake.TestRevision, &autoscalerfake.MetricClient{}, nil, &DeciderSpec{TargetValue: 10, ServiceName: fake.TestService}, context.Background()); err == nil {
+	if _, err := New(fake.TestNamespace, fake.TestRevision, &fake.MetricClient{}, nil, &DeciderSpec{TargetValue: 10, ServiceName: fake.TestService}, context.Background()); err == nil {
 		t.Error("Expected error when ReadyPodCounter interface is nil, but got none.")
 	}
 }
 
 func TestNewErrorWhenGivenNilStatsReporter(t *testing.T) {
 	l := fake.KubeInformer.Core().V1().Endpoints().Lister()
-	if _, err := New(fake.TestNamespace, fake.TestRevision, &autoscalerfake.MetricClient{}, l,
+	if _, err := New(fake.TestNamespace, fake.TestRevision, &fake.MetricClient{}, l,
 		&DeciderSpec{TargetValue: 10, ServiceName: fake.TestService}, nil); err == nil {
 		t.Error("Expected error when EndpointsInformer interface is nil, but got none.")
 	}
 }
 
 func TestAutoscalerNoDataNoAutoscale(t *testing.T) {
-	metrics := &autoscalerfake.MetricClient{
+	metrics := &fake.MetricClient{
 		ErrF: func(key types.NamespacedName, now time.Time) error {
 			return errors.New("no metrics")
 		},
 	}
 
 	a := newTestAutoscaler(t, 10, 100, metrics)
-	a.expectScale(t, time.Now(), 0, 0, MinActivators, false)
+	expectScale(t, a, time.Now(), ScaleResult{0, 0, MinActivators, false})
 }
 
 func expectedEBC(totCap, targetBC, recordedConcurrency, numPods float64) int32 {
@@ -76,7 +78,7 @@ func expectedNA(a *Autoscaler, numP float64) int32 {
 }
 
 func TestAutoscalerStartMetrics(t *testing.T) {
-	metricClient := &autoscalerfake.MetricClient{StableConcurrency: 50.0, PanicConcurrency: 50.0}
+	metricClient := &fake.MetricClient{StableConcurrency: 50.0, PanicConcurrency: 50.0}
 	newTestAutoscalerWithScalingMetric(t, 10, 100, metricClient,
 		"concurrency", true /*startInPanic*/)
 	wantTags := map[string]string{
@@ -96,13 +98,13 @@ func TestAutoscalerMetrics(t *testing.T) {
 		metricskey.LabelServiceName:       fake.TestService,
 	}
 
-	metricClient := &autoscalerfake.MetricClient{StableConcurrency: 50.0, PanicConcurrency: 50.0}
+	metricClient := &fake.MetricClient{StableConcurrency: 50.0, PanicConcurrency: 50.0}
 	a := newTestAutoscaler(t, 10, 100, metricClient)
 	// Non-panic created autoscaler.
 	metricstest.CheckLastValueData(t, panicM.Name(), wantTags, 0)
 	ebc := expectedEBC(10, 100, 50, 1)
 	na := expectedNA(a, 1)
-	a.expectScale(t, time.Now(), 5, ebc, na, true)
+	expectScale(t, a, time.Now(), ScaleResult{5, ebc, na, true})
 	spec, _ := a.currentSpecAndPC()
 
 	metricstest.CheckLastValueData(t, stableRequestConcurrencyM.Name(), wantTags, 50)
@@ -114,11 +116,11 @@ func TestAutoscalerMetrics(t *testing.T) {
 }
 
 func TestAutoscalerMetricsWithRPS(t *testing.T) {
-	metricClient := &autoscalerfake.MetricClient{PanicConcurrency: 50.0, StableRPS: 100}
+	metricClient := &fake.MetricClient{PanicConcurrency: 50.0, StableRPS: 100}
 	a := newTestAutoscalerWithScalingMetric(t, 10, 100, metricClient, "rps", false /*startInPanic*/)
 	ebc := expectedEBC(10, 100, 100, 1)
 	na := expectedNA(a, 1)
-	a.expectScale(t, time.Now(), 10, ebc, na, true)
+	expectScale(t, a, time.Now(), ScaleResult{10, ebc, na, true})
 	spec, _ := a.currentSpecAndPC()
 	wantTags := map[string]string{
 		metricskey.LabelConfigurationName: fake.TestConfig,
@@ -127,7 +129,7 @@ func TestAutoscalerMetricsWithRPS(t *testing.T) {
 		metricskey.LabelServiceName:       fake.TestService,
 	}
 
-	a.expectScale(t, time.Now().Add(61*time.Second), 10, ebc, na, true)
+	expectScale(t, a, time.Now().Add(61*time.Second), ScaleResult{10, ebc, na, true})
 	metricstest.CheckLastValueData(t, stableRPSM.Name(), wantTags, 100)
 	metricstest.CheckLastValueData(t, panicRPSM.Name(), wantTags, 100)
 	metricstest.CheckLastValueData(t, desiredPodCountM.Name(), wantTags, 10)
@@ -137,10 +139,10 @@ func TestAutoscalerMetricsWithRPS(t *testing.T) {
 }
 
 func TestAutoscalerChangeOfPodCountService(t *testing.T) {
-	metrics := &autoscalerfake.MetricClient{StableConcurrency: 50.0}
+	metrics := &fake.MetricClient{StableConcurrency: 50.0}
 	a := newTestAutoscaler(t, 10, 100, metrics)
 	na := expectedNA(a, 1)
-	a.expectScale(t, time.Now(), 5, expectedEBC(10, 100, 50, 1), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{5, expectedEBC(10, 100, 50, 1), na, true})
 
 	const newTS = fake.TestService + "2"
 	newDS := *a.deciderSpec
@@ -152,76 +154,76 @@ func TestAutoscalerChangeOfPodCountService(t *testing.T) {
 	// This should change the EBC computation, but target scale doesn't change.
 
 	na = expectedNA(a, 2)
-	a.expectScale(t, time.Now(), 5, expectedEBC(10, 100, 50, 2), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{5, expectedEBC(10, 100, 50, 2), na, true})
 }
 
 func TestAutoscalerStableModeIncreaseWithConcurrencyDefault(t *testing.T) {
-	metrics := &autoscalerfake.MetricClient{StableConcurrency: 50.0}
+	metrics := &fake.MetricClient{StableConcurrency: 50.0}
 	a := newTestAutoscaler(t, 10, 101, metrics)
 	na := expectedNA(a, 1)
-	a.expectScale(t, time.Now(), 5, expectedEBC(10, 101, 50, 1), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{5, expectedEBC(10, 101, 50, 1), na, true})
 
 	metrics.StableConcurrency = 100
-	a.expectScale(t, time.Now(), 10, expectedEBC(10, 101, 100, 1), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 101, 100, 1), na, true})
 }
 
 func TestAutoscalerStableModeIncreaseWithRPS(t *testing.T) {
-	metrics := &autoscalerfake.MetricClient{StableRPS: 50.0}
+	metrics := &fake.MetricClient{StableRPS: 50.0}
 	a := newTestAutoscalerWithScalingMetric(t, 10, 101, metrics, "rps", false /*startInPanic*/)
 	na := expectedNA(a, 1)
-	a.expectScale(t, time.Now(), 5, expectedEBC(10, 101, 50, 1), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{5, expectedEBC(10, 101, 50, 1), na, true})
 
 	metrics.StableRPS = 100
-	a.expectScale(t, time.Now(), 10, expectedEBC(10, 101, 100, 1), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 101, 100, 1), na, true})
 }
 
 func TestAutoscalerStableModeDecrease(t *testing.T) {
-	metrics := &autoscalerfake.MetricClient{StableConcurrency: 100.0}
+	metrics := &fake.MetricClient{StableConcurrency: 100.0}
 	a := newTestAutoscaler(t, 10, 98, metrics)
 	fake.Endpoints(8, fake.TestService)
 	na := expectedNA(a, 8)
-	a.expectScale(t, time.Now(), 10, expectedEBC(10, 98, 100, 8), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 98, 100, 8), na, true})
 
 	metrics.StableConcurrency = 50
-	a.expectScale(t, time.Now(), 5, expectedEBC(10, 98, 50, 8), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{5, expectedEBC(10, 98, 50, 8), na, true})
 }
 
 func TestAutoscalerStableModeNoTrafficScaleToZero(t *testing.T) {
-	metrics := &autoscalerfake.MetricClient{StableConcurrency: 1}
+	metrics := &fake.MetricClient{StableConcurrency: 1}
 	a := newTestAutoscaler(t, 10, 75, metrics)
 	na := expectedNA(a, 1)
-	a.expectScale(t, time.Now(), 1, expectedEBC(10, 75, 1, 1), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{1, expectedEBC(10, 75, 1, 1), na, true})
 
 	metrics.StableConcurrency = 0.0
-	a.expectScale(t, time.Now(), 0, expectedEBC(10, 75, 0, 1), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{0, expectedEBC(10, 75, 0, 1), na, true})
 }
 
 // QPS is increasing exponentially. Each scaling event bring concurrency
 // back to the target level (1.0) but then traffic continues to increase.
 // At 1296 QPS traffic stabilizes.
 func TestAutoscalerPanicModeExponentialTrackAndStablize(t *testing.T) {
-	metrics := &autoscalerfake.MetricClient{StableConcurrency: 6, PanicConcurrency: 6}
+	metrics := &fake.MetricClient{StableConcurrency: 6, PanicConcurrency: 6}
 	a := newTestAutoscaler(t, 1, 101, metrics)
 	na := expectedNA(a, 1)
-	a.expectScale(t, time.Now(), 6, expectedEBC(1, 101, 6, 1), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{6, expectedEBC(1, 101, 6, 1), na, true})
 
 	fake.Endpoints(6, fake.TestService)
 	na = expectedNA(a, 6)
 	metrics.PanicConcurrency, metrics.StableConcurrency = 36, 36
-	a.expectScale(t, time.Now(), 36, expectedEBC(1, 101, 36, 6), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{36, expectedEBC(1, 101, 36, 6), na, true})
 
 	fake.Endpoints(36, fake.TestService)
 	na = expectedNA(a, 36)
 	metrics.PanicConcurrency, metrics.StableConcurrency = 216, 216
-	a.expectScale(t, time.Now(), 216, expectedEBC(1, 101, 216, 36), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{216, expectedEBC(1, 101, 216, 36), na, true})
 
 	fake.Endpoints(216, fake.TestService)
 	na = expectedNA(a, 216)
 	metrics.PanicConcurrency, metrics.StableConcurrency = 1296, 1296
-	a.expectScale(t, time.Now(), 1296, expectedEBC(1, 101, 1296, 216), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{1296, expectedEBC(1, 101, 1296, 216), na, true})
 	fake.Endpoints(1296, fake.TestService)
 	na = expectedNA(a, 1296)
-	a.expectScale(t, time.Now(), 1296, expectedEBC(1, 101, 1296, 1296), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{1296, expectedEBC(1, 101, 1296, 1296), na, true})
 }
 
 func TestAutoscalerScale(t *testing.T) {
@@ -235,49 +237,49 @@ func TestAutoscalerScale(t *testing.T) {
 		wantInvalid bool
 	}{{
 		label:     "AutoscalerNoDataAtZeroNoAutoscale",
-		as:        newTestAutoscaler(t, 10, 100, &autoscalerfake.MetricClient{}),
+		as:        newTestAutoscaler(t, 10, 100, &fake.MetricClient{}),
 		baseScale: 1,
 		wantScale: 0,
 		wantEBC:   expectedEBC(10, 100, 0, 1),
 	}, {
 		label:     "AutoscalerNoDataAtZeroNoAutoscaleWithExplicitEPs",
-		as:        newTestAutoscaler(t, 10, 100, &autoscalerfake.MetricClient{}),
+		as:        newTestAutoscaler(t, 10, 100, &fake.MetricClient{}),
 		baseScale: 1,
 		wantScale: 0,
 		wantEBC:   expectedEBC(10, 100, 0, 1),
 	}, {
 		label:     "AutoscalerStableModeUnlimitedTBC",
-		as:        newTestAutoscaler(t, 181, -1, &autoscalerfake.MetricClient{StableConcurrency: 21.0}),
+		as:        newTestAutoscaler(t, 181, -1, &fake.MetricClient{StableConcurrency: 21.0}),
 		baseScale: 1,
 		wantScale: 1,
 		wantEBC:   -1,
 	}, {
 		label:     "Autoscaler0TBC",
-		as:        newTestAutoscaler(t, 10, 0, &autoscalerfake.MetricClient{StableConcurrency: 50.0}),
+		as:        newTestAutoscaler(t, 10, 0, &fake.MetricClient{StableConcurrency: 50.0}),
 		baseScale: 1,
 		wantScale: 5,
 		wantEBC:   0,
 	}, {
 		label:     "AutoscalerStableModeNoChange",
-		as:        newTestAutoscaler(t, 10, 100, &autoscalerfake.MetricClient{StableConcurrency: 50.0}),
+		as:        newTestAutoscaler(t, 10, 100, &fake.MetricClient{StableConcurrency: 50.0}),
 		baseScale: 1,
 		wantScale: 5,
 		wantEBC:   expectedEBC(10, 100, 50, 1),
 	}, {
 		label:     "AutoscalerStableModeNoChangeAlreadyScaled",
-		as:        newTestAutoscaler(t, 10, 100, &autoscalerfake.MetricClient{StableConcurrency: 50.0}),
+		as:        newTestAutoscaler(t, 10, 100, &fake.MetricClient{StableConcurrency: 50.0}),
 		baseScale: 5,
 		wantScale: 5,
 		wantEBC:   expectedEBC(10, 100, 50, 5),
 	}, {
 		label:     "AutoscalerStableModeNoChangeAlreadyScaled",
-		as:        newTestAutoscaler(t, 10, 100, &autoscalerfake.MetricClient{StableConcurrency: 50.0}),
+		as:        newTestAutoscaler(t, 10, 100, &fake.MetricClient{StableConcurrency: 50.0}),
 		baseScale: 5,
 		wantScale: 5,
 		wantEBC:   expectedEBC(10, 100, 50, 5),
 	}, {
 		label:     "AutoscalerStableModeIncreaseWithSmallScaleUpRate",
-		as:        newTestAutoscaler(t, 1 /* target */, 1982 /* TBC */, &autoscalerfake.MetricClient{StableConcurrency: 3}),
+		as:        newTestAutoscaler(t, 1 /* target */, 1982 /* TBC */, &fake.MetricClient{StableConcurrency: 3}),
 		baseScale: 2,
 		prepFunc: func(a *Autoscaler) {
 			a.deciderSpec.MaxScaleUpRate = 1.1
@@ -286,7 +288,7 @@ func TestAutoscalerScale(t *testing.T) {
 		wantEBC:   expectedEBC(1, 1982, 3, 2),
 	}, {
 		label:     "AutoscalerStableModeIncreaseWithSmallScaleDownRate",
-		as:        newTestAutoscaler(t, 10 /* target */, 1982 /* TBC */, &autoscalerfake.MetricClient{StableConcurrency: 1}),
+		as:        newTestAutoscaler(t, 10 /* target */, 1982 /* TBC */, &fake.MetricClient{StableConcurrency: 1}),
 		baseScale: 100,
 		prepFunc: func(a *Autoscaler) {
 			a.deciderSpec.MaxScaleDownRate = 1.1
@@ -295,7 +297,7 @@ func TestAutoscalerScale(t *testing.T) {
 		wantEBC:   expectedEBC(10, 1982, 1, 100),
 	}, {
 		label:     "AutoscalerPanicModeDoublePodCount",
-		as:        newTestAutoscaler(t, 10, 84, &autoscalerfake.MetricClient{StableConcurrency: 50, PanicConcurrency: 100}),
+		as:        newTestAutoscaler(t, 10, 84, &fake.MetricClient{StableConcurrency: 50, PanicConcurrency: 100}),
 		baseScale: 1,
 		// PanicConcurrency takes precedence.
 		wantScale: 10,
@@ -309,59 +311,59 @@ func TestAutoscalerScale(t *testing.T) {
 				test.prepFunc(test.as)
 			}
 			wantNA := expectedNA(test.as, float64(test.baseScale))
-			test.as.expectScale(tt, time.Now(), test.wantScale, test.wantEBC, wantNA, !test.wantInvalid)
+			expectScale(tt, test.as, time.Now(), ScaleResult{test.wantScale, test.wantEBC, wantNA, !test.wantInvalid})
 		})
 	}
 }
 
 func TestAutoscalerPanicThenUnPanicScaleDown(t *testing.T) {
-	metrics := &autoscalerfake.MetricClient{StableConcurrency: 100, PanicConcurrency: 100}
+	metrics := &fake.MetricClient{StableConcurrency: 100, PanicConcurrency: 100}
 	a := newTestAutoscaler(t, 10, 93, metrics)
 	na := expectedNA(a, 1)
-	a.expectScale(t, time.Now(), 10, expectedEBC(10, 93, 100, 1), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 93, 100, 1), na, true})
 	fake.Endpoints(10, fake.TestService)
 
 	na = expectedNA(a, 10)
 	panicTime := time.Now()
 	metrics.PanicConcurrency = 1000
-	a.expectScale(t, panicTime, 100, expectedEBC(10, 93, 100, 10), na, true)
+	expectScale(t, a, panicTime, ScaleResult{100, expectedEBC(10, 93, 100, 10), na, true})
 
 	// Traffic dropped off, scale stays as we're still in panic.
 	metrics.PanicConcurrency = 1
 	metrics.StableConcurrency = 1
-	a.expectScale(t, panicTime.Add(30*time.Second), 100, expectedEBC(10, 93, 1, 10), na, true)
+	expectScale(t, a, panicTime.Add(30*time.Second), ScaleResult{100, expectedEBC(10, 93, 1, 10), na, true})
 
 	// Scale down after the StableWindow
-	a.expectScale(t, panicTime.Add(61*time.Second), 1, expectedEBC(10, 93, 1, 10), na, true)
+	expectScale(t, a, panicTime.Add(61*time.Second), ScaleResult{1, expectedEBC(10, 93, 1, 10), na, true})
 }
 
 func TestAutoscalerRateLimitScaleUp(t *testing.T) {
-	metrics := &autoscalerfake.MetricClient{StableConcurrency: 1000}
+	metrics := &fake.MetricClient{StableConcurrency: 1000}
 	a := newTestAutoscaler(t, 10, 61, metrics)
 	na := expectedNA(a, 1)
 
 	// Need 100 pods but only scale x10
-	a.expectScale(t, time.Now(), 10, expectedEBC(10, 61, 1000, 1), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 61, 1000, 1), na, true})
 
 	fake.Endpoints(10, fake.TestService)
 	na = expectedNA(a, 10)
 	// Scale x10 again
-	a.expectScale(t, time.Now(), 100, expectedEBC(10, 61, 1000, 10), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{100, expectedEBC(10, 61, 1000, 10), na, true})
 }
 
 func TestAutoscalerRateLimitScaleDown(t *testing.T) {
-	metrics := &autoscalerfake.MetricClient{StableConcurrency: 1}
+	metrics := &fake.MetricClient{StableConcurrency: 1}
 	a := newTestAutoscaler(t, 10, 61, metrics)
 
 	// Need 1 pods but can only scale down ten times, to 10.
 	fake.Endpoints(100, fake.TestService)
 	na := expectedNA(a, 100)
-	a.expectScale(t, time.Now(), 10, expectedEBC(10, 61, 1, 100), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 61, 1, 100), na, true})
 
 	na = expectedNA(a, 10)
 	fake.Endpoints(10, fake.TestService)
 	// Scale ÷10 again.
-	a.expectScale(t, time.Now(), 1, expectedEBC(10, 61, 1, 10), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{1, expectedEBC(10, 61, 1, 10), na, true})
 }
 
 func eraseEndpoints() {
@@ -371,25 +373,25 @@ func eraseEndpoints() {
 }
 
 func TestAutoscalerUseOnePodAsMinimumIfEndpointsNotFound(t *testing.T) {
-	metrics := &autoscalerfake.MetricClient{StableConcurrency: 1000}
+	metrics := &fake.MetricClient{StableConcurrency: 1000}
 	a := newTestAutoscaler(t, 10, 81, metrics)
 
 	fake.Endpoints(0, fake.TestService)
 	// 2*10 as the rate limited if we can get the actual pods number.
 	// 1*10 as the rate limited since no read pods are there from K8S API.
-	a.expectScale(t, time.Now(), 10, expectedEBC(10, 81, 1000, 0), MinActivators, true)
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 81, 1000, 0), MinActivators, true})
 
 	eraseEndpoints()
 	// 2*10 as the rate limited if we can get the actual pods number.
 	// 1*10 as the rate limited since no Endpoints object is there from K8S API.
-	a.expectScale(t, time.Now(), 10, expectedEBC(10, 81, 1000, 0), MinActivators, true)
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 81, 1000, 0), MinActivators, true})
 }
 
 func TestAutoscalerUpdateTarget(t *testing.T) {
-	metrics := &autoscalerfake.MetricClient{StableConcurrency: 100}
+	metrics := &fake.MetricClient{StableConcurrency: 100}
 	a := newTestAutoscaler(t, 10, 77, metrics)
 	na := expectedNA(a, 1)
-	a.expectScale(t, time.Now(), 10, expectedEBC(10, 77, 100, 1), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 77, 100, 1), na, true})
 
 	fake.Endpoints(10, fake.TestService)
 	a.Update(&DeciderSpec{
@@ -404,7 +406,7 @@ func TestAutoscalerUpdateTarget(t *testing.T) {
 		ServiceName:         fake.TestService,
 	})
 	na = expectedNA(a, 10)
-	a.expectScale(t, time.Now(), 100, expectedEBC(1, 71, 100, 10), na, true)
+	expectScale(t, a, time.Now(), ScaleResult{100, expectedEBC(1, 71, 100, 10), na, true})
 }
 
 func newTestAutoscaler(t *testing.T, targetValue, targetBurstCapacity float64, metrics metrics.MetricClient) *Autoscaler {
@@ -446,25 +448,16 @@ func newTestAutoscalerWithScalingMetric(t *testing.T, targetValue, targetBurstCa
 	return a
 }
 
-func (a *Autoscaler) expectScale(t *testing.T, now time.Time, expectScale, expectEBC, expectNA int32, expectOK bool) {
+func expectScale(t *testing.T, a UniScaler, now time.Time, want ScaleResult) {
 	t.Helper()
-	scale, ebc, na, ok := a.Scale(TestContextWithLogger(t), now)
-	if ok != expectOK {
-		t.Errorf("Unexpected autoscale decision. Expected %v. Got %v.", expectOK, ok)
-	}
-	if got, want := scale, expectScale; got != want {
-		t.Errorf("Scale %d, want: %d", got, want)
-	}
-	if got, want := ebc, expectEBC; got != want {
-		t.Errorf("ExcessBurstCapacity = %d, want: %d", got, want)
-	}
-	if got, want := na, expectNA; got != want {
-		t.Errorf("NumActivators = %d, want: %d", got, want)
+	got := a.Scale(TestContextWithLogger(t), now)
+	if !cmp.Equal(got, want) {
+		t.Error("ScaleResult mismatch(-want,+got):\n", cmp.Diff(want, got))
 	}
 }
 
 func TestStartInPanicMode(t *testing.T) {
-	metrics := &autoscalerfake.StaticMetricClient
+	metrics := &fake.StaticMetricClient
 	deciderSpec := &DeciderSpec{
 		TargetValue:         100,
 		TotalValue:          120,
@@ -507,7 +500,7 @@ func TestStartInPanicMode(t *testing.T) {
 
 func TestNewFail(t *testing.T) {
 	eraseEndpoints()
-	metrics := &autoscalerfake.StaticMetricClient
+	metrics := &fake.StaticMetricClient
 	deciderSpec := &DeciderSpec{
 		TargetValue:         100,
 		TotalValue:          120,

--- a/pkg/autoscaler/scaling/multiscaler.go
+++ b/pkg/autoscaler/scaling/multiscaler.go
@@ -86,13 +86,29 @@ type DeciderStatus struct {
 	NumActivators int32
 }
 
+// ScaleResult holds the scale result of the UniScaler evaluation cycle.
+type ScaleResult struct {
+	// DesiredPodCount is the number of pods Autoscaler suggests for the revision.
+	DesiredPodCount int32
+	// ExcessBurstCapacity is computed headroom of the revision taking into
+	// the account target burst capacity.
+	ExcessBurstCapacity int32
+	// NumActivators is the number of activators required to back this revision.
+	NumActivators int32
+	// ScaleValid specifies whether this scale result is valid, i.e. whether
+	// Autoscaler had all the necessary information to compute a suggestion.
+	ScaleValid bool
+}
+
+var invalidSR = ScaleResult{
+	ScaleValid:    false,
+	NumActivators: MinActivators,
+}
+
 // UniScaler records statistics for a particular Decider and proposes the scale for the Decider's target based on those statistics.
 type UniScaler interface {
-	// Scale either proposes a number of replicas, available excess burst capacity,
-	// and suggested number of activators, or skips proposing.
-	// The proposal is requested at the given time.
-	// The returned boolean is true if and only if a proposal was returned.
-	Scale(context.Context, time.Time) (int32, int32, int32, bool)
+	// Scale computes a scaling suggestion for a revision.
+	Scale(context.Context, time.Time) ScaleResult
 
 	// Update reconfigures the UniScaler according to the DeciderSpec.
 	Update(*DeciderSpec) error
@@ -122,24 +138,24 @@ func sameSign(a, b int32) bool {
 	return (a&math.MinInt32)^(b&math.MinInt32) == 0
 }
 
-func (sr *scalerRunner) updateLatestScale(proposed, ebc, na int32) bool {
+func (sr *scalerRunner) updateLatestScale(sRes ScaleResult) bool {
 	ret := false
 	sr.mux.Lock()
 	defer sr.mux.Unlock()
-	if sr.decider.Status.DesiredScale != proposed {
-		sr.decider.Status.DesiredScale = proposed
+	if sr.decider.Status.DesiredScale != sRes.DesiredPodCount {
+		sr.decider.Status.DesiredScale = sRes.DesiredPodCount
 		ret = true
 	}
-	if sr.decider.Status.NumActivators != na {
-		sr.decider.Status.NumActivators = na
+	if sr.decider.Status.NumActivators != sRes.NumActivators {
+		sr.decider.Status.NumActivators = sRes.NumActivators
 		ret = true
 	}
 
 	// If sign has changed -- then we have to update KPA
-	ret = ret || !sameSign(sr.decider.Status.ExcessBurstCapacity, ebc)
+	ret = ret || !sameSign(sr.decider.Status.ExcessBurstCapacity, sRes.ExcessBurstCapacity)
 
 	// Update with the latest calculation anyway.
-	sr.decider.Status.ExcessBurstCapacity = ebc
+	sr.decider.Status.ExcessBurstCapacity = sRes.ExcessBurstCapacity
 	return ret
 }
 
@@ -323,19 +339,19 @@ func (m *MultiScaler) createScaler(ctx context.Context, decider *Decider) (*scal
 
 func (m *MultiScaler) tickScaler(ctx context.Context, scaler UniScaler, runner *scalerRunner, metricKey types.NamespacedName) {
 	logger := logging.FromContext(ctx)
-	desiredScale, excessBC, numAct, scaled := scaler.Scale(ctx, time.Now())
+	sr := scaler.Scale(ctx, time.Now())
 
-	if !scaled {
+	if !sr.ScaleValid {
 		return
 	}
 
 	// Cannot scale negative (nor we can compute burst capacity).
-	if desiredScale < 0 {
-		logger.Errorf("Cannot scale: desiredScale %d < 0.", desiredScale)
+	if sr.DesiredPodCount < 0 {
+		logger.Errorf("Cannot scale: desiredScale %d < 0.", sr.DesiredPodCount)
 		return
 	}
 
-	if runner.updateLatestScale(desiredScale, excessBC, numAct) {
+	if runner.updateLatestScale(sr) {
 		m.Inform(metricKey)
 	}
 }

--- a/pkg/autoscaler/scaling/multiscaler_test.go
+++ b/pkg/autoscaler/scaling/multiscaler_test.go
@@ -401,7 +401,7 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 	metricKey := types.NamespacedName{Namespace: decider.Namespace, Name: decider.Name}
 	if scaler, exists := ms.scalers[metricKey]; !exists {
 		t.Errorf("Failed to get scaler for metric %s", metricKey)
-	} else if !scaler.updateLatestScale(0, 10, 2) {
+	} else if !scaler.updateLatestScale(ScaleResult{0, 10, 2, true}) {
 		t.Error("Failed to set scale for metric to 0")
 	}
 
@@ -531,11 +531,11 @@ func (u *fakeUniScaler) fakeUniScalerFactory(*Decider) (UniScaler, error) {
 	return u, nil
 }
 
-func (u *fakeUniScaler) Scale(context.Context, time.Time) (int32, int32, int32, bool) {
+func (u *fakeUniScaler) Scale(context.Context, time.Time) ScaleResult {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 	u.scaleCount++
-	return u.replicas, u.surplus, u.numActivators, u.scaled
+	return ScaleResult{u.replicas, u.surplus, u.numActivators, u.scaled}
 }
 
 func (u *fakeUniScaler) getScaleCount() int {


### PR DESCRIPTION
It already returns 4 parameters and recently a PR was floated that added one more
return value. That is unwieldy and swings too wide.
So return a struct instead.
So much prettier and cleaner.

Also other minor touchups around the test code,
especially `expectScale` which was member for some reason
(I don't remember why, but definitely there is no such reason anymore).
Now it is just a `cmp.Equal` check, vs 4 `if got != want` checks.

In tests I used anonymous initialization, which should be fine.

/lint
/assign @markusthoemmes mattmoor