### PR TITLE
Always consider ObservedGeneration for scaling & network types IsReady

### DIFF
--- a/cmd/default-domain/main.go
+++ b/cmd/default-domain/main.go
@@ -127,7 +127,7 @@ func findGatewayAddress(kubeclient *kubernetes.Clientset, client *versioned.Clie
 		if err != nil {
 			return true, err
 		}
-		return ing.Status.IsReady(), nil
+		return ing.IsReady(), nil
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/apis/autoscaling/v1alpha1/metric_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/metric_lifecycle.go
@@ -31,7 +31,8 @@ var condSet = apis.NewLivingConditionSet(
 	MetricConditionReady,
 )
 
-// GetConditionSet retrieves the condition set for this resource. Implements the KRShaped interface.
+// GetConditionSet retrieves the condition set for this resource.
+// Implements the KRShaped interface.
 func (*Metric) GetConditionSet() apis.ConditionSet {
 	return condSet
 }
@@ -66,8 +67,10 @@ func (ms *MetricStatus) MarkMetricFailed(reason, message string) {
 	condSet.Manage(ms).MarkFalse(MetricConditionReady, reason, message)
 }
 
-// IsReady looks at the conditions and if the condition MetricConditionReady
-// is true
-func (ms *MetricStatus) IsReady() bool {
-	return condSet.Manage(ms).IsHappy()
+// IsReady returns true if the Status condition MetricConditionReady
+// is true and the latest spec has been observed.
+func (m *Metric) IsReady() bool {
+	ms := m.Status
+	return ms.ObservedGeneration == m.Generation &&
+		ms.GetCondition(MetricConditionReady).IsTrue()
 }

--- a/pkg/apis/autoscaling/v1alpha1/metric_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/metric_lifecycle_test.go
@@ -123,7 +123,8 @@ func TestMetricIsReady(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if e, a := tc.isReady, tc.status.IsReady(); e != a {
+			m := Metric{Status: tc.status}
+			if e, a := tc.isReady, m.IsReady(); e != a {
 				t.Errorf("Ready = %v, want: %v", a, e)
 			}
 		})

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -150,7 +150,8 @@ func (pa *PodAutoscaler) PanicThresholdPercentage() (percentage float64, ok bool
 // is true and the latest spec has been observed.
 func (pa *PodAutoscaler) IsReady() bool {
 	pas := pa.Status
-	return pa.Generation == pas.ObservedGeneration && podCondSet.Manage(&pas).IsHappy()
+	return pa.Generation == pas.ObservedGeneration &&
+		pas.GetCondition(PodAutoscalerConditionReady).IsTrue()
 }
 
 // IsActive returns true if the pod autoscaler is finished scaling.

--- a/pkg/apis/networking/v1alpha1/certificate_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/certificate_lifecycle.go
@@ -50,9 +50,12 @@ func (cs *CertificateStatus) MarkResourceNotOwned(kind, name string) {
 		fmt.Sprintf("There is an existing %s %q that we do not own.", kind, name))
 }
 
-// IsReady returns true is the Certificate is ready.
-func (cs *CertificateStatus) IsReady() bool {
-	return certificateCondSet.Manage(cs).IsHappy()
+// IsReady returns true is the Certificate is ready
+// and the Certificate resource has been observed.
+func (c *Certificate) IsReady() bool {
+	cs := c.Status
+	return cs.ObservedGeneration == c.Generation &&
+		cs.GetCondition(CertificateConditionReady).IsTrue()
 }
 
 // GetCondition gets a specific condition of the Certificate status.

--- a/pkg/apis/networking/v1alpha1/certificate_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/certificate_lifecycle_test.go
@@ -62,11 +62,12 @@ func TestCertificateGetGroupVersionKind(t *testing.T) {
 }
 
 func TestMarkReady(t *testing.T) {
-	c := &CertificateStatus{}
-	c.InitializeConditions()
-	apistest.CheckConditionOngoing(c, CertificateConditionReady, t)
+	cs := &CertificateStatus{}
+	cs.InitializeConditions()
+	apistest.CheckConditionOngoing(cs, CertificateConditionReady, t)
 
-	c.MarkReady()
+	cs.MarkReady()
+	c := &Certificate{Status: *cs}
 	if !c.IsReady() {
 		t.Error("IsReady=false, want: true")
 	}
@@ -77,7 +78,7 @@ func TestMarkNotReady(t *testing.T) {
 	c.InitializeConditions()
 	apistest.CheckCondition(c, CertificateConditionReady, corev1.ConditionUnknown)
 
-	c.MarkNotReady("unknow", "unknown")
+	c.MarkNotReady("unknown", "unknown")
 	apistest.CheckCondition(c, CertificateConditionReady, corev1.ConditionUnknown)
 }
 

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle.go
@@ -92,8 +92,10 @@ func (is *IngressStatus) MarkIngressNotReady(reason, message string) {
 	ingressCondSet.Manage(is).MarkUnknown(IngressConditionReady, reason, message)
 }
 
-// IsReady looks at the conditions and if the Status has a condition
-// IngressConditionReady returns true if ConditionStatus is True
-func (is *IngressStatus) IsReady() bool {
-	return ingressCondSet.Manage(is).IsHappy()
+// IsReady returns true if the Status condition MetricConditionReady
+// is true and the latest spec has been observed.
+func (i *Ingress) IsReady() bool {
+	is := i.Status
+	return is.ObservedGeneration == i.Generation &&
+		is.GetCondition(IngressConditionReady).IsTrue()
 }

--- a/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/ingress_lifecycle_test.go
@@ -107,7 +107,8 @@ func TestIngressTypicalFlow(t *testing.T) {
 	)
 	apistest.CheckConditionSucceeded(r, IngressConditionLoadBalancerReady, t)
 	apistest.CheckConditionSucceeded(r, IngressConditionReady, t)
-	if !r.IsReady() {
+	i := &Ingress{Status: *r}
+	if !i.IsReady() {
 		t.Fatal("IsReady()=false, wanted true")
 	}
 
@@ -118,7 +119,8 @@ func TestIngressTypicalFlow(t *testing.T) {
 	// Mark network configured, and check that ingress is ready again
 	r.MarkNetworkConfigured()
 	apistest.CheckConditionSucceeded(r, IngressConditionReady, t)
-	if !r.IsReady() {
+	i = &Ingress{Status: *r}
+	if !i.IsReady() {
 		t.Fatal("IsReady()=false, wanted true")
 	}
 

--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go
@@ -90,9 +90,12 @@ func (sss *ServerlessServiceStatus) MarkEndpointsNotReady(reason string) {
 		"K8s Service is not ready")
 }
 
-// IsReady returns true if ServerlessService is ready.
-func (sss *ServerlessServiceStatus) IsReady() bool {
-	return serverlessServiceCondSet.Manage(sss).IsHappy()
+// IsReady returns true if the Status condition Ready
+// is true and the latest spec has been observed.
+func (ss *ServerlessService) IsReady() bool {
+	sss := ss.Status
+	return sss.ObservedGeneration == ss.Generation &&
+		sss.GetCondition(ServerlessServiceConditionReady).IsTrue()
 }
 
 // ProxyFor returns how long it has been since Activator was moved

--- a/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
+++ b/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle_test.go
@@ -78,7 +78,8 @@ func TestSSTypicalFlow(t *testing.T) {
 	apistest.CheckConditionSucceeded(r, ServerlessServiceConditionReady, t)
 
 	// Or another way to check the same condition.
-	if !r.IsReady() {
+	ss := &ServerlessService{Status: *r}
+	if !ss.IsReady() {
 		t.Error("IsReady=false, want: true")
 	}
 	r.MarkEndpointsNotReady("random")

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -102,7 +102,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 
 	// Propagate the service name regardless of the status.
 	pa.Status.ServiceName = sks.Status.ServiceName
-	if !sks.Status.IsReady() {
+	if !sks.IsReady() {
 		pa.Status.MarkInactive("ServicesNotReady", "SKS Services are not ready yet")
 	} else {
 		pa.Status.MarkActive()

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -144,7 +144,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 	// Propagate service name.
 	pa.Status.ServiceName = sks.Status.ServiceName
 	// Currently, SKS.IsReady==True when revision has >0 ready pods.
-	if sks.Status.IsReady() {
+	if sks.IsReady() {
 		podEndpointCounter := resourceutil.NewScopedEndpointsCounter(c.endpointsLister, pa.Namespace, sks.Status.PrivateServiceName)
 		ready, err = podEndpointCounter.ReadyCount()
 		if err != nil {

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -240,7 +240,7 @@ func (c *Reconciler) tls(ctx context.Context, host string, r *v1.Route, traffic 
 		// TODO: we should only mark https for the public visible targets when
 		// we are able to configure visibility per target.
 		setTargetsScheme(&r.Status, dnsNames.List(), "https")
-		if cert.Status.IsReady() {
+		if cert.IsReady() {
 			r.Status.MarkCertificateReady(cert.Name)
 			tls = append(tls, resources.MakeIngressTLS(cert, dnsNames.List()))
 		} else {

--- a/test/conformance/certificate/utils.go
+++ b/test/conformance/certificate/utils.go
@@ -73,7 +73,7 @@ func CreateCertificate(t *testing.T, clients *test.Clients, dnsNames []string) (
 // IsCertificateReady will check the status conditions of the certificate and return true if the certificate is
 // ready.
 func IsCertificateReady(c *v1alpha1.Certificate) (bool, error) {
-	return c.Generation == c.Status.ObservedGeneration && c.Status.IsReady(), nil
+	return c.IsReady(), nil
 }
 
 // WaitForCertificateSecret polls the status of the Secret for the provided Certificate

--- a/test/v1alpha1/ingress.go
+++ b/test/v1alpha1/ingress.go
@@ -54,5 +54,5 @@ func WaitForIngressState(client *test.NetworkingClients, name string, inState fu
 // IsIngressReady will check the status conditions of the ingress and return true if the ingress is
 // ready.
 func IsIngressReady(r *v1alpha1.Ingress) (bool, error) {
-	return r.Generation == r.Status.ObservedGeneration && r.Status.IsReady(), nil
+	return r.IsReady(), nil
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Issue #8004

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Ensuring that we are always considering ObservedGeneration when assessing readiness prevents race conditions where we might be looking at the wrong status (for a previous spec).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
