### PR TITLE
Rename operation name for activator's proxy span and queue-proxy's span

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -129,7 +129,7 @@ func proxyHandler(reqChan chan network.ReqEvent, breaker *queue.Breaker, tracing
 		}
 
 		if tracingEnabled {
-			proxyCtx, proxySpan := trace.StartSpan(r.Context(), "proxy")
+			proxyCtx, proxySpan := trace.StartSpan(r.Context(), "queue_proxy")
 			r = r.WithContext(proxyCtx)
 			defer proxySpan.End()
 		}
@@ -149,7 +149,7 @@ func proxyHandler(reqChan chan network.ReqEvent, breaker *queue.Breaker, tracing
 		if breaker != nil {
 			var waitSpan *trace.Span
 			if tracingEnabled {
-				_, waitSpan = trace.StartSpan(r.Context(), "queueWait")
+				_, waitSpan = trace.StartSpan(r.Context(), "queue_wait")
 			}
 			if err := breaker.Maybe(r.Context(), func() {
 				waitSpan.End()

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -474,14 +474,14 @@ func TestQueueTraceSpans(t *testing.T) {
 			if len(gotSpans) != tc.wantSpans {
 				t.Errorf("Got %d spans, expected %d", len(gotSpans), tc.wantSpans)
 			}
-			spanNames := []string{"probe", "/", "proxy"}
+			spanNames := []string{"probe", "/", "queue_proxy"}
 			if !tc.probeTrace {
 				spanNames = spanNames[1:]
 			}
 			// We want to add `queueWait` span only if there is possible queueing
 			// and if the tests actually expects tracing.
 			if !tc.infiniteCC && tc.wantSpans > 1 {
-				spanNames = append([]string{"queueWait"}, spanNames...)
+				spanNames = append([]string{"queue_wait"}, spanNames...)
 			}
 			gs := []string{}
 			for i := 0; i < len(gotSpans); i++ {

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -75,7 +75,7 @@ func (a *activationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		proxyCtx, proxySpan := r.Context(), (*trace.Span)(nil)
 		if tracingEnabled {
-			proxyCtx, proxySpan = trace.StartSpan(r.Context(), "proxy")
+			proxyCtx, proxySpan = trace.StartSpan(r.Context(), "activator_proxy")
 		}
 		a.proxyRequest(logger, w, r.WithContext(proxyCtx), &url.URL{
 			Scheme: "http",

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -266,7 +266,7 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 				t.Errorf("Got %d spans, expected %d", len(gotSpans), tc.wantSpans)
 			}
 
-			spanNames := []string{"throttler_try", "/", "proxy"}
+			spanNames := []string{"throttler_try", "/", "activator_proxy"}
 			for i, spanName := range spanNames[0:tc.wantSpans] {
 				if gotSpans[i].Name != spanName {
 					t.Errorf("Got span %d named %q, expected %q", i, gotSpans[i].Name, spanName)


### PR DESCRIPTION
## Proposed Changes

This patch renames operation name for activator's proxy span and
queue-proxy's span.

Currently both activator's proxy span and queue-proxy's proxy span
have same name `proxy` for operatioin. It is alright to see the trace data.

(We can distinguish the `proxy`, but...)
![Screenshot from 2020-05-13 19-44-41](https://user-images.githubusercontent.com/2138339/81804454-14624f00-9554-11ea-9055-5c017d6296b8.png)

__But__ it is difficult to find/filter it by the operation name.

(We cannot filter it as both are same name)
![Screenshot from 2020-05-13 19-43-08](https://user-images.githubusercontent.com/2138339/81804514-30fe8700-9554-11ea-9ef7-efc667712e0f.png)

Hence, if we want to find the trace data which _activator is/isn't in the path_,
we cannot filter it.

**Release Note**

```release-note
operation name for activator's proxy span and queue-proxy's span are renamed by {activator,queue}_proxy
```
