### PR TITLE
Increase number of requests for activator HA test to ensure enough stats

### DIFF
--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -38,7 +38,7 @@ import (
 const (
 	activatorDeploymentName = "activator"
 	activatorLabel          = "app=activator"
-	minProbes               = 250  // We want to send at least 250 requests.
+	minProbes               = 400  // We want to send at least 400 requests.
 	SLO                     = 0.99 // We permit 0.01 of requests to fail due to killing the Activator.
 )
 

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -38,7 +38,7 @@ import (
 const (
 	activatorDeploymentName = "activator"
 	activatorLabel          = "app=activator"
-	minProbes               = 100  // We want to send at least 100 requests.
+	minProbes               = 250  // We want to send at least 250 requests.
 	SLO                     = 0.99 // We permit 0.01 of requests to fail due to killing the Activator.
 )
 


### PR DESCRIPTION
Right now it periodically fails with +1..2 requests and those are painful flakes.
So raise number of requests for SLO


/lint
/assign mattmoor @yanweiguo 
/cc @mgencur 