### PR TITLE
Add #activator dimension to the load test.

### DIFF
--- a/test/performance/benchmarks/load-test/continuous/main.go
+++ b/test/performance/benchmarks/load-test/continuous/main.go
@@ -65,7 +65,7 @@ func processResults(ctx context.Context, q *quickstore.Quickstore, results <-cha
 
 	ctx, cancel := context.WithCancel(ctx)
 	deploymentStatus := metrics.FetchDeploymentsStatus(ctx, namespace, selector, time.Second)
-	sksMode := metrics.FetchSKSMode(ctx, namespace, selector, time.Second)
+	sksMode := metrics.FetchSKSStatus(ctx, namespace, selector, time.Second)
 	defer cancel()
 
 	for {
@@ -91,6 +91,7 @@ func processResults(ctx context.Context, q *quickstore.Quickstore, results <-cha
 			}
 			q.AddSamplePoint(mako.XTime(sksm.Time), map[string]float64{
 				"sks": mode,
+				"na":  float64(sksm.NumActivators),
 			})
 		}
 	}

--- a/test/performance/benchmarks/load-test/dev.config
+++ b/test/performance/benchmarks/load-test/dev.config
@@ -57,3 +57,7 @@ metric_info_list: {
   value_key: "sks"
   label: "sks-proxy"
 }
+metric_info_list: {
+  value_key: "na"
+  label: "num-activators"
+}

--- a/test/performance/benchmarks/load-test/prod.config
+++ b/test/performance/benchmarks/load-test/prod.config
@@ -53,3 +53,7 @@ metric_info_list: {
   value_key: "sks"
   label: "sks-proxy"
 }
+metric_info_list: {
+  value_key: "na"
+  label: "num-activators"
+}

--- a/test/performance/metrics/runtime.go
+++ b/test/performance/metrics/runtime.go
@@ -94,13 +94,14 @@ func fetchStatusInternal(ctx context.Context, duration time.Duration,
 
 // ServerlessServiceStatus is a struct that wraps the status of a serverless service.
 type ServerlessServiceStatus struct {
-	Mode netv1alpha1.ServerlessServiceOperationMode
+	Mode          netv1alpha1.ServerlessServiceOperationMode
+	NumActivators int32
 	// Time is the time when the status is fetched
 	Time time.Time
 }
 
-// FetchSKSMode creates a channel that can return the up-to-date ServerlessServiceOperationMode periodically.
-func FetchSKSMode(
+// FetchSKSStatus creates a channel that can return the up-to-date ServerlessServiceOperationMode periodically.
+func FetchSKSStatus(
 	ctx context.Context, namespace string, selector labels.Selector,
 	duration time.Duration,
 ) <-chan ServerlessServiceStatus {
@@ -115,8 +116,9 @@ func FetchSKSMode(
 		}
 		for _, sks := range skses {
 			skss := ServerlessServiceStatus{
-				Mode: sks.Spec.Mode,
-				Time: t,
+				NumActivators: sks.Spec.NumActivators,
+				Mode:          sks.Spec.Mode,
+				Time:          t,
 			}
 			ch <- skss
 		}


### PR DESCRIPTION
It's interesting to see here and to correlate if different runs that got different pod suggestions
and as such different number of activators (I've seen 3-6 range) depending on what autoscaler scraped
(mostly consistent with always case, though).
The test runs are in progress. I'll update prod config when this is lgtm

/assign @chizhg mattmoor