### PR TITLE
Make validation of the panic window % more reasonable.

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -106,8 +106,9 @@ data:
     # enters panic mode. When operating in panic mode, the autoscaler
     # scales on the average concurrency over the panic window which is
     # panic-window-percentage of the stable-window.
+    # Must be in the [1, 100] range.
     # When computing the panic window it will be rounded to the closest
-    # whole second.
+    # whole second, at least 1s.
     panic-window-percentage: "10.0"
 
     # The percentage of the container concurrency target at which to

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -200,9 +200,12 @@ func validate(lc *Config) (*Config, error) {
 		return nil, fmt.Errorf("stable-window = %v, must be specified with at most second precision", lc.StableWindow)
 	}
 
-	effPW := time.Duration(lc.PanicWindowPercentage / 100 * float64(lc.StableWindow))
-	if effPW < BucketSize || effPW > lc.StableWindow {
-		return nil, fmt.Errorf("panic-window-percentage = %v, must be in [%v, 100] interval", lc.PanicWindowPercentage, 100*float64(BucketSize)/float64(lc.StableWindow))
+	// We ensure BucketSize in the `MakeMetric`, so just ensure percentage is in the correct region.
+	if lc.PanicWindowPercentage < autoscaling.PanicWindowPercentageMin ||
+		lc.PanicWindowPercentage > autoscaling.PanicWindowPercentageMax {
+		return nil, fmt.Errorf("panic-window-percentage = %v, must be in [%v, %v] interval",
+			lc.PanicWindowPercentage, autoscaling.PanicWindowPercentageMin, autoscaling.PanicWindowPercentageMax)
+
 	}
 
 	if lc.InitialScale < 0 || (lc.InitialScale == 0 && !lc.AllowZeroInitialScale) {

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -230,8 +230,7 @@ func TestNewConfig(t *testing.T) {
 	}, {
 		name: "panic window percentage too small",
 		input: map[string]string{
-			"stable-window":           "12s",
-			"panic-window-percentage": "5", // 0.6s < BucketSize
+			"panic-window-percentage": "0.1",
 		},
 		wantErr: true,
 	}, {


### PR DESCRIPTION
The code already ensures that we use BucketSize for the panic window anyway.
Also we cannot control the validity anyway, since a valid panic percentage for CM stable window
does not mean that we'll fit into bucket window for a per-revision stable window.
So just verify [1,100] limit.
Also update the comment to be more precise.

/assign @yanweiguo @markusthoemmes 