### PR TITLE
Job templates are immutable so we shouldn't include variant label values

### DIFF
--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -25,7 +25,6 @@ spec:
     metadata:
       labels:
         app: "default-domain"
-        serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
       containers:

--- a/config/post-install/storage-version-migration.yaml
+++ b/config/post-install/storage-version-migration.yaml
@@ -27,7 +27,6 @@ spec:
     metadata:
       labels:
         app: "storage-version-migration"
-        serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
       restartPolicy: OnFailure


### PR DESCRIPTION
Thus applying these post install jobs will be idempotent and won't
result in a kubectl failure.

Note: this doesn't mean the jobs will run again

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
