### PR TITLE
Actually use the new field in the deploy config

### DIFF
--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -46,4 +46,4 @@ data:
 
     # ProgressDeadline is the duration we wait for the deployment to
     # be ready before considering it failed.
-    progressDeadline: "600s"
+    progressDeadline: "120s"

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -46,4 +46,4 @@ data:
 
     # ProgressDeadline is the duration we wait for the deployment to
     # be ready before considering it failed.
-    progressDeadline: "120s"
+    progressDeadline: "600s"

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -34,8 +34,8 @@ const (
 	QueueSidecarImageKey = "queueSidecarImage"
 
 	// ProgressDeadlineDefault is the default value for the config's
-	// ProgressDeadlineSeconds. This matches the K8s default value of 600s.
-	ProgressDeadlineDefault = 600 * time.Second
+	// ProgressDeadlineSeconds. This does not match the K8s default value of 600s.
+	ProgressDeadlineDefault = 120 * time.Second
 
 	registriesSkippingTagResolvingKey = "registriesSkippingTagResolving"
 

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -34,8 +34,8 @@ const (
 	QueueSidecarImageKey = "queueSidecarImage"
 
 	// ProgressDeadlineDefault is the default value for the config's
-	// ProgressDeadlineSeconds.
-	ProgressDeadlineDefault = 120 * time.Second
+	// ProgressDeadlineSeconds. This matches the K8s default value of 600s.
+	ProgressDeadlineDefault = 600 * time.Second
 
 	registriesSkippingTagResolvingKey = "registriesSkippingTagResolving"
 

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -92,6 +92,7 @@ const (
 	paStableWindow           = 45 * time.Second
 	defaultConcurrencyTarget = 10.0
 	defaultTU                = 0.5
+	progressDeadline         = 121 * time.Second
 )
 
 func defaultConfigMapData() map[string]string {
@@ -110,7 +111,7 @@ func defaultConfig() *config.Config {
 	autoscalerConfig, _ := autoscalerconfig.NewConfigFromMap(defaultConfigMapData())
 	deploymentConfig, _ := deployment.NewConfigFromMap(map[string]string{
 		deployment.QueueSidecarImageKey: "bob",
-		deployment.ProgressDeadlineKey:  "2112ms",
+		deployment.ProgressDeadlineKey:  progressDeadline.String(),
 	})
 	return &config.Config{
 		Autoscaler: autoscalerConfig,

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -66,6 +66,7 @@ const (
 )
 
 func TestScaler(t *testing.T) {
+	const activationTimeout = progressDeadline + activationTimeoutBuffer
 	tests := []struct {
 		label               string
 		startReplicas       int

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -260,7 +260,7 @@ func MakeDeployment(rev *v1.Revision,
 		Spec: appsv1.DeploymentSpec{
 			Replicas:                ptr.Int32(1),
 			Selector:                makeSelector(rev),
-			ProgressDeadlineSeconds: ptr.Int32(int32(deployment.ProgressDeadlineDefault.Seconds())),
+			ProgressDeadlineSeconds: ptr.Int32(int32(deploymentConfig.ProgressDeadline.Seconds())),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      makeLabels(rev),

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -61,7 +61,9 @@ var (
 	traceConfig      tracingconfig.Config
 	obsConfig        metrics.ObservabilityConfig
 	asConfig         autoscalerconfig.Config
-	deploymentConfig deployment.Config
+	deploymentConfig = deployment.Config{
+		ProgressDeadline: deployment.ProgressDeadlineDefault,
+	}
 )
 
 const testProbeJSONTemplate = `{"tcpSocket":{"port":%d,"host":"127.0.0.1"}}`


### PR DESCRIPTION
This actually threads the value throughout deployment and kpa code.
Also move default to match that of K8s which is 600s

/assign mattmoor @tcnghia @dprotaso 
/lint
-->

Fixes #6201

