### PR TITLE
Prevent double log revision failed

### DIFF
--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -110,10 +110,13 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, config *v1.Configuration
 
 	case rc.Status == corev1.ConditionFalse:
 		logger.Infof("Revision %q of configuration has failed", revName)
-		// TODO(mattmoor): Only emit the event the first time we see this.
+		beforeReady := config.Status.GetCondition(v1.ConfigurationConditionReady)
 		config.Status.MarkLatestCreatedFailed(lcr.Name, rc.Message)
-		recorder.Eventf(config, corev1.EventTypeWarning, "LatestCreatedFailed",
-			"Latest created revision %q has failed", lcr.Name)
+
+		if !equality.Semantic.DeepEqual(beforeReady, config.Status.GetCondition(v1.ConfigurationConditionReady)) {
+			recorder.Eventf(config, corev1.EventTypeWarning, "LatestCreatedFailed",
+				"Latest created revision %q has failed", lcr.Name)
+		}
 
 	default:
 		return fmt.Errorf("unrecognized condition status: %v on revision %q", rc.Status, revName)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Don't record the "Revision failed" event if configuration ready condition has not changed.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
