### PR TITLE
Revert pull/7756

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -38,7 +38,6 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/networking"
-	nv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
@@ -95,11 +94,12 @@ func NewController(
 	c.scaler = newScaler(ctx, psInformerFactory, impl.EnqueueAfter)
 
 	logger.Info("Setting up KPA-Class event handlers")
-
-	paInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+	// Handle only PodAutoscalers that have KPA annotation.
+	paHandler := cache.FilteringResourceEventHandler{
 		FilterFunc: onlyKPAClass,
 		Handler:    controller.HandleAll(impl.Enqueue),
-	})
+	}
+	paInformer.Informer().AddEventHandler(paHandler)
 
 	// When we see PodAutoscalers deleted, clean up the decider.
 	paInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -113,18 +113,20 @@ func NewController(
 		},
 	})
 
-	onlyPAControlled := controller.FilterGroupVersionKind(nv1alpha1.SchemeGroupVersion.WithKind("PodAutoscaler"))
-	handleMatchingControllers := cache.FilteringResourceEventHandler{
-		FilterFunc: pkgreconciler.ChainFilterFuncs(onlyKPAClass, onlyPAControlled),
-		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
-	}
-	sksInformer.Informer().AddEventHandler(handleMatchingControllers)
-	metricInformer.Informer().AddEventHandler(handleMatchingControllers)
-
 	// Watch all the private service endpoints.
 	endpointsInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: pkgreconciler.LabelFilterFunc(networking.ServiceTypeKey, string(networking.ServiceTypePrivate), false),
 		Handler:    controller.HandleAll(impl.EnqueueLabelOfNamespaceScopedResource("", serving.RevisionLabelKey)),
+	})
+
+	sksInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: onlyKPAClass,
+		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+	})
+
+	metricInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: onlyKPAClass,
+		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
 	// Have the Deciders enqueue the PAs whose decisions have changed.

--- a/pkg/reconciler/certificate/controller.go
+++ b/pkg/reconciler/certificate/controller.go
@@ -29,7 +29,6 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/tracker"
 	"knative.dev/serving/pkg/apis/networking"
-	nv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	cmclient "knative.dev/serving/pkg/client/certmanager/injection/client"
 	cmchallengeinformer "knative.dev/serving/pkg/client/certmanager/injection/informers/acme/v1alpha2/challenge"
 	cmcertinformer "knative.dev/serving/pkg/client/certmanager/injection/informers/certmanager/v1alpha2/certificate"
@@ -77,15 +76,14 @@ func NewController(
 		})
 
 	logger.Info("Setting up event handlers")
-	knCertificateInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: pkgreconciler.AnnotationFilterFunc(networking.CertificateClassAnnotationKey, network.CertManagerCertificateClassName, true),
+	classFilterFunc := pkgreconciler.AnnotationFilterFunc(networking.CertificateClassAnnotationKey, network.CertManagerCertificateClassName, true)
+	certHandler := cache.FilteringResourceEventHandler{
+		FilterFunc: classFilterFunc,
 		Handler:    controller.HandleAll(impl.Enqueue),
-	})
+	}
+	knCertificateInformer.Informer().AddEventHandler(certHandler)
 
-	cmCertificateInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupVersionKind(nv1alpha1.SchemeGroupVersion.WithKind("Certificate")),
-		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
-	})
+	cmCertificateInformer.Informer().AddEventHandler(controller.HandleAll(impl.EnqueueControllerOf))
 
 	c.tracker = tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx))
 

--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -115,17 +115,24 @@ func newControllerWithOptions(
 	logger.Info("Setting up event handlers")
 	revisionInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
-	handleMatchingControllers := cache.FilteringResourceEventHandler{
+	deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterGroupKind(v1.Kind("Revision")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
-	}
-	deploymentInformer.Informer().AddEventHandler(handleMatchingControllers)
-	paInformer.Informer().AddEventHandler(handleMatchingControllers)
-	configMapInformer.Informer().AddEventHandler(handleMatchingControllers)
+	})
+
+	paInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterGroupKind(v1.Kind("Revision")),
+		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+	})
 
 	// We don't watch for changes to Image because we don't incorporate any of its
 	// properties into our own status and should work completely in the absence of
 	// a functioning Image controller.
+
+	configMapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterGroupKind(v1.Kind("Revision")),
+		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+	})
 
 	for _, opt := range opts {
 		opt(c)

--- a/pkg/reconciler/service/controller.go
+++ b/pkg/reconciler/service/controller.go
@@ -60,12 +60,15 @@ func NewController(
 	logger.Info("Setting up event handlers")
 	serviceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
-	handleControllerOf := cache.FilteringResourceEventHandler{
+	configurationInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterGroupKind(v1.Kind("Service")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
-	}
-	configurationInformer.Informer().AddEventHandler(handleControllerOf)
-	routeInformer.Informer().AddEventHandler(handleControllerOf)
+	})
+
+	routeInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterGroupKind(v1.Kind("Service")),
+		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+	})
 
 	return impl
 }


### PR DESCRIPTION
After the commit between commit b435f1360 and f02881526, the tests
started time out around `test/e2e.TestSvcToSvcViaActivator`.

e.g
https://testgrid.knative.dev/serving#istio-1.4-no-mesh
https://testgrid.knative.dev/serving#istio-1.5-no-mesh
https://testgrid.knative.dev/serving#kourier-stable

The test `test/e2e.TestSvcToSvcViaActivator`  got time out after 10m
due to Revision is not ready.

This patch reverts the suspicious commit 0b684d2de90c16cca707f4df7ea0aa64f8587d02..

**Release Note**

```release-note
NONE
```

/cc
