### PR TITLE
Add pod policy objects.

### DIFF
--- a/pkg/activator/net/lb_policy.go
+++ b/pkg/activator/net/lb_policy.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the load load balancing policies for Activator load balancing.
+
+package net
+
+import (
+	"context"
+	"math/rand"
+)
+
+// lbPolicy is a functor that selects a target pod from the list, or (noop, nil) if
+// no such target can be currently acquired.
+// Policies will presume that `targets` list is appropriately guarded by the caller,
+// that is while podTrackers themselves can change during this call, the list
+// and pointers therein are immutable.
+type lbPolicy func(ctx context.Context, targets []*podTracker) (func(), *podTracker)
+
+// randomLBPolicy is a load balancer policy that picks a random target.
+// This approximates the LB policy done by K8s Service (IPTables based).
+func randomLBPolicy(_ context.Context, targets []*podTracker) (func(), *podTracker) {
+	return noop, targets[rand.Intn(len(targets))]
+}
+
+// firstAvailableLBPolicy is a load balancer policy, that picks the first target
+// that has capacity to serve the request right now.
+func firstAvailableLBPolicy(ctx context.Context, targets []*podTracker) (func(), *podTracker) {
+	for _, t := range targets {
+		if cb, ok := t.Reserve(ctx); ok {
+			return cb, t
+		}
+	}
+	return noop, nil
+}

--- a/pkg/activator/net/lb_policy_test.go
+++ b/pkg/activator/net/lb_policy_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"knative.dev/serving/pkg/queue"
+)
+
+func TestFirstAvailable(t *testing.T) {
+	t.Run("1 tracker, 1 slot", func(t *testing.T) {
+		podTrackers := []*podTracker{
+			&podTracker{
+				dest: "this-is-nowhere",
+				b: queue.NewBreaker(queue.BreakerParams{
+					QueueDepth:      1,
+					MaxConcurrency:  1,
+					InitialCapacity: 1,
+				}),
+			},
+		}
+
+		ctx := context.Background()
+		cb, tracker := firstAvailableLBPolicy(ctx, podTrackers)
+		defer cb()
+		if tracker == nil {
+			t.Fatal("Tracker was nil")
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+		defer cancel()
+
+		cb, tracker = firstAvailableLBPolicy(ctx, podTrackers)
+		defer cb()
+		if tracker != nil {
+			t.Fatal("Tracker was not nil")
+		}
+	})
+	t.Run("2 trackers, 1 slot", func(t *testing.T) {
+		podTrackers := []*podTracker{
+			&podTracker{
+				dest: "down-by-the-river",
+				b: queue.NewBreaker(queue.BreakerParams{
+					QueueDepth:      1,
+					MaxConcurrency:  1,
+					InitialCapacity: 1,
+				}),
+			},
+			&podTracker{
+				dest: "heart-of-gold",
+				b: queue.NewBreaker(queue.BreakerParams{
+					QueueDepth:      1,
+					MaxConcurrency:  1,
+					InitialCapacity: 1,
+				}),
+			},
+		}
+
+		ctx := context.Background()
+		cb, tracker := firstAvailableLBPolicy(ctx, podTrackers)
+		defer cb()
+		if tracker == nil {
+			t.Fatal("Tracker was nil")
+		} else if got, want := tracker.dest, podTrackers[0].dest; got != want {
+			t.Errorf("Tracker = %s, want: %s", got, want)
+		}
+
+		cb, tracker = firstAvailableLBPolicy(ctx, podTrackers)
+		defer cb()
+		if tracker == nil {
+			t.Fatal("Tracker was nil")
+		} else if got, want := tracker.dest, podTrackers[1].dest; got != want {
+			t.Errorf("Tracker = %s, want: %s", got, want)
+		}
+	})
+}

--- a/pkg/activator/net/lb_policy_test.go
+++ b/pkg/activator/net/lb_policy_test.go
@@ -26,16 +26,14 @@ import (
 
 func TestFirstAvailable(t *testing.T) {
 	t.Run("1 tracker, 1 slot", func(t *testing.T) {
-		podTrackers := []*podTracker{
-			&podTracker{
-				dest: "this-is-nowhere",
-				b: queue.NewBreaker(queue.BreakerParams{
-					QueueDepth:      1,
-					MaxConcurrency:  1,
-					InitialCapacity: 1,
-				}),
-			},
-		}
+		podTrackers := []*podTracker{{
+			dest: "this-is-nowhere",
+			b: queue.NewBreaker(queue.BreakerParams{
+				QueueDepth:      1,
+				MaxConcurrency:  1,
+				InitialCapacity: 1,
+			}),
+		}}
 
 		ctx := context.Background()
 		cb, tracker := firstAvailableLBPolicy(ctx, podTrackers)
@@ -54,24 +52,21 @@ func TestFirstAvailable(t *testing.T) {
 		}
 	})
 	t.Run("2 trackers, 1 slot", func(t *testing.T) {
-		podTrackers := []*podTracker{
-			&podTracker{
-				dest: "down-by-the-river",
-				b: queue.NewBreaker(queue.BreakerParams{
-					QueueDepth:      1,
-					MaxConcurrency:  1,
-					InitialCapacity: 1,
-				}),
-			},
-			&podTracker{
-				dest: "heart-of-gold",
-				b: queue.NewBreaker(queue.BreakerParams{
-					QueueDepth:      1,
-					MaxConcurrency:  1,
-					InitialCapacity: 1,
-				}),
-			},
-		}
+		podTrackers := []*podTracker{{
+			dest: "down-by-the-river",
+			b: queue.NewBreaker(queue.BreakerParams{
+				QueueDepth:      1,
+				MaxConcurrency:  1,
+				InitialCapacity: 1,
+			}),
+		}, {
+			dest: "heart-of-gold",
+			b: queue.NewBreaker(queue.BreakerParams{
+				QueueDepth:      1,
+				MaxConcurrency:  1,
+				InitialCapacity: 1,
+			}),
+		}}
 
 		ctx := context.Background()
 		cb, tracker := firstAvailableLBPolicy(ctx, podTrackers)


### PR DESCRIPTION
This is technically a noop change, but a code refactor, which introduces pod policy selection
in the load balancing process.
And the existing two are codified as such.
Also this slightly improves the code, since it removes one if statement from the serving path!

For #7664
/assign @yanweiguo @julz 