### PR TITLE
Simplify and unify the metric aggreggation when computing averages.

### DIFF
--- a/pkg/autoscaler/metrics/collector.go
+++ b/pkg/autoscaler/metrics/collector.go
@@ -406,3 +406,28 @@ func (c *collection) close() {
 	close(c.stopCh)
 	c.grp.Wait()
 }
+
+// add adds the stats from `src` to `dst`.
+func (dst *Stat) add(src Stat) {
+	dst.AverageConcurrentRequests += src.AverageConcurrentRequests
+	dst.AverageProxiedConcurrentRequests += src.AverageProxiedConcurrentRequests
+	dst.RequestCount += src.RequestCount
+	dst.ProxiedRequestCount += src.ProxiedRequestCount
+}
+
+// average reduces the aggregate stat from `sample` pods to an averaged one over
+// `total` pods.
+//
+// Assumption: A particular pod can stand for other pods, i.e. other pods
+// have similar concurrency and QPS.
+//
+// Hide the actual pods behind scraper and send only one stat for all the
+// customer pods per scraping. The pod name is set to a unique value, i.e.
+// scraperPodName so in autoscaler all stats are either from activator or
+// scraper.
+func (dst *Stat) average(sample, total float64) {
+	dst.AverageConcurrentRequests = dst.AverageConcurrentRequests / sample * total
+	dst.AverageProxiedConcurrentRequests = dst.AverageProxiedConcurrentRequests / sample * total
+	dst.RequestCount = dst.RequestCount / sample * total
+	dst.ProxiedRequestCount = dst.ProxiedRequestCount / sample * total
+}

--- a/pkg/autoscaler/metrics/collector.go
+++ b/pkg/autoscaler/metrics/collector.go
@@ -417,6 +417,7 @@ func (dst *Stat) add(src Stat) {
 
 // average reduces the aggregate stat from `sample` pods to an averaged one over
 // `total` pods.
+// The method performs no checks on the data, i.e. that total is > 0.
 //
 // Assumption: A particular pod can stand for other pods, i.e. other pods
 // have similar concurrency and QPS.

--- a/pkg/autoscaler/metrics/collector.go
+++ b/pkg/autoscaler/metrics/collector.go
@@ -417,7 +417,7 @@ func (dst *Stat) add(src Stat) {
 
 // average reduces the aggregate stat from `sample` pods to an averaged one over
 // `total` pods.
-// The method performs no checks on the data, i.e. that total is > 0.
+// The method performs no checks on the data, i.e. that sample is > 0.
 //
 // Assumption: A particular pod can stand for other pods, i.e. other pods
 // have similar concurrency and QPS.


### PR DESCRIPTION
We have 2 copies of the basically same code and in general it does not look very nice.
So instead extract the functions to the Stat so it can aggregate on itself
 and then just reduce the collection to a trivial loops.

/lint

Followup for #5978.
/assign @yanweiguo @markusthoemmes 