### PR TITLE
Fix the ordering of handlers to permit probe log writing

### DIFF
--- a/pkg/http/request_log.go
+++ b/pkg/http/request_log.go
@@ -137,7 +137,7 @@ func (h *RequestLogHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	defer func() {
 		// Filter probe requests for request logs if disabled.
-		if network.IsProbe(r) && !h.enableProbeRequestLog {
+		if !h.enableProbeRequestLog && network.IsProbe(r) {
 			return
 		}
 
@@ -167,8 +167,8 @@ func (h *RequestLogHandler) write(t *template.Template, in *RequestLogTemplateIn
 	// Use a local buffer to store the whole template expansion first. If h.writer
 	// is used directly, parallel template executions may result in interleaved
 	// output.
-	w := &bytes.Buffer{}
-	if err := t.Execute(w, in); err != nil {
+	w := bytes.Buffer{}
+	if err := t.Execute(&w, in); err != nil {
 		// Template execution failed. Write an error message with some basic information about the request.
 		fmt.Fprintf(h.writer, "Invalid request log template: method: %v, response code: %v, latency: %v, url: %v\n",
 			in.Request.Method, in.Response.Code, in.Response.Latency, in.Request.URL)


### PR DESCRIPTION
- Also minor improvements to the code in the log writer:
  - checking boolean, which is always false in activator and usually false in QP is faster than first checking HTTP headers.
- keep objects on stack if possible.

/assign @yanweiguo 
For #5068