### PR TITLE
Simplify mutexes in collector state.

### DIFF
--- a/pkg/autoscaler/metrics/collector.go
+++ b/pkg/autoscaler/metrics/collector.go
@@ -112,8 +112,8 @@ type MetricCollector struct {
 	statsScraperFactory StatsScraperFactory
 	tickProvider        func(time.Duration) *time.Ticker
 
-	collections      map[types.NamespacedName]*collection
 	collectionsMutex sync.RWMutex
+	collections      map[types.NamespacedName]*collection
 
 	watcherMutex sync.RWMutex
 	watcher      func(types.NamespacedName)
@@ -239,8 +239,10 @@ func (c *MetricCollector) StableAndPanicRPS(key types.NamespacedName, now time.T
 
 // collection represents the collection of metrics for one specific entity.
 type collection struct {
-	metricMutex sync.RWMutex
-	metric      *av1alpha1.Metric
+	// mux guards access to all of the collection's state.
+	mux sync.RWMutex
+
+	metric *av1alpha1.Metric
 
 	// Fields relevant to metric collection in general.
 	concurrencyBuckets      *aggregation.TimedFloat64Buckets
@@ -249,23 +251,21 @@ type collection struct {
 	rpsPanicBuckets         *aggregation.TimedFloat64Buckets
 
 	// Fields relevant for metric scraping specifically.
-	scraperMutex sync.RWMutex
-	scraper      StatsScraper
-	errMutex     sync.RWMutex
-	lastErr      error
-	grp          sync.WaitGroup
-	stopCh       chan struct{}
+	scraper StatsScraper
+	lastErr error
+	grp     sync.WaitGroup
+	stopCh  chan struct{}
 }
 
 func (c *collection) updateScraper(ss StatsScraper) {
-	c.scraperMutex.Lock()
-	defer c.scraperMutex.Unlock()
+	c.mux.Lock()
+	defer c.mux.Unlock()
 	c.scraper = ss
 }
 
 func (c *collection) getScraper() StatsScraper {
-	c.scraperMutex.RLock()
-	defer c.scraperMutex.RUnlock()
+	c.mux.RLock()
+	defer c.mux.RUnlock()
 	return c.scraper
 }
 
@@ -335,8 +335,8 @@ func (c *collection) close() {
 
 // updateMetric safely updates the metric stored in the collection.
 func (c *collection) updateMetric(metric *av1alpha1.Metric) {
-	c.metricMutex.Lock()
-	defer c.metricMutex.Unlock()
+	c.mux.Lock()
+	defer c.mux.Unlock()
 
 	c.metric = metric
 	c.concurrencyBuckets.ResizeWindow(metric.Spec.StableWindow)
@@ -347,8 +347,8 @@ func (c *collection) updateMetric(metric *av1alpha1.Metric) {
 
 // currentMetric safely returns the current metric stored in the collection.
 func (c *collection) currentMetric() *av1alpha1.Metric {
-	c.metricMutex.RLock()
-	defer c.metricMutex.RUnlock()
+	c.mux.RLock()
+	defer c.mux.RUnlock()
 
 	return c.metric
 }
@@ -356,8 +356,8 @@ func (c *collection) currentMetric() *av1alpha1.Metric {
 // updateLastError updates the last error returned from the scraper
 // and returns true if the error or error state changed.
 func (c *collection) updateLastError(err error) bool {
-	c.errMutex.Lock()
-	defer c.errMutex.Unlock()
+	c.mux.Lock()
+	defer c.mux.Unlock()
 
 	if c.lastErr == err {
 		return false
@@ -367,8 +367,8 @@ func (c *collection) updateLastError(err error) bool {
 }
 
 func (c *collection) lastError() error {
-	c.errMutex.RLock()
-	defer c.errMutex.RUnlock()
+	c.mux.RLock()
+	defer c.mux.RUnlock()
 
 	return c.lastErr
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

I don't know if I even want this, but I wanted to get some feedback on it: I was getting really annoyed with adding a new mutex for every single field added here, making the whole struct really cumbersome. Nothing in here should hold the mutex long enough and/or need it quick enough to justify the smaller contention-areas so I figured: Why not move to a good old single mutex for everything?

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
