### PR TITLE
Add support for Labels in DomainTemplate

### DIFF
--- a/config/core/configmaps/network.yaml
+++ b/config/core/configmaps/network.yaml
@@ -79,10 +79,13 @@ data:
     # entirely from the template. When choosing a new value be thoughtful
     # of the potential for conflicts - for example, when users choose to use
     # characters such as `-` in their service, or namespace, names.
-    # {{.Annotations}} can be used for any customization in the go template if needed.
-    # We strongly recommend keeping namespace part of the template to avoid domain name clashes
-    # Example '{{.Name}}-{{.Namespace}}.{{ index .Annotations "sub"}}.{{.Domain}}'
-    # and you have an annotation {"sub":"foo"}, then the generated template would be {Name}-{Namespace}.foo.{Domain}
+    # {{.Annotations}} or {{.Labels}} can be used for any customization in the
+    # go template if needed.
+    # We strongly recommend keeping namespace part of the template to avoid
+    # domain name clashes:
+    # eg. '{{.Name}}-{{.Namespace}}.{{ index .Annotations "sub"}}.{{.Domain}}'
+    # and you have an annotation {"sub":"foo"}, then the generated template
+    # would be {Name}-{Namespace}.foo.{Domain}
     domainTemplate: "{{.Name}}.{{.Namespace}}.{{.Domain}}"
 
     # tagTemplate specifies the golang text template string to use

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -145,6 +145,7 @@ type DomainTemplateValues struct {
 	Namespace   string
 	Domain      string
 	Annotations map[string]string
+	Labels      map[string]string
 }
 
 // TagTemplateValues are the available properties people can choose from
@@ -313,6 +314,7 @@ func checkDomainTemplate(t *template.Template) error {
 		Namespace:   "bar",
 		Domain:      "baz.com",
 		Annotations: nil,
+		Labels:      nil,
 	}
 	buf := bytes.Buffer{}
 	if err := t.Execute(&buf, data); err != nil {

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -324,6 +324,72 @@ func TestAnnotationsInDomainTemplate(t *testing.T) {
 	}
 }
 
+func TestLabelsInDomainTemplate(t *testing.T) {
+	networkConfigTests := []struct {
+		name               string
+		wantErr            bool
+		wantDomainTemplate string
+		config             *corev1.ConfigMap
+		data               DomainTemplateValues
+	}{{
+		name:               "network configuration with labels in template",
+		wantErr:            false,
+		wantDomainTemplate: "foo.sub1.baz.com",
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      ConfigName,
+			},
+			Data: map[string]string{
+				DefaultIngressClassKey: "foo-ingress",
+				DomainTemplateKey:      `{{.Name}}.{{ index .Labels "sub"}}.{{.Domain}}`,
+			},
+		},
+		data: DomainTemplateValues{
+			Name:      "foo",
+			Namespace: "bar",
+			Labels: map[string]string{
+				"sub": "sub1"},
+			Domain: "baz.com"},
+	}, {
+		name:               "network configuration without labels in template",
+		wantErr:            false,
+		wantDomainTemplate: "foo.bar.baz.com",
+		config: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      ConfigName,
+			},
+			Data: map[string]string{
+				DefaultIngressClassKey: "foo-ingress",
+				DomainTemplateKey:      `{{.Name}}.{{.Namespace}}.{{.Domain}}`,
+			},
+		},
+		data: DomainTemplateValues{
+			Name:      "foo",
+			Namespace: "bar",
+			Domain:    "baz.com"},
+	}}
+
+	for _, tt := range networkConfigTests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualConfig, err := NewConfigFromConfigMap(tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Test: %q; NewConfigFromConfigMap() error = %v, WantErr %v",
+					tt.name, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			got := mustExecute(t, actualConfig.GetDomainTemplate(), tt.data)
+			if got != tt.wantDomainTemplate {
+				t.Errorf("DomainTemplate(data) = %s, wanted %s", got, tt.wantDomainTemplate)
+			}
+		})
+	}
+}
+
 func mustExecute(t *testing.T, tmpl *template.Template, data interface{}) string {
 	t.Helper()
 	buf := bytes.Buffer{}

--- a/pkg/network/zz_generated.deepcopy.go
+++ b/pkg/network/zz_generated.deepcopy.go
@@ -46,6 +46,13 @@ func (in *DomainTemplateValues) DeepCopyInto(out *DomainTemplateValues) {
 			(*out)[key] = val
 		}
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -75,6 +75,7 @@ func DomainNameFromTemplate(ctx context.Context, r metav1.ObjectMeta, name strin
 		Namespace:   r.Namespace,
 		Domain:      domain,
 		Annotations: annotations,
+		Labels:      rLabels,
 	}
 
 	networkConfig := config.FromContext(ctx).Network

--- a/pkg/reconciler/route/domains/domains_test.go
+++ b/pkg/reconciler/route/domains/domains_test.go
@@ -100,6 +100,12 @@ func TestDomainNameFromTemplate(t *testing.T) {
 		want:     "test-name.mysub.example.com",
 		local:    false,
 	}, {
+		name:     "Labels",
+		template: `{{.Name}}.{{ index .Labels "bus"}}.{{.Domain}}`,
+		args:     args{name: "test-name"},
+		want:     "test-name.mybus.example.com",
+		local:    false,
+	}, {
 		// This cannot get through our validation, but verify we handle errors.
 		name:     "BadVarName",
 		template: "{{.Name}}.{{.NNNamespace}}.{{.Domain}}",
@@ -114,6 +120,7 @@ func TestDomainNameFromTemplate(t *testing.T) {
 		Namespace: "default",
 		Labels: map[string]string{
 			"route": "myapp",
+			"bus":   "mybus",
 		},
 		Annotations: map[string]string{
 			"sub": "mysub",


### PR DESCRIPTION
Allow us to access Labels in the DomainTemplate, similar to how people can
access Annotations. This allows people to create custom URLs via the
template and to choose custom domains in the config-domain configMap via
labels - instead of one via annotations and the other via labels.

Signed-off-by: Doug Davis <dug@us.ibm.com>

/lint

## Proposed Changes
* Add support for Labels in DomainTemplate

**Release Note**

```release-note
Can now access Labels in the DomainTemplate property in the config-network ConfigMap
```
