### PR TITLE
Add logging to the stats scraper

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -224,13 +224,13 @@ func uniScalerFactoryFunc(endpointsInformer corev1informers.EndpointsInformer,
 
 func statsScraperFactoryFunc(endpointsLister corev1listers.EndpointsLister,
 	podLister corev1listers.PodLister) asmetrics.StatsScraperFactory {
-	return func(metric *av1alpha1.Metric) (asmetrics.StatsScraper, error) {
+	return func(metric *av1alpha1.Metric, logger *zap.SugaredLogger) (asmetrics.StatsScraper, error) {
 		podCounter := resources.NewScopedEndpointsCounter(
 			endpointsLister, metric.Namespace, metric.Spec.ScrapeTarget)
 		// TODO(vagababov): while metric name == revision name, we should utilize the proper
 		// values from the labels.
 		podAccessor := resources.NewPodAccessor(podLister, metric.Namespace, metric.Name)
-		return asmetrics.NewStatsScraper(metric, podCounter, podAccessor)
+		return asmetrics.NewStatsScraper(metric, podCounter, podAccessor, logger)
 	}
 }
 

--- a/pkg/autoscaler/metrics/collector.go
+++ b/pkg/autoscaler/metrics/collector.go
@@ -44,7 +44,7 @@ var (
 )
 
 // StatsScraperFactory creates a StatsScraper for a given Metric.
-type StatsScraperFactory func(*av1alpha1.Metric) (StatsScraper, error)
+type StatsScraperFactory func(*av1alpha1.Metric, *zap.SugaredLogger) (StatsScraper, error)
 
 // Stat defines a single measurement at a point in time
 type Stat struct {
@@ -136,7 +136,7 @@ func NewMetricCollector(statsScraperFactory StatsScraperFactory, logger *zap.Sug
 // it already exist.
 // Map access optimized via double-checked locking.
 func (c *MetricCollector) CreateOrUpdate(metric *av1alpha1.Metric) error {
-	scraper, err := c.statsScraperFactory(metric)
+	scraper, err := c.statsScraperFactory(metric, c.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -461,7 +462,7 @@ func TestMetricCollectorError(t *testing.T) {
 }
 
 func scraperFactory(scraper StatsScraper, err error) StatsScraperFactory {
-	return func(*av1alpha1.Metric) (StatsScraper, error) {
+	return func(*av1alpha1.Metric, *zap.SugaredLogger) (StatsScraper, error) {
 		return scraper, err
 	}
 }


### PR DESCRIPTION
This was requested in the #7804 review, especially to log the errors about pod
scrape failures.
This finishes #5978

/assign @tcnghia 