### PR TITLE
Reuse concurrency calculation in the activator.

### DIFF
--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"go.uber.org/zap"
@@ -86,81 +87,77 @@ func (cr *ConcurrencyReporter) Run(stopCh <-chan struct{}) {
 }
 
 func (cr *ConcurrencyReporter) run(stopCh <-chan struct{}, reportCh <-chan time.Time) {
-	// Contains the number of in-flight requests per-key
-	outstandingRequestsPerKey := make(map[types.NamespacedName]float64)
-	// Contains the number of incoming requests in the current
-	// reporting period, per key.
-	incomingRequestsPerKey := make(map[types.NamespacedName]float64)
+	// This map holds the concurrency and request count accounting across revisions.
+	stats := make(map[types.NamespacedName]*network.RequestStats)
 	// This map holds whether during this reporting period we reported "first" request
 	// for the revision. Our reporting period is 1s, so there is a high chance that
-	// they will end up in the same metrics bucket.
-	// This is important because for small concurrencies, e.g. 1,
-	// autoscaler might cause noticeable overprovisioning.
+	// they will end up in the same metrics bucket and values in the same bucket are
+	// summed.
+	// This is important because for small concurrencies, e.g. 1, autoscaler might cause
+	// noticeable overprovisioning.
 	reportedFirstRequest := make(map[types.NamespacedName]float64)
 
 	for {
 		select {
 		case event := <-cr.reqCh:
-			switch event.Type {
-			case network.ReqIn:
-				incomingRequestsPerKey[event.Key]++
+			stat := stats[event.Key]
+			if stat == nil {
+				stat = network.NewRequestStats(event.Time)
+				stats[event.Key] = stat
 
-				// Report the first request for a key immediately.
-				if _, ok := outstandingRequestsPerKey[event.Key]; !ok {
-					reportedFirstRequest[event.Key] = 1.
+				// Only generate a from 0 event if this is an incoming request.
+				if event.Type == network.ReqIn {
+					reportedFirstRequest[event.Key] = 1
 					cr.statCh <- []asmetrics.StatMessage{{
 						Key: event.Key,
 						Stat: asmetrics.Stat{
-							// Stat time is unset by design. The receiver will set the time.
+							// Stat time is unset by design. Will be set by receiver.
 							PodName:                   cr.podName,
 							AverageConcurrentRequests: 1,
 							// The way the check above is written, this cannot ever be
-							// anything else but 1.
-							// In theory consider the situation where within the same
-							// reporting period a request arrived and terminated
-							// (making outstandingRequestsPerKey for that key 0) and
-							// then the same situation happened again, and again...
-							// Thus this might be > 1, but we only check for `!ok` not
-							// `!ok || val==0`, which means this is not reported until
-							// the reporting period channel ticks.
-							// Thus this will always be 1.
+							// anything else but 1. The stats map key is only deleted
+							// after a reporting period, so we see this code path at most
+							// once per period.
 							RequestCount: 1,
 						},
 					}}
 				}
-				outstandingRequestsPerKey[event.Key]++
-			case network.ReqOut:
-				outstandingRequestsPerKey[event.Key]--
 			}
-		case <-reportCh:
-			messages := make([]asmetrics.StatMessage, 0, len(outstandingRequestsPerKey))
-			for key, concurrency := range outstandingRequestsPerKey {
-				firstAdj := reportedFirstRequest[key]
-				averageConcurrentRequests := concurrency - firstAdj
-				requestCount := incomingRequestsPerKey[key] - firstAdj
 
-				if concurrency == 0 {
-					delete(outstandingRequestsPerKey, key)
-					averageConcurrentRequests = 0
+			stat.HandleEvent(event)
+		case now := <-reportCh:
+			messages := make([]asmetrics.StatMessage, 0, len(stats))
+			for key, stat := range stats {
+				report := stat.Report(now)
+				firstAdj := reportedFirstRequest[key]
+
+				// This is only 0 if we have seen no activity for the entire reporting
+				// period at all.
+				if report.AverageConcurrency == 0 {
+					delete(stats, key)
 				}
 
+				// Subtract the request we already reported when first seeing the
+				// revision. We report a min of 0 here because the initial report is
+				// always a concurrency of 1 and the actual concurrency reported over
+				// the reporting period might be < 1.
+				averageConcurrency := math.Max(report.AverageConcurrency-firstAdj, 0)
+				requestCount := report.RequestCount - firstAdj
 				messages = append(messages, asmetrics.StatMessage{
 					Key: key,
 					Stat: asmetrics.Stat{
 						// Stat time is unset by design. The receiver will set the time.
-						PodName: cr.podName,
-						// Subtract the request we already reported when first seeing the revision.
-						AverageConcurrentRequests: averageConcurrentRequests,
+						PodName:                   cr.podName,
+						AverageConcurrentRequests: averageConcurrency,
 						RequestCount:              requestCount,
 					},
 				})
-				cr.reportToMetricsBackend(key, concurrency)
+				cr.reportToMetricsBackend(key, report.AverageConcurrency)
 			}
 			if len(messages) > 0 {
 				cr.statCh <- messages
 			}
 
-			incomingRequestsPerKey = make(map[types.NamespacedName]float64)
 			reportedFirstRequest = make(map[types.NamespacedName]float64)
 		case <-stopCh:
 			return

--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -141,15 +141,15 @@ func (cr *ConcurrencyReporter) run(stopCh <-chan struct{}, reportCh <-chan time.
 				// revision. We report a min of 0 here because the initial report is
 				// always a concurrency of 1 and the actual concurrency reported over
 				// the reporting period might be < 1.
-				averageConcurrency := math.Max(report.AverageConcurrency-firstAdj, 0)
-				requestCount := report.RequestCount - firstAdj
+				adjustedConcurrency := math.Max(report.AverageConcurrency-firstAdj, 0)
+				adjustedCount := report.RequestCount - firstAdj
 				messages = append(messages, asmetrics.StatMessage{
 					Key: key,
 					Stat: asmetrics.Stat{
 						// Stat time is unset by design. The receiver will set the time.
 						PodName:                   cr.podName,
-						AverageConcurrentRequests: averageConcurrency,
-						RequestCount:              requestCount,
+						AverageConcurrentRequests: adjustedConcurrency,
+						RequestCount:              adjustedCount,
 					},
 				})
 				cr.reportToMetricsBackend(key, report.AverageConcurrency)

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -23,9 +23,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-
 	"k8s.io/apimachinery/pkg/types"
-
 	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/pkg/metrics/metricstest"
 	rtesting "knative.dev/pkg/reconciler/testing"
@@ -51,8 +49,9 @@ var (
 )
 
 type reqOp struct {
-	op  int
-	key types.NamespacedName
+	op   int
+	time int
+	key  types.NamespacedName
 }
 
 func TestStats(t *testing.T) {
@@ -61,7 +60,7 @@ func TestStats(t *testing.T) {
 		ops           []reqOp
 		expectedStats []metrics.StatMessage
 	}{{
-		name: "Scale-from-zero sends stat",
+		name: "scale-from-zero sends stat",
 		ops: []reqOp{{
 			op:  requestOpStart,
 			key: rev1,
@@ -75,29 +74,36 @@ func TestStats(t *testing.T) {
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   activatorPodName,
-			}}, {
+			},
+		}, {
 			Key: rev2,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   activatorPodName,
-			}},
-		}}, {
+			},
+		}},
+	}, {
 		name: "in'n out",
 		ops: []reqOp{{
-			op:  requestOpStart,
-			key: rev1,
+			op:   requestOpStart,
+			key:  rev1,
+			time: 0,
 		}, {
-			op:  requestOpEnd,
-			key: rev1,
+			op:   requestOpEnd,
+			key:  rev1,
+			time: 1,
 		}, {
-			op:  requestOpStart,
-			key: rev1,
+			op:   requestOpStart,
+			key:  rev1,
+			time: 1,
 		}, {
-			op:  requestOpEnd,
-			key: rev1,
+			op:   requestOpEnd,
+			key:  rev1,
+			time: 2,
 		}, {
-			op: requestOpTick, // This won't result in reporting anything at all.
+			op:   requestOpTick,
+			time: 2,
 		}},
 		expectedStats: []metrics.StatMessage{{
 			Key: rev1,
@@ -105,25 +111,31 @@ func TestStats(t *testing.T) {
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   activatorPodName,
-			}}, {
+			},
+		}, {
 			Key: rev1,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 0,
 				RequestCount:              1,
 				PodName:                   activatorPodName,
-			}},
-		}}, {
-		name: "Scale to two",
+			},
+		}},
+	}, {
+		name: "scale to two",
 		ops: []reqOp{{
-			op:  requestOpStart,
-			key: rev1,
+			op:   requestOpStart,
+			key:  rev1,
+			time: 0,
 		}, {
-			op:  requestOpStart,
-			key: rev1,
+			op:   requestOpStart,
+			key:  rev1,
+			time: 0,
 		}, {
-			op: requestOpTick,
+			op:   requestOpTick,
+			time: 1,
 		}, {
-			op: requestOpTick,
+			op:   requestOpTick,
+			time: 2,
 		}},
 		expectedStats: []metrics.StatMessage{{
 			Key: rev1,
@@ -131,54 +143,74 @@ func TestStats(t *testing.T) {
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   activatorPodName,
-			}}, {
+			},
+		}, {
 			Key: rev1,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 1, // We subtract the one concurrent request we already reported.
 				RequestCount:              1,
 				PodName:                   activatorPodName,
-			}}, {
+			},
+		}, {
 			Key: rev1,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 2, // Next reporting period, report both requests in flight.
 				RequestCount:              0, // No new requests have appeared.
 				PodName:                   activatorPodName,
-			}},
-		}}, {
-		name: "Scale-from-zero after tick sends stat",
+			},
+		}},
+	}, {
+		name: "scale-from-zero after tick sends stat",
 		ops: []reqOp{{
-			op:  requestOpStart,
-			key: rev1,
+			op:   requestOpStart,
+			key:  rev1,
+			time: 0,
 		}, {
-			op:  requestOpEnd,
-			key: rev1,
+			op:   requestOpEnd,
+			key:  rev1,
+			time: 1,
 		}, {
-			op: requestOpTick,
+			op:   requestOpTick, // ticks a zero stat but doesn't unset state
+			time: 1,
 		}, {
-			op:  requestOpStart,
-			key: rev1,
+			op:   requestOpTick, // nothing happened, unset state
+			time: 2,
+		}, {
+			op:   requestOpStart, // scale from 0 again
+			key:  rev1,
+			time: 3,
 		}},
 		expectedStats: []metrics.StatMessage{{
 			Key: rev1,
 			Stat: metrics.Stat{
-				AverageConcurrentRequests: 1,
+				AverageConcurrentRequests: 1, // scale from 0 stat
 				RequestCount:              1,
 				PodName:                   activatorPodName,
-			}}, {
+			},
+		}, {
 			Key: rev1,
 			Stat: metrics.Stat{
-				AverageConcurrentRequests: 0,
+				AverageConcurrentRequests: 0, // first stat, discounted by 1
 				RequestCount:              0,
 				PodName:                   activatorPodName,
-			}}, {
+			},
+		}, {
 			Key: rev1,
 			Stat: metrics.Stat{
-				AverageConcurrentRequests: 1,
+				AverageConcurrentRequests: 0, // nothing seen for the entire period
+				RequestCount:              0,
+				PodName:                   activatorPodName,
+			},
+		}, {
+			Key: rev1,
+			Stat: metrics.Stat{
+				AverageConcurrentRequests: 1, // scale from 0 again
 				RequestCount:              1,
 				PodName:                   activatorPodName,
-			}},
-		}}, {
-		name: "Multiple revisions tick",
+			},
+		}},
+	}, {
+		name: "multiple revisions tick",
 		ops: []reqOp{{
 			op:  requestOpStart,
 			key: rev1,
@@ -197,39 +229,80 @@ func TestStats(t *testing.T) {
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   activatorPodName,
-			}}, {
+			},
+		}, {
 			Key: rev2,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   activatorPodName,
-			}}, {
+			},
+		}, {
 			Key: rev3,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 1,
 				RequestCount:              1,
 				PodName:                   activatorPodName,
-			}}, {
+			},
+		}, {
 			Key: rev1,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 0,
 				RequestCount:              0,
 				PodName:                   activatorPodName,
-			}}, {
+			},
+		}, {
 			Key: rev2,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 0,
 				RequestCount:              0,
 				PodName:                   activatorPodName,
-			}}, {
+			},
+		}, {
 			Key: rev3,
 			Stat: metrics.Stat{
 				AverageConcurrentRequests: 0,
 				RequestCount:              0,
 				PodName:                   activatorPodName,
-			}},
+			},
 		}},
-	}
+	}, {
+		name: "interleaved requests",
+		ops: []reqOp{{
+			op:   requestOpStart,
+			key:  rev1,
+			time: 0,
+		}, {
+			op:   requestOpStart,
+			key:  rev1,
+			time: 0,
+		}, {
+			op:   requestOpEnd,
+			key:  rev1,
+			time: 1,
+		}, {
+			op:   requestOpEnd,
+			key:  rev1,
+			time: 2,
+		}, {
+			op: requestOpTick,
+		}},
+		expectedStats: []metrics.StatMessage{{
+			Key: rev1,
+			Stat: metrics.Stat{
+				AverageConcurrentRequests: 1,
+				RequestCount:              1,
+				PodName:                   activatorPodName,
+			},
+		}, {
+			Key: rev1,
+			Stat: metrics.Stat{
+				AverageConcurrentRequests: 0.5,
+				RequestCount:              1,
+				PodName:                   activatorPodName,
+			},
+		}},
+	}}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
@@ -242,13 +315,14 @@ func TestStats(t *testing.T) {
 
 			// Apply request operations
 			for _, op := range tc.ops {
+				time := time.Time{}.Add(time.Duration(op.time) * time.Millisecond)
 				switch op.op {
 				case requestOpStart:
-					s.reqChan <- network.ReqEvent{Key: op.key, Type: network.ReqIn}
+					s.reqChan <- network.ReqEvent{Key: op.key, Type: network.ReqIn, Time: time}
 				case requestOpEnd:
-					s.reqChan <- network.ReqEvent{Key: op.key, Type: network.ReqOut}
+					s.reqChan <- network.ReqEvent{Key: op.key, Type: network.ReqOut, Time: time}
 				case requestOpTick:
-					s.reportBiChan <- time.Time{}
+					s.reportBiChan <- time
 				}
 			}
 
@@ -302,7 +376,7 @@ func TestMetricsReported(t *testing.T) {
 	s.reqChan <- network.ReqEvent{Key: rev1, Type: network.ReqIn}
 	s.reqChan <- network.ReqEvent{Key: rev1, Type: network.ReqIn}
 	s.reqChan <- network.ReqEvent{Key: rev1, Type: network.ReqIn}
-	s.reportBiChan <- time.Time{}
+	s.reportBiChan <- time.Time{}.Add(1 * time.Millisecond)
 	<-s.statChan // The scale from 0 quick-report
 	<-s.statChan // The actual report we want to see
 

--- a/pkg/activator/handler/requestevent_handler.go
+++ b/pkg/activator/handler/requestevent_handler.go
@@ -15,8 +15,8 @@ package handler
 
 import (
 	"net/http"
+	"time"
 
-	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/network"
 )
@@ -27,7 +27,6 @@ func NewRequestEventHandler(reqChan chan network.ReqEvent, next http.Handler) *R
 	handler := &RequestEventHandler{
 		nextHandler: next,
 		reqChan:     reqChan,
-		clock:       system.RealClock{},
 	}
 
 	return handler
@@ -37,15 +36,14 @@ func NewRequestEventHandler(reqChan chan network.ReqEvent, next http.Handler) *R
 type RequestEventHandler struct {
 	nextHandler http.Handler
 	reqChan     chan network.ReqEvent
-	clock       system.Clock
 }
 
 func (h *RequestEventHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	revisionKey := util.RevIDFrom(r.Context())
 
-	h.reqChan <- network.ReqEvent{Key: revisionKey, Type: network.ReqIn, Time: h.clock.Now()}
+	h.reqChan <- network.ReqEvent{Key: revisionKey, Type: network.ReqIn, Time: time.Now()}
 	defer func() {
-		h.reqChan <- network.ReqEvent{Key: revisionKey, Type: network.ReqOut, Time: h.clock.Now()}
+		h.reqChan <- network.ReqEvent{Key: revisionKey, Type: network.ReqOut, Time: time.Now()}
 	}()
 	h.nextHandler.ServeHTTP(w, r)
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

The activator will now report fractional concurrencies as well, making the reporting in general more accurate as metrics are reported over an arbitrary reporting period.

This is pretty much the final change towards sharing the metric generation between queue-proxy and activator.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov
