### PR TITLE
Order ContainerStatuses the same as spec.Containers

### DIFF
--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -108,9 +108,6 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) erro
 			if err != nil {
 				return errors.New(v1.RevisionContainerMissingMessage(container.Image, fmt.Sprintf("failed to resolve image to digest: %v", err)))
 			} else {
-				if container.Name == "" {
-					return nil
-				}
 				if len(rev.Spec.Containers) == 1 || len(container.Ports) != 0 {
 					rev.Status.DeprecatedImageDigest = digest
 				}
@@ -124,6 +121,7 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) erro
 	}
 	if err := digestGrp.Wait(); err != nil {
 		rev.Status.MarkContainerHealthyFalse(v1.ReasonContainerMissing, err.Error())
+		rev.Status.ContainerStatuses = make([]v1.ContainerStatuses, 0)
 		return err
 	}
 	return nil

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -18,6 +18,7 @@ package revision
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -105,7 +106,7 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) erro
 			digest, err := c.resolver.Resolve(container.Image,
 				opt, cfgs.Deployment.RegistriesSkippingTagResolving)
 			if err != nil {
-				return fmt.Errorf(v1.RevisionContainerMissingMessage(container.Image, fmt.Sprintf("failed to resolve image to digest: %v", err)))
+				return errors.New(v1.RevisionContainerMissingMessage(container.Image, fmt.Sprintf("failed to resolve image to digest: %v", err)))
 			} else {
 				if container.Name == "" {
 					return nil

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -105,7 +105,7 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) erro
 			digest, err := c.resolver.Resolve(container.Image,
 				opt, cfgs.Deployment.RegistriesSkippingTagResolving)
 			if err != nil {
-				return fmt.Errorf(v1.RevisionContainerMissingMessage(container.Image, err.Error()))
+				return fmt.Errorf(v1.RevisionContainerMissingMessage(container.Image, fmt.Sprintf("failed to resolve image to digest: %v", err)))
 			} else {
 				if container.Name == "" {
 					return nil

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -133,7 +133,7 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) erro
 	digestGrp.Wait()
 	close(digests)
 
-	digestSlice := make([]digestData, len(digests))
+	digestSlice := make([]digestData, 0, len(digests))
 	for v := range digests {
 		digestSlice = append(digestSlice, v)
 	}

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -346,12 +346,17 @@ func TestRevWithImageDigests(t *testing.T) {
 
 	rev := testRevision(corev1.PodSpec{
 		Containers: []corev1.Container{{
+			Name:  "first",
 			Image: "gcr.io/repo/image",
 			Ports: []corev1.ContainerPort{{
 				ContainerPort: 8888,
 			}},
 		}, {
+			Name:  "second",
 			Image: "docker.io/repo/image",
+		}, {
+			Name:  "third",
+			Image: "docker.io/anotherrepo/image",
 		}},
 	})
 	createRevision(t, ctx, controller, rev)
@@ -368,6 +373,11 @@ func TestRevWithImageDigests(t *testing.T) {
 	updateRevision(t, ctx, controller, rev)
 	if len(rev.Spec.Containers) != len(rev.Status.ContainerStatuses) {
 		t.Error("Image digests does not match with the provided containers")
+	}
+	for i, c := range rev.Spec.Containers {
+		if c.Name != rev.Status.ContainerStatuses[i].Name {
+			t.Error("Container statuses do not match the order of containers in spec")
+		}
 	}
 	rev.Status.ContainerStatuses = []v1.ContainerStatuses{}
 	updateRevision(t, ctx, controller, rev)


### PR DESCRIPTION
/lint

Fixes #7658

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
* Order ContainerStatuses so it has the same order as spec.Containers

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Order ContainerStatuses so it has the same order as spec.Containers
```
