### PR TITLE
Skip TestActivatorHAGraceful to allow for proper debugging.

### DIFF
--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -42,6 +42,7 @@ const (
 )
 
 func TestActivatorHAGraceful(t *testing.T) {
+	t.Skip("TODO(8066): This was added too optimistically. Needs debugging and triaging.")
 	testActivatorHA(t, nil, 1)
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Ref #8066 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

We kind of optimistically added TestActivatorHAGraceful assuming it should always pass. It doesn't. The test will be skipped but we should really look at what's wrong there and triage if the activator really can't be gracefully shutdown without losing traffic occasionally.

/assign @vagababov 
