### PR TITLE
Implement krshaped for networking

### DIFF
--- a/pkg/apis/networking/v1alpha1/certificate_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/certificate_lifecycle.go
@@ -69,6 +69,11 @@ const (
 
 var certificateCondSet = apis.NewLivingConditionSet(CertificateConditionReady)
 
+// GetConditionSet retrieves the condition set for this resource. Implements the KRShaped interface.
+func (*Certificate) GetConditionSet() apis.ConditionSet {
+	return certificateCondSet
+}
+
 // GetGroupVersionKind returns the GroupVersionKind of Certificate.
 func (c *Certificate) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Certificate")

--- a/pkg/apis/networking/v1alpha1/certificate_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/certificate_lifecycle_test.go
@@ -45,6 +45,14 @@ func TestCertificateDuckTypes(t *testing.T) {
 	}
 }
 
+func TestCertificateGetConditionSet(t *testing.T) {
+	r := &Certificate{}
+	want := apis.ConditionReady
+	if got := r.GetConditionSet().GetTopLevelConditionType(); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}
+
 func TestCertificateGetGroupVersionKind(t *testing.T) {
 	c := Certificate{}
 	expected := SchemeGroupVersion.WithKind("Certificate")

--- a/pkg/apis/networking/v1alpha1/certificate_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/certificate_lifecycle_test.go
@@ -47,9 +47,9 @@ func TestCertificateDuckTypes(t *testing.T) {
 
 func TestCertificateGetConditionSet(t *testing.T) {
 	r := &Certificate{}
-	want := apis.ConditionReady
-	if got := r.GetConditionSet().GetTopLevelConditionType(); got != want {
-		t.Errorf("got: %v, want: %v", got, want)
+
+	if got, want := r.GetConditionSet().GetTopLevelConditionType(), apis.ConditionReady; got != want {
+		t.Errorf("GotConditionSet=%v, want=%v", got, want)
 	}
 }
 

--- a/pkg/apis/networking/v1alpha1/certificate_types.go
+++ b/pkg/apis/networking/v1alpha1/certificate_types.go
@@ -57,6 +57,9 @@ var (
 
 	// Check that we can create OwnerReferences to a Certificate..
 	_ kmeta.OwnerRefable = (*Certificate)(nil)
+
+	// Check that the type conforms to the duck Knative Resource shape.
+	_ duckv1.KRShaped = (*Certificate)(nil)
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -115,4 +118,14 @@ type HTTP01Challenge struct {
 
 	// ServicePort is the port of the service to serve HTTP01 challenge requests.
 	ServicePort intstr.IntOrString `json:"servicePort,omitempty"`
+}
+
+// GetTypeMeta retrieves the ObjectMeta of the Certificate. Implements the KRShaped interface.
+func (t *Certificate) GetTypeMeta() *metav1.TypeMeta {
+	return &t.TypeMeta
+}
+
+// GetStatus retrieves the status of the Certificate. Implements the KRShaped interface.
+func (t *Certificate) GetStatus() *duckv1.Status {
+	return &t.Status.Status
 }

--- a/pkg/apis/networking/v1alpha1/certificate_types_test.go
+++ b/pkg/apis/networking/v1alpha1/certificate_types_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1alpha1
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCertificateGetStatus(t *testing.T) {
+	r := &Certificate{
+		Status: CertificateStatus{},
+	}
+	want := &r.Status.Status
+	if got := r.GetStatus(); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}
+
+func TestCertificateGetObjectMeta(t *testing.T) {
+	r := &Certificate{
+		TypeMeta: metav1.TypeMeta{},
+	}
+	want := &r.TypeMeta
+	if got := r.GetTypeMeta(); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}

--- a/pkg/apis/networking/v1alpha1/certificate_types_test.go
+++ b/pkg/apis/networking/v1alpha1/certificate_types_test.go
@@ -25,9 +25,9 @@ func TestCertificateGetStatus(t *testing.T) {
 	r := &Certificate{
 		Status: CertificateStatus{},
 	}
-	want := &r.Status.Status
-	if got := r.GetStatus(); got != want {
-		t.Errorf("got: %v, want: %v", got, want)
+
+	if got, want := r.GetStatus(), &r.Status.Status; got != want {
+		t.Errorf("GotStatus=%v, want=%v", got, want)
 	}
 }
 
@@ -35,8 +35,8 @@ func TestCertificateGetObjectMeta(t *testing.T) {
 	r := &Certificate{
 		TypeMeta: metav1.TypeMeta{},
 	}
-	want := &r.TypeMeta
-	if got := r.GetTypeMeta(); got != want {
-		t.Errorf("got: %v, want: %v", got, want)
+
+	if got, want := r.GetTypeMeta(), &r.TypeMeta; got != want {
+		t.Errorf("GotTypeMeta=%v, want=%v", got, want)
 	}
 }

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
@@ -28,6 +28,11 @@ var ingressCondSet = apis.NewLivingConditionSet(
 	IngressConditionLoadBalancerReady,
 )
 
+// GetConditionSet retrieves the condition set for this resource. Implements the KRShaped interface.
+func (*Ingress) GetConditionSet() apis.ConditionSet {
+	return ingressCondSet
+}
+
 // GetGroupVersionKind returns SchemeGroupVersion of an Ingress
 func (i *Ingress) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Ingress")

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
@@ -47,9 +47,9 @@ func TestIngressDuckTypes(t *testing.T) {
 
 func TestIngressGetConditionSet(t *testing.T) {
 	r := &Ingress{}
-	want := apis.ConditionReady
-	if got := r.GetConditionSet().GetTopLevelConditionType(); got != want {
-		t.Errorf("got: %v, want: %v", got, want)
+
+	if got, want := r.GetConditionSet().GetTopLevelConditionType(), apis.ConditionReady; got != want {
+		t.Errorf("GotConditionSet=%v, want=%v", got, want)
 	}
 }
 

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
@@ -45,6 +45,14 @@ func TestIngressDuckTypes(t *testing.T) {
 	}
 }
 
+func TestIngressGetConditionSet(t *testing.T) {
+	r := &Ingress{}
+	want := apis.ConditionReady
+	if got := r.GetConditionSet().GetTopLevelConditionType(); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}
+
 func TestIngressGetGroupVersionKind(t *testing.T) {
 	ci := Ingress{}
 	expected := SchemeGroupVersion.WithKind("Ingress")

--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -60,6 +60,9 @@ var (
 
 	// Check that we can create OwnerReferences to a Ingress.
 	_ kmeta.OwnerRefable = (*Ingress)(nil)
+
+	// Check that the type conforms to the duck Knative Resource shape.
+	_ duckv1.KRShaped = (*Ingress)(nil)
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -342,3 +345,13 @@ const (
 	// IngressConditionLoadBalancerReady is set when the Ingress has a ready LoadBalancer.
 	IngressConditionLoadBalancerReady apis.ConditionType = "LoadBalancerReady"
 )
+
+// GetTypeMeta retrieves the ObjectMeta of the Ingress. Implements the KRShaped interface.
+func (t *Ingress) GetTypeMeta() *metav1.TypeMeta {
+	return &t.TypeMeta
+}
+
+// GetStatus retrieves the status of the Ingress. Implements the KRShaped interface.
+func (t *Ingress) GetStatus() *duckv1.Status {
+	return &t.Status.Status
+}

--- a/pkg/apis/networking/v1alpha1/ingress_types_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1alpha1
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIngressGetStatus(t *testing.T) {
+	r := &Ingress{
+		Status: IngressStatus{},
+	}
+	want := &r.Status.Status
+	if got := r.GetStatus(); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}
+
+func TestIngressGetObjectMeta(t *testing.T) {
+	r := &Ingress{
+		TypeMeta: metav1.TypeMeta{},
+	}
+	want := &r.TypeMeta
+	if got := r.GetTypeMeta(); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}

--- a/pkg/apis/networking/v1alpha1/ingress_types_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types_test.go
@@ -39,3 +39,4 @@ func TestIngressGetObjectMeta(t *testing.T) {
 	if got, want := r.GetTypeMeta(), &r.TypeMeta; got != want {
 		t.Errorf("GotTypeMeta=%v, want=%v", got, want)
 	}
+}

--- a/pkg/apis/networking/v1alpha1/ingress_types_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types_test.go
@@ -25,9 +25,9 @@ func TestIngressGetStatus(t *testing.T) {
 	r := &Ingress{
 		Status: IngressStatus{},
 	}
-	want := &r.Status.Status
-	if got := r.GetStatus(); got != want {
-		t.Errorf("got: %v, want: %v", got, want)
+
+	if got, want := r.GetStatus(), &r.Status.Status; got != want {
+		t.Errorf("GotStatus=%v, want=%v", got, want)
 	}
 }
 
@@ -35,8 +35,7 @@ func TestIngressGetObjectMeta(t *testing.T) {
 	r := &Ingress{
 		TypeMeta: metav1.TypeMeta{},
 	}
-	want := &r.TypeMeta
-	if got := r.GetTypeMeta(); got != want {
-		t.Errorf("got: %v, want: %v", got, want)
+
+	if got, want := r.GetTypeMeta(), &r.TypeMeta; got != want {
+		t.Errorf("GotTypeMeta=%v, want=%v", got, want)
 	}
-}

--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
@@ -29,6 +29,11 @@ var serverlessServiceCondSet = apis.NewLivingConditionSet(
 	ServerlessServiceConditionEndspointsPopulated,
 )
 
+// GetConditionSet retrieves the condition set for this resource. Implements the KRShaped interface.
+func (*ServerlessService) GetConditionSet() apis.ConditionSet {
+	return serverlessServiceCondSet
+}
+
 // GetGroupVersionKind returns the GVK for the ServerlessService.
 func (ss *ServerlessService) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("ServerlessService")

--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
@@ -47,11 +47,10 @@ func TestServerlessServiceDuckTypes(t *testing.T) {
 
 func TestServerlessServiceGetConditionSet(t *testing.T) {
 	r := &ServerlessService{}
-	want := apis.ConditionReady
-	if got := r.GetConditionSet().GetTopLevelConditionType(); got != want {
-		t.Errorf("got: %v, want: %v", got, want)
+	
+	if got, want := r.GetConditionSet().GetTopLevelConditionType(), apis.ConditionReady; got != want {
+		t.Errorf("GotConditionSet=%v, want=%v", got, want)
 	}
-}
 
 func TestGetGroupVersionKind(t *testing.T) {
 	ss := ServerlessService{}

--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
@@ -50,6 +50,7 @@ func TestServerlessServiceGetConditionSet(t *testing.T) {
 	if got, want := r.GetConditionSet().GetTopLevelConditionType(), apis.ConditionReady; got != want {
 		t.Errorf("GotConditionSet=%v, want=%v", got, want)
 	}
+}
 
 func TestGetGroupVersionKind(t *testing.T) {
 	ss := ServerlessService{}

--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	apistest "knative.dev/pkg/apis/testing"
@@ -41,6 +42,14 @@ func TestServerlessServiceDuckTypes(t *testing.T) {
 				t.Errorf("VerifyType(ServerlessService, %T) = %v", test.t, err)
 			}
 		})
+	}
+}
+
+func TestServerlessServiceGetConditionSet(t *testing.T) {
+	r := &ServerlessService{}
+	want := apis.ConditionReady
+	if got := r.GetConditionSet().GetTopLevelConditionType(); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
 	}
 }
 

--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
@@ -47,7 +47,6 @@ func TestServerlessServiceDuckTypes(t *testing.T) {
 
 func TestServerlessServiceGetConditionSet(t *testing.T) {
 	r := &ServerlessService{}
-	
 	if got, want := r.GetConditionSet().GetTopLevelConditionType(), apis.ConditionReady; got != want {
 		t.Errorf("GotConditionSet=%v, want=%v", got, want)
 	}

--- a/pkg/apis/networking/v1alpha1/serverlessservice_types.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_types.go
@@ -59,6 +59,9 @@ var (
 
 	// Check that we can create OwnerReferences to a ServerlessService.
 	_ kmeta.OwnerRefable = (*ServerlessService)(nil)
+
+	// Check that the type conforms to the duck Knative Resource shape.
+	_ duckv1.KRShaped = (*ServerlessService)(nil)
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -139,3 +142,13 @@ const (
 	// (e.g. due to target burst capacity settings).
 	ActivatorEndpointsPopulated apis.ConditionType = "ActivatorEndpointsPopulated"
 )
+
+// GetTypeMeta retrieves the ObjectMeta of the ServerlessService. Implements the KRShaped interface.
+func (t *ServerlessService) GetTypeMeta() *metav1.TypeMeta {
+	return &t.TypeMeta
+}
+
+// GetStatus retrieves the status of the ServerlessService. Implements the KRShaped interface.
+func (t *ServerlessService) GetStatus() *duckv1.Status {
+	return &t.Status.Status
+}

--- a/pkg/apis/networking/v1alpha1/serverlessservice_types_test.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_types_test.go
@@ -25,9 +25,9 @@ func TestServerlessServiceGetStatus(t *testing.T) {
 	r := &ServerlessService{
 		Status: ServerlessServiceStatus{},
 	}
-	want := &r.Status.Status
-	if got := r.GetStatus(); got != want {
-		t.Errorf("got: %v, want: %v", got, want)
+
+	if got, want := r.GetStatus(), &r.Status.Status; got != want {
+		t.Errorf("GotStatus=%v, want=%v", got, want)
 	}
 }
 
@@ -35,8 +35,8 @@ func TestServerlessServiceGetObjectMeta(t *testing.T) {
 	r := &ServerlessService{
 		TypeMeta: metav1.TypeMeta{},
 	}
-	want := &r.TypeMeta
-	if got := r.GetTypeMeta(); got != want {
-		t.Errorf("got: %v, want: %v", got, want)
+
+	if got, want := r.GetTypeMeta(), &r.TypeMeta; got != want {
+		t.Errorf("GotTypeMeta=%v, want=%v", got, want)
 	}
 }

--- a/pkg/apis/networking/v1alpha1/serverlessservice_types_test.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_types_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1alpha1
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestServerlessServiceGetStatus(t *testing.T) {
+	r := &ServerlessService{
+		Status: ServerlessServiceStatus{},
+	}
+	want := &r.Status.Status
+	if got := r.GetStatus(); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}
+
+func TestServerlessServiceGetObjectMeta(t *testing.T) {
+	r := &ServerlessService{
+		TypeMeta: metav1.TypeMeta{},
+	}
+	want := &r.TypeMeta
+	if got := r.GetTypeMeta(); got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Issue #1226

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Implements the KRShaped interface for the v1alpha1 networking resources
    * Will allow common logic in the generated reconciler
