### PR TITLE
Fix wrong env value GATEWAY_NAMESPACE to GATEWAY_NAMESPACE_OVERRIDE

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -32,8 +32,8 @@ function setup_auto_tls_env_variables() {
 
   export CUSTOM_DOMAIN_SUFFIX="$(($RANDOM % 10000)).${E2E_PROJECT_ID}.${DOMAIN_NAME}"
 
-  local INGRESS_NAMESPACE=${GATEWAY_NAMESPACE}
-  if [[ -z "${GATEWAY_NAMESPACE}" ]]; then
+  local INGRESS_NAMESPACE=${GATEWAY_NAMESPACE_OVERRIDE}
+  if [[ -z "${GATEWAY_NAMESPACE_OVERRIDE}" ]]; then
     INGRESS_NAMESPACE="istio-system"
   fi
   local INGRESS_SERVICE=${GATEWAY_OVERRIDE}


### PR DESCRIPTION
## Proposed Changes

This patch replaces `GATEWAY_NAMESPACE` with `GATEWAY_NAMESPACE_OVERRIDE`
in `e2e-auto-tls-tests.sh`.

Fixes #

**Release Note**

```release-note
NONE
```
