### PR TITLE
chore: Hardened cleanup rm expression in update-deps.sh

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -62,8 +62,8 @@ go mod vendor
 echo "Applying patches"
 git apply ${REPO_ROOT_DIR}/hack/patches/*.patch
 
-rm -rf $(find vendor/ -name 'OWNERS')
-rm -rf $(find vendor/ -name '*_test.go')
+# Remove unwanted vendor files
+find vendor/ \( -name "OWNERS" -o -name "*_test.go" \) -print0 | xargs -0 rm -f
 
 export GOFLAGS=-mod=vendor
 


### PR DESCRIPTION
A `rm -rf $(find . ...)` is quite disastrous when you have directories that contain spaces
(not uncommon on Windows eg, or someone prepared a "w00t /" file for you in your external dependencies). Also `-r` is not really needed here as no directories are to be removed.

Instead, use the idiom `find -print0 | xargs -0` to properly dealing with filenames that have spaces.