### PR TITLE
Update the location where to retrieve net-istio

### DIFF
--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -67,6 +67,8 @@ readonly MONITORING_TRACE_JAEGER_YAML=${YAML_OUTPUT_DIR}/monitoring-tracing-jaeg
 readonly MONITORING_TRACE_JAEGER_IN_MEM_YAML=${YAML_OUTPUT_DIR}/monitoring-tracing-jaeger-in-mem.yaml
 readonly MONITORING_LOG_ELASTICSEARCH_YAML=${YAML_OUTPUT_DIR}/monitoring-logs-elasticsearch.yaml
 
+readonly NET_ISTIO_YAML=${YAML_OUTPUT_DIR}/net-istio.yaml
+
 # Flags for all ko commands
 KO_YAML_FLAGS="-P"
 [[ "${KO_DOCKER_REPO}" != gcr.io/* ]] && KO_YAML_FLAGS=""
@@ -74,9 +76,16 @@ readonly KO_YAML_FLAGS="${KO_YAML_FLAGS} ${KO_FLAGS} --strict"
 
 if [[ -n "${TAG}" ]]; then
   LABEL_YAML_CMD=(sed -e "s|serving.knative.dev/release: devel|serving.knative.dev/release: \"${TAG}\"|")
+  NET_ISTIO_YAML_LINK=https://github.com/knative/net-istio/releases/download/${TAG}/release.yaml
+  if [[ `wget -S --spider "${NET_ISTIO_YAML_LINK}"  2>&1 | grep 'HTTP/1.1 404 Not Found'` ]]; then
+    NET_ISTIO_YAML_LINK=https://storage.googleapis.com/knative-nightly/net-istio/latest/release.yaml
+  fi
 else
   LABEL_YAML_CMD=(cat)
+  NET_ISTIO_YAML_LINK=https://storage.googleapis.com/knative-nightly/net-istio/latest/release.yaml
 fi
+
+readonly NET_ISTIO_YAML_LINK
 
 : ${KO_DOCKER_REPO:="ko.local"}
 export KO_DOCKER_REPO
@@ -99,10 +108,13 @@ ko resolve ${KO_YAML_FLAGS} -f config/hpa-autoscaling/ | "${LABEL_YAML_CMD[@]}" 
 # Create nscert related yaml
 ko resolve ${KO_YAML_FLAGS} -f config/namespace-wildcard-certs | "${LABEL_YAML_CMD[@]}" > "${SERVING_NSCERT_YAML}"
 
+# Download the net-istio.yaml
+wget "${NET_ISTIO_YAML_LINK}" -O "${NET_ISTIO_YAML}"
+
 # Create serving.yaml with all of the default components
 cat "${SERVING_CORE_YAML}" > "${SERVING_YAML}"
 cat "${SERVING_HPA_YAML}" >> "${SERVING_YAML}"
-cat "./third_party/net-istio.yaml" >> "${SERVING_YAML}"
+cat "${NET_ISTIO_YAML}" >> "${SERVING_YAML}"
 
 # Metrics via Prometheus & Grafana
 ko resolve ${KO_YAML_FLAGS} -R \


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #7593

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* This PR changes the location to pull the net-istio.yaml from knative/net-istio repo.
* Link validation is added. If the link is not available on the releases page of net-istio repository, we use the nightly build link.

cc @markusthoemmes @tcnghia @nak3 
