### PR TITLE
Add experimental RewriteHost field to KIngress

### DIFF
--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -212,6 +212,13 @@ type HTTPIngressPath struct {
 	// +optional
 	Path string `json:"path,omitempty"`
 
+	// RewriteHost rewrites the incoming request's host header. The request will
+	// then be re-evaluated based on the new host header.
+	//
+	// This field is currently experimental and not supported by all Ingress
+	// implementations.
+	RewriteHost string `json:"rewriteHost,omitempty"`
+
 	// Splits defines the referenced service endpoints to which the traffic
 	// will be forwarded to.
 	Splits []IngressBackendSplit `json:"splits"`

--- a/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -217,10 +217,14 @@ type HTTPIngressPath struct {
 	//
 	// This field is currently experimental and not supported by all Ingress
 	// implementations.
+	//
+	// If RewriteHost is specified, Splits must not be.
 	RewriteHost string `json:"rewriteHost,omitempty"`
 
 	// Splits defines the referenced service endpoints to which the traffic
 	// will be forwarded to.
+	//
+	// If Splits are specified, RewriteHost must not be.
 	Splits []IngressBackendSplit `json:"splits"`
 
 	// AppendHeaders allow specifying additional HTTP headers to add

--- a/pkg/apis/networking/v1alpha1/ingress_validation.go
+++ b/pkg/apis/networking/v1alpha1/ingress_validation.go
@@ -109,8 +109,6 @@ func (h HTTPIngressPath) Validate(ctx context.Context) *apis.FieldError {
 				Paths:   []string{"splits"},
 			})
 		}
-	case h.RewriteHost != "":
-		// no validation needed for this case
 	}
 
 	if h.Retries != nil {

--- a/pkg/apis/networking/v1alpha1/ingress_validation.go
+++ b/pkg/apis/networking/v1alpha1/ingress_validation.go
@@ -87,10 +87,12 @@ func (h HTTPIngressPath) Validate(ctx context.Context) *apis.FieldError {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
 	var all *apis.FieldError
-	// Must provide as least one split.
-	if len(h.Splits) == 0 {
-		all = all.Also(apis.ErrMissingField("splits"))
-	} else {
+	switch {
+	case len(h.Splits) == 0 && h.RewriteHost == "":
+		all = all.Also(apis.ErrMissingOneOf("splits", "rewriteHost"))
+	case len(h.Splits) != 0 && h.RewriteHost != "":
+		all = all.Also(apis.ErrMultipleOneOf("splits", "rewriteHost"))
+	case len(h.Splits) != 0:
 		totalPct := 0
 		for idx, split := range h.Splits {
 			if err := split.Validate(ctx); err != nil {
@@ -107,7 +109,10 @@ func (h HTTPIngressPath) Validate(ctx context.Context) *apis.FieldError {
 				Paths:   []string{"splits"},
 			})
 		}
+	case h.RewriteHost != "":
+		// no validation needed for this case
 	}
+
 	if h.Retries != nil {
 		all = all.Also(h.Retries.Validate(ctx).ViaField("retries"))
 	}


### PR DESCRIPTION
First part of #7748. 

Adds the `RewriteHost` field to KIngress and allows it to be specified if-and-only-if `Splits` are not.

**Note:** there are a couple small changes here vs [the proposal doc](https://docs.google.com/document/d/1xK-g55kFdRRpYsiHyesmYWKURWi1sJlIWxMwkRmlyuM): (1) moved field up a level since we don't actually need it to be within splits - happy to bump it back down if anyone has a use case for that (2) didn't introduce a feature flag here since KIngress is internal anyway (feature flag will be required for any user-facing feature consuming the field).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Introduces an experimental `rewriteHost` field to KIngress allowing for host header rewriting.
```

/assign @tcnghia @mattmoor 