### PR TITLE
Add a new config-deployment parameter

### DIFF
--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -44,6 +44,6 @@ data:
     # List of repositories for which tag to digest resolving should be skipped
     registriesSkippingTagResolving: "ko.local,dev.local"
 
-    # ProgressDeadlineSeconds is the time in seconds we wait for the deployment to
+    # ProgressDeadlineSeconds is the duration we wait for the deployment to
     # be ready before considering it failed.
-    progressDeadline: "120"
+    progressDeadline: "120s"

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -44,6 +44,6 @@ data:
     # List of repositories for which tag to digest resolving should be skipped
     registriesSkippingTagResolving: "ko.local,dev.local"
 
-    # ProgressDeadlineSeconds is the duration we wait for the deployment to
+    # ProgressDeadline is the duration we wait for the deployment to
     # be ready before considering it failed.
     progressDeadline: "120s"

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -43,3 +43,7 @@ data:
 
     # List of repositories for which tag to digest resolving should be skipped
     registriesSkippingTagResolving: "ko.local,dev.local"
+
+    # ProgressDeadlineSeconds is the time in seconds we wait for the deployment to
+    # be ready before considering it failed.
+    progressDeadline: "120"

--- a/pkg/deployment/config_test.go
+++ b/pkg/deployment/config_test.go
@@ -18,92 +18,123 @@ package deployment
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"knative.dev/pkg/system"
 
 	. "knative.dev/pkg/configmap/testing"
+	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
 )
 
-var noSidecarImage = ""
+const noSidecarImage = ""
 
 func TestControllerConfigurationFromFile(t *testing.T) {
 	cm, example := ConfigMapsFromTestFile(t, ConfigName, QueueSidecarImageKey)
 
 	if _, err := NewConfigFromConfigMap(cm); err != nil {
-		t.Errorf("NewConfigFromConfigMap(actual) = %v", err)
+		t.Error("NewConfigFromConfigMap(actual) =", err)
 	}
 
-	if _, err := NewConfigFromConfigMap(example); err != nil {
-		t.Errorf("NewConfigFromConfigMap(example) = %v", err)
+	if got, err := NewConfigFromConfigMap(example); err != nil {
+		t.Error("NewConfigFromConfigMap(example) =", err)
+	} else {
+		want := defaultConfig()
+		// We require QSI to be explicitly set. So do it here.
+		want.QueueSidecarImage = "ko://knative.dev/serving/cmd/queue"
+		if !cmp.Equal(got, want) {
+			t.Error("Example stanza does not match default, diff(-want,+got):", cmp.Diff(want, got))
+		}
 	}
 }
 
 func TestControllerConfiguration(t *testing.T) {
 	configTests := []struct {
-		name           string
-		wantErr        bool
-		wantController interface{}
-		config         *corev1.ConfigMap
+		name       string
+		wantErr    bool
+		wantConfig *Config
+		data       map[string]string
 	}{{
-		name:    "controller configuration with bad registries",
-		wantErr: false,
-		wantController: &Config{
+		name: "controller configuration with bad registries",
+		wantConfig: &Config{
 			RegistriesSkippingTagResolving: sets.NewString("ko.local", ""),
 			QueueSidecarImage:              noSidecarImage,
+			ProgressDeadlineSeconds:        ProgressDeadlineSecondsDefault,
 		},
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{
-				QueueSidecarImageKey:           noSidecarImage,
-				registriesSkippingTagResolving: "ko.local,,",
-			},
-		}}, {
-		name:    "controller configuration with registries",
-		wantErr: false,
-		wantController: &Config{
-			RegistriesSkippingTagResolving: sets.NewString("ko.local", "ko.dev"),
-			QueueSidecarImage:              noSidecarImage,
-		},
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{
-				QueueSidecarImageKey:           noSidecarImage,
-				registriesSkippingTagResolving: "ko.local,ko.dev",
-			},
+		data: map[string]string{
+			QueueSidecarImageKey:              noSidecarImage,
+			registriesSkippingTagResolvingKey: "ko.local,,",
 		},
 	}, {
-		name:           "controller with no side car image",
-		wantErr:        true,
-		wantController: (*Config)(nil),
-		config: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
-				Name:      ConfigName,
-			},
-			Data: map[string]string{},
+		name: "controller configuration good progress deadline",
+		wantConfig: &Config{
+			RegistriesSkippingTagResolving: sets.NewString("ko.local", "dev.local"),
+			QueueSidecarImage:              noSidecarImage,
+			ProgressDeadlineSeconds:        444 * time.Second,
+		},
+		data: map[string]string{
+			QueueSidecarImageKey: noSidecarImage,
+			progressDeadlineKey:  "444",
+		},
+	}, {
+		name: "controller configuration with registries",
+		wantConfig: &Config{
+			RegistriesSkippingTagResolving: sets.NewString("ko.local", "ko.dev"),
+			QueueSidecarImage:              noSidecarImage,
+			ProgressDeadlineSeconds:        ProgressDeadlineSecondsDefault,
+		},
+		data: map[string]string{
+			QueueSidecarImageKey:              noSidecarImage,
+			registriesSkippingTagResolvingKey: "ko.local,ko.dev",
+		},
+	}, {
+		name:    "controller with no side car image",
+		wantErr: true,
+		data:    map[string]string{},
+	}, {
+		name:    "controller configuration invalid progress deadline",
+		wantErr: true,
+		data: map[string]string{
+			QueueSidecarImageKey: noSidecarImage,
+			progressDeadlineKey:  "not-a-number",
+		},
+	}, {
+		name:    "controller configuration invalid progress deadline II",
+		wantErr: true,
+		data: map[string]string{
+			QueueSidecarImageKey: noSidecarImage,
+			progressDeadlineKey:  "-21",
+		},
+	}, {
+		name:    "controller configuration invalid progress deadline III",
+		wantErr: true,
+		data: map[string]string{
+			QueueSidecarImageKey: noSidecarImage,
+			progressDeadlineKey:  "0",
 		},
 	}}
 
 	for _, tt := range configTests {
-		actualController, err := NewConfigFromConfigMap(tt.config)
+		t.Run(tt.name, func(t *testing.T) {
+			gotConfig, err := NewConfigFromConfigMap(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: system.Namespace(),
+					Name:      ConfigName,
+				},
+				Data: tt.data,
+			})
 
-		if (err != nil) != tt.wantErr {
-			t.Fatalf("Test: %q; NewConfigFromConfigMap() error = %v, WantErr %v", tt.name, err, tt.wantErr)
-		}
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewConfigFromConfigMap() error = %v, want: %v", err, tt.wantErr)
+			}
 
-		if diff := cmp.Diff(actualController, tt.wantController); diff != "" {
-			t.Fatalf("Test: %q; want %v, but got %v", tt.name, tt.wantController, actualController)
-		}
+			if got, want := gotConfig, tt.wantConfig; !cmp.Equal(got, want) {
+				t.Error("Config mismatch, diff(-want,+got):", cmp.Diff(want, got))
+			}
+		})
 	}
 }

--- a/pkg/deployment/config_test.go
+++ b/pkg/deployment/config_test.go
@@ -63,7 +63,7 @@ func TestControllerConfiguration(t *testing.T) {
 		wantConfig: &Config{
 			RegistriesSkippingTagResolving: sets.NewString("ko.local", ""),
 			QueueSidecarImage:              noSidecarImage,
-			ProgressDeadlineSeconds:        ProgressDeadlineSecondsDefault,
+			ProgressDeadline:               ProgressDeadlineDefault,
 		},
 		data: map[string]string{
 			QueueSidecarImageKey:              noSidecarImage,
@@ -74,18 +74,18 @@ func TestControllerConfiguration(t *testing.T) {
 		wantConfig: &Config{
 			RegistriesSkippingTagResolving: sets.NewString("ko.local", "dev.local"),
 			QueueSidecarImage:              noSidecarImage,
-			ProgressDeadlineSeconds:        444 * time.Second,
+			ProgressDeadline:               444 * time.Second,
 		},
 		data: map[string]string{
 			QueueSidecarImageKey: noSidecarImage,
-			progressDeadlineKey:  "444",
+			progressDeadlineKey:  "444s",
 		},
 	}, {
 		name: "controller configuration with registries",
 		wantConfig: &Config{
 			RegistriesSkippingTagResolving: sets.NewString("ko.local", "ko.dev"),
 			QueueSidecarImage:              noSidecarImage,
-			ProgressDeadlineSeconds:        ProgressDeadlineSecondsDefault,
+			ProgressDeadline:               ProgressDeadlineDefault,
 		},
 		data: map[string]string{
 			QueueSidecarImageKey:              noSidecarImage,

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -32,10 +32,10 @@ import (
 	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/networking"
 	nv1a1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
 	aresources "knative.dev/serving/pkg/reconciler/autoscaling/resources"
-	rresources "knative.dev/serving/pkg/reconciler/revision/resources"
 	"knative.dev/serving/pkg/resources"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,7 +61,7 @@ const (
 	// race the Revision reconciler and scale down the pods before it can actually surface the pod errors.
 	// We should instead do pod failure diagnostics here immediately before scaling down the Deployment.
 	activationTimeoutBuffer = 10 * time.Second
-	activationTimeout       = time.Duration(rresources.ProgressDeadlineSeconds)*time.Second + activationTimeoutBuffer
+	activationTimeout       = deployment.ProgressDeadlineSecondsDefault + activationTimeoutBuffer
 )
 
 var probeOptions = []interface{}{

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -61,7 +61,7 @@ const (
 	// race the Revision reconciler and scale down the pods before it can actually surface the pod errors.
 	// We should instead do pod failure diagnostics here immediately before scaling down the Deployment.
 	activationTimeoutBuffer = 10 * time.Second
-	activationTimeout       = deployment.ProgressDeadlineSecondsDefault + activationTimeoutBuffer
+	activationTimeout       = deployment.ProgressDeadlineDefault + activationTimeoutBuffer
 )
 
 var probeOptions = []interface{}{

--- a/pkg/reconciler/revision/resources/constants.go
+++ b/pkg/reconciler/revision/resources/constants.go
@@ -30,10 +30,6 @@ const (
 
 	// AppLabelKey is the label defining the application's name.
 	AppLabelKey = "app"
-
-	// ProgressDeadlineSeconds is the time in seconds we wait for the deployment to
-	// be ready before considering it failed.
-	ProgressDeadlineSeconds = int32(120)
 )
 
 var (

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -260,7 +260,7 @@ func MakeDeployment(rev *v1.Revision,
 		Spec: appsv1.DeploymentSpec{
 			Replicas:                ptr.Int32(1),
 			Selector:                makeSelector(rev),
-			ProgressDeadlineSeconds: ptr.Int32(ProgressDeadlineSeconds),
+			ProgressDeadlineSeconds: ptr.Int32(int32(deployment.ProgressDeadlineSecondsDefault.Seconds())),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      makeLabels(rev),

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -260,7 +260,7 @@ func MakeDeployment(rev *v1.Revision,
 		Spec: appsv1.DeploymentSpec{
 			Replicas:                ptr.Int32(1),
 			Selector:                makeSelector(rev),
-			ProgressDeadlineSeconds: ptr.Int32(int32(deployment.ProgressDeadlineSecondsDefault.Seconds())),
+			ProgressDeadlineSeconds: ptr.Int32(int32(deployment.ProgressDeadlineDefault.Seconds())),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      makeLabels(rev),

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -204,7 +204,7 @@ var (
 					serving.RevisionUID: "1234",
 				},
 			},
-			ProgressDeadlineSeconds: ptr.Int32(int32(deployment.ProgressDeadlineSecondsDefault.Seconds())),
+			ProgressDeadlineSeconds: ptr.Int32(int32(deployment.ProgressDeadlineDefault.Seconds())),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -37,6 +37,7 @@ import (
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
+	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
 )
 
@@ -203,7 +204,7 @@ var (
 					serving.RevisionUID: "1234",
 				},
 			},
-			ProgressDeadlineSeconds: ptr.Int32(ProgressDeadlineSeconds),
+			ProgressDeadlineSeconds: ptr.Int32(int32(deployment.ProgressDeadlineSecondsDefault.Seconds())),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{


### PR DESCRIPTION
This will guide how long are we allowing the deployment to take
before we consider it failed.
See #6201 for details.

This also moves the constant a bit, so a few file have to change.
Also internally make it duration so it's more self consistent.

Also make lots of various clean ups in the config-default tests and the code itself.
Next we'll thread it through the code rather than using constants all around.


/lint

/assign mattmoor
/cc @yuzisun 