### PR TITLE
Add a `tag` label to the requests metrics of queue-proxy

### DIFF
--- a/pkg/metrics/key.go
+++ b/pkg/metrics/key.go
@@ -35,6 +35,7 @@ var (
 	ContainerTagKey      = tag.MustNewKey(metricskey.ContainerName)
 	ResponseCodeKey      = tag.MustNewKey(metricskey.LabelResponseCode)
 	ResponseCodeClassKey = tag.MustNewKey(metricskey.LabelResponseCodeClass)
+	RouteTagKey          = tag.MustNewKey("tag")
 
 	CommonRevisionKeys = []tag.Key{NamespaceTagKey, ServiceTagKey, ConfigTagKey, RevisionTagKey}
 )

--- a/pkg/metrics/tags.go
+++ b/pkg/metrics/tags.go
@@ -135,6 +135,16 @@ func AugmentWithResponse(baseCtx context.Context, responseCode int) context.Cont
 	return ctx
 }
 
+// AugmentWithResponseAndRouteTag augments the given context with response-code and route-tag specific tags.
+func AugmentWithResponseAndRouteTag(baseCtx context.Context, responseCode int, routeTag string) context.Context {
+	ctx, _ := tag.New(
+		baseCtx,
+		tag.Upsert(ResponseCodeKey, strconv.Itoa(responseCode)),
+		tag.Upsert(ResponseCodeClassKey, responseCodeClass(responseCode)),
+		tag.Upsert(RouteTagKey, routeTag))
+	return ctx
+}
+
 // responseCodeClass converts response code to a string of response code class.
 // e.g. The response code class is "5xx" for response code 503.
 func responseCodeClass(responseCode int) string {

--- a/pkg/queue/request_metric.go
+++ b/pkg/queue/request_metric.go
@@ -61,8 +61,9 @@ var (
 )
 
 const (
-	defaultTargetName   = "default"
-	undefinedTargetName = "undefined"
+	defaultTagName   = "DEFAULT"
+	undefinedTagName = "UNDEFINED"
+	disabledTagName  = "DISABLED"
 )
 
 type requestMetricsHandler struct {
@@ -214,14 +215,14 @@ func GetRouteTagNameFromRequest(r *http.Request) string {
 		if isDefaultRoute == "" {
 			// If there are no tag header and no `Knative-Serving-Default-Route` header,
 			// it means that the tag header based routing is disabled, so the tag value is set to `disabled`.
-			return "disabled"
+			return disabledTagName
 		}
 		// If there is no tag header, just returns "default".
-		return defaultTargetName
+		return defaultTagName
 	} else if isDefaultRoute == "true" {
 		// If there is a tag header with not-empty string and the request is routed via the default route,
 		// returns "undefined".
-		return undefinedTargetName
+		return undefinedTagName
 	}
 	// Otherwise, returns the value of the tag header.
 	return name

--- a/pkg/queue/request_metric_test.go
+++ b/pkg/queue/request_metric_test.go
@@ -57,7 +57,7 @@ func TestRequestMetricsHandler(t *testing.T) {
 		metricskey.ContainerName:          "queue-proxy",
 		metricskey.LabelResponseCode:      "200",
 		metricskey.LabelResponseCodeClass: "2xx",
-		"tag":                             "disabled",
+		"tag":                             disabledTagName,
 	}
 
 	metricstest.CheckCountData(t, "request_count", wantTags, 1)
@@ -104,7 +104,7 @@ func TestRequestMetricsHandlerWithEnablingTagOnRequestMetrics(t *testing.T) {
 	req.Header.Del(network.TagHeaderName)
 	req.Header.Set(network.DefaultRouteHeaderName, "true")
 	handler.ServeHTTP(resp, req)
-	wantTags["tag"] = "default"
+	wantTags["tag"] = defaultTagName
 	metricstest.CheckCountData(t, "request_count", wantTags, 1)
 
 	reset()
@@ -112,7 +112,7 @@ func TestRequestMetricsHandlerWithEnablingTagOnRequestMetrics(t *testing.T) {
 	req.Header.Set(network.TagHeaderName, "test-tag")
 	req.Header.Set(network.DefaultRouteHeaderName, "true")
 	handler.ServeHTTP(resp, req)
-	wantTags["tag"] = "undefined"
+	wantTags["tag"] = undefinedTagName
 	metricstest.CheckCountData(t, "request_count", wantTags, 1)
 
 	reset()
@@ -156,7 +156,7 @@ func TestRequestMetricsHandlerPanickingHandler(t *testing.T) {
 			metricskey.ContainerName:          "queue-proxy",
 			metricskey.LabelResponseCode:      "500",
 			metricskey.LabelResponseCodeClass: "5xx",
-			"tag":                             "disabled",
+			"tag":                             disabledTagName,
 		}
 		metricstest.CheckCountData(t, "request_count", wantTags, 1)
 		metricstest.CheckDistributionCount(t, "request_latencies", wantTags, 1) // Dummy latency range.

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -75,6 +75,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		name string
 		rev  *v1.Revision
 		lc   logging.Config
+		nc   network.Config
 		oc   metrics.ObservabilityConfig
 		dc   deployment.Config
 		want corev1.Container


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
For observability for the tag-based routing ([Tag Header based Routing](https://docs.google.com/document/d/12t_3NE4EqvW_l0hfVlQcAGKkwkAM56tTn2wN_JtHbSQ/edit#heading=h.n8a530nnrb)), this PR includes following changes.

* All the `request_*` metrics in queue-proxy have an additional label `tag` in order to distinguish the metrics by the tag. Basically, the value of the label is a name of the tag, and if the tag is not defined, it is `undefined`. In case of the default route, the `tag` label will have `default`.
* If a request has an undefined tag in the tag header, the header `Knative-Serving-Undefined-Tag` is appended to the response with the value `true`.

Basic idea for detecting a request with the undefined tag is as follows.
A request having the undefined tag in the tag header(`Knative-Serving-Tag`) is routed via the default route in current implementation as PR (https://github.com/knative/serving/pull/6036). Since all the requests routed via the default route have the header `Knative-Serving-Default-Route: true`, we can detect such requests by checking the two headers: `Knative-Serving-Default-Route` and `Knative-Serving-Tag`. 

All the features in this PR can be toggled by `tagHeaderBasedRouting` in `config-network` config map.

For the details of overall proposal, please refer to https://docs.google.com/document/d/12t_3NE4EqvW_l0hfVlQcAGKkwkAM56tTn2wN_JtHbSQ/edit

**Release Note**

```release-note
```
