### PR TITLE
Service initial scale

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -21,6 +21,8 @@ metadata:
     serving.knative.dev/release: devel
 
 data:
+  allow-zero-initial-scale: "true"
+  initial-scale: "0"
   _example: |
     ################################
     #                              #
@@ -176,3 +178,13 @@ data:
     # See the algorithm here: http://bit.ly/38XiCZ3.
     # TODO(vagababov): tune after actual benchmarking.
     activator-capacity: "100.0"
+
+    # allow-zero-initial-scale specifies whether developers can set
+    # the autoscaling.internal.knative.dev/initialScale annotation to
+    # 0, and whether operators can set initial-scale to 0.
+    allow-zero-initial-scale: "false"
+
+    # initial-scale specifies the initial revision size when
+    # a new service is deployed. This number can be set to 0 iff
+    # allow-zero-initial-scale is true.
+    initial-scale: "1"

--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -21,8 +21,6 @@ metadata:
     serving.knative.dev/release: devel
 
 data:
-  allow-zero-initial-scale: "true"
-  initial-scale: "0"
   _example: |
     ################################
     #                              #

--- a/pkg/autoscaler/fake/fake_metric_client.go
+++ b/pkg/autoscaler/fake/fake_metric_client.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	kubeinformers "k8s.io/client-go/informers"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
-	fakeclientset "knative.dev/serving/pkg/client/clientset/versioned/fake"
 )
 
 var (
@@ -33,8 +32,6 @@ var (
 	KubeClient = fakek8s.NewSimpleClientset()
 	// KubeInformer constructs a new instance of sharedInformerFactory for all namespaces.
 	KubeInformer = kubeinformers.NewSharedInformerFactory(KubeClient, 0)
-	// ServingClient holds instances of interfaces for making requests to Knative serving client.
-	ServingClient = fakeclientset.NewSimpleClientset()
 )
 
 const (

--- a/pkg/autoscaler/fake/fake_metric_client.go
+++ b/pkg/autoscaler/fake/fake_metric_client.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	kubeinformers "k8s.io/client-go/informers"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
+	fakeclientset "knative.dev/serving/pkg/client/clientset/versioned/fake"
+	informers "knative.dev/serving/pkg/client/informers/externalversions"
 )
 
 var (
@@ -32,6 +34,10 @@ var (
 	KubeClient = fakek8s.NewSimpleClientset()
 	// KubeInformer constructs a new instance of sharedInformerFactory for all namespaces.
 	KubeInformer = kubeinformers.NewSharedInformerFactory(KubeClient, 0)
+	// ServingClient holds instances of interfaces for making requests to Knative serving client.
+	ServingClient = fakeclientset.NewSimpleClientset()
+	// RevInformer constructs a fake v1 revision informer factory.
+	RevInformer = informers.NewSharedInformerFactory(ServingClient, 0).Serving().V1().Revisions()
 )
 
 const (

--- a/pkg/autoscaler/fake/fake_metric_client.go
+++ b/pkg/autoscaler/fake/fake_metric_client.go
@@ -26,7 +26,6 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
 	fakeclientset "knative.dev/serving/pkg/client/clientset/versioned/fake"
-	informers "knative.dev/serving/pkg/client/informers/externalversions"
 )
 
 var (
@@ -36,8 +35,6 @@ var (
 	KubeInformer = kubeinformers.NewSharedInformerFactory(KubeClient, 0)
 	// ServingClient holds instances of interfaces for making requests to Knative serving client.
 	ServingClient = fakeclientset.NewSimpleClientset()
-	// RevInformer constructs a fake v1 revision informer factory.
-	RevInformer = informers.NewSharedInformerFactory(ServingClient, 0).Serving().V1().Revisions()
 )
 
 const (

--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -111,7 +111,7 @@ func New(
 		panicTime:    pt,
 		maxPanicPods: int32(curC),
 
-		initialScaleTime: 0 * time.Second,
+		initialScaleTime: 0,
 	}, nil
 }
 

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -187,7 +187,7 @@ func TestAutoscalerStableModeIncreaseWithRPS(t *testing.T) {
 func TestAutoscalerUnpanicAfterSlowIncrease(t *testing.T) {
 	// Do initial jump from 10 to 25 pods.
 	metrics := &fake.MetricClient{StableConcurrency: 11, PanicConcurrency: 25}
-	a := newTestAutoscaler(t, 1, 98, metrics)
+	a := newTestAutoscaler(t, 1, 98, 1, metrics)
 	fake.Endpoints(10, fake.TestService)
 
 	na := expectedNA(a, 10)
@@ -225,7 +225,7 @@ func TestAutoscalerUnpanicAfterSlowIncrease(t *testing.T) {
 func TestAutoscalerExtendPanicWindow(t *testing.T) {
 	// Do initial jump from 10 to 25 pods.
 	metrics := &fake.MetricClient{StableConcurrency: 11, PanicConcurrency: 25}
-	a := newTestAutoscaler(t, 1, 98, metrics)
+	a := newTestAutoscaler(t, 1, 98, 1, metrics)
 	fake.Endpoints(10, fake.TestService)
 
 	na := expectedNA(a, 10)

--- a/pkg/autoscaler/scaling/multiscaler.go
+++ b/pkg/autoscaler/scaling/multiscaler.go
@@ -70,6 +70,10 @@ type DeciderSpec struct {
 	StableWindow time.Duration
 	// The name of the k8s service for pod information.
 	ServiceName string
+	// InitialScale is the calculated initial scale of the revision, taking both
+	// revision initial scale and cluster initial scale into account. Revision initial
+	// scale overrides cluster initial scale.
+	InitialScale int32
 }
 
 // DeciderStatus is the current scale recommendation.

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -253,7 +253,9 @@ func reportMetrics(pa *pav1alpha1.PodAutoscaler, pc podCounts) error {
 //    | -1   | >= min | activating | active     |
 //    | -1   | >= min | active     | active     |
 func (c *Reconciler) computeActiveCondition(ctx context.Context, pa *pav1alpha1.PodAutoscaler, pc podCounts) {
+	logger := logging.FromContext(ctx)
 	minReady := c.activeThreshold(ctx, pa)
+	logger.Debugf("computeActiveCondition pc is %#v, minReady is %v", pc, minReady)
 
 	switch {
 	case pc.want == 0:

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -313,6 +313,7 @@ func (c *Reconciler) activeThreshold(ctx context.Context, pa *pav1alpha1.PodAuto
 	} else {
 		min = int32(math.Max(float64(min), float64(defaultScale)))
 	}
+	logger.Debugf("Active threshold is %d", min)
 	return int(min)
 }
 

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -302,8 +302,8 @@ func (c *Reconciler) activeThreshold(ctx context.Context, pa *pav1alpha1.PodAuto
 	}
 
 	if c.scaler.lastReconcileTime != nil {
-		c.scaler.initialScaleTime += time.Since(*c.scaler.lastReconcileTime)
-		if c.scaler.initialScaleTime < config.FromContext(ctx).Autoscaler.StableWindow {
+		c.scaler.initialScaleDuration += time.Since(*c.scaler.lastReconcileTime)
+		if c.scaler.initialScaleDuration < config.FromContext(ctx).Autoscaler.StableWindow {
 			defaultScale = initScale
 		}
 	} else {

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -70,8 +70,7 @@ func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autosc
 		revInitScaleInt, err := strconv.Atoi(revInitScale)
 		if err != nil {
 			logger.Errorf("Error processing revision initial scale %d: %v", revInitScale, err)
-		}
-		if revInitScaleInt > 1 {
+		} else {
 			initScale = int32(revInitScaleInt)
 		}
 	}

--- a/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
@@ -135,6 +135,10 @@ func TestMakeDecider(t *testing.T) {
 		pa:   pa(WithPAInitialScale("5")),
 		want: decider(withTarget(100.0), withPanicThreshold(2.0), withTotal(100), withInitialScale(5), withInitialScaleAnnotation("5")),
 	}, {
+		name: "with invalid initial scale annotation",
+		pa:   pa(WithPAInitialScale("invalid")),
+		want: decider(withTarget(100.0), withPanicThreshold(2.0), withTotal(100), withInitialScaleAnnotation("invalid")),
+	}, {
 		name: "use cluster initial scale",
 		cfgOpt: func(c autoscalerconfig.Config) *autoscalerconfig.Config {
 			c.InitialScale = 3

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -538,7 +538,7 @@ func TestScaler(t *testing.T) {
 			cp := &countingProber{}
 			revisionScaler.probeManager = cp
 			revisionScaler.lastReconcileTime = test.scalerLastReconcileTime
-			revisionScaler.initialScaleTime = test.scalerInitialScaleTime
+			revisionScaler.initialScaleDuration = test.scalerInitialScaleTime
 			revisionScaler.initialScale = test.scalerInitialScale
 
 			// We test like this because the dynamic client's fake doesn't properly handle
@@ -598,11 +598,11 @@ func TestScaler(t *testing.T) {
 				}
 			}
 			if test.wantInitialScaleTimeUpdate {
-				if gotUpdatedInitialScaleTime := revisionScaler.initialScaleTime; gotUpdatedInitialScaleTime == test.scalerInitialScaleTime {
+				if gotUpdatedInitialScaleTime := revisionScaler.initialScaleDuration; gotUpdatedInitialScaleTime == test.scalerInitialScaleTime {
 					t.Error("scalerInitialScaleTime not updated")
 				}
 			} else {
-				if gotUpdatedInitialScaleTime := revisionScaler.initialScaleTime; gotUpdatedInitialScaleTime != test.scalerInitialScaleTime {
+				if gotUpdatedInitialScaleTime := revisionScaler.initialScaleDuration; gotUpdatedInitialScaleTime != test.scalerInitialScaleTime {
 					t.Error("scalerInitialScaleTime should not be updated")
 				}
 			}

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -248,7 +248,7 @@ func MakeDeployment(rev *v1.Revision,
 		return nil, fmt.Errorf("failed to create PodSpec: %w", err)
 	}
 
-	replicaCount := ptr.Int32(autoscalerConfig.InitialScale)
+	replicaCount := autoscalerConfig.InitialScale
 	ann, found := rev.ObjectMeta.Annotations[autoscaling.InitialScaleAnnotationKey]
 	if found {
 		initialScale, err := strconv.Atoi(ann)
@@ -256,7 +256,7 @@ func MakeDeployment(rev *v1.Revision,
 			return nil, fmt.Errorf("failed to process initialScale annotation: %w", err)
 		}
 		if initialScale != 0 || autoscalerConfig.AllowZeroInitialScale {
-			replicaCount = ptr.Int32(int32(initialScale))
+			replicaCount = int32(initialScale)
 		}
 	}
 
@@ -272,7 +272,7 @@ func MakeDeployment(rev *v1.Revision,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(rev)},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas:                replicaCount,
+			Replicas:                ptr.Int32(replicaCount),
 			Selector:                makeSelector(rev),
 			ProgressDeadlineSeconds: ptr.Int32(int32(deploymentConfig.ProgressDeadline.Seconds())),
 			Template: corev1.PodTemplateSpec{

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -725,7 +725,7 @@ func TestMakePodSpec(t *testing.T) {
 
 func TestMissingProbeError(t *testing.T) {
 	if _, err := MakeDeployment(revision("bar", "foo"), &logConfig, &traceConfig,
-		&network.Config{}, &obsConfig, asConfig, &deploymentConfig); err == nil {
+		&network.Config{}, &obsConfig, &asConfig, &deploymentConfig); err == nil {
 		t.Error("expected error from MakeDeployment")
 	}
 }
@@ -784,14 +784,7 @@ func TestMakeDeployment(t *testing.T) {
 		rev: revision("bar", "foo",
 			withoutLabels,
 			func(revision *v1.Revision) {
-				container(revision.Spec.GetContainer(),
-					withReadinessProbe(corev1.Handler{
-						TCPSocket: &corev1.TCPSocketAction{
-							Host: "127.0.0.1",
-							Port: intstr.FromInt(12345),
-						},
-					}),
-				)
+				container(revision.Spec.GetContainer(), withTCPReadinessProbe())
 			},
 		),
 		want: appsv1deployment(func(deploy *appsv1.Deployment) {
@@ -803,14 +796,7 @@ func TestMakeDeployment(t *testing.T) {
 		rev: revision("bar", "foo",
 			withoutLabels,
 			func(revision *v1.Revision) {
-				container(revision.Spec.GetContainer(),
-					withReadinessProbe(corev1.Handler{
-						TCPSocket: &corev1.TCPSocketAction{
-							Host: "127.0.0.1",
-							Port: intstr.FromInt(12345),
-						},
-					}),
-				)
+				container(revision.Spec.GetContainer(), withTCPReadinessProbe())
 				revision.ObjectMeta.Annotations = map[string]string{autoscaling.InitialScaleAnnotationKey: "20"}
 			},
 		),

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -57,10 +57,13 @@ var (
 	}
 
 	// The default CM values.
-	logConfig        logging.Config
-	traceConfig      tracingconfig.Config
-	obsConfig        metrics.ObservabilityConfig
-	asConfig, _      = autoscalerconfig.NewConfigFromMap(map[string]string{})
+	logConfig   logging.Config
+	traceConfig tracingconfig.Config
+	obsConfig   metrics.ObservabilityConfig
+	asConfig    = autoscalerconfig.Config{
+		InitialScale:          1,
+		AllowZeroInitialScale: false,
+	}
 	deploymentConfig deployment.Config
 )
 
@@ -255,7 +258,7 @@ func TestMakeQueueContainer(t *testing.T) {
 					}},
 				}
 			}
-			got, err := makeQueueContainer(test.rev, &test.lc, &traceConfig, &test.oc, asConfig, &test.cc)
+			got, err := makeQueueContainer(test.rev, &test.lc, &traceConfig, &test.oc, &asConfig, &test.cc)
 			if err != nil {
 				t.Fatal("makeQueueContainer returned error:", err)
 			}
@@ -384,7 +387,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := makeQueueContainer(test.rev, &logConfig, &traceConfig, &obsConfig, asConfig, &deploymentConfig)
+			got, err := makeQueueContainer(test.rev, &logConfig, &traceConfig, &obsConfig, &asConfig, &deploymentConfig)
 			if err != nil {
 				t.Fatal("makeQueueContainer returned error:", err)
 			}
@@ -459,7 +462,7 @@ func TestProbeGenerationHTTPDefaults(t *testing.T) {
 		}
 	})
 
-	got, err := makeQueueContainer(rev, &logConfig, &traceConfig, &obsConfig, asConfig, &deploymentConfig)
+	got, err := makeQueueContainer(rev, &logConfig, &traceConfig, &obsConfig, &asConfig, &deploymentConfig)
 	if err != nil {
 		t.Fatal("makeQueueContainer returned error")
 	}
@@ -531,7 +534,7 @@ func TestProbeGenerationHTTP(t *testing.T) {
 		}
 	})
 
-	got, err := makeQueueContainer(rev, &logConfig, &traceConfig, &obsConfig, asConfig, &deploymentConfig)
+	got, err := makeQueueContainer(rev, &logConfig, &traceConfig, &obsConfig, &asConfig, &deploymentConfig)
 	if err != nil {
 		t.Fatal("makeQueueContainer returned error")
 	}
@@ -707,7 +710,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 				Value: string(wantProbeJSON),
 			})
 
-			got, err := makeQueueContainer(testRev, &logConfig, &traceConfig, &obsConfig, asConfig, &deploymentConfig)
+			got, err := makeQueueContainer(testRev, &logConfig, &traceConfig, &obsConfig, &asConfig, &deploymentConfig)
 			if err != nil {
 				t.Fatal("makeQueueContainer returned error")
 			}

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -60,7 +60,7 @@ var (
 	logConfig        logging.Config
 	traceConfig      tracingconfig.Config
 	obsConfig        metrics.ObservabilityConfig
-	asConfig         autoscalerconfig.Config
+	asConfig, _      = autoscalerconfig.NewConfigFromMap(map[string]string{})
 	deploymentConfig deployment.Config
 )
 
@@ -255,7 +255,7 @@ func TestMakeQueueContainer(t *testing.T) {
 					}},
 				}
 			}
-			got, err := makeQueueContainer(test.rev, &test.lc, &traceConfig, &test.oc, &asConfig, &test.cc)
+			got, err := makeQueueContainer(test.rev, &test.lc, &traceConfig, &test.oc, asConfig, &test.cc)
 			if err != nil {
 				t.Fatal("makeQueueContainer returned error:", err)
 			}
@@ -384,7 +384,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := makeQueueContainer(test.rev, &logConfig, &traceConfig, &obsConfig, &asConfig, &deploymentConfig)
+			got, err := makeQueueContainer(test.rev, &logConfig, &traceConfig, &obsConfig, asConfig, &deploymentConfig)
 			if err != nil {
 				t.Fatal("makeQueueContainer returned error:", err)
 			}
@@ -459,7 +459,7 @@ func TestProbeGenerationHTTPDefaults(t *testing.T) {
 		}
 	})
 
-	got, err := makeQueueContainer(rev, &logConfig, &traceConfig, &obsConfig, &asConfig, &deploymentConfig)
+	got, err := makeQueueContainer(rev, &logConfig, &traceConfig, &obsConfig, asConfig, &deploymentConfig)
 	if err != nil {
 		t.Fatal("makeQueueContainer returned error")
 	}
@@ -531,7 +531,7 @@ func TestProbeGenerationHTTP(t *testing.T) {
 		}
 	})
 
-	got, err := makeQueueContainer(rev, &logConfig, &traceConfig, &obsConfig, &asConfig, &deploymentConfig)
+	got, err := makeQueueContainer(rev, &logConfig, &traceConfig, &obsConfig, asConfig, &deploymentConfig)
 	if err != nil {
 		t.Fatal("makeQueueContainer returned error")
 	}
@@ -707,7 +707,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 				Value: string(wantProbeJSON),
 			})
 
-			got, err := makeQueueContainer(testRev, &logConfig, &traceConfig, &obsConfig, &asConfig, &deploymentConfig)
+			got, err := makeQueueContainer(testRev, &logConfig, &traceConfig, &obsConfig, asConfig, &deploymentConfig)
 			if err != nil {
 				t.Fatal("makeQueueContainer returned error")
 			}

--- a/pkg/reconciler/testing/v1/factory.go
+++ b/pkg/reconciler/testing/v1/factory.go
@@ -113,11 +113,11 @@ func MakeFactory(ctor Ctor) rtesting.Factory {
 		// Validate all Create operations through the serving client.
 		client.PrependReactor("create", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			// TODO(n3wscott): context.Background is the best we can do at the moment, but it should be set-able.
-			return rtesting.ValidateCreates(context.Background(), action)
+			return rtesting.ValidateCreates(r.Ctx, action)
 		})
 		client.PrependReactor("update", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			// TODO(n3wscott): context.Background is the best we can do at the moment, but it should be set-able.
-			return rtesting.ValidateUpdates(context.Background(), action)
+			return rtesting.ValidateUpdates(r.Ctx, action)
 		})
 
 		actionRecorderList := rtesting.ActionRecorderList{istioClient, dynamicClient, client, kubeClient, cachingClient}

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -187,6 +187,11 @@ func WithMetricAnnotation(metric string) PodAutoscalerOption {
 	return withAnnotationValue(autoscaling.MetricAnnotationKey, metric)
 }
 
+// WithPAInitialScale adds a initial scale annotation to the PA.
+func WithPAInitialScale(initialScale string) PodAutoscalerOption {
+	return withAnnotationValue(autoscaling.InitialScaleAnnotationKey, initialScale)
+}
+
 // WithMetricOwnersRemoved clears the owner references of this PodAutoscaler.
 func WithMetricOwnersRemoved(m *asv1a1.Metric) {
 	m.OwnerReferences = nil

--- a/pkg/testing/v1/revision.go
+++ b/pkg/testing/v1/revision.go
@@ -17,10 +17,12 @@ limitations under the License.
 package v1
 
 import (
+	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/serving/pkg/apis/autoscaling"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -187,5 +189,18 @@ func WithRevisionLabel(key, value string) RevisionOption {
 func WithContainerStatuses(containerStatus []v1.ContainerStatuses) RevisionOption {
 	return func(r *v1.Revision) {
 		r.Status.ContainerStatuses = containerStatus
+	}
+}
+
+// WithInitialScale updates the initialScale annotation to
+// the provided value
+func WithInitialScale(initialScale int) RevisionOption {
+	return func(rev *v1.Revision) {
+		ans := rev.Annotations
+		if ans == nil {
+			ans = make(map[string]string, 1)
+		}
+		ans[autoscaling.InitialScaleAnnotationKey] = strconv.Itoa(initialScale)
+		rev.SetAnnotations(ans)
 	}
 }

--- a/pkg/testing/v1/service.go
+++ b/pkg/testing/v1/service.go
@@ -61,6 +61,7 @@ func ServiceWithoutNamespace(name string, so ...ServiceOption) *v1.Service {
 			Name: name,
 		},
 	}
+	s.SetDefaults(context.Background())
 	for _, opt := range so {
 		opt(s)
 	}

--- a/test/e2e/initial_scale_test.go
+++ b/test/e2e/initial_scale_test.go
@@ -37,7 +37,6 @@ import (
 // the revision level. This test runs after the cluster wide flag allow-zero-initial-scale
 // is set to true.
 func TestInitScaleZero(t *testing.T) {
-	t.Skip()
 	t.Parallel()
 	cancel := logstream.Start(t)
 	defer cancel()
@@ -57,7 +56,6 @@ func TestInitScaleZero(t *testing.T) {
 // TestInitScalePositive tests setting of annotation initialScale to greater than 0 on
 // the revision level.
 func TestInitScalePositive(t *testing.T) {
-	t.Skip()
 	t.Parallel()
 	cancel := logstream.Start(t)
 	defer cancel()


### PR DESCRIPTION
- Update Autoscaler.Scale(...) and make Autoscaler hold state of initial scale
- Update scaler.Scale(...) because Autoscaler.Scale(...) starts running a few seconds after scaler.Scale(...)
- Update KPA reconciler to adjust active threshold

/lint
/hold

Part 4 of #7682

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adding two config-autoscaler settings: allow-zero-initial-scale and initial-scale.
Users are also able to specify the initial scale on a per service basis with annotation autoscaling.internal.knative.dev/initialScale.
```

/cc @vagababov @markusthoemmes @dprotaso mattmoor
