### PR TITLE
Reuse common types between activator and queue-proxy concurrency reporting.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -168,7 +168,7 @@ func main() {
 	statCh := make(chan []asmetrics.StatMessage)
 	defer close(statCh)
 
-	reqCh := make(chan activatorhandler.ReqEvent, requestCountingQueueLength)
+	reqCh := make(chan network.ReqEvent, requestCountingQueueLength)
 	defer close(reqCh)
 
 	// Start throttler.

--- a/pkg/activator/handler/requestevent_handler.go
+++ b/pkg/activator/handler/requestevent_handler.go
@@ -16,32 +16,16 @@ package handler
 import (
 	"net/http"
 
-	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/serving/pkg/activator/util"
-)
-
-// ReqEvent represents an incoming/finished request with a given key
-type ReqEvent struct {
-	Key       types.NamespacedName
-	EventType ReqEventType
-}
-
-// ReqEventType specifies the type of event (In/Out)
-type ReqEventType int
-
-const (
-	// ReqIn represents an incoming request
-	ReqIn ReqEventType = iota
-	// ReqOut represents a finished request
-	ReqOut
+	"knative.dev/serving/pkg/network"
 )
 
 // NewRequestEventHandler creates a handler that sends events
 // about incoming/closed http connections to the given channel.
-func NewRequestEventHandler(reqChan chan ReqEvent, next http.Handler) *RequestEventHandler {
+func NewRequestEventHandler(reqChan chan network.ReqEvent, next http.Handler) *RequestEventHandler {
 	handler := &RequestEventHandler{
 		nextHandler: next,
-		ReqChan:     reqChan,
+		reqChan:     reqChan,
 	}
 
 	return handler
@@ -50,15 +34,15 @@ func NewRequestEventHandler(reqChan chan ReqEvent, next http.Handler) *RequestEv
 // RequestEventHandler sends events to the given channel.
 type RequestEventHandler struct {
 	nextHandler http.Handler
-	ReqChan     chan ReqEvent
+	reqChan     chan network.ReqEvent
 }
 
 func (h *RequestEventHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	revisionKey := util.RevIDFrom(r.Context())
 
-	h.ReqChan <- ReqEvent{Key: revisionKey, EventType: ReqIn}
+	h.reqChan <- network.ReqEvent{Key: revisionKey, Type: network.ReqIn}
 	defer func() {
-		h.ReqChan <- ReqEvent{Key: revisionKey, EventType: ReqOut}
+		h.reqChan <- network.ReqEvent{Key: revisionKey, Type: network.ReqOut}
 	}()
 	h.nextHandler.ServeHTTP(w, r)
 }

--- a/pkg/network/stats.go
+++ b/pkg/network/stats.go
@@ -18,13 +18,20 @@ package network
 
 import (
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ReqEvent represents either an incoming or closed request.
 // +k8s:deepcopy-gen=false
 type ReqEvent struct {
+	// Time is the time the request event happened.
 	Time time.Time
+	// Type is the type of the request event.
 	Type ReqEventType
+	// Key is the revision the event is associated with.
+	// +optional
+	Key types.NamespacedName
 }
 
 // ReqEventType denotes the type (incoming/closed) of a ReqEvent.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As the title states, this makes use of the `ReqEvent` types in the activator's concurrency reporting too.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @julz 
