### PR TITLE
Remove superfluous formats

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -87,19 +87,19 @@ import (
 )
 
 const (
-	gracePeriod              = 60 * time.Second
-	stableWindow             = 5 * time.Minute
-	paStableWindow           = 45 * time.Second
 	defaultConcurrencyTarget = 10.0
 	defaultTU                = 0.5
+	gracePeriod              = 60 * time.Second
+	paStableWindow           = 45 * time.Second
 	progressDeadline         = 121 * time.Second
+	stableWindow             = 5 * time.Minute
 )
 
 func defaultConfigMapData() map[string]string {
 	return map[string]string{
 		"max-scale-up-rate":                       "12.0",
-		"container-concurrency-target-percentage": fmt.Sprintf("%f", defaultTU),
-		"container-concurrency-target-default":    fmt.Sprintf("%f", defaultConcurrencyTarget),
+		"container-concurrency-target-percentage": fmt.Sprint(defaultTU),
+		"container-concurrency-target-default":    fmt.Sprint(defaultConcurrencyTarget),
 		"stable-window":                           stableWindow.String(),
 		"panic-window":                            "10s",
 		"scale-to-zero-grace-period":              gracePeriod.String(),
@@ -1109,14 +1109,14 @@ func TestGlobalResyncOnUpdateAutoscalerConfigMap(t *testing.T) {
 
 	// Wait for decider to be created.
 	if decider, err := pollDeciders(fakeDeciders, testNamespace, testRevision, nil); err != nil {
-		t.Fatalf("Failed to get decider: %v", err)
+		t.Fatal("Failed to get decider:", err)
 	} else if got, want := decider.Spec.TargetValue, defaultConcurrencyTarget*defaultTU; got != want {
 		t.Fatalf("TargetValue = %f, want %f", got, want)
 	}
 
 	const concurrencyTargetAfterUpdate = 100.0
 	data := defaultConfigMapData()
-	data["container-concurrency-target-default"] = fmt.Sprintf("%f", concurrencyTargetAfterUpdate)
+	data["container-concurrency-target-default"] = fmt.Sprint(concurrencyTargetAfterUpdate)
 	watcher.OnChange(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      autoscalerconfig.ConfigName,
@@ -1145,7 +1145,7 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatalf("StartInformers() = %v", err)
+		t.Fatal("StartInformers() =", err)
 	}
 
 	var eg errgroup.Group

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -137,7 +137,7 @@ var (
 			Value: "false",
 		}, {
 			Name:  "TRACING_CONFIG_SAMPLE_RATE",
-			Value: "0.000000",
+			Value: "0",
 		}, {
 			Name:  "USER_PORT",
 			Value: "8080",

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -307,7 +307,7 @@ func makeQueueContainer(rev *v1.Revision, loggingConfig *logging.Config, tracing
 			Value: strconv.FormatBool(tracingConfig.Debug),
 		}, {
 			Name:  "TRACING_CONFIG_SAMPLE_RATE",
-			Value: fmt.Sprintf("%f", tracingConfig.SampleRate),
+			Value: fmt.Sprint(tracingConfig.SampleRate),
 		}, {
 			Name:  "USER_PORT",
 			Value: strconv.Itoa(int(userPort)),

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -776,7 +776,7 @@ var defaultEnv = map[string]string{
 	"TRACING_CONFIG_BACKEND":                "",
 	"TRACING_CONFIG_ZIPKIN_ENDPOINT":        "",
 	"TRACING_CONFIG_STACKDRIVER_PROJECT_ID": "",
-	"TRACING_CONFIG_SAMPLE_RATE":            "0.000000",
+	"TRACING_CONFIG_SAMPLE_RATE":            "0",
 	"TRACING_CONFIG_DEBUG":                  "false",
 	"SERVING_REQUEST_LOG_TEMPLATE":          "",
 	"SERVING_REQUEST_METRICS_BACKEND":       "",


### PR DESCRIPTION
Also incidentally improve tests, by removing redundant .0000.


/assign @yanweiguo @markusthoemmes 