### PR TITLE
Fix #7446 and just keep the default CM in LE

### DIFF
--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -20,11 +20,6 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 data:
-  # An inactive but valid configuration follows; see example.
-  resourceLock: "leases"
-  leaseDuration: "15s"
-  renewDeadline: "10s"
-  retryPeriod: "2s"
   _example: |
     ################################
     #                              #

--- a/pkg/leaderelection/config_test.go
+++ b/pkg/leaderelection/config_test.go
@@ -96,8 +96,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 }
 func TestServingConfig(t *testing.T) {
-	actual, example := ConfigMapsFromTestFile(t, "config-leader-election",
-		"resourceLock", "leaseDuration", "renewDeadline", "retryPeriod")
+	actual, example := ConfigMapsFromTestFile(t, "config-leader-election")
 	for _, test := range []struct {
 		name string
 		data *corev1.ConfigMap


### PR DESCRIPTION
- 0.14 knows how to deal with empty default
- so we can remove the explicit default


/assign mattmoor