### PR TITLE
Create strict mode for dryrun validation

### DIFF
--- a/pkg/webhook/podspec_dryrun.go
+++ b/pkg/webhook/podspec_dryrun.go
@@ -45,7 +45,7 @@ func decodeTemplate(ctx context.Context, val interface{}) (*v1.RevisionTemplateS
 	return templ, nil
 }
 
-func validatePodSpec(ctx context.Context, ps v1.RevisionSpec, namespace, mode string) *apis.FieldError {
+func validatePodSpec(ctx context.Context, ps v1.RevisionSpec, namespace string, mode DryRunMode) *apis.FieldError {
 	om := metav1.ObjectMeta{
 		GenerateName: "dry-run-validation",
 		Namespace:    namespace,
@@ -70,7 +70,7 @@ func validatePodSpec(ctx context.Context, ps v1.RevisionSpec, namespace, mode st
 }
 
 // dryRunPodSpec makes a dry-run call to k8s to validate the podspec
-func dryRunPodSpec(ctx context.Context, pod *corev1.Pod, mode string) *apis.FieldError {
+func dryRunPodSpec(ctx context.Context, pod *corev1.Pod, mode DryRunMode) *apis.FieldError {
 	logger := logging.FromContext(ctx)
 	client := kubeclient.Get(ctx)
 	pods := client.CoreV1().Pods(pod.GetNamespace())

--- a/pkg/webhook/podspec_dryrun.go
+++ b/pkg/webhook/podspec_dryrun.go
@@ -79,7 +79,7 @@ func dryRunPodSpec(ctx context.Context, pod *corev1.Pod, mode DryRunMode) *apis.
 	if _, err := pods.CreateWithOptions(ctx, pod, options); err != nil {
 		// Ignore failures for implementations that don't support dry-run.
 		// This likely means there are other webhooks on the PodSpec Create action which do not declare sideEffects:none
-		if mode != Strict && strings.Contains(err.Error(), "does not support dry run") {
+		if mode != DryRunStrict && strings.Contains(err.Error(), "does not support dry run") {
 			logger.Warnw("dry run validation failed, a webhook did not support dry-run", zap.Error(err))
 			return nil
 		}

--- a/pkg/webhook/podspec_dryrun.go
+++ b/pkg/webhook/podspec_dryrun.go
@@ -79,7 +79,7 @@ func dryRunPodSpec(ctx context.Context, pod *corev1.Pod, mode string) *apis.Fiel
 	if _, err := pods.CreateWithOptions(ctx, pod, options); err != nil {
 		// Ignore failures for implementations that don't support dry-run.
 		// This likely means there are other webhooks on the PodSpec Create action which do not declare sideEffects:none
-		if mode != "strict" && strings.Contains(err.Error(), "does not support dry run") {
+		if mode != Strict && strings.Contains(err.Error(), "does not support dry run") {
 			logger.Warnw("dry run validation failed, a webhook did not support dry-run", zap.Error(err))
 			return nil
 		}

--- a/pkg/webhook/podspec_dryrun.go
+++ b/pkg/webhook/podspec_dryrun.go
@@ -45,7 +45,7 @@ func decodeTemplate(ctx context.Context, val interface{}) (*v1.RevisionTemplateS
 	return templ, nil
 }
 
-func validatePodSpec(ctx context.Context, ps v1.RevisionSpec, namespace string) *apis.FieldError {
+func validatePodSpec(ctx context.Context, ps v1.RevisionSpec, namespace, mode string) *apis.FieldError {
 	om := metav1.ObjectMeta{
 		GenerateName: "dry-run-validation",
 		Namespace:    namespace,
@@ -66,11 +66,11 @@ func validatePodSpec(ctx context.Context, ps v1.RevisionSpec, namespace string) 
 		Spec:       *podSpec,
 	}
 
-	return dryRunPodSpec(ctx, pod)
+	return dryRunPodSpec(ctx, pod, mode)
 }
 
 // dryRunPodSpec makes a dry-run call to k8s to validate the podspec
-func dryRunPodSpec(ctx context.Context, pod *corev1.Pod) *apis.FieldError {
+func dryRunPodSpec(ctx context.Context, pod *corev1.Pod, mode string) *apis.FieldError {
 	logger := logging.FromContext(ctx)
 	client := kubeclient.Get(ctx)
 	pods := client.CoreV1().Pods(pod.GetNamespace())
@@ -79,7 +79,7 @@ func dryRunPodSpec(ctx context.Context, pod *corev1.Pod) *apis.FieldError {
 	if _, err := pods.CreateWithOptions(ctx, pod, options); err != nil {
 		// Ignore failures for implementations that don't support dry-run.
 		// This likely means there are other webhooks on the PodSpec Create action which do not declare sideEffects:none
-		if strings.Contains(err.Error(), "does not support dry run") {
+		if mode != "strict" && strings.Contains(err.Error(), "does not support dry run") {
 			logger.Warnw("dry run validation failed, a webhook did not support dry-run", zap.Error(err))
 			return nil
 		}

--- a/pkg/webhook/podspec_dryrun_test.go
+++ b/pkg/webhook/podspec_dryrun_test.go
@@ -108,6 +108,28 @@ func TestExtraServiceValidation(t *testing.T) {
 		},
 		modifyContext: dryRunNotSupported,
 	}, {
+		name: "dryrun strict mode",
+		s: &v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "valid",
+				Namespace: "foo",
+				Annotations: map[string]string{
+					"features.knative.dev/podspec-dryrun": "strict",
+				},
+			},
+			Spec: v1.ServiceSpec{
+				ConfigurationSpec: goodConfigSpec,
+				RouteSpec: v1.RouteSpec{
+					Traffic: []v1.TrafficTarget{{
+						LatestRevision: ptr.Bool(true),
+						Percent:        ptr.Int64(100),
+					}},
+				},
+			},
+		},
+		modifyContext: dryRunNotSupported,
+		want:          "dry run failed with fakekube does not support dry run: spec.template",
+	}, {
 		name: "no template found",
 		s: &v1.Service{
 			ObjectMeta: om,

--- a/pkg/webhook/validate_service.go
+++ b/pkg/webhook/validate_service.go
@@ -29,7 +29,7 @@ import (
 )
 
 // PodSpecDryRunAnnotation gates the podspec dryrun feature and runs with the value 'enabled'
-var PodSpecDryRunAnnotation = "features.knative.dev/podspec-dryrun"
+const PodSpecDryRunAnnotation = "features.knative.dev/podspec-dryrun"
 
 // DryRunMode represents possible values of the PodSpecDryRunAnnotation
 type DryRunMode string
@@ -38,7 +38,7 @@ const (
 	// Enabled will run the dryrun logic. Will succeed if dryrun is unsupported.
 	DryRunEnabled DryRunMode = "enabled"
 
-	// Strict will run the dryrun logic and fails if dryrun is not supported.
+	// Strict will run the dryrun logic and fail if dryrun is not supported.
 	DryRunStrict DryRunMode = "strict"
 )
 

--- a/pkg/webhook/validate_service.go
+++ b/pkg/webhook/validate_service.go
@@ -35,10 +35,10 @@ const PodSpecDryRunAnnotation = "features.knative.dev/podspec-dryrun"
 type DryRunMode string
 
 const (
-	// Enabled will run the dryrun logic. Will succeed if dryrun is unsupported.
+	// DryRunEnabled will run the dryrun logic. Will succeed if dryrun is unsupported.
 	DryRunEnabled DryRunMode = "enabled"
 
-	// Strict will run the dryrun logic and fail if dryrun is not supported.
+	// DryRunStrict will run the dryrun logic and fail if dryrun is not supported.
 	DryRunStrict DryRunMode = "strict"
 )
 

--- a/pkg/webhook/validate_service.go
+++ b/pkg/webhook/validate_service.go
@@ -28,22 +28,18 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
+// PodSpecDryRunAnnotation gates the podspec dryrun feature and runs with the value 'enabled'
+var PodSpecDryRunAnnotation = "features.knative.dev/podspec-dryrun"
+
 // DryRunMode represents possible values of the PodSpecDryRunAnnotation
 type DryRunMode string
 
 const (
 	// Enabled will run the dryrun logic. Will succeed if dryrun is unsupported.
-	Enabled DryRunMode = "enabled"
+	DryRunEnabled DryRunMode = "enabled"
 
 	// Strict will run the dryrun logic and fails if dryrun is not supported.
-	Strict DryRunMode = "strict"
-)
-
-// PodSpecDryRunAnnotation gates the podspec dryrun feature and runs with the value 'enabled'
-var (
-	PodSpecDryRunAnnotation = "features.knative.dev/podspec-dryrun"
-
-	toMode = map[string]DryRunMode{"enabled": Enabled, "strict": Strict}
+	DryRunStrict DryRunMode = "strict"
 )
 
 // ValidateRevisionTemplate runs extra validation on Service resources
@@ -53,8 +49,8 @@ func ValidateRevisionTemplate(ctx context.Context, uns *unstructured.Unstructure
 	// TODO(https://github.com/knative/serving/issues/3425): remove this guard once variations
 	// of this are well-tested. Only run extra validation for the dry-run test.
 	// This will be in place to while the feature is tested for compatibility and later removed.
-	mode, has := toMode[uns.GetAnnotations()[PodSpecDryRunAnnotation]]
-	if !has {
+	mode := DryRunMode(uns.GetAnnotations()[PodSpecDryRunAnnotation])
+	if mode != DryRunStrict && mode != DryRunEnabled {
 		return nil
 	}
 

--- a/pkg/webhook/validate_service.go
+++ b/pkg/webhook/validate_service.go
@@ -40,7 +40,8 @@ func ValidateRevisionTemplate(ctx context.Context, uns *unstructured.Unstructure
 	// TODO(https://github.com/knative/serving/issues/3425): remove this guard once variations
 	// of this are well-tested. Only run extra validation for the dry-run test.
 	// This will be in place to while the feature is tested for compatibility and later removed.
-	if uns.GetAnnotations()[PodSpecDryRunAnnotation] != "enabled" {
+	mode := uns.GetAnnotations()[PodSpecDryRunAnnotation]
+	if mode != "enabled" && mode != "strict" {
 		return nil
 	}
 
@@ -74,7 +75,7 @@ func ValidateRevisionTemplate(ctx context.Context, uns *unstructured.Unstructure
 		}
 	}
 
-	if err := validatePodSpec(ctx, templ.Spec, namespace); err != nil {
+	if err := validatePodSpec(ctx, templ.Spec, namespace, mode); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/webhook/validate_service.go
+++ b/pkg/webhook/validate_service.go
@@ -28,9 +28,16 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
-var (
-	// PodSpecDryRunAnnotation gates the podspec dryrun feature and runs with the value 'enabled'
-	PodSpecDryRunAnnotation = "features.knative.dev/podspec-dryrun"
+// PodSpecDryRunAnnotation gates the podspec dryrun feature and runs with the value 'enabled'
+var PodSpecDryRunAnnotation = "features.knative.dev/podspec-dryrun"
+
+// Possible values of the PodSpecDryRunAnnotation
+const (
+	// Enabled will run the dryrun logic. Will succeed if dryrun is unsupported.
+	Enabled = "enabled"
+
+	// Strict will run the dryrun logic and fails if dryrun is not supported.
+	Strict = "strict"
 )
 
 // ValidateRevisionTemplate runs extra validation on Service resources
@@ -41,7 +48,7 @@ func ValidateRevisionTemplate(ctx context.Context, uns *unstructured.Unstructure
 	// of this are well-tested. Only run extra validation for the dry-run test.
 	// This will be in place to while the feature is tested for compatibility and later removed.
 	mode := uns.GetAnnotations()[PodSpecDryRunAnnotation]
-	if mode != "enabled" && mode != "strict" {
+	if mode != Enabled && mode != Strict {
 		return nil
 	}
 

--- a/test/e2e/service_validation_test.go
+++ b/test/e2e/service_validation_test.go
@@ -51,7 +51,7 @@ func TestServiceValidationWithInvalidPodSpec(t *testing.T) {
 	// Setup Service
 	t.Logf("Creating a new Service %s", names.Service)
 	service, err := v1test.CreateService(t, clients, names,
-		WithServiceAnnotation(webhook.PodSpecDryRunAnnotation, webhook.Strict))
+		WithServiceAnnotation(webhook.PodSpecDryRunAnnotation, string(webhook.Strict)))
 	if err != nil {
 		t.Fatal("Create Service:", err)
 	}

--- a/test/e2e/service_validation_test.go
+++ b/test/e2e/service_validation_test.go
@@ -51,7 +51,7 @@ func TestServiceValidationWithInvalidPodSpec(t *testing.T) {
 	// Setup Service
 	t.Logf("Creating a new Service %s", names.Service)
 	service, err := v1test.CreateService(t, clients, names,
-		WithServiceAnnotation(webhook.PodSpecDryRunAnnotation, "strict"))
+		WithServiceAnnotation(webhook.PodSpecDryRunAnnotation, webhook.Strict))
 	if err != nil {
 		t.Fatal("Create Service:", err)
 	}

--- a/test/e2e/service_validation_test.go
+++ b/test/e2e/service_validation_test.go
@@ -51,7 +51,7 @@ func TestServiceValidationWithInvalidPodSpec(t *testing.T) {
 	// Setup Service
 	t.Logf("Creating a new Service %s", names.Service)
 	service, err := v1test.CreateService(t, clients, names,
-		WithServiceAnnotation(webhook.PodSpecDryRunAnnotation, "enabled"))
+		WithServiceAnnotation(webhook.PodSpecDryRunAnnotation, "strict"))
 	if err != nil {
 		t.Fatal("Create Service:", err)
 	}

--- a/test/e2e/service_validation_test.go
+++ b/test/e2e/service_validation_test.go
@@ -51,7 +51,7 @@ func TestServiceValidationWithInvalidPodSpec(t *testing.T) {
 	// Setup Service
 	t.Logf("Creating a new Service %s", names.Service)
 	service, err := v1test.CreateService(t, clients, names,
-		WithServiceAnnotation(webhook.PodSpecDryRunAnnotation, string(webhook.Strict)))
+		WithServiceAnnotation(webhook.PodSpecDryRunAnnotation, string(webhook.DryRunStrict)))
 	if err != nil {
 		t.Fatal("Create Service:", err)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Issue  #3425

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Include another value "strict" for the dryrun enabled annotation.
     * This value does not swallow "unsupported" and will be enabled for the e2e test 
     * Other use-cases will use the standard behavior, but this allows this test to assess the feature properly by forcing its use.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
