### PR TITLE
Remove out of date comment

### DIFF
--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -147,8 +147,7 @@ func (cr *ConcurrencyReporter) run(stopCh <-chan struct{}, reportCh <-chan time.
 					Key: key,
 					Stat: asmetrics.Stat{
 						// Stat time is unset by design. The receiver will set the time.
-						PodName: cr.podName,
-						// Subtract the request we already reported when first seeing the revision.
+						PodName:                   cr.podName,
 						AverageConcurrentRequests: averageConcurrentRequests,
 						RequestCount:              requestCount,
 					},


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

The referenced subtraction happens a few lines earlier these days - on L138 (and is clear enough now via variable naming not to need the comment)