### PR TITLE
Use ClusterIP for our monitoring services so we can still access them using kubectl proxy

### DIFF
--- a/config/monitoring/metrics/prometheus/100-grafana.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana.yaml
@@ -118,6 +118,23 @@ data:
       options:
         path: /grafana-dashboard-definition/scaling
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: knative-monitoring
+  labels:
+    app: grafana
+    serving.knative.dev/release: devel
+spec:
+  type: NodePort
+  ports:
+  - port: 30802
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    app: grafana
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/config/monitoring/metrics/prometheus/100-grafana.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana.yaml
@@ -127,7 +127,6 @@ metadata:
     app: grafana
     serving.knative.dev/release: devel
 spec:
-  type: NodePort
   ports:
   - port: 30802
     protocol: TCP

--- a/config/monitoring/metrics/prometheus/300-prometheus.yaml
+++ b/config/monitoring/metrics/prometheus/300-prometheus.yaml
@@ -219,6 +219,21 @@ subjects:
   name: prometheus-system
   namespace: knative-monitoring
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-system-np
+  namespace: knative-monitoring
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  type: NodePort
+  selector:
+    app: prometheus
+  ports:
+    - port: 8080
+      targetPort: 9090
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/config/monitoring/metrics/prometheus/300-prometheus.yaml
+++ b/config/monitoring/metrics/prometheus/300-prometheus.yaml
@@ -227,7 +227,6 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 spec:
-  type: NodePort
   selector:
     app: prometheus
   ports:

--- a/third_party/config/monitoring/logging/elasticsearch/kibana.yaml
+++ b/third_party/config/monitoring/logging/elasticsearch/kibana.yaml
@@ -1,3 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana-logging
+  namespace: knative-monitoring
+  labels:
+    app: kibana-logging
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "Kibana"
+spec:
+  type: NodePort
+  selector:
+    app: kibana-logging
+  ports:
+  - port: 5601
+    protocol: TCP
+    targetPort: ui
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/third_party/config/monitoring/logging/elasticsearch/kibana.yaml
+++ b/third_party/config/monitoring/logging/elasticsearch/kibana.yaml
@@ -8,7 +8,6 @@ metadata:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Kibana"
 spec:
-  type: NodePort
   selector:
     app: kibana-logging
   ports:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Use ClusterIP for our monitoring services so we can still access them using `kubectl proxy`. 

See: https://github.com/knative/serving/pull/7640#issuecomment-621397731

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Revert https://github.com/knative/serving/pull/7640
* Use clusterIP service types to expose monitoring services 


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
