### PR TITLE
Validate the stable window is not larger than WindowMax

### DIFF
--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -193,9 +193,12 @@ func validate(lc *Config) (*Config, error) {
 	}
 
 	// We can't permit stable window be less than our aggregation window for correctness.
-	if lc.StableWindow < autoscaling.WindowMin {
-		return nil, fmt.Errorf("stable-window = %v, must be at least %v", lc.StableWindow, autoscaling.WindowMin)
+	// Or too big, so that our desicions are too imprecise.
+	if lc.StableWindow < autoscaling.WindowMin || lc.StableWindow > autoscaling.WindowMax {
+		return nil, fmt.Errorf("stable-window = %v, must be in [%v; %v] range", lc.StableWindow,
+			autoscaling.WindowMin, autoscaling.WindowMax)
 	}
+
 	if lc.StableWindow.Round(time.Second) != lc.StableWindow {
 		return nil, fmt.Errorf("stable-window = %v, must be specified with at most second precision", lc.StableWindow)
 	}

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -193,7 +193,7 @@ func validate(lc *Config) (*Config, error) {
 	}
 
 	// We can't permit stable window be less than our aggregation window for correctness.
-	// Or too big, so that our desicions are too imprecise.
+	// Or too big, so that our desisions are too imprecise.
 	if lc.StableWindow < autoscaling.WindowMin || lc.StableWindow > autoscaling.WindowMax {
 		return nil, fmt.Errorf("stable-window = %v, must be in [%v; %v] range", lc.StableWindow,
 			autoscaling.WindowMin, autoscaling.WindowMax)

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -204,6 +204,12 @@ func TestNewConfig(t *testing.T) {
 		},
 		wantErr: true,
 	}, {
+		name: "stable window too big",
+		input: map[string]string{
+			"stable-window": "1h1s",
+		},
+		wantErr: true,
+	}, {
 		name: "stable window too small",
 		input: map[string]string{
 			"stable-window": "1s",


### PR DESCRIPTION
When setting window via annotation we validate that it's not larger than window max,
but we don't do that when processing config map value.
But we should for consistency and also because that large of an event horizon makes our decisions
very sloppy.

/assign @markusthoemmes @yanweiguo 
/hold

Markus, if you think this is fine for the release, just unhold :-) Otherwise, I'll do that tomorrow morning.