### PR TITLE
Use actual number of activators for condition check if it is smaller than NumActivators

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -140,7 +140,11 @@ func waitForActivatorEndpoints(resources *v1test.ResourceObjects, clients *test.
 
 		// The subset is set. But in theory it might be revision pods,
 		// so verify below that at least 1 address is an activator pod.
-		if presources.ReadyAddressCount(svcEps) > int(sks.Spec.NumActivators) {
+		expectedActivators := presources.ReadyAddressCount(aeps)
+		if expectedActivators > int(sks.Spec.NumActivators) {
+			expectedActivators = int(sks.Spec.NumActivators)
+		}
+		if presources.ReadyAddressCount(svcEps) != expectedActivators {
 			return false, nil
 		}
 		aset := sets.NewString()

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -140,7 +140,7 @@ func waitForActivatorEndpoints(resources *v1test.ResourceObjects, clients *test.
 
 		// The subset is set. But in theory it might be revision pods,
 		// so verify below that at least 1 address is an activator pod.
-		if presources.ReadyAddressCount(svcEps) != int(sks.Spec.NumActivators) {
+		if presources.ReadyAddressCount(svcEps) > int(sks.Spec.NumActivators) {
 			return false, nil
 		}
 		aset := sets.NewString()

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -140,11 +140,11 @@ func waitForActivatorEndpoints(resources *v1test.ResourceObjects, clients *test.
 
 		// The subset is set. But in theory it might be revision pods,
 		// so verify below that at least 1 address is an activator pod.
-		expectedActivators := presources.ReadyAddressCount(aeps)
-		if expectedActivators > int(sks.Spec.NumActivators) {
-			expectedActivators = int(sks.Spec.NumActivators)
+		wantAct := int(sks.Spec.NumActivators)
+		if numAct := presources.ReadyAddressCount(aeps); wantAct > numAct {
+			wantAct = numAct
 		}
-		if presources.ReadyAddressCount(svcEps) != expectedActivators {
+		if presources.ReadyAddressCount(svcEps) != wantAct {
 			return false, nil
 		}
 		aset := sets.NewString()


### PR DESCRIPTION
Please refer to https://github.com/knative/serving/issues/7630 for the detail.

When running e2e test like `TestSvcToSvcViaActivator/both-disabled`
with only one activator pod, the test always fails with `Never got
Activator endpoints in the service: timed out waiting for the
condition`.

To fix it, this patch changes the condition.

/lint

Fixes https://github.com/knative/serving/issues/7630

**Release Note**

```release-note
NONE
```
