### PR TITLE
Break statistic calculation out of queue-proxy code.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -575,7 +575,7 @@
   revision = "bf2b5ad3c0a925c44a0d2842c5d8182113cd248e"
 
 [[projects]]
-  digest = "0:"
+  digest = "1:1e59759b895f57302df03c5632dc6bbedcdf6782a2b6259246ff653dd214ac45"
   name = "github.com/jetstack/cert-manager"
   packages = [
     "pkg/apis/acme",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -575,7 +575,7 @@
   revision = "bf2b5ad3c0a925c44a0d2842c5d8182113cd248e"
 
 [[projects]]
-  digest = "1:1e59759b895f57302df03c5632dc6bbedcdf6782a2b6259246ff653dd214ac45"
+  digest = "0:"
   name = "github.com/jetstack/cert-manager"
   packages = [
     "pkg/apis/acme",

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -77,7 +77,7 @@ func TestHandlerReqEvent(t *testing.T) {
 
 	params := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
 	breaker := queue.NewBreaker(params)
-	reqChan := make(chan queue.ReqEvent, 10)
+	reqChan := make(chan network.ReqEvent, 10)
 	h := proxyHandler(reqChan, breaker, true /*tracingEnabled*/, proxy)
 
 	writer := httptest.NewRecorder()
@@ -91,8 +91,8 @@ func TestHandlerReqEvent(t *testing.T) {
 	h(writer, req)
 	select {
 	case e := <-reqChan:
-		if e.EventType != queue.ProxiedIn {
-			t.Errorf("Got: %v, Want: %v\n", e.EventType, queue.ProxiedIn)
+		if e.Type != network.ProxiedIn {
+			t.Errorf("Got: %v, Want: %v\n", e.Type, network.ProxiedIn)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Timed out waiting for an event to be intercepted")
@@ -482,7 +482,7 @@ func TestQueueTraceSpans(t *testing.T) {
 				if !tc.infiniteCC {
 					breaker = queue.NewBreaker(params)
 				}
-				reqChan := make(chan queue.ReqEvent, 10)
+				reqChan := make(chan network.ReqEvent, 10)
 
 				proxy.Transport = &ochttp.Transport{
 					Base: pkgnet.AutoTransport,
@@ -533,7 +533,7 @@ func TestQueueTraceSpans(t *testing.T) {
 
 func BenchmarkProxyHandler(b *testing.B) {
 	var baseHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	reqChan := make(chan queue.ReqEvent, requestCountingQueueLength)
+	reqChan := make(chan network.ReqEvent, requestCountingQueueLength)
 	defer close(reqChan)
 	reportTicker := time.NewTicker(reportingPeriod)
 	defer reportTicker.Stop()

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -92,7 +92,7 @@ func TestHandlerReqEvent(t *testing.T) {
 	select {
 	case e := <-reqChan:
 		if e.Type != network.ProxiedIn {
-			t.Errorf("Got: %v, Want: %v\n", e.Type, network.ProxiedIn)
+			t.Errorf("Got: %v, Want: %v", e.Type, network.ProxiedIn)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Timed out waiting for an event to be intercepted")

--- a/pkg/network/stats.go
+++ b/pkg/network/stats.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"time"
+)
+
+// ReqEvent represents either an incoming or closed request.
+// +k8s:deepcopy-gen=false
+type ReqEvent struct {
+	Time time.Time
+	Type ReqEventType
+}
+
+// ReqEventType denotes the type (incoming/closed) of a ReqEvent.
+type ReqEventType int
+
+const (
+	// ReqIn represents an incoming request
+	ReqIn ReqEventType = iota
+	// ReqOut represents a finished request
+	ReqOut
+	// ProxiedIn represents an incoming request through a proxy.
+	ProxiedIn
+	// ProxiedOut represents a finished proxied request.
+	ProxiedOut
+)
+
+// NewRequestStats builds a RequestStats instance, started at the given time.
+func NewRequestStats(startedAt time.Time) *RequestStats {
+	return &RequestStats{lastChange: startedAt}
+}
+
+// RequestStats collects statistics about requests as they flow in and out of the system.
+// +k8s:deepcopy-gen=false
+type RequestStats struct {
+	// State variables that track the current state. Not reset after reporting.
+	concurrency, proxiedConcurrency float64
+	lastChange                      time.Time
+
+	// Reporting variables that track state over the current window. Reset after
+	// reporting.
+	requestCount, proxiedCount                      float64
+	computedConcurrency, computedProxiedConcurrency float64
+	secondsInUse                                    float64
+}
+
+func (s *RequestStats) compute(now time.Time) {
+	if durationSinceChange := now.Sub(s.lastChange); durationSinceChange > 0 {
+		durationSecs := durationSinceChange.Seconds()
+		s.secondsInUse += durationSecs
+		s.computedConcurrency += s.concurrency * durationSecs
+		s.computedProxiedConcurrency += s.proxiedConcurrency * durationSecs
+		s.lastChange = now
+	}
+}
+
+// HandleEvent handles an incoming or outgoing request event and updates
+// the state accordingly.
+func (s *RequestStats) HandleEvent(event ReqEvent) {
+	s.compute(event.Time)
+
+	switch event.Type {
+	case ProxiedIn:
+		s.proxiedConcurrency++
+		s.proxiedCount++
+		fallthrough
+	case ReqIn:
+		s.requestCount++
+		s.concurrency++
+	case ProxiedOut:
+		s.proxiedConcurrency--
+		fallthrough
+	case ReqOut:
+		s.concurrency--
+	}
+}
+
+// Report returns averageConcurrency, averageProxiedConcurrency, requestCount and proxiedCount
+// relative to the given time. The state will be reset for another reporting cycle afterwards.
+func (s *RequestStats) Report(now time.Time) (avgC float64, avgPC float64, rC float64, pC float64) {
+	s.compute(now)
+	defer s.reset()
+
+	if s.secondsInUse > 0 {
+		avgC = s.computedConcurrency / s.secondsInUse
+		avgPC = s.computedProxiedConcurrency / s.secondsInUse
+	}
+	return avgC, avgPC, s.requestCount, s.proxiedCount
+}
+
+// reset resets the state so a new reporting cycle can start.
+func (s *RequestStats) reset() {
+	s.computedConcurrency, s.computedProxiedConcurrency = 0, 0
+	s.requestCount, s.proxiedCount = 0, 0
+	s.secondsInUse = 0
+}

--- a/pkg/network/stats.go
+++ b/pkg/network/stats.go
@@ -79,6 +79,7 @@ type RequestStats struct {
 
 // RequestStatsReport are the metrics reported from the the request stats collector
 // at a given time.
+// +k8s:deepcopy-gen=false
 type RequestStatsReport struct {
 	// AverageConcurrency is the average concurrency over the reporting timeframe.
 	// This is calculated via the utilization at a given concurrency. For example:

--- a/pkg/network/stats_test.go
+++ b/pkg/network/stats_test.go
@@ -159,7 +159,7 @@ func TestRequestStats(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// All tests are relative to epoch.
-			stats := NewRequestStats(time.Unix(0, 0))
+			stats := NewRequestStats(time.Time{})
 			reports := make([]RequestStatsReport, 0, len(test.want))
 			test.events(
 				eventFunc(stats, ReqIn),
@@ -167,12 +167,12 @@ func TestRequestStats(t *testing.T) {
 				eventFunc(stats, ProxiedIn),
 				eventFunc(stats, ProxiedOut),
 				func(ms int64) {
-					reports = append(reports, stats.Report(time.Unix(0, ms*int64(time.Millisecond))))
+					reports = append(reports, stats.Report(time.Time{}.Add(time.Duration(ms)*time.Millisecond)))
 				},
 			)
 
 			if !cmp.Equal(reports, test.want) {
-				t.Errorf("Got = %v, want = %v, diff %s", reports, test.want, cmp.Diff(reports, test.want))
+				t.Errorf("Got = %v, want = %v, diff(-want,+got): %s", reports, test.want, cmp.Diff(test.want, reports))
 			}
 		})
 	}
@@ -181,7 +181,7 @@ func TestRequestStats(t *testing.T) {
 func eventFunc(stats *RequestStats, typ ReqEventType) func(int64) {
 	return func(ms int64) {
 		stats.HandleEvent(ReqEvent{
-			Time: time.Unix(0, ms*int64(time.Millisecond)),
+			Time: time.Time{}.Add(time.Duration(ms) * time.Millisecond),
 			Type: typ,
 		})
 	}

--- a/pkg/network/stats_test.go
+++ b/pkg/network/stats_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type report struct {
+	Concurrency, ProxiedConcurrency float64
+	Count, ProxiedCount             float64
+}
+
+func TestRequestStats(t *testing.T) {
+	tests := []struct {
+		name   string
+		events func(in, out, inP, outP, report func(int64))
+		want   []report
+	}{{
+		name: "no requests",
+		events: func(in, out, inP, outP, report func(int64)) {
+			report(1000)
+		},
+		want: []report{{
+			Concurrency: 0,
+			Count:       0,
+		}},
+	}, {
+		name: "1 request, entire time",
+		events: func(in, out, inP, outP, report func(int64)) {
+			in(0)
+			out(1000)
+			report(1000)
+		},
+		want: []report{{
+			Concurrency: 1,
+			Count:       1,
+		}},
+	}, {
+		name: "1 request, half the time",
+		events: func(in, out, inP, outP, report func(int64)) {
+			in(0)
+			out(3000)
+			report(6000)
+		},
+		want: []report{{
+			Concurrency: 0.5,
+			Count:       1,
+		}},
+	}, {
+		name: "very short request",
+		events: func(in, out, inP, outP, report func(int64)) {
+			in(0)
+			out(1)
+			report(1000)
+		},
+		want: []report{{
+			Concurrency: float64(1) / float64(1000),
+			Count:       1,
+		}},
+	}, {
+		name: "3 requests, fill entire time",
+		events: func(in, out, inP, outP, report func(int64)) {
+			in(0)
+			out(300)
+			in(300)
+			out(600)
+			in(600)
+			out(1000)
+			report(1000)
+		},
+		want: []report{{
+			Concurrency: 1,
+			Count:       3,
+		}},
+	}, {
+		name: "interleaved requests",
+		events: func(in, out, inP, outP, report func(int64)) {
+			in(0)
+			in(100)
+			out(600)
+			out(1000)
+			report(1000)
+		},
+		want: []report{{
+			Concurrency: 1.5,
+			Count:       2,
+		}},
+	}, {
+		name: "request across reporting",
+		events: func(in, out, inP, outP, report func(int64)) {
+			in(0)
+			report(1000)
+			out(1500)
+			report(2000)
+		},
+		want: []report{{
+			Concurrency: 1,
+			Count:       1,
+		}, {
+			Concurrency: 0.5,
+			Count:       0,
+		}},
+	}, {
+		name: "1 request, proxied, entire time",
+		events: func(in, out, inP, outP, report func(int64)) {
+			inP(0)
+			outP(1000)
+			report(1000)
+		},
+		want: []report{{
+			Concurrency:        1,
+			ProxiedConcurrency: 1,
+			Count:              1,
+			ProxiedCount:       1,
+		}},
+	}, {
+		name: "1 request, proxied, half the time",
+		events: func(in, out, inP, outP, report func(int64)) {
+			inP(0)
+			outP(500)
+			report(1000)
+		},
+		want: []report{{
+			Concurrency:        0.5,
+			ProxiedConcurrency: 0.5,
+			Count:              1,
+			ProxiedCount:       1,
+		}},
+	}, {
+		name: "2 requests, proxied and non proxied",
+		events: func(in, out, inP, outP, report func(int64)) {
+			inP(0)
+			in(0)
+			outP(500)
+			out(1000)
+			report(1000)
+		},
+		want: []report{{
+			Concurrency:        1.5,
+			ProxiedConcurrency: 0.5,
+			Count:              2,
+			ProxiedCount:       1,
+		}},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// All tests are relative to epoch.
+			stats := NewRequestStats(time.Unix(0, 0))
+			reports := make([]report, 0, len(test.want))
+			test.events(
+				eventFunc(stats, ReqIn),
+				eventFunc(stats, ReqOut),
+				eventFunc(stats, ProxiedIn),
+				eventFunc(stats, ProxiedOut),
+				func(ms int64) {
+					aC, aPC, rC, pC := stats.Report(time.Unix(0, ms*int64(time.Millisecond)))
+					reports = append(reports, report{
+						Concurrency:        aC,
+						ProxiedConcurrency: aPC,
+						Count:              rC,
+						ProxiedCount:       pC,
+					})
+				},
+			)
+
+			if !cmp.Equal(reports, test.want) {
+				t.Errorf("Got = %v, want = %v, diff %s", reports, test.want, cmp.Diff(reports, test.want))
+			}
+		})
+	}
+}
+
+func eventFunc(stats *RequestStats, typ ReqEventType) func(int64) {
+	return func(ms int64) {
+		stats.HandleEvent(ReqEvent{
+			Time: time.Unix(0, ms*int64(time.Millisecond)),
+			Type: typ,
+		})
+	}
+}

--- a/pkg/queue/stats.go
+++ b/pkg/queue/stats.go
@@ -32,8 +32,13 @@ func NewStats(startedAt time.Time, reqCh chan network.ReqEvent, reportCh <-chan 
 			case event := <-reqCh:
 				state.HandleEvent(event)
 			case now := <-reportCh:
-				avgC, avgPC, rC, pC := state.Report(now)
-				report(avgC, avgPC, rC, pC)
+				stats := state.Report(now)
+				report(
+					stats.AverageConcurrency,
+					stats.AverageProxiedConcurrency,
+					stats.RequestCount,
+					stats.ProxiedRequestCount,
+				)
 			}
 		}
 	}()

--- a/pkg/queue/stats.go
+++ b/pkg/queue/stats.go
@@ -18,92 +18,22 @@ package queue
 
 import (
 	"time"
-)
 
-// ReqEvent represents either an incoming or closed request.
-type ReqEvent struct {
-	Time      time.Time
-	EventType ReqEventType
-}
-
-// ReqEventType denotes the type (incoming/closed) of a ReqEvent.
-type ReqEventType int
-
-const (
-	// ReqIn represents an incoming request
-	ReqIn ReqEventType = iota
-	// ReqOut represents a finished request
-	ReqOut
-	// ProxiedIn represents an incoming request through a proxy.
-	ProxiedIn
-	// ProxiedOut represents a finished proxied request.
-	ProxiedOut
+	"knative.dev/serving/pkg/network"
 )
 
 // NewStats instantiates a new instance of Stats.
-func NewStats(startedAt time.Time, reqCh chan ReqEvent, reportCh <-chan time.Time, report func(float64, float64, float64, float64)) {
+func NewStats(startedAt time.Time, reqCh chan network.ReqEvent, reportCh <-chan time.Time, report func(float64, float64, float64, float64)) {
 	go func() {
-		var (
-			// State variables that track the current state. Not reset after reporting.
-			concurrency, proxiedConcurrency float64
-			lastChange                      = startedAt
-
-			// Reporting variables that track state over the current window. Reset after
-			// reporting.
-			requestCount, proxiedCount                      float64
-			computedConcurrency, computedProxiedConcurrency float64
-			secondsInUse                                    float64
-		)
-
-		// Updates the lastChanged/timeOnConcurrency state
-		// Note: due to nature of the channels used below, the ReportChan
-		// can race the ReqChan, thus an event can arrive that has a lower
-		// timestamp than `lastChange`. This is ignored, since it only makes
-		// for very slight differences.
-		updateState := func(time time.Time) {
-			if durationSinceChange := time.Sub(lastChange); durationSinceChange > 0 {
-				durationSecs := durationSinceChange.Seconds()
-				secondsInUse += durationSecs
-				computedConcurrency += concurrency * durationSecs
-				computedProxiedConcurrency += proxiedConcurrency * durationSecs
-				lastChange = time
-			}
-		}
+		state := network.NewRequestStats(startedAt)
 
 		for {
 			select {
 			case event := <-reqCh:
-				updateState(event.Time)
-
-				switch event.EventType {
-				case ProxiedIn:
-					proxiedConcurrency++
-					proxiedCount++
-					fallthrough
-				case ReqIn:
-					requestCount++
-					concurrency++
-				case ProxiedOut:
-					proxiedConcurrency--
-					fallthrough
-				case ReqOut:
-					concurrency--
-				}
+				state.HandleEvent(event)
 			case now := <-reportCh:
-				updateState(now)
-
-				var averageConcurrency, averageProxiedConcurrency float64
-				if secondsInUse > 0 {
-					averageConcurrency = computedConcurrency / secondsInUse
-					averageProxiedConcurrency = computedProxiedConcurrency / secondsInUse
-				}
-
-				report(averageConcurrency, averageProxiedConcurrency, requestCount, proxiedCount)
-
-				// Reset the stat counts which have been reported.
-				computedConcurrency, computedProxiedConcurrency = 0, 0
-				requestCount, proxiedCount = 0, 0
-				secondsInUse = 0
+				avgC, avgPC, rC, pC := state.Report(now)
+				report(avgC, avgPC, rC, pC)
 			}
 		}
 	}()

--- a/pkg/queue/stats_test.go
+++ b/pkg/queue/stats_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"knative.dev/serving/pkg/network"
 )
 
 type reportedStat struct {
@@ -239,14 +240,14 @@ func TestTwoRequestsOneProxied(t *testing.T) {
 
 // Test type to hold the bi-directional time channels
 type testStats struct {
-	reqChan      chan ReqEvent
+	reqChan      chan network.ReqEvent
 	reportBiChan chan time.Time
 	statChan     chan reportedStat
 }
 
 func newTestStats(now time.Time) *testStats {
 	reportBiChan := make(chan time.Time)
-	reqChan := make(chan ReqEvent)
+	reqChan := make(chan network.ReqEvent)
 	statChan := make(chan reportedStat)
 	report := func(acr float64, apcr float64, rc float64, prc float64) {
 		statChan <- reportedStat{
@@ -265,19 +266,19 @@ func newTestStats(now time.Time) *testStats {
 }
 
 func (s *testStats) requestStart(now time.Time) {
-	s.reqChan <- ReqEvent{Time: now, EventType: ReqIn}
+	s.reqChan <- network.ReqEvent{Time: now, Type: network.ReqIn}
 }
 
 func (s *testStats) requestEnd(now time.Time) {
-	s.reqChan <- ReqEvent{Time: now, EventType: ReqOut}
+	s.reqChan <- network.ReqEvent{Time: now, Type: network.ReqOut}
 }
 
 func (s *testStats) proxiedStart(now time.Time) {
-	s.reqChan <- ReqEvent{Time: now, EventType: ProxiedIn}
+	s.reqChan <- network.ReqEvent{Time: now, Type: network.ProxiedIn}
 }
 
 func (s *testStats) proxiedEnd(now time.Time) {
-	s.reqChan <- ReqEvent{Time: now, EventType: ProxiedOut}
+	s.reqChan <- network.ReqEvent{Time: now, Type: network.ProxiedOut}
 }
 
 func (s *testStats) report(now time.Time) reportedStat {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Next step in a refactoring to share the metric calculation between the activator and queue-proxy. This moves the respective calculation out of the queue-proxy code and gives it a common interface.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @yanweiguo 
