### PR TITLE
Allow the metric collector to start and stop.

### DIFF
--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -241,7 +241,7 @@ func TestMetricCollectorNoScraper(t *testing.T) {
 	// Try ticking but nothing reacts as we're not scraping
 	select {
 	case mtp.Channel <- now:
-		t.Fatalf("Unexpected reaction to tick")
+		t.Fatal("Unexpected reaction to tick")
 	case <-time.After(50 * time.Millisecond):
 		// All good.
 	}
@@ -320,7 +320,7 @@ func TestMetricCollectorScraperOffOnOff(t *testing.T) {
 	// Try ticking but nothing reacts as we're not scraping
 	select {
 	case mtp.Channel <- now:
-		t.Fatalf("Unexpected reaction to tick")
+		t.Fatal("Unexpected reaction to tick")
 	case <-time.After(50 * time.Millisecond):
 		// All good.
 	}
@@ -332,7 +332,7 @@ func TestMetricCollectorScraperOffOnOff(t *testing.T) {
 	case mtp.Channel <- now:
 		// All good.
 	case <-time.After(50 * time.Millisecond):
-		t.Fatalf("Expected tick to be accepted")
+		t.Fatal("Expected tick to be accepted")
 	}
 
 	// Turn scraper off again
@@ -341,7 +341,7 @@ func TestMetricCollectorScraperOffOnOff(t *testing.T) {
 	// Try ticking but nothing reacts as we're not scraping
 	select {
 	case mtp.Channel <- now:
-		t.Fatalf("Unexpected reaction to tick")
+		t.Fatal("Unexpected reaction to tick")
 	case <-time.After(50 * time.Millisecond):
 		// All good.
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Ref #7324.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Allows the metric scraper to be started and stopped explicitly (including shutting down the goroutine) to be able to improve efficiency even more in cases where the activator is in path and no useful metrics are to be scraped from actual pods anyway.

As a sideeffect, this gets rid of the goroutine altogether in the optimization we already have, where we never scrape for revisions with TBC=-1.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
