### PR TITLE
Minimize allocations when mangling forwarded header.

### DIFF
--- a/pkg/queue/forwarded_shim.go
+++ b/pkg/queue/forwarded_shim.go
@@ -17,7 +17,6 @@ limitations under the License.
 package queue
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 )
@@ -51,51 +50,69 @@ func ForwardedShimHandler(h http.Handler) http.Handler {
 			return
 		}
 
-		// The forwarded header is a list of forwarded elements
-		elements := []string{}
-
-		// The x-forwarded-header consists of multiple nodes
-		nodes := strings.Split(xff, ",")
-
-		// Sanitize nodes
-		for i, node := range nodes {
-			// Remove extra whitespace
-			node = strings.TrimSpace(node)
-
-			// For simplicity, an address is IPv6 it contains a colon (:)
-			if strings.Contains(node, ":") {
-				// Convert IPv6 address to "[ipv6 addr]" format
-				node = fmt.Sprintf("\"[%s]\"", node)
-			}
-
-			nodes[i] = node
-		}
-
-		// The first element has a 'for', 'proto' and 'host' pair, as available
-		pairs := []string{}
-
-		if xff != "" {
-			pairs = append(pairs, "for="+nodes[0])
-		}
-		if xfh != "" {
-			pairs = append(pairs, "host="+xfh)
-		}
-		if xfp != "" {
-			pairs = append(pairs, "proto="+xfp)
-		}
-
-		// The pairs are joined with a semi-colon (;) into a single element
-		elements = append(elements, strings.Join(pairs, ";"))
-
-		// Each subsequent x-forwarded-for node gets its own pair element
-		for _, node := range nodes[1:] {
-			elements = append(elements, "for="+node)
-		}
-
-		// The elements are joined with a comma (,) to form the header
-		fwd = strings.Join(elements, ", ")
-
-		// Add forwarded header
-		r.Header.Set("Forwarded", fwd)
+		r.Header.Set("Forwarded", generateForwarded(xff, xfp, xfh))
 	})
+}
+
+func generateForwarded(xff, xfp, xfh string) string {
+	fwd := &strings.Builder{}
+	// The size is dominated by the side of the indiviual headers.
+	// + 5 + 1 for host= and delimiter
+	// + 6 + 1 for proto= and delimiter
+	// + (5 + 4) * x for each for= clause and delimiter (assuming ipv6)
+	fwd.Grow(len(xff) + len(xfp) + len(xfh) + 6 + 7 + 9*(strings.Count(xff, ",")+1))
+
+	node, next := consumeNode(xff, 0)
+	if node != "" {
+		fwd.WriteString("for=")
+		writeNode(fwd, node)
+	}
+	if xfh != "" {
+		if node != "" {
+			fwd.WriteRune(';')
+		}
+		fwd.WriteString("host=")
+		fwd.WriteString(xfh)
+	}
+	if xfp != "" {
+		if node != "" || xfh != "" {
+			fwd.WriteRune(';')
+		}
+		fwd.WriteString("proto=")
+		fwd.WriteString(xfp)
+	}
+
+	for next < len(xff) {
+		node, next = consumeNode(xff, next)
+		fwd.WriteString(", for=")
+		writeNode(fwd, node)
+	}
+
+	return fwd.String()
+}
+
+func consumeNode(xff string, from int) (string, int) {
+	if xff == "" {
+		return "", 0
+	}
+	// The x-forwarded-header consists of multiple nodes, split by ","
+	rest := xff[from:len(xff)]
+	i := strings.Index(rest, ",")
+	if i == -1 {
+		i = len(rest)
+	}
+	return strings.TrimSpace(rest[:i]), from + i + 1
+}
+
+func writeNode(fwd *strings.Builder, node string) {
+	// For simplicity, an address is IPv6 it contains a colon (:)
+	ipv6 := strings.Contains(node, ":")
+	if ipv6 {
+		// Convert IPv6 address to "[ipv6 addr]" format
+		fwd.WriteString(`"[`)
+	}
+	fwd.WriteString(node)
+	if ipv6 {
+		fwd.WriteString(`]"`)
+	}
 }

--- a/pkg/queue/forwarded_shim.go
+++ b/pkg/queue/forwarded_shim.go
@@ -96,7 +96,7 @@ func consumeNode(xff string, from int) (string, int) {
 		return "", 0
 	}
 	// The x-forwarded-header consists of multiple nodes, split by ","
-	rest := xff[from:len(xff)]
+	rest := xff[from:]
 	i := strings.Index(rest, ",")
 	if i == -1 {
 		i = len(rest)

--- a/pkg/queue/forwarded_shim.go
+++ b/pkg/queue/forwarded_shim.go
@@ -63,7 +63,7 @@ func generateForwarded(xff, xfp, xfh string) string {
 	fwd.Grow(len(xff) + len(xfp) + len(xfh) + 6 + 7 + 9*(strings.Count(xff, ",")+1))
 
 	node, next := consumeNode(xff, 0)
-	if node != "" {
+	if xff != "" {
 		fwd.WriteString("for=")
 		writeNode(fwd, node)
 	}

--- a/pkg/queue/forwarded_shim_test.go
+++ b/pkg/queue/forwarded_shim_test.go
@@ -115,3 +115,9 @@ func TestForwardedShimHandler(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkForwardedShimHandler(b *testing.B) {
+	for j := 0; j < b.N; j++ {
+		generateForwarded("127.0.0.1,127.0.0.2,::1", "http", "localhost")
+	}
+}

--- a/pkg/queue/forwarded_shim_test.go
+++ b/pkg/queue/forwarded_shim_test.go
@@ -69,6 +69,10 @@ func TestForwardedShimHandler(t *testing.T) {
 		xfp:  "p",
 		want: "host=h;proto=p",
 	}, {
+		name: "broken for",
+		xff:  ",,,",
+		want: "for=, for=, for=",
+	}, {
 		name: "existing fwd",
 		xff:  "127.0.0.1, ::1",
 		xfh:  "h",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

**Note:** This is totally premature optimization. This is likely not an issue in production at all.

I tried this to have a little fun with writing code that uses as little allocations as possible. Just for fun mostly. Ended up with something I kinda liked and the benchmark difference is awesome. Sending this in for discussion thus anyway. Less allocations is always better, right?

### Benchmark results

```
benchmark                            old ns/op     new ns/op     delta
BenchmarkForwardedShimHandler-12     846           134           -84.16%
benchmark                            old allocs     new allocs     delta
BenchmarkForwardedShimHandler-12     14             1              -92.86%
benchmark                            old bytes     new bytes     delta
BenchmarkForwardedShimHandler-12     480           96            -80.00%
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @tanzeeb 
