### PR TITLE
Fix flake in TestMetricCollectorScraper.

### DIFF
--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -153,9 +153,12 @@ func TestMetricCollectorScraper(t *testing.T) {
 	var gotRPS, gotConcurrency, panicRPS, panicConcurrency float64
 	// Poll to see that the async loop completed.
 	wait.PollImmediate(10*time.Millisecond, 100*time.Millisecond, func() (bool, error) {
-		gotConcurrency, _, _ = coll.StableAndPanicConcurrency(metricKey, now)
-		gotRPS, _, _ = coll.StableAndPanicRPS(metricKey, now)
-		return gotConcurrency == wantConcurrency && gotRPS == wantRPS, nil
+		gotConcurrency, panicConcurrency, _ = coll.StableAndPanicConcurrency(metricKey, now)
+		gotRPS, panicRPS, _ = coll.StableAndPanicRPS(metricKey, now)
+		return gotConcurrency == wantConcurrency &&
+			panicConcurrency == wantPConcurrency &&
+			gotRPS == wantRPS &&
+			panicRPS == wantPRPS, nil
 	})
 
 	gotConcurrency, panicConcurrency, _ = coll.StableAndPanicConcurrency(metricKey, now)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Flake seen here: https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_serving/7668/pull-knative-serving-unit-tests/1252852896718917633

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

The stable and panic buckets are filled sequentially and non-atomically in the background. It is plausible that the stable values are already calculated while the panic ones aren't yet.

This hardens that situation by waiting for both values to be equal to the expected values.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
