### PR TITLE
Use label rather than assuming Metric name equals Revision name

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -229,8 +229,8 @@ func statsScraperFactoryFunc(endpointsLister corev1listers.EndpointsLister,
 			return nil, nil
 		}
 
-		revisionName, ok := metric.Labels[serving.RevisionLabelKey]
-		if !ok || revisionName == "" {
+		revisionName := metric.Labels[serving.RevisionLabelKey]
+		if revisionName == "" {
 			return nil, fmt.Errorf("label %q not found or empty in Metric %s", serving.RevisionLabelKey, metric.Name)
 		}
 

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -225,15 +225,18 @@ func uniScalerFactoryFunc(endpointsInformer corev1informers.EndpointsInformer,
 func statsScraperFactoryFunc(endpointsLister corev1listers.EndpointsLister,
 	podLister corev1listers.PodLister) asmetrics.StatsScraperFactory {
 	return func(metric *av1alpha1.Metric, logger *zap.SugaredLogger) (asmetrics.StatsScraper, error) {
-		if metric.Spec.ScrapeTarget != "" {
-			podCounter := resources.NewScopedEndpointsCounter(
-				endpointsLister, metric.Namespace, metric.Spec.ScrapeTarget)
-			// TODO(vagababov): while metric name == revision name, we should utilize the proper
-			// values from the labels.
-			podAccessor := resources.NewPodAccessor(podLister, metric.Namespace, metric.Name)
-			return asmetrics.NewStatsScraper(metric, podCounter, podAccessor, logger)
+		if metric.Spec.ScrapeTarget == "" {
+			return nil, nil
 		}
-		return nil, nil
+
+		revisionName, ok := metric.Labels[serving.RevisionLabelKey]
+		if !ok || revisionName == "" {
+			return nil, fmt.Errorf("label %q not found or empty in Metric %s", serving.RevisionLabelKey, metric.Name)
+		}
+
+		podCounter := resources.NewScopedEndpointsCounter(endpointsLister, metric.Namespace, metric.Spec.ScrapeTarget)
+		podAccessor := resources.NewPodAccessor(podLister, metric.Namespace, revisionName)
+		return asmetrics.NewStatsScraper(metric, podCounter, podAccessor, logger)
 	}
 }
 


### PR DESCRIPTION
See @vagababov todo in the diff. Also converted `scrapeTarget != ""` check in to a guard clause to lose a little bit of indentation.
