### PR TITLE
Fix flake in TestVisibilitySplit

### DIFF
--- a/test/conformance/ingress/visibility_test.go
+++ b/test/conformance/ingress/visibility_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package ingress
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -28,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/serving/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/pool"
 	"knative.dev/serving/test"
 )
 
@@ -185,15 +187,29 @@ func TestVisibilitySplit(t *testing.T) {
 		// The increment to make for each request, so that the values of seen reflect the
 		// percentage of the total number of requests we are making.
 		increment = 100.0 / totalRequests
-		// Allow the Ingress to be within 5% of the configured value.
-		margin = 5.0
+		// Allow the Ingress to be within 10% of the configured value.
+		margin = 10.0
 	)
+	wg := pool.New(8)
+	resultCh := make(chan string, totalRequests)
+
 	for i := 0.0; i < totalRequests; i++ {
-		ri := RuntimeRequest(t, client, "http://"+publicHostName)
-		if ri == nil {
-			continue
-		}
-		seen[ri.Request.Headers.Get(headerName)] += increment
+		wg.Go(func() error {
+			ri := RuntimeRequest(t, client, "http://"+publicHostName)
+			if ri == nil {
+				return errors.New("failed to request")
+			}
+			resultCh <- ri.Request.Headers.Get(headerName)
+			return nil
+		})
+	}
+	if err := wg.Wait(); err != nil {
+		t.Errorf("Error while sending requests: %v", err)
+	}
+	close(resultCh)
+
+	for r := range resultCh {
+		seen[r] += increment
 	}
 
 	for name, want := range weights {


### PR DESCRIPTION
This patch fixes increases the margin to 10% from 5% in
`TestVisibilitySplit`.

The current 5% margin is not enough to pass the test. Please refer following failed logs:

Example-1. https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-istio-1.5-no-mesh/1258978786263699456
```
    TestVisibilitySplit: visibility_test.go:206: Target "visibility-split-pgcoweur" received 31.400000%, wanted 37.000000 +/- 5.000000
    TestVisibilitySplit: visibility_test.go:206: Target "visibility-split-vyhtslxs" received 21.200000%, wanted 16.000000 +/- 5.000000
```

Example-2: https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-istio-1.5-mesh/1257282446324404224

```
    TestVisibilitySplit: visibility_test.go:206: Target "visibility-split-bcrablqt" received 43.800000%, wanted 37.000000 +/- 5.000000
```

Also this patch changes to test with concurent request like https://github.com/knative/serving/pull/7757.

/lint

**Release Note**

```release-note
NONE
```
