### PR TITLE
Add activator's pod IP instead of serivce IP to tag

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -169,7 +169,7 @@ func main() {
 	throttler := activatornet.NewThrottler(ctx, env.PodIP)
 	go throttler.Run(ctx)
 
-	oct := tracing.NewOpenCensusTracer(tracing.WithExporter(networking.ActivatorServiceName, logger))
+	oct := tracing.NewOpenCensusTracer(tracing.WithExporterFull(networking.ActivatorServiceName, env.PodIP, logger))
 
 	tracerUpdater := configmap.TypeFilter(&tracingconfig.Config{})(func(name string, value interface{}) {
 		cfg := value.(*tracingconfig.Config)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -365,7 +365,7 @@ func buildTransport(env config, logger *zap.SugaredLogger) http.RoundTripper {
 		return pkgnet.AutoTransport
 	}
 
-	oct := tracing.NewOpenCensusTracer(tracing.WithExporter(env.ServingPod, logger))
+	oct := tracing.NewOpenCensusTracer(tracing.WithExporterFull(env.ServingPod, env.ServingPodIP, logger))
 	oct.ApplyConfig(&tracingconfig.Config{
 		Backend:              env.TracingConfigBackend,
 		Debug:                env.TracingConfigDebug,


### PR DESCRIPTION
## Proposed Changes

Currently zipkin/jaeger client uses `activator-service` for exporter's
endpoint. Although It works, it has some problems:

e.g.
- UI shows activator's svc IP instead of endpoint IP. So we cannot debug when multiple endpoint pods exit.

![image](https://user-images.githubusercontent.com/2138339/89609517-1289fc80-d8b3-11ea-9c89-8d97130c7e21.png)

- If activator pod started earlier than actiator-service's DNS
registration, the tracing failed to configure. Please see error below:

`{"level":"error","ts":"2020-05-21T10:13:23.687Z","logger":"activator","caller":"activator/main.go:197","msg":"Unable to apply open census tracer config","knative.dev/controller":"activator","knative.dev/pod":"activator-7db4dc788c-k422r","error":"lookup activator-service on 172.30.0.10:53: no such host","stacktrace":"main.main.func2\n\t/opt/app-root/src/go/src/knative.dev/serving/cmd/activator/main.go:197\nknative.dev/serving/vendor/knative.dev/pkg/configmap.TypeFilter.func1.1\n\t/opt/app-root/src/go/src/knative.dev/serving/vendor/knative.dev/pkg/configmap/filter.go:45\nknative.dev/serving/vendor/knative.dev/pkg/configmap.(*UntypedStore).OnConfigChanged.func1\n\t/opt/app-root/src/go/src/knative.dev/serving/vendor/knative.dev/pkg/configmap/store.go:162"}`

Hence, this patch adds activator's pod IP to reporter and create a tag of the IP.

**Release Note**

```release-note
```

/lint
