### PR TITLE
Fix more of the throttler tests

### DIFF
--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -439,10 +439,10 @@ func TestThrottlerSuccesses(t *testing.T) {
 			}
 
 			// Make sure our informer event has fired.
-			if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
-				return atomic.LoadInt32(&rt.activatorIndex) != -1, nil
+			if err := wait.PollImmediate(10*time.Millisecond, 3*time.Second, func() (bool, error) {
+				return atomic.LoadInt32(&rt.activatorIndex) != -1 && rt.breaker.Capacity() > 0, nil
 			}); err != nil {
-				t.Fatal("Timed out waiting for the Activator Endpoints to be computed")
+				t.Fatal("Timed out waiting for the capacity to be updated")
 			}
 			t.Logf("This activator idx = %d", rt.activatorIndex)
 


### PR DESCRIPTION
This is a continuation of https://github.com/knative/serving/pull/7629
for a different test

As I commented there we have others that needs fixing.

```
>go test -race -run=TestThrottlerSuccesses -count=50
PASS
ok      knative.dev/serving/pkg/activator/net   49.642s
```


/assign @tcnghia @markusthoemmes 