### PR TITLE
Fix flake in TestDestroyPodWithRequests

### DIFF
--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -281,11 +281,11 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	}
 	t.Logf("Saw %d pods. Pods: %s", len(pods.Items), spew.Sdump(pods))
 
-	// The request will sleep for more than 15 seconds.
-	// NOTE: it needs to be less than TERMINATION_DRAIN_DURATION_SECONDS.
+	// The request will sleep for more than 12 seconds.
+	// NOTE: 12s + 6s must be less than drainSleepDuration and TERMINATION_DRAIN_DURATION_SECONDS.
 	u, _ := url.Parse(routeURL.String())
 	q := u.Query()
-	q.Set("sleep", "15001")
+	q.Set("sleep", "12001")
 	u.RawQuery = q.Encode()
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {


### PR DESCRIPTION
## Proposed Changes

This patch decrease the sleep time in TestDestroyPodWithRequests.

The test occasionally fails due to the incomplete of last
request. This is because the current sleep time (15s + 6s) is longer
than drainSleepDuration so the request was drained. Please refer to
the log:

https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-istio-1.5-no-mesh/1253089832167542785

To fix it, this decrease the sleep time for request from 15s to 12s.

/lint

**Release Note**

```release-note
NONE
```
