### PR TITLE
[WIP] Added network policy to block local traffic

### DIFF
--- a/config/networking-networkpolicy.yaml
+++ b/config/networking-networkpolicy.yaml
@@ -25,6 +25,7 @@ spec:
   policyTypes:
   - Ingress
   ingress:
-    ports:
-    - protocol: TCP
-      port: queue-port
+    - from:
+      ports:
+      - protocol: TCP
+        port: queue-port

--- a/config/networking-networkpolicy.yaml
+++ b/config/networking-networkpolicy.yaml
@@ -1,0 +1,31 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: knative-serving-user-container-policy
+  namespace: default
+spec:
+  podSelector:
+    matchExpressions:
+      - key: serving.knative.dev/revision
+        operator: Exists
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    ports:
+    - protocol: TCP
+      port: queue-port

--- a/config/networking-networkpolicy.yaml
+++ b/config/networking-networkpolicy.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ spec:
   policyTypes:
   - Ingress
   ingress:
-  - from:
     ports:
     - protocol: TCP
       port: queue-port

--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -26,6 +26,7 @@ import (
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
 	configmapinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/configmap"
 	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
+	networkpolicyinformer "knative.dev/pkg/client/injection/kube/informers/networking/v1/networkpolicy"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	painformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
@@ -73,6 +74,7 @@ func newControllerWithOptions(
 	logger := logging.FromContext(ctx)
 	deploymentInformer := deploymentinformer.Get(ctx)
 	serviceInformer := serviceinformer.Get(ctx)
+	networkPolicyInformer := networkpolicyinformer.Get(ctx)
 	configMapInformer := configmapinformer.Get(ctx)
 	imageInformer := imageinformer.Get(ctx)
 	revisionInformer := revisioninformer.Get(ctx)
@@ -86,6 +88,7 @@ func newControllerWithOptions(
 		podAutoscalerLister: paInformer.Lister(),
 		imageLister:         imageInformer.Lister(),
 		deploymentLister:    deploymentInformer.Lister(),
+		networkPolicyLister: networkPolicyInformer.Lister(),
 		serviceLister:       serviceInformer.Lister(),
 		resolver: &digestResolver{
 			client:    kubeclient.Get(ctx),

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
+	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	caching "knative.dev/caching/pkg/apis/caching/v1alpha1"
 	"knative.dev/pkg/kmeta"
@@ -113,6 +114,12 @@ func (c *Reconciler) createImageCache(ctx context.Context, rev *v1.Revision) (*c
 	image := resources.MakeImageCache(rev)
 
 	return c.cachingclient.CachingV1alpha1().Images(image.Namespace).Create(image)
+}
+
+func (c *Reconciler) createNetworkPolicy(ctx context.Context, rev *v1.Revision) (*netv1.NetworkPolicy, error) {
+	np := resources.MakeNetworkPolicy(rev)
+
+	return c.kubeclient.NetworkingV1().NetworkPolicies(np.Namespace).Create(np)
 }
 
 func (c *Reconciler) createPA(ctx context.Context, rev *v1.Revision) (*autoscaling.PodAutoscaler, error) {

--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -128,6 +128,25 @@ func (c *Reconciler) reconcileImageCache(ctx context.Context, rev *v1.Revision) 
 	return nil
 }
 
+func (c *Reconciler) reconcileNetworkPolicy(ctx context.Context, rev *v1.Revision) error {
+	logger := logging.FromContext(ctx)
+
+	ns := rev.Namespace
+	networkPolicy := resourcenames.NetworkPolicy(rev)
+	_, err := c.networkPolicyLister.NetworkPolicies(ns).Get(networkPolicy)
+	if apierrs.IsNotFound(err) {
+		_, err := c.createNetworkPolicy(ctx, rev)
+		if err != nil {
+			return fmt.Errorf("failed to create network policy %q: %w", networkPolicy, err)
+		}
+		logger.Infof("Created netowrk policy %q", networkPolicy)
+	} else if err != nil {
+		return fmt.Errorf("failed to get network policy %q: %w", networkPolicy, err)
+	}
+
+	return nil
+}
+
 func (c *Reconciler) reconcilePA(ctx context.Context, rev *v1.Revision) error {
 	ns := rev.Namespace
 	paName := resourcenames.PA(rev)

--- a/pkg/reconciler/revision/resources/names/names.go
+++ b/pkg/reconciler/revision/resources/names/names.go
@@ -28,6 +28,11 @@ func ImageCache(rev kmeta.Accessor) string {
 	return kmeta.ChildName(rev.GetName(), "-cache")
 }
 
+// NetworkPolicy returns the name for the revision
+func NetworkPolicy(rev kmeta.Accessor) string {
+	return kmeta.ChildName(rev.GetName(), "-networkpolicy")
+}
+
 // PA returns the PA name for the revision.
 func PA(rev kmeta.Accessor) string {
 	return rev.GetName()

--- a/pkg/reconciler/revision/resources/networkpolicy.go
+++ b/pkg/reconciler/revision/resources/networkpolicy.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/kmeta"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/reconciler/revision/resources/names"
+)
+
+// Creates a Network Policy
+func MakeNetworkPolicy(rev *v1.Revision) *netv1.NetworkPolicy {
+	return &netv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            names.NetworkPolicy(rev),
+			Namespace:       rev.Namespace,
+			Labels:          makeLabels(rev),
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(rev)},
+		},
+		Spec: netv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "serving.knative.dev/revision",
+						Operator: metav1.LabelSelectorOpExists,
+					},
+				},
+			},
+			Ingress: []netv1.NetworkPolicyIngressRule{
+				{
+					Ports: []netv1.NetworkPolicyPort{{
+						Port: &intstr.IntOrString{
+							Type:   intstr.String,
+							StrVal: "queue-port",
+						},
+					}},
+					From: []netv1.NetworkPolicyPeer{},
+				},
+			},
+			Egress:      []netv1.NetworkPolicyEgressRule{},
+			PolicyTypes: []netv1.PolicyType{"Ingress"},
+		},
+	}
+}

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	netv1listers "k8s.io/client-go/listers/networking/v1"
 	cachingclientset "knative.dev/caching/pkg/client/clientset/versioned"
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
 	revisionreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/revision"
@@ -55,6 +56,7 @@ type Reconciler struct {
 	imageLister         cachinglisters.ImageLister
 	deploymentLister    appsv1listers.DeploymentLister
 	serviceLister       corev1listers.ServiceLister
+	networkPolicyLister netv1listers.NetworkPolicyLister
 
 	resolver resolver
 }
@@ -119,6 +121,9 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, rev *v1.Revision) pkgrec
 	}, {
 		name: "PA",
 		f:    c.reconcilePA,
+	}, {
+		name: "network policy",
+		f:    c.reconcileNetworkPolicy,
 	}}
 
 	for _, phase := range phases {

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -22,6 +22,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
@@ -80,6 +81,7 @@ func TestReconcile(t *testing.T) {
 			pa("foo", "first-reconcile"),
 			deploy(t, "foo", "first-reconcile"),
 			image("foo", "first-reconcile"),
+			networkpolicy("foo", "first-reconcile"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: rev("foo", "first-reconcile",
@@ -698,6 +700,15 @@ func image(namespace, name string, co ...configOption) *caching.Image {
 	}
 
 	return resources.MakeImageCache(rev(namespace, name))
+}
+
+func networkpolicy(namespace, name string, np ...NetworkPolicyOption) *netv1.NetworkPolicy {
+	rev := rev(namespace, name)
+	k := resources.MakeNetworkPolicy(rev)
+	for _, opt := range np {
+		opt(k)
+	}
+	return k
 }
 
 func pa(namespace, name string, ko ...PodAutoscalerOption) *asv1a1.PodAutoscaler {

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/kmeta"
@@ -252,6 +253,9 @@ func WithSubsets(ep *corev1.Endpoints) {
 func WithEndpointsOwnersRemoved(eps *corev1.Endpoints) {
 	eps.OwnerReferences = nil
 }
+
+// NetworkPolicyOption is an option that can be applied to a NetworkPolicy.
+type NetworkPolicyOption func(*netv1.NetworkPolicy)
 
 // PodOption enables further configuration of a Pod.
 type PodOption func(*corev1.Pod)

--- a/test/config/networking-networkpolicy.yaml
+++ b/test/config/networking-networkpolicy.yaml
@@ -16,7 +16,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: knative-serving-user-container-policy
-  namespace: default
+  namespace: serving-tests
 spec:
   podSelector:
     matchExpressions:


### PR DESCRIPTION
https://github.com/knative/serving/issues/6520


## Proposed Changes
* Added a network policy to the original configuration that will block traffic to the pod unless it goes through the queue-port. 


**Release Note**

```release-note
This network policy blocks traffic to a pod unless it goes through the queue-port. This should resolve issues where you could curl a pod using the pod IP(local) instead of the route. 
```
