### PR TITLE
Include storage migration job in upgrade test & disable gen checks

### DIFF
--- a/test/upgrade/service_postupgrade_test.go
+++ b/test/upgrade/service_postupgrade_test.go
@@ -34,20 +34,23 @@ import (
 
 func TestServicePostUpgrade(t *testing.T) {
 	t.Parallel()
-	clients := e2e.Setup(t)
+	// Renable once our minimum K8s version includes a fix for CRD generation bumping
+	// See: https://github.com/knative/serving/issues/6984
+	//
+	// clients := e2e.Setup(t)
 
-	// Before updating the service, the route and configuration objects should
-	// not be updated just because there has been an upgrade.
-	if hasGeneration, err := configHasGeneration(clients, serviceName, 1); err != nil {
-		t.Fatalf("Error comparing Configuration generation: %v", err)
-	} else if !hasGeneration {
-		t.Fatal("Configuration is updated after an upgrade.")
-	}
-	if hasGeneration, err := routeHasGeneration(clients, serviceName, 1); err != nil {
-		t.Fatalf("Error comparing Route generation: %v", err)
-	} else if !hasGeneration {
-		t.Fatal("Route is updated after an upgrade.")
-	}
+	// // Before updating the service, the route and configuration objects should
+	// // not be updated just because there has been an upgrade.
+	// if hasGeneration, err := configHasGeneration(clients, serviceName, 1); err != nil {
+	// 	t.Fatalf("Error comparing Configuration generation: %v", err)
+	// } else if !hasGeneration {
+	// 	t.Fatal("Configuration is updated after an upgrade.")
+	// }
+	// if hasGeneration, err := routeHasGeneration(clients, serviceName, 1); err != nil {
+	// 	t.Fatalf("Error comparing Route generation: %v", err)
+	// } else if !hasGeneration {
+	// 	t.Fatal("Route is updated after an upgrade.")
+	// }
 	updateService(serviceName, t)
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

We want to catch any issues with the storage version migration job so we now run it as part of our upgrade tests. Operations WG found that we hit the CRD k8s bump (when running the migrating job) causing the serving upgrade test to fail.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Run storage version migration job as part of our upgrade tests
* PostUpgrade test disables generation bump check due to a [k8s bug](https://github.com/knative/serving/issues/6984)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
