### PR TITLE
Ignore the impossible situation

### DIFF
--- a/pkg/autoscaler/scaling/multiscaler.go
+++ b/pkg/autoscaler/scaling/multiscaler.go
@@ -338,16 +338,9 @@ func (m *MultiScaler) createScaler(ctx context.Context, decider *Decider) (*scal
 }
 
 func (m *MultiScaler) tickScaler(ctx context.Context, scaler UniScaler, runner *scalerRunner, metricKey types.NamespacedName) {
-	logger := logging.FromContext(ctx)
 	sr := scaler.Scale(ctx, time.Now())
 
 	if !sr.ScaleValid {
-		return
-	}
-
-	// Cannot scale negative (nor we can compute burst capacity).
-	if sr.DesiredPodCount < 0 {
-		logger.Errorf("Cannot scale: desiredScale %d < 0.", sr.DesiredPodCount)
 		return
 	}
 

--- a/pkg/autoscaler/scaling/multiscaler_test.go
+++ b/pkg/autoscaler/scaling/multiscaler_test.go
@@ -422,57 +422,6 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 	}
 }
 
-func TestMultiScalerIgnoreNegativeScale(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ms, uniScaler := createMultiScaler(ctx, TestLogger(t))
-	mtp := &fake.ManualTickProvider{
-		Channel: make(chan time.Time, 1),
-	}
-	ms.tickProvider = mtp.NewTicker
-
-	decider := newDecider()
-
-	uniScaler.setScaleResult(-1, 10, 2, true)
-
-	// Before it exists, we should get a NotFound.
-	m, err := ms.Get(ctx, decider.Namespace, decider.Name)
-	if !apierrors.IsNotFound(err) {
-		t.Errorf("Get() = (%v, %v), want not found error", m, err)
-	}
-
-	errCh := make(chan error)
-	ms.Watch(func(key types.NamespacedName) {
-		// Let the main process know when this is called.
-		errCh <- nil
-	})
-
-	_, err = ms.Create(ctx, decider)
-	if err != nil {
-		t.Fatalf("Create() = %v", err)
-	}
-
-	// Verify that we get no "ticks", because the desired scale is negative
-	mtp.Channel <- time.Now()
-	if err := verifyNoTick(errCh); err != nil {
-		t.Fatal(err)
-	}
-
-	err = ms.Delete(ctx, decider.Namespace, decider.Name)
-	if err != nil {
-		t.Errorf("Delete() = %v", err)
-	}
-
-	// Verify that we stop seeing "ticks"
-	mtp.Channel <- time.Now()
-	if err := verifyNoTick(errCh); err != nil {
-		t.Fatal(err)
-	}
-	if err := ms.Delete(ctx, decider.Namespace, decider.Name); err != nil {
-		t.Errorf("Delete() = %v", err)
-	}
-}
-
 func TestMultiScalerUpdate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Autoscaler never returns -1, instead it returns ScaleValid flag set to false.
-1 is only set on Decider status by the multiscaler itself on creation.

/assign @yanweiguo @markusthoemmes 