### PR TITLE
Enable prober in HA tests for Controller

### DIFF
--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -53,12 +53,14 @@ func TestControllerHA(t *testing.T) {
 	service1Names, resources := createPizzaPlanetService(t)
 	test.EnsureTearDown(t, clients, &service1Names)
 
+	prober := test.RunRouteProber(t.Logf, clients, resources.Service.Status.URL.URL())
+	defer test.AssertProberDefault(t, prober)
+
 	for _, leader := range leaders.List() {
 		if err := clients.KubeClient.Kube.CoreV1().Pods(system.Namespace()).Delete(leader,
 			&metav1.DeleteOptions{}); err != nil && !apierrs.IsNotFound(err) {
 			t.Fatalf("Failed to delete pod %s: %v", leader, err)
 		}
-
 		if err := pkgTest.WaitForPodDeleted(clients.KubeClient, leader, system.Namespace()); err != nil {
 			t.Fatalf("Did not observe %s to actually be deleted: %v", leader, err)
 		}
@@ -68,8 +70,6 @@ func TestControllerHA(t *testing.T) {
 	if _, err := pkgHa.WaitForNewLeaders(t, clients.KubeClient, controllerDeploymentName, system.Namespace(), leaders, NumControllerReconcilers*test.ServingFlags.Buckets); err != nil {
 		t.Fatal("Failed to find new leader:", err)
 	}
-
-	assertServiceEventuallyWorks(t, clients, service1Names, resources.Service.Status.URL.URL(), test.PizzaPlanetText1)
 
 	// Verify that after changing the leader we can still create a new kservice
 	service2Names, _ := createPizzaPlanetService(t)


### PR DESCRIPTION
Pulling this code from https://github.com/knative/serving/pull/7777 where the test failed.
Need to debug and see why it failed there.
Update: I only saw the failure once in the current PR. And then couldn't reproduce it 10 times. 
I'd say this PR is ready to go in the current form.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
