### PR TITLE
Wait for capacity change in multiple activators test.

### DIFF
--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -736,13 +736,15 @@ func TestMultipleActivators(t *testing.T) {
 		t.Fatalf("RevisionThrottler can't be found: %v", err)
 	}
 
-	// Make sure our informer event has fired.
+	// Verify capacity gets updated. This is the very last thing we update
+	// so we now know that we got and processed both the activator endpoints
+	// and the application endpoints.
 	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
-		return atomic.LoadInt32(&rt.activatorIndex) != -1, nil
+		return rt.breaker.Capacity() == 1, nil
 	}); err != nil {
-		t.Fatal("Timed out waiting for the Activator Endpoints to be computed")
+		t.Fatal("Timed out waiting for the capacity to be updated")
 	}
-	t.Logf("This activator idx = %d", rt.activatorIndex)
+	t.Logf("This activator idx = %d", atomic.LoadInt32(&rt.activatorIndex))
 
 	// Test with 2 activators, 3 endpoints we can send 1 request and the second times out.
 	var mux sync.Mutex


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This test used to wait for the activator index to change before going on. That condition only tells half of the truth. After we set the activator index, the capacity computation is not yet done and it might take a while for that to happen and to propagate to the state. Our requests can race that and we assume that only one request is allowed to pass in this test. If more than one requests pass, they both get locked forever and thus the test times out.

Instead, we need to wait for the capacity to be the expected value. That is the very last computation in the update flow and once that's done, we know that an activator is successfully assigned and that we processed the provided application endpoints successfully.

Occurred here: https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1250909497723981824

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
