### PR TITLE
Performance improvements in QP in probing mode

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -256,8 +256,7 @@ func probeQueueHealthPath(timeoutSeconds int, env probeConfig) error {
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		// Return nil error for retrying
-		return fmt.Errorf("error creating request: %w", err)
+		return fmt.Errorf("probe failed: error creating request: %w", err)
 	}
 	// Add the header to indicate this is a probe request.
 	req.Header.Add(network.ProbeHeaderName, queue.Name)


### PR DESCRIPTION
- reuse the http requests, they are immutable
- parse much smaller subset of config

/assign @mattmoor  @julz 
For #8147