### PR TITLE
nit: Fix comment for the scaling size of activator

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -398,7 +398,7 @@ data:
 EOF
 
   echo ">> Patching activator HPA"
-  # We set min replicas to 2 for testing multiple activator pods.
+  # We set min replicas to 15 for testing multiple activator pods.
   kubectl -n ${SYSTEM_NAMESPACE} patch hpa activator --patch '{"spec":{"minReplicas":15}}' || return 1
 }
 


### PR DESCRIPTION
## Proposed Changes

This patch fixes the small but wrong comment about scaling size of activator pods.

**Release Note**

```release-note
NONE
```
