### PR TITLE
Improve the metadata validation tests

### DIFF
--- a/pkg/apis/serving/metadata_validation_test.go
+++ b/pkg/apis/serving/metadata_validation_test.go
@@ -439,7 +439,8 @@ func TestAnnotationUpdate(t *testing.T) {
 			}
 			SetUserInfo(ctx, test.prev.Spec, test.this.Spec, test.this)
 			if !cmp.Equal(test.this.Annotations, test.want) {
-				t.Errorf("Annotations = %v, want: %v, diff (-want, +got):\n%s", test.this.Annotations, test.want, cmp.Diff(test.want, test.this.Annotations))
+				t.Errorf("Annotations = %v, want: %v, diff (-want, +got):\n%s", test.this.Annotations, test.want,
+					cmp.Diff(test.want, test.this.Annotations))
 			}
 		})
 	}


### PR DESCRIPTION
- Fix the empty errors, they must be gone
- Fix the type to be *FieldError, thus removing the need for typed nils and
  much easier test value checking
- Various other improvements

/assign @dprotaso mattmoor