### PR TITLE
Remove outdated comment from route controller.

### DIFF
--- a/pkg/reconciler/route/controller.go
+++ b/pkg/reconciler/route/controller.go
@@ -69,8 +69,6 @@ func newControllerWithClock(
 	ingressInformer := ingressinformer.Get(ctx)
 	certificateInformer := certificateinformer.Get(ctx)
 
-	// No need to lock domainConfigMutex yet since the informers that can modify
-	// domainConfig haven't started yet.
 	c := &Reconciler{
 		kubeclient:          kubeclient.Get(ctx),
 		client:              servingclient.Get(ctx),


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

There is no domainConfigMutex at all. This might date waaaaay back to when we didn't have config stores and stuff. It's confusing anyway.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @nak3
