### PR TITLE
Remove some redundancy in the code

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1149,11 +1149,8 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 	sksl := fakesksinformer.Get(ctx).Lister()
 	if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
 		l, err := sksl.List(labels.Everything())
-		if err != nil {
-			return false, err
-		}
 		// We only create a single SKS object.
-		return len(l) > 0, nil
+		return len(l) > 0, err
 	}); err != nil {
 		t.Fatalf("Failed to see SKS propagation: %v", err)
 	}

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -534,20 +534,17 @@ func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 			revL := fakerevisioninformer.Get(ctx).Lister()
 			if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
 				l, err := revL.List(labels.Everything())
-				if err != nil {
-					return false, err
-				}
 				// We only create a single revision.
-				return len(l) > 0, nil
+				return len(l) > 0, err
 			}); err != nil {
-				t.Fatalf("Failed to see Revision propagation: %v", err)
+				t.Fatalf("Failed to see Revision propagation:", err)
 			}
 			t.Log("Seen revision propagation")
 
 			watcher.OnChange(test.configMapToUpdate)
 
 			if err := h.WaitForHooks(3 * time.Second); err != nil {
-				t.Errorf("Global Resync Failed: %v", err)
+				t.Error("Global Resync Failed:", err)
 			}
 		})
 	}

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -537,7 +537,7 @@ func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 				// We only create a single revision.
 				return len(l) > 0, err
 			}); err != nil {
-				t.Fatalf("Failed to see Revision propagation:", err)
+				t.Fatal("Failed to see Revision propagation:", err)
 			}
 			t.Log("Seen revision propagation")
 

--- a/pkg/reconciler/serverlessservice/global_resync_test.go
+++ b/pkg/reconciler/serverlessservice/global_resync_test.go
@@ -127,12 +127,9 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 	eps := fakeendpointsinformer.Get(ctx).Lister()
 	if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
 		l, err := eps.List(labels.Everything())
-		if err != nil {
-			return false, err
-		}
-		return len(l) >= 4, nil
+		return len(l) >= 4, err
 	}); err != nil {
-		t.Fatalf("Failed to see endpoint creation: %v", err)
+		t.Fatal("Failed to see endpoint creation:", err)
 	}
 	t.Log("Updating the activator endpoints now...")
 
@@ -143,6 +140,6 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 	}
 
 	if err := updateHooks.WaitForHooks(3 * time.Second); err != nil {
-		t.Fatalf("Hooks timed out: %v", err)
+		t.Fatal("Hooks timed out:", err)
 	}
 }


### PR DESCRIPTION
- we don't need to check for error independently, nil lists are len-able

/assign @tcnghia @markusthoemmes mattmoor