### PR TITLE
Calculate request stats directly rather than asyncronous.

### DIFF
--- a/pkg/queue/stats.go
+++ b/pkg/queue/stats.go
@@ -24,23 +24,16 @@ import (
 
 // ReportStats continually processes network events from reqCh and reports
 // aggregated stats via the `report` function whenever reportCh ticks.
-func ReportStats(startedAt time.Time, reqCh chan network.ReqEvent, reportCh <-chan time.Time, report func(float64, float64, float64, float64)) {
-	state := network.NewRequestStats(startedAt)
-
+func ReportStats(startedAt time.Time, stats *network.RequestStats, reportCh <-chan time.Time, report func(float64, float64, float64, float64)) {
 	for {
 		select {
-		case event, ok := <-reqCh:
-			if !ok {
-				return
-			}
-			state.HandleEvent(event)
 		case now := <-reportCh:
-			stats := state.Report(now)
+			stat := stats.Report(now)
 			report(
-				stats.AverageConcurrency,
-				stats.AverageProxiedConcurrency,
-				stats.RequestCount,
-				stats.ProxiedRequestCount,
+				stat.AverageConcurrency,
+				stat.AverageProxiedConcurrency,
+				stat.RequestCount,
+				stat.ProxiedRequestCount,
 			)
 		}
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

I was curious if we can improve the performance of our stat calculation further, given it's under investigation and on the request path of both the activator and the queue-proxy.

Turns out: We can! And it's even simpler then before.

Using mutexes here is actually quicker than sending the event to a separate goroutine to be processed there. It probably has something to do with CPU pipelining, caches etc etc. The amount of work that needs to happen under lock is so small that it's not worth going async.

As a bonus we get rid of the `reqCh` which had an arbitrary buffer set on it.

**TIL:** Question everything!

## queue-proxy proxy handler benchmark

```
benchmark                                                old ns/op     new ns/op     delta
BenchmarkProxyHandler/sequential-breaker-10-16           1832          1353          -26.15%
BenchmarkProxyHandler/parallel-breaker-10-16             1623          1331          -17.99%
BenchmarkProxyHandler/sequential-breaker-infinite-16     1297          903           -30.38%
BenchmarkProxyHandler/parallel-breaker-infinite-16       1521          632           -58.45%
benchmark                                                old allocs     new allocs     delta
BenchmarkProxyHandler/sequential-breaker-10-16           8              8              +0.00%
BenchmarkProxyHandler/parallel-breaker-10-16             8              8              +0.00%
BenchmarkProxyHandler/sequential-breaker-infinite-16     5              5              +0.00%
BenchmarkProxyHandler/parallel-breaker-infinite-16       5              5              +0.00%
benchmark                                                old bytes     new bytes     delta
BenchmarkProxyHandler/sequential-breaker-10-16           768           768           +0.00%
BenchmarkProxyHandler/parallel-breaker-10-16             768           768           +0.00%
BenchmarkProxyHandler/sequential-breaker-infinite-16     576           576           +0.00%
BenchmarkProxyHandler/parallel-breaker-infinite-16       576           576           +0.00%
```

## New benchmark results

### Direct

```
goos: linux
goarch: amd64
pkg: knative.dev/serving/pkg/network
BenchmarkRequestStatsDirect-16    	 2556703	       470 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	knative.dev/serving/pkg/network	1.687s
```

### Through channel

```
goos: linux
goarch: amd64
pkg: knative.dev/serving/pkg/network
BenchmarkRequestStatsThroughChannels-16    	 1611502	       761 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	knative.dev/serving/pkg/network	1.991s
```

/assign @vagababov @julz 
