### PR TITLE
Add e2e tests for service initial scale

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -80,6 +80,7 @@ fi
 
 # Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go)
 kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch='{"data":{"allow-zero-initial-scale":"true"}}'
+add_trap "kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch='{\"data\":{\"allow-zero-initial-scale\":\"false\"}}'" SIGKILL SIGTERM SIGQUIT
 
 # Run conformance and e2e tests.
 
@@ -94,8 +95,6 @@ if (( HTTPS )); then
   turn_off_auto_tls
 fi
 
-# Reset allow-zero-initial-scale
-add_trap "kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch='{\"data\":{\"allow-zero-initial-scale\":\"false\"}}'" SIGKILL SIGTERM SIGQUIT
 
 # Certificate conformance tests must be run separately
 # because they need cert-manager specific configurations.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -79,7 +79,7 @@ if (( HTTPS )); then
 fi
 
 # Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go)
-add_trap "kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch='{\"data\":{\"allow-zero-initial-scale\":\"true\"}}'" SIGKILL SIGTERM SIGQUIT
+add_trap "kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch=\"{\"data\":{\"allow-zero-initial-scale\":\"true\"}}\"" SIGKILL SIGTERM SIGQUIT
 
 # Run conformance and e2e tests.
 
@@ -95,7 +95,7 @@ if (( HTTPS )); then
 fi
 
 # Reset allow-zero-initial-scale
-add_trap "kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch='{\"data\":{\"allow-zero-initial-scale\":\"false\"}}'" SIGKILL SIGTERM SIGQUIT
+add_trap "kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch=\"{\"data\":{\"allow-zero-initial-scale\":\"false\"}}\"" SIGKILL SIGTERM SIGQUIT
 
 # Certificate conformance tests must be run separately
 # because they need cert-manager specific configurations.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -78,6 +78,9 @@ if (( HTTPS )); then
   add_trap "turn_off_auto_tls" SIGKILL SIGTERM SIGQUIT
 fi
 
+# Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go)
+kubectl -n "${SYSTEM_NAMESPACE}" patch configmap/config-autoscaler --type=merge --patch='{"data":{"allow-zero-initial-scale":"true"}}'
+
 # Run conformance and e2e tests.
 
 go_test_e2e -timeout=30m \

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -79,7 +79,7 @@ if (( HTTPS )); then
 fi
 
 # Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go)
-kubectl -n "${SYSTEM_NAMESPACE}" patch configmap/config-autoscaler --type=merge --patch='{"data":{"allow-zero-initial-scale":"true"}}'
+add_trap "kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch='{\"data\":{\"allow-zero-initial-scale\":\"true\"}}'" SIGKILL SIGTERM SIGQUIT
 
 # Run conformance and e2e tests.
 
@@ -95,7 +95,7 @@ if (( HTTPS )); then
 fi
 
 # Reset allow-zero-initial-scale
-kubectl -n "${SYSTEM_NAMESPACE}" patch configmap/config-autoscaler --type=merge --patch='{"data":{"allow-zero-initial-scale":"false"}}'
+add_trap "kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch='{\"data\":{\"allow-zero-initial-scale\":\"false\"}}'" SIGKILL SIGTERM SIGQUIT
 
 # Certificate conformance tests must be run separately
 # because they need cert-manager specific configurations.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -94,6 +94,9 @@ if (( HTTPS )); then
   turn_off_auto_tls
 fi
 
+# Reset allow-zero-initial-scale
+kubectl -n "${SYSTEM_NAMESPACE}" patch configmap/config-autoscaler --type=merge --patch='{"data":{"allow-zero-initial-scale":"false"}}'
+
 # Certificate conformance tests must be run separately
 # because they need cert-manager specific configurations.
 kubectl apply -f ${TMP_DIR}/test/config/autotls/certmanager/selfsigned/

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -79,7 +79,7 @@ if (( HTTPS )); then
 fi
 
 # Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go)
-add_trap "kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch=\"{\"data\":{\"allow-zero-initial-scale\":\"true\"}}\"" SIGKILL SIGTERM SIGQUIT
+kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch='{"data":{"allow-zero-initial-scale":"true"}}'
 
 # Run conformance and e2e tests.
 
@@ -95,7 +95,7 @@ if (( HTTPS )); then
 fi
 
 # Reset allow-zero-initial-scale
-add_trap "kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch=\"{\"data\":{\"allow-zero-initial-scale\":\"false\"}}\"" SIGKILL SIGTERM SIGQUIT
+add_trap "kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch='{\"data\":{\"allow-zero-initial-scale\":\"false\"}}'" SIGKILL SIGTERM SIGQUIT
 
 # Certificate conformance tests must be run separately
 # because they need cert-manager specific configurations.

--- a/test/e2e/initial_scale_test.go
+++ b/test/e2e/initial_scale_test.go
@@ -53,7 +53,7 @@ func TestInitScaleZero(t *testing.T) {
 	createRunLatestServiceReadyWithNumPods(t, clients, names, 0,
 		v1a1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.InitialScaleAnnotationKey: "0",
-	}))
+		}))
 }
 
 // TestInitScalePositive tests setting of annotation initialScale to greater than 0 on
@@ -76,7 +76,7 @@ func TestInitScalePositive(t *testing.T) {
 	createRunLatestServiceReadyWithNumPods(t, clients, names, 3,
 		v1a1testing.WithConfigAnnotations(map[string]string{
 			autoscaling.InitialScaleAnnotationKey: "3",
-	}))
+		}))
 }
 
 func createRunLatestServiceReadyWithNumPods(t *testing.T, clients *test.Clients, names test.ResourceNames, wantPods int, fopt ...v1a1testing.ServiceOption) {

--- a/test/e2e/initial_scale_test.go
+++ b/test/e2e/initial_scale_test.go
@@ -19,65 +19,23 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/pkg/apis/autoscaling"
+	"knative.dev/serving/pkg/apis/serving"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	v1a1testing "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
 
-var (
-	initScale10 = map[string]string{
-		autoscaling.InitialScaleAnnotationKey: "10",
-	}
-	initScale0 = map[string]string{
-		autoscaling.InitialScaleAnnotationKey: "0",
-	}
-)
-
-// TestInitScaleZeroServiceLevel tests setting of annotation scaleToZeroOnDeploy on
+// TestInitScaleZero tests setting of annotation initialScale to 0 on
 // the revision level. This test runs after the cluster wide flag allow-zero-initial-scale
 // is set to true.
-func TestInitScaleZeroServiceLevel(t *testing.T) {
-	t.Skip()
-	t.Parallel()
-	cancel := logstream.Start(t)
-	defer cancel()
-
-	clients := Setup(t)
-	names0 := test.ResourceNames{
-		Service: test.ObjectNameForTest(t),
-		Image:   "helloworld",
-	}
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names0) })
-	defer test.TearDown(clients, names0)
-
-	t.Log("Creating a new Service with initial scale zero and verifying that no pods are created")
-	if _, err := v1a1test.CreateRunLatestServiceReadyWithNumPods(t, clients, &names0,
-		0, v1a1testing.WithConfigAnnotations(initScale0)); err != nil {
-		t.Fatalf("Failed to create initial Service: %v: %v", names0.Service, err)
-	}
-
-	names10 := test.ResourceNames{
-		Service: test.ObjectNameForTest(t),
-		Image:   "helloworld",
-	}
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names10) })
-	defer test.TearDown(clients, names10)
-	t.Log("Creating a new Service with scale to zero on deploy being false and verifying that pods are created")
-	if _, err := v1a1test.CreateRunLatestServiceReadyWithNumPods(t, clients, &names10,
-		10, v1a1testing.WithConfigAnnotations(initScale10)); err != nil {
-		t.Fatalf("Failed to create initial Service: %v: %v", names10.Service, err)
-	}
-}
-
-// TestInitScaleZeroMinScaleServiceLevel tests setting of annotation scaleToZeroOnDeploy on
-// the service level with minScale > 0. This test runs after the cluster wide flag allow-zero-initial-scale
-// is set to true.
-func TestInitScaleZeroMinScaleServiceLevel(t *testing.T) {
-	t.Skip()
+func TestInitScaleZero(t *testing.T) {
 	t.Parallel()
 	cancel := logstream.Start(t)
 	defer cancel()
@@ -90,11 +48,59 @@ func TestInitScaleZeroMinScaleServiceLevel(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	t.Log("Creating a new Service with scale to zero on deploy being true and minScale greater than 0; verify that one pod is created")
-	if _, err := v1a1test.CreateRunLatestServiceReadyWithNumPods(t, clients, &names, 1, v1a1testing.WithConfigAnnotations(map[string]string{
-		autoscaling.MinScaleAnnotationKey:     "1",
-		autoscaling.InitialScaleAnnotationKey: "0",
-	})); err != nil {
+	t.Log("Creating a new Service with initial scale zero and verifying that no pods are created")
+	if _, err := v1a1test.CreateRunLatestServiceReadyWithNumPods(t, clients, &names, 0,
+		v1a1testing.WithConfigAnnotations(map[string]string{
+			autoscaling.InitialScaleAnnotationKey: "0",
+		})); err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+}
+
+// TestInitScalePositive tests setting of annotation initialScale to greater than 0 on
+// the revision level.
+func TestInitScalePositive(t *testing.T) {
+	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
+	clients := Setup(t)
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "helloworld",
+	}
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
+
+	t.Log("Creating a new Service with initialScale 3 and verifying that pods are created")
+	if _, err := v1a1test.CreateLatestService(t, clients, names,
+		v1a1testing.WithConfigAnnotations(map[string]string{
+			autoscaling.InitialScaleAnnotationKey: "3",
+		})); err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+	wantPods := 3
+	t.Logf("Waiting for Service %q to transition to Ready with %d number of pods.", names.Service, wantPods)
+	selector := fmt.Sprintf("%s=%s", serving.ConfigurationLabelKey, names.Service)
+	if err := v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, func(s *v1alpha1.Service) (b bool, e error) {
+		pods := clients.KubeClient.Kube.CoreV1().Pods(test.ServingNamespace)
+		podList, err := pods.List(metav1.ListOptions{
+			LabelSelector: selector,
+			FieldSelector: "status.phase=Running",
+		})
+		if err != nil {
+			return false, err
+		}
+		gotPods := len(podList.Items)
+		if gotPods == wantPods {
+			return s.Generation == s.Status.ObservedGeneration && s.Status.IsReady(), nil
+		}
+		if gotPods > wantPods {
+			return false, fmt.Errorf("expected %d pods created, got %d", wantPods, gotPods)
+		}
+		// Continue to check if numPods > gotPods
+		return false, nil
+	}, "ServiceIsReadyWithNumPods"); err != nil {
+		t.Fatal(err.Error())
 	}
 }

--- a/test/e2e/initial_scale_test.go
+++ b/test/e2e/initial_scale_test.go
@@ -83,7 +83,7 @@ func createRunLatestServiceReadyWithNumPods(t *testing.T, clients *test.Clients,
 	t.Log("Creating a new Service.", "service", names.Service)
 	_, err := v1a1test.CreateLatestService(t, clients, names, fopt...)
 	if err != nil {
-		t.Fatal(err.Error())
+		t.Fatal("Failed creating initial service:", err)
 	}
 
 	t.Logf("Waiting for Service %q to transition to Ready with %d number of pods.", names.Service, wantPods)
@@ -106,6 +106,6 @@ func createRunLatestServiceReadyWithNumPods(t *testing.T, clients *test.Clients,
 		}
 		return false, nil
 	}, "ServiceIsReadyWithWantPods"); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal("Service does not have the desired number of pods running:", err)
 	}
 }

--- a/test/e2e/initial_scale_test.go
+++ b/test/e2e/initial_scale_test.go
@@ -78,8 +78,8 @@ func createAndVerifyInitialScaleService(t *testing.T, clients *test.Clients, nam
 	t.Log("Creating a new Service.", "service", names.Service)
 	_, err := v1test.CreateService(t, clients, names,
 		v1testing.WithConfigAnnotations(map[string]string{
-		autoscaling.InitialScaleAnnotationKey: strconv.Itoa(wantPods),
-	}))
+			autoscaling.InitialScaleAnnotationKey: strconv.Itoa(wantPods),
+		}))
 	if err != nil {
 		t.Fatal("Failed creating initial service:", err)
 	}

--- a/test/e2e/initial_scale_test.go
+++ b/test/e2e/initial_scale_test.go
@@ -36,6 +36,7 @@ import (
 // the revision level. This test runs after the cluster wide flag allow-zero-initial-scale
 // is set to true.
 func TestInitScaleZero(t *testing.T) {
+	t.Skip()
 	t.Parallel()
 	cancel := logstream.Start(t)
 	defer cancel()
@@ -60,6 +61,7 @@ func TestInitScaleZero(t *testing.T) {
 // TestInitScalePositive tests setting of annotation initialScale to greater than 0 on
 // the revision level.
 func TestInitScalePositive(t *testing.T) {
+	t.Skip()
 	t.Parallel()
 	cancel := logstream.Start(t)
 	defer cancel()

--- a/test/e2e/initial_scale_test.go
+++ b/test/e2e/initial_scale_test.go
@@ -1,0 +1,100 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	"knative.dev/pkg/test/logstream"
+	"knative.dev/serving/pkg/apis/autoscaling"
+	v1a1testing "knative.dev/serving/pkg/testing/v1alpha1"
+	"knative.dev/serving/test"
+	v1a1test "knative.dev/serving/test/v1alpha1"
+)
+
+var (
+	initScale10 = map[string]string{
+		autoscaling.InitialScaleAnnotationKey: "10",
+	}
+	initScale0 = map[string]string{
+		autoscaling.InitialScaleAnnotationKey: "0",
+	}
+)
+
+// TestInitScaleZeroServiceLevel tests setting of annotation scaleToZeroOnDeploy on
+// the revision level. This test runs after the cluster wide flag allow-zero-initial-scale
+// is set to true.
+func TestInitScaleZeroServiceLevel(t *testing.T) {
+	t.Skip()
+	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
+	clients := Setup(t)
+	names0 := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "helloworld",
+	}
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names0) })
+	defer test.TearDown(clients, names0)
+
+	t.Log("Creating a new Service with initial scale zero and verifying that no pods are created")
+	if _, err := v1a1test.CreateRunLatestServiceReadyWithNumPods(t, clients, &names0,
+		0, v1a1testing.WithConfigAnnotations(initScale0)); err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names0.Service, err)
+	}
+
+	names10 := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "helloworld",
+	}
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names10) })
+	defer test.TearDown(clients, names10)
+	t.Log("Creating a new Service with scale to zero on deploy being false and verifying that pods are created")
+	if _, err := v1a1test.CreateRunLatestServiceReadyWithNumPods(t, clients, &names10,
+		10, v1a1testing.WithConfigAnnotations(initScale10)); err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names10.Service, err)
+	}
+}
+
+// TestInitScaleZeroMinScaleServiceLevel tests setting of annotation scaleToZeroOnDeploy on
+// the service level with minScale > 0. This test runs after the cluster wide flag allow-zero-initial-scale
+// is set to true.
+func TestInitScaleZeroMinScaleServiceLevel(t *testing.T) {
+	t.Skip()
+	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
+	clients := Setup(t)
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "helloworld",
+	}
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
+
+	t.Log("Creating a new Service with scale to zero on deploy being true and minScale greater than 0; verify that one pod is created")
+	if _, err := v1a1test.CreateRunLatestServiceReadyWithNumPods(t, clients, &names, 1, v1a1testing.WithConfigAnnotations(map[string]string{
+		autoscaling.MinScaleAnnotationKey:     "1",
+		autoscaling.InitialScaleAnnotationKey: "0",
+	})); err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+}

--- a/test/v1alpha1/service.go
+++ b/test/v1alpha1/service.go
@@ -151,16 +151,13 @@ func CreateRunLatestServiceReadyWithNumPods(t pkgTest.TLegacy, clients *test.Cli
 	names.Route = serviceresourcenames.Route(svc)
 	names.Config = serviceresourcenames.Configuration(svc)
 
-	// If the Service name was not specified, populate it
-	if names.Service == "" {
-		names.Service = svc.Name
-	}
-
 	t.Logf("Waiting for Service %q to transition to Ready with %d number of pods.", names.Service, numPods)
+	selector := fmt.Sprintf("%s=%s", serving.ConfigurationLabelKey, names.Service)
 	if err = WaitForServiceState(clients.ServingAlphaClient, names.Service, func(s *v1alpha1.Service) (b bool, e error) {
 		pods := clients.KubeClient.Kube.CoreV1().Pods(test.ServingNamespace)
 		podList, err := pods.List(metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", serving.ConfigurationLabelKey, names.Service),
+			LabelSelector: selector,
+			FieldSelector: "status.phase=Running",
 		})
 		if err != nil {
 			return false, err

--- a/test/v1alpha1/service.go
+++ b/test/v1alpha1/service.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/test/logging"
-	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
 
@@ -115,63 +114,6 @@ func CreateRunLatestServiceReady(t pkgTest.TLegacy, clients *test.Clients, names
 
 	t.Log("Waiting for Service to transition to Ready.", "service", names.Service)
 	if err = WaitForServiceState(clients.ServingAlphaClient, names.Service, IsServiceReady, "ServiceIsReady"); err != nil {
-		return nil, err
-	}
-
-	t.Log("Checking to ensure Service Status is populated for Ready service")
-	err = validateCreatedServiceStatus(clients, names)
-	if err != nil {
-		return nil, err
-	}
-
-	t.Log("Getting latest objects Created by Service")
-	resources, err := GetResourceObjects(clients, *names)
-	if err == nil {
-		t.Log("Successfully created Service", names.Service)
-	}
-	return resources, err
-}
-
-// CreateRunLatestServiceReadyWithNumPods creates a new Service in state 'Ready' with the provided number of pods running.
-// This function expects Service and Image name passed in through 'names'. Names is updated with the Route and
-// Configuration created by the Service and ResourceObjects is returned with the Service, Route, and Configuration objects.
-// Returns error if the service does not come up correctly.
-func CreateRunLatestServiceReadyWithNumPods(t pkgTest.TLegacy, clients *test.Clients, names *test.ResourceNames, numPods int, fopt ...rtesting.ServiceOption) (*ResourceObjects, error) {
-	if names.Image == "" {
-		return nil, fmt.Errorf("expected non-empty Image name; got Image=%v", names.Image)
-	}
-
-	t.Log("Creating a new Service.", "service", names.Service)
-	svc, err := CreateLatestService(t, clients, *names, fopt...)
-	if err != nil {
-		return nil, err
-	}
-
-	// Populate Route and Configuration Objects with name
-	names.Route = serviceresourcenames.Route(svc)
-	names.Config = serviceresourcenames.Configuration(svc)
-
-	t.Logf("Waiting for Service %q to transition to Ready with %d number of pods.", names.Service, numPods)
-	selector := fmt.Sprintf("%s=%s", serving.ConfigurationLabelKey, names.Service)
-	if err = WaitForServiceState(clients.ServingAlphaClient, names.Service, func(s *v1alpha1.Service) (b bool, e error) {
-		pods := clients.KubeClient.Kube.CoreV1().Pods(test.ServingNamespace)
-		podList, err := pods.List(metav1.ListOptions{
-			LabelSelector: selector,
-			FieldSelector: "status.phase=Running",
-		})
-		if err != nil {
-			return false, err
-		}
-		gotPods := len(podList.Items)
-		if gotPods == numPods {
-			return s.Generation == s.Status.ObservedGeneration && s.Status.IsReady(), nil
-		}
-		if gotPods > numPods {
-			return false, fmt.Errorf("expected %d pods created, got %d", numPods, gotPods)
-		}
-		// Continue to check if numPods > gotPods
-		return false, nil
-	}, "ServiceIsReadyWithNumPods"); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR adds the e2e tests for service initial scale.
/lint

Part 3 of #7682

/assign @dprotaso @markusthoemmes @vagababov mattmoor
