### PR TITLE
Align panic threshold with configuration knob.

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -193,7 +193,7 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) ScaleResult {
 	logger.With(zap.String("mode", "panic")).Debugf("Observed average scaling metric value: %0.3f, targeting %0.3f.",
 		observedPanicValue, spec.TargetValue)
 
-	isOverPanicThreshold := observedPanicValue/readyPodsCount >= spec.PanicThreshold
+	isOverPanicThreshold := dppc/readyPodsCount >= spec.PanicThreshold
 
 	a.stateMux.Lock()
 	defer a.stateMux.Unlock()

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -421,7 +421,7 @@ func newTestAutoscalerWithScalingMetric(t *testing.T, targetValue, targetBurstCa
 		TargetValue:         targetValue,
 		TotalValue:          targetValue / targetUtilization, // For UTs presume 75% utilization
 		TargetBurstCapacity: targetBurstCapacity,
-		PanicThreshold:      2 * targetValue,
+		PanicThreshold:      2,
 		MaxScaleUpRate:      10,
 		MaxScaleDownRate:    10,
 		ActivatorCapacity:   activatorCapacity,

--- a/pkg/autoscaler/scaling/multiscaler.go
+++ b/pkg/autoscaler/scaling/multiscaler.go
@@ -59,8 +59,10 @@ type DeciderSpec struct {
 	TargetBurstCapacity float64
 	// ActivatorCapacity is the single activator capacity, for subsetting.
 	ActivatorCapacity float64
-	// PanicThreshold is the threshold value of panic to stable concurrency
-	// ratio to transition into panic mode.
+	// PanicThreshold is the threshold at which panic mode is entered. It represents
+	// a factor of the currently observed load over the panic window over the ready
+	// pods. I.e. if this is 2, panic mode will be entered if the observed metric
+	// is twice as high as the current population can handle.
 	PanicThreshold float64
 	// StableWindow is needed to determine when to exit panic mode.
 	StableWindow time.Duration

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -54,7 +54,7 @@ func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autosc
 	}
 
 	target, total := resources.ResolveMetricTarget(pa, config)
-	panicThreshold := target * panicThresholdPercentage / 100.0
+	panicThreshold := panicThresholdPercentage / 100.0
 
 	tbc := config.TargetBurstCapacity
 	if x, ok := pa.TargetBC(); ok {

--- a/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
@@ -42,11 +42,11 @@ func TestMakeDecider(t *testing.T) {
 	}{{
 		name: "defaults",
 		pa:   pa(),
-		want: decider(withTarget(100.0), withPanicThreshold(200.0), withTotal(100)),
+		want: decider(withTarget(100.0), withPanicThreshold(2.0), withTotal(100)),
 	}, {
 		name: "tu < 1", // See #4449 why Target=100
 		pa:   pa(),
-		want: decider(withTarget(80), withPanicThreshold(160.0), withTotal(100)),
+		want: decider(withTarget(80), withPanicThreshold(2.0), withTotal(100)),
 		cfgOpt: func(c autoscalerconfig.Config) *autoscalerconfig.Config {
 			c.ContainerConcurrencyTargetFraction = 0.8
 			return &c
@@ -54,7 +54,7 @@ func TestMakeDecider(t *testing.T) {
 	}, {
 		name: "scale up and scale down rates",
 		pa:   pa(),
-		want: decider(withTarget(100.0), withPanicThreshold(200.0), withTotal(100),
+		want: decider(withTarget(100.0), withPanicThreshold(2.0), withTotal(100),
 			withScaleUpDownRates(19.84, 19.88)),
 		cfgOpt: func(c autoscalerconfig.Config) *autoscalerconfig.Config {
 			c.MaxScaleUpRate = 19.84
@@ -72,7 +72,7 @@ func TestMakeDecider(t *testing.T) {
 	}, {
 		name: "with container concurrency and tu < 1",
 		pa:   pa(WithPAContainerConcurrency(100)),
-		want: decider(withTarget(80), withTotal(100), withPanicThreshold(160)), // PanicThreshold depends on TCC.
+		want: decider(withTarget(80), withTotal(100), withPanicThreshold(2.0)),
 		cfgOpt: func(c autoscalerconfig.Config) *autoscalerconfig.Config {
 			c.ContainerConcurrencyTargetFraction = 0.8
 			return &c
@@ -80,7 +80,7 @@ func TestMakeDecider(t *testing.T) {
 	}, {
 		name: "with burst capacity set",
 		pa:   pa(WithPAContainerConcurrency(120)),
-		want: decider(withTarget(96), withTotal(120), withPanicThreshold(192), withTargetBurstCapacity(63)),
+		want: decider(withTarget(96), withTotal(120), withPanicThreshold(2.0), withTargetBurstCapacity(63)),
 		cfgOpt: func(c autoscalerconfig.Config) *autoscalerconfig.Config {
 			c.TargetBurstCapacity = 63
 			c.ContainerConcurrencyTargetFraction = 0.8
@@ -89,7 +89,7 @@ func TestMakeDecider(t *testing.T) {
 	}, {
 		name: "with activator capacity override",
 		pa:   pa(),
-		want: decider(withActivatorCapacity(420), withTarget(100.0), withPanicThreshold(200.0), withTotal(100)),
+		want: decider(withActivatorCapacity(420), withTarget(100.0), withPanicThreshold(2.0), withTotal(100)),
 		cfgOpt: func(c autoscalerconfig.Config) *autoscalerconfig.Config {
 			c.ActivatorCapacity = 420
 			return &c
@@ -97,7 +97,7 @@ func TestMakeDecider(t *testing.T) {
 	}, {
 		name: "with burst capacity set on the annotation",
 		pa:   pa(WithPAContainerConcurrency(120), withTBCAnnotation("211")),
-		want: decider(withTarget(96), withTotal(120), withPanicThreshold(192),
+		want: decider(withTarget(96), withTotal(120), withPanicThreshold(2.0),
 			withDeciderTBCAnnotation("211"), withTargetBurstCapacity(211)),
 		cfgOpt: func(c autoscalerconfig.Config) *autoscalerconfig.Config {
 			c.TargetBurstCapacity = 63
@@ -116,7 +116,7 @@ func TestMakeDecider(t *testing.T) {
 		name: "with higher panic target",
 		pa:   pa(WithTargetAnnotation("10"), WithPanicThresholdPercentageAnnotation("400")),
 		want: decider(
-			withTarget(10.0), withPanicThreshold(40.0), withTotal(10),
+			withTarget(10.0), withPanicThreshold(4.0), withTotal(10),
 			withTargetAnnotation("10"), withPanicThresholdPercentageAnnotation("400")),
 	}, {
 		name: "with service name",
@@ -124,12 +124,12 @@ func TestMakeDecider(t *testing.T) {
 		svc:  "rock-solid",
 		want: decider(
 			withService("rock-solid"),
-			withTarget(10.0), withPanicThreshold(40.0), withTotal(10.0),
+			withTarget(10.0), withPanicThreshold(4.0), withTotal(10.0),
 			withTargetAnnotation("10"), withPanicThresholdPercentageAnnotation("400")),
 	}, {
 		name: "with metric annotation",
 		pa:   pa(WithMetricAnnotation("rps")),
-		want: decider(withTarget(100.0), withPanicThreshold(200.0), withTotal(100), withMetric("rps"), withMetricAnnotation("rps")),
+		want: decider(withTarget(100.0), withPanicThreshold(2.0), withTotal(100), withMetric("rps"), withMetricAnnotation("rps")),
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

When reading through this code to document it, I noticed that `PanicThreshold` had a slightly different meaning here than it has on the actual knob configuring it. To avoid confusion, this does a small change to align its meaning without an intended change in the overall computation.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
