### PR TITLE
Increase Activator probe failure threshold from 30s to 2min.

### DIFF
--- a/config/core/deployments/activator.yaml
+++ b/config/core/deployments/activator.yaml
@@ -93,6 +93,7 @@ spec:
             httpHeaders:
             - name: k-kubelet-probe
               value: "activator"
+          failureThreshold: 12
         livenessProbe: *probe
 
       # The activator (often) sits on the dataplane, and may proxy long (e.g.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Addresses #6529

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
Today, kubelet will restart an Activator `Pod` after 30 seconds of probes failing. Probes fail when the WebSocket to Autoscaler is not connected. 30 seconds is not very long, k8s can take some time to re-schedule Autoscaler if it dies in a large or busy cluster.

Killing Activator impacts traffic because even if it has no access to Autoscaler, Activator can route requests to their destination, unless the revision was scaled to 0. In this case, this change aggravates the problem.

~~Also, if Autoscaler doesn't receive metrics from Activator, I am assuming it will scale everything to 0, in which case keeping the Activator alive longer doesn't help.
It seems the right thing to do would be for the Autoscaler to do nothing if it doesn't get new reports from Activator. This way, the control plane being down doesn't impact the data plane.~~

/assign @vagababov @markusthoemmes  


