### PR TITLE
Make sure all pods run in leader-elected mode in HA tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -118,19 +118,40 @@ fi
 kubectl -n "${SYSTEM_NAMESPACE}" patch configmap/config-leader-election --type=merge \
   --patch='{"data":{"enabledComponents":"controller,hpaautoscaler"}}'
 add_trap "kubectl get cm config-leader-election -n ${SYSTEM_NAMESPACE} -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -" SIGKILL SIGTERM SIGQUIT
-# Delete HPA to stabilize HA tests
-kubectl -n "${SYSTEM_NAMESPACE}" delete hpa activator
-# Make sure all pods run in leader-elected mode.
-kubectl delete pods --all -n "${SYSTEM_NAMESPACE}"
-# Scale up components for HA tests
-for deployment in controller autoscaler-hpa activator; do
+
+# Save activator HPA original values for later use.
+min_replicas=$(kubectl get hpa activator -n "${SYSTEM_NAMESPACE}" -ojsonpath='{.spec.minReplicas}')
+max_replicas=$(kubectl get hpa activator -n "${SYSTEM_NAMESPACE}" -ojsonpath='{.spec.maxReplicas}')
+kubectl patch hpa activator -n "${SYSTEM_NAMESPACE}" \
+  --type 'merge' \
+  --patch '{"spec": {"maxReplicas": '2', "minReplicas": '2'}}'
+add_trap "kubectl patch hpa activator -n ${SYSTEM_NAMESPACE} \
+  --type 'merge' \
+  --patch '{\"spec\": {\"maxReplicas\": '$max_replicas', \"minReplicas\": '$minReplicas'}}'" SIGKILL SIGTERM SIGQUIT
+
+for deployment in controller autoscaler-hpa; do
+  # Make sure all pods run in leader-elected mode.
+  kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "$deployment" --replicas=0
+  # Scale up components for HA tests
   kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "$deployment" --replicas=2
 done
+add_trap "for deployment in controller autoscaler-hpa; do \
+  kubectl -n ${SYSTEM_NAMESPACE} scale deployment $deployment --replicas=0; \
+  kubectl -n ${SYSTEM_NAMESPACE} scale deployment $deployment --replicas=1; done" SIGKILL SIGTERM SIGQUIT
+
 # Wait for a new leader Controller to prevent race conditions during service reconciliation
 wait_for_leader_controller || failed=1
 # Define short -spoofinterval to ensure frequent probing while stopping pods
 go_test_e2e -timeout=15m -failfast -parallel=1 ./test/ha -spoofinterval="10ms" || failed=1
+
 kubectl get cm config-leader-election -n "${SYSTEM_NAMESPACE}" -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -
+for deployment in controller autoscaler-hpa; do
+  kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "$deployment" --replicas=0
+  kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "$deployment" --replicas=1
+done
+kubectl patch hpa activator -n "${SYSTEM_NAMESPACE}" \
+  --type 'merge' \
+  --patch '{"spec": {"maxReplicas": '$max_replicas', "minReplicas": '$min_replicas'}}'
 
 # Dump cluster state in case of failure
 (( failed )) && dump_cluster_state

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -141,6 +141,10 @@ add_trap "for deployment in controller autoscaler-hpa; do \
 
 # Wait for a new leader Controller to prevent race conditions during service reconciliation
 wait_for_leader_controller || failed=1
+
+# Give the controller time to sync with the rest of the system components.
+sleep 30
+
 # Define short -spoofinterval to ensure frequent probing while stopping pods
 go_test_e2e -timeout=15m -failfast -parallel=1 ./test/ha -spoofinterval="10ms" || failed=1
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -120,6 +120,8 @@ kubectl -n "${SYSTEM_NAMESPACE}" patch configmap/config-leader-election --type=m
 add_trap "kubectl get cm config-leader-election -n ${SYSTEM_NAMESPACE} -oyaml | sed '/.*enabledComponents.*/d' | kubectl replace -f -" SIGKILL SIGTERM SIGQUIT
 # Delete HPA to stabilize HA tests
 kubectl -n "${SYSTEM_NAMESPACE}" delete hpa activator
+# Make sure all pods run in leader-elected mode.
+kubectl delete pods --all -n "${SYSTEM_NAMESPACE}"
 # Scale up components for HA tests
 for deployment in controller autoscaler-hpa activator; do
   kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "$deployment" --replicas=2

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -83,7 +83,7 @@ func getPublicEndpoints(t *testing.T, clients *test.Clients, revision string) ([
 }
 
 func waitForChangedPublicEndpoints(t *testing.T, clients *test.Clients, revision string, origEndpoints []string) error {
-	return wait.PollImmediate(100*time.Millisecond, time.Minute, func() (bool, error) {
+	return wait.PollImmediate(time.Second, 2*time.Minute, func() (bool, error) {
 		newEndpoints, err := getPublicEndpoints(t, clients, revision)
 		return !cmp.Equal(origEndpoints, newEndpoints), err
 	})


### PR DESCRIPTION
A workaround for https://github.com/knative/serving/issues/7797
This should fix intermittent failures in HA tests.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
