### PR TITLE
Pre-work for direct pod scraping

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -221,7 +221,7 @@ func statsScraperFactoryFunc(endpointsLister corev1listers.EndpointsLister) asme
 	return func(metric *av1alpha1.Metric) (asmetrics.StatsScraper, error) {
 		podCounter := resources.NewScopedEndpointsCounter(
 			endpointsLister, metric.Namespace, metric.Spec.ScrapeTarget)
-		return asmetrics.NewServiceScraper(metric, podCounter)
+		return asmetrics.NewStatsScraper(metric, podCounter)
 	}
 }
 

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -181,7 +181,7 @@ func (s *serviceScraper) Scrape(window time.Duration) (Stat, error) {
 
 // scrapeService scrapes the metrics using service endpoint
 // as its target, rather than individual pods.
-func (s *serviceScraper) scrapeService(scrapeService time.Duration, readyPods int) (Stat, error) {
+func (s *serviceScraper) scrapeService(window time.Duration, readyPods int) (Stat, error) {
 	frpc := float64(readyPods)
 
 	sampleSizeF := populationMeanSampleSize(frpc)
@@ -191,7 +191,7 @@ func (s *serviceScraper) scrapeService(scrapeService time.Duration, readyPods in
 	scrapedPods := &sync.Map{}
 
 	grp := errgroup.Group{}
-	youngPodCutOffSecs := scrapeService.Seconds()
+	youngPodCutOffSecs := window.Seconds()
 	startTime := time.Now()
 	for i := 0; i < sampleSize; i++ {
 		grp.Go(func() error {

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -116,9 +116,9 @@ type serviceScraper struct {
 	statsCtx context.Context
 }
 
-// NewServiceScraper creates a new StatsScraper for the Revision which
+// NewStatsScraper creates a new StatsScraper for the Revision which
 // the given Metric is responsible for.
-func NewServiceScraper(metric *av1alpha1.Metric, counter resources.EndpointsCounter) (StatsScraper, error) {
+func NewStatsScraper(metric *av1alpha1.Metric, counter resources.EndpointsCounter) (StatsScraper, error) {
 	sClient, err := newHTTPScrapeClient(cacheDisabledClient)
 	if err != nil {
 		return nil, err

--- a/pkg/autoscaler/metrics/stats_scraper_test.go
+++ b/pkg/autoscaler/metrics/stats_scraper_test.go
@@ -79,7 +79,7 @@ func TestNewServiceScraperWithClientHappyCase(t *testing.T) {
 	counter := resources.NewScopedEndpointsCounter(
 		fake.KubeInformer.Core().V1().Endpoints().Lister(),
 		fake.TestNamespace, fake.TestService)
-	sc, err := NewServiceScraper(metric, counter)
+	sc, err := NewStatsScraper(metric, counter)
 	if err != nil {
 		t.Fatal("NewServiceScraper =", err)
 	}


### PR DESCRIPTION
- make types not needed to be public private
- separate the call to the service scraper to a different method
- raise test coverage
- precompute the constant port and scrape path.

/assign @markusthoemmes 
For #5978 