### PR TITLE
Add new ConfigMap fields for service initial scale

### DIFF
--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -67,6 +67,14 @@ type Config struct {
 	// the number of activators per revision.
 	ActivatorCapacity float64
 
+	// AllowZeroInitialScale indicates whether DefaultInitialScale and
+	// autoscaling.internal.knative.dev/initialScale are allowed to be set to 0.
+	AllowZeroInitialScale bool
+
+	// DefaultInitialScale is the cluster-wide initial revision size for newly deploy
+	// services. This can be set to 0 iff AllowZeroInitialScale is true.
+	DefaultInitialScale int32
+
 	// General autoscaler algorithm configuration.
 	MaxScaleUpRate           float64
 	MaxScaleDownRate         float64
@@ -99,6 +107,8 @@ func defaultConfig() *Config {
 		ScaleToZeroGracePeriod:   30 * time.Second,
 		TickInterval:             2 * time.Second,
 		PodAutoscalerClass:       autoscaling.KPA,
+		AllowZeroInitialScale:    false,
+		DefaultInitialScale:      1,
 	}
 }
 
@@ -118,6 +128,9 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		{
 			key:   "enable-graceful-scaledown",
 			field: &lc.EnableGracefulScaledown,
+		}, {
+			key:   "allow-zero-initial-scale",
+			field: &lc.AllowZeroInitialScale,
 		}} {
 		if raw, ok := data[b.key]; ok {
 			*b.field = strings.EqualFold(raw, "true")
@@ -162,6 +175,25 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 				return nil, err
 			}
 			*f64.field = val
+		}
+	}
+
+	// Process int fields
+	for _, i := range []struct {
+		key          string
+		field        *int32
+		defaultValue int32
+	}{{
+		key:          "default-initial-scale",
+		field:        &lc.DefaultInitialScale,
+		defaultValue: 1,
+	}} {
+		if raw, ok := data[i.key]; !ok {
+			*i.field = i.defaultValue
+		} else if val, err := strconv.ParseInt(raw, 10, 32); err != nil {
+			return nil, err
+		} else {
+			*i.field = int32(val)
 		}
 	}
 
@@ -248,6 +280,12 @@ func validate(lc *Config) (*Config, error) {
 		return nil, fmt.Errorf("panic-window-percentage = %v, must be in [%v, 100] interval", lc.PanicWindowPercentage, 100*float64(BucketSize)/float64(lc.StableWindow))
 	}
 
+	if lc.DefaultInitialScale < 0 {
+		return nil, fmt.Errorf("default-initial-scale = %v, must be greater than 0", lc.DefaultInitialScale)
+	}
+	if lc.DefaultInitialScale == 0 && !lc.AllowZeroInitialScale {
+		return nil, fmt.Errorf("default-initial-scale = %v, must be greater than 1 when allow-zero-initial-scale = %v", lc.DefaultInitialScale, lc.AllowZeroInitialScale)
+	}
 	return lc, nil
 }
 

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -71,7 +71,7 @@ type Config struct {
 	// autoscaling.internal.knative.dev/initialScale are allowed to be set to 0.
 	AllowZeroInitialScale bool
 
-	// DefaultInitialScale is the cluster-wide initial revision size for newly deploy
+	// DefaultInitialScale is the cluster-wide initial revision size for newly deployed
 	// services. This can be set to 0 iff AllowZeroInitialScale is true.
 	DefaultInitialScale int32
 

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -278,11 +278,8 @@ func validate(lc *Config) (*Config, error) {
 		return nil, fmt.Errorf("panic-window-percentage = %v, must be in [%v, 100] interval", lc.PanicWindowPercentage, 100*float64(BucketSize)/float64(lc.StableWindow))
 	}
 
-	if lc.InitialScale < 0 {
+	if lc.InitialScale < 0 || (lc.InitialScale == 0 && !lc.AllowZeroInitialScale) {
 		return nil, fmt.Errorf("initial-scale = %v, must be at least 0 (or at least 1 when allow-zero-initial-scale is false)", lc.InitialScale)
-	}
-	if lc.InitialScale == 0 && !lc.AllowZeroInitialScale {
-		return nil, fmt.Errorf("initial-scale = %v, must be at least 1 since allow-zero-initial-scale is false", lc.InitialScale)
 	}
 	return lc, nil
 }

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -180,19 +180,17 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 
 	// Process int fields
 	for _, i := range []struct {
-		key          string
-		field        *int32
-		defaultValue int32
+		key   string
+		field *int32
 	}{{
-		key:          "initial-scale",
-		field:        &lc.InitialScale,
-		defaultValue: 1,
+		key:   "initial-scale",
+		field: &lc.InitialScale,
 	}} {
-		if raw, ok := data[i.key]; !ok {
-			*i.field = i.defaultValue
-		} else if val, err := strconv.ParseInt(raw, 10, 32); err != nil {
-			return nil, err
-		} else {
+		if raw, ok := data[i.key]; ok {
+			val, err := strconv.ParseInt(raw, 10, 32)
+			if err != nil {
+				return nil, err
+			}
 			*i.field = int32(val)
 		}
 	}

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -67,13 +67,13 @@ type Config struct {
 	// the number of activators per revision.
 	ActivatorCapacity float64
 
-	// AllowZeroInitialScale indicates whether DefaultInitialScale and
+	// AllowZeroInitialScale indicates whether InitialScale and
 	// autoscaling.internal.knative.dev/initialScale are allowed to be set to 0.
 	AllowZeroInitialScale bool
 
-	// DefaultInitialScale is the cluster-wide initial revision size for newly deployed
+	// InitialScale is the cluster-wide default initial revision size for newly deployed
 	// services. This can be set to 0 iff AllowZeroInitialScale is true.
-	DefaultInitialScale int32
+	InitialScale int32
 
 	// General autoscaler algorithm configuration.
 	MaxScaleUpRate           float64
@@ -108,7 +108,7 @@ func defaultConfig() *Config {
 		TickInterval:             2 * time.Second,
 		PodAutoscalerClass:       autoscaling.KPA,
 		AllowZeroInitialScale:    false,
-		DefaultInitialScale:      1,
+		InitialScale:             1,
 	}
 }
 
@@ -184,8 +184,8 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		field        *int32
 		defaultValue int32
 	}{{
-		key:          "default-initial-scale",
-		field:        &lc.DefaultInitialScale,
+		key:          "initial-scale",
+		field:        &lc.InitialScale,
 		defaultValue: 1,
 	}} {
 		if raw, ok := data[i.key]; !ok {
@@ -280,11 +280,11 @@ func validate(lc *Config) (*Config, error) {
 		return nil, fmt.Errorf("panic-window-percentage = %v, must be in [%v, 100] interval", lc.PanicWindowPercentage, 100*float64(BucketSize)/float64(lc.StableWindow))
 	}
 
-	if lc.DefaultInitialScale < 0 {
-		return nil, fmt.Errorf("default-initial-scale = %v, must be greater than 0", lc.DefaultInitialScale)
+	if lc.InitialScale < 0 {
+		return nil, fmt.Errorf("initial-scale = %v, must be at least 0 (or at least 1 when allow-zero-initial-scale is false)", lc.InitialScale)
 	}
-	if lc.DefaultInitialScale == 0 && !lc.AllowZeroInitialScale {
-		return nil, fmt.Errorf("default-initial-scale = %v, must be greater than 1 when allow-zero-initial-scale = %v", lc.DefaultInitialScale, lc.AllowZeroInitialScale)
+	if lc.InitialScale == 0 && !lc.AllowZeroInitialScale {
+		return nil, fmt.Errorf("initial-scale = %v, must be at least 1 since allow-zero-initial-scale is false", lc.InitialScale)
 	}
 	return lc, nil
 }

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -242,6 +242,39 @@ func TestNewConfig(t *testing.T) {
 			"scale-to-zero-grace-period": "4s",
 		},
 		wantErr: true,
+	}, {
+		name: "with invalid default initial scale",
+		input: map[string]string{
+			"allow-zero-initial-scale": "false",
+			"default-initial-scale":    "0",
+		},
+		wantErr: true,
+	}, {
+		name: "with negative default initial scale",
+		input: map[string]string{
+			"allow-zero-initial-scale": "false",
+			"default-initial-scale":    "-1",
+		},
+		wantErr: true,
+	}, {
+		name: "with non-parsible default initial scale",
+		input: map[string]string{
+			"allow-zero-initial-scale": "false",
+			"default-initial-scale":    "invalid",
+		},
+		wantErr: true,
+	}, {
+		name: "with valid default initial scale",
+		input: map[string]string{
+			"allow-zero-initial-scale": "true",
+			"default-initial-scale":    "0",
+		},
+		want: func() *Config {
+			c := defaultConfig()
+			c.AllowZeroInitialScale = true
+			c.DefaultInitialScale = 0
+			return c
+		}(),
 	}}
 
 	for _, test := range tests {

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -243,7 +243,7 @@ func TestNewConfig(t *testing.T) {
 		},
 		wantErr: true,
 	}, {
-		name: "with invalid default initial scale",
+		name: "with prohibited default initial scale",
 		input: map[string]string{
 			"allow-zero-initial-scale": "false",
 			"default-initial-scale":    "0",
@@ -257,7 +257,7 @@ func TestNewConfig(t *testing.T) {
 		},
 		wantErr: true,
 	}, {
-		name: "with non-parsible default initial scale",
+		name: "with non-parseable default initial scale",
 		input: map[string]string{
 			"allow-zero-initial-scale": "false",
 			"default-initial-scale":    "invalid",
@@ -273,6 +273,17 @@ func TestNewConfig(t *testing.T) {
 			c := defaultConfig()
 			c.AllowZeroInitialScale = true
 			c.DefaultInitialScale = 0
+			return c
+		}(),
+
+	}, {
+		name: "with non-parseable allow-zero-initial-scale",
+		input: map[string]string{
+			"allow-zero-initial-scale": "invalid",
+		},
+		want: func() *Config {
+			c := defaultConfig()
+			c.AllowZeroInitialScale = false
 			return c
 		}(),
 	}}

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -246,33 +246,33 @@ func TestNewConfig(t *testing.T) {
 		name: "with prohibited default initial scale",
 		input: map[string]string{
 			"allow-zero-initial-scale": "false",
-			"default-initial-scale":    "0",
+			"initial-scale":            "0",
 		},
 		wantErr: true,
 	}, {
 		name: "with negative default initial scale",
 		input: map[string]string{
 			"allow-zero-initial-scale": "false",
-			"default-initial-scale":    "-1",
+			"initial-scale":            "-1",
 		},
 		wantErr: true,
 	}, {
 		name: "with non-parseable default initial scale",
 		input: map[string]string{
 			"allow-zero-initial-scale": "false",
-			"default-initial-scale":    "invalid",
+			"initial-scale":            "invalid",
 		},
 		wantErr: true,
 	}, {
 		name: "with valid default initial scale",
 		input: map[string]string{
 			"allow-zero-initial-scale": "true",
-			"default-initial-scale":    "0",
+			"initial-scale":            "0",
 		},
 		want: func() *Config {
 			c := defaultConfig()
 			c.AllowZeroInitialScale = true
-			c.DefaultInitialScale = 0
+			c.InitialScale = 0
 			return c
 		}(),
 	}, {

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -275,7 +275,6 @@ func TestNewConfig(t *testing.T) {
 			c.DefaultInitialScale = 0
 			return c
 		}(),
-
 	}, {
 		name: "with non-parseable allow-zero-initial-scale",
 		input: map[string]string{


### PR DESCRIPTION
Adding two new ConfigMap fields `allow-zero-initial-scale` and `default-initial-scale` to config-autoscaler.

/lint

Part 1 of #7682

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```