### PR TITLE
Fix flake in TestPathAndPercentageSplit

### DIFF
--- a/test/conformance/ingress/path_test.go
+++ b/test/conformance/ingress/path_test.go
@@ -232,11 +232,11 @@ func TestPathAndPercentageSplit(t *testing.T) {
 		})
 	}
 	if err := wg.Wait(); err != nil {
-		t.Errorf("unexpected error: %v", err)
+		t.Errorf("Error while sending requests: %v", err)
 	}
 	close(resultCh)
 
-	got := make(map[string]float64, 2)
+	got := make(map[string]float64, len(wantKeys))
 	for r := range resultCh {
 		got[r]++
 	}

--- a/test/conformance/ingress/path_test.go
+++ b/test/conformance/ingress/path_test.go
@@ -212,7 +212,7 @@ func TestPathAndPercentageSplit(t *testing.T) {
 	const (
 		total     = 100
 		totalHalf = total / 2
-		tolerance = total * 0.15
+		tolerance = total * 0.20
 	)
 	got := make(map[string]float64, 2)
 	wantKeys := sets.NewString(fooName, barName)


### PR DESCRIPTION
## Proposed Changes

This patch increases the number of requests in TestPathAndPercentageSplit.

TestPathAndPercentageSplit sometimes fails because requests were not well
balanced (>=15%). But as per logs, it just exceeded 1 or 2 requests
like:

https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-istio-1.4-no-mesh/1255352174985089024
https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-kourier-stable/1255354213559439360
https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-kourier-stable/1255022088574472192

e.g.
```
path_test.go:233: Header path-and-percentage-split-sxzgzgfz got: 34 times, want in [35, 65] range
path_test.go:233: Header path-and-percentage-split-oyrvlgmf got: 66 times, want in [35, 65] range
```

Since it is just a problem with the probability, this patch increases
the number of requests and minimize the margin.

/lint

**Release Note**

```release-note
NONE
```
