### PR TITLE
Update outdated doc link to errors

### DIFF
--- a/test/conformance/api/v1/errorcondition_test.go
+++ b/test/conformance/api/v1/errorcondition_test.go
@@ -40,7 +40,7 @@ const (
 )
 
 // TestContainerErrorMsg is to validate the error condition defined at
-// https://github.com/knative/serving/blob/master/docs/spec/errors.md
+// https://github.com/knative/docs/blob/master/docs/serving/spec/knative-api-specification-1.0.md#error-signalling
 // for the container image missing scenario.
 func TestContainerErrorMsg(t *testing.T) {
 	t.Parallel()

--- a/test/conformance/api/v1alpha1/errorcondition_test.go
+++ b/test/conformance/api/v1alpha1/errorcondition_test.go
@@ -39,7 +39,7 @@ const (
 )
 
 // TestContainerErrorMsg is to validate the error condition defined at
-// https://github.com/knative/serving/blob/master/docs/spec/errors.md
+// https://github.com/knative/docs/blob/master/docs/serving/spec/knative-api-specification-1.0.md#error-signalling
 // for the container image missing scenario.
 func TestContainerErrorMsg(t *testing.T) {
 	t.Parallel()

--- a/test/conformance/api/v1beta1/errorcondition_test.go
+++ b/test/conformance/api/v1beta1/errorcondition_test.go
@@ -40,7 +40,7 @@ const (
 )
 
 // TestContainerErrorMsg is to validate the error condition defined at
-// https://github.com/knative/serving/blob/master/docs/spec/errors.md
+// https://github.com/knative/docs/blob/master/docs/serving/spec/knative-api-specification-1.0.md#error-signalling
 // for the container image missing scenario.
 func TestContainerErrorMsg(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Proposed Changes
Fixing some outdated doc links

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
