### PR TITLE
Stop renewing the panic start time on every pod count increment.

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -220,7 +220,6 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) ScaleResult {
 		// We do not scale down while in panic mode. Only increases will be applied.
 		if desiredPodCount > a.maxPanicPods {
 			logger.Infof("Increasing pods from %d to %d.", originalReadyPodsCount, desiredPodCount)
-			a.panicTime = now
 			a.maxPanicPods = desiredPodCount
 		} else if desiredPodCount < a.maxPanicPods {
 			logger.Infof("Skipping decrease from %d to %d.", a.maxPanicPods, desiredPodCount)

--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -200,6 +200,9 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) ScaleResult {
 		logger.Info("PANICKING.")
 		a.panicTime = now
 		pkgmetrics.Record(a.reporterCtx, panicM.M(1))
+	} else if isOverPanicThreshold {
+		// If we're still over panic threshold right now — extend the panic window.
+		a.panicTime = now
 	} else if !a.panicTime.IsZero() && !isOverPanicThreshold && a.panicTime.Add(spec.StableWindow).Before(now) {
 		// Stop panicking after the surge has made its way into the stable metric.
 		logger.Info("Un-panicking.")

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -183,6 +183,44 @@ func TestAutoscalerStableModeIncreaseWithRPS(t *testing.T) {
 	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 101, 99, 1), na, true})
 }
 
+func TestAutoscalerUnpanicAfterSlowIncrease(t *testing.T) {
+	// Do initial jump from 10 to 25 pods.
+	metrics := &fake.MetricClient{StableConcurrency: 11, PanicConcurrency: 25}
+	a := newTestAutoscaler(t, 1, 98, metrics)
+	fake.Endpoints(10, fake.TestService)
+
+	na := expectedNA(a, 10)
+	tm := time.Now()
+	expectScale(t, a, tm, ScaleResult{25, expectedEBC(1, 98, 25, 10), na, true})
+	if a.panicTime != tm {
+		t.Errorf("PanicTime = %v, want: %v", a.panicTime, tm)
+	}
+	// Now the stable window has passed, and we've been adding 1 pod per cycle.
+	// For window of 60s, that's +30 pods.
+	// Checkpoint in the middle.
+	fake.Endpoints(25+15, fake.TestService)
+
+	a.metricClient = &fake.MetricClient{StableConcurrency: 30, PanicConcurrency: 41}
+	tm = tm.Add(stableWindow / 2)
+
+	na = expectedNA(a, 40)
+	expectScale(t, a, tm, ScaleResult{41, expectedEBC(1, 98, 41, 40), na, true})
+	if a.panicTime == tm {
+		t.Error("Panic Time should not have moved")
+	}
+
+	// Now at the end. Panic must end.
+	fake.Endpoints(25+30, fake.TestService)
+	a.metricClient = &fake.MetricClient{StableConcurrency: 50, PanicConcurrency: 56}
+	tm = tm.Add(stableWindow/2 + tickInterval)
+
+	na = expectedNA(a, 55)
+	expectScale(t, a, tm, ScaleResult{50 /* no longer in panic*/, expectedEBC(1, 98, 56, 55), na, true})
+	if !a.panicTime.IsZero() {
+		t.Errorf("PanicTime = %v, want: 0", a.panicTime)
+	}
+}
+
 func TestAutoscalerStableModeDecrease(t *testing.T) {
 	metrics := &fake.MetricClient{StableConcurrency: 100.0, PanicConcurrency: 100}
 	a := newTestAutoscaler(t, 10, 98, metrics)

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -195,9 +195,8 @@ func TestAutoscalerUnpanicAfterSlowIncrease(t *testing.T) {
 	if a.panicTime != tm {
 		t.Errorf("PanicTime = %v, want: %v", a.panicTime, tm)
 	}
-	// Now the stable window has passed, and we've been adding 1 pod per cycle.
-	// For window of 60s, that's +30 pods.
-	// Checkpoint in the middle.
+	// Now the half of the stable window has passed, and we've been adding 1 pod per cycle.
+	// For window of 60s, that's +15 pods.
 	fake.Endpoints(25+15, fake.TestService)
 
 	a.metricClient = &fake.MetricClient{StableConcurrency: 30, PanicConcurrency: 41}
@@ -209,7 +208,7 @@ func TestAutoscalerUnpanicAfterSlowIncrease(t *testing.T) {
 		t.Error("Panic Time should not have moved")
 	}
 
-	// Now at the end. Panic must end.
+	// Now at the end. Panic must end. And +30 pods.
 	fake.Endpoints(25+30, fake.TestService)
 	a.metricClient = &fake.MetricClient{StableConcurrency: 50, PanicConcurrency: 56}
 	tm = tm.Add(stableWindow/2 + tickInterval)

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -221,6 +221,32 @@ func TestAutoscalerUnpanicAfterSlowIncrease(t *testing.T) {
 	}
 }
 
+func TestAutoscalerExtendPanicWindow(t *testing.T) {
+	// Do initial jump from 10 to 25 pods.
+	metrics := &fake.MetricClient{StableConcurrency: 11, PanicConcurrency: 25}
+	a := newTestAutoscaler(t, 1, 98, metrics)
+	fake.Endpoints(10, fake.TestService)
+
+	na := expectedNA(a, 10)
+	start := time.Now()
+	tm := start
+	expectScale(t, a, tm, ScaleResult{25, expectedEBC(1, 98, 25, 10), na, true})
+	if a.panicTime != tm {
+		t.Errorf("PanicTime = %v, want: %v", a.panicTime, tm)
+	}
+	// Now the half of the stable window has passed, and we're still surging.
+	fake.Endpoints(25+15, fake.TestService)
+
+	a.metricClient = &fake.MetricClient{StableConcurrency: 30, PanicConcurrency: 80}
+	tm = tm.Add(stableWindow / 2)
+
+	na = expectedNA(a, 40)
+	expectScale(t, a, tm, ScaleResult{80, expectedEBC(1, 98, 80, 40), na, true})
+	if a.panicTime != tm {
+		t.Errorf("PanicTime = %v, want: %v", a.panicTime, tm)
+	}
+}
+
 func TestAutoscalerStableModeDecrease(t *testing.T) {
 	metrics := &fake.MetricClient{StableConcurrency: 100.0, PanicConcurrency: 100}
 	a := newTestAutoscaler(t, 10, 98, metrics)

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -190,7 +190,8 @@ func TestAutoscalerUnpanicAfterSlowIncrease(t *testing.T) {
 	fake.Endpoints(10, fake.TestService)
 
 	na := expectedNA(a, 10)
-	tm := time.Now()
+	start := time.Now()
+	tm := start
 	expectScale(t, a, tm, ScaleResult{25, expectedEBC(1, 98, 25, 10), na, true})
 	if a.panicTime != tm {
 		t.Errorf("PanicTime = %v, want: %v", a.panicTime, tm)
@@ -204,7 +205,7 @@ func TestAutoscalerUnpanicAfterSlowIncrease(t *testing.T) {
 
 	na = expectedNA(a, 40)
 	expectScale(t, a, tm, ScaleResult{41, expectedEBC(1, 98, 41, 40), na, true})
-	if a.panicTime == tm {
+	if a.panicTime != start {
 		t.Error("Panic Time should not have moved")
 	}
 


### PR DESCRIPTION
This is not correct, for example if we had a jump in 3x pods and then added a pod each cycle.
This would bring us to extending panic mode, when it's no longer necessary.

In fact if we need to be in panic the isOverPanicThreshold would still guard it.

As discussed in slack also add a fancy test to verify (it failed before the change in 2 points)

/assign @yanweiguo @markusthoemmes 