### PR TITLE
Remove unneeded use of atomic.AddInt32

### DIFF
--- a/pkg/http/response_recorder.go
+++ b/pkg/http/response_recorder.go
@@ -34,7 +34,7 @@ var (
 // that captures the response code and size.
 type ResponseRecorder struct {
 	ResponseCode int
-	ResponseSize int32
+	ResponseSize int
 
 	writer      http.ResponseWriter
 	wroteHeader bool
@@ -77,7 +77,7 @@ func (rr *ResponseRecorder) Header() http.Header {
 
 // Write writes the data to the connection as part of an HTTP reply.
 func (rr *ResponseRecorder) Write(p []byte) (int, error) {
-	atomic.AddInt32(&rr.ResponseSize, (int32)(len(p)))
+	rr.ResponseSize += len(p)
 	return rr.writer.Write(p)
 }
 

--- a/pkg/http/response_recorder_test.go
+++ b/pkg/http/response_recorder_test.go
@@ -40,7 +40,7 @@ func TestResponseRecorder(t *testing.T) {
 		hijack        bool
 		writeSize     int
 		wantStatus    int
-		wantSize      int32
+		wantSize      int
 	}{{
 		name:          "no hijack",
 		initialStatus: http.StatusAccepted,


### PR DESCRIPTION
The underlying responseWriter.Write isnt thread-safe anyway, and in general
io.Write shouldn't be assumed to be thread-safe without explicit documentation
to that effect. Avoiding the atomic is a performance win since this code is in
the request path in a few places.
