### PR TITLE
Fix flake in nonhttp01.TestSecret

### DIFF
--- a/test/conformance/certificate/nonhttp01/certificate_test.go
+++ b/test/conformance/certificate/nonhttp01/certificate_test.go
@@ -33,6 +33,11 @@ func TestSecret(t *testing.T) {
 	cert, cancel := utils.CreateCertificate(t, clients, []string{certName})
 	defer cancel()
 
+	t.Logf("Waiting for Certificate %q to transition to Ready", cert.Name)
+	if err := utils.WaitForCertificateState(clients.NetworkingClient, cert.Name, utils.IsCertificateReady, "CertificateIsReady"); err != nil {
+		t.Fatalf("Error waiting for the certificate to become ready for the latest revision: %v", err)
+	}
+
 	err := utils.WaitForCertificateSecret(t, clients, cert, t.Name())
 	if err != nil {
 		t.Errorf("Failed to wait for secret: %v", err)

--- a/test/conformance/certificate/utils.go
+++ b/test/conformance/certificate/utils.go
@@ -70,6 +70,12 @@ func CreateCertificate(t *testing.T, clients *test.Clients, dnsNames []string) (
 	return cert, cleanup
 }
 
+// IsCertificateReady will check the status conditions of the certificate and return true if the certificate is
+// ready.
+func IsCertificateReady(c *v1alpha1.Certificate) (bool, error) {
+	return c.Generation == c.Status.ObservedGeneration && c.Status.IsReady(), nil
+}
+
 // WaitForCertificateSecret polls the status of the Secret for the provided Certificate
 // until it exists or the timeout is exceeded. It then validates its contents
 func WaitForCertificateSecret(t *testing.T, client *test.Clients, cert *v1alpha1.Certificate, desc string) error {


### PR DESCRIPTION
## Proposed Changes

This patch adds WaitForCertificateState to TestSecret after creating
the Secret.

When certificate is not Ready yet, secret will be created by
cert-manager but still empty. Please refer to the log:

https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-istio-1.5-no-mesh/1252304690243178496

To fix it, this patch WaitForCertificateState().

/lint

**Release Note**

```release-note
NONE
```
