### PR TITLE
Revert #7729 which seems to be a source of new flakes.

### DIFF
--- a/third_party/net-istio.yaml
+++ b/third_party/net-istio.yaml
@@ -18,7 +18,7 @@ metadata:
   # These are the permissions needed by the Istio Ingress implementation.
   name: knative-serving-istio
   labels:
-    serving.knative.dev/release: "v20200428-157cedc"
+    serving.knative.dev/release: "v20200424-03cda57"
     serving.knative.dev/controller: "true"
     networking.knative.dev/ingress-provider: istio
 rules:
@@ -48,7 +48,7 @@ metadata:
   name: knative-ingress-gateway
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200428-157cedc"
+    serving.knative.dev/release: "v20200424-03cda57"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -85,7 +85,7 @@ metadata:
   name: cluster-local-gateway
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200428-157cedc"
+    serving.knative.dev/release: "v20200424-03cda57"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -118,7 +118,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.istio.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v20200428-157cedc"
+    serving.knative.dev/release: "v20200424-03cda57"
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -153,7 +153,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.istio.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v20200428-157cedc"
+    serving.knative.dev/release: "v20200424-03cda57"
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -190,7 +190,7 @@ metadata:
   name: istio-webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200428-157cedc"
+    serving.knative.dev/release: "v20200424-03cda57"
 
 ---
 # Copyright 2018 The Knative Authors
@@ -213,7 +213,7 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200428-157cedc"
+    serving.knative.dev/release: "v20200424-03cda57"
     networking.knative.dev/ingress-provider: istio
 data:
   _example: |
@@ -283,7 +283,7 @@ metadata:
   name: networking-istio
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200428-157cedc"
+    serving.knative.dev/release: "v20200424-03cda57"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -299,14 +299,14 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: networking-istio
-        serving.knative.dev/release: "v20200428-157cedc"
+        serving.knative.dev/release: "v20200424-03cda57"
     spec:
       serviceAccountName: controller
       containers:
       - name: networking-istio
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/controller@sha256:630f3f6d08b97b3f787edf321d66b1122387d5cf8e0e3716cc34b0eea8b69651
+        image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/controller@sha256:67a6b650348c22011c2ca5824a5c7f229e587c613ff784b70dfd5c5c8535cb7b
         resources:
           requests:
             cpu: 30m
@@ -358,7 +358,7 @@ metadata:
   name: istio-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200428-157cedc"
+    serving.knative.dev/release: "v20200424-03cda57"
 spec:
   selector:
     matchLabels:
@@ -371,14 +371,14 @@ spec:
       labels:
         app: istio-webhook
         role: istio-webhook
-        serving.knative.dev/release: "v20200428-157cedc"
+        serving.knative.dev/release: "v20200424-03cda57"
     spec:
       serviceAccountName: controller
       containers:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/webhook@sha256:fa4d4ce7cce6b0c135b5a7aeaab51eee11c96ee70b13f394ffe8adad9f462929
+        image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/webhook@sha256:20fa75b4b40a619bb1e011a6e02f1a1663794359450110076220b8a560c3d6df
         resources:
           requests:
             cpu: 20m
@@ -432,7 +432,7 @@ metadata:
   namespace: knative-serving
   labels:
     role: istio-webhook
-    serving.knative.dev/release: "v20200428-157cedc"
+    serving.knative.dev/release: "v20200424-03cda57"
 spec:
   ports:
   - # Define metrics and profiling for them to be accessible within service meshes.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

*  Revert #7729 which seems to be a source of new flakes.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
