### PR TITLE
Report concurrency as a float from the activator.

### DIFF
--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -62,7 +62,7 @@ func NewConcurrencyReporter(ctx context.Context, podName string,
 	}
 }
 
-func (cr *ConcurrencyReporter) reportToMetricsBackend(key types.NamespacedName, concurrency int64) {
+func (cr *ConcurrencyReporter) reportToMetricsBackend(key types.NamespacedName, concurrency float64) {
 	ns := key.Namespace
 	revName := key.Name
 	revision, err := cr.rl.Revisions(ns).Get(revName)
@@ -153,7 +153,7 @@ func (cr *ConcurrencyReporter) run(stopCh <-chan struct{}, reportCh <-chan time.
 						RequestCount:              requestCount,
 					},
 				})
-				cr.reportToMetricsBackend(key, int64(concurrency))
+				cr.reportToMetricsBackend(key, concurrency)
 			}
 			if len(messages) > 0 {
 				cr.statCh <- messages

--- a/pkg/activator/handler/metrics.go
+++ b/pkg/activator/handler/metrics.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	requestConcurrencyM = stats.Int64(
+	requestConcurrencyM = stats.Float64(
 		"request_concurrency",
 		"Concurrent requests that are routed to Activator",
 		stats.UnitDimensionless)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Once we cut over to the shared concurrency calculation code, the concurrency reported by the activator can contain fractions.

Breaking this out into a separate PR to surface this change clearly.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @julz 
