### PR TITLE
Adopt @vagababov style for consistency.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -115,12 +115,12 @@ func main() {
 	msp := metrics.NewMemStatsAll()
 	msp.Start(ctx, 30*time.Second)
 	if err := view.Register(msp.DefaultViews()...); err != nil {
-		log.Fatalf("Error exporting go memstats view: %v", err)
+		log.Fatal("Error exporting go memstats view: ", err)
 	}
 
 	cfg, err := sharedmain.GetConfig(*masterURL, *kubeconfig)
 	if err != nil {
-		log.Fatal("Error building kubeconfig:", err)
+		log.Fatal("Error building kubeconfig: ", err)
 	}
 
 	log.Printf("Registering %d clients", len(injection.Default.GetClients()))
@@ -131,7 +131,7 @@ func main() {
 
 	var env config
 	if err := envconfig.Process("", &env); err != nil {
-		log.Fatalf("Failed to process env: %v", err)
+		log.Fatal("Failed to process env: ", err)
 	}
 
 	kubeClient := kubeclient.Get(ctx)
@@ -139,7 +139,7 @@ func main() {
 	// We sometimes startup faster than we can reach kube-api. Poll on failure to prevent us terminating
 	if perr := wait.PollImmediate(time.Second, 60*time.Second, func() (bool, error) {
 		if err = version.CheckMinimumVersion(kubeClient.Discovery()); err != nil {
-			log.Printf("Failed to get k8s version %v", err)
+			log.Print("Failed to get k8s version ", err)
 		}
 		return err == nil, nil
 	}); perr != nil {

--- a/cmd/activator/request_log_test.go
+++ b/cmd/activator/request_log_test.go
@@ -52,7 +52,7 @@ func TestUpdateRequestLogFromConfigMap(t *testing.T) {
 	handler, err := pkghttp.NewRequestLogHandler(baseHandler, buf, "",
 		requestLogTemplateInputGetter(revisionLister(t, true)), false /*enableProbeRequestLog*/)
 	if err != nil {
-		t.Fatalf("want: no error, got: %v", err)
+		t.Fatal("want: no error, got:", err)
 	}
 
 	tests := []struct {

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -86,12 +86,12 @@ func main() {
 	msp := metrics.NewMemStatsAll()
 	msp.Start(ctx, 30*time.Second)
 	if err := view.Register(msp.DefaultViews()...); err != nil {
-		log.Fatalf("Error exporting go memstats view: %v", err)
+		log.Fatal("Error exporting go memstats view: ", err)
 	}
 
 	cfg, err := sharedmain.GetConfig(*masterURL, *kubeconfig)
 	if err != nil {
-		log.Fatal("Error building kubeconfig:", err)
+		log.Fatal("Error building kubeconfig: ", err)
 	}
 
 	log.Printf("Registering %d clients", len(injection.Default.GetClients()))
@@ -110,7 +110,7 @@ func main() {
 	// We sometimes startup faster than we can reach kube-api. Poll on failure to prevent us terminating
 	if perr := wait.PollImmediate(time.Second, 60*time.Second, func() (bool, error) {
 		if err = version.CheckMinimumVersion(kubeClient.Discovery()); err != nil {
-			log.Printf("Failed to get k8s version %v", err)
+			log.Print("Failed to get k8s version ", err)
 		}
 		return err == nil, nil
 	}); perr != nil {
@@ -120,7 +120,7 @@ func main() {
 	// Set up our logger.
 	loggingConfig, err := sharedmain.GetLoggingConfig(ctx)
 	if err != nil {
-		log.Fatal("Error loading/parsing logging configuration:", err)
+		log.Fatal("Error loading/parsing logging configuration: ", err)
 	}
 	logger, atomicLevel := logging.NewLoggerFromConfig(loggingConfig, component)
 	defer flush(logger)

--- a/cmd/default-domain/main.go
+++ b/cmd/default-domain/main.go
@@ -180,7 +180,7 @@ func main() {
 	// If there is a catch-all domain configured, then bail out (successfully) here.
 	defaultDomain := domainConfig.LookupDomainForLabels(map[string]string{})
 	if defaultDomain != routecfg.DefaultDomain {
-		logger.Infof("Domain is configured as: %v", defaultDomain)
+		logger.Info("Domain is configured as: ", defaultDomain)
 		return
 	}
 
@@ -220,6 +220,6 @@ func main() {
 		logger.Fatalw("Error updating ConfigMap", zap.Error(err))
 	}
 
-	logger.Infof("Updated default domain to: %s", domain)
+	logger.Info("Updated default domain to: ", domain)
 	server.Shutdown(context.Background())
 }

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -284,7 +284,7 @@ func TestProbeFailFast(t *testing.T) {
 
 	ts := newProbeTestServer(func(w http.ResponseWriter) {
 		if preferScaledown, err := preferPodForScaledown(f.Name()); err != nil {
-			t.Fatalf("Failed to process downward API labels: %v", err)
+			t.Fatal("Failed to process downward API labels:", err)
 		} else if preferScaledown {
 			w.WriteHeader(http.StatusBadRequest)
 		}
@@ -542,7 +542,7 @@ func BenchmarkProxyHandler(b *testing.B) {
 		"ns", "testksvc", "testksvc",
 		"pod", reportingPeriod)
 	if err != nil {
-		b.Fatalf("Failed to create stats reporter: %v", err)
+		b.Fatal("Failed to create stats reporter:", err)
 	}
 	queue.NewStats(time.Now(), reqChan, reportTicker.C, promStatReporter.Report)
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -340,7 +340,7 @@ func TestStats(t *testing.T) {
 			// Verify we're not getting extra events.
 			select {
 			case x := <-s.statChan:
-				t.Fatalf("Extra events received: %v", x)
+				t.Fatal("Extra events received:", x)
 			case <-time.After(5 * time.Millisecond):
 				// Lookin' good.
 			}

--- a/pkg/activator/handler/context_handler.go
+++ b/pkg/activator/handler/context_handler.go
@@ -72,7 +72,7 @@ func (h *contextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func sendError(err error, w http.ResponseWriter) {
-	msg := fmt.Sprintf("Error getting active endpoint: %v", err)
+	msg := fmt.Sprint("Error getting active endpoint: ", err)
 	if k8serrors.IsNotFound(err) {
 		http.Error(w, msg, http.StatusNotFound)
 		return

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -152,7 +152,7 @@ func TestActivationHandler(t *testing.T) {
 
 			gotBody, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
-				t.Fatalf("Error reading body: %v", err)
+				t.Fatal("Error reading body:", err)
 			}
 			if string(gotBody) != test.wantBody {
 				t.Errorf("Unexpected response body. Response body %q, want %q", gotBody, test.wantBody)
@@ -238,7 +238,7 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 			}
 			cfg, err := tracingconfig.NewTracingConfigFromConfigMap(cm)
 			if err != nil {
-				t.Fatalf("Failed to generate config: %v", err)
+				t.Fatal("Failed to generate config:", err)
 			}
 			if err := oct.ApplyConfig(cfg); err != nil {
 				t.Errorf("Failed to apply tracer config: %v", err)

--- a/pkg/activator/handler/healthz_handler.go
+++ b/pkg/activator/handler/healthz_handler.go
@@ -33,7 +33,7 @@ type HealthHandler struct {
 func (h *HealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if network.IsKubeletProbe(r) {
 		if err := h.HealthCheck(); err != nil {
-			h.Logger.Warnf("Healthcheck failed: %v", err)
+			h.Logger.Warn("Healthcheck failed: ", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		} else {
 			w.WriteHeader(http.StatusOK)

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -202,7 +202,7 @@ func TestThrottlerErrorNoRevision(t *testing.T) {
 	revisions := fakerevisioninformer.Get(ctx)
 	waitInformers, err := controller.RunInformers(ctx.Done(), revisions.Informer())
 	if err != nil {
-		t.Fatalf("Failed to start informers: %v", err)
+		t.Fatal("Failed to start informers:", err)
 	}
 	defer func() {
 		cancel()
@@ -254,7 +254,7 @@ func TestThrottlerErrorOneTimesOut(t *testing.T) {
 	revisions := fakerevisioninformer.Get(ctx)
 	waitInformers, err := controller.RunInformers(ctx.Done(), revisions.Informer())
 	if err != nil {
-		t.Fatalf("Failed to start informers: %v", err)
+		t.Fatal("Failed to start informers:", err)
 	}
 	defer func() {
 		cancel()
@@ -386,7 +386,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 			waitInformers, err := controller.RunInformers(ctx.Done(), endpoints.Informer(),
 				revisions.Informer())
 			if err != nil {
-				t.Fatalf("Failed to start informers: %v", err)
+				t.Fatal("Failed to start informers:", err)
 			}
 			defer func() {
 				cancel()
@@ -435,7 +435,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 			revID := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
 			rt, err := throttler.getOrCreateRevisionThrottler(revID)
 			if err != nil {
-				t.Fatalf("RevisionThrottler can't be found: %v", err)
+				t.Fatal("RevisionThrottler can't be found:", err)
 			}
 
 			// Make sure our informer event has fired.
@@ -589,7 +589,7 @@ func TestActivatorsIndexUpdate(t *testing.T) {
 
 	waitInformers, err := controller.RunInformers(ctx.Done(), endpoints.Informer(), revisions.Informer())
 	if err != nil {
-		t.Fatalf("Failed to start informers: %v", err)
+		t.Fatal("Failed to start informers:", err)
 	}
 
 	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
@@ -637,7 +637,7 @@ func TestActivatorsIndexUpdate(t *testing.T) {
 
 	rt, err := throttler.getOrCreateRevisionThrottler(revID)
 	if err != nil {
-		t.Fatalf("RevisionThrottler can't be found: %v", err)
+		t.Fatal("RevisionThrottler can't be found:", err)
 	}
 
 	// Verify capacity gets updated. This is the very last thing we update
@@ -685,7 +685,7 @@ func TestMultipleActivators(t *testing.T) {
 
 	waitInformers, err := controller.RunInformers(ctx.Done(), endpoints.Informer(), revisions.Informer())
 	if err != nil {
-		t.Fatalf("Failed to start informers: %v", err)
+		t.Fatal("Failed to start informers:", err)
 	}
 
 	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1)
@@ -733,7 +733,7 @@ func TestMultipleActivators(t *testing.T) {
 
 	rt, err := throttler.getOrCreateRevisionThrottler(revID)
 	if err != nil {
-		t.Fatalf("RevisionThrottler can't be found: %v", err)
+		t.Fatal("RevisionThrottler can't be found:", err)
 	}
 
 	// Verify capacity gets updated. This is the very last thing we update

--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -140,14 +140,14 @@ func ValidateRevisionName(ctx context.Context, name, generateName string) *apis.
 	if generateName != "" {
 		if msgs := validation.NameIsDNS1035Label(generateName, true); len(msgs) > 0 {
 			return apis.ErrInvalidValue(
-				fmt.Sprintf("not a DNS 1035 label prefix: %v", msgs),
+				fmt.Sprint("not a DNS 1035 label prefix: ", msgs),
 				"metadata.generateName")
 		}
 	}
 	if name != "" {
 		if msgs := validation.NameIsDNS1035Label(name, false); len(msgs) > 0 {
 			return apis.ErrInvalidValue(
-				fmt.Sprintf("not a DNS 1035 label: %v", msgs),
+				fmt.Sprint("not a DNS 1035 label: ", msgs),
 				"metadata.name")
 		}
 		om := apis.ParentMeta(ctx)

--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -187,7 +187,7 @@ func ExitCodeReason(exitCode int32) string {
 // RevisionContainerExitingMessage constructs the status message if a container
 // fails to come up.
 func RevisionContainerExitingMessage(message string) string {
-	return fmt.Sprintf("Container failed with: %s", message)
+	return fmt.Sprint("Container failed with: ", message)
 }
 
 // RevisionContainerMissingMessage constructs the status message if a given image

--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -64,7 +64,7 @@ func validateTrafficList(ctx context.Context, traffic []TrafficTarget) *apis.Fie
 		}
 		if msgs := validation.IsDNS1035Label(tt.Tag); len(msgs) > 0 {
 			errs = errs.Also(apis.ErrInvalidArrayValue(
-				fmt.Sprintf("not a DNS 1035 label: %v", msgs),
+				fmt.Sprint("not a DNS 1035 label: ", msgs),
 				"tag", i))
 		}
 		if idx, ok := trafficMap[tt.Tag]; ok {

--- a/pkg/apis/serving/v1alpha1/service_validation.go
+++ b/pkg/apis/serving/v1alpha1/service_validation.go
@@ -164,7 +164,7 @@ func (rt *ReleaseType) Validate(ctx context.Context) *apis.FieldError {
 		}
 		if msgs := validation.IsDNS1035Label(r); len(msgs) > 0 {
 			errs = errs.Also(apis.ErrInvalidArrayValue(
-				fmt.Sprintf("not a DNS 1035 label: %v", msgs),
+				fmt.Sprint("not a DNS 1035 label: ", msgs),
 				"revisions", i))
 		}
 	}

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -292,7 +292,7 @@ func TestNewConfig(t *testing.T) {
 			got, err := NewConfigFromConfigMap(&corev1.ConfigMap{
 				Data: test.input,
 			})
-			t.Logf("Error = %v", err)
+			t.Log("Error =", err)
 			if (err != nil) != test.wantErr {
 				t.Errorf("NewConfig() = %v, want %v", err, test.wantErr)
 			}

--- a/pkg/autoscaler/fake/fake_metric_client.go
+++ b/pkg/autoscaler/fake/fake_metric_client.go
@@ -99,7 +99,7 @@ var StaticMetricClient = MetricClient{
 func Endpoints(count int, svc string) {
 	epAddresses := make([]corev1.EndpointAddress, count)
 	for i := 1; i <= count; i++ {
-		ip := fmt.Sprintf("127.0.0.%v", i)
+		ip := fmt.Sprint("127.0.0.", i)
 		epAddresses[i-1] = corev1.EndpointAddress{IP: ip}
 	}
 

--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -366,7 +366,7 @@ func TestMetricCollectorRecord(t *testing.T) {
 	coll.Record(metricKey, stat)
 	stable, panic, err := coll.StableAndPanicConcurrency(metricKey, now)
 	if err != nil {
-		t.Fatalf("StableAndPanicConcurrency: %v", err)
+		t.Fatal("StableAndPanicConcurrency:", err)
 	}
 	// Scale to the window sizes.
 	const (
@@ -379,7 +379,7 @@ func TestMetricCollectorRecord(t *testing.T) {
 	}
 	stable, panic, err = coll.StableAndPanicRPS(metricKey, now)
 	if err != nil {
-		t.Fatalf("StableAndPanicRPS: %v", err)
+		t.Fatal("StableAndPanicRPS:", err)
 	}
 	if math.Abs(stable-wantS) > tolerance || math.Abs(panic-wantP) > tolerance {
 		t.Errorf("StableAndPanicRPS() = %v, %v; want %v, %v", stable, panic, wantS, wantP)

--- a/pkg/autoscaler/metrics/stats_scraper_test.go
+++ b/pkg/autoscaler/metrics/stats_scraper_test.go
@@ -166,7 +166,7 @@ func TestScrapeReportStatWhenAllCallsSucceed(t *testing.T) {
 	now := time.Now()
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
-		t.Fatalf("Unexpected error from scraper.Scrape(): %v", err)
+		t.Fatal("Unexpected error from scraper.Scrape():", err)
 	}
 
 	if got.Time.Before(now) {
@@ -217,7 +217,7 @@ func TestScrapeAllPodsYoungPods(t *testing.T) {
 	now := time.Now()
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
-		t.Fatalf("Unexpected error from scraper.Scrape(): %v", err)
+		t.Fatal("Unexpected error from scraper.Scrape():", err)
 	}
 
 	if got.Time.Before(now) {
@@ -282,7 +282,7 @@ func TestScrapeSomePodsOldPods(t *testing.T) {
 	now := time.Now()
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
-		t.Fatalf("Unexpected error from scraper.Scrape(): %v", err)
+		t.Fatal("Unexpected error from scraper.Scrape():", err)
 	}
 
 	if got.Time.Before(now) {

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -438,11 +438,11 @@ func newTestAutoscalerWithScalingMetric(t *testing.T, targetValue, targetBurstCa
 	}
 	ctx, err := smetrics.RevisionContext(fake.TestNamespace, fake.TestService, fake.TestConfig, fake.TestRevision)
 	if err != nil {
-		t.Fatalf("Error creating context: %v", err)
+		t.Fatal("Error creating context:", err)
 	}
 	a, err := New(fake.TestNamespace, fake.TestRevision, metrics, l, deciderSpec, ctx)
 	if err != nil {
-		t.Fatalf("Error creating test autoscaler: %v", err)
+		t.Fatal("Error creating test autoscaler:", err)
 	}
 	fake.Endpoints(1, fake.TestService)
 	return a
@@ -474,7 +474,7 @@ func TestStartInPanicMode(t *testing.T) {
 		fake.Endpoints(i, fake.TestService)
 		a, err := New(fake.TestNamespace, fake.TestRevision, metrics, l, deciderSpec, context.Background())
 		if err != nil {
-			t.Fatalf("Error creating test autoscaler: %v", err)
+			t.Fatal("Error creating test autoscaler:", err)
 		}
 		if !a.panicTime.IsZero() {
 			t.Errorf("Create at scale %d had panic mode on", i)
@@ -488,7 +488,7 @@ func TestStartInPanicMode(t *testing.T) {
 	fake.Endpoints(2, fake.TestService)
 	a, err := New(fake.TestNamespace, fake.TestRevision, metrics, l, deciderSpec, context.Background())
 	if err != nil {
-		t.Fatalf("Error creating test autoscaler: %v", err)
+		t.Fatal("Error creating test autoscaler:", err)
 	}
 	if a.panicTime.IsZero() {
 		t.Error("Create at scale 2 had panic mode off")

--- a/pkg/autoscaler/scaling/multiscaler_test.go
+++ b/pkg/autoscaler/scaling/multiscaler_test.go
@@ -108,11 +108,11 @@ func TestMultiScalerScaling(t *testing.T) {
 
 	_, err = ms.Create(ctx, decider)
 	if err != nil {
-		t.Fatalf("Create() = %v", err)
+		t.Fatal("Create() =", err)
 	}
 	d, err := ms.Get(ctx, decider.Namespace, decider.Name)
 	if err != nil {
-		t.Fatalf("Get() = %v", err)
+		t.Fatal("Get() =", err)
 	}
 	if got, want := d.Status.DesiredScale, int32(-1); got != want {
 		t.Errorf("Decider.Status.DesiredScale = %d, want: %d", got, want)
@@ -133,7 +133,7 @@ func TestMultiScalerScaling(t *testing.T) {
 	// Verify new values are propagated.
 	d, err = ms.Get(ctx, decider.Namespace, decider.Name)
 	if err != nil {
-		t.Fatalf("Get() = %v", err)
+		t.Fatal("Get() =", err)
 	}
 	if got, want := d.Status.DesiredScale, int32(1); got != want {
 		t.Errorf("Decider.Status.DesiredScale = %d, want: %d", got, want)
@@ -156,7 +156,7 @@ func TestMultiScalerScaling(t *testing.T) {
 	// Verify new value is proposed for activator count only.
 	d, err = ms.Get(ctx, decider.Namespace, decider.Name)
 	if err != nil {
-		t.Fatalf("Get() = %v", err)
+		t.Fatal("Get() =", err)
 	}
 	if got, want := d.Status.DesiredScale, int32(1); got != want {
 		t.Errorf("Decider.Status.DesiredScale = %d, want: %d", got, want)
@@ -197,11 +197,11 @@ func TestMultiscalerCreateTBC42(t *testing.T) {
 
 	_, err := ms.Create(ctx, decider)
 	if err != nil {
-		t.Fatalf("Create() = %v", err)
+		t.Fatal("Create() =", err)
 	}
 	d, err := ms.Get(ctx, decider.Namespace, decider.Name)
 	if err != nil {
-		t.Fatalf("Get() = %v", err)
+		t.Fatal("Get() =", err)
 	}
 	if got, want := d.Status.DesiredScale, int32(-1); got != want {
 		t.Errorf("Decider.Status.DesiredScale = %d, want: %d", got, want)
@@ -224,11 +224,11 @@ func TestMultiscalerCreateTBCMinus1(t *testing.T) {
 
 	_, err := ms.Create(ctx, decider)
 	if err != nil {
-		t.Fatalf("Create() = %v", err)
+		t.Fatal("Create() =", err)
 	}
 	d, err := ms.Get(ctx, decider.Namespace, decider.Name)
 	if err != nil {
-		t.Fatalf("Get() = %v", err)
+		t.Fatal("Get() =", err)
 	}
 	if got, want := d.Status.DesiredScale, int32(-1); got != want {
 		t.Errorf("Decider.Status.DesiredScale = %d, want: %d", got, want)
@@ -258,7 +258,7 @@ func TestMultiScalerOnlyCapacityChange(t *testing.T) {
 
 	_, err := ms.Create(ctx, decider)
 	if err != nil {
-		t.Fatalf("Create() = %v", err)
+		t.Fatal("Create() =", err)
 	}
 
 	// Verify that we see a "tick".
@@ -304,7 +304,7 @@ func TestMultiScalerTickUpdate(t *testing.T) {
 
 	_, err = ms.Create(ctx, decider)
 	if err != nil {
-		t.Fatalf("Create() = %v", err)
+		t.Fatal("Create() =", err)
 	}
 	time.Sleep(50 * time.Millisecond)
 
@@ -357,7 +357,7 @@ func TestMultiScalerScaleToZero(t *testing.T) {
 
 	_, err = ms.Create(ctx, decider)
 	if err != nil {
-		t.Fatalf("Create() = %v", err)
+		t.Fatal("Create() =", err)
 	}
 
 	// Verify that we see a "tick"
@@ -396,7 +396,7 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 
 	_, err := ms.Create(ctx, decider)
 	if err != nil {
-		t.Fatalf("Create() = %v", err)
+		t.Fatal("Create() =", err)
 	}
 	metricKey := types.NamespacedName{Namespace: decider.Namespace, Name: decider.Name}
 	if scaler, exists := ms.scalers[metricKey]; !exists {
@@ -434,7 +434,7 @@ func TestMultiScalerUpdate(t *testing.T) {
 	// Create the decider and verify the Spec
 	_, err := ms.Create(ctx, decider)
 	if err != nil {
-		t.Fatalf("Create() = %v", err)
+		t.Fatal("Create() =", err)
 	}
 	m, err := ms.Get(ctx, decider.Namespace, decider.Name)
 	if err != nil {

--- a/pkg/gc/config_test.go
+++ b/pkg/gc/config_test.go
@@ -98,7 +98,7 @@ func TestOurConfig(t *testing.T) {
 			got, err := NewConfigFromConfigMapFunc(logtesting.TestContextWithLogger(t))(
 				&corev1.ConfigMap{Data: tt.data})
 			if tt.fail != (err != nil) {
-				t.Fatalf("Unexpected error value: %v", err)
+				t.Fatal("Unexpected error value:", err)
 			}
 
 			if !cmp.Equal(tt.want, got) {

--- a/pkg/http/request_log_test.go
+++ b/pkg/http/request_log_test.go
@@ -211,7 +211,7 @@ func TestSetTemplate(t *testing.T) {
 	buf := bytes.NewBufferString("")
 	handler, err := NewRequestLogHandler(baseHandler, buf, "", defaultInputGetter, false)
 	if err != nil {
-		t.Fatalf("want: no error, got: %v", err)
+		t.Fatal("want: no error, got:", err)
 	}
 
 	for _, test := range tests {
@@ -236,7 +236,7 @@ func TestSetTemplate(t *testing.T) {
 func BenchmarkRequestLogHandlerNoTemplate(b *testing.B) {
 	handler, err := NewRequestLogHandler(baseHandler, ioutil.Discard, "", defaultInputGetter, false)
 	if err != nil {
-		b.Fatalf("Failed to create handler: %v", err)
+		b.Fatal("Failed to create handler:", err)
 	}
 	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
 	resp := httptest.NewRecorder()
@@ -261,7 +261,7 @@ func BenchmarkRequestLogHandlerDefaultTemplate(b *testing.B) {
 	tpl := `{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}`
 	handler, err := NewRequestLogHandler(baseHandler, ioutil.Discard, tpl, defaultInputGetter, false)
 	if err != nil {
-		b.Fatalf("Failed to create handler: %v", err)
+		b.Fatal("Failed to create handler:", err)
 	}
 	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
 	resp := httptest.NewRecorder()

--- a/pkg/leaderelection/config_test.go
+++ b/pkg/leaderelection/config_test.go
@@ -125,7 +125,7 @@ func TestServingConfig(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			cm, err := ValidateConfig(test.data)
 			if err != nil {
-				t.Fatalf("Error parsing config = %v", err)
+				t.Fatal("Error parsing config =", err)
 			}
 			if got, want := cm, test.want; !cmp.Equal(got, want) {
 				t.Errorf("Config mismatch: (-want,+got):\n%s", cmp.Diff(want, got))

--- a/pkg/metrics/tags_test.go
+++ b/pkg/metrics/tags_test.go
@@ -42,7 +42,7 @@ func register(t *testing.T) func() {
 			Aggregation: view.LastValue(),
 			TagKeys:     append(CommonRevisionKeys, ResponseCodeKey, ResponseCodeClassKey, PodTagKey, ContainerTagKey),
 		}); err != nil {
-		t.Fatalf("Failed to register view: %v", err)
+		t.Fatal("Failed to register view:", err)
 	}
 
 	return func() {
@@ -201,7 +201,7 @@ func mustCtx(t *testing.T, f func() (context.Context, error)) context.Context {
 
 	ctx, err := f()
 	if err != nil {
-		t.Fatalf("Failed to create a new context: %v", err)
+		t.Fatal("Failed to create a new context:", err)
 	}
 	return ctx
 }

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -235,7 +235,7 @@ func TestTemplateCaching(t *testing.T) {
 		DomainTemplateKey: anotherTemplate,
 	})
 	if err != nil {
-		t.Fatalf("Config parsing failure = %v", err)
+		t.Fatal("Config parsing failure =", err)
 	}
 	if got, want := actualConfig.DomainTemplate, anotherTemplate; got != want {
 		t.Errorf("DomainTemplate = %q, want: %q", got, want)
@@ -247,7 +247,7 @@ func TestTemplateCaching(t *testing.T) {
 	// Reset to default. And make sure it is cached.
 	actualConfig, err = NewConfigFromMap(map[string]string{})
 	if err != nil {
-		t.Fatalf("Config parsing failure = %v", err)
+		t.Fatal("Config parsing failure =", err)
 	}
 
 	if got, want := actualConfig.DomainTemplate, DefaultDomainTemplate; got != want {

--- a/pkg/network/status/status_test.go
+++ b/pkg/network/status/status_test.go
@@ -59,7 +59,7 @@ func TestProbeLifecycle(t *testing.T) {
 	ing := ingTemplate.DeepCopy()
 	hash, err := ingress.InsertProbe(ing)
 	if err != nil {
-		t.Fatalf("Failed to insert probe: %v", err)
+		t.Fatal("Failed to insert probe:", err)
 	}
 
 	// Simulate that the latest configuration is not applied yet by returning a different
@@ -130,7 +130,7 @@ func TestProbeLifecycle(t *testing.T) {
 	// The first call to IsReady must succeed and return false
 	ok, err := prober.IsReady(context.Background(), ing)
 	if err != nil {
-		t.Fatalf("IsReady failed: %v", err)
+		t.Fatal("IsReady failed:", err)
 	}
 	if ok {
 		t.Fatal("IsReady() returned true")
@@ -152,7 +152,7 @@ func TestProbeLifecycle(t *testing.T) {
 	// The subsequent calls to IsReady must succeed and return true
 	for i := 0; i < 5; i++ {
 		if ok, err = prober.IsReady(context.Background(), ing); err != nil {
-			t.Fatalf("IsReady failed: %v", err)
+			t.Fatal("IsReady failed:", err)
 		}
 		if !ok {
 			t.Fatal("IsReady() returned false")
@@ -175,7 +175,7 @@ func TestProbeLifecycle(t *testing.T) {
 	// The state has been removed and IsReady must return False
 	ok, err = prober.IsReady(context.Background(), ing)
 	if err != nil {
-		t.Fatalf("IsReady failed: %v", err)
+		t.Fatal("IsReady failed:", err)
 	}
 	if ok {
 		t.Fatal("IsReady() returned true")
@@ -276,7 +276,7 @@ func TestCancelPodProbing(t *testing.T) {
 	ing := ingTemplate.DeepCopy()
 	ok, err := prober.IsReady(context.Background(), ing)
 	if err != nil {
-		t.Fatalf("IsReady failed: %v", err)
+		t.Fatal("IsReady failed:", err)
 	}
 	if ok {
 		t.Fatal("IsReady() returned true")
@@ -299,7 +299,7 @@ func TestCancelPodProbing(t *testing.T) {
 
 		ok, err = prober.IsReady(context.Background(), copy)
 		if err != nil {
-			t.Fatalf("IsReady failed: %v", err)
+			t.Fatal("IsReady failed:", err)
 		}
 		if ok {
 			t.Fatal("IsReady() returned true")
@@ -315,7 +315,7 @@ func TestCancelPodProbing(t *testing.T) {
 
 	ok, err = prober.IsReady(context.Background(), ing)
 	if err != nil {
-		t.Fatalf("IsReady failed: %v", err)
+		t.Fatal("IsReady failed:", err)
 	}
 	if ok {
 		t.Fatal("IsReady() returned true")
@@ -353,7 +353,7 @@ func TestPartialPodCancellation(t *testing.T) {
 	ing := ingTemplate.DeepCopy()
 	hash, err := ingress.InsertProbe(ing)
 	if err != nil {
-		t.Fatalf("Failed to insert probe: %v", err)
+		t.Fatal("Failed to insert probe:", err)
 	}
 
 	// Simulate a probe target returning HTTP 200 OK and the correct hash
@@ -414,7 +414,7 @@ func TestPartialPodCancellation(t *testing.T) {
 
 	ok, err := prober.IsReady(context.Background(), ing)
 	if err != nil {
-		t.Fatalf("IsReady failed: %v", err)
+		t.Fatal("IsReady failed:", err)
 	}
 	if ok {
 		t.Fatal("IsReady() returned true")
@@ -484,7 +484,7 @@ func TestCancelIngressProbing(t *testing.T) {
 
 	ok, err := prober.IsReady(context.Background(), ing)
 	if err != nil {
-		t.Fatalf("IsReady failed: %v", err)
+		t.Fatal("IsReady failed:", err)
 	}
 	if ok {
 		t.Fatal("IsReady() returned true")
@@ -508,7 +508,7 @@ func TestCancelIngressProbing(t *testing.T) {
 
 	ok, err = prober.IsReady(context.Background(), ing)
 	if err != nil {
-		t.Fatalf("IsReady failed: %v", err)
+		t.Fatal("IsReady failed:", err)
 	}
 	if ok {
 		t.Fatal("IsReady() returned true")

--- a/pkg/pool/pool_test.go
+++ b/pkg/pool/pool_test.go
@@ -212,7 +212,7 @@ func TestWithContextWaitCancels(t *testing.T) {
 		})
 	}
 	if err := pool.Wait(); err != nil {
-		t.Fatalf("pool.Wait = %v", err)
+		t.Fatal("pool.Wait =", err)
 	}
 	select {
 	case <-ctx.Done():

--- a/pkg/queue/prometheus_stats_reporter_test.go
+++ b/pkg/queue/prometheus_stats_reporter_test.go
@@ -194,12 +194,12 @@ func getData(t *testing.T, gv *prometheus.GaugeVec) float64 {
 		destinationPodLabel:    pod,
 	})
 	if err != nil {
-		t.Fatalf("GaugeVec.GetMetricWith() error = %v", err)
+		t.Fatal("GaugeVec.GetMetricWith() error =", err)
 	}
 
 	m := dto.Metric{}
 	if err := g.Write(&m); err != nil {
-		t.Fatalf("Gauge.Write() error = %v", err)
+		t.Fatal("Gauge.Write() error =", err)
 	}
 	return m.Gauge.GetValue()
 }

--- a/pkg/queue/readiness/probe_test.go
+++ b/pkg/queue/readiness/probe_test.go
@@ -492,7 +492,7 @@ func TestKnHTTPTimeoutFailure(t *testing.T) {
 func TestKnTCPProbeSuccess(t *testing.T) {
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
-		t.Fatalf("Error setting up tcp listener: %v", err)
+		t.Fatal("Error setting up tcp listener:", err)
 	}
 	defer listener.Close()
 	addr := listener.Addr().(*net.TCPAddr)
@@ -553,7 +553,7 @@ func TestKnTCPProbeFailure(t *testing.T) {
 func TestKnTCPProbeSuccessWithThreshold(t *testing.T) {
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
-		t.Fatalf("Error setting up tcp listener: %v", err)
+		t.Fatal("Error setting up tcp listener:", err)
 	}
 	defer listener.Close()
 	addr := listener.Addr().(*net.TCPAddr)
@@ -583,7 +583,7 @@ func TestKnTCPProbeSuccessWithThreshold(t *testing.T) {
 func TestKnTCPProbeSuccessThresholdIncludesFailure(t *testing.T) {
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
-		t.Fatalf("Error setting up tcp listener: %v", err)
+		t.Fatal("Error setting up tcp listener:", err)
 	}
 	addr := listener.Addr().(*net.TCPAddr)
 
@@ -610,7 +610,7 @@ func TestKnTCPProbeSuccessThresholdIncludesFailure(t *testing.T) {
 	}()
 
 	if _, err = listener.Accept(); err != nil {
-		t.Fatalf("Failed to accept TCP conn: %v", err)
+		t.Fatal("Failed to accept TCP conn:", err)
 	}
 	connCount++
 
@@ -621,13 +621,13 @@ func TestKnTCPProbeSuccessThresholdIncludesFailure(t *testing.T) {
 
 	listener2, err := net.Listen("tcp", fmt.Sprintf(":%d", addr.Port))
 	if err != nil {
-		t.Fatalf("Error setting up tcp listener: %v", err)
+		t.Fatal("Error setting up tcp listener:", err)
 	}
 
 	for {
 		if connCount < desiredConnCount {
 			if _, err = listener2.Accept(); err != nil {
-				t.Fatalf("Failed to accept TCP conn: %v", err)
+				t.Fatal("Failed to accept TCP conn:", err)
 			}
 			connCount++
 		} else {

--- a/pkg/queue/request_metric_test.go
+++ b/pkg/queue/request_metric_test.go
@@ -40,7 +40,7 @@ func TestRequestMetricsHandler(t *testing.T) {
 	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	handler, err := NewRequestMetricsHandler(baseHandler, "ns", "svc", "cfg", "rev", "pod")
 	if err != nil {
-		t.Fatalf("Failed to create handler: %v", err)
+		t.Fatal("Failed to create handler:", err)
 	}
 
 	resp := httptest.NewRecorder()
@@ -82,7 +82,7 @@ func TestRequestMetricsHandlerPanickingHandler(t *testing.T) {
 	})
 	handler, err := NewRequestMetricsHandler(baseHandler, "ns", "svc", "cfg", "rev", "pod")
 	if err != nil {
-		t.Fatalf("Failed to create handler: %v", err)
+		t.Fatal("Failed to create handler:", err)
 	}
 
 	resp := httptest.NewRecorder()
@@ -115,7 +115,7 @@ func BenchmarkNewRequestMetricsHandler(b *testing.B) {
 	handler, err := NewAppRequestMetricsHandler(baseHandler, breaker, "test-ns",
 		"test-svc", "test-cfg", "test-rev", "test-pod")
 	if err != nil {
-		b.Fatalf("failed to create request metric handler: %v", err)
+		b.Fatal("failed to create request metric handler:", err)
 	}
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, targetURI, nil)
@@ -144,7 +144,7 @@ func TestAppRequestMetricsHandlerPanickingHandler(t *testing.T) {
 	handler, err := NewAppRequestMetricsHandler(baseHandler, breaker,
 		"ns", "svc", "cfg", "rev", "pod")
 	if err != nil {
-		t.Fatalf("Failed to create handler: %v", err)
+		t.Fatal("Failed to create handler:", err)
 	}
 
 	resp := httptest.NewRecorder()
@@ -176,7 +176,7 @@ func TestAppRequestMetricsHandler(t *testing.T) {
 	handler, err := NewAppRequestMetricsHandler(baseHandler, breaker,
 		"ns", "svc", "cfg", "rev", "pod")
 	if err != nil {
-		t.Fatalf("Failed to create handler: %v", err)
+		t.Fatal("Failed to create handler:", err)
 	}
 
 	resp := httptest.NewRecorder()
@@ -232,7 +232,7 @@ func BenchmarkAppRequestMetricsHandler(b *testing.B) {
 	handler, err := NewAppRequestMetricsHandler(baseHandler, breaker,
 		"ns", "svc", "cfg", "rev", "pod")
 	if err != nil {
-		b.Fatalf("Failed to create handler: %v", err)
+		b.Fatal("Failed to create handler:", err)
 	}
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
 

--- a/pkg/reconciler/accessor/core/secret_test.go
+++ b/pkg/reconciler/accessor/core/secret_test.go
@@ -107,7 +107,7 @@ func TestReconcileSecretCreate(t *testing.T) {
 	h.OnCreate(&kubeClient.Fake, "secrets", func(obj runtime.Object) HookResult {
 		got := obj.(*corev1.Secret)
 		if diff := cmp.Diff(got, desired); diff != "" {
-			t.Logf("Unexpected Secret (-want, +got): %v", diff)
+			t.Log("Unexpected Secret (-want, +got):", diff)
 			return HookIncomplete
 		}
 		return HookComplete
@@ -140,7 +140,7 @@ func TestReconcileSecretUpdate(t *testing.T) {
 	h.OnUpdate(&kubeClient.Fake, "secrets", func(obj runtime.Object) HookResult {
 		got := obj.(*corev1.Secret)
 		if diff := cmp.Diff(got, desired); diff != "" {
-			t.Logf("Unexpected Secret (-want, +got): %v", diff)
+			t.Log("Unexpected Secret (-want, +got):", diff)
 			return HookIncomplete
 		}
 		return HookComplete
@@ -184,7 +184,7 @@ func setup(ctx context.Context, secrets []*corev1.Secret,
 
 	waitInformers, err := controller.RunInformers(ctx.Done(), secretInformer.Informer())
 	if err != nil {
-		t.Fatalf("failed to start secret informer: %v", err)
+		t.Fatal("failed to start secret informer:", err)
 	}
 
 	return &FakeAccessor{

--- a/pkg/reconciler/accessor/networking/certificate_test.go
+++ b/pkg/reconciler/accessor/networking/certificate_test.go
@@ -101,7 +101,7 @@ func TestReconcileCertificateCreate(t *testing.T) {
 	h.OnCreate(&client.Fake, "certificates", func(obj runtime.Object) HookResult {
 		got := obj.(*v1alpha1.Certificate)
 		if diff := cmp.Diff(got, desired); diff != "" {
-			t.Logf("Unexpected Certificate (-want, +got): %v", diff)
+			t.Log("Unexpected Certificate (-want, +got):", diff)
 			return HookIncomplete
 		}
 		return HookComplete
@@ -134,7 +134,7 @@ func TestReconcileCertificateUpdate(t *testing.T) {
 	h.OnUpdate(&client.Fake, "certificates", func(obj runtime.Object) HookResult {
 		got := obj.(*v1alpha1.Certificate)
 		if diff := cmp.Diff(got, desired); diff != "" {
-			t.Logf("Unexpected Certificate (-want, +got): %v", diff)
+			t.Log("Unexpected Certificate (-want, +got):", diff)
 			return HookIncomplete
 		}
 		return HookComplete
@@ -159,7 +159,7 @@ func setup(ctx context.Context, certs []*v1alpha1.Certificate,
 
 	waitInformers, err := controller.RunInformers(ctx.Done(), certInformer.Informer())
 	if err != nil {
-		t.Fatalf("failed to start Certificate informer: %v", err)
+		t.Fatal("failed to start Certificate informer:", err)
 	}
 
 	return &FakeAccessor{

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1078,7 +1078,7 @@ func TestGlobalResyncOnUpdateAutoscalerConfigMap(t *testing.T) {
 	grp := errgroup.Group{}
 	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
-		t.Fatalf("failed to start informers: %v", err)
+		t.Fatal("failed to start informers:", err)
 	}
 	defer func() {
 		cancel()
@@ -1089,7 +1089,7 @@ func TestGlobalResyncOnUpdateAutoscalerConfigMap(t *testing.T) {
 	}()
 
 	if err := watcher.Start(ctx.Done()); err != nil {
-		t.Fatalf("failed to start configmap watcher: %v", err)
+		t.Fatal("failed to start configmap watcher:", err)
 	}
 
 	grp.Go(func() error { controller.StartAll(ctx, ctl); return nil })
@@ -1130,7 +1130,7 @@ func TestGlobalResyncOnUpdateAutoscalerConfigMap(t *testing.T) {
 		return d.Spec.TargetValue == concurrencyTargetAfterUpdate
 	}
 	if decider, err := pollDeciders(fakeDeciders, testNamespace, testRevision, cond); err != nil {
-		t.Fatalf("Failed to get decider: %v", err)
+		t.Fatal("Failed to get decider:", err)
 	} else if got, want := decider.Spec.TargetValue, concurrencyTargetAfterUpdate*defaultTU; got != want {
 		t.Fatalf("TargetValue = %f, want %f", got, want)
 	}
@@ -1175,7 +1175,7 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 		// We only create a single SKS object.
 		return len(l) > 0, err
 	}); err != nil {
-		t.Fatalf("Failed to see SKS propagation: %v", err)
+		t.Fatal("Failed to see SKS propagation:", err)
 	}
 
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(kpa)
@@ -1197,7 +1197,7 @@ func TestControllerSynchronizesCreatesAndDeletes(t *testing.T) {
 		}
 		return newKPA.Status.IsReady(), nil
 	}); err != nil {
-		t.Fatalf("PA failed to become ready: %v", err)
+		t.Fatal("PA failed to become ready:", err)
 	}
 
 	fakeservingclient.Get(ctx).ServingV1alpha1().Revisions(testNamespace).Delete(testRevision, nil)
@@ -1289,7 +1289,7 @@ func TestControllerCreateError(t *testing.T) {
 	ctx, cancel, infs := SetupFakeContextWithCancel(t)
 	waitInformers, err := controller.RunInformers(ctx.Done(), infs...)
 	if err != nil {
-		t.Fatalf("Error starting up informers: %v", err)
+		t.Fatal("Error starting up informers:", err)
 	}
 	defer func() {
 		cancel()
@@ -1325,7 +1325,7 @@ func TestControllerUpdateError(t *testing.T) {
 	ctx, cancel, infs := SetupFakeContextWithCancel(t)
 	waitInformers, err := controller.RunInformers(ctx.Done(), infs...)
 	if err != nil {
-		t.Fatalf("Error starting up informers: %v", err)
+		t.Fatal("Error starting up informers:", err)
 	}
 	defer func() {
 		cancel()
@@ -1361,7 +1361,7 @@ func TestControllerGetError(t *testing.T) {
 	ctx, cancel, infs := SetupFakeContextWithCancel(t)
 	waitInformers, err := controller.RunInformers(ctx.Done(), infs...)
 	if err != nil {
-		t.Fatalf("Error starting up informers: %v", err)
+		t.Fatal("Error starting up informers:", err)
 	}
 	defer func() {
 		cancel()
@@ -1396,7 +1396,7 @@ func TestScaleFailure(t *testing.T) {
 	ctx, cancel, infs := SetupFakeContextWithCancel(t)
 	waitInformers, err := controller.RunInformers(ctx.Done(), infs...)
 	if err != nil {
-		t.Fatalf("Error starting up informers: %v", err)
+		t.Fatal("Error starting up informers:", err)
 	}
 	defer func() {
 		cancel()

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -385,7 +385,7 @@ func TestScaler(t *testing.T) {
 			ctx = config.ToContext(ctx, defaultConfig())
 			desiredScale, err := revisionScaler.scale(ctx, pa, sks, test.scaleTo)
 			if err != nil {
-				t.Error("Scale got an unexpected error: ", err)
+				t.Error("Scale got an unexpected error:", err)
 			}
 			if err == nil && desiredScale != test.wantReplicas {
 				t.Errorf("desiredScale = %d, wanted %d", desiredScale, test.wantReplicas)
@@ -471,7 +471,7 @@ func TestDisableScaleToZero(t *testing.T) {
 			desiredScale, err := revisionScaler.scale(ctx, pa, nil /*sks doesn't matter in this test*/, test.scaleTo)
 
 			if err != nil {
-				t.Error("Scale got an unexpected error: ", err)
+				t.Error("Scale got an unexpected error:", err)
 			}
 			if err == nil && desiredScale != test.wantReplicas {
 				t.Errorf("desiredScale = %d, wanted %d", desiredScale, test.wantReplicas)
@@ -553,12 +553,12 @@ func newDeployment(t *testing.T, dynamicClient dynamic.Interface, name string, r
 		Resource: "deployments",
 	}).Namespace(testNamespace).Create(uns, metav1.CreateOptions{})
 	if err != nil {
-		t.Fatalf("Create() = %v", err)
+		t.Fatal("Create() =", err)
 	}
 
 	deployment := &appsv1.Deployment{}
 	if err := duck.FromUnstructured(u, deployment); err != nil {
-		t.Fatalf("FromUnstructured() = %v", err)
+		t.Fatal("FromUnstructured() =", err)
 	}
 	return deployment
 }

--- a/pkg/reconciler/configuration/queueing_test.go
+++ b/pkg/reconciler/configuration/queueing_test.go
@@ -86,7 +86,7 @@ func TestNewConfigurationCallsSyncHandler(t *testing.T) {
 	defer func() {
 		cancel()
 		if err := eg.Wait(); err != nil {
-			t.Fatalf("Error running controller: %v", err)
+			t.Fatal("Error running controller:", err)
 		}
 	}()
 

--- a/pkg/reconciler/metric/metric_test.go
+++ b/pkg/reconciler/metric/metric_test.go
@@ -191,7 +191,7 @@ func TestReconcileWithCollector(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatalf("StartInformers() = %v", err)
+		t.Fatal("StartInformers() =", err)
 	}
 
 	var eg errgroup.Group

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -75,7 +75,7 @@ func newTestSetup(t *testing.T, configs ...*corev1.ConfigMap) (
 	ctx, ccl, ifs := SetupFakeContextWithCancel(t)
 	wf, err := controller.RunInformers(ctx.Done(), ifs...)
 	if err != nil {
-		t.Fatalf("Error starting informers: %v", err)
+		t.Fatal("Error starting informers:", err)
 	}
 	cancel := func() {
 		ccl()
@@ -110,7 +110,7 @@ func newTestSetup(t *testing.T, configs ...*corev1.ConfigMap) (
 		configMapWatcher.OnChange(cfg)
 	}
 	if err := configMapWatcher.Start(ctx.Done()); err != nil {
-		t.Fatalf("failed to start config manager: %v", err)
+		t.Fatal("failed to start config manager:", err)
 	}
 
 	certEvents := make(chan *v1alpha1.Certificate)
@@ -477,7 +477,7 @@ func TestDomainConfigDomain(t *testing.T) {
 			ctx, ccl, ifs := SetupFakeContextWithCancel(t)
 			wf, err := controller.RunInformers(ctx.Done(), ifs...)
 			if err != nil {
-				t.Fatalf("Error starting informers: %v", err)
+				t.Fatal("Error starting informers:", err)
 			}
 			defer func() {
 				ccl()
@@ -500,7 +500,7 @@ func TestDomainConfigDomain(t *testing.T) {
 
 			cert, err := fakeservingclient.Get(ctx).NetworkingV1alpha1().Certificates(ns).Get(test.wantCertName, metav1.GetOptions{})
 			if err != nil {
-				t.Fatalf("Could not get certificate: %v", err)
+				t.Fatal("Could not get certificate:", err)
 			}
 			if got, want := cert.Spec.DNSNames[0], test.wantDNSName; got != want {
 				t.Errorf("DNSName[0] = %s, want %s", got, want)

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -105,7 +105,7 @@ func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1.Revis
 	}
 
 	// If what comes back has a different spec, then signal the change.
-	logger.Infof("Reconciled deployment diff (-desired, +observed): %v", diff)
+	logger.Info("Reconciled deployment diff (-desired, +observed): ", diff)
 	return d, nil
 }
 

--- a/pkg/reconciler/revision/queueing_test.go
+++ b/pkg/reconciler/revision/queueing_test.go
@@ -248,12 +248,12 @@ func TestNewRevisionCallsSyncHandler(t *testing.T) {
 
 	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
-		t.Fatalf("Error starting informers: %v", err)
+		t.Fatal("Error starting informers:", err)
 	}
 	defer func() {
 		cancel()
 		if err := eg.Wait(); err != nil {
-			t.Fatalf("Error running controller: %v", err)
+			t.Fatal("Error running controller:", err)
 		}
 		waitInformers()
 	}()
@@ -263,7 +263,7 @@ func TestNewRevisionCallsSyncHandler(t *testing.T) {
 	})
 
 	if _, err := servingClient.ServingV1().Revisions(rev.Namespace).Create(rev); err != nil {
-		t.Fatalf("Error creating revision: %v", err)
+		t.Fatal("Error creating revision:", err)
 	}
 
 	if err := h.WaitForHooks(time.Second * 3); err != nil {

--- a/pkg/reconciler/revision/resolve_test.go
+++ b/pkg/reconciler/revision/resolve_test.go
@@ -54,7 +54,7 @@ type digestible interface {
 func mustDigest(t *testing.T, d digestible) v1.Hash {
 	h, err := d.Digest()
 	if err != nil {
-		t.Fatalf("Digest() = %v", err)
+		t.Fatal("Digest() =", err)
 	}
 	return h
 }
@@ -62,7 +62,7 @@ func mustDigest(t *testing.T, d digestible) v1.Hash {
 func mustRawManifest(t *testing.T, img partial.WithRawManifest) []byte {
 	m, err := img.RawManifest()
 	if err != nil {
-		t.Fatalf("RawManifest() = %v", err)
+		t.Fatal("RawManifest() =", err)
 	}
 	return m
 }
@@ -136,11 +136,11 @@ func TestResolve(t *testing.T) {
 
 	idx, err := random.Index(1, 3, 1024)
 	if err != nil {
-		t.Fatalf("random.Index() = %v", err)
+		t.Fatal("random.Index() =", err)
 	}
 	manifest, err := idx.IndexManifest()
 	if err != nil {
-		t.Fatalf("idx.IndexManifest() = %v", err)
+		t.Fatal("idx.IndexManifest() =", err)
 	}
 	img, err := idx.Image(manifest.Manifests[0].Digest)
 	if err != nil {
@@ -170,7 +170,7 @@ func TestResolve(t *testing.T) {
 		// Create a tag pointing to an image on our fake registry
 		tag, err := name.NewTag(fmt.Sprintf("%s/%s:%s", u.Host, expectedRepo, ref), name.WeakValidation)
 		if err != nil {
-			t.Fatalf("NewTag() = %v", err)
+			t.Fatal("NewTag() =", err)
 		}
 
 		// Set up a fake service account with pull secrets for our fake registry
@@ -204,13 +204,13 @@ func TestResolve(t *testing.T) {
 		}
 		resolvedDigest, err := dr.Resolve(tag.String(), opt, emptyRegistrySet)
 		if err != nil {
-			t.Fatalf("Resolve() = %v", err)
+			t.Fatal("Resolve() =", err)
 		}
 
 		// Make sure that we get back the appropriate digest.
 		digest, err := name.NewDigest(resolvedDigest, name.WeakValidation)
 		if err != nil {
-			t.Fatalf("NewDigest() = %v", err)
+			t.Fatal("NewDigest() =", err)
 		}
 		if got, want := digest.DigestStr(), dgst.String(); got != want {
 			t.Fatalf("Resolve() = %v, want %v", got, want)
@@ -234,7 +234,7 @@ func TestResolveWithDigest(t *testing.T) {
 	}
 	resolvedDigest, err := dr.Resolve(originalDigest, opt, emptyRegistrySet)
 	if err != nil {
-		t.Fatalf("Resolve() = %v", err)
+		t.Fatal("Resolve() =", err)
 	}
 
 	if diff := cmp.Diff(originalDigest, resolvedDigest); diff != "" {
@@ -279,7 +279,7 @@ func TestResolveWithPingFailure(t *testing.T) {
 	// Create a tag pointing to an image on our fake registry
 	tag, err := name.NewTag(fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo), name.WeakValidation)
 	if err != nil {
-		t.Fatalf("NewTag() = %v", err)
+		t.Fatal("NewTag() =", err)
 	}
 
 	// Set up a fake service account with pull secrets for our fake registry
@@ -316,7 +316,7 @@ func TestResolveWithManifestFailure(t *testing.T) {
 	// Create a tag pointing to an image on our fake registry
 	tag, err := name.NewTag(fmt.Sprintf("%s/%s:latest", u.Host, expectedRepo), name.WeakValidation)
 	if err != nil {
-		t.Fatalf("NewTag() = %v", err)
+		t.Fatal("NewTag() =", err)
 	}
 
 	// Set up a fake service account with pull secrets for our fake registry
@@ -392,7 +392,7 @@ func TestResolveSkippingRegistry(t *testing.T) {
 
 	resolvedDigest, err := dr.Resolve("localhost:5000/ubuntu:latest", opt, registriesToSkip)
 	if err != nil {
-		t.Fatalf("Resolve() = %v", err)
+		t.Fatal("Resolve() =", err)
 	}
 
 	if got, want := resolvedDigest, ""; got != want {
@@ -454,7 +454,7 @@ yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
 
 	tmpDir, err := ioutil.TempDir("", "TestNewResolverTransport-")
 	if err != nil {
-		t.Fatalf("failed to create tempdir for certs: %v", err)
+		t.Fatal("failed to create tempdir for certs:", err)
 	}
 	defer os.RemoveAll(tmpDir)
 
@@ -464,7 +464,7 @@ yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
 			// Setup.
 			path, err := writeCertFile(tmpDir, tc.certBundle, tc.certBundleContents)
 			if err != nil {
-				t.Fatalf("Failed to write cert bundle file: %v", err)
+				t.Fatal("Failed to write cert bundle file:", err)
 			}
 
 			// The actual test.
@@ -501,7 +501,7 @@ func containsSubject(t *testing.T, subjects [][]byte, contents []byte) bool {
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		t.Fatalf("failed to parse certificate: %v", err)
+		t.Fatal("failed to parse certificate:", err)
 	}
 
 	for _, b := range subjects {

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -752,7 +752,7 @@ func TestMakePodSpec(t *testing.T) {
 			})
 			got, err := makePodSpec(test.rev, &logConfig, &traceConfig, &test.oc, &test.ac, &deploymentConfig)
 			if err != nil {
-				t.Fatalf("makePodSpec returned error: %v", err)
+				t.Fatal("makePodSpec returned error:", err)
 			}
 			if diff := cmp.Diff(test.want, got, quantityComparer); diff != "" {
 				t.Errorf("makePodSpec (-want, +got) = %v", diff)
@@ -834,13 +834,13 @@ func TestMakeDeployment(t *testing.T) {
 			podSpec, err := makePodSpec(test.rev, &logConfig, &traceConfig,
 				&obsConfig, &asConfig, &deploymentConfig)
 			if err != nil {
-				t.Fatalf("makePodSpec returned error: %v", err)
+				t.Fatal("makePodSpec returned error:", err)
 			}
 			test.want.Spec.Template.Spec = *podSpec
 			got, err := MakeDeployment(test.rev, &logConfig, &traceConfig,
 				&network.Config{}, &obsConfig, &asConfig, &deploymentConfig)
 			if err != nil {
-				t.Fatalf("got unexpected error: %v", err)
+				t.Fatal("got unexpected error:", err)
 			}
 			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(resource.Quantity{})); diff != "" {
 				t.Error("MakeDeployment (-want, +got) =", diff)

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -270,7 +270,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			}
 			got, err := makeQueueContainer(test.rev, &test.lc, &traceConfig, &test.oc, &asConfig, &test.cc)
 			if err != nil {
-				t.Fatalf("makeQueueContainer returned error: %v", err)
+				t.Fatal("makeQueueContainer returned error:", err)
 			}
 
 			test.want.Env = append(test.want.Env, corev1.EnvVar{
@@ -412,7 +412,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := makeQueueContainer(test.rev, &logConfig, &traceConfig, &obsConfig, &asConfig, &cc)
 			if err != nil {
-				t.Fatalf("makeQueueContainer returned error: %v", err)
+				t.Fatal("makeQueueContainer returned error:", err)
 			}
 			test.want.Env = append(test.want.Env, corev1.EnvVar{
 				Name:  "SERVING_READINESS_PROBE",

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -278,7 +278,7 @@ func TestResolutionFailed(t *testing.T) {
 
 	rev, err := fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Couldn't get revision: %v", err)
+		t.Fatal("Couldn't get revision:", err)
 	}
 
 	// Ensure that the Revision status is updated.
@@ -332,7 +332,7 @@ func TestUpdateRevWithWithUpdatedLoggingURL(t *testing.T) {
 
 	updatedRev, err := revClient.Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Couldn't get revision: %v", err)
+		t.Fatal("Couldn't get revision:", err)
 	}
 
 	expectedLoggingURL := fmt.Sprintf("http://new-logging.test.com?filter=%s", rev.UID)
@@ -358,7 +358,7 @@ func TestRevWithImageDigests(t *testing.T) {
 	revClient := fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace)
 	rev, err := revClient.Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Couldn't get revision: %v", err)
+		t.Fatal("Couldn't get revision:", err)
 	}
 	if len(rev.Status.ContainerStatuses) < 2 {
 		t.Error("Revision status does not have imageDigests")
@@ -549,7 +549,7 @@ func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 
 			waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
 			if err != nil {
-				t.Fatalf("Failed to start informers: %v", err)
+				t.Fatal("Failed to start informers:", err)
 			}
 			defer func() {
 				cancel()
@@ -560,7 +560,7 @@ func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 			}()
 
 			if err := watcher.Start(ctx.Done()); err != nil {
-				t.Fatalf("Failed to start configuration manager: %v", err)
+				t.Fatal("Failed to start configuration manager:", err)
 			}
 
 			grp.Go(func() error { return ctrl.Run(1, ctx.Done()) })
@@ -690,7 +690,7 @@ func TestGlobalResyncOnConfigMapUpdateDeployment(t *testing.T) {
 
 			waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
 			if err != nil {
-				t.Fatalf("Failed to start informers: %v", err)
+				t.Fatal("Failed to start informers:", err)
 			}
 			defer func() {
 				cancel()
@@ -701,7 +701,7 @@ func TestGlobalResyncOnConfigMapUpdateDeployment(t *testing.T) {
 			}()
 
 			if err := watcher.Start(ctx.Done()); err != nil {
-				t.Fatalf("Failed to start configuration manager: %v", err)
+				t.Fatal("Failed to start configuration manager:", err)
 			}
 
 			grp.Go(func() error { return ctrl.Run(1, ctx.Done()) })

--- a/pkg/reconciler/route/queueing_test.go
+++ b/pkg/reconciler/route/queueing_test.go
@@ -90,7 +90,7 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 
 	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
-		t.Fatalf("Failed to start informers: %v", err)
+		t.Fatal("Failed to start informers:", err)
 	}
 
 	// Run the controller.
@@ -103,18 +103,18 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 	defer func() {
 		cancel()
 		if err := eg.Wait(); err != nil {
-			t.Fatalf("Error running controller: %v", err)
+			t.Fatal("Error running controller:", err)
 		}
 		waitInformers()
 	}()
 
 	if _, err := servingClient.ServingV1().Revisions(rev.Namespace).Create(rev); err != nil {
-		t.Fatalf("Unexpected error creating revision: %v", err)
+		t.Fatal("Unexpected error creating revision:", err)
 	}
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
 
 	if _, err := servingClient.ServingV1().Routes(route.Namespace).Create(route); err != nil {
-		t.Fatalf("Unexpected error creating route: %v", err)
+		t.Fatal("Unexpected error creating route:", err)
 	}
 	fakerouteinformer.Get(ctx).Informer().GetIndexer().Add(route)
 

--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -156,7 +156,7 @@ func (c *Reconciler) updatePlaceholderServices(ctx context.Context, route *v1.Ro
 			desiredService, err := resources.MakeK8sService(ctx, route, service.Name, ingress, resources.IsClusterLocalService(service))
 			if err != nil {
 				// Loadbalancer not ready, no need to update.
-				logger.Warnf("Failed to update k8s service: %v", err)
+				logger.Warn("Failed to update k8s service: ", err)
 				return nil
 			}
 

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -129,21 +129,21 @@ func TestReconcileTargetValidRevision(t *testing.T) {
 	// after reconciliation
 	beforeTimestamp, err := getLastPinnedTimestamp(t, rev)
 	if err != nil {
-		t.Fatalf("Error getting last pinned: %v", err)
+		t.Fatal("Error getting last pinned:", err)
 	}
 
 	if err = reconciler.reconcileTargetRevisions(ctx, &tc, r); err != nil {
-		t.Fatalf("Error reconciling target revisions: %v", err)
+		t.Fatal("Error reconciling target revisions:", err)
 	}
 
 	// Verify last pinned annotation is updated correctly
 	newRev, err := fakeservingclient.Get(ctx).ServingV1().Revisions(r.Namespace).Get(rev.Name, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Error getting revision: %v", err)
+		t.Fatal("Error getting revision:", err)
 	}
 	afterTimestamp, err := getLastPinnedTimestamp(t, newRev)
 	if err != nil {
-		t.Fatalf("Error getting last pinned timestamps: %v", err)
+		t.Fatal("Error getting last pinned timestamps:", err)
 	}
 	if beforeTimestamp == afterTimestamp {
 		t.Fatal("The last pinned timestamp is not updated")
@@ -177,7 +177,7 @@ func TestReconcileRevisionTargetDoesNotExist(t *testing.T) {
 
 	// Try reconciling target revisions for a revision that does not exist. No err should be returned
 	if err := reconciler.reconcileTargetRevisions(ctx, &tcInvalidRev, r); err != nil {
-		t.Fatalf("Error reconciling target revisions: %v", err)
+		t.Fatal("Error reconciling target revisions:", err)
 	}
 }
 

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -326,7 +326,7 @@ func (c *Reconciler) configureTraffic(ctx context.Context, r *v1.Route) (*traffi
 		return nil, trafficErr
 	}
 	if badTarget != nil && isTargetError {
-		logger.Infof("Marking bad traffic target: %v", badTarget)
+		logger.Info("Marking bad traffic target: ", badTarget)
 		badTarget.MarkBadTrafficTarget(&r.Status)
 
 		// Traffic targets aren't ready, no need to configure Route.

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -83,7 +83,7 @@ func getTestRevision(name string) *v1.Revision {
 func getTestRevisionWithCondition(name string, cond apis.Condition) *v1.Revision {
 	return &v1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
-			SelfLink:  fmt.Sprintf("/apis/serving/v1/namespaces/test/revisions/%s", name),
+			SelfLink:  fmt.Sprint("/apis/serving/v1/namespaces/test/revisions/", name),
 			Name:      name,
 			Namespace: testNamespace,
 		},
@@ -353,7 +353,7 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 	ctx, informers, ctl, _, cf := newTestSetup(t)
 	wicb, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
-		t.Fatalf("Error starting informers: %v", err)
+		t.Fatal("Error starting informers:", err)
 	}
 	defer func() {
 		cf()
@@ -1189,7 +1189,7 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 
 			waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
 			if err != nil {
-				t.Fatalf("Failed to start informers: %v", err)
+				t.Fatal("Failed to start informers:", err)
 			}
 			defer func() {
 				cf()
@@ -1200,7 +1200,7 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 			}()
 
 			if err := watcher.Start(ctx.Done()); err != nil {
-				t.Fatalf("failed to start configuration manager: %v", err)
+				t.Fatal("failed to start configuration manager:", err)
 			}
 
 			grp.Go(func() error { return ctrl.Run(1, ctx.Done()) })

--- a/pkg/reconciler/serverlessservice/global_resync_test.go
+++ b/pkg/reconciler/serverlessservice/global_resync_test.go
@@ -63,28 +63,28 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 	// Create activator endpoints.
 	aEps := activatorEndpoints(WithSubsets)
 	if _, err := kubeClnt.CoreV1().Endpoints(aEps.Namespace).Create(aEps); err != nil {
-		t.Fatalf("Error creating activator endpoints: %v", err)
+		t.Fatal("Error creating activator endpoints:", err)
 	}
 
 	// Private endpoints are supposed to exist, since we're using selector mode for the service.
 	privEps := endpointspriv(ns1, sks1)
 	if _, err := kubeClnt.CoreV1().Endpoints(privEps.Namespace).Create(privEps); err != nil {
-		t.Fatalf("Error creating private endpoints: %v", err)
+		t.Fatal("Error creating private endpoints:", err)
 	}
 	// This is passive, so no endpoints.
 	privEps = endpointspriv(ns2, sks2, withOtherSubsets)
 	if _, err := kubeClnt.CoreV1().Endpoints(privEps.Namespace).Create(privEps); err != nil {
-		t.Fatalf("Error creating private endpoints: %v", err)
+		t.Fatal("Error creating private endpoints:", err)
 	}
 
 	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
-		t.Fatalf("Error starting informers: %v", err)
+		t.Fatal("Error starting informers:", err)
 	}
 	defer func() {
 		cancel()
 		if err := grp.Wait(); err != nil {
-			t.Fatalf("Error waiting for contoller to terminate: %v", err)
+			t.Fatal("Error waiting for contoller to terminate:", err)
 		}
 		waitInformers()
 	}()
@@ -118,10 +118,10 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 	sksObj2 := SKS(ns2, sks2, WithPrivateService, WithPubService, WithDeployRef(sks2), markHappy)
 
 	if _, err := fakeservingclient.Get(ctx).NetworkingV1alpha1().ServerlessServices(ns1).Create(sksObj1); err != nil {
-		t.Fatalf("Error creating SKS1: %v", err)
+		t.Fatal("Error creating SKS1:", err)
 	}
 	if _, err := fakeservingclient.Get(ctx).NetworkingV1alpha1().ServerlessServices(ns2).Create(sksObj2); err != nil {
-		t.Fatalf("Error creating SKS2: %v", err)
+		t.Fatal("Error creating SKS2:", err)
 	}
 
 	eps := fakeendpointsinformer.Get(ctx).Lister()
@@ -136,7 +136,7 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 	// Now that we have established the baseline, update the activator endpoints.
 	aEps = activatorEndpoints(withOtherSubsets)
 	if _, err := kubeClnt.CoreV1().Endpoints(aEps.Namespace).Update(aEps); err != nil {
-		t.Fatalf("Error creating activator endpoints: %v", err)
+		t.Fatal("Error creating activator endpoints:", err)
 	}
 
 	if err := updateHooks.WaitForHooks(3 * time.Second); err != nil {

--- a/pkg/reconciler/service/resources/configuration_test.go
+++ b/pkg/reconciler/service/resources/configuration_test.go
@@ -50,7 +50,7 @@ func TestConfigurationHasNoKubectlAnnotation(t *testing.T) {
 	s := createServiceWithKubectlAnnotation()
 	c, err := MakeConfiguration(s)
 	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+		t.Fatal("Unexpected error:", err)
 	}
 	if v, ok := c.Annotations[corev1.LastAppliedConfigAnnotation]; ok {
 		t.Errorf("Annotation %s = %q, want empty", corev1.LastAppliedConfigAnnotation, v)

--- a/pkg/reconciler/service/resources/route_test.go
+++ b/pkg/reconciler/service/resources/route_test.go
@@ -33,7 +33,7 @@ func TestRouteSpec(t *testing.T) {
 	testConfigName := names.Configuration(s)
 	r, err := MakeRoute(s)
 	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+		t.Fatal("Unexpected error:", err)
 	}
 	if got, want := r.Name, testServiceName; got != want {
 		t.Errorf("Expected %q for service name got %q", want, got)
@@ -66,7 +66,7 @@ func TestRouteHasNoKubectlAnnotation(t *testing.T) {
 	s := createServiceWithKubectlAnnotation()
 	r, err := MakeRoute(s)
 	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+		t.Fatal("Unexpected error:", err)
 	}
 	if v, ok := r.Annotations[corev1.LastAppliedConfigAnnotation]; ok {
 		t.Errorf("Annotation %s = %q, want empty", corev1.LastAppliedConfigAnnotation, v)

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -211,7 +211,7 @@ func configSemanticEquals(ctx context.Context, desiredConfig, config *v1.Configu
 		logger.Errorw("Error diffing config spec", zap.Error(err))
 		return false, fmt.Errorf("failed to diff Configuration: %w", err)
 	}
-	logger.Infof("Reconciling configuration diff (-desired, +observed):\n%s", specDiff)
+	logger.Info("Reconciling configuration diff (-desired, +observed):\n", specDiff)
 	return equality.Semantic.DeepEqual(desiredConfig.Spec, config.Spec) &&
 		equality.Semantic.DeepEqual(desiredConfig.ObjectMeta.Labels, config.ObjectMeta.Labels) &&
 		equality.Semantic.DeepEqual(desiredConfig.ObjectMeta.Annotations, config.ObjectMeta.Annotations) &&
@@ -260,7 +260,7 @@ func routeSemanticEquals(ctx context.Context, desiredRoute, route *v1.Route) (bo
 		logger.Errorw("Error diffing route spec", zap.Error(err))
 		return false, fmt.Errorf("failed to diff Route: %w", err)
 	}
-	logger.Infof("Reconciling route diff (-desired, +observed):\n%s", specDiff)
+	logger.Info("Reconciling route diff (-desired, +observed):\n", specDiff)
 	return equality.Semantic.DeepEqual(desiredRoute.Spec, route.Spec) &&
 		equality.Semantic.DeepEqual(desiredRoute.ObjectMeta.Labels, route.ObjectMeta.Labels) &&
 		equality.Semantic.DeepEqual(desiredRoute.ObjectMeta.Annotations, route.ObjectMeta.Annotations) &&

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -786,7 +786,7 @@ func config(name, namespace string, so ServiceOption, co ...ConfigOption) *v1.Co
 	s.SetDefaults(context.Background())
 	cfg, err := resources.MakeConfiguration(s)
 	if err != nil {
-		panic(fmt.Sprintf("MakeConfiguration() = %v", err))
+		panic(fmt.Sprint("MakeConfiguration() = ", err))
 	}
 	for _, opt := range co {
 		opt(cfg)
@@ -799,7 +799,7 @@ func route(name, namespace string, so ServiceOption, ro ...RouteOption) *v1.Rout
 	s.SetDefaults(context.Background())
 	route, err := resources.MakeRoute(s)
 	if err != nil {
-		panic(fmt.Sprintf("MakeRoute() = %v", err))
+		panic(fmt.Sprint("MakeRoute() = ", err))
 	}
 	for _, opt := range ro {
 		opt(route)

--- a/pkg/reconciler/testing/v1/factory.go
+++ b/pkg/reconciler/testing/v1/factory.go
@@ -140,23 +140,23 @@ func ToUnstructured(t *testing.T, sch *runtime.Scheme, objs []runtime.Object) (u
 		// Determine and set the TypeMeta for this object based on our test scheme.
 		gvks, _, err := sch.ObjectKinds(obj)
 		if err != nil {
-			t.Fatalf("Unable to determine kind for type: %v", err)
+			t.Fatal("Unable to determine kind for type:", err)
 		}
 		apiv, k := gvks[0].ToAPIVersionAndKind()
 		ta, err := meta.TypeAccessor(obj)
 		if err != nil {
-			t.Fatalf("Unable to create type accessor: %v", err)
+			t.Fatal("Unable to create type accessor:", err)
 		}
 		ta.SetAPIVersion(apiv)
 		ta.SetKind(k)
 
 		b, err := json.Marshal(obj)
 		if err != nil {
-			t.Fatalf("Unable to marshal: %v", err)
+			t.Fatal("Unable to marshal:", err)
 		}
 		u := &unstructured.Unstructured{}
 		if err := json.Unmarshal(b, u); err != nil {
-			t.Fatalf("Unable to unmarshal: %v", err)
+			t.Fatal("Unable to unmarshal:", err)
 		}
 		us = append(us, u)
 	}

--- a/pkg/reconciler/testing/v1alpha1/factory.go
+++ b/pkg/reconciler/testing/v1alpha1/factory.go
@@ -137,23 +137,23 @@ func ToUnstructured(t *testing.T, sch *runtime.Scheme, objs []runtime.Object) (u
 		// Determine and set the TypeMeta for this object based on our test scheme.
 		gvks, _, err := sch.ObjectKinds(obj)
 		if err != nil {
-			t.Fatalf("Unable to determine kind for type: %v", err)
+			t.Fatal("Unable to determine kind for type:", err)
 		}
 		apiv, k := gvks[0].ToAPIVersionAndKind()
 		ta, err := meta.TypeAccessor(obj)
 		if err != nil {
-			t.Fatalf("Unable to create type accessor: %v", err)
+			t.Fatal("Unable to create type accessor:", err)
 		}
 		ta.SetAPIVersion(apiv)
 		ta.SetKind(k)
 
 		b, err := json.Marshal(obj)
 		if err != nil {
-			t.Fatalf("Unable to marshal: %v", err)
+			t.Fatal("Unable to marshal:", err)
 		}
 		u := &unstructured.Unstructured{}
 		if err := json.Unmarshal(b, u); err != nil {
-			t.Fatalf("Unable to unmarshal: %v", err)
+			t.Fatal("Unable to unmarshal:", err)
 		}
 		us = append(us, u)
 	}

--- a/pkg/resources/scale_test.go
+++ b/pkg/resources/scale_test.go
@@ -101,7 +101,7 @@ func TestGetScaleResource(t *testing.T) {
 	}
 	scale, err := GetScaleResource(testNamespace, objectRef, psInformerFactory)
 	if err != nil {
-		t.Fatalf("GetScale got error = %v", err)
+		t.Fatal("GetScale got error =", err)
 	}
 	if got, want := scale.Status.Replicas, int32(5); got != want {
 		t.Errorf("GetScale.Status.Replicas = %d, want: %d", got, want)
@@ -143,12 +143,12 @@ func newDeployment(t *testing.T, dynamicClient dynamic.Interface, name string, r
 		Resource: "deployments",
 	}).Namespace(testNamespace).Create(uns, metav1.CreateOptions{})
 	if err != nil {
-		t.Fatalf("Create() = %v", err)
+		t.Fatal("Create() =", err)
 	}
 
 	deployment := &v1.Deployment{}
 	if err := duck.FromUnstructured(u, deployment); err != nil {
-		t.Fatalf("FromUnstructured() = %v", err)
+		t.Fatal("FromUnstructured() =", err)
 	}
 	return deployment
 }

--- a/test/apicoverage/image/webhook/webhook_server.go
+++ b/test/apicoverage/image/webhook/webhook_server.go
@@ -58,6 +58,6 @@ func SetupWebhookServer() {
 
 	err := webhookConf.SetupWebhook(m, ac.ResourceMap, namespace, signals.SetupSignalHandler())
 	if err != nil {
-		log.Fatalf("Encountered error setting up Webhook: %v", err)
+		log.Fatal("Encountered error setting up Webhook: ", err)
 	}
 }

--- a/test/apicoverage/tools/main.go
+++ b/test/apicoverage/tools/main.go
@@ -56,7 +56,7 @@ func main() {
 	artifactsDir := prow.GetLocalArtifactsDir()
 	if _, err := os.Stat(artifactsDir); os.IsNotExist(err) {
 		if err = os.MkdirAll(artifactsDir, 0777); err != nil {
-			log.Fatalf("Failed to create directory: %v", err)
+			log.Fatal("Failed to create directory: ", err)
 		}
 	}
 	tools.CleanupJunitFiles(artifactsDir)
@@ -65,19 +65,19 @@ func main() {
 		if err := tools.WriteResourcePercentages(path.Join(
 			artifactsDir, "junit_bazel.xml"),
 			getFailedResourceCoverages()); err != nil {
-			log.Fatalf("Failed writing resource coverage percentages: %v",
+			log.Fatal("Failed writing resource coverage percentages: ",
 				err)
 		}
 		return
 	}
 
 	if kubeConfigPath, err = tools.GetDefaultKubePath(); err != nil {
-		log.Fatalf("Error retrieving kubeConfig path: %v", err)
+		log.Fatal("Error retrieving kubeConfig path: ", err)
 	}
 
 	if serviceIP, err = tools.GetWebhookServiceIP(kubeConfigPath, "",
 		common.WebhookNamespace, common.CommonComponentName); err != nil {
-		log.Fatalf("Error retrieving Service IP: %v", err)
+		log.Fatal("Error retrieving Service IP: ", err)
 	}
 
 	for resource := range common.ResourceMap {
@@ -92,16 +92,16 @@ func main() {
 
 	if err := tools.GetAndWriteTotalCoverage(serviceIP, path.Join(artifactsDir,
 		"totalcoverage.html")); err != nil {
-		log.Fatalf("total coverage retrieval failed: %v", err)
+		log.Fatal("total coverage retrieval failed: ", err)
 	}
 
 	if coverage, err := tools.GetResourcePercentages(serviceIP); err != nil {
-		log.Fatalf("Failed retrieving resource coverage percentages: %v",
+		log.Fatal("Failed retrieving resource coverage percentages: ",
 			err)
 	} else {
 		if err = tools.WriteResourcePercentages(path.Join(
 			artifactsDir, "junit_bazel.xml"), coverage); err != nil {
-			log.Fatalf("Failed writing resource coverage percentages: %v",
+			log.Fatal("Failed writing resource coverage percentages: ",
 				err)
 		}
 	}

--- a/test/conformance/api/v1/blue_green_test.go
+++ b/test/conformance/api/v1/blue_green_test.go
@@ -102,7 +102,7 @@ func TestBlueGreenRoute(t *testing.T) {
 			Percent:      ptr.Int64(50),
 		}},
 	}); err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 
 	t.Log("Wait for the service domains to be ready")
@@ -133,7 +133,7 @@ func TestBlueGreenRoute(t *testing.T) {
 	// does not expose a Status, so we rely on probes to know when they are effective.
 	// Since we are updating the service the teal domain probe will succeed before our changes
 	// take effect so we probe the green domain.
-	t.Logf("Probing %s", greenURL)
+	t.Log("Probing", greenURL)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
@@ -160,6 +160,6 @@ func TestBlueGreenRoute(t *testing.T) {
 		return checkDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
 	})
 	if err := g.Wait(); err != nil {
-		t.Fatalf("Error sending requests: %v", err)
+		t.Fatal("Error sending requests:", err)
 	}
 }

--- a/test/conformance/api/v1/configuration_test.go
+++ b/test/conformance/api/v1/configuration_test.go
@@ -150,7 +150,7 @@ func checkNoKeysPresent(expected map[string]string, actual map[string]string, t 
 		}
 	}
 	if len(present) != 0 {
-		t.Logf("Unexpected keys: %v", present)
+		t.Log("Unexpected keys:", present)
 	}
 	return len(present) == 0
 }

--- a/test/conformance/api/v1/errorcondition_test.go
+++ b/test/conformance/api/v1/errorcondition_test.go
@@ -62,7 +62,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	t.Logf("Creating a new Service %s", names.Service)
 	svc, err := createService(t, clients, names, 2)
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 
 	names.Config = serviceresourcenames.Configuration(svc)
@@ -91,7 +91,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	}, "ContainerImageNotPresent")
 
 	if err != nil {
-		t.Fatalf("Failed to validate configuration state: %s", err)
+		t.Fatal("Failed to validate configuration state:", err)
 	}
 
 	revisionName, err := getRevisionFromConfiguration(clients, names.Config)
@@ -113,7 +113,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	}, "ImagePathInvalid")
 
 	if err != nil {
-		t.Fatalf("Failed to validate revision state: %s", err)
+		t.Fatal("Failed to validate revision state:", err)
 	}
 
 	t.Log("Checking to ensure Route is in desired state")
@@ -190,7 +190,7 @@ func TestContainerExitingMsg(t *testing.T) {
 			}, "ConfigContainersCrashing")
 
 			if err != nil {
-				t.Fatalf("Failed to validate configuration state: %s", err)
+				t.Fatal("Failed to validate configuration state:", err)
 			}
 
 			revisionName, err := getRevisionFromConfiguration(clients, names.Config)
@@ -212,7 +212,7 @@ func TestContainerExitingMsg(t *testing.T) {
 			}, "RevisionContainersCrashing")
 
 			if err != nil {
-				t.Fatalf("Failed to validate revision state: %s", err)
+				t.Fatal("Failed to validate revision state:", err)
 			}
 		})
 	}

--- a/test/conformance/api/v1/generatename_test.go
+++ b/test/conformance/api/v1/generatename_test.go
@@ -124,7 +124,7 @@ func TestServiceGenerateName(t *testing.T) {
 	defer func() { test.TearDown(clients, names) }()
 
 	// Create the service using the generate name field. If the service does not become ready this will fail.
-	t.Logf("Creating new service with generateName %s", generateName)
+	t.Log("Creating new service with generateName", generateName)
 	resources, err := v1test.CreateServiceReady(t, clients, &names, setServiceGenerateName(generateName))
 	if err != nil {
 		t.Fatalf("Failed to create service with generateName %s: %v", generateName, err)
@@ -159,7 +159,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer func() { test.TearDown(clients, names) }()
 
-	t.Logf("Creating new configuration with generateName %s", generateName)
+	t.Log("Creating new configuration with generateName", generateName)
 	config, err := v1test.CreateConfiguration(t, clients, names, setConfigurationGenerateName(generateName))
 	if err != nil {
 		t.Fatalf("Failed to create configuration with generateName %s: %v", generateName, err)
@@ -180,7 +180,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 	}
 
 	// Create a route that maps to the revision created by the configuration above
-	t.Logf("Create new Route with generateName %s", generateName)
+	t.Log("Create new Route with generateName", generateName)
 	route, err := v1test.CreateRoute(t, clients, names, setRouteGenerateName(generateName))
 	if err != nil {
 		t.Fatalf("Failed to create route with generateName %s: %v", generateName, err)

--- a/test/conformance/api/v1/resources_test.go
+++ b/test/conformance/api/v1/resources_test.go
@@ -75,7 +75,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 	}
 
 	sendPostRequest := func(resolvableDomain bool, url *url.URL) (*spoof.Response, error) {
-		t.Logf("Request %s", url)
+		t.Log("Request", url)
 		client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), resolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
 		if err != nil {
 			return nil, err

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -112,7 +112,7 @@ func TestRevisionTimeout(t *testing.T) {
 	t.Log("Creating a new Service ")
 	svc, err := createService(t, clients, names, 2)
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 	names.Route = serviceresourcenames.Route(svc)
 	names.Config = serviceresourcenames.Configuration(svc)
@@ -169,7 +169,7 @@ func TestRevisionTimeout(t *testing.T) {
 			Percent:      ptr.Int64(50),
 		}},
 	}); err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 
 	t.Log("Wait for the service domains to be ready")
@@ -195,7 +195,7 @@ func TestRevisionTimeout(t *testing.T) {
 		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", service.Status.Traffic)
 	}
 
-	t.Logf("Probing %s", rev5sURL)
+	t.Log("Probing", rev5sURL)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,

--- a/test/conformance/api/v1/route_test.go
+++ b/test/conformance/api/v1/route_test.go
@@ -113,13 +113,13 @@ func TestRouteCreation(t *testing.T) {
 	t.Log("Creating a new Route and Configuration")
 	config, err := v1test.CreateConfiguration(t, clients, names)
 	if err != nil {
-		t.Fatalf("Failed to create Configuration: %v", err)
+		t.Fatal("Failed to create Configuration:", err)
 	}
 	objects.Config = config
 
 	route, err := v1test.CreateRoute(t, clients, names)
 	if err != nil {
-		t.Fatalf("Failed to create Route: %v", err)
+		t.Fatal("Failed to create Route:", err)
 	}
 	objects.Route = route
 
@@ -134,7 +134,7 @@ func TestRouteCreation(t *testing.T) {
 		t.Fatalf("Failed to get URL from route %s: %v", names.Route, err)
 	}
 
-	t.Logf("The Route URL is: %s", url)
+	t.Log("The Route URL is:", url)
 	assertResourcesUpdatedWhenRevisionIsReady(t, clients, names, url, "1", test.PizzaPlanetText1)
 
 	// We start a prober at background thread to test if Route is always healthy even during Route update.

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -92,12 +92,12 @@ func TestService(t *testing.T) {
 	t.Log("Service should reflect new revision created and ready in status.")
 	names.Revision, err = v1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("New image not reflected in Service: %v", err)
+		t.Fatal("New image not reflected in Service:", err)
 	}
 
 	t.Log("Waiting for Service to transition to Ready.")
 	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("Error waiting for the service to become ready for the latest revision: %v", err)
+		t.Fatal("Error waiting for the service to become ready for the latest revision:", err)
 	}
 
 	// Validate State after Image Update
@@ -140,12 +140,12 @@ func TestService(t *testing.T) {
 	t.Log("Waiting for the new revision to appear as LatestRevision.")
 	names.Revision, err = v1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("The new revision has not become ready in Service: %v", err)
+		t.Fatal("The new revision has not become ready in Service:", err)
 	}
 
 	t.Log("Waiting for Service to transition to Ready.")
 	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("Error waiting for the service to become ready for the latest revision: %v", err)
+		t.Fatal("Error waiting for the service to become ready for the latest revision:", err)
 	}
 
 	// Validate the Service shape.
@@ -272,7 +272,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 
 	t.Log("Validating service shape.")
 	if err := validateReleaseServiceShape(objects); err != nil {
-		t.Fatalf("Release shape is incorrect: %v", err)
+		t.Fatal("Release shape is incorrect:", err)
 	}
 	if err := validateAnnotations(objects); err != nil {
 		t.Errorf("Service annotations are incorrect: %v", err)
@@ -292,7 +292,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		}},
 	})
 	if err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 
 	desiredTrafficShape := map[string]v1.TrafficTarget{
@@ -371,7 +371,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		}},
 	})
 	if err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 
 	desiredTrafficShape = map[string]v1.TrafficTarget{
@@ -454,7 +454,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		}},
 	})
 	if err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 
 	// Verify in the end it's still the case.
@@ -528,12 +528,12 @@ func TestAnnotationPropagation(t *testing.T) {
 	t.Log("Service should reflect new revision created and ready in status.")
 	names.Revision, err = v1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("New image not reflected in Service: %v", err)
+		t.Fatal("New image not reflected in Service:", err)
 	}
 
 	t.Log("Waiting for Service to transition to Ready.")
 	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("Error waiting for the service to become ready for the latest revision: %v", err)
+		t.Fatal("Error waiting for the service to become ready for the latest revision:", err)
 	}
 	objects, err = v1test.GetResourceObjects(clients, names)
 	if err != nil {
@@ -561,12 +561,12 @@ func TestAnnotationPropagation(t *testing.T) {
 	t.Log("Service should reflect new revision created and ready in status.")
 	names.Revision, err = v1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("New image not reflected in Service: %v", err)
+		t.Fatal("New image not reflected in Service:", err)
 	}
 
 	t.Log("Waiting for Service to transition to Ready.")
 	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("Error waiting for the service to become ready for the latest revision: %v", err)
+		t.Fatal("Error waiting for the service to become ready for the latest revision:", err)
 	}
 	objects, err = v1test.GetResourceObjects(clients, names)
 	if err != nil {

--- a/test/conformance/api/v1/single_threaded_test.go
+++ b/test/conformance/api/v1/single_threaded_test.go
@@ -48,13 +48,13 @@ func TestSingleConcurrency(t *testing.T) {
 
 	objects, err := v1test.CreateServiceReady(t, clients, &names, rtesting.WithContainerConcurrency(1))
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 	url := objects.Service.Status.URL.URL()
 
 	// Ready does not actually mean Ready for a Route just yet.
 	// See https://github.com/knative/serving/issues/1582
-	t.Logf("Probing %s", url)
+	t.Log("Probing", url)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
@@ -68,7 +68,7 @@ func TestSingleConcurrency(t *testing.T) {
 
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
 	if err != nil {
-		t.Fatalf("Error creating spoofing client: %v", err)
+		t.Fatal("Error creating spoofing client:", err)
 	}
 
 	concurrency := 5

--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -64,14 +64,14 @@ func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.U
 		// Check for each of the responses we expect from the base domain.
 		resp := resp
 		g.Go(func() error {
-			t.Logf("Waiting for route to update %s", baseDomain)
+			t.Log("Waiting for route to update", baseDomain)
 			return waitForExpectedResponse(t, clients, baseDomain, resp)
 		})
 	}
 	for i, s := range subdomains {
 		i, s := i, s
 		g.Go(func() error {
-			t.Logf("Waiting for route to update %s", s)
+			t.Log("Waiting for route to update", s)
 			return waitForExpectedResponse(t, clients, s, targetsExpected[i])
 		})
 	}
@@ -197,7 +197,7 @@ func sendRequests(client spoof.Interface, url *url.URL, num int) ([]string, erro
 // The checks in this method should be able to be performed at any point in a
 // runLatest Service's lifecycle so long as the service is in a "Ready" state.
 func validateDataPlane(t pkgTest.TLegacy, clients *test.Clients, names test.ResourceNames, expectedText string) error {
-	t.Logf("Checking that the endpoint vends the expected text: %s", expectedText)
+	t.Log("Checking that the endpoint vends the expected text:", expectedText)
 	_, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,

--- a/test/conformance/api/v1/volumes_test.go
+++ b/test/conformance/api/v1/volumes_test.go
@@ -56,9 +56,9 @@ func TestConfigMapVolume(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create configmap: %v", err)
+		t.Fatal("Failed to create configmap:", err)
 	}
-	t.Logf("Successfully created configMap: %v", configMap)
+	t.Log("Successfully created configMap:", configMap)
 
 	cleanup := func() {
 		test.TearDown(clients, names)
@@ -126,9 +126,9 @@ func TestProjectedConfigMapVolume(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create configmap: %v", err)
+		t.Fatal("Failed to create configmap:", err)
 	}
-	t.Logf("Successfully created configMap: %v", configMap)
+	t.Log("Successfully created configMap:", configMap)
 
 	cleanup := func() {
 		test.TearDown(clients, names)
@@ -198,9 +198,9 @@ func TestSecretVolume(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create secret: %v", err)
+		t.Fatal("Failed to create secret:", err)
 	}
-	t.Logf("Successfully created secret: %v", secret)
+	t.Log("Successfully created secret:", secret)
 
 	cleanup := func() {
 		test.TearDown(clients, names)
@@ -264,9 +264,9 @@ func TestProjectedSecretVolume(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create secret: %v", err)
+		t.Fatal("Failed to create secret:", err)
 	}
-	t.Logf("Successfully created secret: %v", secret)
+	t.Log("Successfully created secret:", secret)
 
 	cleanup := func() {
 		test.TearDown(clients, names)
@@ -337,9 +337,9 @@ func TestProjectedComplex(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create configmap: %v", err)
+		t.Fatal("Failed to create configmap:", err)
 	}
-	t.Logf("Successfully created configMap: %v", configMap)
+	t.Log("Successfully created configMap:", configMap)
 
 	// Create the Secret with random text.
 	secret, err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Create(&corev1.Secret{
@@ -351,9 +351,9 @@ func TestProjectedComplex(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create secret: %v", err)
+		t.Fatal("Failed to create secret:", err)
 	}
-	t.Logf("Successfully created secret: %v", secret)
+	t.Log("Successfully created secret:", secret)
 
 	cleanup := func() {
 		test.TearDown(clients, names)

--- a/test/conformance/api/v1alpha1/blue_green_test.go
+++ b/test/conformance/api/v1alpha1/blue_green_test.go
@@ -106,7 +106,7 @@ func TestBlueGreenRoute(t *testing.T) {
 			},
 		}},
 	}); err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 
 	t.Log("Wait for the service domains to be ready")
@@ -137,7 +137,7 @@ func TestBlueGreenRoute(t *testing.T) {
 	// does not expose a Status, so we rely on probes to know when they are effective.
 	// Since we are updating the service the teal domain probe will succeed before our changes
 	// take effect so we probe the green domain.
-	t.Logf("Probing %s", greenURL)
+	t.Log("Probing", greenURL)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
@@ -164,6 +164,6 @@ func TestBlueGreenRoute(t *testing.T) {
 		return checkDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
 	})
 	if err := g.Wait(); err != nil {
-		t.Fatalf("Error sending requests: %v", err)
+		t.Fatal("Error sending requests:", err)
 	}
 }

--- a/test/conformance/api/v1alpha1/configuration_test.go
+++ b/test/conformance/api/v1alpha1/configuration_test.go
@@ -151,7 +151,7 @@ func checkNoKeysPresent(expected map[string]string, actual map[string]string, t 
 		}
 	}
 	if len(present) != 0 {
-		t.Logf("Unexpected keys: %v", present)
+		t.Log("Unexpected keys:", present)
 	}
 	return len(present) == 0
 }

--- a/test/conformance/api/v1alpha1/errorcondition_test.go
+++ b/test/conformance/api/v1alpha1/errorcondition_test.go
@@ -61,7 +61,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	t.Logf("Creating a new Service %s", names.Service)
 	svc, err := v1a1test.CreateLatestService(t, clients, names)
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 	names.Config = serviceresourcenames.Configuration(svc)
 	names.Route = serviceresourcenames.Route(svc)
@@ -89,7 +89,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	}, "ContainerImageNotPresent")
 
 	if err != nil {
-		t.Fatalf("Failed to validate configuration state: %s", err)
+		t.Fatal("Failed to validate configuration state:", err)
 	}
 
 	revisionName, err := getRevisionFromConfiguration(clients, names.Config)
@@ -111,7 +111,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	}, "ImagePathInvalid")
 
 	if err != nil {
-		t.Fatalf("Failed to validate revision state: %s", err)
+		t.Fatal("Failed to validate revision state:", err)
 	}
 
 	t.Log("When the revision has error condition, route should not be ready.")
@@ -188,7 +188,7 @@ func TestContainerExitingMsg(t *testing.T) {
 			}, "ConfigContainersCrashing")
 
 			if err != nil {
-				t.Fatalf("Failed to validate configuration state: %s", err)
+				t.Fatal("Failed to validate configuration state:", err)
 			}
 
 			revisionName, err := getRevisionFromConfiguration(clients, names.Config)
@@ -210,7 +210,7 @@ func TestContainerExitingMsg(t *testing.T) {
 			}, "RevisionContainersCrashing")
 
 			if err != nil {
-				t.Fatalf("Failed to validate revision state: %s", err)
+				t.Fatal("Failed to validate revision state:", err)
 			}
 		})
 	}

--- a/test/conformance/api/v1alpha1/generatename_test.go
+++ b/test/conformance/api/v1alpha1/generatename_test.go
@@ -124,7 +124,7 @@ func TestServiceGenerateName(t *testing.T) {
 	defer func() { test.TearDown(clients, names) }()
 
 	// Create the service using the generate name field. If the service does not become ready this will fail.
-	t.Logf("Creating new service with generateName %s", generateName)
+	t.Log("Creating new service with generateName", generateName)
 	resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
 		setServiceGenerateName(generateName))
 	if err != nil {
@@ -160,7 +160,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer func() { test.TearDown(clients, names) }()
 
-	t.Logf("Creating new configuration with generateName %s", generateName)
+	t.Log("Creating new configuration with generateName", generateName)
 	config, err := v1a1test.CreateConfiguration(t, clients, names, setConfigurationGenerateName(generateName))
 	if err != nil {
 		t.Fatalf("Failed to create configuration with generateName %s: %v", generateName, err)
@@ -181,7 +181,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 	}
 
 	// Create a route that maps to the revision created by the configuration above
-	t.Logf("Create new Route with generateName %s", generateName)
+	t.Log("Create new Route with generateName", generateName)
 	route, err := v1a1test.CreateRoute(t, clients, names, setRouteGenerateName(generateName))
 	if err != nil {
 		t.Fatalf("Failed to create route with generateName %s: %v", generateName, err)

--- a/test/conformance/api/v1alpha1/resources_test.go
+++ b/test/conformance/api/v1alpha1/resources_test.go
@@ -76,7 +76,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 	}
 
 	sendPostRequest := func(resolvableDomain bool, url *url.URL) (*spoof.Response, error) {
-		t.Logf("Request %s", url)
+		t.Log("Request", url)
 		client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), resolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
 		if err != nil {
 			return nil, err

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -113,7 +113,7 @@ func TestRevisionTimeout(t *testing.T) {
 	t.Log("Creating a new Service in runLatest")
 	svc, err := createLatestService(t, clients, names, 2)
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 	names.Route = serviceresourcenames.Route(svc)
 	names.Config = serviceresourcenames.Configuration(svc)
@@ -174,7 +174,7 @@ func TestRevisionTimeout(t *testing.T) {
 			},
 		}},
 	}); err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 
 	t.Log("Wait for the service to be ready")
@@ -200,7 +200,7 @@ func TestRevisionTimeout(t *testing.T) {
 		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", service.Status.Traffic)
 	}
 
-	t.Logf("Probing %s", rev5sURL)
+	t.Log("Probing", rev5sURL)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,

--- a/test/conformance/api/v1alpha1/route_test.go
+++ b/test/conformance/api/v1alpha1/route_test.go
@@ -110,13 +110,13 @@ func TestRouteCreation(t *testing.T) {
 	t.Log("Creating a new Route and Configuration")
 	config, err := v1a1test.CreateConfiguration(t, clients, names)
 	if err != nil {
-		t.Fatalf("Failed to create Configuration: %v", err)
+		t.Fatal("Failed to create Configuration:", err)
 	}
 	objects.Config = config
 
 	route, err := v1a1test.CreateRoute(t, clients, names)
 	if err != nil {
-		t.Fatalf("Failed to create Route: %v", err)
+		t.Fatal("Failed to create Route:", err)
 	}
 	objects.Route = route
 
@@ -131,7 +131,7 @@ func TestRouteCreation(t *testing.T) {
 		t.Fatalf("Failed to get URL from route %s: %v", names.Route, err)
 	}
 
-	t.Logf("The Route URL is: %s", url)
+	t.Log("The Route URL is:", url)
 	assertResourcesUpdatedWhenRevisionIsReady(t, clients, names, url, "1", test.PizzaPlanetText1)
 
 	// We start a prober at background thread to test if Route is always healthy even during Route update.

--- a/test/conformance/api/v1alpha1/service_test.go
+++ b/test/conformance/api/v1alpha1/service_test.go
@@ -91,12 +91,12 @@ func TestRunLatestService(t *testing.T) {
 	t.Log("Service should reflect new revision created and ready in status.")
 	names.Revision, err = v1a1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("New image not reflected in Service: %v", err)
+		t.Fatal("New image not reflected in Service:", err)
 	}
 
 	t.Log("Waiting for Service to transition to Ready.")
 	if err := v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, v1a1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("Error waiting for the service to become ready for the latest revision: %v", err)
+		t.Fatal("Error waiting for the service to become ready for the latest revision:", err)
 	}
 
 	// Validate State after Image Update
@@ -139,12 +139,12 @@ func TestRunLatestService(t *testing.T) {
 	t.Log("Waiting for the new revision to appear as LatestRevision.")
 	names.Revision, err = v1a1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("The new revision has not become ready in Service: %v", err)
+		t.Fatal("The new revision has not become ready in Service:", err)
 	}
 
 	t.Log("Waiting for Service to transition to Ready.")
 	if err := v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, v1a1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("Error waiting for the service to become ready for the latest revision: %v", err)
+		t.Fatal("Error waiting for the service to become ready for the latest revision:", err)
 	}
 
 	// Validate the Service shape.
@@ -273,7 +273,7 @@ func TestReleaseService(t *testing.T) {
 
 	t.Log("Validating service shape.")
 	if err := validateReleaseServiceShape(objects); err != nil {
-		t.Fatalf("Release shape is incorrect: %v", err)
+		t.Fatal("Release shape is incorrect:", err)
 	}
 	if err := validateAnnotations(objects); err != nil {
 		t.Errorf("Service annotations are incorrect: %v", err)
@@ -297,7 +297,7 @@ func TestReleaseService(t *testing.T) {
 		}},
 	})
 	if err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 
 	desiredTrafficShape := map[string]v1alpha1.TrafficTarget{
@@ -388,7 +388,7 @@ func TestReleaseService(t *testing.T) {
 		}},
 	})
 	if err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 
 	desiredTrafficShape = map[string]v1alpha1.TrafficTarget{
@@ -485,7 +485,7 @@ func TestReleaseService(t *testing.T) {
 		}},
 	})
 	if err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 
 	// Verify in the end it's still the case.
@@ -562,12 +562,12 @@ func TestAnnotationPropagation(t *testing.T) {
 	t.Log("Service should reflect new revision created and ready in status.")
 	names.Revision, err = v1a1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("New image not reflected in Service: %v", err)
+		t.Fatal("New image not reflected in Service:", err)
 	}
 
 	t.Log("Waiting for Service to transition to Ready.")
 	if err := v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, v1a1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("Error waiting for the service to become ready for the latest revision: %v", err)
+		t.Fatal("Error waiting for the service to become ready for the latest revision:", err)
 	}
 	objects, err = v1a1test.GetResourceObjects(clients, names)
 	if err != nil {
@@ -597,12 +597,12 @@ func TestAnnotationPropagation(t *testing.T) {
 	t.Log("Service should reflect new revision created and ready in status.")
 	names.Revision, err = v1a1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("New image not reflected in Service: %v", err)
+		t.Fatal("New image not reflected in Service:", err)
 	}
 
 	t.Log("Waiting for Service to transition to Ready.")
 	if err := v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, v1a1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("Error waiting for the service to become ready for the latest revision: %v", err)
+		t.Fatal("Error waiting for the service to become ready for the latest revision:", err)
 	}
 	objects, err = v1a1test.GetResourceObjects(clients, names)
 	if err != nil {

--- a/test/conformance/api/v1alpha1/single_threaded_test.go
+++ b/test/conformance/api/v1alpha1/single_threaded_test.go
@@ -48,13 +48,13 @@ func TestSingleConcurrency(t *testing.T) {
 	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
 		v1a1opts.WithContainerConcurrency(1))
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 	url := objects.Service.Status.URL.URL()
 
 	// Ready does not actually mean Ready for a Route just yet.
 	// See https://github.com/knative/serving/issues/1582
-	t.Logf("Probing %s", url)
+	t.Log("Probing", url)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
@@ -69,7 +69,7 @@ func TestSingleConcurrency(t *testing.T) {
 
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
 	if err != nil {
-		t.Fatalf("Error creating spoofing client: %v", err)
+		t.Fatal("Error creating spoofing client:", err)
 	}
 
 	concurrency := 5

--- a/test/conformance/api/v1alpha1/util.go
+++ b/test/conformance/api/v1alpha1/util.go
@@ -64,14 +64,14 @@ func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.U
 		// Check for each of the responses we expect from the base domain.
 		resp := resp
 		g.Go(func() error {
-			t.Logf("Waiting for route to update %s", baseDomain)
+			t.Log("Waiting for route to update", baseDomain)
 			return waitForExpectedResponse(t, clients, baseDomain, resp)
 		})
 	}
 	for i, s := range subdomains {
 		i, s := i, s
 		g.Go(func() error {
-			t.Logf("Waiting for route to update %s", s)
+			t.Log("Waiting for route to update", s)
 			return waitForExpectedResponse(t, clients, s, targetsExpected[i])
 		})
 	}
@@ -197,7 +197,7 @@ func sendRequests(client spoof.Interface, url *url.URL, num int) ([]string, erro
 // The checks in this method should be able to be performed at any point in a
 // runLatest Service's lifecycle so long as the service is in a "Ready" state.
 func validateRunLatestDataPlane(t pkgTest.TLegacy, clients *test.Clients, names test.ResourceNames, expectedText string) error {
-	t.Logf("Checking that the endpoint vends the expected text: %s", expectedText)
+	t.Log("Checking that the endpoint vends the expected text:", expectedText)
 	_, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,

--- a/test/conformance/api/v1alpha1/volumes_test.go
+++ b/test/conformance/api/v1alpha1/volumes_test.go
@@ -56,9 +56,9 @@ func TestConfigMapVolume(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create configmap: %v", err)
+		t.Fatal("Failed to create configmap:", err)
 	}
-	t.Logf("Successfully created configMap: %v", configMap)
+	t.Log("Successfully created configMap:", configMap)
 
 	cleanup := func() {
 		test.TearDown(clients, names)
@@ -127,9 +127,9 @@ func TestProjectedConfigMapVolume(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create configmap: %v", err)
+		t.Fatal("Failed to create configmap:", err)
 	}
-	t.Logf("Successfully created configMap: %v", configMap)
+	t.Log("Successfully created configMap:", configMap)
 
 	cleanup := func() {
 		test.TearDown(clients, names)
@@ -200,9 +200,9 @@ func TestSecretVolume(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create secret: %v", err)
+		t.Fatal("Failed to create secret:", err)
 	}
-	t.Logf("Successfully created secret: %v", secret)
+	t.Log("Successfully created secret:", secret)
 
 	cleanup := func() {
 		test.TearDown(clients, names)
@@ -267,9 +267,9 @@ func TestProjectedSecretVolume(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create secret: %v", err)
+		t.Fatal("Failed to create secret:", err)
 	}
-	t.Logf("Successfully created secret: %v", secret)
+	t.Log("Successfully created secret:", secret)
 
 	cleanup := func() {
 		test.TearDown(clients, names)
@@ -341,9 +341,9 @@ func TestProjectedComplex(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create configmap: %v", err)
+		t.Fatal("Failed to create configmap:", err)
 	}
-	t.Logf("Successfully created configMap: %v", configMap)
+	t.Log("Successfully created configMap:", configMap)
 
 	// Create the Secret with random text.
 	secret, err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Create(&corev1.Secret{
@@ -355,9 +355,9 @@ func TestProjectedComplex(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create secret: %v", err)
+		t.Fatal("Failed to create secret:", err)
 	}
-	t.Logf("Successfully created secret: %v", secret)
+	t.Log("Successfully created secret:", secret)
 
 	cleanup := func() {
 		test.TearDown(clients, names)

--- a/test/conformance/api/v1beta1/blue_green_test.go
+++ b/test/conformance/api/v1beta1/blue_green_test.go
@@ -102,7 +102,7 @@ func TestBlueGreenRoute(t *testing.T) {
 			Percent:      ptr.Int64(50),
 		}},
 	}); err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 
 	t.Log("Wait for the service domains to be ready")
@@ -133,7 +133,7 @@ func TestBlueGreenRoute(t *testing.T) {
 	// does not expose a Status, so we rely on probes to know when they are effective.
 	// Since we are updating the service the teal domain probe will succeed before our changes
 	// take effect so we probe the green domain.
-	t.Logf("Probing %s", greenURL)
+	t.Log("Probing", greenURL)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
@@ -160,6 +160,6 @@ func TestBlueGreenRoute(t *testing.T) {
 		return checkDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
 	})
 	if err := g.Wait(); err != nil {
-		t.Fatalf("Error sending requests: %v", err)
+		t.Fatal("Error sending requests:", err)
 	}
 }

--- a/test/conformance/api/v1beta1/configuration_test.go
+++ b/test/conformance/api/v1beta1/configuration_test.go
@@ -150,7 +150,7 @@ func checkNoKeysPresent(expected map[string]string, actual map[string]string, t 
 		}
 	}
 	if len(present) != 0 {
-		t.Logf("Unexpected keys: %v", present)
+		t.Log("Unexpected keys:", present)
 	}
 	return len(present) == 0
 }

--- a/test/conformance/api/v1beta1/errorcondition_test.go
+++ b/test/conformance/api/v1beta1/errorcondition_test.go
@@ -62,7 +62,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	t.Logf("Creating a new Service %s", names.Service)
 	svc, err := createService(t, clients, names, 2)
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 
 	names.Config = serviceresourcenames.Configuration(svc)
@@ -91,7 +91,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	}, "ContainerImageNotPresent")
 
 	if err != nil {
-		t.Fatalf("Failed to validate configuration state: %s", err)
+		t.Fatal("Failed to validate configuration state:", err)
 	}
 
 	revisionName, err := getRevisionFromConfiguration(clients, names.Config)
@@ -113,7 +113,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	}, "ImagePathInvalid")
 
 	if err != nil {
-		t.Fatalf("Failed to validate revision state: %s", err)
+		t.Fatal("Failed to validate revision state:", err)
 	}
 
 	t.Log("Checking to ensure Route is in desired state")
@@ -190,7 +190,7 @@ func TestContainerExitingMsg(t *testing.T) {
 			}, "ConfigContainersCrashing")
 
 			if err != nil {
-				t.Fatalf("Failed to validate configuration state: %s", err)
+				t.Fatal("Failed to validate configuration state:", err)
 			}
 
 			revisionName, err := getRevisionFromConfiguration(clients, names.Config)
@@ -212,7 +212,7 @@ func TestContainerExitingMsg(t *testing.T) {
 			}, "RevisionContainersCrashing")
 
 			if err != nil {
-				t.Fatalf("Failed to validate revision state: %s", err)
+				t.Fatal("Failed to validate revision state:", err)
 			}
 		})
 	}

--- a/test/conformance/api/v1beta1/generatename_test.go
+++ b/test/conformance/api/v1beta1/generatename_test.go
@@ -124,7 +124,7 @@ func TestServiceGenerateName(t *testing.T) {
 	defer func() { test.TearDown(clients, names) }()
 
 	// Create the service using the generate name field. If the serivce does not become ready this will fail.
-	t.Logf("Creating new service with generateName %s", generateName)
+	t.Log("Creating new service with generateName", generateName)
 	resources, err := v1b1test.CreateServiceReady(t, clients, &names, setServiceGenerateName(generateName))
 	if err != nil {
 		t.Fatalf("Failed to create service with generateName %s: %v", generateName, err)
@@ -159,7 +159,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer func() { test.TearDown(clients, names) }()
 
-	t.Logf("Creating new configuration with generateName %s", generateName)
+	t.Log("Creating new configuration with generateName", generateName)
 	config, err := v1b1test.CreateConfiguration(t, clients, names, setConfigurationGenerateName(generateName))
 	if err != nil {
 		t.Fatalf("Failed to create configuration with generateName %s: %v", generateName, err)
@@ -180,7 +180,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 	}
 
 	// Create a route that maps to the revision created by the configuration above
-	t.Logf("Create new Route with generateName %s", generateName)
+	t.Log("Create new Route with generateName", generateName)
 	route, err := v1b1test.CreateRoute(t, clients, names, setRouteGenerateName(generateName))
 	if err != nil {
 		t.Fatalf("Failed to create route with generateName %s: %v", generateName, err)

--- a/test/conformance/api/v1beta1/resources_test.go
+++ b/test/conformance/api/v1beta1/resources_test.go
@@ -75,7 +75,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 	}
 
 	sendPostRequest := func(resolvableDomain bool, url *url.URL) (*spoof.Response, error) {
-		t.Logf("Request %s", url)
+		t.Log("Request", url)
 		client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), resolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
 		if err != nil {
 			return nil, err

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -113,7 +113,7 @@ func TestRevisionTimeout(t *testing.T) {
 	t.Log("Creating a new Service ")
 	svc, err := createService(t, clients, names, 2)
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 	names.Route = serviceresourcenames.Route(svc)
 	names.Config = serviceresourcenames.Configuration(svc)
@@ -170,7 +170,7 @@ func TestRevisionTimeout(t *testing.T) {
 			Percent:      ptr.Int64(50),
 		}},
 	}); err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 
 	t.Log("Wait for the service domains to be ready")
@@ -196,7 +196,7 @@ func TestRevisionTimeout(t *testing.T) {
 		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", service.Status.Traffic)
 	}
 
-	t.Logf("Probing %s", rev5sURL)
+	t.Log("Probing", rev5sURL)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,

--- a/test/conformance/api/v1beta1/route_test.go
+++ b/test/conformance/api/v1beta1/route_test.go
@@ -113,13 +113,13 @@ func TestRouteCreation(t *testing.T) {
 	t.Log("Creating a new Route and Configuration")
 	config, err := v1b1test.CreateConfiguration(t, clients, names)
 	if err != nil {
-		t.Fatalf("Failed to create Configuration: %v", err)
+		t.Fatal("Failed to create Configuration:", err)
 	}
 	objects.Config = config
 
 	route, err := v1b1test.CreateRoute(t, clients, names)
 	if err != nil {
-		t.Fatalf("Failed to create Route: %v", err)
+		t.Fatal("Failed to create Route:", err)
 	}
 	objects.Route = route
 
@@ -134,7 +134,7 @@ func TestRouteCreation(t *testing.T) {
 		t.Fatalf("Failed to get URL from route %s: %v", names.Route, err)
 	}
 
-	t.Logf("The Route URL is: %s", url)
+	t.Log("The Route URL is:", url)
 	assertResourcesUpdatedWhenRevisionIsReady(t, clients, names, url, "1", test.PizzaPlanetText1)
 
 	// We start a prober at background thread to test if Route is always healthy even during Route update.

--- a/test/conformance/api/v1beta1/service_test.go
+++ b/test/conformance/api/v1beta1/service_test.go
@@ -93,12 +93,12 @@ func TestService(t *testing.T) {
 	t.Log("Service should reflect new revision created and ready in status.")
 	names.Revision, err = v1b1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("New image not reflected in Service: %v", err)
+		t.Fatal("New image not reflected in Service:", err)
 	}
 
 	t.Log("Waiting for Service to transition to Ready.")
 	if err := v1b1test.WaitForServiceState(clients.ServingBetaClient, names.Service, v1b1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("Error waiting for the service to become ready for the latest revision: %v", err)
+		t.Fatal("Error waiting for the service to become ready for the latest revision:", err)
 	}
 
 	// Validate State after Image Update
@@ -141,12 +141,12 @@ func TestService(t *testing.T) {
 	t.Log("Waiting for the new revision to appear as LatestRevision.")
 	names.Revision, err = v1b1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("The new revision has not become ready in Service: %v", err)
+		t.Fatal("The new revision has not become ready in Service:", err)
 	}
 
 	t.Log("Waiting for Service to transition to Ready.")
 	if err := v1b1test.WaitForServiceState(clients.ServingBetaClient, names.Service, v1b1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("Error waiting for the service to become ready for the latest revision: %v", err)
+		t.Fatal("Error waiting for the service to become ready for the latest revision:", err)
 	}
 
 	// Validate the Service shape.
@@ -273,7 +273,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 
 	t.Log("Validating service shape.")
 	if err := validateReleaseServiceShape(objects); err != nil {
-		t.Fatalf("Release shape is incorrect: %v", err)
+		t.Fatal("Release shape is incorrect:", err)
 	}
 	if err := validateAnnotations(objects); err != nil {
 		t.Errorf("Service annotations are incorrect: %v", err)
@@ -293,7 +293,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		}},
 	})
 	if err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 
 	desiredTrafficShape := map[string]v1.TrafficTarget{
@@ -372,7 +372,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		}},
 	})
 	if err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 
 	desiredTrafficShape = map[string]v1.TrafficTarget{
@@ -455,7 +455,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		}},
 	})
 	if err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 
 	// Verify in the end it's still the case.
@@ -529,12 +529,12 @@ func TestAnnotationPropagation(t *testing.T) {
 	t.Log("Service should reflect new revision created and ready in status.")
 	names.Revision, err = v1b1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("New image not reflected in Service: %v", err)
+		t.Fatal("New image not reflected in Service:", err)
 	}
 
 	t.Log("Waiting for Service to transition to Ready.")
 	if err := v1b1test.WaitForServiceState(clients.ServingBetaClient, names.Service, v1b1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("Error waiting for the service to become ready for the latest revision: %v", err)
+		t.Fatal("Error waiting for the service to become ready for the latest revision:", err)
 	}
 	objects, err = v1b1test.GetResourceObjects(clients, names)
 	if err != nil {
@@ -562,12 +562,12 @@ func TestAnnotationPropagation(t *testing.T) {
 	t.Log("Service should reflect new revision created and ready in status.")
 	names.Revision, err = v1b1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("New image not reflected in Service: %v", err)
+		t.Fatal("New image not reflected in Service:", err)
 	}
 
 	t.Log("Waiting for Service to transition to Ready.")
 	if err := v1b1test.WaitForServiceState(clients.ServingBetaClient, names.Service, v1b1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("Error waiting for the service to become ready for the latest revision: %v", err)
+		t.Fatal("Error waiting for the service to become ready for the latest revision:", err)
 	}
 	objects, err = v1b1test.GetResourceObjects(clients, names)
 	if err != nil {

--- a/test/conformance/api/v1beta1/single_threaded_test.go
+++ b/test/conformance/api/v1beta1/single_threaded_test.go
@@ -48,13 +48,13 @@ func TestSingleConcurrency(t *testing.T) {
 
 	objects, err := v1b1test.CreateServiceReady(t, clients, &names, rtesting.WithContainerConcurrency(1))
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 	url := objects.Service.Status.URL.URL()
 
 	// Ready does not actually mean Ready for a Route just yet.
 	// See https://github.com/knative/serving/issues/1582
-	t.Logf("Probing %s", url)
+	t.Log("Probing", url)
 	if _, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,
@@ -68,7 +68,7 @@ func TestSingleConcurrency(t *testing.T) {
 
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
 	if err != nil {
-		t.Fatalf("Error creating spoofing client: %v", err)
+		t.Fatal("Error creating spoofing client:", err)
 	}
 
 	concurrency := 5

--- a/test/conformance/api/v1beta1/util.go
+++ b/test/conformance/api/v1beta1/util.go
@@ -64,14 +64,14 @@ func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.U
 		// Check for each of the responses we expect from the base domain.
 		resp := resp
 		g.Go(func() error {
-			t.Logf("Waiting for route to update %s", baseDomain)
+			t.Log("Waiting for route to update", baseDomain)
 			return waitForExpectedResponse(t, clients, baseDomain, resp)
 		})
 	}
 	for i, s := range subdomains {
 		i, s := i, s
 		g.Go(func() error {
-			t.Logf("Waiting for route to update %s", s)
+			t.Log("Waiting for route to update", s)
 			return waitForExpectedResponse(t, clients, s, targetsExpected[i])
 		})
 	}
@@ -197,7 +197,7 @@ func sendRequests(client spoof.Interface, url *url.URL, num int) ([]string, erro
 // The checks in this method should be able to be performed at any point in a
 // runLatest Service's lifecycle so long as the service is in a "Ready" state.
 func validateDataPlane(t pkgTest.TLegacy, clients *test.Clients, names test.ResourceNames, expectedText string) error {
-	t.Logf("Checking that the endpoint vends the expected text: %s", expectedText)
+	t.Log("Checking that the endpoint vends the expected text:", expectedText)
 	_, err := pkgTest.WaitForEndpointState(
 		clients.KubeClient,
 		t.Logf,

--- a/test/conformance/api/v1beta1/volumes_test.go
+++ b/test/conformance/api/v1beta1/volumes_test.go
@@ -56,9 +56,9 @@ func TestConfigMapVolume(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create configmap: %v", err)
+		t.Fatal("Failed to create configmap:", err)
 	}
-	t.Logf("Successfully created configMap: %v", configMap)
+	t.Log("Successfully created configMap:", configMap)
 
 	cleanup := func() {
 		test.TearDown(clients, names)
@@ -126,9 +126,9 @@ func TestProjectedConfigMapVolume(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create configmap: %v", err)
+		t.Fatal("Failed to create configmap:", err)
 	}
-	t.Logf("Successfully created configMap: %v", configMap)
+	t.Log("Successfully created configMap:", configMap)
 
 	cleanup := func() {
 		test.TearDown(clients, names)
@@ -198,9 +198,9 @@ func TestSecretVolume(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create secret: %v", err)
+		t.Fatal("Failed to create secret:", err)
 	}
-	t.Logf("Successfully created secret: %v", secret)
+	t.Log("Successfully created secret:", secret)
 
 	cleanup := func() {
 		test.TearDown(clients, names)
@@ -264,9 +264,9 @@ func TestProjectedSecretVolume(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create secret: %v", err)
+		t.Fatal("Failed to create secret:", err)
 	}
-	t.Logf("Successfully created secret: %v", secret)
+	t.Log("Successfully created secret:", secret)
 
 	cleanup := func() {
 		test.TearDown(clients, names)
@@ -337,9 +337,9 @@ func TestProjectedComplex(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create configmap: %v", err)
+		t.Fatal("Failed to create configmap:", err)
 	}
-	t.Logf("Successfully created configMap: %v", configMap)
+	t.Log("Successfully created configMap:", configMap)
 
 	// Create the Secret with random text.
 	secret, err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Create(&corev1.Secret{
@@ -351,9 +351,9 @@ func TestProjectedComplex(t *testing.T) {
 		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to create secret: %v", err)
+		t.Fatal("Failed to create secret:", err)
 	}
-	t.Logf("Successfully created secret: %v", secret)
+	t.Log("Successfully created secret:", secret)
 
 	cleanup := func() {
 		test.TearDown(clients, names)

--- a/test/conformance/certificate/http01/certificate_test.go
+++ b/test/conformance/certificate/http01/certificate_test.go
@@ -46,12 +46,12 @@ func TestHTTP01Challenge(t *testing.T) {
 				return len(c.Status.HTTP01Challenges) == len(c.Spec.DNSNames), nil
 			},
 			t.Name()); err != nil {
-			t.Fatalf("failed to wait for HTTP01 challenges: %v", err)
+			t.Fatal("failed to wait for HTTP01 challenges:", err)
 		}
 
 		cert, err := clients.NetworkingClient.Certificates.Get(cert.Name, metav1.GetOptions{})
 		if err != nil {
-			t.Fatalf("failed to fetch certificate: %v", err)
+			t.Fatal("failed to fetch certificate:", err)
 		}
 
 		utils.VerifyChallenges(t, clients, cert)

--- a/test/conformance/certificate/nonhttp01/certificate_test.go
+++ b/test/conformance/certificate/nonhttp01/certificate_test.go
@@ -35,7 +35,7 @@ func TestSecret(t *testing.T) {
 
 	t.Logf("Waiting for Certificate %q to transition to Ready", cert.Name)
 	if err := utils.WaitForCertificateState(clients.NetworkingClient, cert.Name, utils.IsCertificateReady, "CertificateIsReady"); err != nil {
-		t.Fatalf("Error waiting for the certificate to become ready for the latest revision: %v", err)
+		t.Fatal("Error waiting for the certificate to become ready for the latest revision:", err)
 	}
 
 	err := utils.WaitForCertificateSecret(t, clients, cert, t.Name())

--- a/test/conformance/certificate/utils.go
+++ b/test/conformance/certificate/utils.go
@@ -64,7 +64,7 @@ func CreateCertificate(t *testing.T, clients *test.Clients, dnsNames []string) (
 
 	cert, err := clients.NetworkingClient.Certificates.Create(cert)
 	if err != nil {
-		t.Fatalf("Error creating Certificate: %v", err)
+		t.Fatal("Error creating Certificate:", err)
 	}
 
 	return cert, cleanup

--- a/test/conformance/ingress/grpc_test.go
+++ b/test/conformance/ingress/grpc_test.go
@@ -75,7 +75,7 @@ func TestGRPC(t *testing.T) {
 		}),
 	)
 	if err != nil {
-		t.Fatalf("Dial() = %v", err)
+		t.Fatal("Dial() =", err)
 	}
 	defer conn.Close()
 	pc := ping.NewPingServiceClient(conn)
@@ -85,7 +85,7 @@ func TestGRPC(t *testing.T) {
 
 	stream, err := pc.PingStream(ctx)
 	if err != nil {
-		t.Fatalf("PingStream() = %v", err)
+		t.Fatal("PingStream() =", err)
 	}
 
 	for i := 0; i < 100; i++ {
@@ -147,7 +147,7 @@ func TestGRPCSplit(t *testing.T) {
 		}),
 	)
 	if err != nil {
-		t.Fatalf("Dial() = %v", err)
+		t.Fatal("Dial() =", err)
 	}
 	defer conn.Close()
 	pc := ping.NewPingServiceClient(conn)

--- a/test/conformance/ingress/timeout_test.go
+++ b/test/conformance/ingress/timeout_test.go
@@ -101,7 +101,7 @@ func checkTimeout(t *testing.T, client *http.Client, name string, code int, init
 	resp, err := client.Get(fmt.Sprintf("http://%s.example.com?initialTimeout=%d&timeout=%d",
 		name, initial.Milliseconds(), timeout.Milliseconds()))
 	if err != nil {
-		t.Fatalf("Error making GET request: %v", err)
+		t.Fatal("Error making GET request:", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != code {

--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -536,7 +536,7 @@ func createService(t *testing.T, clients *test.Clients, svc *corev1.Service) con
 	})
 	svc, err := clients.KubeClient.Kube.CoreV1().Services(svc.Namespace).Create(svc)
 	if err != nil {
-		t.Fatalf("Error creating Service: %v", err)
+		t.Fatal("Error creating Service:", err)
 	}
 
 	return func() {
@@ -555,7 +555,7 @@ func createPodAndService(t *testing.T, clients *test.Clients, pod *corev1.Pod, s
 	test.CleanupOnInterrupt(func() { clients.KubeClient.Kube.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{}) })
 	pod, err := clients.KubeClient.Kube.CoreV1().Pods(pod.Namespace).Create(pod)
 	if err != nil {
-		t.Fatalf("Error creating Pod: %v", err)
+		t.Fatal("Error creating Pod:", err)
 	}
 	cancel := func() {
 		err := clients.KubeClient.Kube.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})
@@ -570,7 +570,7 @@ func createPodAndService(t *testing.T, clients *test.Clients, pod *corev1.Pod, s
 	svc, err = clients.KubeClient.Kube.CoreV1().Services(svc.Namespace).Create(svc)
 	if err != nil {
 		cancel()
-		t.Fatalf("Error creating Service: %v", err)
+		t.Fatal("Error creating Service:", err)
 	}
 
 	// Wait for the Pod to show up in the Endpoints resource.
@@ -590,7 +590,7 @@ func createPodAndService(t *testing.T, clients *test.Clients, pod *corev1.Pod, s
 	})
 	if waitErr != nil {
 		cancel()
-		t.Fatalf("Error waiting for Endpoints to contain a Pod IP: %v", waitErr)
+		t.Fatal("Error waiting for Endpoints to contain a Pod IP:", waitErr)
 	}
 
 	return func() {
@@ -622,7 +622,7 @@ func CreateIngress(t *testing.T, clients *test.Clients, spec v1alpha1.IngressSpe
 	test.CleanupOnInterrupt(func() { clients.NetworkingClient.Ingresses.Delete(ing.Name, &metav1.DeleteOptions{}) })
 	ing, err := clients.NetworkingClient.Ingresses.Create(ing)
 	if err != nil {
-		t.Fatalf("Error creating Ingress: %v", err)
+		t.Fatal("Error creating Ingress:", err)
 	}
 
 	return ing, func() {
@@ -639,12 +639,12 @@ func CreateIngressReadyDialContext(t *testing.T, clients *test.Clients, spec v1a
 
 	if err := v1a1test.WaitForIngressState(clients.NetworkingClient, ing.Name, v1a1test.IsIngressReady, t.Name()); err != nil {
 		cancel()
-		t.Fatalf("Error waiting for ingress state: %v", err)
+		t.Fatal("Error waiting for ingress state:", err)
 	}
 	ing, err := clients.NetworkingClient.Ingresses.Get(ing.Name, metav1.GetOptions{})
 	if err != nil {
 		cancel()
-		t.Fatalf("Error getting Ingress: %v", err)
+		t.Fatal("Error getting Ingress:", err)
 	}
 
 	// Create a dialer based on the Ingress' public load balancer.
@@ -683,12 +683,12 @@ func UpdateIngress(t *testing.T, clients *test.Clients, name string, spec v1alph
 
 	ing, err := clients.NetworkingClient.Ingresses.Get(name, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Error getting Ingress: %v", err)
+		t.Fatal("Error getting Ingress:", err)
 	}
 
 	ing.Spec = spec
 	if _, err := clients.NetworkingClient.Ingresses.Update(ing); err != nil {
-		t.Fatalf("Error updating Ingress: %v", err)
+		t.Fatal("Error updating Ingress:", err)
 	}
 }
 
@@ -697,7 +697,7 @@ func UpdateIngressReady(t *testing.T, clients *test.Clients, name string, spec v
 	UpdateIngress(t, clients, name, spec)
 
 	if err := v1a1test.WaitForIngressState(clients.NetworkingClient, name, v1a1test.IsIngressReady, t.Name()); err != nil {
-		t.Fatalf("Error waiting for ingress state: %v", err)
+		t.Fatal("Error waiting for ingress state:", err)
 	}
 }
 
@@ -712,13 +712,13 @@ func CreateTLSSecretWithCertPool(t *testing.T, clients *test.Clients, hosts []st
 
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
 	if err != nil {
-		t.Fatalf("ecdsa.GenerateKey() = %v", err)
+		t.Fatal("ecdsa.GenerateKey() =", err)
 	}
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := cryptorand.Int(cryptorand.Reader, serialNumberLimit)
 	if err != nil {
-		t.Fatalf("Failed to generate serial number: %v", err)
+		t.Fatal("Failed to generate serial number:", err)
 	}
 
 	template := x509.Certificate{
@@ -741,12 +741,12 @@ func CreateTLSSecretWithCertPool(t *testing.T, clients *test.Clients, hosts []st
 
 	derBytes, err := x509.CreateCertificate(cryptorand.Reader, &template, &template, &priv.PublicKey, priv)
 	if err != nil {
-		t.Fatalf("x509.CreateCertificate() = %v", err)
+		t.Fatal("x509.CreateCertificate() =", err)
 	}
 
 	cert, err := x509.ParseCertificate(derBytes)
 	if err != nil {
-		t.Fatalf("ParseCertificate() = %v", err)
+		t.Fatal("ParseCertificate() =", err)
 	}
 	// Ideally we'd undo this in "cancel", but there doesn't
 	// seem to be a mechanism to remove things from a pool.
@@ -754,16 +754,16 @@ func CreateTLSSecretWithCertPool(t *testing.T, clients *test.Clients, hosts []st
 
 	certPEM := &bytes.Buffer{}
 	if err := pem.Encode(certPEM, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
-		t.Fatalf("Failed to write data to cert.pem: %s", err)
+		t.Fatal("Failed to write data to cert.pem:", err)
 	}
 
 	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
 	if err != nil {
-		t.Fatalf("Unable to marshal private key: %v", err)
+		t.Fatal("Unable to marshal private key:", err)
 	}
 	privPEM := &bytes.Buffer{}
 	if err := pem.Encode(privPEM, &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}); err != nil {
-		t.Fatalf("Failed to write data to key.pem: %s", err)
+		t.Fatal("Failed to write data to key.pem:", err)
 	}
 
 	name := test.ObjectNameForTest(t)
@@ -785,7 +785,7 @@ func CreateTLSSecretWithCertPool(t *testing.T, clients *test.Clients, hosts []st
 		clients.KubeClient.Kube.CoreV1().Secrets(secret.Namespace).Delete(secret.Name, &metav1.DeleteOptions{})
 	})
 	if _, err := clients.KubeClient.Kube.CoreV1().Secrets(secret.Namespace).Create(secret); err != nil {
-		t.Fatalf("Error creating Secret: %v", err)
+		t.Fatal("Error creating Secret:", err)
 	}
 	return name, func() {
 		err := clients.KubeClient.Kube.CoreV1().Secrets(secret.Namespace).Delete(secret.Name, &metav1.DeleteOptions{})
@@ -819,7 +819,7 @@ func CreateDialContext(t *testing.T, ing *v1alpha1.Ingress, clients *test.Client
 	internalDomain := ing.Status.PublicLoadBalancer.Ingress[0].DomainInternal
 	parts := strings.SplitN(internalDomain, ".", 3)
 	if len(parts) < 3 {
-		t.Fatalf("Too few parts in internal domain: %s", internalDomain)
+		t.Fatal("Too few parts in internal domain:", internalDomain)
 	}
 	name, namespace := parts[0], parts[1]
 

--- a/test/conformance/ingress/websocket_test.go
+++ b/test/conformance/ingress/websocket_test.go
@@ -75,7 +75,7 @@ func TestWebsocket(t *testing.T) {
 	u := url.URL{Scheme: "ws", Host: domain, Path: "/"}
 	conn, _, err := dialer.Dial(u.String(), http.Header{"Host": {domain}})
 	if err != nil {
-		t.Fatalf("Dial() = %v", err)
+		t.Fatal("Dial() =", err)
 	}
 	defer conn.Close()
 
@@ -142,7 +142,7 @@ func TestWebsocketSplit(t *testing.T) {
 	for i := 0; i < maxRequests; i++ {
 		conn, _, err := dialer.Dial(u.String(), http.Header{"Host": {domain}})
 		if err != nil {
-			t.Fatalf("Dial() = %v", err)
+			t.Fatal("Dial() =", err)
 		}
 		defer conn.Close()
 

--- a/test/conformance/runtime/cgroup_test.go
+++ b/test/conformance/runtime/cgroup_test.go
@@ -64,7 +64,7 @@ func TestMustHaveCgroupConfigured(t *testing.T) {
 
 	_, ri, err := fetchRuntimeInfo(t, clients, WithResourceRequirements(resources))
 	if err != nil {
-		t.Fatalf("Error fetching runtime info: %v", err)
+		t.Fatal("Error fetching runtime info:", err)
 	}
 
 	cgroups := ri.Host.Cgroups
@@ -120,7 +120,7 @@ func TestShouldHaveCgroupReadOnly(t *testing.T) {
 	clients := test.Setup(t)
 	_, ri, err := fetchRuntimeInfo(t, clients)
 	if err != nil {
-		t.Fatalf("Error fetching runtime info: %v", err)
+		t.Fatal("Error fetching runtime info:", err)
 	}
 
 	cgroups := ri.Host.Cgroups

--- a/test/conformance/runtime/cmd_args_test.go
+++ b/test/conformance/runtime/cmd_args_test.go
@@ -44,7 +44,7 @@ func TestCmdArgs(t *testing.T) {
 
 	_, ri, err := fetchRuntimeInfo(t, clients, withCmdArgs(cmds, args))
 	if err != nil {
-		t.Fatalf("Failed to fetch runtime info: %v", err)
+		t.Fatal("Failed to fetch runtime info:", err)
 	}
 
 	want := append(cmds, args...)

--- a/test/conformance/runtime/file_descriptor_test.go
+++ b/test/conformance/runtime/file_descriptor_test.go
@@ -31,7 +31,7 @@ func TestShouldHaveStdinEOF(t *testing.T) {
 
 	_, ri, err := fetchRuntimeInfo(t, clients)
 	if err != nil {
-		t.Fatalf("Error fetching runtime info: %v", err)
+		t.Fatal("Error fetching runtime info:", err)
 	}
 
 	if ri.Host == nil {

--- a/test/conformance/runtime/header_test.go
+++ b/test/conformance/runtime/header_test.go
@@ -42,7 +42,7 @@ func TestMustHaveHeadersSet(t *testing.T) {
 
 	_, ri, err := fetchRuntimeInfo(t, clients)
 	if err != nil {
-		t.Fatalf("Error fetching runtime info: %v", err)
+		t.Fatal("Error fetching runtime info:", err)
 	}
 
 	// For incoming requests, the Host header is promoted to the
@@ -97,7 +97,7 @@ func TestShouldHaveHeadersSet(t *testing.T) {
 
 	_, ri, err := fetchRuntimeInfo(t, clients, pkgTest.WithHeader(userHeaders))
 	if err != nil {
-		t.Fatalf("Error fetching runtime info: %v", err)
+		t.Fatal("Error fetching runtime info:", err)
 	}
 
 	headers := ri.Request.Headers

--- a/test/conformance/runtime/protocol_test.go
+++ b/test/conformance/runtime/protocol_test.go
@@ -67,7 +67,7 @@ func TestProtocols(t *testing.T) {
 			clients := test.Setup(t)
 			_, ri, err := fetchRuntimeInfo(t, clients, withPort(tt.portName))
 			if err != nil {
-				t.Fatalf("Failed to fetch runtime info: %v", err)
+				t.Fatal("Failed to fetch runtime info:", err)
 			}
 
 			if tt.wantMajor != ri.Request.ProtoMajor || tt.wantMinor != ri.Request.ProtoMinor {

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -87,7 +87,7 @@ func TestProbeRuntime(t *testing.T) {
 			}
 			// Check if scaling down works even if access from liveness probe exists.
 			if err := e2e.WaitForScaleToZero(t, revisionresourcenames.Deployment(resources.Revision), clients); err != nil {
-				t.Fatalf("Could not scale to zero: %v", err)
+				t.Fatal("Could not scale to zero:", err)
 			}
 		})
 	}

--- a/test/conformance/runtime/sysctl_test.go
+++ b/test/conformance/runtime/sysctl_test.go
@@ -33,7 +33,7 @@ func TestShouldHaveSysctlReadOnly(t *testing.T) {
 	clients := test.Setup(t)
 	_, ri, err := fetchRuntimeInfo(t, clients)
 	if err != nil {
-		t.Fatalf("Error fetching runtime info: %v", err)
+		t.Fatal("Error fetching runtime info:", err)
 	}
 
 	mounts := ri.Host.Mounts

--- a/test/conformance/runtime/user_test.go
+++ b/test/conformance/runtime/user_test.go
@@ -47,7 +47,7 @@ func TestMustRunAsUser(t *testing.T) {
 	// default user's working dir.
 	_, ri, err := fetchRuntimeInfo(t, clients, WithSecurityContext(securityContext), WithWorkingDir("/"))
 	if err != nil {
-		t.Fatalf("Error fetching runtime info: %v", err)
+		t.Fatal("Error fetching runtime info:", err)
 	}
 
 	if ri.Host == nil {
@@ -78,7 +78,7 @@ func TestShouldRunAsUserContainerDefault(t *testing.T) {
 	_, ri, err := fetchRuntimeInfo(t, clients)
 
 	if err != nil {
-		t.Fatalf("Error fetching runtime info: %v", err)
+		t.Fatal("Error fetching runtime info:", err)
 	}
 
 	if ri.Host == nil {

--- a/test/conformance/runtime/workingdir_test.go
+++ b/test/conformance/runtime/workingdir_test.go
@@ -40,7 +40,7 @@ func TestWorkingDirService(t *testing.T) {
 
 	_, ri, err := fetchRuntimeInfo(t, clients, withWorkingDir(wd))
 	if err != nil {
-		t.Fatalf("Failed to fetch runtime info: %v", err)
+		t.Fatal("Failed to fetch runtime info:", err)
 	}
 
 	if ri.Host.User.Cwd.Directory != wd {

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -66,7 +66,7 @@ func TestActivatorOverload(t *testing.T) {
 			service.Spec.Template.Annotations = map[string]string{"autoscaling.knative.dev/maxScale": "10"}
 		})
 	if err != nil {
-		t.Fatalf("Unable to create resources: %v", err)
+		t.Fatal("Unable to create resources:", err)
 	}
 
 	// Make sure the service responds correctly before scaling to 0.
@@ -90,7 +90,7 @@ func TestActivatorOverload(t *testing.T) {
 	domain := resources.Route.Status.URL.Host
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
 	if err != nil {
-		t.Fatalf("Error creating the Spoofing client: %v", err)
+		t.Fatal("Error creating the Spoofing client:", err)
 	}
 
 	url := fmt.Sprintf("http://%s/?timeout=%d", domain, serviceSleep)

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -576,7 +576,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 
 	cfg, err := autoscalerCM(ctx.clients)
 	if err != nil {
-		t.Fatalf("Error retrieving autoscaler configmap: %v", err)
+		t.Fatal("Error retrieving autoscaler configmap:", err)
 	}
 	var (
 		grp    errgroup.Group
@@ -594,7 +594,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 
 	// Wait for the activator endpoints to equalize.
 	if err := waitForActivatorEndpoints(ctx.resources, ctx.clients); err != nil {
-		t.Fatalf("Never got Activator endpoints in the service: %v", err)
+		t.Fatal("Never got Activator endpoints in the service:", err)
 	}
 
 	// Start second load generator.
@@ -611,7 +611,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 		// We want exactly 2. Not 1, not panicing 3, just 2.
 		return x == 2, nil
 	}); err != nil {
-		t.Fatalf("Desired scale of 2 never achieved: %v", err)
+		t.Fatal("Desired scale of 2 never achieved:", err)
 	}
 
 	// Now read the service endpoints and make sure there are 2 endpoints there.
@@ -643,18 +643,18 @@ func TestTargetBurstCapacityMinusOne(t *testing.T) {
 
 	_, err := autoscalerCM(ctx.clients)
 	if err != nil {
-		t.Fatalf("Error retrieving autoscaler configmap: %v", err)
+		t.Fatal("Error retrieving autoscaler configmap:", err)
 	}
 	aeps, err := ctx.clients.KubeClient.Kube.CoreV1().Endpoints(
 		system.Namespace()).Get(networking.ActivatorServiceName, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Error getting activator endpoints: %v", err)
+		t.Fatal("Error getting activator endpoints:", err)
 	}
-	t.Logf("Activator endpoints: %v", aeps)
+	t.Log("Activator endpoints:", aeps)
 
 	// Wait for the activator endpoints to equalize.
 	if err := waitForActivatorEndpoints(ctx.resources, ctx.clients); err != nil {
-		t.Fatalf("Never got Activator endpoints in the service: %v", err)
+		t.Fatal("Never got Activator endpoints in the service:", err)
 	}
 }
 
@@ -672,7 +672,7 @@ func TestFastScaleToZero(t *testing.T) {
 
 	cfg, err := autoscalerCM(ctx.clients)
 	if err != nil {
-		t.Fatalf("Error retrieving autoscaler configmap: %v", err)
+		t.Fatal("Error retrieving autoscaler configmap:", err)
 	}
 
 	epsL, err := ctx.clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace).List(metav1.ListOptions{
@@ -682,7 +682,7 @@ func TestFastScaleToZero(t *testing.T) {
 		),
 	})
 	if err != nil || len(epsL.Items) == 0 {
-		t.Fatalf("No endpoints or error: %v", err)
+		t.Fatal("No endpoints or error:", err)
 	}
 
 	epsN := epsL.Items[0].Name

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -103,7 +103,7 @@ func testAutoTLS(t *testing.T) {
 				LatestRevision: ptr.Bool(true),
 			}},
 		}); err != nil {
-			t.Fatalf("Failed to update Service route spec: %v", err)
+			t.Fatal("Failed to update Service route spec:", err)
 		}
 		if err = v1test.WaitForRouteState(clients.ServingClient, names.Route, routeTrafficHTTPS, "RouteTrafficIsHTTPS"); err != nil {
 			t.Fatalf("Traffic for route: %s is not HTTPS: %v", names.Route, err)
@@ -111,7 +111,7 @@ func testAutoTLS(t *testing.T) {
 
 		ing, err := clients.NetworkingClient.Ingresses.Get(routenames.Ingress(objects.Route), metav1.GetOptions{})
 		if err != nil {
-			t.Fatalf("Failed to get ingress: %v", err)
+			t.Fatal("Failed to get ingress:", err)
 		}
 		for _, tls := range ing.Spec.TLS {
 			// Each new cert has to be added to the root pool so we can make requests.
@@ -126,7 +126,7 @@ func testAutoTLS(t *testing.T) {
 
 		route, err := clients.ServingClient.Routes.Get(objects.Route.Name, metav1.GetOptions{})
 		if err != nil {
-			t.Fatalf("Failed to get route: %v", err)
+			t.Fatal("Failed to get route:", err)
 		}
 		httpsClient := createHTTPSClient(t, clients, objects, rootCAs)
 		for _, traffic := range route.Status.Traffic {

--- a/test/e2e/autotls/config/disablenscert/main.go
+++ b/test/e2e/autotls/config/disablenscert/main.go
@@ -37,23 +37,23 @@ var env config
 
 func main() {
 	if err := envconfig.Process("", &env); err != nil {
-		log.Fatal("Failed to process environment variable:", err)
+		log.Fatal("Failed to process environment variable: ", err)
 	}
 
 	cfg, err := sharedmain.GetConfig("", "")
 	if err != nil {
-		log.Fatal("Failed to build config:", err)
+		log.Fatal("Failed to build config: ", err)
 	}
 	clients, err := test.NewClientsFromConfig(cfg, test.ServingNamespace)
 	if err != nil {
-		log.Fatal("Failed to create clients:", err)
+		log.Fatal("Failed to create clients: ", err)
 	}
 	whiteLists := sets.String{}
 	if env.NamespaceWithCert != "" {
 		whiteLists.Insert(env.NamespaceWithCert)
 	}
 	if err := disableNamespaceCertWithWhiteList(clients, whiteLists); err != nil {
-		log.Fatal("Failed to disable namespace cert:", err)
+		log.Fatal("Failed to disable namespace cert: ", err)
 	}
 }
 

--- a/test/e2e/autotls/config/dnscleanup/main.go
+++ b/test/e2e/autotls/config/dnscleanup/main.go
@@ -35,6 +35,6 @@ func main() {
 		Domain: env.FullHostName,
 	}
 	if err := config.DeleteDNSRecord(record, env.CloudDNSServiceAccountKeyFile, env.CloudDNSProject, env.DNSZone); err != nil {
-		log.Fatalf("Failed to setup DNS record: %v", err)
+		log.Fatal("Failed to setup DNS record: ", err)
 	}
 }

--- a/test/e2e/autotls/config/dnssetup/main.go
+++ b/test/e2e/autotls/config/dnssetup/main.go
@@ -40,7 +40,7 @@ func main() {
 		log.Fatalf("Failed to process environment variable: %v.", err)
 	}
 	if err := setupDNSRecord(); err != nil {
-		log.Fatalf("Failed to setup DNS record: %v", err)
+		log.Fatal("Failed to setup DNS record: ", err)
 	}
 }
 

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -65,10 +65,10 @@ func TestDestroyPodInflight(t *testing.T) {
 
 	t.Log("Creating a new Route and Configuration")
 	if _, err := v1test.CreateConfiguration(t, clients, names, rtesting.WithConfigRevisionTimeoutSeconds(revisionTimeoutSeconds)); err != nil {
-		t.Fatalf("Failed to create Configuration: %v", err)
+		t.Fatal("Failed to create Configuration:", err)
 	}
 	if _, err := v1test.CreateRoute(t, clients, names); err != nil {
-		t.Fatalf("Failed to create Route: %v", err)
+		t.Fatal("Failed to create Route:", err)
 	}
 
 	t.Log("When the Revision can have traffic routed to it, the Route is marked as Ready")
@@ -90,7 +90,7 @@ func TestDestroyPodInflight(t *testing.T) {
 		return false, nil
 	}, "ConfigurationUpdatedWithRevision")
 	if err != nil {
-		t.Fatalf("Error obtaining Revision's name %v", err)
+		t.Fatal("Error obtaining Revision's name", err)
 	}
 
 	if _, err = pkgTest.WaitForEndpointState(
@@ -107,7 +107,7 @@ func TestDestroyPodInflight(t *testing.T) {
 
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, routeURL.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
 	if err != nil {
-		t.Fatalf("Error creating spoofing client: %v", err)
+		t.Fatal("Error creating spoofing client:", err)
 	}
 
 	// The timeout app sleeps for the time passed via the timeout query parameter in milliseconds
@@ -117,7 +117,7 @@ func TestDestroyPodInflight(t *testing.T) {
 	u.RawQuery = q.Encode()
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
-		t.Fatalf("Error creating http request: %v", err)
+		t.Fatal("Error creating http request:", err)
 	}
 
 	g, _ := errgroup.WithContext(context.Background())
@@ -176,7 +176,7 @@ func TestDestroyPodTimely(t *testing.T) {
 	objects, err := v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
 	if err != nil {
-		t.Fatalf("Failed to create a service: %v", err)
+		t.Fatal("Failed to create a service:", err)
 	}
 	routeURL := objects.Route.Status.URL.URL()
 
@@ -196,7 +196,7 @@ func TestDestroyPodTimely(t *testing.T) {
 		LabelSelector: fmt.Sprintf("%s=%s", serving.RevisionLabelKey, objects.Revision.Name),
 	})
 	if err != nil || len(pods.Items) == 0 {
-		t.Fatalf("No pods or error: %v", err)
+		t.Fatal("No pods or error:", err)
 	}
 	t.Logf("Saw %d pods", len(pods.Items))
 
@@ -261,7 +261,7 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	objects, err := v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
 	if err != nil {
-		t.Fatalf("Failed to create a service: %v", err)
+		t.Fatal("Failed to create a service:", err)
 	}
 	routeURL := objects.Route.Status.URL.URL()
 
@@ -281,7 +281,7 @@ func TestDestroyPodWithRequests(t *testing.T) {
 		LabelSelector: fmt.Sprintf("%s=%s", serving.RevisionLabelKey, objects.Revision.Name),
 	})
 	if err != nil || len(pods.Items) == 0 {
-		t.Fatalf("No pods or error: %v", err)
+		t.Fatal("No pods or error:", err)
 	}
 	t.Logf("Saw %d pods. Pods: %s", len(pods.Items), spew.Sdump(pods))
 
@@ -293,11 +293,11 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	u.RawQuery = q.Encode()
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
-		t.Fatalf("Error creating HTTP request: %v", err)
+		t.Fatal("Error creating HTTP request:", err)
 	}
 	httpClient, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, u.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
 	if err != nil {
-		t.Fatalf("Error creating spoofing client: %v", err)
+		t.Fatal("Error creating spoofing client:", err)
 	}
 
 	// Start several requests staggered with 1s delay.

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -66,7 +66,7 @@ func SetupWithNamespace(t *testing.T, namespace string) *test.Clients {
 		pkgTest.Flags.Cluster,
 		namespace)
 	if err != nil {
-		t.Fatalf("Couldn't initialize clients: %v", err)
+		t.Fatal("Couldn't initialize clients:", err)
 	}
 	return clients
 }

--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -52,7 +52,7 @@ func TestEgressTraffic(t *testing.T) {
 		}))
 
 	if err != nil {
-		t.Fatalf("Failed to create a service: %v", err)
+		t.Fatal("Failed to create a service:", err)
 	}
 	if service.Route.Status.URL == nil {
 		t.Fatalf("Can't get internal request domain: service.Route.Status.URL is nil")

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -90,7 +90,7 @@ func unaryTest(t *testing.T, resources *v1test.ResourceObjects, clients *test.Cl
 	const want = "Hello!"
 	got, err := pingGRPC(host, domain, want)
 	if err != nil {
-		t.Fatalf("gRPC ping = %v", err)
+		t.Fatal("gRPC ping =", err)
 	}
 	if got != want {
 		t.Fatalf("response = %q, want = %q", got, want)
@@ -185,7 +185,7 @@ func loadBalancingTest(t *testing.T, resources *v1test.ResourceObjects, clients 
 	})
 
 	if err := grp.Wait(); err != nil {
-		ctx.t.Fatalf("error: %v", err)
+		ctx.t.Fatal("error: ", err)
 	}
 
 	gotHosts := countKeys()
@@ -273,7 +273,7 @@ func streamTest(t *testing.T, resources *v1test.ResourceObjects, clients *test.C
 	t.Logf("Connecting to grpc-ping using host %q and authority %q", host, domain)
 	conn, err := dial(host, domain)
 	if err != nil {
-		t.Fatalf("Fail to dial: %v", err)
+		t.Fatal("Fail to dial:", err)
 	}
 	defer conn.Close()
 
@@ -285,7 +285,7 @@ func streamTest(t *testing.T, resources *v1test.ResourceObjects, clients *test.C
 
 	stream, err := pc.PingStream(ctx)
 	if err != nil {
-		t.Fatalf("Error creating stream: %v", err)
+		t.Fatal("Error creating stream:", err)
 	}
 
 	count := 3
@@ -296,12 +296,12 @@ func streamTest(t *testing.T, resources *v1test.ResourceObjects, clients *test.C
 
 		err = stream.Send(&ping.Request{Msg: want})
 		if err != nil {
-			t.Fatalf("Error sending request: %v", err)
+			t.Fatal("Error sending request:", err)
 		}
 
 		resp, err := stream.Recv()
 		if err != nil {
-			t.Fatalf("Error receiving response: %v", err)
+			t.Fatal("Error receiving response:", err)
 		}
 
 		got := resp.Msg
@@ -363,7 +363,7 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 		if pkgTest.Flags.IngressEndpoint == "" {
 			host, err = ingress.GetIngressEndpoint(clients.KubeClient.Kube)
 			if err != nil {
-				t.Fatalf("Could not get service endpoint: %v", err)
+				t.Fatal("Could not get service endpoint:", err)
 			}
 		}
 	}
@@ -383,7 +383,7 @@ func TestGRPCUnaryPingViaActivator(t *testing.T) {
 	testGRPC(t,
 		func(t *testing.T, resources *v1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
 			if err := waitForActivatorEndpoints(resources, clients); err != nil {
-				t.Fatalf("Never got Activator endpoints in the service: %v", err)
+				t.Fatal("Never got Activator endpoints in the service:", err)
 			}
 			unaryTest(t, resources, clients, names, host, domain)
 		},
@@ -397,7 +397,7 @@ func TestGRPCStreamingPingViaActivator(t *testing.T) {
 	testGRPC(t,
 		func(t *testing.T, resources *v1test.ResourceObjects, clients *test.Clients, names test.ResourceNames, host, domain string) {
 			if err := waitForActivatorEndpoints(resources, clients); err != nil {
-				t.Fatalf("Never got Activator endpoints in the service: %v", err)
+				t.Fatal("Never got Activator endpoints in the service:", err)
 			}
 			streamTest(t, resources, clients, names, host, domain)
 		},

--- a/test/e2e/image_pull_error_test.go
+++ b/test/e2e/image_pull_error_test.go
@@ -71,7 +71,7 @@ func TestImagePullError(t *testing.T) {
 	}, "ContainerUnpullable")
 
 	if err != nil {
-		t.Fatalf("Failed to validate service state: %s", err)
+		t.Fatal("Failed to validate service state:", err)
 	}
 
 	revisionName, err := revisionFromConfiguration(clients, names.Config)
@@ -93,7 +93,7 @@ func TestImagePullError(t *testing.T) {
 	})
 
 	if err != nil {
-		t.Fatalf("Failed to validate revision state: %s", err)
+		t.Fatal("Failed to validate revision state:", err)
 	}
 }
 

--- a/test/e2e/istio/authorization_test.go
+++ b/test/e2e/istio/authorization_test.go
@@ -116,6 +116,6 @@ func TestClusterLocalAuthorization(t *testing.T) {
 		test.ServingFlags.ResolvableDomain,
 		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https),
 	); err != nil {
-		t.Fatalf("Failed to start endpoint of httpproxy: %v", err)
+		t.Fatal("Failed to start endpoint of httpproxy:", err)
 	}
 }

--- a/test/e2e/istio/probing_test.go
+++ b/test/e2e/istio/probing_test.go
@@ -292,7 +292,7 @@ func TestIstioProbing(t *testing.T) {
 			}
 			err = g.Wait()
 			if err != nil {
-				t.Fatalf("Failed to probe the Service: %v", err)
+				t.Fatal("Failed to probe the Service:", err)
 			}
 		})
 	}
@@ -330,7 +330,7 @@ func setupGateway(t *testing.T, clients *test.Clients, names test.ResourceNames,
 	// Restart the Gateway pods: this is needed because Istio without SDS won't refresh the cert when the secret is updated
 	pods, err := clients.KubeClient.Kube.CoreV1().Pods("istio-system").List(metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
-		t.Fatalf("Failed to list Gateway pods: %v", err)
+		t.Fatal("Failed to list Gateway pods:", err)
 	}
 
 	// TODO(bancel): there is a race condition here if a pod listed in the call above is deleted before calling watch below
@@ -339,7 +339,7 @@ func setupGateway(t *testing.T, clients *test.Clients, names test.ResourceNames,
 	wg.Add(len(pods.Items))
 	wtch, err := clients.KubeClient.Kube.CoreV1().Pods("istio-system").Watch(metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
-		t.Fatalf("Failed to watch Gateway pods: %v", err)
+		t.Fatal("Failed to watch Gateway pods:", err)
 	}
 	defer wtch.Stop()
 
@@ -359,7 +359,7 @@ func setupGateway(t *testing.T, clients *test.Clients, names test.ResourceNames,
 
 	err = clients.KubeClient.Kube.CoreV1().Pods("istio-system").DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
-		t.Fatalf("Failed to delete Gateway pods: %v", err)
+		t.Fatal("Failed to delete Gateway pods:", err)
 	}
 
 	wg.Wait()
@@ -373,7 +373,7 @@ func setupHTTPS(t *testing.T, kubeClient *pkgTest.KubeClient, hosts []string) sp
 
 	cert, key, err := generateCertificate(hosts)
 	if err != nil {
-		t.Fatalf("Failed to generate the certificate: %v", err)
+		t.Fatal("Failed to generate the certificate:", err)
 	}
 
 	rootCAs, _ := x509.SystemCertPool()

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -57,13 +57,13 @@ func TestMinScale(t *testing.T) {
 
 	t.Log("Creating route")
 	if _, err := v1test.CreateRoute(t, clients, names); err != nil {
-		t.Fatalf("Failed to create Route: %v", err)
+		t.Fatal("Failed to create Route:", err)
 	}
 
 	t.Log("Creating configuration")
 	cfg, err := v1test.CreateConfiguration(t, clients, names, withMinScale(minScale))
 	if err != nil {
-		t.Fatalf("Failed to create Configuration: %v", err)
+		t.Fatal("Failed to create Configuration:", err)
 	}
 
 	revName := latestRevisionName(t, clients, names.Config, "")
@@ -88,7 +88,7 @@ func TestMinScale(t *testing.T) {
 
 	t.Log("Updating configuration")
 	if _, err := v1test.PatchConfig(t, clients, cfg, rtesting.WithConfigEnv(corev1.EnvVar{Name: "FOO", Value: "BAR"})); err != nil {
-		t.Fatalf("Failed to update Configuration: %v", err)
+		t.Fatal("Failed to update Configuration:", err)
 	}
 
 	newRevName := latestRevisionName(t, clients, names.Config, revName)

--- a/test/e2e/pod_schedule_error_test.go
+++ b/test/e2e/pod_schedule_error_test.go
@@ -85,7 +85,7 @@ func TestPodScheduleError(t *testing.T) {
 	}, "ContainerUnscheduleable")
 
 	if err != nil {
-		t.Fatalf("Failed to validate service state: %s", err)
+		t.Fatal("Failed to validate service state:", err)
 	}
 
 	revisionName, err := revisionFromConfiguration(clients, names.Config)
@@ -107,7 +107,7 @@ func TestPodScheduleError(t *testing.T) {
 	}, errorReason)
 
 	if err != nil {
-		t.Fatalf("Failed to validate revision state: %s", err)
+		t.Fatal("Failed to validate revision state:", err)
 	}
 }
 

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -193,12 +193,12 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 				// If we don't do this first, then we'll see tons of 503s from the ongoing probes
 				// as we tear down the things they are probing.
 				defer pm.Stop()
-				t.Fatalf("Unexpected error: %v", err)
+				t.Fatal("Unexpected error:", err)
 			}
 
 			// This ProberManager implementation waits for minProbes before actually stopping.
 			if err := pm.Stop(); err != nil {
-				t.Fatalf("Stop() = %v", err)
+				t.Fatal("Stop() =", err)
 			}
 			// Check each of the local SLOs
 			pm.Foreach(func(u *url.URL, p test.Prober) {

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -98,7 +98,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 		if gatewayTarget == "" {
 			var err error
 			if gatewayTarget, err = ingress.GetIngressEndpoint(clients.KubeClient.Kube); err != nil {
-				t.Fatalf("Failed to get gateway IP: %v", err)
+				t.Fatal("Failed to get gateway IP:", err)
 			}
 		}
 		envVars = append(envVars, corev1.EnvVar{
@@ -137,7 +137,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 		test.ServingFlags.ResolvableDomain,
 		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https),
 	); err != nil {
-		t.Fatalf("Failed to start endpoint of httpproxy: %v", err)
+		t.Fatal("Failed to start endpoint of httpproxy:", err)
 	}
 	t.Log("httpproxy is ready.")
 
@@ -150,7 +150,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 			// to resolve the shorter domain(s) off-cluster.
 			return
 		}
-		t.Fatalf("Unexpected error when sending request to helloworld: %v", err)
+		t.Fatal("Unexpected error when sending request to helloworld:", err)
 	}
 	expectedStatus := http.StatusNotFound
 	if accessibleExternal {
@@ -242,12 +242,12 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 			"sidecar.istio.io/inject":          strconv.FormatBool(injectB),
 		}), withInternalVisibility)
 	if err != nil {
-		t.Fatalf("Failed to create a service: %v", err)
+		t.Fatal("Failed to create a service:", err)
 	}
 
 	// Wait for the activator endpoints to equalize.
 	if err := waitForActivatorEndpoints(resources, clients); err != nil {
-		t.Fatalf("Never got Activator endpoints in the service: %v", err)
+		t.Fatal("Never got Activator endpoints in the service:", err)
 	}
 
 	// Send request to helloworld app via httpproxy service

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -134,7 +134,7 @@ func TestSubrouteVisibilityPublicToPrivate(t *testing.T) {
 	serviceName := serviceNameForRoute(subrouteTag1, resources.Route.Name)
 	svc, err := clients.KubeClient.Kube.CoreV1().Services(test.ServingNamespace).Get(serviceName, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Failed to get k8s service to modify: %v", err)
+		t.Fatal("Failed to get k8s service to modify:", err)
 	}
 
 	svcCopy := svc.DeepCopy()
@@ -146,7 +146,7 @@ func TestSubrouteVisibilityPublicToPrivate(t *testing.T) {
 	}
 
 	if _, err = clients.KubeClient.Kube.CoreV1().Services(test.ServingNamespace).Patch(serviceName, types.JSONPatchType, svcpatchBytes); err != nil {
-		t.Fatalf("Failed to patch service: %v", err)
+		t.Fatal("Failed to patch service:", err)
 	}
 
 	//Create subroute2 in kservice.
@@ -158,7 +158,7 @@ func TestSubrouteVisibilityPublicToPrivate(t *testing.T) {
 		})
 
 	if _, err = v1test.UpdateServiceRouteSpec(t, clients, names, v1.RouteSpec{Traffic: ksvcCopyRouteTraffic}); err != nil {
-		t.Fatalf("Failed to patch service: %v", err)
+		t.Fatal("Failed to patch service:", err)
 	}
 
 	if err = v1test.WaitForRouteState(clients.ServingClient, resources.Route.Name, func(r *v1.Route) (bool, error) {
@@ -338,7 +338,7 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 	serviceName1 := serviceNameForRoute(subrouteTag1, resources.Route.Name)
 	svc1, err := clients.KubeClient.Kube.CoreV1().Services(test.ServingNamespace).Get(serviceName1, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Failed to get k8s service to modify: %v", err)
+		t.Fatal("Failed to get k8s service to modify:", err)
 	}
 
 	svc1Copy := svc1.DeepCopy()
@@ -350,11 +350,11 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 	}
 
 	if _, err = clients.KubeClient.Kube.CoreV1().Services(test.ServingNamespace).Patch(serviceName1, types.JSONPatchType, svc1patchBytes); err != nil {
-		t.Fatalf("Failed to patch service: %v", err)
+		t.Fatal("Failed to patch service:", err)
 	}
 
 	if err = v1test.WaitForRouteState(clients.ServingClient, resources.Route.Name, v1test.IsRouteReady, "Route is ready"); err != nil {
-		t.Fatalf("Route did not become ready: %v", err)
+		t.Fatal("Route did not become ready:", err)
 	}
 
 	if isClusterLocal, err := isTrafficClusterLocal(publicRoute.Status.Traffic, subrouteTag1); err != nil {

--- a/test/e2e/websocket.go
+++ b/test/e2e/websocket.go
@@ -70,7 +70,7 @@ func connect(t *testing.T, clients *test.Clients, domain string) (*websocket.Con
 		}
 		if resp == nil {
 			// We don't have an HTTP response, probably TCP errors.
-			t.Logf("Connection failed: %v", err)
+			t.Log("Connection failed:", err)
 			return false, nil
 		}
 
@@ -123,10 +123,10 @@ func uniqueHostConnections(t *testing.T, names test.ResourceNames, size int) (*s
 					}
 
 					if _, ok := uniqueHostConns.LoadOrStore(host, conn); !ok {
-						t.Logf("New pod has been discovered: %s", host)
+						t.Log("New pod has been discovered:", host)
 						return nil
 					} else {
-						t.Logf("Existing pod has been returned: %s", host)
+						t.Log("Existing pod has been returned:", host)
 						conn.Close()
 					}
 				}

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -138,7 +138,7 @@ func TestWebSocket(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 
 	if _, err := v1test.CreateServiceReady(t, clients, &names); err != nil {
-		t.Fatalf("Failed to create WebSocket server: %v", err)
+		t.Fatal("Failed to create WebSocket server:", err)
 	}
 
 	// Validate the websocket connection.
@@ -170,12 +170,12 @@ func TestWebSocketViaActivator(t *testing.T) {
 		}),
 	)
 	if err != nil {
-		t.Fatalf("Failed to create WebSocket server: %v", err)
+		t.Fatal("Failed to create WebSocket server:", err)
 	}
 
 	// Wait for the activator endpoints to equalize.
 	if err := waitForActivatorEndpoints(resources, clients); err != nil {
-		t.Fatalf("Never got Activator endpoints in the service: %v", err)
+		t.Fatal("Never got Activator endpoints in the service:", err)
 	}
 	if err := validateWebSocketConnection(t, clients, names); err != nil {
 		t.Error(err)
@@ -238,7 +238,7 @@ func TestWebSocketBlueGreenRoute(t *testing.T) {
 			Percent:      ptr.Int64(50),
 		}},
 	}); err != nil {
-		t.Fatalf("Failed to update Service route spec: %v", err)
+		t.Fatal("Failed to update Service route spec:", err)
 	}
 
 	t.Log("Wait for the service domains to be ready")
@@ -267,7 +267,7 @@ func TestWebSocketBlueGreenRoute(t *testing.T) {
 	// But since Istio network programming takes some time to take effect
 	// and it doesn't have a Status, we'll probe `green` until it's ready first.
 	if err := validateWebSocketConnection(t, clients, green); err != nil {
-		t.Fatalf("Error initializing WS connection: %v", err)
+		t.Fatal("Error initializing WS connection:", err)
 	}
 
 	// The actual test.

--- a/test/ha/autoscalerhpa_test.go
+++ b/test/ha/autoscalerhpa_test.go
@@ -45,7 +45,7 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 
 	leaderController, err := getLeader(t, clients, autoscalerHPALease)
 	if err != nil {
-		t.Fatalf("Failed to get leader: %v", err)
+		t.Fatal("Failed to get leader:", err)
 	}
 
 	names, resources := createPizzaPlanetService(t,
@@ -65,7 +65,7 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 
 	// Make sure a new leader has been elected
 	if _, err = getLeader(t, clients, autoscalerHPALease); err != nil {
-		t.Fatalf("Failed to find new leader: %v", err)
+		t.Fatal("Failed to find new leader:", err)
 	}
 
 	url := resources.Service.Status.URL.URL()
@@ -81,7 +81,7 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 	t.Log("Service should be able to generate a new revision after changing the leader controller")
 	names.Revision, err = v1test.WaitForServiceLatestRevision(clients, names)
 	if err != nil {
-		t.Fatalf("New image not reflected in Service: %v", err)
+		t.Fatal("New image not reflected in Service:", err)
 	}
 
 	assertServiceEventuallyWorks(t, clients, names, url, test.PizzaPlanetText2)

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -40,7 +40,7 @@ func TestControllerHA(t *testing.T) {
 
 	leaderController, err := getLeader(t, clients, controllerDeploymentName)
 	if err != nil {
-		t.Fatalf("Failed to get leader: %v", err)
+		t.Fatal("Failed to get leader:", err)
 	}
 
 	service1Names, resources := createPizzaPlanetService(t)
@@ -55,7 +55,7 @@ func TestControllerHA(t *testing.T) {
 
 	// Make sure a new leader has been elected
 	if _, err = getLeader(t, clients, controllerDeploymentName); err != nil {
-		t.Fatalf("Failed to find new leader: %v", err)
+		t.Fatal("Failed to find new leader:", err)
 	}
 
 	assertServiceEventuallyWorks(t, clients, service1Names, resources.Service.Status.URL.URL(), test.PizzaPlanetText1)

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -121,7 +121,7 @@ func createPizzaPlanetService(t *testing.T, fopt ...rtesting.ServiceOption) (tes
 	}
 	resources, err := v1test.CreateServiceReady(t, clients, &names, fopt...)
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 
 	assertServiceEventuallyWorks(t, clients, names, resources.Service.Status.URL.URL(), test.PizzaPlanetText1)
@@ -132,7 +132,7 @@ func assertServiceEventuallyWorks(t *testing.T, clients *test.Clients, names tes
 	t.Helper()
 	// Wait for the Service to be ready.
 	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatal("Service not ready: ", err)
+		t.Fatal("Service not ready:", err)
 	}
 	// Wait for the Service to serve the expected text.
 	if _, err := pkgTest.WaitForEndpointState(

--- a/test/performance/benchmarks/dataplane-probe/continuous/main.go
+++ b/test/performance/benchmarks/dataplane-probe/continuous/main.go
@@ -50,7 +50,7 @@ func main() {
 	// Use the benchmark key created
 	mc, err := mako.Setup(ctx)
 	if err != nil {
-		log.Fatalf("Failed to setup mako: %v", err)
+		log.Fatal("Failed to setup mako: ", err)
 	}
 	q, qclose, ctx := mc.Quickstore, mc.ShutDownFunc, mc.Context
 	// Use a fresh context here so that our RPC to terminate the sidecar

--- a/test/performance/benchmarks/deployment-probe/continuous/main.go
+++ b/test/performance/benchmarks/deployment-probe/continuous/main.go
@@ -123,7 +123,7 @@ func main() {
 	}
 	mc, err := mako.Setup(ctx, tags...)
 	if err != nil {
-		log.Fatalf("Failed to setup mako: %v", err)
+		log.Fatal("Failed to setup mako: ", err)
 	}
 	q, qclose, ctx := mc.Quickstore, mc.ShutDownFunc, mc.Context
 	// Use a fresh context here so that our RPC to terminate the sidecar

--- a/test/performance/benchmarks/load-test/continuous/main.go
+++ b/test/performance/benchmarks/load-test/continuous/main.go
@@ -118,7 +118,7 @@ func main() {
 	tbcTag := "tbc=" + *flavor
 	mc, err := mako.Setup(ctx, tbcTag)
 	if err != nil {
-		log.Fatalf("Failed to setup mako: %v", err)
+		log.Fatal("Failed to setup mako: ", err)
 	}
 	q, qclose, ctx := mc.Quickstore, mc.ShutDownFunc, mc.Context
 	// Use a fresh context here so that our RPC to terminate the sidecar

--- a/test/performance/benchmarks/scale-from-zero/continuous/main.go
+++ b/test/performance/benchmarks/scale-from-zero/continuous/main.go
@@ -244,7 +244,7 @@ func testScaleFromZero(clients *test.Clients, count int) {
 	parallelTag := fmt.Sprintf("parallel=%d", count)
 	mc, err := mako.Setup(context.Background(), parallelTag)
 	if err != nil {
-		log.Fatalf("failed to setup mako: %v", err)
+		log.Fatal("failed to setup mako: ", err)
 	}
 	q, qclose, ctx := mc.Quickstore, mc.ShutDownFunc, mc.Context
 	defer qclose(ctx)
@@ -277,7 +277,7 @@ func main() {
 	flag.Parse()
 	clients, err := clientsFromConfig()
 	if err != nil {
-		log.Fatalf("Failed to setup clients: %v", err)
+		log.Fatal("Failed to setup clients: ", err)
 	}
 
 	testScaleFromZero(clients, *parallelCount)

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -51,7 +51,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 	tName := t.Name()
 	perfClients, err := Setup(t)
 	if err != nil {
-		t.Fatalf("Cannot initialize performance client: %v", err)
+		t.Fatal("Cannot initialize performance client:", err)
 	}
 
 	clients := perfClients.E2EClients
@@ -66,7 +66,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 	t.Log("Creating a new Service")
 	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 
 	routeURL := objs.Route.Status.URL.URL()
@@ -85,7 +85,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 	endpoint, err := spoof.ResolveEndpoint(clients.KubeClient.Kube, routeURL.Hostname(), test.ServingFlags.ResolvableDomain,
 		pkgTest.Flags.IngressEndpoint)
 	if err != nil {
-		t.Fatalf("Cannot resolve service endpoint: %v", err)
+		t.Fatal("Cannot resolve service endpoint:", err)
 	}
 
 	u, _ := url.Parse(routeURL.String())
@@ -111,7 +111,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 	tc = append(tc, perf.CreatePerfTestCase(float32(metrics.Latencies.P99.Seconds()*1000), "p99(ms)", tName))
 
 	if err = testgrid.CreateXMLOutput(tc, tName); err != nil {
-		t.Fatalf("Cannot create output xml: %v", err)
+		t.Fatal("Cannot create output xml:", err)
 	}
 }
 

--- a/test/performance/metrics/runtime.go
+++ b/test/performance/metrics/runtime.go
@@ -75,7 +75,7 @@ func fetchStatusInternal(ctx context.Context, duration time.Duration,
 		// Overlay the desired and ready pod counts.
 		deployments, err := f()
 		if err != nil {
-			log.Printf("Error getting deployment(s): %v", err)
+			log.Print("Error getting deployment(s): ", err)
 			return err
 		}
 
@@ -111,7 +111,7 @@ func FetchSKSStatus(
 		// Overlay the SKS "mode".
 		skses, err := sksl.ServerlessServices(namespace).List(selector)
 		if err != nil {
-			log.Printf("Error listing serverless services: %v", err)
+			log.Print("Error listing serverless services: ", err)
 			return err
 		}
 		for _, sks := range skses {

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -62,7 +62,7 @@ func generateTraffic(t *testing.T, client *spoof.SpoofingClient, url string, con
 				default:
 					res, err := client.Do(req)
 					if err != nil {
-						t.Logf("Error sending request: %v", err)
+						t.Log("Error sending request:", err)
 					}
 					resChannel <- res
 				}
@@ -132,14 +132,14 @@ func TestObservedConcurrency(t *testing.T) {
 		})
 	}
 	if err := testgrid.CreateXMLOutput(tc, t.Name()); err != nil {
-		t.Fatalf("Cannot create output xml: %v", err)
+		t.Fatal("Cannot create output xml:", err)
 	}
 }
 
 func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 	perfClients, err := Setup(t)
 	if err != nil {
-		t.Fatalf("Cannot initialize performance client: %v", err)
+		t.Fatal("Cannot initialize performance client:", err)
 	}
 
 	names := test.ResourceNames{
@@ -161,7 +161,7 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 		}),
 		v1opts.WithContainerConcurrency(1))
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 
 	baseURL := objs.Route.Status.URL.URL()
@@ -179,7 +179,7 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, baseURL.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
 	if err != nil {
-		t.Fatalf("Error creating spoofing client: %v", err)
+		t.Fatal("Error creating spoofing client:", err)
 	}
 
 	// This just helps with preallocation.
@@ -204,7 +204,7 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 			}
 			start, end, err := parseResponse(string(response.Body))
 			if err != nil {
-				t.Logf("Failed to parse the body: %v", err)
+				t.Log("Failed to parse the body:", err)
 				failedRequests++
 				continue
 			}
@@ -218,7 +218,7 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 	})
 
 	if err := eg.Wait(); err != nil {
-		t.Fatalf("Failed to generate traffic and process responses: %v", err)
+		t.Fatal("Failed to generate traffic and process responses:", err)
 	}
 	t.Logf("Generated %d requests with %d failed", len(events)+failedRequests, failedRequests)
 

--- a/test/test_images/grpc-ping/main.go
+++ b/test/test_images/grpc-ping/main.go
@@ -63,7 +63,7 @@ func (s *server) PingStream(stream ping.PingService_PingStreamServer) error {
 			return nil
 		}
 		if err != nil {
-			log.Printf("Failed to receive ping: %v", err)
+			log.Print("Failed to receive ping: ", err)
 			return err
 		}
 
@@ -74,7 +74,7 @@ func (s *server) PingStream(stream ping.PingService_PingStreamServer) error {
 		log.Printf("Sending pong: %v", resp.Msg)
 		err = stream.Send(resp)
 		if err != nil {
-			log.Printf("Failed to send pong: %v", err)
+			log.Print("Failed to send pong: ", err)
 			return err
 		}
 	}
@@ -98,7 +98,7 @@ func main() {
 
 	if wantHostname, _ := strconv.ParseBool(os.Getenv("HOSTNAME")); wantHostname {
 		hostname, _ = os.Hostname()
-		log.Printf("Setting hostname in response %s", hostname)
+		log.Print("Setting hostname in response ", hostname)
 	}
 
 	g := grpc.NewServer()

--- a/test/test_images/httpproxy/httpproxy.go
+++ b/test/test_images/httpproxy/httpproxy.go
@@ -68,11 +68,11 @@ func getTargetHostEnv() string {
 func initialHTTPProxy(proxyURL string) *httputil.ReverseProxy {
 	target, err := url.Parse(proxyURL)
 	if err != nil {
-		log.Fatalf("Failed to parse url %v", proxyURL)
+		log.Fatal("Failed to parse url ", proxyURL)
 	}
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.ErrorHandler = func(w http.ResponseWriter, req *http.Request, err error) {
-		log.Printf("error reverse proxying request: %v", err)
+		log.Print("error reverse proxying request: ", err)
 		http.Error(w, err.Error(), http.StatusBadGateway)
 	}
 	return proxy
@@ -92,12 +92,12 @@ func main() {
 	if gateway != "" {
 		targetHost = gateway
 	}
-	targetURL := fmt.Sprintf("http://%s", targetHost)
+	targetURL := fmt.Sprint("http://", targetHost)
 	log.Print("target is " + targetURL)
 	httpProxy = initialHTTPProxy(targetURL)
 
-	address := fmt.Sprintf(":%s", port)
-	log.Printf("Listening on address: %s", address)
+	address := fmt.Sprint(":", port)
+	log.Print("Listening on address: ", address)
 	// Handle forwarding requests which uses "K-Network-Hash" header.
 	probeHandler := network.NewProbeHandler(http.HandlerFunc(handler)).ServeHTTP
 	test.ListenAndServeGracefully(address, probeHandler)

--- a/test/test_images/runtime/main.go
+++ b/test/test_images/runtime/main.go
@@ -40,7 +40,7 @@ func main() {
 	if len(args) > 0 && args[0] == "probe" {
 		url := "http://localhost:" + port
 		if _, err := http.Get(url); err != nil {
-			log.Fatalf("Failed to probe %v", err)
+			log.Fatal("Failed to probe ", err)
 		}
 		return
 	}
@@ -48,6 +48,6 @@ func main() {
 	mux := http.NewServeMux()
 	handlers.InitHandlers(mux)
 
-	log.Printf("Server starting on port %s", port)
+	log.Print("Server starting on port ", port)
 	test.ListenAndServeGracefullyWithHandler(":"+port, mux)
 }

--- a/test/upgrade/probe_test.go
+++ b/test/upgrade/probe_test.go
@@ -40,7 +40,7 @@ func TestProbe(t *testing.T) {
 	// create a named pipe and wait for the upgrade script to write to it
 	// to signal that we should stop probing.
 	if err := syscall.Mkfifo(pipe, 0666); err != nil {
-		t.Fatalf("Failed to create pipe: %v", err)
+		t.Fatal("Failed to create pipe:", err)
 	}
 	defer os.Remove(pipe)
 
@@ -53,7 +53,7 @@ func TestProbe(t *testing.T) {
 
 	objects, err := v1test.CreateServiceReady(t, clients, &names)
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 	url := objects.Service.Status.URL.URL()
 

--- a/test/upgrade/service_postdowngrade_test.go
+++ b/test/upgrade/service_postdowngrade_test.go
@@ -42,7 +42,7 @@ func TestServicePostDowngrade(t *testing.T) {
 	t.Logf("Getting service %q", names.Service)
 	svc, err := clients.ServingClient.Services.Get(names.Service, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Failed to get Service: %v", err)
+		t.Fatal("Failed to get Service:", err)
 	}
 	names.Route = serviceresourcenames.Route(svc)
 	names.Config = serviceresourcenames.Configuration(svc)

--- a/test/upgrade/service_postupgrade_test.go
+++ b/test/upgrade/service_postupgrade_test.go
@@ -75,7 +75,7 @@ func TestBYORevisionPostUpgrade(t *testing.T) {
 			Percent:      ptr.Int64(100),
 		}},
 	}); err != nil {
-		t.Fatalf("Failed to update Service: %v", err)
+		t.Fatal("Failed to update Service:", err)
 	}
 }
 
@@ -105,7 +105,7 @@ func updateService(serviceName string, t *testing.T) {
 	t.Logf("Getting service %q", names.Service)
 	svc, err := clients.ServingClient.Services.Get(names.Service, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Failed to get Service: %v", err)
+		t.Fatal("Failed to get Service:", err)
 	}
 	names.Route = serviceresourcenames.Route(svc)
 	names.Config = serviceresourcenames.Configuration(svc)

--- a/test/upgrade/service_preupgrade_test.go
+++ b/test/upgrade/service_preupgrade_test.go
@@ -44,7 +44,7 @@ func TestServicePreUpgrade(t *testing.T) {
 		}),
 	)
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 	url := resources.Service.Status.URL.URL()
 	assertServiceResourcesUpdated(t, clients, names, url, test.PizzaPlanetText1)
@@ -65,13 +65,13 @@ func TestServicePreUpgradeAndScaleToZero(t *testing.T) {
 		}),
 	)
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 	url := resources.Service.Status.URL.URL()
 	assertServiceResourcesUpdated(t, clients, names, url, test.PizzaPlanetText1)
 
 	if err := e2e.WaitForScaleToZero(t, revisionresourcenames.Deployment(resources.Revision), clients); err != nil {
-		t.Fatalf("Could not scale to zero: %v", err)
+		t.Fatal("Could not scale to zero:", err)
 	}
 }
 
@@ -87,6 +87,6 @@ func TestBYORevisionPreUpgrade(t *testing.T) {
 
 	if _, err := v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithBYORevisionName(byoRevName)); err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 }

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -68,7 +68,7 @@ func createNewService(serviceName string, t *testing.T) {
 
 	resources, err := v1test.CreateServiceReady(t, clients, &names)
 	if err != nil {
-		t.Fatalf("Failed to create Service: %v", err)
+		t.Fatal("Failed to create Service:", err)
 	}
 	url := resources.Service.Status.URL.URL()
 	assertServiceResourcesUpdated(t, clients, names, url, test.PizzaPlanetText1)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:
/assign @vagababov 
/lint
-->
## What
* Fixes the `Printf`, `Infof`, `*f` with a single trailing `%v` or `%s` to the non`f` function
* Fixes the non `f` statements that were wrongly fixed before: `testing` non `f` methods use `fmt.Sprintln` which adds a space between the args while `log`, `zap`, `fmt` non `f` methods use `fmt.Sprint` which doesn't add a space between the args.

## How
Wrote a linter using `go/parser`