### PR TITLE
Remove NodePort exposure from Grafana, Prometheus and Kibana

### DIFF
--- a/config/monitoring/metrics/prometheus/100-grafana.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana.yaml
@@ -118,23 +118,6 @@ data:
       options:
         path: /grafana-dashboard-definition/scaling
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: grafana
-  namespace: knative-monitoring
-  labels:
-    app: grafana
-    serving.knative.dev/release: devel
-spec:
-  type: NodePort
-  ports:
-  - port: 30802
-    protocol: TCP
-    targetPort: 3000
-  selector:
-    app: grafana
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/config/monitoring/metrics/prometheus/300-prometheus.yaml
+++ b/config/monitoring/metrics/prometheus/300-prometheus.yaml
@@ -219,21 +219,6 @@ subjects:
   name: prometheus-system
   namespace: knative-monitoring
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: prometheus-system-np
-  namespace: knative-monitoring
-  labels:
-    serving.knative.dev/release: devel
-spec:
-  type: NodePort
-  selector:
-    app: prometheus
-  ports:
-    - port: 8080
-      targetPort: 9090
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/third_party/config/monitoring/logging/elasticsearch/kibana.yaml
+++ b/third_party/config/monitoring/logging/elasticsearch/kibana.yaml
@@ -1,21 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: kibana-logging
-  namespace: knative-monitoring
-  labels:
-    app: kibana-logging
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "Kibana"
-spec:
-  type: NodePort
-  selector:
-    app: kibana-logging
-  ports:
-  - port: 5601
-    protocol: TCP
-    targetPort: ui
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes
Hi there ✨

By default, the monitoring component is exposing the Grafana, Prometheus and Kibana interfaces to the public Internet via NodePorts. If an user deploy Knative using the default docs and never look into it, they might be exposing sensitive information.

On top of that, all the documentation related to accessing the Grafana and Kibana UI are done via `kubectl proxy`, so we don't even tell the users that these services are open.

This change removes those NodePorts, making the default installation more secure.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
- Remove NodePort exposure from the Grafana, Kibana and Prometheus UI interface on Knative Monitoring.
```
