### PR TITLE
Add more detailed logging to queue-proxy shutdown.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -380,7 +380,7 @@ func main() {
 	healthState := &health.State{}
 
 	server := buildServer(env, healthState, probe, reqChan, logger)
-	adminServer := buildAdminServer(healthState)
+	adminServer := buildAdminServer(healthState, logger)
 	metricsServer := buildMetricsServer(promStatReporter)
 
 	servers := map[string]*http.Server{
@@ -423,11 +423,12 @@ func main() {
 	case <-signals.SetupSignalHandler():
 		logger.Info("Received TERM signal, attempting to gracefully shutdown servers.")
 		healthState.Shutdown(func() {
-			// Give Istio time to sync our "not ready" state.
+			logger.Infof("Sleeping %v to allow K8s propagation of non-ready state", drainSleepDuration)
 			time.Sleep(drainSleepDuration)
 
 			// Calling server.Shutdown() allows pending requests to
 			// complete, while no new work is accepted.
+			logger.Info("Shutting down main server")
 			if err := server.Shutdown(context.Background()); err != nil {
 				logger.Errorw("Failed to shutdown proxy server", zap.Error(err))
 			}
@@ -435,12 +436,14 @@ func main() {
 			delete(servers, "main")
 		})
 
-		flush(logger)
 		for serverName, srv := range servers {
+			logger.Infof("Shutting down %s server", serverName)
 			if err := srv.Shutdown(context.Background()); err != nil {
 				logger.Errorw("Failed to shutdown server", zap.String("server", serverName), zap.Error(err))
 			}
 		}
+		logger.Info("Shutdown complete, exiting...")
+		flush(logger)
 	}
 }
 
@@ -555,9 +558,13 @@ func supportsMetrics(env config, logger *zap.SugaredLogger) bool {
 	return true
 }
 
-func buildAdminServer(healthState *health.State) *http.Server {
+func buildAdminServer(healthState *health.State, logger *zap.SugaredLogger) *http.Server {
 	adminMux := http.NewServeMux()
-	adminMux.HandleFunc(queue.RequestQueueDrainPath, healthState.DrainHandlerFunc())
+	drainHandler := healthState.DrainHandlerFunc()
+	adminMux.HandleFunc(queue.RequestQueueDrainPath, func(w http.ResponseWriter, r *http.Request) {
+		logger.Info("Attached drain handler from user-container")
+		drainHandler(w, r)
+	})
 
 	return &http.Server{
 		Addr:    ":" + strconv.Itoa(networking.QueueAdminPort),

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -418,6 +418,7 @@ func main() {
 	select {
 	case err := <-errCh:
 		logger.Errorw("Failed to bring up queue-proxy, shutting down.", zap.Error(err))
+		// This extra flush is needed because defers are not handled via os.Exit calls.
 		flush(logger)
 		os.Exit(1)
 	case <-signals.SetupSignalHandler():
@@ -443,7 +444,6 @@ func main() {
 			}
 		}
 		logger.Info("Shutdown complete, exiting...")
-		flush(logger)
 	}
 }
 

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -221,6 +221,16 @@ func TestDestroyPodTimely(t *testing.T) {
 		return true, nil
 	}); err != nil {
 		t.Logf("Latest state: %s", spew.Sprint(latestPodState))
+
+		// Fetch logs from the queue-proxy.
+		logs, err := clients.KubeClient.Kube.CoreV1().Pods(test.ServingNamespace).GetLogs(podToDelete, &corev1.PodLogOptions{
+			Container: "queue-proxy",
+		}).Do().Raw()
+		if err != nil {
+			t.Error("Failed fetching logs from queue-proxy", err)
+		}
+		t.Log("queue-proxy logs", string(logs))
+
 		t.Fatalf("Did not observe %q to actually be deleted", podToDelete)
 	}
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

To be able to hunt the flakiness of `TestDestroyPodTimely` we need to capture the queue-proxy's logs.

This also adds a bit more verbosity to the shutdown logs to give us a better timeline on what happened when. I left it at Info level as it's only printed once per pod and might also help users understand what's going on when their pods terminate.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
