### PR TITLE
Use graceful shutdowns in the activator HA test.

### DIFF
--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -38,7 +38,7 @@ const (
 	activatorDeploymentName = "activator"
 	activatorLabel          = "app=activator"
 	minProbes               = 400 // We want to send at least 400 requests.
-	slo                     = 100 // We should see 0 failed requests or else we have a bug.
+	slo                     = 1   // We should see 0 failed requests or else we have a bug.
 )
 
 // The Activator does not have leader election enabled.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

These tests currently use a non-graceful shutdown, which might happen if a node suddenly crashes etc. While those tests certainly have a place to be, it's veeery hard to reason about them as there are so many outside factors that can affect the behavior of the system that are not even necessarily under our control.

Instead, we discussed in #autoscaling to switch this to graceful shutdowns. This has the nice side effect that we can expect 100% of all requests to pass in this test. If we even drop just one of them, we definitely have a bug.

This also fills a testing gap we have today: We don't test that normal operation actually works. Node migrations etc. are a thing too (for example when upgrading Kubernetes clusters) and I'd think it's even more important for us to keep working without interruption in those situations.

The other kind of test is more of a chaos test where we only really want to assume that operations comes back at some point that's not tooooo far in the future. As said above, it's very hard to reason about the actual outage and how much we accept there though.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/hold

I want @mgencur to see and approve this before it gets merged.
