### PR TITLE
Patch to mutatingwebhookconfiguration istio-sidecar-injector's sideEffects for CI

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -62,7 +62,11 @@ failed=0
 # Run tests serially in the mesh and https scenarios
 parallelism=""
 use_https=""
-(( MESH )) && parallelism="-parallel 1"
+if (( MESH )); then
+  parallelism="-parallel 1"
+  # This is a workaround until Istio fixes https://github.com/istio/istio/issues/23485.
+  kubectl patch mutatingwebhookconfigurations istio-sidecar-injector -p '{"webhooks": [{"name": "sidecar-injector.istio.io", "sideEffects": "None"}]}'
+fi
 
 if [[ "${ISTIO_VERSION}" == "1.5-latest" ]]; then
   parallelism="-parallel 1"


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/7825

## Proposed Changes

Currently `TestServiceValidationWithInvalidPodSpec` always fails
because MutatingWebhookConfiguration(`istio-sidecar-injector`) does not
set sideEffects and uses default value `Unknown`.
Please refer to https://github.com/knative/serving/issues/7825.

It is just a bug in Istio and actually `admissionregistration.k8s.io/v1`
must [set to `None` or `NoneOnDryRun`](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects).

Hence this patch sets to `None` until Istio fixes https://github.com/istio/istio/issues/23485.

**Release Note**

```release-note
NONE
```
