### PR TITLE
Make sure we ignore non running pods

### DIFF
--- a/pkg/resources/pods.go
+++ b/pkg/resources/pods.go
@@ -77,12 +77,9 @@ func (pc PodAccessor) PodIPsByAge() ([]string, error) {
 	}
 	// Keep only running ones.
 	write := 0
-	for i := range pods {
-		p := pods[i]
+	for _, p := range pods {
 		if p.Status.Phase == corev1.PodRunning && p.DeletionTimestamp == nil {
-			if write != i {
-				pods[write] = p
-			}
+			pods[write] = p
 			write++
 		}
 	}

--- a/pkg/resources/pods.go
+++ b/pkg/resources/pods.go
@@ -60,7 +60,7 @@ func pendingTerminatingCount(pods []*corev1.Pod) (int, int, error) {
 	for _, pod := range pods {
 		switch pod.Status.Phase {
 		case corev1.PodRunning:
-			if pod.ObjectMeta.DeletionTimestamp != nil {
+			if pod.DeletionTimestamp != nil {
 				terminating++
 			}
 		case corev1.PodPending:
@@ -75,6 +75,19 @@ func (pc PodAccessor) PodIPsByAge() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Keep only running ones.
+	write := 0
+	for i := range pods {
+		p := pods[i]
+		if p.Status.Phase == corev1.PodRunning && p.DeletionTimestamp == nil {
+			if write != i {
+				pods[write] = p
+			}
+			write++
+		}
+	}
+	pods = pods[:write]
+
 	if len(pods) > 1 {
 		// This results in a few reflection calls, which we can easily avoid.
 		sort.SliceStable(pods, func(i, j int) bool {

--- a/pkg/resources/pods_test.go
+++ b/pkg/resources/pods_test.go
@@ -84,7 +84,7 @@ func TestPodsSortedByAge(t *testing.T) {
 			pod("unforgiven-ii", withStartTime(aTime), withIP("1.1.1.1"), withPhase(corev1.PodPending),
 				func(p *corev1.Pod) {
 					n := metav1.Now()
-					p.DeletionTimestamp = &n
+					p.DeletionTimestamp = &n // Pod deleted.
 				},
 			),
 		},

--- a/pkg/resources/pods_test.go
+++ b/pkg/resources/pods_test.go
@@ -72,6 +72,37 @@ func TestPodsSortedByAge(t *testing.T) {
 			pod("enter-sandman", withStartTime(time.Now()), withIP("1.2.3.5")),
 		},
 		want: []string{"2.3.4.5", "1.2.3.4", "1.2.3.5", "3.4.5.6"},
+	}, {
+		name: "one pod, but can't use",
+		pods: []*corev1.Pod{
+			pod("unforgiven", withStartTime(aTime), withIP("1.1.1.1"), withPhase(corev1.PodPending)),
+		},
+		want: []string{},
+	}, {
+		name: "one pod, but can't use II",
+		pods: []*corev1.Pod{
+			pod("unforgiven-ii", withStartTime(aTime), withIP("1.1.1.1"), withPhase(corev1.PodPending),
+				func(p *corev1.Pod) {
+					n := metav1.Now()
+					p.DeletionTimestamp = &n
+				},
+			),
+		},
+		want: []string{},
+	}, {
+		name: "lock step",
+		pods: []*corev1.Pod{
+			pod("hit-the-lights", withStartTime(aTime), withIP("1.1.1.1"), withPhase(corev1.PodRunning),
+				func(p *corev1.Pod) {
+					n := metav1.Now()
+					p.DeletionTimestamp = &n
+				},
+			),
+			pod("whiplash", withStartTime(aTime), withIP("1.2.3.4")),
+			pod("unforgiven", withStartTime(aTime), withIP("1.3.4.5"), withPhase(corev1.PodFailed)),
+			pod("motorbreath", withStartTime(aTime.Add(-time.Second)), withIP("1.2.3.9")),
+		},
+		want: []string{"1.2.3.9", "1.2.3.4"},
 	}}
 
 	for _, tc := range tests {
@@ -164,7 +195,9 @@ func pod(name string, pos ...podOption) *corev1.Pod {
 			Namespace: testNamespace,
 			Labels:    map[string]string{serving.RevisionLabelKey: testRevision},
 		},
-		Status: corev1.PodStatus{},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
 	}
 	for _, po := range pos {
 		po(p)

--- a/pkg/resources/pods_test.go
+++ b/pkg/resources/pods_test.go
@@ -81,7 +81,7 @@ func TestPodsSortedByAge(t *testing.T) {
 	}, {
 		name: "one pod, but can't use II",
 		pods: []*corev1.Pod{
-			pod("unforgiven-ii", withStartTime(aTime), withIP("1.1.1.1"), withPhase(corev1.PodPending),
+			pod("unforgiven-ii", withStartTime(aTime), withIP("1.1.1.1"), withPhase(corev1.PodRunning),
 				func(p *corev1.Pod) {
 					n := metav1.Now()
 					p.DeletionTimestamp = &n // Pod deleted.


### PR DESCRIPTION
For counting concurrency we need to return only running pods
otherwise they're not scrapable.

This is for #5978
/assign @markusthoemmes @yanweiguo 