### PR TITLE
Migrate off the deprecated config map watch function

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -233,7 +233,7 @@ func main() {
 
 	// Watch the observability config map
 	configMapWatcher.Watch(metrics.ConfigMapName(),
-		metrics.UpdateExporterFromConfigMap(component, logger),
+		metrics.ConfigMapWatcher(component, nil /* SecretFetcher */, logger),
 		updateRequestLogFromConfigMap(logger, reqLogHandler),
 		profilingHandler.UpdateFromConfigMap)
 

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -137,7 +137,7 @@ func main() {
 	cmw.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, component))
 	// Watch the observability config map
 	cmw.Watch(metrics.ConfigMapName(),
-		metrics.UpdateExporterFromConfigMap(component, logger),
+		metrics.ConfigMapWatcher(component, nil /* SecretFetcher */, logger),
 		profilingHandler.UpdateFromConfigMap)
 
 	endpointsInformer := endpointsinformer.Get(ctx)


### PR DESCRIPTION
The last two usages then the func in pkg repository can be removed.

/assign @vagababov 