### PR TITLE
Remove unnecessary casts

### DIFF
--- a/pkg/reconciler/autoscaling/resources/sks_test.go
+++ b/pkg/reconciler/autoscaling/resources/sks_test.go
@@ -56,7 +56,7 @@ func TestMakeSKS(t *testing.T) {
 	}
 
 	const mode = nv1a1.SKSOperationModeServe
-	const na = int32(42)
+	const na = 42
 
 	want := &nv1a1.ServerlessService{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -51,27 +51,27 @@ const (
 var (
 	queueHTTPPort = corev1.ContainerPort{
 		Name:          requestQueueHTTPPortName,
-		ContainerPort: int32(networking.BackendHTTPPort),
+		ContainerPort: networking.BackendHTTPPort,
 	}
 	queueHTTP2Port = corev1.ContainerPort{
 		Name:          requestQueueHTTPPortName,
-		ContainerPort: int32(networking.BackendHTTP2Port),
+		ContainerPort: networking.BackendHTTP2Port,
 	}
 	queueNonServingPorts = []corev1.ContainerPort{{
 		// Provides health checks and lifecycle hooks.
 		Name:          v1.QueueAdminPortName,
-		ContainerPort: int32(networking.QueueAdminPort),
+		ContainerPort: networking.QueueAdminPort,
 	}, {
 		Name:          v1.AutoscalingQueueMetricsPortName,
-		ContainerPort: int32(networking.AutoscalingQueueMetricsPort),
+		ContainerPort: networking.AutoscalingQueueMetricsPort,
 	}, {
 		Name:          v1.UserQueueMetricsPortName,
-		ContainerPort: int32(networking.UserQueueMetricsPort),
+		ContainerPort: networking.UserQueueMetricsPort,
 	}}
 
 	profilingPort = corev1.ContainerPort{
 		Name:          profilingPortName,
-		ContainerPort: int32(profiling.ProfilingPort),
+		ContainerPort: profiling.ProfilingPort,
 	}
 
 	queueSecurityContext = &corev1.SecurityContext{

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -522,7 +522,7 @@ func TestProbeGenerationHTTP(t *testing.T) {
 			revision.Spec.PodSpec.Containers = []corev1.Container{{
 				Name: containerName,
 				Ports: []corev1.ContainerPort{{
-					ContainerPort: int32(userPort),
+					ContainerPort: userPort,
 				}},
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{
@@ -611,7 +611,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 				Containers: []corev1.Container{{
 					Name: containerName,
 					Ports: []corev1.ContainerPort{{
-						ContainerPort: int32(userPort),
+						ContainerPort: userPort,
 					}},
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
@@ -702,7 +702,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 				Containers: []corev1.Container{{
 					Name: containerName,
 					Ports: []corev1.ContainerPort{{
-						ContainerPort: int32(userPort),
+						ContainerPort: userPort,
 					}},
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{


### PR DESCRIPTION
Following https://github.com/knative/serving/pull/7689 remove the casts of the consts.
Consts are 'number' type and are autocased by compiler.

/assign @tcnghia @markusthoemmes 

#healthy-code-on-the-commode 😄 