### PR TITLE
Replace pending request channel with atomic integer.

### DIFF
--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -114,9 +114,7 @@ func (b *Breaker) Maybe(ctx context.Context, thunk func()) error {
 		return ErrRequestQueueFull
 	}
 
-	defer func() {
-		b.releasePending()
-	}()
+	defer b.releasePending()
 
 	// Wait for capacity in the active queue.
 	if err := b.sem.acquire(ctx); err != nil {

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 )
 
 var (
@@ -44,8 +45,9 @@ type BreakerParams struct {
 // executions in excess of the concurrency limit. Function call attempts
 // beyond the limit of the queue are failed immediately.
 type Breaker struct {
-	pendingRequests chan struct{}
-	sem             *semaphore
+	inFlight   int64
+	totalSlots int64
+	sem        *semaphore
 }
 
 // NewBreaker creates a Breaker with the desired queue depth,
@@ -62,31 +64,45 @@ func NewBreaker(params BreakerParams) *Breaker {
 	}
 	sem := newSemaphore(params.MaxConcurrency, params.InitialCapacity)
 	return &Breaker{
-		pendingRequests: make(chan struct{}, params.QueueDepth+params.MaxConcurrency),
-		sem:             sem,
+		totalSlots: int64(params.QueueDepth + params.MaxConcurrency),
+		sem:        sem,
 	}
+}
+
+// tryAcquirePending tries to acquire a slot on the pending "queue".
+func (b *Breaker) tryAcquirePending() bool {
+	for {
+		cur := atomic.LoadInt64(&b.inFlight)
+		if cur == b.totalSlots {
+			return false
+		}
+		if atomic.CompareAndSwapInt64(&b.inFlight, cur, cur+1) {
+			return true
+		}
+	}
+}
+
+// releasePending releases a slot on the pending "queue".
+func (b *Breaker) releasePending() {
+	atomic.AddInt64(&b.inFlight, -1)
 }
 
 // Reserve reserves an execution slot in the breaker, to permit
 // richer semantics in the caller.
 // The caller on success must execute the callback when done with work.
 func (b *Breaker) Reserve(ctx context.Context) (func(), bool) {
-	select {
-	default:
-		// Pending request queue is full.  Report failure.
+	if !b.tryAcquirePending() {
 		return nil, false
-	case b.pendingRequests <- struct{}{}:
-		// Pending request has capacity, reserve a slot, if there's one
-		// available.
-		if !b.sem.tryAcquire(ctx) {
-			<-b.pendingRequests
-			return nil, false
-		}
-		return func() {
-			b.sem.release()
-			<-b.pendingRequests
-		}, true
 	}
+
+	if !b.sem.tryAcquire(ctx) {
+		b.releasePending()
+		return nil, false
+	}
+	return func() {
+		b.sem.release()
+		b.releasePending()
+	}, true
 }
 
 // Maybe conditionally executes thunk based on the Breaker concurrency
@@ -94,37 +110,33 @@ func (b *Breaker) Reserve(ctx context.Context) (func(), bool) {
 // already consumed, Maybe returns immediately without calling thunk. If
 // the thunk was executed, Maybe returns true, else false.
 func (b *Breaker) Maybe(ctx context.Context, thunk func()) error {
-	select {
-	default:
-		// Pending request queue is full.  Report failure.
+	if !b.tryAcquirePending() {
 		return ErrRequestQueueFull
-	case b.pendingRequests <- struct{}{}:
-		// Pending request has capacity.
-		// Defer releasing pending request queue.
-		defer func() {
-			<-b.pendingRequests
-		}()
-
-		// Wait for capacity in the active queue.
-		if err := b.sem.acquire(ctx); err != nil {
-			return err
-		}
-		// Defer releasing capacity in the active.
-		// It's safe to ignore the error returned by release since we
-		// make sure the semaphore is only manipulated here and acquire
-		// + release calls are equally paired.
-		defer b.sem.release()
-
-		// Do the thing.
-		thunk()
-		// Report success
-		return nil
 	}
+
+	defer func() {
+		b.releasePending()
+	}()
+
+	// Wait for capacity in the active queue.
+	if err := b.sem.acquire(ctx); err != nil {
+		return err
+	}
+	// Defer releasing capacity in the active.
+	// It's safe to ignore the error returned by release since we
+	// make sure the semaphore is only manipulated here and acquire
+	// + release calls are equally paired.
+	defer b.sem.release()
+
+	// Do the thing.
+	thunk()
+	// Report success
+	return nil
 }
 
 // InFlight returns the number of requests currently in flight in this breaker.
 func (b *Breaker) InFlight() int {
-	return len(b.pendingRequests)
+	return int(atomic.LoadInt64(&b.inFlight))
 }
 
 // UpdateConcurrency updates the maximum number of in-flight requests.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Other than the "active" queue, the pending queue never blocks the caller. Requests are either admitted or denied immmediately. We don't need to resort to channel ops for that and can instead use atomic integer operations for that.

## Reserve benchmark

```
benchmark                                 old ns/op     new ns/op     delta
BenchmarkBreakerReserve/sequential-16     123           93.3          -24.15%
BenchmarkBreakerReserve/parallel-16       465           395           -15.05%
```

## Maybe benchmark

```
benchmark                                    old ns/op     new ns/op     delta
BenchmarkBreakerMaybe/1-sequential-16        113           95.8          -15.22%
BenchmarkBreakerMaybe/1-parallel-16          398           309           -22.36%
BenchmarkBreakerMaybe/10-sequential-16       114           97.0          -14.91%
BenchmarkBreakerMaybe/10-parallel-16         1014          929           -8.38%
BenchmarkBreakerMaybe/100-sequential-16      111           96.6          -12.97%
BenchmarkBreakerMaybe/100-parallel-16        327           225           -31.19%
BenchmarkBreakerMaybe/1000-sequential-16     111           97.2          -12.43%
BenchmarkBreakerMaybe/1000-parallel-16       340           180           -47.06%
```

/assign @vagababov @julz 
