### PR TITLE
Add service initial scale annotation and validation

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -149,7 +149,8 @@ func validateMetric(annotations map[string]string) *apis.FieldError {
 
 func validateInitialScale(allowInitScaleZero bool, annotations map[string]string) *apis.FieldError {
 	if initialScale, ok := annotations[InitialScaleAnnotationKey]; ok {
-		if !allowInitScaleZero && initialScale == "0" {
+		initScaleInt, err := strconv.Atoi(initialScale)
+		if err != nil || (!allowInitScaleZero && initScaleInt == 0) {
 			return apis.ErrInvalidValue(initialScale, InitialScaleAnnotationKey)
 		}
 	}

--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -42,8 +42,9 @@ func ValidateAnnotations(allowInitScaleZero bool, anns map[string]string) *apis.
 	if len(anns) == 0 {
 		return nil
 	}
-	return validateMinMaxScale(anns).Also(validateFloats(anns)).Also(validateWindows(anns).Also(validateMetric(anns).
-		Also(validateInitialScale(allowInitScaleZero, anns))))
+	return validateMinMaxScale(anns).Also(validateFloats(anns)).
+		Also(validateWindows(anns).Also(validateMetric(anns).
+			Also(validateInitialScale(allowInitScaleZero, anns))))
 }
 
 func validateFloats(annotations map[string]string) *apis.FieldError {

--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -150,7 +150,7 @@ func validateMetric(annotations map[string]string) *apis.FieldError {
 func validateInitialScale(allowInitScaleZero bool, annotations map[string]string) *apis.FieldError {
 	if initialScale, ok := annotations[InitialScaleAnnotationKey]; ok {
 		initScaleInt, err := strconv.Atoi(initialScale)
-		if err != nil || (!allowInitScaleZero && initScaleInt == 0) {
+		if err != nil || initScaleInt < 0 || (!allowInitScaleZero && initScaleInt == 0) {
 			return apis.ErrInvalidValue(initialScale, InitialScaleAnnotationKey)
 		}
 	}

--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -42,7 +42,8 @@ func ValidateAnnotations(allowInitScaleZero bool, anns map[string]string) *apis.
 	if len(anns) == 0 {
 		return nil
 	}
-	return validateMinMaxScale(anns).Also(validateFloats(anns)).Also(validateWindows(anns).Also(validateMetric(anns).Also(validateInitialScale(allowInitScaleZero, anns))))
+	return validateMinMaxScale(anns).Also(validateFloats(anns)).Also(validateWindows(anns).Also(validateMetric(anns).
+		Also(validateInitialScale(allowInitScaleZero, anns))))
 }
 
 func validateFloats(annotations map[string]string) *apis.FieldError {

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -26,9 +26,10 @@ import (
 
 func TestValidateScaleBoundAnnotations(t *testing.T) {
 	cases := []struct {
-		name        string
-		annotations map[string]string
-		expectErr   string
+		name               string
+		annotations        map[string]string
+		expectErr          string
+		allowInitScaleZero bool
 	}{{
 		name:        "nil annotations",
 		annotations: nil,
@@ -235,10 +236,15 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "other than HPA and KPA class",
 		annotations: map[string]string{ClassAnnotationKey: "other", MetricAnnotationKey: RPS},
+	}, {
+		name:               "initial scale is zero but cluster doesn't allow",
+		allowInitScaleZero: false,
+		annotations:        map[string]string{InitialScaleAnnotationKey: "0"},
+		expectErr:          "invalid value: 0: autoscaling.knative.dev/initialScale",
 	}}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got, want := ValidateAnnotations(c.annotations).Error(), c.expectErr; !reflect.DeepEqual(got, want) {
+			if got, want := ValidateAnnotations(c.allowInitScaleZero, c.annotations).Error(), c.expectErr; !reflect.DeepEqual(got, want) {
 				t.Errorf("Err = %q, want: %q, diff:\n%s", got, want, cmp.Diff(got, want))
 			}
 		})

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -241,6 +241,19 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 		allowInitScaleZero: false,
 		annotations:        map[string]string{InitialScaleAnnotationKey: "0"},
 		expectErr:          "invalid value: 0: autoscaling.knative.dev/initialScale",
+	}, {
+		name:               "initial scale is zero and cluster allows",
+		allowInitScaleZero: true,
+		annotations:        map[string]string{InitialScaleAnnotationKey: "0"},
+	}, {
+		name:               "initial scale is greater than 0",
+		allowInitScaleZero: false,
+		annotations:        map[string]string{InitialScaleAnnotationKey: "2"},
+	}, {
+		name:               "initial scale non-parseable",
+		allowInitScaleZero: false,
+		annotations:        map[string]string{InitialScaleAnnotationKey: "invalid"},
+		expectErr:          "invalid value: invalid: autoscaling.knative.dev/initialScale",
 	}}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -164,4 +164,9 @@ const (
 	// by the autoscaler as a candidate for removal. Once the label is set to "true", it
 	// signals the QueueProxy to fail readiness on the pod
 	PreferForScaleDownLabelKey = GroupName + "/prefer-for-scale-down"
+
+	// InitialScaleAnnotationKey is the annotation to specify the initial scale of
+	// a revision when a service is initially deployed. This number can be set to 0 iff
+	// allow-zero-initial-scale of config-autoscaler is true.
+	InitialScaleAnnotationKey = GroupName + "/initialScale"
 )

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -44,6 +44,11 @@ const (
 	//   autoscaling.knative.dev/maxScale: "10"
 	MaxScaleAnnotationKey = GroupName + "/maxScale"
 
+	// InitialScaleAnnotationKey is the annotation to specify the initial scale of
+	// a revision when a service is initially deployed. This number can be set to 0 iff
+	// allow-zero-initial-scale of config-autoscaler is true.
+	InitialScaleAnnotationKey = GroupName + "/initialScale"
+
 	// MetricAnnotationKey is the annotation to specify what metric the PodAutoscaler
 	// should be scaled on. For example,
 	//   autoscaling.knative.dev/metric: cpu
@@ -164,9 +169,4 @@ const (
 	// by the autoscaler as a candidate for removal. Once the label is set to "true", it
 	// signals the QueueProxy to fail readiness on the pod
 	PreferForScaleDownLabelKey = GroupName + "/prefer-for-scale-down"
-
-	// InitialScaleAnnotationKey is the annotation to specify the initial scale of
-	// a revision when a service is initially deployed. This number can be set to 0 iff
-	// allow-zero-initial-scale of config-autoscaler is true.
-	InitialScaleAnnotationKey = GroupName + "/initialScale"
 )

--- a/pkg/apis/autoscaling/v1alpha1/metric_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/metric_validation.go
@@ -26,7 +26,7 @@ import (
 
 // Validate validates the entire Metric.
 func (m *Metric) Validate(ctx context.Context) *apis.FieldError {
-	errs := serving.ValidateObjectMetadata(m.GetObjectMeta()).ViaField("metadata")
+	errs := serving.ValidateObjectMetadata(ctx, m.GetObjectMeta()).ViaField("metadata")
 	return errs.Also(m.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 

--- a/pkg/apis/autoscaling/v1alpha1/metric_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/metric_validation.go
@@ -26,8 +26,8 @@ import (
 
 // Validate validates the entire Metric.
 func (m *Metric) Validate(ctx context.Context) *apis.FieldError {
-	errs := serving.ValidateObjectMetadata(ctx, m.GetObjectMeta()).ViaField("metadata")
-	return errs.Also(m.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
+	return serving.ValidateObjectMetadata(ctx, m.GetObjectMeta()).ViaField("metadata").
+		Also(m.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 
 // Validate validates Metric's Spec.

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (pa *PodAutoscaler) Validate(ctx context.Context) *apis.FieldError {
-	errs := serving.ValidateObjectMetadata(pa.GetObjectMeta()).ViaField("metadata")
+	errs := serving.ValidateObjectMetadata(ctx, pa.GetObjectMeta()).ViaField("metadata")
 	return errs.Also(pa.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -25,8 +25,8 @@ import (
 )
 
 func (pa *PodAutoscaler) Validate(ctx context.Context) *apis.FieldError {
-	errs := serving.ValidateObjectMetadata(ctx, pa.GetObjectMeta()).ViaField("metadata")
-	return errs.Also(pa.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
+	return serving.ValidateObjectMetadata(ctx, pa.GetObjectMeta()).ViaField("metadata").
+		Also(pa.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 
 // Validate validates PodAutoscaler Spec.

--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -42,13 +42,7 @@ var (
 // ValidateObjectMetadata validates that `metadata` stanza of the
 // resources is correct.
 func ValidateObjectMetadata(ctx context.Context, meta metav1.Object) *apis.FieldError {
-	allowZeroInitialScale := false
-	if config.FromContext(ctx) != nil {
-		autoscalerConfig := config.FromContext(ctx).Autoscaler
-		if autoscalerConfig != nil {
-			allowZeroInitialScale = autoscalerConfig.AllowZeroInitialScale
-		}
-	}
+	allowZeroInitialScale := config.FromContextOrDefaults(ctx).Autoscaler.AllowZeroInitialScale
 	return apis.ValidateObjectMetadata(meta).
 		Also(autoscaling.ValidateAnnotations(allowZeroInitialScale, meta.GetAnnotations()).
 			Also(validateKnativeAnnotations(meta.GetAnnotations())).

--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -41,9 +41,16 @@ var (
 
 // ValidateObjectMetadata validates that `metadata` stanza of the
 // resources is correct.
-func ValidateObjectMetadata(meta metav1.Object) *apis.FieldError {
+func ValidateObjectMetadata(ctx context.Context, meta metav1.Object) *apis.FieldError {
+	allowZeroInitialScale := false
+	if config.FromContext(ctx) != nil {
+		autoscalerConfig := config.FromContext(ctx).Autoscaler
+		if autoscalerConfig != nil {
+			allowZeroInitialScale = autoscalerConfig.AllowZeroInitialScale
+		}
+	}
 	return apis.ValidateObjectMetadata(meta).
-		Also(autoscaling.ValidateAnnotations(meta.GetAnnotations()).
+		Also(autoscaling.ValidateAnnotations(allowZeroInitialScale, meta.GetAnnotations()).
 			Also(validateKnativeAnnotations(meta.GetAnnotations())).
 			ViaField("annotations"))
 }

--- a/pkg/apis/serving/metadata_validation_test.go
+++ b/pkg/apis/serving/metadata_validation_test.go
@@ -151,6 +151,36 @@ func TestValidateObjectMetadata(t *testing.T) {
 			},
 		},
 	}, {
+		name: "revision initial scale not parseable",
+		ctx:  config.ToContext(context.Background(), &config.Config{Autoscaler: &autoscalerconfig.Config{AllowZeroInitialScale: true}}),
+		objectMeta: &metav1.ObjectMeta{
+			GenerateName: "some-name",
+			Annotations: map[string]string{
+				autoscaling.InitialScaleAnnotationKey: "invalid",
+			},
+		},
+		expectErr: (&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
+			(&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
+				(&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
+					(&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
+						apis.ErrInvalidValue("invalid", "annotations."+autoscaling.InitialScaleAnnotationKey),
+					)))),
+	}, {
+		name: "negative revision initial scale",
+		ctx:  config.ToContext(context.Background(), &config.Config{Autoscaler: &autoscalerconfig.Config{AllowZeroInitialScale: true}}),
+		objectMeta: &metav1.ObjectMeta{
+			GenerateName: "some-name",
+			Annotations: map[string]string{
+				autoscaling.InitialScaleAnnotationKey: "-2",
+			},
+		},
+		expectErr: (&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
+			(&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
+				(&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
+					(&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
+						apis.ErrInvalidValue("-2", "annotations."+autoscaling.InitialScaleAnnotationKey),
+					)))),
+	}, {
 		name: "cluster allows zero revision initial scale",
 		ctx:  config.ToContext(context.Background(), &config.Config{Autoscaler: &autoscalerconfig.Config{AllowZeroInitialScale: true}}),
 		objectMeta: &metav1.ObjectMeta{

--- a/pkg/apis/serving/metadata_validation_test.go
+++ b/pkg/apis/serving/metadata_validation_test.go
@@ -152,9 +152,7 @@ func TestValidateObjectMetadata(t *testing.T) {
 		},
 	}, {
 		name: "cluster allows zero revision initial scale",
-		ctx: config.ToContext(context.Background(), asCfg(map[string]string{
-			"allow-zero-initial-scale": "true",
-		})),
+		ctx:  config.ToContext(context.Background(), &config.Config{Autoscaler: &autoscalerconfig.Config{AllowZeroInitialScale: true}}),
 		objectMeta: &metav1.ObjectMeta{
 			GenerateName: "some-name",
 			Annotations: map[string]string{
@@ -175,7 +173,7 @@ func TestValidateObjectMetadata(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if c.ctx == nil {
-				c.ctx = context.Background()
+				c.ctx = config.ToContext(context.Background(), &config.Config{Autoscaler: &autoscalerconfig.Config{AllowZeroInitialScale: false}})
 			}
 			err := ValidateObjectMetadata(c.ctx, c.objectMeta)
 			if got, want := err.Error(), c.expectErr.Error(); got != want {
@@ -263,13 +261,6 @@ func cfg(m map[string]string) *config.Config {
 	d, _ := config.NewDefaultsConfigFromMap(m)
 	return &config.Config{
 		Defaults: d,
-	}
-}
-
-func asCfg(m map[string]string) *config.Config {
-	as, _ := autoscalerconfig.NewConfigFromMap(m)
-	return &config.Config{
-		Autoscaler: as,
 	}
 }
 

--- a/pkg/apis/serving/metadata_validation_test.go
+++ b/pkg/apis/serving/metadata_validation_test.go
@@ -159,12 +159,7 @@ func TestValidateObjectMetadata(t *testing.T) {
 				autoscaling.InitialScaleAnnotationKey: "invalid",
 			},
 		},
-		expectErr: (&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
-			(&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
-				(&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
-					(&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
-						apis.ErrInvalidValue("invalid", "annotations."+autoscaling.InitialScaleAnnotationKey),
-					)))),
+		expectErr: apis.ErrInvalidValue("invalid", "annotations."+autoscaling.InitialScaleAnnotationKey),
 	}, {
 		name: "negative revision initial scale",
 		ctx:  config.ToContext(context.Background(), &config.Config{Autoscaler: &autoscalerconfig.Config{AllowZeroInitialScale: true}}),
@@ -174,12 +169,7 @@ func TestValidateObjectMetadata(t *testing.T) {
 				autoscaling.InitialScaleAnnotationKey: "-2",
 			},
 		},
-		expectErr: (&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
-			(&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
-				(&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
-					(&apis.FieldError{Message: "", Paths: []string(nil), Details: ""}).Also(
-						apis.ErrInvalidValue("-2", "annotations."+autoscaling.InitialScaleAnnotationKey),
-					)))),
+		expectErr: apis.ErrInvalidValue("-2", "annotations."+autoscaling.InitialScaleAnnotationKey),
 	}, {
 		name: "cluster allows zero revision initial scale",
 		ctx:  config.ToContext(context.Background(), &config.Config{Autoscaler: &autoscalerconfig.Config{AllowZeroInitialScale: true}}),

--- a/pkg/apis/serving/v1/configuration_validation.go
+++ b/pkg/apis/serving/v1/configuration_validation.go
@@ -32,7 +32,7 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 	// have changed (i.e. due to config-defaults changes), we elide the metadata and
 	// spec validation.
 	if !apis.IsInStatusUpdate(ctx) {
-		errs = errs.Also(serving.ValidateObjectMetadata(c.GetObjectMeta()).Also(
+		errs = errs.Also(serving.ValidateObjectMetadata(ctx, c.GetObjectMeta()).Also(
 			c.validateLabels().ViaField("labels")).ViaField("metadata"))
 		ctx = apis.WithinParent(ctx, c.ObjectMeta)
 		errs = errs.Also(c.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))

--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -23,12 +23,13 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmp"
 	"knative.dev/serving/pkg/apis/autoscaling"
+	apisconfig "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 )
 
 // Validate ensures Revision is properly configured.
 func (r *Revision) Validate(ctx context.Context) *apis.FieldError {
-	errs := serving.ValidateObjectMetadata(r.GetObjectMeta()).Also(
+	errs := serving.ValidateObjectMetadata(ctx, r.GetObjectMeta()).Also(
 		r.ValidateLabels().ViaField("labels")).ViaField("metadata")
 	errs = errs.Also(r.Status.Validate(apis.WithinStatus(ctx)).ViaField("status"))
 
@@ -57,7 +58,14 @@ func (r *Revision) Validate(ctx context.Context) *apis.FieldError {
 // Validate implements apis.Validatable
 func (rts *RevisionTemplateSpec) Validate(ctx context.Context) *apis.FieldError {
 	errs := rts.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec")
-	errs = errs.Also(autoscaling.ValidateAnnotations(rts.GetAnnotations()).ViaField("metadata.annotations"))
+	allowZeroInitialScale := false
+	if apisconfig.FromContext(ctx) != nil {
+		autoscalerConfig := apisconfig.FromContext(ctx).Autoscaler
+		if autoscalerConfig != nil {
+			allowZeroInitialScale = autoscalerConfig.AllowZeroInitialScale
+		}
+	}
+	errs = errs.Also(autoscaling.ValidateAnnotations(allowZeroInitialScale, rts.GetAnnotations()).ViaField("metadata.annotations"))
 
 	// If the RevisionTemplateSpec has a name specified, then check that
 	// it follows the requirements on the name.

--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -58,9 +58,7 @@ func (r *Revision) Validate(ctx context.Context) *apis.FieldError {
 // Validate implements apis.Validatable
 func (rts *RevisionTemplateSpec) Validate(ctx context.Context) *apis.FieldError {
 	errs := rts.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec")
-	allowZeroInitialScale := false
-	autoscalerConfig := apisconfig.FromContextOrDefaults(ctx).Autoscaler
-	allowZeroInitialScale = autoscalerConfig.AllowZeroInitialScale
+	allowZeroInitialScale := apisconfig.FromContextOrDefaults(ctx).Autoscaler.AllowZeroInitialScale
 	errs = errs.Also(autoscaling.ValidateAnnotations(allowZeroInitialScale, rts.GetAnnotations()).ViaField("metadata.annotations"))
 
 	// If the RevisionTemplateSpec has a name specified, then check that

--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -59,12 +59,8 @@ func (r *Revision) Validate(ctx context.Context) *apis.FieldError {
 func (rts *RevisionTemplateSpec) Validate(ctx context.Context) *apis.FieldError {
 	errs := rts.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec")
 	allowZeroInitialScale := false
-	if apisconfig.FromContext(ctx) != nil {
-		autoscalerConfig := apisconfig.FromContext(ctx).Autoscaler
-		if autoscalerConfig != nil {
-			allowZeroInitialScale = autoscalerConfig.AllowZeroInitialScale
-		}
-	}
+	autoscalerConfig := apisconfig.FromContextOrDefaults(ctx).Autoscaler
+	allowZeroInitialScale = autoscalerConfig.AllowZeroInitialScale
 	errs = errs.Also(autoscaling.ValidateAnnotations(allowZeroInitialScale, rts.GetAnnotations()).ViaField("metadata.annotations"))
 
 	// If the RevisionTemplateSpec has a name specified, then check that

--- a/pkg/apis/serving/v1/revision_validation_test.go
+++ b/pkg/apis/serving/v1/revision_validation_test.go
@@ -732,6 +732,7 @@ func TestImmutableFields(t *testing.T) {
 func TestRevisionTemplateSpecValidation(t *testing.T) {
 	tests := []struct {
 		name string
+		ctx  context.Context
 		rts  *RevisionTemplateSpec
 		want *apis.FieldError
 	}{{
@@ -891,11 +892,54 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 			Message: "invalid value: 50mx",
 			Paths:   []string{fmt.Sprintf("[%s]", serving.QueueSideCarResourcePercentageAnnotation)},
 		}).ViaField("metadata.annotations"),
+	}, {
+		name: "Invalid initial scale when cluster doesn't allow zero",
+		ctx:  autoscalerConfigCtx(false, 1),
+		rts: &RevisionTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					autoscaling.InitialScaleAnnotationKey: "0",
+				},
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "helloworld",
+					}},
+				},
+			},
+		},
+		want: (&apis.FieldError{
+			Message: "invalid value: 0",
+			Paths:   []string{fmt.Sprintf("%s", autoscaling.InitialScaleAnnotationKey)},
+		}).ViaField("metadata.annotations"),
+	}, {
+		name: "Valid initial scale when cluster allows zero",
+		ctx:  autoscalerConfigCtx(true, 1),
+		rts: &RevisionTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					autoscaling.InitialScaleAnnotationKey: "0",
+				},
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "helloworld",
+					}},
+				},
+			},
+		},
+		want: nil,
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := apis.WithinParent(context.Background(), metav1.ObjectMeta{
+			ctx := context.Background()
+			if test.ctx != nil {
+				ctx = test.ctx
+			}
+			ctx = apis.WithinParent(ctx, metav1.ObjectMeta{
 				Name: "parent",
 			})
 
@@ -905,4 +949,12 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func autoscalerConfigCtx(allowInitialScaleZero bool, initialScale int) context.Context {
+	testConfigs := &config.Config{}
+	testConfigs.Autoscaler, _ = autoscalerconfig.NewConfigFromMap(map[string]string{})
+	testConfigs.Autoscaler.AllowZeroInitialScale = allowInitialScaleZero
+	testConfigs.Autoscaler.InitialScale = int32(initialScale)
+	return config.ToContext(context.Background(), testConfigs)
 }

--- a/pkg/apis/serving/v1/revision_validation_test.go
+++ b/pkg/apis/serving/v1/revision_validation_test.go
@@ -911,7 +911,7 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 		},
 		want: (&apis.FieldError{
 			Message: "invalid value: 0",
-			Paths:   []string{fmt.Sprintf("%s", autoscaling.InitialScaleAnnotationKey)},
+			Paths:   []string{autoscaling.InitialScaleAnnotationKey},
 		}).ViaField("metadata.annotations"),
 	}, {
 		name: "Valid initial scale when cluster allows zero",

--- a/pkg/apis/serving/v1/revision_validation_test.go
+++ b/pkg/apis/serving/v1/revision_validation_test.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -953,8 +954,9 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 
 func autoscalerConfigCtx(allowInitialScaleZero bool, initialScale int) context.Context {
 	testConfigs := &config.Config{}
-	testConfigs.Autoscaler, _ = autoscalerconfig.NewConfigFromMap(map[string]string{})
-	testConfigs.Autoscaler.AllowZeroInitialScale = allowInitialScaleZero
-	testConfigs.Autoscaler.InitialScale = int32(initialScale)
+	testConfigs.Autoscaler, _ = autoscalerconfig.NewConfigFromMap(map[string]string{
+		"allow-zero-initial-scale": strconv.FormatBool(allowInitialScaleZero),
+		"initial-scale":            strconv.Itoa(initialScale),
+	})
 	return config.ToContext(context.Background(), testConfigs)
 }

--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -28,7 +28,7 @@ import (
 
 // Validate makes sure that Route is properly configured.
 func (r *Route) Validate(ctx context.Context) *apis.FieldError {
-	errs := serving.ValidateObjectMetadata(r.GetObjectMeta()).Also(
+	errs := serving.ValidateObjectMetadata(ctx, r.GetObjectMeta()).Also(
 		r.validateLabels().ViaField("labels")).ViaField("metadata")
 	errs = errs.Also(r.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 	errs = errs.Also(r.Status.Validate(apis.WithinStatus(ctx)).ViaField("status"))

--- a/pkg/apis/serving/v1/service_validation.go
+++ b/pkg/apis/serving/v1/service_validation.go
@@ -31,7 +31,7 @@ func (s *Service) Validate(ctx context.Context) (errs *apis.FieldError) {
 	// have changed (i.e. due to config-defaults changes), we elide the metadata and
 	// spec validation.
 	if !apis.IsInStatusUpdate(ctx) {
-		errs = errs.Also(serving.ValidateObjectMetadata(s.GetObjectMeta()).Also(
+		errs = errs.Also(serving.ValidateObjectMetadata(ctx, s.GetObjectMeta()).Also(
 			s.validateLabels().ViaField("labels")).ViaField("metadata"))
 		ctx = apis.WithinParent(ctx, s.ObjectMeta)
 		errs = errs.Also(s.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))

--- a/pkg/apis/serving/v1alpha1/configuration_validation.go
+++ b/pkg/apis/serving/v1alpha1/configuration_validation.go
@@ -32,7 +32,7 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 	// have changed (i.e. due to config-defaults changes), we elide the metadata and
 	// spec validation.
 	if !apis.IsInStatusUpdate(ctx) {
-		errs = errs.Also(serving.ValidateObjectMetadata(c.GetObjectMeta()).ViaField("metadata"))
+		errs = errs.Also(serving.ValidateObjectMetadata(ctx, c.GetObjectMeta()).ViaField("metadata"))
 		ctx = apis.WithinParent(ctx, c.ObjectMeta)
 		errs = errs.Also(c.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 	}

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -59,12 +59,8 @@ func (r *Revision) Validate(ctx context.Context) *apis.FieldError {
 // Validate ensures RevisionTemplateSpec is properly configured.
 func (rt *RevisionTemplateSpec) Validate(ctx context.Context) *apis.FieldError {
 	allowZeroInitialScale := false
-	if apisconfig.FromContext(ctx) != nil {
-		autoscalerConfig := apisconfig.FromContext(ctx).Autoscaler
-		if autoscalerConfig != nil {
-			allowZeroInitialScale = autoscalerConfig.AllowZeroInitialScale
-		}
-	}
+	autoscalerConfig := apisconfig.FromContextOrDefaults(ctx).Autoscaler
+	allowZeroInitialScale = autoscalerConfig.AllowZeroInitialScale
 	errs := rt.Spec.Validate(ctx).ViaField("spec")
 	errs = errs.Also(autoscaling.ValidateAnnotations(allowZeroInitialScale, rt.GetAnnotations()).ViaField("metadata.annotations"))
 	// If the DeprecatedRevisionTemplate has a name specified, then check that

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -23,6 +23,7 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmp"
 	"knative.dev/serving/pkg/apis/autoscaling"
+	apisconfig "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 )
 
@@ -45,7 +46,7 @@ func (r *Revision) checkImmutableFields(ctx context.Context, original *Revision)
 
 // Validate ensures Revision is properly configured.
 func (r *Revision) Validate(ctx context.Context) *apis.FieldError {
-	errs := serving.ValidateObjectMetadata(r.GetObjectMeta()).ViaField("metadata")
+	errs := serving.ValidateObjectMetadata(ctx, r.GetObjectMeta()).ViaField("metadata")
 	if apis.IsInUpdate(ctx) {
 		old := apis.GetBaseline(ctx).(*Revision)
 		errs = errs.Also(r.checkImmutableFields(ctx, old))
@@ -57,8 +58,15 @@ func (r *Revision) Validate(ctx context.Context) *apis.FieldError {
 
 // Validate ensures RevisionTemplateSpec is properly configured.
 func (rt *RevisionTemplateSpec) Validate(ctx context.Context) *apis.FieldError {
+	allowZeroInitialScale := false
+	if apisconfig.FromContext(ctx) != nil {
+		autoscalerConfig := apisconfig.FromContext(ctx).Autoscaler
+		if autoscalerConfig != nil {
+			allowZeroInitialScale = autoscalerConfig.AllowZeroInitialScale
+		}
+	}
 	errs := rt.Spec.Validate(ctx).ViaField("spec")
-	errs = errs.Also(autoscaling.ValidateAnnotations(rt.GetAnnotations()).ViaField("metadata.annotations"))
+	errs = errs.Also(autoscaling.ValidateAnnotations(allowZeroInitialScale, rt.GetAnnotations()).ViaField("metadata.annotations"))
 	// If the DeprecatedRevisionTemplate has a name specified, then check that
 	// it follows the requirements on the name.
 	errs = errs.Also(serving.ValidateRevisionName(ctx, rt.Name, rt.GenerateName))

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -58,9 +58,7 @@ func (r *Revision) Validate(ctx context.Context) *apis.FieldError {
 
 // Validate ensures RevisionTemplateSpec is properly configured.
 func (rt *RevisionTemplateSpec) Validate(ctx context.Context) *apis.FieldError {
-	allowZeroInitialScale := false
-	autoscalerConfig := apisconfig.FromContextOrDefaults(ctx).Autoscaler
-	allowZeroInitialScale = autoscalerConfig.AllowZeroInitialScale
+	allowZeroInitialScale := apisconfig.FromContextOrDefaults(ctx).Autoscaler.AllowZeroInitialScale
 	errs := rt.Spec.Validate(ctx).ViaField("spec")
 	errs = errs.Also(autoscaling.ValidateAnnotations(allowZeroInitialScale, rt.GetAnnotations()).ViaField("metadata.annotations"))
 	// If the DeprecatedRevisionTemplate has a name specified, then check that

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -930,8 +931,9 @@ func TestRevisionProtocolType(t *testing.T) {
 
 func autoscalerConfigCtx(allowInitialScaleZero bool, initialScale int) context.Context {
 	testConfigs := &config.Config{}
-	testConfigs.Autoscaler, _ = autoscalerconfig.NewConfigFromMap(map[string]string{})
-	testConfigs.Autoscaler.AllowZeroInitialScale = allowInitialScaleZero
-	testConfigs.Autoscaler.InitialScale = int32(initialScale)
+	testConfigs.Autoscaler, _ = autoscalerconfig.NewConfigFromMap(map[string]string{
+		"allow-zero-initial-scale": strconv.FormatBool(allowInitialScaleZero),
+		"initial-scale":            strconv.Itoa(initialScale),
+	})
 	return config.ToContext(context.Background(), testConfigs)
 }

--- a/pkg/apis/serving/v1alpha1/revision_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation_test.go
@@ -514,7 +514,7 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 		},
 		want: (&apis.FieldError{
 			Message: "invalid value: 0",
-			Paths:   []string{fmt.Sprintf("%s", autoscaling.InitialScaleAnnotationKey)},
+			Paths:   []string{autoscaling.InitialScaleAnnotationKey},
 		}).ViaField("metadata.annotations"),
 	}, {
 		name: "Valid initial scale when cluster allows zero",

--- a/pkg/apis/serving/v1alpha1/route_validation.go
+++ b/pkg/apis/serving/v1alpha1/route_validation.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (r *Route) Validate(ctx context.Context) *apis.FieldError {
-	errs := serving.ValidateObjectMetadata(r.GetObjectMeta()).ViaField("metadata")
+	errs := serving.ValidateObjectMetadata(ctx, r.GetObjectMeta()).ViaField("metadata")
 	errs = errs.Also(r.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 
 	if apis.IsInUpdate(ctx) {

--- a/pkg/apis/serving/v1alpha1/service_validation.go
+++ b/pkg/apis/serving/v1alpha1/service_validation.go
@@ -35,7 +35,7 @@ func (s *Service) Validate(ctx context.Context) (errs *apis.FieldError) {
 	// have changed (i.e. due to config-defaults changes), we elide the metadata and
 	// spec validation.
 	if !apis.IsInStatusUpdate(ctx) {
-		errs = errs.Also(serving.ValidateObjectMetadata(s.GetObjectMeta()).ViaField("metadata"))
+		errs = errs.Also(serving.ValidateObjectMetadata(ctx, s.GetObjectMeta()).ViaField("metadata"))
 		ctx = apis.WithinParent(ctx, s.ObjectMeta)
 		errs = errs.Also(s.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 	}

--- a/pkg/apis/serving/v1beta1/configuration_validation.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation.go
@@ -32,7 +32,7 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 	// have changed (i.e. due to config-defaults changes), we elide the metadata and
 	// spec validation.
 	if !apis.IsInStatusUpdate(ctx) {
-		errs = errs.Also(serving.ValidateObjectMetadata(c.GetObjectMeta()).Also(
+		errs = errs.Also(serving.ValidateObjectMetadata(ctx, c.GetObjectMeta()).Also(
 			c.validateLabels().ViaField("labels")).ViaField("metadata"))
 		ctx = apis.WithinParent(ctx, c.ObjectMeta)
 		errs = errs.Also(c.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))

--- a/pkg/apis/serving/v1beta1/revision_validation.go
+++ b/pkg/apis/serving/v1beta1/revision_validation.go
@@ -27,7 +27,7 @@ import (
 
 // Validate ensures Revision is properly configured.
 func (r *Revision) Validate(ctx context.Context) *apis.FieldError {
-	errs := serving.ValidateObjectMetadata(r.GetObjectMeta()).Also(
+	errs := serving.ValidateObjectMetadata(ctx, r.GetObjectMeta()).Also(
 		r.ValidateLabels().ViaField("labels")).ViaField("metadata")
 	errs = errs.Also(r.Status.Validate(apis.WithinStatus(ctx)).ViaField("status"))
 

--- a/pkg/apis/serving/v1beta1/route_validation.go
+++ b/pkg/apis/serving/v1beta1/route_validation.go
@@ -26,7 +26,7 @@ import (
 
 // Validate makes sure that Route is properly configured.
 func (r *Route) Validate(ctx context.Context) *apis.FieldError {
-	errs := serving.ValidateObjectMetadata(r.GetObjectMeta()).Also(
+	errs := serving.ValidateObjectMetadata(ctx, r.GetObjectMeta()).Also(
 		r.validateLabels().ViaField("labels")).ViaField("metadata")
 	errs = errs.Also(r.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 	errs = errs.Also(r.Status.Validate(apis.WithinStatus(ctx)).ViaField("status"))

--- a/pkg/apis/serving/v1beta1/service_validation.go
+++ b/pkg/apis/serving/v1beta1/service_validation.go
@@ -31,7 +31,7 @@ func (s *Service) Validate(ctx context.Context) (errs *apis.FieldError) {
 	// have changed (i.e. due to config-defaults changes), we elide the metadata and
 	// spec validation.
 	if !apis.IsInStatusUpdate(ctx) {
-		errs = errs.Also(serving.ValidateObjectMetadata(s.GetObjectMeta()).Also(
+		errs = errs.Also(serving.ValidateObjectMetadata(ctx, s.GetObjectMeta()).Also(
 			s.validateLabels().ViaField("labels")).ViaField("metadata"))
 		ctx = apis.WithinParent(ctx, s.ObjectMeta)
 		errs = errs.Also(s.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))


### PR DESCRIPTION
Add new autoscaling annotation initialScale and validation.

/lint
/hold
for Part 1

Part 2 of #7682

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
/assign @dprotaso @markusthoemmes @vagababov
