### PR TITLE
Rename TestServiceToServiceCallViaActivator TestSvcToSvcViaActivator

### DIFF
--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -266,7 +266,7 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 
 // Same test as TestServiceToServiceCall but before sending requests
 // we're waiting for target app to be scaled to zero
-func TestServiceToServiceCallViaActivator(t *testing.T) {
+func TestSvcToSvcViaActivator(t *testing.T) {
 	t.Parallel()
 	cancel := logstream.Start(t)
 	defer cancel()


### PR DESCRIPTION
## Proposed Changes

This patch renames `TestServiceToServiceCallViaActivator` `TestSvcToSvcViaActivator`.

The test name is too long and so URLs created from this test name hits
an unintentional error.

/lint

**Release Note**

```release-note
NONE
```

/cc @markusthoemmes 
