### PR TITLE
Skip TestUpdate due to excessive flaking.

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -87,6 +87,8 @@ add_trap "kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --typ
 go_test_e2e -timeout=30m \
   $(go list ./test/conformance/... | grep -v certificate) \
   ./test/e2e ./test/e2e/hpa \
+  `# Skip TestUpdate due to excessive flaking https://github.com/knative/serving/issues/8032` \
+  -run="Test[^U]|TestUpdate.+" \
   ${parallelism} \
   "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -88,7 +88,7 @@ go_test_e2e -timeout=30m \
   $(go list ./test/conformance/... | grep -v certificate) \
   ./test/e2e ./test/e2e/hpa \
   `# Skip TestUpdate due to excessive flaking https://github.com/knative/serving/issues/8032` \
-  -run="Test[^U]|TestUpdate.+" \
+  -run="Test[^U]|TestU[^p]|TestUp[^d]|TestUpd[^a]|TestUpda[^t]|TestUpdat[^e]|TestUpdate.+" \
   ${parallelism} \
   "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -85,11 +85,15 @@ add_trap "kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --typ
 # Run conformance and e2e tests.
 
 go_test_e2e -timeout=30m \
-  $(go list ./test/conformance/... | grep -v certificate) \
+  $(go list ./test/conformance/... | grep -v 'certificate\|ingress' ) \
   ./test/e2e ./test/e2e/hpa \
-  `# Skip TestUpdate due to excessive flaking https://github.com/knative/serving/issues/8032` \
-  -run="Test[^U]|TestU[^p]|TestUp[^d]|TestUpd[^a]|TestUpda[^t]|TestUpdat[^e]|TestUpdate.+" \
   ${parallelism} \
+  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
+
+# We run KIngress conformance ingress separately, to make it easier to skip some tests.
+go_test_e2e -timeout=20m ./test/conformance/ingress ${parallelism}  \
+  `# Skip TestUpdate due to excessive flaking https://github.com/knative/serving/issues/8032` \
+  -run="Test[^U]" \
   "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 
 if (( HTTPS )); then


### PR DESCRIPTION
We don't want to just do `t.Skip()` since the test may still be useful for `net-*` repositories.  I opened https://github.com/knative/serving/issues/8032 to track the work of fixing this test.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
