### PR TITLE
Remove unnecessary small window settings.

### DIFF
--- a/test/e2e/istio/authorization_test.go
+++ b/test/e2e/istio/authorization_test.go
@@ -25,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logstream"
-	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/serving"
 	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
@@ -61,8 +60,7 @@ func TestClusterLocalAuthorization(t *testing.T) {
 	resources, err := v1test.CreateServiceReady(t, clients, &names,
 		withInternalVisibility,
 		rtesting.WithConfigAnnotations(map[string]string{
-			autoscaling.WindowAnnotationKey: "6s",    // shortest permitted; this is not required here, but for uniformity.
-			"sidecar.istio.io/inject":       "false", // Do not enable injection otherwise get authentication error.
+			"sidecar.istio.io/inject": "false", // Do not enable injection otherwise get authentication error.
 		}))
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
@@ -99,8 +97,7 @@ func TestClusterLocalAuthorization(t *testing.T) {
 	resources, err = v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithEnv(envVars...),
 		rtesting.WithConfigAnnotations(map[string]string{
-			autoscaling.WindowAnnotationKey: "6s",    // shortest permitted; this is not required here, but for uniformity.
-			"sidecar.istio.io/inject":       "false", // Do not enable injection otherwise get authentication error.
+			"sidecar.istio.io/inject": "false", // Do not enable injection otherwise get authentication error.
 		}))
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -120,8 +120,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 	resources, err := v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithEnv(envVars...),
 		rtesting.WithConfigAnnotations(map[string]string{
-			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
-			"sidecar.istio.io/inject":       strconv.FormatBool(inject),
+			"sidecar.istio.io/inject": strconv.FormatBool(inject),
 		}))
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
@@ -186,11 +185,7 @@ func TestServiceToServiceCall(t *testing.T) {
 
 	withInternalVisibility := rtesting.WithServiceLabel(
 		serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
-	resources, err := v1test.CreateServiceReady(t, clients, &names,
-		withInternalVisibility,
-		rtesting.WithConfigAnnotations(map[string]string{
-			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
-		}))
+	resources, err := v1test.CreateServiceReady(t, clients, &names, withInternalVisibility)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -291,10 +286,7 @@ func TestCallToPublicService(t *testing.T) {
 	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
 	defer test.TearDown(clients, names)
 
-	resources, err := v1test.CreateServiceReady(t, clients, &names,
-		rtesting.WithConfigAnnotations(map[string]string{
-			autoscaling.WindowAnnotationKey: "6s", // shortest permitted; this is not required here, but for uniformity.
-		}))
+	resources, err := v1test.CreateServiceReady(t, clients, &names)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As the respective comments state, the low window settings are not needed at all.

I'm also hunting a "flakecauser" and believe that these settings add unnecessary flakiness currently as they tighten the window of when something can become ready. We should of course fix any timing related bugs too, but that's a separate concern.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
