### PR TITLE
Update autoscaler package doc comment

### DIFF
--- a/pkg/autoscaler/doc.go
+++ b/pkg/autoscaler/doc.go
@@ -16,13 +16,6 @@ limitations under the License.
 
 /*
 Package autoscaler calculates the number of pods necessary for the desired
-level of concurrency per pod. It operates in two modes, stable mode and panic
-mode.
-
-The stable mode is for general operation while the panic mode has, by default,
-a much shorter window and will be used to quickly scale a revision up if a
-burst of traffic comes in. As the panic window is a lot shorter, it will react
-more quickly to load. The revision will not scale down while in panic mode to
-avoid a lot of churn.
+level of concurrency per pod.
 */
 package autoscaler

--- a/pkg/autoscaler/doc.go
+++ b/pkg/autoscaler/doc.go
@@ -15,25 +15,14 @@ limitations under the License.
 */
 
 /*
-Package autoscaler calculates the number of pods necessary for the
-desired level of concurrency per pod (stableConcurrencyPerPod). It
-operates in two modes, stable mode and panic mode.
+Package autoscaler calculates the number of pods necessary for the desired
+level of concurrency per pod. It operates in two modes, stable mode and panic
+mode.
 
-Stable mode calculates the average concurrency observed over the last
-60 seconds and adjusts the observed pod count to achieve the target
-value. Current observed pod count is the number of unique pod names
-which show up in the last 60 seconds.
-
-Panic mode calculates the average concurrency observed over the last 6
-seconds and adjusts the observed pod count to achieve the stable
-target value. Panic mode is engaged when the observed 6 second average
-concurrency reaches 2x the target stable concurrency. Panic mode will
-last at least 60 seconds--longer if the 2x threshold is repeatedly
-breached. During panic mode the number of pods is never decreased in
-order to prevent flapping.
-
-Package autoscaler supports both single-tenant (one autoscaler per
-revision) and multitenant (one autoscaler for all revisions) autoscalers;
-config/controller.yaml determines which kind of autoscaler is used.
+The stable mode is for general operation while the panic mode has, by default,
+a much shorter window and will be used to quickly scale a revision up if a
+burst of traffic comes in. As the panic window is a lot shorter, it will react
+more quickly to load. The revision will not scale down while in panic mode to
+avoid a lot of churn.
 */
 package autoscaler


### PR DESCRIPTION
The autoscaler package doc comment was last updated in 2018 and refers to a no-longer-existing field `stableConcurrencyPerPod` and to a single-tenant mode, which also no longer exists :)

This updates it with some of @markusthoemmes's nice text from https://knative.dev/development/serving/configuring-autoscaling (which is a bit more generic so shouldn't go out of date so quickly).