### PR TITLE
We have to wait for initial reconcile as well in route.

### DIFF
--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/logging"


### PR DESCRIPTION
So https://storage.googleapis.com/knative-prow/pr-logs/pull/knative_serving/7752/pull-knative-serving-unit-tests/1255248581837721600/build-log.txt this failure
showed that we updated the CM when the initial reconcile was still underway (with old ctx set to the previous value).
Since the check is for status to change it did change but not to what we want.
So we need to wait in both places: for initial and final reconciliations to finish.

/assign @tcnghia 