### PR TITLE
Harden GRPC split test.

### DIFF
--- a/test/conformance/ingress/grpc_test.go
+++ b/test/conformance/ingress/grpc_test.go
@@ -155,8 +155,9 @@ func TestGRPCSplit(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
+	const maxRequests = 100
 	got := sets.NewString()
-	for i := 0; i < 10; i++ {
+	for i := 0; i < maxRequests; i++ {
 		stream, err := pc.PingStream(ctx)
 		if err != nil {
 			t.Errorf("PingStream() = %v", err)
@@ -172,11 +173,15 @@ func TestGRPCSplit(t *testing.T) {
 		for j := 0; j < 10; j++ {
 			checkGRPCRoundTrip(t, stream, suffix)
 		}
+
+		if want.Equal(got) {
+			// Short circuit if we've seen all splits.
+			return
+		}
 	}
 
-	if !want.Equal(got) {
-		t.Errorf("(-want, +got) = %s", cmp.Diff(want, got))
-	}
+	// Us getting here means we haven't seen splits.
+	t.Errorf("(over %d requests) (-want, +got) = %s", maxRequests, cmp.Diff(want, got))
 }
 
 func findGRPCSuffix(t *testing.T, stream ping.PingService_PingStreamClient) string {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Flake happened here https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1254835449042571266

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Roughly the same fix as 7b06eead175bb71df8c8ea8619b2af23b007d289. I searched the codebase and didn't find more occurrences of the same code.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @nak3 
