### PR TITLE
Update activator to honour revision's timeout seconds when handling requests.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -208,10 +208,10 @@ func main() {
 	var ah http.Handler = activatorhandler.New(ctx, throttler)
 	ah = handler.NewTimeToFirstByteTimeoutHandler(ah, "activator request timeout", func(r *http.Request) time.Duration {
 		rev := util.RevisionFrom(r.Context())
-		if rev != nil && rev.Spec.TimeoutSeconds != nil {
+		if rev != nil {
 			return time.Duration(*rev.Spec.TimeoutSeconds) * time.Second
 		}
-		return time.Duration(apiconfig.DefaultRevisionTimeoutSeconds) * time.Second
+		return apiconfig.DefaultRevisionTimeoutSeconds * time.Second
 	})
 	ah = activatorhandler.NewRequestEventHandler(reqCh, ah)
 	ah = tracing.HTTPSpanMiddleware(ah)

--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -207,8 +207,7 @@ func main() {
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first
 	var ah http.Handler = activatorhandler.New(ctx, throttler)
 	ah = handler.NewTimeToFirstByteTimeoutHandler(ah, "activator request timeout", func(r *http.Request) time.Duration {
-		rev := util.RevisionFrom(r.Context())
-		if rev != nil {
+		if rev := util.RevisionFrom(r.Context()); rev != nil {
 			return time.Duration(*rev.Spec.TimeoutSeconds) * time.Second
 		}
 		return apiconfig.DefaultRevisionTimeoutSeconds * time.Second

--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -56,9 +56,12 @@ import (
 	activatorconfig "knative.dev/serving/pkg/activator/config"
 	activatorhandler "knative.dev/serving/pkg/activator/handler"
 	activatornet "knative.dev/serving/pkg/activator/net"
+	"knative.dev/serving/pkg/activator/util"
+	apiconfig "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/networking"
 	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
 	pkghttp "knative.dev/serving/pkg/http"
+	"knative.dev/serving/pkg/http/handler"
 	"knative.dev/serving/pkg/logging"
 	"knative.dev/serving/pkg/network"
 )
@@ -203,6 +206,13 @@ func main() {
 	// Create activation handler chain
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first
 	var ah http.Handler = activatorhandler.New(ctx, throttler)
+	ah = handler.NewTimeToFirstByteTimeoutHandler(ah, "activator request timeout", func(r *http.Request) time.Duration {
+		rev := util.RevisionFrom(r.Context())
+		if rev != nil && rev.Spec.TimeoutSeconds != nil {
+			return time.Duration(*rev.Spec.TimeoutSeconds) * time.Second
+		}
+		return time.Duration(apiconfig.DefaultRevisionTimeoutSeconds) * time.Second
+	})
 	ah = activatorhandler.NewRequestEventHandler(reqCh, ah)
 	ah = tracing.HTTPSpanMiddleware(ah)
 	ah = configStore.HTTPMiddleware(ah)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -51,6 +51,7 @@ import (
 	activatorutil "knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/apis/networking"
 	pkghttp "knative.dev/serving/pkg/http"
+	"knative.dev/serving/pkg/http/handler"
 	"knative.dev/serving/pkg/logging"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/queue"
@@ -452,6 +453,7 @@ func buildServer(env config, healthState *health.State, rp *readiness.Probe, sta
 	breaker := buildBreaker(env)
 	metricsSupported := supportsMetrics(env, logger)
 	tracingEnabled := env.TracingConfigBackend != tracingconfig.None
+	timeout := time.Duration(env.RevisionTimeoutSeconds) * time.Second
 
 	// Create queue handler chain.
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first.
@@ -461,8 +463,9 @@ func buildServer(env config, healthState *health.State, rp *readiness.Probe, sta
 	}
 	composedHandler = proxyHandler(breaker, stats, tracingEnabled, composedHandler)
 	composedHandler = queue.ForwardedShimHandler(composedHandler)
-	composedHandler = queue.TimeToFirstByteTimeoutHandler(composedHandler,
-		time.Duration(env.RevisionTimeoutSeconds)*time.Second, "request timeout")
+	composedHandler = handler.NewTimeToFirstByteTimeoutHandler(composedHandler, "request timeout", func(*http.Request) time.Duration {
+		return timeout
+	})
 	composedHandler = pushRequestLogHandler(composedHandler, env)
 
 	if metricsSupported {

--- a/pkg/activator/handler/context_handler_test.go
+++ b/pkg/activator/handler/context_handler_test.go
@@ -24,7 +24,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	"knative.dev/pkg/ptr"
 	rtesting "knative.dev/pkg/reconciler/testing"
 	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/activator/util"
@@ -35,8 +34,6 @@ func TestContextHandler(t *testing.T) {
 	defer cancel()
 	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevName}
 	revision := revision(revID.Namespace, revID.Name)
-	revTimeoutSeconds := ptr.Int64(42)
-	revision.Spec.TimeoutSeconds = revTimeoutSeconds
 	revisionInformer(ctx, revision)
 
 	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -88,13 +85,11 @@ func TestContextHandlerError(t *testing.T) {
 
 func BenchmarkContextHandler(b *testing.B) {
 	tests := []struct {
-		label                  string
-		revisionName           string
-		revisionTimeoutSeconds *int64
+		label        string
+		revisionName string
 	}{{
-		label:                  "context handler success",
-		revisionName:           testRevName,
-		revisionTimeoutSeconds: ptr.Int64(100),
+		label:        "context handler success",
+		revisionName: testRevName,
 	}, {
 		label:        "context handler failure",
 		revisionName: "fake",
@@ -111,7 +106,6 @@ func BenchmarkContextHandler(b *testing.B) {
 	req.Header.Set(activator.RevisionHeaderNamespace, testNamespace)
 
 	for _, test := range tests {
-		revision.Spec.TimeoutSeconds = test.revisionTimeoutSeconds
 		req.Header.Set(activator.RevisionHeaderName, test.revisionName)
 		b.Run(fmt.Sprintf("%s-sequential", test.label), func(b *testing.B) {
 			resp := httptest.NewRecorder()

--- a/pkg/http/handler/timeout.go
+++ b/pkg/http/handler/timeout.go
@@ -28,11 +28,11 @@ import (
 	"knative.dev/pkg/websocket"
 )
 
-type timeoutFunc func(req *http.Request) time.Duration
+type TimeoutFunc func(req *http.Request) time.Duration
 
 type timeToFirstByteTimeoutHandler struct {
 	handler     http.Handler
-	timeoutFunc timeoutFunc
+	timeoutFunc TimeoutFunc
 	body        string
 }
 
@@ -52,7 +52,7 @@ type timeToFirstByteTimeoutHandler struct {
 // https://golang.org/pkg/net/http/#Handler.
 //
 // The implementation is largely inspired by http.TimeoutHandler.
-func NewTimeToFirstByteTimeoutHandler(h http.Handler, msg string, timeoutFunc timeoutFunc) http.Handler {
+func NewTimeToFirstByteTimeoutHandler(h http.Handler, msg string, timeoutFunc TimeoutFunc) http.Handler {
 	return &timeToFirstByteTimeoutHandler{
 		handler:     h,
 		body:        msg,

--- a/pkg/http/handler/timeout.go
+++ b/pkg/http/handler/timeout.go
@@ -28,8 +28,7 @@ import (
 	"knative.dev/pkg/websocket"
 )
 
-// TimeoutFunc should calculate/process then return the duration
-// to be used by the timeout handler.
+// TimeoutFunc returns the timeout duration to be used by the timeout handler.
 type TimeoutFunc func(req *http.Request) time.Duration
 
 type timeToFirstByteTimeoutHandler struct {
@@ -38,7 +37,7 @@ type timeToFirstByteTimeoutHandler struct {
 	body        string
 }
 
-// TimeToFirstByteTimeoutHandler returns a Handler that runs `h` with the
+// NewTimeToFirstByteTimeoutHandler returns a Handler that runs `h` with the
 // given time limit from the timeout function in which the first byte of
 // the response must be written.
 //

--- a/pkg/http/handler/timeout.go
+++ b/pkg/http/handler/timeout.go
@@ -28,6 +28,8 @@ import (
 	"knative.dev/pkg/websocket"
 )
 
+// TimeoutFunc should calculate/process then return the duration
+// to be used by the timeout handler.
 type TimeoutFunc func(req *http.Request) time.Duration
 
 type timeToFirstByteTimeoutHandler struct {

--- a/pkg/http/handler/timeout_test.go
+++ b/pkg/http/handler/timeout_test.go
@@ -73,8 +73,12 @@ func TestTimeoutWriterErrorsWriteAfterTimeout(t *testing.T) {
 }
 
 func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
+	const (
+		longTimeout = 10 * time.Second
+	)
+
 	longTimeoutFunc := func(*http.Request) time.Duration {
-		return 10 * time.Second
+		return longTimeout
 	}
 	failingTimeoutFunc := func(*http.Request) time.Duration {
 		return 0 * time.Millisecond

--- a/pkg/http/handler/timeout_test.go
+++ b/pkg/http/handler/timeout_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2020 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,7 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package queue
+
+package handler
 
 import (
 	"io"
@@ -24,15 +25,69 @@ import (
 	"time"
 )
 
+func TestTimeoutWriterAllowsForAdditionalWrites(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	handler := &timeoutWriter{w: recorder}
+	handler.WriteHeader(http.StatusOK)
+	handler.TimeoutAndWriteError("error")
+	if _, err := io.WriteString(handler, "test"); err != nil {
+		t.Fatalf("handler.Write() = %v, want no error", err)
+	}
+
+	if got, want := recorder.Code, http.StatusOK; got != want {
+		t.Errorf("recorder.Status = %d, want %d", got, want)
+	}
+	if got, want := recorder.Body.String(), "test"; got != want {
+		t.Errorf("recorder.Body = %s, want %s", got, want)
+	}
+}
+
+func TestTimeoutWriterDoesntFlushAfterTimeout(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	handler := &timeoutWriter{w: recorder}
+	handler.TimeoutAndWriteError("error")
+	handler.Flush()
+
+	if got, want := recorder.Flushed, false; got != want {
+		t.Errorf("recorder.Flushed = %t, want %t", got, want)
+	}
+}
+
+func TestTimeoutWriterFlushesAfterTimeout(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	handler := &timeoutWriter{w: recorder}
+	handler.Flush()
+
+	if got, want := recorder.Flushed, true; got != want {
+		t.Errorf("recorder.Flushed = %t, want %t", got, want)
+	}
+}
+
+func TestTimeoutWriterErrorsWriteAfterTimeout(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	handler := &timeoutWriter{w: recorder}
+	handler.TimeoutAndWriteError("error")
+	if _, err := handler.Write([]byte("hello")); err != http.ErrHandlerTimeout {
+		t.Errorf("ErrHandlerTimeout got %v, want: %s", err, http.ErrHandlerTimeout)
+	}
+}
+
 func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 	const (
 		failingTimeout = 0 * time.Millisecond
 		longTimeout    = 10 * time.Second
 	)
 
+	longTimeoutFunc := func(*http.Request) time.Duration {
+		return longTimeout
+	}
+	failingTimeoutFunc := func(*http.Request) time.Duration {
+		return failingTimeout
+	}
+
 	tests := []struct {
 		name               string
-		timeout            time.Duration
+		timeoutFunc        timeoutFunc
 		handler            func(mux *sync.Mutex, writeErrors chan error) http.Handler
 		timeoutMessage     string
 		wantStatus         int
@@ -41,8 +96,8 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 		wantPanic          bool
 		sleepBeforeExiting time.Duration
 	}{{
-		name:    "all good",
-		timeout: longTimeout,
+		name:        "all good",
+		timeoutFunc: longTimeoutFunc,
 		handler: func(*sync.Mutex, chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Write([]byte("hi"))
@@ -51,8 +106,8 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 		wantStatus: http.StatusOK,
 		wantBody:   "hi",
 	}, {
-		name:    "custom timeout message",
-		timeout: failingTimeout,
+		name:        "custom timeout message",
+		timeoutFunc: failingTimeoutFunc,
 		handler: func(mux *sync.Mutex, writeErrors chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				mux.Lock()
@@ -66,8 +121,8 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 		wantBody:       "request timeout",
 		wantWriteError: true,
 	}, {
-		name:    "propagate panic",
-		timeout: longTimeout,
+		name:        "propagate panic",
+		timeoutFunc: longTimeoutFunc,
 		handler: func(*sync.Mutex, chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				panic(http.ErrAbortHandler)
@@ -77,8 +132,8 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 		wantBody:   "request timeout",
 		wantPanic:  true,
 	}, {
-		name:    "timeout before panic",
-		timeout: failingTimeout,
+		name:        "timeout before panic",
+		timeoutFunc: failingTimeoutFunc,
 		handler: func(*sync.Mutex, chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				time.Sleep(1 * time.Second)
@@ -101,7 +156,7 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 			var reqMux sync.Mutex
 			writeErrors := make(chan error, 1)
 			rr := httptest.NewRecorder()
-			handler := TimeToFirstByteTimeoutHandler(test.handler(&reqMux, writeErrors), test.timeout, test.timeoutMessage)
+			handler := NewTimeToFirstByteTimeoutHandler(test.handler(&reqMux, writeErrors), test.timeoutMessage, test.timeoutFunc)
 
 			defer func() {
 				if test.wantPanic {
@@ -131,38 +186,5 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 
 			time.Sleep(test.sleepBeforeExiting)
 		})
-	}
-}
-
-func TestTimeoutWriterAllowsForAdditionalWrites(t *testing.T) {
-	recorder := httptest.NewRecorder()
-	handler := &timeoutWriter{
-		w: recorder,
-	}
-
-	handler.WriteHeader(http.StatusOK)
-	handler.TimeoutAndWriteError("error")
-	if _, err := io.WriteString(handler, "test"); err != nil {
-		t.Fatalf("handler.Write() = %v, want no error", err)
-	}
-
-	if got, want := recorder.Code, http.StatusOK; got != want {
-		t.Errorf("recorder.Status = %d, want %d", got, want)
-	}
-	if got, want := recorder.Body.String(), "test"; got != want {
-		t.Errorf("recorder.Body = %s, want %s", got, want)
-	}
-}
-
-func TestTimeoutWriterDoesntFlushAfterTimeout(t *testing.T) {
-	recorder := httptest.NewRecorder()
-	handler := &timeoutWriter{
-		w: recorder,
-	}
-
-	handler.TimeoutAndWriteError("error")
-	handler.Flush()
-	if got, want := recorder.Flushed, false; got != want {
-		t.Errorf("recorder.Flushed = %t, want %t", got, want)
 	}
 }

--- a/pkg/http/handler/timeout_test.go
+++ b/pkg/http/handler/timeout_test.go
@@ -73,16 +73,11 @@ func TestTimeoutWriterErrorsWriteAfterTimeout(t *testing.T) {
 }
 
 func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
-	const (
-		failingTimeout = 0 * time.Millisecond
-		longTimeout    = 10 * time.Second
-	)
-
 	longTimeoutFunc := func(*http.Request) time.Duration {
-		return longTimeout
+		return 10 * time.Second
 	}
 	failingTimeoutFunc := func(*http.Request) time.Duration {
-		return failingTimeout
+		return 0 * time.Millisecond
 	}
 
 	tests := []struct {

--- a/pkg/http/handler/timeout_test.go
+++ b/pkg/http/handler/timeout_test.go
@@ -86,7 +86,7 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		timeoutFunc        timeoutFunc
+		timeoutFunc        TimeoutFunc
 		handler            func(mux *sync.Mutex, writeErrors chan error) http.Handler
 		timeoutMessage     string
 		wantStatus         int

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -19,16 +19,13 @@ limitations under the License.
 package v1
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
 	"time"
 
-	"github.com/mattbaird/jsonpatch"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	pkgTest "knative.dev/pkg/test"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
@@ -36,6 +33,8 @@ import (
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"
 	v1test "knative.dev/serving/test/v1"
+
+	. "knative.dev/serving/pkg/testing/v1"
 )
 
 // createService creates a service in namespace with the name names.Service
@@ -44,20 +43,6 @@ func createService(t *testing.T, clients *test.Clients, names test.ResourceNames
 	service := v1test.Service(names, WithRevisionTimeoutSeconds(revisionTimeoutSeconds))
 	v1test.LogResourceObject(t, v1test.ResourceObjects{Service: service})
 	return clients.ServingClient.Services.Create(service)
-}
-
-func updateServiceWithTimeout(clients *test.Clients, names test.ResourceNames, revisionTimeoutSeconds int64) error {
-	patches := []jsonpatch.JsonPatchOperation{{
-		Operation: "replace",
-		Path:      "/spec/template/spec/timeoutSeconds",
-		Value:     revisionTimeoutSeconds,
-	}}
-	patchBytes, err := json.Marshal(patches)
-	if err != nil {
-		return err
-	}
-	_, err = clients.ServingClient.Services.Patch(names.Service, types.JSONPatchType, patchBytes, "")
-	return err
 }
 
 // sendRequests send a request to "endpoint", returns error if unexpected response code, nil otherwise.

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -29,14 +29,13 @@ import (
 	"github.com/mattbaird/jsonpatch"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/pkg/ptr"
 	pkgTest "knative.dev/pkg/test"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
 	"knative.dev/serving/test"
+	"knative.dev/serving/test/e2e"
 	v1test "knative.dev/serving/test/v1"
-
-	. "knative.dev/serving/pkg/testing/v1"
 )
 
 // createService creates a service in namespace with the name names.Service
@@ -100,144 +99,129 @@ func TestRevisionTimeout(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 
-	var rev2s, rev5s test.ResourceNames
-	names := test.ResourceNames{
-		Service: test.ObjectNameForTest(t),
-		Image:   test.Timeout,
+	testCases := []struct {
+		name           string
+		shouldScaleTo0 bool
+		timeoutSeconds int64
+		expectedStatus int
+		initialSleep   int
+		sleep          int
+	}{
+		{
+			name:           "when scaling up from 0 and does not exceed timeout seconds",
+			shouldScaleTo0: true,
+			timeoutSeconds: 5,
+			expectedStatus: http.StatusOK,
+			initialSleep:   0,
+			sleep:          0,
+		},
+		{
+			name:           "when scaling up from 0 and it writes first byte before timeout",
+			shouldScaleTo0: true,
+			timeoutSeconds: 5,
+			expectedStatus: http.StatusOK,
+			initialSleep:   0,
+			sleep:          10,
+		},
+		{
+			name:           "when scaling up from 0 and it does exceed timeout seconds",
+			shouldScaleTo0: true,
+			timeoutSeconds: 1, // If the pods come up faster than 1s, this test might fail.
+			expectedStatus: http.StatusGatewayTimeout,
+		},
+		{
+			name:           "when pods already exist, and it does not exceed timeout seconds",
+			timeoutSeconds: 5,
+			expectedStatus: http.StatusOK,
+			initialSleep:   2,
+			sleep:          0,
+		},
+		{
+			name:           "when pods already exist, and it does exceed timeout seconds",
+			timeoutSeconds: 5,
+			expectedStatus: http.StatusGatewayTimeout,
+			initialSleep:   7,
+			sleep:          1,
+		},
+		{
+			name:           "when pods already exist, and it writes first byte before timeout",
+			timeoutSeconds: 5,
+			expectedStatus: http.StatusOK,
+			initialSleep:   0,
+			sleep:          10,
+		},
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			names := test.ResourceNames{
+				Service: test.ObjectNameForTest(t),
+				Image:   test.Timeout,
+			}
 
-	t.Log("Creating a new Service ")
-	svc, err := createService(t, clients, names, 2)
-	if err != nil {
-		t.Fatal("Failed to create Service:", err)
-	}
-	names.Route = serviceresourcenames.Route(svc)
-	names.Config = serviceresourcenames.Configuration(svc)
+			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+			defer test.TearDown(clients, names)
 
-	t.Log("The Service will be updated with the name of the Revision once it is created")
-	revisionName, err := v1test.WaitForServiceLatestRevision(clients, names)
-	if err != nil {
-		t.Fatalf("Service %s was not updated with the new revision: %v", names.Service, err)
-	}
-	rev2s.Revision = revisionName
+			t.Log("Creating a new Service ")
+			svc, err := createService(t, clients, names, tc.timeoutSeconds)
+			if err != nil {
+				t.Fatal("Failed to create Service:", err)
+			}
 
-	t.Log("When the Service reports as Ready, everything should be ready")
-	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
-	}
+			names.Route = serviceresourcenames.Route(svc)
+			names.Config = serviceresourcenames.Configuration(svc)
 
-	t.Log("Updating the Service to use a different revision timeout")
-	err = updateServiceWithTimeout(clients, names, 5)
-	if err != nil {
-		t.Fatalf("Patch update for Service %s with new timeout 5s failed: %v", names.Service, err)
-	}
+			t.Log("The Service will be updated with the name of the Revision once it is created")
+			revisionName, err := v1test.WaitForServiceLatestRevision(clients, names)
+			if err != nil {
+				t.Fatalf("Service %s was not updated with the new revision: %v", names.Service, err)
+			}
+			names.Revision = revisionName
 
-	// getNextRevisionName waits for names.Revision to change, so we set it to the rev2s revision and wait for the (new) rev5s revision.
-	names.Revision = rev2s.Revision
+			t.Log("When the Service reports as Ready, everything should be ready")
+			if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
+				t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
+			}
 
-	t.Log("Since the Service was updated a new Revision will be created and the Service will be updated")
-	rev5s.Revision, err = v1test.WaitForServiceLatestRevision(clients, names)
-	if err != nil {
-		t.Fatalf("Service %s was not updated with the Revision with timeout 5s: %v", names.Service, err)
-	}
+			service, err := clients.ServingClient.Services.Get(names.Service, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Error fetching Service %s: %v", names.Service, err)
+			}
 
-	t.Logf("Waiting for revision %q to be ready", rev2s.Revision)
-	if err := v1test.WaitForRevisionState(clients.ServingClient, rev2s.Revision, v1test.IsRevisionReady, "RevisionIsReady"); err != nil {
-		t.Fatalf("The Revision %q still can't serve traffic: %v", rev2s.Revision, err)
-	}
-	t.Logf("Waiting for revision %q to be ready", rev5s.Revision)
-	if err := v1test.WaitForRevisionState(clients.ServingClient, rev5s.Revision, v1test.IsRevisionReady, "RevisionIsReady"); err != nil {
-		t.Fatalf("The Revision %q still can't serve traffic: %v", rev5s.Revision, err)
-	}
+			if service.Status.URL == nil {
+				t.Fatalf("Unable to fetch URLs from service: %#v", service.Status)
+			}
 
-	// Set names for traffic targets to make them directly routable.
-	rev2s.TrafficTarget = "rev2s"
-	rev5s.TrafficTarget = "rev5s"
+			serviceURL := url.URL(*service.Status.URL)
 
-	t.Log("Updating RouteSpec")
-	if _, err := v1test.UpdateServiceRouteSpec(t, clients, names, v1.RouteSpec{
-		Traffic: []v1.TrafficTarget{{
-			Tag:          rev2s.TrafficTarget,
-			RevisionName: rev2s.Revision,
-			Percent:      ptr.Int64(50),
-		}, {
-			Tag:          rev5s.TrafficTarget,
-			RevisionName: rev5s.Revision,
-			Percent:      ptr.Int64(50),
-		}},
-	}); err != nil {
-		t.Fatal("Failed to update Service:", err)
-	}
+			if tc.shouldScaleTo0 {
+				t.Log("Waiting to scale down to 0")
+				revision, err := clients.ServingClient.Revisions.Get(names.Revision, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Error fetching Service %s: %v", names.Service, err)
+				}
 
-	t.Log("Wait for the service domains to be ready")
-	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("The Service %s was not marked as Ready to serve traffic: %v", names.Service, err)
-	}
+				if err := e2e.WaitForScaleToZero(t, revisionresourcenames.Deployment(revision), clients); err != nil {
+					t.Fatal("Could not scale to zero:", err)
+				}
+			} else {
+				t.Log("Probing to force at least non-zero pods", &serviceURL)
+				if _, err := pkgTest.WaitForEndpointState(
+					clients.KubeClient,
+					t.Logf,
+					&serviceURL,
+					v1test.RetryingRouteInconsistency(pkgTest.IsOneOfStatusCodes(http.StatusOK, http.StatusGatewayTimeout)),
+					"WaitForSuccessfulResponse",
+					test.ServingFlags.ResolvableDomain,
+					test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https)); err != nil {
+					t.Fatalf("Error probing %s: %v", &serviceURL, err)
+				}
+			}
 
-	service, err := clients.ServingClient.Services.Get(names.Service, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
-	}
-
-	var rev2sURL, rev5sURL *url.URL
-	for _, tt := range service.Status.Traffic {
-		if tt.Tag == rev2s.TrafficTarget {
-			rev2sURL = tt.URL.URL()
-		}
-		if tt.Tag == rev5s.TrafficTarget {
-			rev5sURL = tt.URL.URL()
-		}
-	}
-	if rev2sURL == nil || rev5sURL == nil {
-		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", service.Status.Traffic)
-	}
-
-	t.Log("Probing", rev5sURL)
-	if _, err := pkgTest.WaitForEndpointState(
-		clients.KubeClient,
-		t.Logf,
-		rev5sURL,
-		v1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
-		"WaitForSuccessfulResponse",
-		test.ServingFlags.ResolvableDomain,
-		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https)); err != nil {
-		t.Fatalf("Error probing %s: %v", rev5sURL, err)
-	}
-	t.Log("Probing", rev2sURL)
-	if _, err := pkgTest.WaitForEndpointState(
-		clients.KubeClient,
-		t.Logf,
-		rev2sURL,
-		v1test.RetryingRouteInconsistency(pkgTest.IsOneOfStatusCodes(http.StatusOK, http.StatusGatewayTimeout)),
-		"WaitForSuccessfulResponse",
-		test.ServingFlags.ResolvableDomain,
-		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https)); err != nil {
-		t.Fatalf("Error probing %s: %v", rev2sURL, err)
-	}
-	// Quick sanity check
-	if err := sendRequest(t, clients, rev2sURL, 0, 0, http.StatusOK); err != nil {
-		t.Errorf("Failed request with sleep 0s with revision timeout 2s: %v", err)
-	}
-	if err := sendRequest(t, clients, rev5sURL, 0, 0, http.StatusOK); err != nil {
-		t.Errorf("Failed request with sleep 0s with revision timeout 5s: %v", err)
-	}
-
-	// Fail by surpassing the initial timeout.
-	if err := sendRequest(t, clients, rev2sURL, 5*time.Second, 0, http.StatusGatewayTimeout); err != nil {
-		t.Errorf("Did not fail request with sleep 5s with revision timeout 2s: %v", err)
-	}
-	if err := sendRequest(t, clients, rev5sURL, 7*time.Second, 0, http.StatusGatewayTimeout); err != nil {
-		t.Errorf("Did not fail request with sleep 7s with revision timeout 5s: %v", err)
-	}
-
-	// Not fail by not surpassing in the initial timeout, but in the overall request duration.
-	if err := sendRequest(t, clients, rev2sURL, time.Second, 3*time.Second, http.StatusOK); err != nil {
-		t.Errorf("Did not fail request with sleep 1s/3s with revision timeout 2s: %v", err)
-	}
-	if err := sendRequest(t, clients, rev5sURL, 3*time.Second, 3*time.Second, http.StatusOK); err != nil {
-		t.Errorf("Failed request with sleep 3s/3s with revision timeout 5s: %v", err)
+			if err := sendRequest(t, clients, &serviceURL, time.Duration(tc.initialSleep)*time.Second, time.Duration(tc.sleep)*time.Second, tc.expectedStatus); err != nil {
+				t.Errorf("Failed request with intialSleep %ds, sleep %ds, with revision timeout %ds and expecting status %v: %v",
+					tc.initialSleep, tc.sleep, tc.timeoutSeconds, tc.expectedStatus, err)
+			}
+		})
 	}
 }

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -94,17 +94,17 @@ func TestRevisionTimeout(t *testing.T) {
 	}{{
 		name:           "when scaling up from 0 and does not exceed timeout seconds",
 		shouldScaleTo0: true,
-		timeoutSeconds: 5,
+		timeoutSeconds: 10,
 		expectedStatus: http.StatusOK,
 		initialSleep:   0,
 		sleep:          0,
 	}, {
 		name:           "when scaling up from 0 and it writes first byte before timeout",
 		shouldScaleTo0: true,
-		timeoutSeconds: 5,
+		timeoutSeconds: 10,
 		expectedStatus: http.StatusOK,
 		initialSleep:   0,
-		sleep:          10,
+		sleep:          15,
 	}, {
 		name:           "when scaling up from 0 and it does exceed timeout seconds",
 		shouldScaleTo0: true,
@@ -112,22 +112,22 @@ func TestRevisionTimeout(t *testing.T) {
 		expectedStatus: http.StatusGatewayTimeout,
 	}, {
 		name:           "when pods already exist, and it does not exceed timeout seconds",
-		timeoutSeconds: 5,
+		timeoutSeconds: 10,
 		expectedStatus: http.StatusOK,
 		initialSleep:   2,
 		sleep:          0,
 	}, {
 		name:           "when pods already exist, and it does exceed timeout seconds",
-		timeoutSeconds: 5,
+		timeoutSeconds: 10,
 		expectedStatus: http.StatusGatewayTimeout,
-		initialSleep:   7,
-		sleep:          1,
+		initialSleep:   12,
+		sleep:          0,
 	}, {
 		name:           "when pods already exist, and it writes first byte before timeout",
-		timeoutSeconds: 5,
+		timeoutSeconds: 10,
 		expectedStatus: http.StatusOK,
 		initialSleep:   0,
-		sleep:          10,
+		sleep:          15,
 	}}
 
 	for _, tc := range testCases {

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -91,51 +91,44 @@ func TestRevisionTimeout(t *testing.T) {
 		expectedStatus int
 		initialSleep   int
 		sleep          int
-	}{
-		{
-			name:           "when scaling up from 0 and does not exceed timeout seconds",
-			shouldScaleTo0: true,
-			timeoutSeconds: 5,
-			expectedStatus: http.StatusOK,
-			initialSleep:   0,
-			sleep:          0,
-		},
-		{
-			name:           "when scaling up from 0 and it writes first byte before timeout",
-			shouldScaleTo0: true,
-			timeoutSeconds: 5,
-			expectedStatus: http.StatusOK,
-			initialSleep:   0,
-			sleep:          10,
-		},
-		{
-			name:           "when scaling up from 0 and it does exceed timeout seconds",
-			shouldScaleTo0: true,
-			timeoutSeconds: 1, // If the pods come up faster than 1s, this test might fail.
-			expectedStatus: http.StatusGatewayTimeout,
-		},
-		{
-			name:           "when pods already exist, and it does not exceed timeout seconds",
-			timeoutSeconds: 5,
-			expectedStatus: http.StatusOK,
-			initialSleep:   2,
-			sleep:          0,
-		},
-		{
-			name:           "when pods already exist, and it does exceed timeout seconds",
-			timeoutSeconds: 5,
-			expectedStatus: http.StatusGatewayTimeout,
-			initialSleep:   7,
-			sleep:          1,
-		},
-		{
-			name:           "when pods already exist, and it writes first byte before timeout",
-			timeoutSeconds: 5,
-			expectedStatus: http.StatusOK,
-			initialSleep:   0,
-			sleep:          10,
-		},
-	}
+	}{{
+		name:           "when scaling up from 0 and does not exceed timeout seconds",
+		shouldScaleTo0: true,
+		timeoutSeconds: 5,
+		expectedStatus: http.StatusOK,
+		initialSleep:   0,
+		sleep:          0,
+	}, {
+		name:           "when scaling up from 0 and it writes first byte before timeout",
+		shouldScaleTo0: true,
+		timeoutSeconds: 5,
+		expectedStatus: http.StatusOK,
+		initialSleep:   0,
+		sleep:          10,
+	}, {
+		name:           "when scaling up from 0 and it does exceed timeout seconds",
+		shouldScaleTo0: true,
+		timeoutSeconds: 1, // If the pods come up faster than 1s, this test might fail.
+		expectedStatus: http.StatusGatewayTimeout,
+	}, {
+		name:           "when pods already exist, and it does not exceed timeout seconds",
+		timeoutSeconds: 5,
+		expectedStatus: http.StatusOK,
+		initialSleep:   2,
+		sleep:          0,
+	}, {
+		name:           "when pods already exist, and it does exceed timeout seconds",
+		timeoutSeconds: 5,
+		expectedStatus: http.StatusGatewayTimeout,
+		initialSleep:   7,
+		sleep:          1,
+	}, {
+		name:           "when pods already exist, and it writes first byte before timeout",
+		timeoutSeconds: 5,
+		expectedStatus: http.StatusOK,
+		initialSleep:   0,
+		sleep:          10,
+	}}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -179,7 +179,7 @@ func TestRevisionTimeout(t *testing.T) {
 					t.Fatal("Could not scale to zero:", err)
 				}
 			} else {
-				t.Log("Probing to force at least one pod", &serviceURL)
+				t.Log("Probing to force at least one pod", serviceURL.String())
 				if _, err := pkgTest.WaitForEndpointState(
 					clients.KubeClient,
 					t.Logf,

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -29,7 +29,6 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
-	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"
 	v1test "knative.dev/serving/test/v1"
@@ -141,13 +140,10 @@ func TestRevisionTimeout(t *testing.T) {
 			defer test.TearDown(clients, names)
 
 			t.Log("Creating a new Service ")
-			svc, err := createService(t, clients, names, tc.timeoutSeconds)
+			_, err := createService(t, clients, names, tc.timeoutSeconds)
 			if err != nil {
 				t.Fatal("Failed to create Service:", err)
 			}
-
-			names.Route = serviceresourcenames.Route(svc)
-			names.Config = serviceresourcenames.Configuration(svc)
 
 			t.Log("The Service will be updated with the name of the Revision once it is created")
 			revisionName, err := v1test.WaitForServiceLatestRevision(clients, names)
@@ -183,7 +179,7 @@ func TestRevisionTimeout(t *testing.T) {
 					t.Fatal("Could not scale to zero:", err)
 				}
 			} else {
-				t.Log("Probing to force at least non-zero pods", &serviceURL)
+				t.Log("Probing to force at least one pod", &serviceURL)
 				if _, err := pkgTest.WaitForEndpointState(
 					clients.KubeClient,
 					t.Logf,

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -206,7 +206,17 @@ func TestRevisionTimeout(t *testing.T) {
 		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https)); err != nil {
 		t.Fatalf("Error probing %s: %v", rev5sURL, err)
 	}
-
+	t.Log("Probing", rev2sURL)
+	if _, err := pkgTest.WaitForEndpointState(
+		clients.KubeClient,
+		t.Logf,
+		rev2sURL,
+		v1test.RetryingRouteInconsistency(pkgTest.IsOneOfStatusCodes(http.StatusOK, http.StatusGatewayTimeout)),
+		"WaitForSuccessfulResponse",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https)); err != nil {
+		t.Fatalf("Error probing %s: %v", rev2sURL, err)
+	}
 	// Quick sanity check
 	if err := sendRequest(t, clients, rev2sURL, 0, 0, http.StatusOK); err != nil {
 		t.Errorf("Failed request with sleep 0s with revision timeout 2s: %v", err)

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -94,17 +94,17 @@ func TestRevisionTimeout(t *testing.T) {
 	}{{
 		name:           "when scaling up from 0 and does not exceed timeout seconds",
 		shouldScaleTo0: true,
-		timeoutSeconds: 5,
+		timeoutSeconds: 10,
 		expectedStatus: http.StatusOK,
 		initialSleep:   0,
 		sleep:          0,
 	}, {
 		name:           "when scaling up from 0 and it writes first byte before timeout",
 		shouldScaleTo0: true,
-		timeoutSeconds: 5,
+		timeoutSeconds: 10,
 		expectedStatus: http.StatusOK,
 		initialSleep:   0,
-		sleep:          10,
+		sleep:          15,
 	}, {
 		name:           "when scaling up from 0 and it does exceed timeout seconds",
 		shouldScaleTo0: true,
@@ -112,22 +112,22 @@ func TestRevisionTimeout(t *testing.T) {
 		expectedStatus: http.StatusGatewayTimeout,
 	}, {
 		name:           "when pods already exist, and it does not exceed timeout seconds",
-		timeoutSeconds: 5,
+		timeoutSeconds: 10,
 		expectedStatus: http.StatusOK,
 		initialSleep:   2,
 		sleep:          0,
 	}, {
 		name:           "when pods already exist, and it does exceed timeout seconds",
-		timeoutSeconds: 5,
+		timeoutSeconds: 10,
 		expectedStatus: http.StatusGatewayTimeout,
-		initialSleep:   7,
-		sleep:          1,
+		initialSleep:   12,
+		sleep:          0,
 	}, {
 		name:           "when pods already exist, and it writes first byte before timeout",
-		timeoutSeconds: 5,
+		timeoutSeconds: 10,
 		expectedStatus: http.StatusOK,
 		initialSleep:   0,
-		sleep:          10,
+		sleep:          15,
 	}}
 
 	for _, tc := range testCases {

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -19,22 +19,19 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
 	"time"
 
-	"github.com/mattbaird/jsonpatch"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/pkg/ptr"
 	pkgTest "knative.dev/pkg/test"
-	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
 	"knative.dev/serving/test"
+	"knative.dev/serving/test/e2e"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 
 	. "knative.dev/serving/pkg/testing/v1alpha1"
@@ -46,20 +43,6 @@ func createLatestService(t *testing.T, clients *test.Clients, names test.Resourc
 	service := v1a1test.LatestService(names, WithRevisionTimeoutSeconds(revisionTimeoutSeconds))
 	v1a1test.LogResourceObject(t, v1a1test.ResourceObjects{Service: service})
 	return clients.ServingAlphaClient.Services.Create(service)
-}
-
-func updateServiceWithTimeout(clients *test.Clients, names test.ResourceNames, revisionTimeoutSeconds int64) error {
-	patches := []jsonpatch.JsonPatchOperation{{
-		Operation: "replace",
-		Path:      "/spec/template/spec/timeoutSeconds",
-		Value:     revisionTimeoutSeconds,
-	}}
-	patchBytes, err := json.Marshal(patches)
-	if err != nil {
-		return err
-	}
-	_, err = clients.ServingAlphaClient.Services.Patch(names.Service, types.JSONPatchType, patchBytes, "")
-	return err
 }
 
 // sendRequests send a request to "endpoint", returns error if unexpected response code, nil otherwise.
@@ -101,150 +84,129 @@ func TestRevisionTimeout(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 
-	var rev2s, rev5s test.ResourceNames
-	names := test.ResourceNames{
-		Service: test.ObjectNameForTest(t),
-		Image:   test.Timeout,
+	testCases := []struct {
+		name           string
+		shouldScaleTo0 bool
+		timeoutSeconds int64
+		expectedStatus int
+		initialSleep   int
+		sleep          int
+	}{
+		{
+			name:           "when scaling up from 0 and does not exceed timeout seconds",
+			shouldScaleTo0: true,
+			timeoutSeconds: 5,
+			expectedStatus: http.StatusOK,
+			initialSleep:   0,
+			sleep:          0,
+		},
+		{
+			name:           "when scaling up from 0 and it writes first byte before timeout",
+			shouldScaleTo0: true,
+			timeoutSeconds: 5,
+			expectedStatus: http.StatusOK,
+			initialSleep:   0,
+			sleep:          10,
+		},
+		{
+			name:           "when scaling up from 0 and it does exceed timeout seconds",
+			shouldScaleTo0: true,
+			timeoutSeconds: 1, // If the pods come up faster than 1s, this test might fail.
+			expectedStatus: http.StatusGatewayTimeout,
+		},
+		{
+			name:           "when pods already exist, and it does not exceed timeout seconds",
+			timeoutSeconds: 5,
+			expectedStatus: http.StatusOK,
+			initialSleep:   2,
+			sleep:          0,
+		},
+		{
+			name:           "when pods already exist, and it does exceed timeout seconds",
+			timeoutSeconds: 5,
+			expectedStatus: http.StatusGatewayTimeout,
+			initialSleep:   7,
+			sleep:          1,
+		},
+		{
+			name:           "when pods already exist, and it writes first byte before timeout",
+			timeoutSeconds: 5,
+			expectedStatus: http.StatusOK,
+			initialSleep:   0,
+			sleep:          10,
+		},
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			names := test.ResourceNames{
+				Service: test.ObjectNameForTest(t),
+				Image:   test.Timeout,
+			}
 
-	t.Log("Creating a new Service in runLatest")
-	svc, err := createLatestService(t, clients, names, 2)
-	if err != nil {
-		t.Fatal("Failed to create Service:", err)
-	}
-	names.Route = serviceresourcenames.Route(svc)
-	names.Config = serviceresourcenames.Configuration(svc)
+			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+			defer test.TearDown(clients, names)
 
-	t.Log("The Service will be updated with the name of the Revision once it is created")
-	revisionName, err := v1a1test.WaitForServiceLatestRevision(clients, names)
-	if err != nil {
-		t.Fatalf("Service %s was not updated with the new revision: %v", names.Service, err)
-	}
-	rev2s.Revision = revisionName
+			t.Log("Creating a new Service ")
+			svc, err := createLatestService(t, clients, names, tc.timeoutSeconds)
+			if err != nil {
+				t.Fatal("Failed to create Service:", err)
+			}
 
-	t.Log("When the Service reports as Ready, everything should be ready")
-	if err := v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, v1a1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
-	}
+			names.Route = serviceresourcenames.Route(svc)
+			names.Config = serviceresourcenames.Configuration(svc)
 
-	t.Log("Updating the Service to use a different revision timeout")
-	err = updateServiceWithTimeout(clients, names, 5)
-	if err != nil {
-		t.Fatalf("Patch update for Service %s with new timeout 5s failed: %v", names.Service, err)
-	}
+			t.Log("The Service will be updated with the name of the Revision once it is created")
+			revisionName, err := v1a1test.WaitForServiceLatestRevision(clients, names)
+			if err != nil {
+				t.Fatalf("Service %s was not updated with the new revision: %v", names.Service, err)
+			}
+			names.Revision = revisionName
 
-	// getNextRevisionName waits for names.Revision to change, so we set it to the rev2s revision and wait for the (new) rev5s revision.
-	names.Revision = rev2s.Revision
+			t.Log("When the Service reports as Ready, everything should be ready")
+			if err := v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, v1a1test.IsServiceReady, "ServiceIsReady"); err != nil {
+				t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
+			}
 
-	t.Log("Since the Service was updated a new Revision will be created and the Service will be updated")
-	rev5s.Revision, err = v1a1test.WaitForServiceLatestRevision(clients, names)
-	if err != nil {
-		t.Fatalf("Service %s was not updated with the Revision with timeout 5s: %v", names.Service, err)
-	}
+			service, err := clients.ServingAlphaClient.Services.Get(names.Service, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Error fetching Service %s: %v", names.Service, err)
+			}
 
-	t.Logf("Waiting for revision %q to be ready", rev2s.Revision)
-	if err := v1a1test.WaitForRevisionState(clients.ServingAlphaClient, rev2s.Revision, v1a1test.IsRevisionReady, "RevisionIsReady"); err != nil {
-		t.Fatalf("The Revision %q still can't serve traffic: %v", rev2s.Revision, err)
-	}
-	t.Logf("Waiting for revision %q to be ready", rev5s.Revision)
-	if err := v1a1test.WaitForRevisionState(clients.ServingAlphaClient, rev5s.Revision, v1a1test.IsRevisionReady, "RevisionIsReady"); err != nil {
-		t.Fatalf("The Revision %q still can't serve traffic: %v", rev5s.Revision, err)
-	}
+			if service.Status.URL == nil {
+				t.Fatalf("Unable to fetch URLs from service: %#v", service.Status)
+			}
 
-	// Set names for traffic targets to make them directly routable.
-	rev2s.TrafficTarget = "rev2s"
-	rev5s.TrafficTarget = "rev5s"
+			serviceURL := url.URL(*service.Status.URL)
 
-	t.Log("Updating RouteSpec")
-	if _, err := v1a1test.UpdateServiceRouteSpec(t, clients, names, v1alpha1.RouteSpec{
-		Traffic: []v1alpha1.TrafficTarget{{
-			TrafficTarget: v1.TrafficTarget{
-				Tag:          rev2s.TrafficTarget,
-				RevisionName: rev2s.Revision,
-				Percent:      ptr.Int64(50),
-			},
-		}, {
-			TrafficTarget: v1.TrafficTarget{
-				Tag:          rev5s.TrafficTarget,
-				RevisionName: rev5s.Revision,
-				Percent:      ptr.Int64(50),
-			},
-		}},
-	}); err != nil {
-		t.Fatal("Failed to update Service:", err)
-	}
+			if tc.shouldScaleTo0 {
+				t.Log("Waiting to scale down to 0")
+				revision, err := clients.ServingBetaClient.Revisions.Get(names.Revision, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Error fetching Service %s: %v", names.Service, err)
+				}
 
-	t.Log("Wait for the service to be ready")
-	if err := v1a1test.WaitForServiceState(clients.ServingAlphaClient, names.Service, v1a1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("The Service %s was not marked as Ready to serve traffic: %v", names.Service, err)
-	}
+				if err := e2e.WaitForScaleToZero(t, revisionresourcenames.Deployment(revision), clients); err != nil {
+					t.Fatal("Could not scale to zero:", err)
+				}
+			} else {
+				t.Log("Probing to force at least non-zero pods", &serviceURL)
+				if _, err := pkgTest.WaitForEndpointState(
+					clients.KubeClient,
+					t.Logf,
+					&serviceURL,
+					v1a1test.RetryingRouteInconsistency(pkgTest.IsOneOfStatusCodes(http.StatusOK, http.StatusGatewayTimeout)),
+					"WaitForSuccessfulResponse",
+					test.ServingFlags.ResolvableDomain,
+					test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https)); err != nil {
+					t.Fatalf("Error probing %s: %v", &serviceURL, err)
+				}
+			}
 
-	service, err := clients.ServingAlphaClient.Services.Get(names.Service, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
-	}
-
-	var rev2sURL, rev5sURL *url.URL
-	for _, tt := range service.Status.Traffic {
-		if tt.Tag == rev2s.TrafficTarget {
-			rev2sURL = tt.URL.URL()
-		}
-		if tt.Tag == rev5s.TrafficTarget {
-			rev5sURL = tt.URL.URL()
-		}
-	}
-	if rev2sURL == nil || rev5sURL == nil {
-		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", service.Status.Traffic)
-	}
-
-	t.Log("Probing", rev5sURL)
-	if _, err := pkgTest.WaitForEndpointState(
-		clients.KubeClient,
-		t.Logf,
-		rev5sURL,
-		v1a1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
-		"WaitForSuccessfulResponse",
-		test.ServingFlags.ResolvableDomain,
-		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https)); err != nil {
-		t.Fatalf("Error probing %s: %v", rev5sURL, err)
-	}
-
-	t.Log("Probing", rev2sURL)
-	if _, err := pkgTest.WaitForEndpointState(
-		clients.KubeClient,
-		t.Logf,
-		rev2sURL,
-		v1a1test.RetryingRouteInconsistency(pkgTest.IsOneOfStatusCodes(http.StatusOK, http.StatusGatewayTimeout)),
-		"WaitForSuccessfulResponse",
-		test.ServingFlags.ResolvableDomain,
-		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https)); err != nil {
-		t.Fatalf("Error probing %s: %v", rev2sURL, err)
-	}
-
-	// Quick sanity check
-	if err := sendRequest(t, clients, rev2sURL, 0, 0, http.StatusOK); err != nil {
-		t.Errorf("Failed request with sleep 0s with revision timeout 2s: %v", err)
-	}
-	if err := sendRequest(t, clients, rev5sURL, 0, 0, http.StatusOK); err != nil {
-		t.Errorf("Failed request with sleep 0s with revision timeout 5s: %v", err)
-	}
-
-	// Fail by surpassing the initial timeout.
-	if err := sendRequest(t, clients, rev2sURL, 5*time.Second, 0, http.StatusGatewayTimeout); err != nil {
-		t.Errorf("Did not fail request with sleep 5s with revision timeout 2s: %v", err)
-	}
-	if err := sendRequest(t, clients, rev5sURL, 7*time.Second, 0, http.StatusGatewayTimeout); err != nil {
-		t.Errorf("Did not fail request with sleep 7s with revision timeout 5s: %v", err)
-	}
-
-	// Not fail by not surpassing in the initial timeout, but in the overall request duration.
-	if err := sendRequest(t, clients, rev2sURL, time.Second, 3*time.Second, http.StatusOK); err != nil {
-		t.Errorf("Did not fail request with sleep 1s/3s with revision timeout 2s: %v", err)
-	}
-	if err := sendRequest(t, clients, rev5sURL, 3*time.Second, 3*time.Second, http.StatusOK); err != nil {
-		t.Errorf("Failed request with sleep 3s/3s with revision timeout 5s: %v", err)
+			if err := sendRequest(t, clients, &serviceURL, time.Duration(tc.initialSleep)*time.Second, time.Duration(tc.sleep)*time.Second, tc.expectedStatus); err != nil {
+				t.Errorf("Failed request with intialSleep %ds, sleep %ds, with revision timeout %ds and expecting status %v: %v",
+					tc.initialSleep, tc.sleep, tc.timeoutSeconds, tc.expectedStatus, err)
+			}
+		})
 	}
 }

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -91,51 +91,44 @@ func TestRevisionTimeout(t *testing.T) {
 		expectedStatus int
 		initialSleep   int
 		sleep          int
-	}{
-		{
-			name:           "when scaling up from 0 and does not exceed timeout seconds",
-			shouldScaleTo0: true,
-			timeoutSeconds: 5,
-			expectedStatus: http.StatusOK,
-			initialSleep:   0,
-			sleep:          0,
-		},
-		{
-			name:           "when scaling up from 0 and it writes first byte before timeout",
-			shouldScaleTo0: true,
-			timeoutSeconds: 5,
-			expectedStatus: http.StatusOK,
-			initialSleep:   0,
-			sleep:          10,
-		},
-		{
-			name:           "when scaling up from 0 and it does exceed timeout seconds",
-			shouldScaleTo0: true,
-			timeoutSeconds: 1, // If the pods come up faster than 1s, this test might fail.
-			expectedStatus: http.StatusGatewayTimeout,
-		},
-		{
-			name:           "when pods already exist, and it does not exceed timeout seconds",
-			timeoutSeconds: 5,
-			expectedStatus: http.StatusOK,
-			initialSleep:   2,
-			sleep:          0,
-		},
-		{
-			name:           "when pods already exist, and it does exceed timeout seconds",
-			timeoutSeconds: 5,
-			expectedStatus: http.StatusGatewayTimeout,
-			initialSleep:   7,
-			sleep:          1,
-		},
-		{
-			name:           "when pods already exist, and it writes first byte before timeout",
-			timeoutSeconds: 5,
-			expectedStatus: http.StatusOK,
-			initialSleep:   0,
-			sleep:          10,
-		},
-	}
+	}{{
+		name:           "when scaling up from 0 and does not exceed timeout seconds",
+		shouldScaleTo0: true,
+		timeoutSeconds: 5,
+		expectedStatus: http.StatusOK,
+		initialSleep:   0,
+		sleep:          0,
+	}, {
+		name:           "when scaling up from 0 and it writes first byte before timeout",
+		shouldScaleTo0: true,
+		timeoutSeconds: 5,
+		expectedStatus: http.StatusOK,
+		initialSleep:   0,
+		sleep:          10,
+	}, {
+		name:           "when scaling up from 0 and it does exceed timeout seconds",
+		shouldScaleTo0: true,
+		timeoutSeconds: 1, // If the pods come up faster than 1s, this test might fail.
+		expectedStatus: http.StatusGatewayTimeout,
+	}, {
+		name:           "when pods already exist, and it does not exceed timeout seconds",
+		timeoutSeconds: 5,
+		expectedStatus: http.StatusOK,
+		initialSleep:   2,
+		sleep:          0,
+	}, {
+		name:           "when pods already exist, and it does exceed timeout seconds",
+		timeoutSeconds: 5,
+		expectedStatus: http.StatusGatewayTimeout,
+		initialSleep:   7,
+		sleep:          1,
+	}, {
+		name:           "when pods already exist, and it writes first byte before timeout",
+		timeoutSeconds: 5,
+		expectedStatus: http.StatusOK,
+		initialSleep:   0,
+		sleep:          10,
+	}}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -29,7 +29,6 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
-	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"
 	v1a1test "knative.dev/serving/test/v1alpha1"
@@ -141,13 +140,10 @@ func TestRevisionTimeout(t *testing.T) {
 			defer test.TearDown(clients, names)
 
 			t.Log("Creating a new Service ")
-			svc, err := createLatestService(t, clients, names, tc.timeoutSeconds)
+			_, err := createLatestService(t, clients, names, tc.timeoutSeconds)
 			if err != nil {
 				t.Fatal("Failed to create Service:", err)
 			}
-
-			names.Route = serviceresourcenames.Route(svc)
-			names.Config = serviceresourcenames.Configuration(svc)
 
 			t.Log("The Service will be updated with the name of the Revision once it is created")
 			revisionName, err := v1a1test.WaitForServiceLatestRevision(clients, names)
@@ -183,7 +179,7 @@ func TestRevisionTimeout(t *testing.T) {
 					t.Fatal("Could not scale to zero:", err)
 				}
 			} else {
-				t.Log("Probing to force at least non-zero pods", &serviceURL)
+				t.Log("Probing to force at least one pod", &serviceURL)
 				if _, err := pkgTest.WaitForEndpointState(
 					clients.KubeClient,
 					t.Logf,

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -179,7 +179,7 @@ func TestRevisionTimeout(t *testing.T) {
 					t.Fatal("Could not scale to zero:", err)
 				}
 			} else {
-				t.Log("Probing to force at least one pod", &serviceURL)
+				t.Log("Probing to force at least one pod", serviceURL.String())
 				if _, err := pkgTest.WaitForEndpointState(
 					clients.KubeClient,
 					t.Logf,

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -212,6 +212,18 @@ func TestRevisionTimeout(t *testing.T) {
 		t.Fatalf("Error probing %s: %v", rev5sURL, err)
 	}
 
+	t.Log("Probing", rev2sURL)
+	if _, err := pkgTest.WaitForEndpointState(
+		clients.KubeClient,
+		t.Logf,
+		rev2sURL,
+		v1a1test.RetryingRouteInconsistency(pkgTest.IsOneOfStatusCodes(http.StatusOK, http.StatusGatewayTimeout)),
+		"WaitForSuccessfulResponse",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https)); err != nil {
+		t.Fatalf("Error probing %s: %v", rev2sURL, err)
+	}
+
 	// Quick sanity check
 	if err := sendRequest(t, clients, rev2sURL, 0, 0, http.StatusOK); err != nil {
 		t.Errorf("Failed request with sleep 0s with revision timeout 2s: %v", err)

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -94,17 +94,17 @@ func TestRevisionTimeout(t *testing.T) {
 	}{{
 		name:           "when scaling up from 0 and does not exceed timeout seconds",
 		shouldScaleTo0: true,
-		timeoutSeconds: 5,
+		timeoutSeconds: 10,
 		expectedStatus: http.StatusOK,
 		initialSleep:   0,
 		sleep:          0,
 	}, {
 		name:           "when scaling up from 0 and it writes first byte before timeout",
 		shouldScaleTo0: true,
-		timeoutSeconds: 5,
+		timeoutSeconds: 10,
 		expectedStatus: http.StatusOK,
 		initialSleep:   0,
-		sleep:          10,
+		sleep:          15,
 	}, {
 		name:           "when scaling up from 0 and it does exceed timeout seconds",
 		shouldScaleTo0: true,
@@ -112,22 +112,22 @@ func TestRevisionTimeout(t *testing.T) {
 		expectedStatus: http.StatusGatewayTimeout,
 	}, {
 		name:           "when pods already exist, and it does not exceed timeout seconds",
-		timeoutSeconds: 5,
+		timeoutSeconds: 10,
 		expectedStatus: http.StatusOK,
 		initialSleep:   2,
 		sleep:          0,
 	}, {
 		name:           "when pods already exist, and it does exceed timeout seconds",
-		timeoutSeconds: 5,
+		timeoutSeconds: 10,
 		expectedStatus: http.StatusGatewayTimeout,
-		initialSleep:   7,
-		sleep:          1,
+		initialSleep:   12,
+		sleep:          0,
 	}, {
 		name:           "when pods already exist, and it writes first byte before timeout",
-		timeoutSeconds: 5,
+		timeoutSeconds: 10,
 		expectedStatus: http.StatusOK,
 		initialSleep:   0,
-		sleep:          10,
+		sleep:          15,
 	}}
 
 	for _, tc := range testCases {

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -91,51 +91,44 @@ func TestRevisionTimeout(t *testing.T) {
 		expectedStatus int
 		initialSleep   int
 		sleep          int
-	}{
-		{
-			name:           "when scaling up from 0 and does not exceed timeout seconds",
-			shouldScaleTo0: true,
-			timeoutSeconds: 5,
-			expectedStatus: http.StatusOK,
-			initialSleep:   0,
-			sleep:          0,
-		},
-		{
-			name:           "when scaling up from 0 and it writes first byte before timeout",
-			shouldScaleTo0: true,
-			timeoutSeconds: 5,
-			expectedStatus: http.StatusOK,
-			initialSleep:   0,
-			sleep:          10,
-		},
-		{
-			name:           "when scaling up from 0 and it does exceed timeout seconds",
-			shouldScaleTo0: true,
-			timeoutSeconds: 1, // If the pods come up faster than 1s, this test might fail.
-			expectedStatus: http.StatusGatewayTimeout,
-		},
-		{
-			name:           "when pods already exist, and it does not exceed timeout seconds",
-			timeoutSeconds: 5,
-			expectedStatus: http.StatusOK,
-			initialSleep:   2,
-			sleep:          0,
-		},
-		{
-			name:           "when pods already exist, and it does exceed timeout seconds",
-			timeoutSeconds: 5,
-			expectedStatus: http.StatusGatewayTimeout,
-			initialSleep:   7,
-			sleep:          1,
-		},
-		{
-			name:           "when pods already exist, and it writes first byte before timeout",
-			timeoutSeconds: 5,
-			expectedStatus: http.StatusOK,
-			initialSleep:   0,
-			sleep:          10,
-		},
-	}
+	}{{
+		name:           "when scaling up from 0 and does not exceed timeout seconds",
+		shouldScaleTo0: true,
+		timeoutSeconds: 5,
+		expectedStatus: http.StatusOK,
+		initialSleep:   0,
+		sleep:          0,
+	}, {
+		name:           "when scaling up from 0 and it writes first byte before timeout",
+		shouldScaleTo0: true,
+		timeoutSeconds: 5,
+		expectedStatus: http.StatusOK,
+		initialSleep:   0,
+		sleep:          10,
+	}, {
+		name:           "when scaling up from 0 and it does exceed timeout seconds",
+		shouldScaleTo0: true,
+		timeoutSeconds: 1, // If the pods come up faster than 1s, this test might fail.
+		expectedStatus: http.StatusGatewayTimeout,
+	}, {
+		name:           "when pods already exist, and it does not exceed timeout seconds",
+		timeoutSeconds: 5,
+		expectedStatus: http.StatusOK,
+		initialSleep:   2,
+		sleep:          0,
+	}, {
+		name:           "when pods already exist, and it does exceed timeout seconds",
+		timeoutSeconds: 5,
+		expectedStatus: http.StatusGatewayTimeout,
+		initialSleep:   7,
+		sleep:          1,
+	}, {
+		name:           "when pods already exist, and it writes first byte before timeout",
+		timeoutSeconds: 5,
+		expectedStatus: http.StatusOK,
+		initialSleep:   0,
+		sleep:          10,
+	}}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -179,7 +179,7 @@ func TestRevisionTimeout(t *testing.T) {
 					t.Fatal("Could not scale to zero:", err)
 				}
 			} else {
-				t.Log("Probing to force at least pods", &serviceURL)
+				t.Log("Probing to force at least one pod", serviceURL.String())
 				if _, err := pkgTest.WaitForEndpointState(
 					clients.KubeClient,
 					t.Logf,

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -29,7 +29,6 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
-	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"
 	v1b1test "knative.dev/serving/test/v1beta1"
@@ -141,13 +140,10 @@ func TestRevisionTimeout(t *testing.T) {
 			defer test.TearDown(clients, names)
 
 			t.Log("Creating a new Service ")
-			svc, err := createService(t, clients, names, tc.timeoutSeconds)
+			_, err := createService(t, clients, names, tc.timeoutSeconds)
 			if err != nil {
 				t.Fatal("Failed to create Service:", err)
 			}
-
-			names.Route = serviceresourcenames.Route(svc)
-			names.Config = serviceresourcenames.Configuration(svc)
 
 			t.Log("The Service will be updated with the name of the Revision once it is created")
 			revisionName, err := v1b1test.WaitForServiceLatestRevision(clients, names)
@@ -183,7 +179,7 @@ func TestRevisionTimeout(t *testing.T) {
 					t.Fatal("Could not scale to zero:", err)
 				}
 			} else {
-				t.Log("Probing to force at least non-zero pods", &serviceURL)
+				t.Log("Probing to force at least pods", &serviceURL)
 				if _, err := pkgTest.WaitForEndpointState(
 					clients.KubeClient,
 					t.Logf,

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -19,22 +19,19 @@ limitations under the License.
 package v1beta1
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
 	"time"
 
-	"github.com/mattbaird/jsonpatch"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/pkg/ptr"
 	pkgTest "knative.dev/pkg/test"
-	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
+	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
 	"knative.dev/serving/test"
+	"knative.dev/serving/test/e2e"
 	v1b1test "knative.dev/serving/test/v1beta1"
 
 	. "knative.dev/serving/pkg/testing/v1beta1"
@@ -46,20 +43,6 @@ func createService(t *testing.T, clients *test.Clients, names test.ResourceNames
 	service := v1b1test.Service(names, WithRevisionTimeoutSeconds(revisionTimeoutSeconds))
 	v1b1test.LogResourceObject(t, v1b1test.ResourceObjects{Service: service})
 	return clients.ServingBetaClient.Services.Create(service)
-}
-
-func updateServiceWithTimeout(clients *test.Clients, names test.ResourceNames, revisionTimeoutSeconds int64) error {
-	patches := []jsonpatch.JsonPatchOperation{{
-		Operation: "replace",
-		Path:      "/spec/template/spec/timeoutSeconds",
-		Value:     revisionTimeoutSeconds,
-	}}
-	patchBytes, err := json.Marshal(patches)
-	if err != nil {
-		return err
-	}
-	_, err = clients.ServingBetaClient.Services.Patch(names.Service, types.JSONPatchType, patchBytes, "")
-	return err
 }
 
 // sendRequests send a request to "endpoint", returns error if unexpected response code, nil otherwise.
@@ -101,145 +84,129 @@ func TestRevisionTimeout(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 
-	var rev2s, rev5s test.ResourceNames
-	names := test.ResourceNames{
-		Service: test.ObjectNameForTest(t),
-		Image:   test.Timeout,
+	testCases := []struct {
+		name           string
+		shouldScaleTo0 bool
+		timeoutSeconds int64
+		expectedStatus int
+		initialSleep   int
+		sleep          int
+	}{
+		{
+			name:           "when scaling up from 0 and does not exceed timeout seconds",
+			shouldScaleTo0: true,
+			timeoutSeconds: 5,
+			expectedStatus: http.StatusOK,
+			initialSleep:   0,
+			sleep:          0,
+		},
+		{
+			name:           "when scaling up from 0 and it writes first byte before timeout",
+			shouldScaleTo0: true,
+			timeoutSeconds: 5,
+			expectedStatus: http.StatusOK,
+			initialSleep:   0,
+			sleep:          10,
+		},
+		{
+			name:           "when scaling up from 0 and it does exceed timeout seconds",
+			shouldScaleTo0: true,
+			timeoutSeconds: 1, // If the pods come up faster than 1s, this test might fail.
+			expectedStatus: http.StatusGatewayTimeout,
+		},
+		{
+			name:           "when pods already exist, and it does not exceed timeout seconds",
+			timeoutSeconds: 5,
+			expectedStatus: http.StatusOK,
+			initialSleep:   2,
+			sleep:          0,
+		},
+		{
+			name:           "when pods already exist, and it does exceed timeout seconds",
+			timeoutSeconds: 5,
+			expectedStatus: http.StatusGatewayTimeout,
+			initialSleep:   7,
+			sleep:          1,
+		},
+		{
+			name:           "when pods already exist, and it writes first byte before timeout",
+			timeoutSeconds: 5,
+			expectedStatus: http.StatusOK,
+			initialSleep:   0,
+			sleep:          10,
+		},
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			names := test.ResourceNames{
+				Service: test.ObjectNameForTest(t),
+				Image:   test.Timeout,
+			}
 
-	t.Log("Creating a new Service ")
-	svc, err := createService(t, clients, names, 2)
-	if err != nil {
-		t.Fatal("Failed to create Service:", err)
-	}
-	names.Route = serviceresourcenames.Route(svc)
-	names.Config = serviceresourcenames.Configuration(svc)
+			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+			defer test.TearDown(clients, names)
 
-	t.Log("The Service will be updated with the name of the Revision once it is created")
-	revisionName, err := v1b1test.WaitForServiceLatestRevision(clients, names)
-	if err != nil {
-		t.Fatalf("Service %s was not updated with the new revision: %v", names.Service, err)
-	}
-	rev2s.Revision = revisionName
+			t.Log("Creating a new Service ")
+			svc, err := createService(t, clients, names, tc.timeoutSeconds)
+			if err != nil {
+				t.Fatal("Failed to create Service:", err)
+			}
 
-	t.Log("When the Service reports as Ready, everything should be ready")
-	if err := v1b1test.WaitForServiceState(clients.ServingBetaClient, names.Service, v1b1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
-	}
+			names.Route = serviceresourcenames.Route(svc)
+			names.Config = serviceresourcenames.Configuration(svc)
 
-	t.Log("Updating the Service to use a different revision timeout")
-	err = updateServiceWithTimeout(clients, names, 5)
-	if err != nil {
-		t.Fatalf("Patch update for Service %s with new timeout 5s failed: %v", names.Service, err)
-	}
+			t.Log("The Service will be updated with the name of the Revision once it is created")
+			revisionName, err := v1b1test.WaitForServiceLatestRevision(clients, names)
+			if err != nil {
+				t.Fatalf("Service %s was not updated with the new revision: %v", names.Service, err)
+			}
+			names.Revision = revisionName
 
-	// getNextRevisionName waits for names.Revision to change, so we set it to the rev2s revision and wait for the (new) rev5s revision.
-	names.Revision = rev2s.Revision
+			t.Log("When the Service reports as Ready, everything should be ready")
+			if err := v1b1test.WaitForServiceState(clients.ServingBetaClient, names.Service, v1b1test.IsServiceReady, "ServiceIsReady"); err != nil {
+				t.Fatalf("The Service %s was not marked as Ready to serve traffic to Revision %s: %v", names.Service, names.Revision, err)
+			}
 
-	t.Log("Since the Service was updated a new Revision will be created and the Service will be updated")
-	rev5s.Revision, err = v1b1test.WaitForServiceLatestRevision(clients, names)
-	if err != nil {
-		t.Fatalf("Service %s was not updated with the Revision with timeout 5s: %v", names.Service, err)
-	}
+			service, err := clients.ServingClient.Services.Get(names.Service, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Error fetching Service %s: %v", names.Service, err)
+			}
 
-	t.Logf("Waiting for revision %q to be ready", rev2s.Revision)
-	if err := v1b1test.WaitForRevisionState(clients.ServingBetaClient, rev2s.Revision, v1b1test.IsRevisionReady, "RevisionIsReady"); err != nil {
-		t.Fatalf("The Revision %q still can't serve traffic: %v", rev2s.Revision, err)
-	}
-	t.Logf("Waiting for revision %q to be ready", rev5s.Revision)
-	if err := v1b1test.WaitForRevisionState(clients.ServingBetaClient, rev5s.Revision, v1b1test.IsRevisionReady, "RevisionIsReady"); err != nil {
-		t.Fatalf("The Revision %q still can't serve traffic: %v", rev5s.Revision, err)
-	}
+			if service.Status.URL == nil {
+				t.Fatalf("Unable to fetch URLs from service: %#v", service.Status)
+			}
 
-	// Set names for traffic targets to make them directly routable.
-	rev2s.TrafficTarget = "rev2s"
-	rev5s.TrafficTarget = "rev5s"
+			serviceURL := url.URL(*service.Status.URL)
 
-	t.Log("Updating RouteSpec")
-	if _, err := v1b1test.UpdateServiceRouteSpec(t, clients, names, v1.RouteSpec{
-		Traffic: []v1.TrafficTarget{{
-			Tag:          rev2s.TrafficTarget,
-			RevisionName: rev2s.Revision,
-			Percent:      ptr.Int64(50),
-		}, {
-			Tag:          rev5s.TrafficTarget,
-			RevisionName: rev5s.Revision,
-			Percent:      ptr.Int64(50),
-		}},
-	}); err != nil {
-		t.Fatal("Failed to update Service:", err)
-	}
+			if tc.shouldScaleTo0 {
+				t.Log("Waiting to scale down to 0")
+				revision, err := clients.ServingBetaClient.Revisions.Get(names.Revision, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Error fetching Service %s: %v", names.Service, err)
+				}
 
-	t.Log("Wait for the service domains to be ready")
-	if err := v1b1test.WaitForServiceState(clients.ServingBetaClient, names.Service, v1b1test.IsServiceReady, "ServiceIsReady"); err != nil {
-		t.Fatalf("The Service %s was not marked as Ready to serve traffic: %v", names.Service, err)
-	}
+				if err := e2e.WaitForScaleToZero(t, revisionresourcenames.Deployment(revision), clients); err != nil {
+					t.Fatal("Could not scale to zero:", err)
+				}
+			} else {
+				t.Log("Probing to force at least non-zero pods", &serviceURL)
+				if _, err := pkgTest.WaitForEndpointState(
+					clients.KubeClient,
+					t.Logf,
+					&serviceURL,
+					v1b1test.RetryingRouteInconsistency(pkgTest.IsOneOfStatusCodes(http.StatusOK, http.StatusGatewayTimeout)),
+					"WaitForSuccessfulResponse",
+					test.ServingFlags.ResolvableDomain,
+					test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https)); err != nil {
+					t.Fatalf("Error probing %s: %v", &serviceURL, err)
+				}
+			}
 
-	service, err := clients.ServingBetaClient.Services.Get(names.Service, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
-	}
-
-	var rev2sURL, rev5sURL *url.URL
-	for _, tt := range service.Status.Traffic {
-		if tt.Tag == rev2s.TrafficTarget {
-			rev2sURL = tt.URL.URL()
-		}
-		if tt.Tag == rev5s.TrafficTarget {
-			rev5sURL = tt.URL.URL()
-		}
-	}
-	if rev2sURL == nil || rev5sURL == nil {
-		t.Fatalf("Unable to fetch URLs from traffic targets: %#v", service.Status.Traffic)
-	}
-
-	t.Log("Probing", rev5sURL)
-	if _, err := pkgTest.WaitForEndpointState(
-		clients.KubeClient,
-		t.Logf,
-		rev5sURL,
-		v1b1test.RetryingRouteInconsistency(pkgTest.IsStatusOK),
-		"WaitForSuccessfulResponse",
-		test.ServingFlags.ResolvableDomain,
-		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https)); err != nil {
-		t.Fatalf("Error probing %s: %v", rev5sURL, err)
-	}
-	t.Log("Probing", rev2sURL)
-	if _, err := pkgTest.WaitForEndpointState(
-		clients.KubeClient,
-		t.Logf,
-		rev2sURL,
-		v1b1test.RetryingRouteInconsistency(pkgTest.IsOneOfStatusCodes(http.StatusOK, http.StatusGatewayTimeout)),
-		"WaitForSuccessfulResponse",
-		test.ServingFlags.ResolvableDomain,
-		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https)); err != nil {
-		t.Fatalf("Error probing %s: %v", rev2sURL, err)
-	}
-
-	// Quick sanity check
-	if err := sendRequest(t, clients, rev2sURL, 0, 0, http.StatusOK); err != nil {
-		t.Errorf("Failed request with sleep 0s with revision timeout 2s: %v", err)
-	}
-	if err := sendRequest(t, clients, rev5sURL, 0, 0, http.StatusOK); err != nil {
-		t.Errorf("Failed request with sleep 0s with revision timeout 5s: %v", err)
-	}
-
-	// Fail by surpassing the initial timeout.
-	if err := sendRequest(t, clients, rev2sURL, 5*time.Second, 0, http.StatusGatewayTimeout); err != nil {
-		t.Errorf("Did not fail request with sleep 5s with revision timeout 2s: %v", err)
-	}
-	if err := sendRequest(t, clients, rev5sURL, 7*time.Second, 0, http.StatusGatewayTimeout); err != nil {
-		t.Errorf("Did not fail request with sleep 7s with revision timeout 5s: %v", err)
-	}
-
-	// Not fail by not surpassing in the initial timeout, but in the overall request duration.
-	if err := sendRequest(t, clients, rev2sURL, time.Second, 3*time.Second, http.StatusOK); err != nil {
-		t.Errorf("Did not fail request with sleep 1s/3s with revision timeout 2s: %v", err)
-	}
-	if err := sendRequest(t, clients, rev5sURL, 3*time.Second, 3*time.Second, http.StatusOK); err != nil {
-		t.Errorf("Failed request with sleep 3s/3s with revision timeout 5s: %v", err)
+			if err := sendRequest(t, clients, &serviceURL, time.Duration(tc.initialSleep)*time.Second, time.Duration(tc.sleep)*time.Second, tc.expectedStatus); err != nil {
+				t.Errorf("Failed request with intialSleep %ds, sleep %ds, with revision timeout %ds and expecting status %v: %v",
+					tc.initialSleep, tc.sleep, tc.timeoutSeconds, tc.expectedStatus, err)
+			}
+		})
 	}
 }

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -207,6 +207,17 @@ func TestRevisionTimeout(t *testing.T) {
 		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https)); err != nil {
 		t.Fatalf("Error probing %s: %v", rev5sURL, err)
 	}
+	t.Log("Probing", rev2sURL)
+	if _, err := pkgTest.WaitForEndpointState(
+		clients.KubeClient,
+		t.Logf,
+		rev2sURL,
+		v1b1test.RetryingRouteInconsistency(pkgTest.IsOneOfStatusCodes(http.StatusOK, http.StatusGatewayTimeout)),
+		"WaitForSuccessfulResponse",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https)); err != nil {
+		t.Fatalf("Error probing %s: %v", rev2sURL, err)
+	}
 
 	// Quick sanity check
 	if err := sendRequest(t, clients, rev2sURL, 0, 0, http.StatusOK); err != nil {

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -7,7 +7,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,6 +21,7 @@ package e2e
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 
@@ -28,8 +29,11 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	pkgtest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logstream"
+	"knative.dev/pkg/test/spoof"
+	"knative.dev/serving/pkg/apis/autoscaling"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	rnames "knative.dev/serving/pkg/reconciler/revision/resources/names"
+	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 	v1test "knative.dev/serving/test/v1"
 )
@@ -123,4 +127,98 @@ func TestActivatorOverload(t *testing.T) {
 		}()
 	}
 	group.Wait()
+}
+
+func TestActivatorRevisionTimeout(t *testing.T) {
+	t.Parallel()
+	cancel := logstream.Start(t)
+	defer cancel()
+
+	const (
+		// The number of concurrent requests to hit the activator with.
+		concurrency = 1
+		// How long the service will process the request in ms.
+		serviceSleep = 10000
+		// body of timeout response from activator
+		wantTimeoutRespBody = "activator request timeout"
+	)
+	var (
+		group       sync.WaitGroup
+		resp        []*spoof.Response
+		timeoutResp = 0
+		successResp = 0
+	)
+	clients := Setup(t)
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "timeout",
+	}
+	resp = make([]*spoof.Response, 5)
+
+	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	defer test.TearDown(clients, names)
+
+	t.Log("Creating a service with run latest configuration.")
+	// Create a service with concurrency 1 that sleeps for serviceSleep ms. Limit its maxScale to 1 containers and TBC = -1
+	resources, err := v1test.CreateServiceReady(t, clients, &names,
+		rtesting.WithContainerConcurrency(1),
+		rtesting.WithRevisionTimeoutSeconds(15),
+		rtesting.WithConfigAnnotations(map[string]string{
+			autoscaling.TargetBurstCapacityKey: "-1",
+			autoscaling.MaxScaleAnnotationKey:  "1",
+		}))
+	if err != nil {
+		t.Fatal("Unable to create resources:", err)
+	}
+
+	domain := resources.Route.Status.URL.Host
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
+	if err != nil {
+		t.Fatal("Error creating the Spoofing client:", err)
+	}
+
+	url := fmt.Sprintf("http://%s/?timeout=%d", domain, serviceSleep)
+
+	t.Log("Starting to send out requests")
+
+	// Send requests async and wait for the responses.
+	for i := 0; i < 5; i++ {
+		group.Add(1)
+		go func(i int) {
+			defer group.Done()
+			// We need to create a new request per HTTP request because
+			// the spoofing client mutates them.
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				t.Errorf("error creating http request: %v", err)
+			}
+			res, err := client.Do(req)
+			if err != nil {
+				t.Errorf("unexpected error sending a request, %v", err)
+				return
+			}
+			resp[i] = res
+		}(i)
+	}
+	group.Wait()
+
+	for _, res := range resp {
+		switch res.StatusCode {
+		case http.StatusOK:
+			successResp++
+		case http.StatusGatewayTimeout:
+			if responseString := string(res.Body); !strings.Contains(responseString, wantTimeoutRespBody) {
+				t.Errorf("got = %s, want: %s, response: %s", responseString, wantTimeoutRespBody, res)
+				return
+			}
+			timeoutResp++
+		default:
+			t.Errorf("Unexpected response: %s", res)
+		}
+	}
+	// Among 5 requests only 2 should be handled by user containers. Of those 2 handled requests, 1st req finishes at 10s and 2nd request gets
+	// response bytes written before timeout. Rest of them(3 req) should timeout in activator.
+	if successResp != 2 || timeoutResp != 3 {
+		t.Errorf("want successful:2 timeout:3, got succeess: %d; timeout: %d; responses collection: %v", successResp, timeoutResp, resp)
+	}
 }

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -219,6 +219,6 @@ func TestActivatorRevisionTimeout(t *testing.T) {
 	// Among 5 requests only 2 should be handled by user containers. Of those 2 handled requests, 1st req finishes at 10s and 2nd request gets
 	// response bytes written before timeout. Rest of them(3 req) should timeout in activator.
 	if successResp != 2 || timeoutResp != 3 {
-		t.Errorf("want successful:2 timeout:3, got succeess: %d; timeout: %d; responses collection: %v", successResp, timeoutResp, resp)
+		t.Errorf("Want successful:2 timeout:3, got succeess: %d; timeout: %d; responses collection: %v", successResp, timeoutResp, resp)
 	}
 }

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -21,7 +21,6 @@ package e2e
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 	"testing"
 
@@ -29,11 +28,8 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	pkgtest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logstream"
-	"knative.dev/pkg/test/spoof"
-	"knative.dev/serving/pkg/apis/autoscaling"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	rnames "knative.dev/serving/pkg/reconciler/revision/resources/names"
-	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 	v1test "knative.dev/serving/test/v1"
 )
@@ -127,98 +123,4 @@ func TestActivatorOverload(t *testing.T) {
 		}()
 	}
 	group.Wait()
-}
-
-func TestActivatorRevisionTimeout(t *testing.T) {
-	t.Parallel()
-	cancel := logstream.Start(t)
-	defer cancel()
-
-	const (
-		// The number of concurrent requests to hit the activator with.
-		concurrency = 1
-		// How long the service will process the request in ms.
-		serviceSleep = 10000
-		// body of timeout response from activator
-		wantTimeoutRespBody = "activator request timeout"
-	)
-	var (
-		group       sync.WaitGroup
-		resp        []*spoof.Response
-		timeoutResp = 0
-		successResp = 0
-	)
-	clients := Setup(t)
-	names := test.ResourceNames{
-		Service: test.ObjectNameForTest(t),
-		Image:   "timeout",
-	}
-	resp = make([]*spoof.Response, 5)
-
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
-
-	t.Log("Creating a service with run latest configuration.")
-	// Create a service with concurrency 1 that sleeps for serviceSleep ms. Limit its maxScale to 1 containers and TBC = -1
-	resources, err := v1test.CreateServiceReady(t, clients, &names,
-		rtesting.WithContainerConcurrency(1),
-		rtesting.WithRevisionTimeoutSeconds(15),
-		rtesting.WithConfigAnnotations(map[string]string{
-			autoscaling.TargetBurstCapacityKey: "-1",
-			autoscaling.MaxScaleAnnotationKey:  "1",
-		}))
-	if err != nil {
-		t.Fatal("Unable to create resources:", err)
-	}
-
-	domain := resources.Route.Status.URL.Host
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, domain, test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
-	if err != nil {
-		t.Fatal("Error creating the Spoofing client:", err)
-	}
-
-	url := fmt.Sprintf("http://%s/?timeout=%d", domain, serviceSleep)
-
-	t.Log("Starting to send out requests")
-
-	// Send requests async and wait for the responses.
-	for i := 0; i < 5; i++ {
-		group.Add(1)
-		go func(i int) {
-			defer group.Done()
-			// We need to create a new request per HTTP request because
-			// the spoofing client mutates them.
-			req, err := http.NewRequest(http.MethodGet, url, nil)
-			if err != nil {
-				t.Errorf("error creating http request: %v", err)
-			}
-			res, err := client.Do(req)
-			if err != nil {
-				t.Errorf("unexpected error sending a request, %v", err)
-				return
-			}
-			resp[i] = res
-		}(i)
-	}
-	group.Wait()
-
-	for _, res := range resp {
-		switch res.StatusCode {
-		case http.StatusOK:
-			successResp++
-		case http.StatusGatewayTimeout:
-			if responseString := string(res.Body); !strings.Contains(responseString, wantTimeoutRespBody) {
-				t.Errorf("got = %s, want: %s, response: %s", responseString, wantTimeoutRespBody, res)
-				return
-			}
-			timeoutResp++
-		default:
-			t.Errorf("Unexpected response: %s", res)
-		}
-	}
-	// Among 5 requests only 2 should be handled by user containers. Of those 2 handled requests, 1st req finishes at 10s and 2nd request gets
-	// response bytes written before timeout. Rest of them(3 req) should timeout in activator.
-	if successResp != 2 || timeoutResp != 3 {
-		t.Errorf("Want successful:2 timeout:3, got succeess: %d; timeout: %d; responses collection: %v", successResp, timeoutResp, resp)
-	}
 }


### PR DESCRIPTION
Fixes #7796 

## Proposed Changes

* Refactoring timeout handler used by queue proxy to a generic package `knative.dev/pkg/http/handler`
* Update activator to use timeout handler when dealing with requests.

**Release Note**

```release-note
Activator now times out if received requests are not handled by the revision based on the revision's timeout seconds.
```

/lint