### PR TITLE
Rename deprecated functions and small linting nits.

### DIFF
--- a/pkg/http/request_log.go
+++ b/pkg/http/request_log.go
@@ -155,7 +155,7 @@ func (h *RequestLogHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.write(t, h.inputGetter(r, &RequestLogResponse{
 				Code:    rr.ResponseCode,
 				Latency: latency,
-				Size:    (int)(rr.ResponseSize),
+				Size:    rr.ResponseSize,
 			}))
 		}
 	}()

--- a/pkg/reconciler/configuration/controller.go
+++ b/pkg/reconciler/configuration/controller.go
@@ -53,7 +53,7 @@ func NewController(
 	configurationInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	revisionInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupKind(v1.Kind("Configuration")),
+		FilterFunc: controller.FilterControllerGK(v1.Kind("Configuration")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/pkg/reconciler/gc/controller.go
+++ b/pkg/reconciler/gc/controller.go
@@ -59,7 +59,7 @@ func NewController(
 		configurationInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 		revisionInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-			FilterFunc: controller.FilterGroupKind(v1.Kind("Configuration")),
+			FilterFunc: controller.FilterControllerGK(v1.Kind("Configuration")),
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
 

--- a/pkg/reconciler/nscert/controller.go
+++ b/pkg/reconciler/nscert/controller.go
@@ -57,9 +57,8 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		nsInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 		knCertificateInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-			FilterFunc: controller.FilterGroupVersionKind(
-				corev1.SchemeGroupVersion.WithKind("Namespace")),
-			Handler: controller.HandleAll(impl.EnqueueControllerOf),
+			FilterFunc: controller.FilterControllerGVK(corev1.SchemeGroupVersion.WithKind("Namespace")),
+			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
 
 		logger.Info("Setting up ConfigMap receivers")

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -115,7 +115,7 @@ func newTestSetup(t *testing.T, configs ...*corev1.ConfigMap) (
 
 	certEvents := make(chan *v1alpha1.Certificate)
 	fakecertinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Namespace")),
+		FilterFunc: controller.FilterControllerGVK(corev1.SchemeGroupVersion.WithKind("Namespace")),
 		Handler: controller.HandleAll(func(obj interface{}) {
 			certEvents <- obj.(*v1alpha1.Certificate)
 		}),

--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -116,12 +116,12 @@ func newControllerWithOptions(
 	revisionInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupKind(v1.Kind("Revision")),
+		FilterFunc: controller.FilterControllerGK(v1.Kind("Revision")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
 	paInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupKind(v1.Kind("Revision")),
+		FilterFunc: controller.FilterControllerGK(v1.Kind("Revision")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
@@ -130,7 +130,7 @@ func newControllerWithOptions(
 	// a functioning Image controller.
 
 	configMapInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupKind(v1.Kind("Revision")),
+		FilterFunc: controller.FilterControllerGK(v1.Kind("Revision")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/pkg/reconciler/route/controller.go
+++ b/pkg/reconciler/route/controller.go
@@ -96,7 +96,7 @@ func newControllerWithClock(
 	routeInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	serviceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupKind(v1.Kind("Route")),
+		FilterFunc: controller.FilterControllerGK(v1.Kind("Route")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
@@ -130,7 +130,7 @@ func newControllerWithClock(
 	))
 
 	certificateInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupKind(v1.Kind("Route")),
+		FilterFunc: controller.FilterControllerGK(v1.Kind("Route")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/pkg/reconciler/serverlessservice/controller.go
+++ b/pkg/reconciler/serverlessservice/controller.go
@@ -74,7 +74,7 @@ func NewController(
 
 	// Watch all the services that we have created.
 	serviceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupVersionKind(netv1alpha1.SchemeGroupVersion.WithKind("ServerlessService")),
+		FilterFunc: controller.FilterControllerGVK(netv1alpha1.SchemeGroupVersion.WithKind("ServerlessService")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/pkg/reconciler/service/controller.go
+++ b/pkg/reconciler/service/controller.go
@@ -61,12 +61,12 @@ func NewController(
 	serviceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	configurationInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupKind(v1.Kind("Service")),
+		FilterFunc: controller.FilterControllerGK(v1.Kind("Service")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
 	routeInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupKind(v1.Kind("Service")),
+		FilterFunc: controller.FilterControllerGK(v1.Kind("Service")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

- Renamed the `FilterGroup[Version]Kind` functions to `FilterControllerG[V]K` for more clarity.
- Remove an unneeded conversion.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
