### PR TITLE
Remove unnecessary and confusing context from tryAcquire.

### DIFF
--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -109,7 +109,7 @@ func (b *Breaker) Reserve(ctx context.Context) (func(), bool) {
 		return nil, false
 	}
 
-	if !b.sem.tryAcquire(ctx) {
+	if !b.sem.tryAcquire() {
 		b.releasePending()
 		return nil, false
 	}
@@ -187,7 +187,7 @@ type semaphore struct {
 
 // tryAcquire receives the token from the semaphore if there's one
 // otherwise an error is returned.
-func (s *semaphore) tryAcquire(ctx context.Context) bool {
+func (s *semaphore) tryAcquire() bool {
 	select {
 	case <-s.queue:
 		return true

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -251,7 +251,7 @@ func TestSemaphoreAcquireHasNoCapacity(t *testing.T) {
 
 func TestSemaphoreAcquireNonBlockingHasNoCapacity(t *testing.T) {
 	sem := newSemaphore(1, 0)
-	if sem.tryAcquire(context.Background()) {
+	if sem.tryAcquire() {
 		t.Error("Should have failed immediately")
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This function has nothing to do with the context. It always returns immediately and the context gives a false impression of it potentially timing out or something.

/assign @vagababov 

