### PR TITLE
Harden websocket split test.

### DIFF
--- a/test/conformance/ingress/websocket_test.go
+++ b/test/conformance/ingress/websocket_test.go
@@ -137,8 +137,9 @@ func TestWebsocketSplit(t *testing.T) {
 	}
 	u := url.URL{Scheme: "ws", Host: domain, Path: "/"}
 
+	const maxRequests = 100
 	got := sets.NewString()
-	for i := 0; i < 10; i++ {
+	for i := 0; i < maxRequests; i++ {
 		conn, _, err := dialer.Dial(u.String(), http.Header{"Host": {domain}})
 		if err != nil {
 			t.Fatalf("Dial() = %v", err)
@@ -154,11 +155,15 @@ func TestWebsocketSplit(t *testing.T) {
 		for j := 0; j < 10; j++ {
 			checkWebsocketRoundTrip(t, conn, suffix)
 		}
+
+		if want.Equal(got) {
+			// Short circuit if we've seen all splits.
+			return
+		}
 	}
 
-	if !want.Equal(got) {
-		t.Errorf("(-want, +got) = %s", cmp.Diff(want, got))
-	}
+	// Us getting here means we haven't seen splits.
+	t.Errorf("(over %d requests) (-want, +got) = %s", maxRequests, cmp.Diff(want, got))
 }
 
 func findWebsocketSuffix(t *testing.T, conn *websocket.Conn) string {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Flake in https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1253264985656659969

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Very similar to #7687. 

This bumps the amount of requests tried to see all splits significantly but also adds a short-circuit to succeed the test as soon as we've seen all splits (which is the reason for the test).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @nak3 @tcnghia 
