### PR TITLE
Attempt to not use retry in KIngress.

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_defaults.go
+++ b/pkg/apis/networking/v1alpha1/ingress_defaults.go
@@ -24,7 +24,6 @@ import (
 	"knative.dev/pkg/apis"
 
 	"knative.dev/serving/pkg/apis/config"
-	"knative.dev/serving/pkg/apis/networking"
 )
 
 // SetDefaults populates default values in Ingress
@@ -76,15 +75,5 @@ func (p *HTTPIngressPath) SetDefaults(ctx context.Context) {
 
 	if p.Timeout == nil {
 		p.Timeout = &metav1.Duration{Duration: maxTimeout}
-	}
-
-	if p.Retries == nil {
-		p.Retries = &HTTPRetry{
-			PerTryTimeout: &metav1.Duration{Duration: maxTimeout},
-			Attempts:      networking.DefaultRetryCount,
-		}
-	}
-	if p.Retries.PerTryTimeout == nil {
-		p.Retries.PerTryTimeout = &metav1.Duration{Duration: maxTimeout}
 	}
 }

--- a/pkg/apis/networking/v1alpha1/ingress_defaults_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_defaults_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"knative.dev/serving/pkg/apis/config"
-	"knative.dev/serving/pkg/apis/networking"
 )
 
 var defaultMaxRevisionTimeout = time.Duration(config.DefaultMaxRevisionTimeoutSeconds) * time.Second
@@ -57,7 +56,7 @@ func TestIngressDefaulting(t *testing.T) {
 			},
 		},
 	}, {
-		name: "split-timeout-retry-defaulting",
+		name: "split-timeout-defaulting",
 		in: &Ingress{
 			Spec: IngressSpec{
 				Rules: []IngressRule{{
@@ -92,10 +91,6 @@ func TestIngressDefaulting(t *testing.T) {
 							}},
 							// Timeout and Retries are filled in.
 							Timeout: &metav1.Duration{Duration: defaultMaxRevisionTimeout},
-							Retries: &HTTPRetry{
-								PerTryTimeout: &metav1.Duration{Duration: defaultMaxRevisionTimeout},
-								Attempts:      networking.DefaultRetryCount,
-							},
 						}},
 					},
 				}},
@@ -161,73 +156,6 @@ func TestIngressDefaulting(t *testing.T) {
 							Timeout: &metav1.Duration{Duration: 10 * time.Second},
 							Retries: &HTTPRetry{
 								PerTryTimeout: &metav1.Duration{Duration: 10 * time.Second},
-								Attempts:      2,
-							},
-						}},
-					},
-				}},
-				Visibility: IngressVisibilityExternalIP,
-			},
-		},
-	}, {
-		name: "perTryTimeout-in-retry-defaulting",
-		in: &Ingress{
-			Spec: IngressSpec{
-				Rules: []IngressRule{{
-					HTTP: &HTTPIngressRuleValue{
-						Paths: []HTTPIngressPath{{
-							Splits: []IngressBackendSplit{{
-								IngressBackend: IngressBackend{
-									ServiceName:      "revision-000",
-									ServiceNamespace: "default",
-									ServicePort:      intstr.FromInt(8080),
-								},
-								Percent: 30,
-							}, {
-								IngressBackend: IngressBackend{
-									ServiceName:      "revision-001",
-									ServiceNamespace: "default",
-									ServicePort:      intstr.FromInt(8080),
-								},
-								Percent: 70,
-							}},
-							Timeout: &metav1.Duration{Duration: 10 * time.Second},
-							Retries: &HTTPRetry{
-								Attempts: 2,
-							},
-						}},
-					},
-				}},
-				Visibility: IngressVisibilityExternalIP,
-			},
-		},
-		want: &Ingress{
-			Spec: IngressSpec{
-				Rules: []IngressRule{{
-					HTTP: &HTTPIngressRuleValue{
-						Paths: []HTTPIngressPath{{
-							Splits: []IngressBackendSplit{{
-								IngressBackend: IngressBackend{
-									ServiceName:      "revision-000",
-									ServiceNamespace: "default",
-									ServicePort:      intstr.FromInt(8080),
-								},
-								// Percent is kept intact.
-								Percent: 30,
-							}, {
-								IngressBackend: IngressBackend{
-									ServiceName:      "revision-001",
-									ServiceNamespace: "default",
-									ServicePort:      intstr.FromInt(8080),
-								},
-								// Percent is kept intact.
-								Percent: 70,
-							}},
-							// Timeout and Retries are kept intact.
-							Timeout: &metav1.Duration{Duration: 10 * time.Second},
-							Retries: &HTTPRetry{
-								// PerTryTimeout is filled in.
-								PerTryTimeout: &metav1.Duration{Duration: defaultMaxRevisionTimeout},
 								Attempts:      2,
 							},
 						}},


### PR DESCRIPTION
As part of https://github.com/knative/serving/issues/6549, we would like to see if we can live without retry in order to decide if we will drop retry entirely from the KIngress API.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*  Do not use retry in KIngress.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
