### PR TITLE
Print error when test prober gets error

### DIFF
--- a/test/prober.go
+++ b/test/prober.go
@@ -160,6 +160,7 @@ func (m *manager) Spawn(url *url.URL) Prober {
 					close(p.minDoneCh)
 				}
 				if err != nil {
+					p.logf("%q error: %v", p.url, err)
 					atomic.AddInt64(&p.failures, 1)
 				} else if res.StatusCode != http.StatusOK {
 					p.logf("%q status = %d, want: %d", p.url, res.StatusCode, http.StatusOK)


### PR DESCRIPTION
## Proposed Changes

This patch makes a tiny change which prints error when test prober
failed.

Currently the response gets error status, it output like follows, but
it does not output anything when request failed to send.

```
2020/05/27 14:01:29 "http://upgrade-probe-serving-tests.apps.ci-op-ljhk5z68-3518e.origin-ci-int-aws.dev.rhcloud.com" status = 503, want: 200
2020/05/27 14:01:29 response: status: 503, body: upstream connect error or disconnect/reset before headers. reset reason: connection failure, headers: map[Content-Length:[91] Content-Type:[text/plain] Date:[Wed, 27 May 2020 14:01:28 GMT] Server:[envoy] Set-Cookie:[b3d174154462385a6d30ba73fdbb2dba=a5ad20fc6e667f480eaf88758e4c1522; path=/; HttpOnly] Zipkin_trace_id:[a46cc5c65f5f1f26003480786e32b39e]]
```

No output for `client.Do()` error.

/lint

**Release Note**

```release-note
NONE
```
