### PR TITLE
Clean up resources by using yaml path which has the replaced namespace

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -144,7 +144,7 @@ function cleanup_per_selfsigned_namespace_auto_tls() {
   kubectl delete -f ${SERVING_NSCERT_YAML} --ignore-not-found=true
 
   kubectl delete kcert --all -n serving-tests
-  kubectl delete -f ./test/config/autotls/certmanager/selfsigned/ --ignore-not-found=true
+  kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/selfsigned/ --ignore-not-found=true
 }
 
 function setup_dns_record() {
@@ -174,7 +174,7 @@ add_trap "cleanup_auto_tls_common" EXIT SIGKILL SIGTERM SIGQUIT
 subheader "Auto TLS test for per-ksvc certificate provision using self-signed CA"
 setup_selfsigned_per_ksvc_auto_tls
 go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
-kubectl delete -f ./test/config/autotls/certmanager/selfsigned/
+kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/selfsigned/
 
 subheader "Auto TLS test for per-namespace certificate provision using self-signed CA"
 setup_selfsigned_per_namespace_auto_tls
@@ -186,7 +186,7 @@ subheader "Auto TLS test for per-ksvc certificate provision using HTTP01 challen
 setup_http01_auto_tls
 add_trap "delete_dns_record" SIGKILL SIGTERM SIGQUIT
 go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
-kubectl delete -f ./test/config/autotls/certmanager/http01/
+kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
 delete_dns_record
 
 subheader "Cleanup auto tls"


### PR DESCRIPTION
## Proposed Changes

This patch changes yaml path to cleanup resources.

In test scripts, all resources are generated in `${TMP_DIR}` directory and
replaced the namespaces. Hence, we need to use the replaced yaml file
to cleanup resources.

e.g You can see find following errors in any build log.
```
Error from server (NotFound): error when deleting "test/config/autotls/certmanager/selfsigned/config-certmanager.yaml": configmaps "config-certmanager" not found
Error from server (NotFound): error when deleting "test/config/autotls/certmanager/http01/config-certmanager.yaml": configmaps "config-certmanager" not found
Error from server (NotFound): error when deleting "test/config/autotls/certmanager/http01/mesh-issuer.yaml": clusterissuers.cert-manager.io "http01-issuer" not found
```

**Release Note**

```release-note
NONE
```
