### PR TITLE
Expose certificate conformance tests to be consumed downstream

### DIFF
--- a/test/conformance/certificate/http01/certificate.go
+++ b/test/conformance/certificate/http01/certificate.go
@@ -1,5 +1,3 @@
-// +build e2e
-
 /*
 Copyright 2020 The Knative Authors
 

--- a/test/conformance/certificate/http01/run.go
+++ b/test/conformance/certificate/http01/run.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http01
+
+import "testing"
+
+func RunConformance(t *testing.T) {
+	t.Run("http01", TestHTTP01Challenge)
+}

--- a/test/conformance/certificate/http01/run_test.go
+++ b/test/conformance/certificate/http01/run_test.go
@@ -1,0 +1,25 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import "testing"
+
+func TestCertificateConformance(t *testing.T) {
+	RunConformance(t)
+}

--- a/test/conformance/certificate/http01/run_test.go
+++ b/test/conformance/certificate/http01/run_test.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package ingress
+package http01
 
 import "testing"
 

--- a/test/conformance/certificate/nonhttp01/certificate.go
+++ b/test/conformance/certificate/nonhttp01/certificate.go
@@ -1,5 +1,3 @@
-// +build e2e
-
 /*
 Copyright 2020 The Knative Authors
 

--- a/test/conformance/certificate/nonhttp01/run.go
+++ b/test/conformance/certificate/nonhttp01/run.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nonhttp01
+
+import "testing"
+
+func RunConformance(t *testing.T) {
+	t.Run("secret", TestSecret)
+}

--- a/test/conformance/certificate/nonhttp01/run_test.go
+++ b/test/conformance/certificate/nonhttp01/run_test.go
@@ -1,0 +1,25 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nonhttp01
+
+import "testing"
+
+func TestCertificateConformance(t *testing.T) {
+	RunConformance(t)
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes downstream consumers who vendor with go.mod to run conformance tests

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

- [x] https://github.com/knative/net-http01/pull/30
- [x] https://github.com/knative/net-certmanager/pull/22

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Certificate conformance tests have been moved out of test files so they can be consumed downstream
```
