### PR TITLE
Minor syntax tweak so value can be reused

### DIFF
--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -118,10 +118,11 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) erro
 					digestError: err,
 				}
 			} else {
+				isServingContainer := len(rev.Spec.Containers) == 1 || len(container.Ports) != 0
 				digests <- digestData{
 					digestValue:        digest,
 					containerName:      container.Name,
-					isServingContainer: len(rev.Spec.Containers) == 1 || len(container.Ports) != 0,
+					isServingContainer: isServingContainer,
 				}
 			}
 			return nil


### PR DESCRIPTION
Totally proprietary request :-)  but we inject some code in this func
and we need to know when we're dealing with the "ServingContainer", just like
the isServingContainer flag needs to know.  Today we replicate the:
```
len(rev.Spec.Containers) == 1 || len(container.Ports) != 0
```
check but that's risky if in the future the logic to determine when we're
on the ServingContainer changes. By storing the result in a var, instead of
doing it in-line in the struct def'n, it allows our code to reuse that logic
w/o having to duplicate it and getting out of sync - thus spending a while
debugging to see why things broke.

This is strictly a syntax change, should have zero impact on the runtime.

Signed-off-by: Doug Davis <dug@us.ibm.com>