### PR TITLE
Improve some debug logging.

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -123,8 +123,9 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 	//			already scaled to 0).
 	// 2. The excess burst capacity is negative.
 	if want == 0 || decider.Status.ExcessBurstCapacity < 0 || want == -1 && pa.Status.IsInactive() {
-		logger.Infof("SKS should be in proxy mode: want = %d, ebc = %d, PA Inactive? = %v",
-			want, decider.Status.ExcessBurstCapacity, pa.Status.IsInactive())
+		logger.Infof("SKS should be in proxy mode: want = %d, ebc = %d, #act's = %d PA Inactive? = %v",
+			want, decider.Status.ExcessBurstCapacity, decider.Status.NumActivators,
+			pa.Status.IsInactive())
 		mode = nv1alpha1.SKSOperationModeProxy
 	}
 


### PR DESCRIPTION
I've been debugging some autoscaler/SKS failures in the e2e tests
and I noticed we're missing #activatrs in the logs.
In addition the Spew'd argument is evaluated each time we're doing debug log
even if debug is not enabled, so gate that, since it might be pretty expensive
(desugar, otoh, is quite cheap and advertised as such).
Finally log (debug, gated) the chosed subset of the endpoints.

/assign @markusthoemmes 