### PR TITLE
Remove broken symlinks to cert-manager yamls

### DIFF
--- a/config/200-clusterrole-certmanager.yaml
+++ b/config/200-clusterrole-certmanager.yaml
@@ -1,1 +1,0 @@
-cert-manager/200-clusterrole.yaml

--- a/config/config-certmanager.yaml
+++ b/config/config-certmanager.yaml
@@ -1,1 +1,0 @@
-cert-manager/config.yaml

--- a/config/networking-certmanager.yaml
+++ b/config/networking-certmanager.yaml
@@ -1,1 +1,0 @@
-cert-manager/controller.yaml


### PR DESCRIPTION
Looks like https://github.com/knative/serving/pull/7824 removed `config/cert-manager/*` but several symlinks in `config/` still point at it leading to errors like:

~~~~
ko apply -f config/
2020/05/04 10:55:10 error processing import paths in "config/200-clusterrole-certmanager.yaml": open config/200-clusterrole-certmanager.yaml: no such file or directory
~~~~