### PR TITLE
Separate shutting down v. not ready in queue proxy.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -281,7 +281,7 @@ func probeQueueHealthPath(timeoutSeconds int, env probeConfig) error {
 		defer res.Body.Close()
 		success := health.IsHTTPProbeReady(res)
 
-		// Both preferPodForScaledown and IsHTTPProbeShuttingDon can fail readiness faster.
+		// Both preferPodForScaledown and IsHTTPProbeShuttingDown can fail readiness faster.
 		// The check for preferPodForScaledown() fails readiness faster in the presence of the label,
 		// while shutting down has a different response code than not ready.
 		if preferScaleDown, err := preferPodForScaledown(env.DownwardAPILabelsPath); err != nil {

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -212,6 +212,34 @@ func TestProbeQueueNotReady(t *testing.T) {
 	}
 }
 
+func TestProbeQueueShuttingDownFailsFast(t *testing.T) {
+	ts := newProbeTestServer(func(w http.ResponseWriter) {
+		w.WriteHeader(http.StatusConflict)
+	})
+
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
+	}
+
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("Failed to convert port(%s) to int: %v", u.Port(), err)
+	}
+
+	start := time.Now()
+	if err = probeQueueHealthPath(1, probeConfig{QueueServingPort: port}); err == nil {
+		t.Error("probeQueueHealthPath did not fail")
+	}
+
+	// if fails due to timeout and not cancelation, then it took too long
+	if time.Since(start) >= 1*time.Second {
+		t.Error("took too long to fail")
+	}
+}
+
 func TestProbeQueueReady(t *testing.T) {
 	queueProbed := ptr.Int32(0)
 	ts := newProbeTestServer(func(w http.ResponseWriter) {

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -214,7 +214,7 @@ func TestProbeQueueNotReady(t *testing.T) {
 
 func TestProbeQueueShuttingDownFailsFast(t *testing.T) {
 	ts := newProbeTestServer(func(w http.ResponseWriter) {
-		w.WriteHeader(http.StatusConflict)
+		w.WriteHeader(http.StatusGone)
 	})
 
 	defer ts.Close()

--- a/pkg/queue/health/health_state.go
+++ b/pkg/queue/health/health_state.go
@@ -105,7 +105,7 @@ func (h *State) HandleHealthProbe(prober func() bool, isAggressive bool, w http.
 	}
 
 	sendShuttingDown := func() {
-		w.WriteHeader(http.StatusConflict)
+		w.WriteHeader(http.StatusGone)
 		io.WriteString(w, shuttingDownBody)
 	}
 

--- a/pkg/queue/health/health_state.go
+++ b/pkg/queue/health/health_state.go
@@ -27,7 +27,7 @@ const (
 	aliveBody = "queue"
 	// Return `queue not ready` as body for 503 response for queue not yet ready.
 	notAliveBody = "queue not ready"
-	// Return `shutting down` as body for 503 response if the queue got a shutdown request.
+	// Return `shutting down` as body for 410 response if the queue got a shutdown request.
 	shuttingDownBody = "shutting down"
 )
 

--- a/pkg/queue/health/health_state_test.go
+++ b/pkg/queue/health/health_state_test.go
@@ -97,7 +97,7 @@ func TestHealthStateHealthHandler(t *testing.T) {
 		name:         "shuttingDown: true, K-Probe",
 		state:        &State{shuttingDown: true},
 		isAggressive: false,
-		wantStatus:   http.StatusConflict,
+		wantStatus:   http.StatusGone,
 		wantBody:     shuttingDownBody,
 	}, {
 		name:         "no prober, shuttingDown: false",
@@ -110,7 +110,7 @@ func TestHealthStateHealthHandler(t *testing.T) {
 		state:        &State{shuttingDown: true},
 		prober:       func() bool { return true },
 		isAggressive: true,
-		wantStatus:   http.StatusConflict,
+		wantStatus:   http.StatusGone,
 		wantBody:     shuttingDownBody,
 	}, {
 		name:         "prober: true, shuttingDown: false",

--- a/pkg/queue/health/health_state_test.go
+++ b/pkg/queue/health/health_state_test.go
@@ -97,8 +97,8 @@ func TestHealthStateHealthHandler(t *testing.T) {
 		name:         "shuttingDown: true, K-Probe",
 		state:        &State{shuttingDown: true},
 		isAggressive: false,
-		wantStatus:   http.StatusServiceUnavailable,
-		wantBody:     notAliveBody,
+		wantStatus:   http.StatusConflict,
+		wantBody:     shuttingDownBody,
 	}, {
 		name:         "no prober, shuttingDown: false",
 		state:        &State{},
@@ -110,8 +110,8 @@ func TestHealthStateHealthHandler(t *testing.T) {
 		state:        &State{shuttingDown: true},
 		prober:       func() bool { return true },
 		isAggressive: true,
-		wantStatus:   http.StatusServiceUnavailable,
-		wantBody:     notAliveBody,
+		wantStatus:   http.StatusConflict,
+		wantBody:     shuttingDownBody,
 	}, {
 		name:         "prober: true, shuttingDown: false",
 		state:        &State{},

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -110,6 +110,6 @@ func IsHTTPProbeShuttingDown(res *http.Response) bool {
 		return false
 	}
 
-	// status 409 indicates the probe returned a shutdown scenario.
-	return res.StatusCode == http.StatusConflict
+	// status 410 (Gone) indicates the probe returned a shutdown scenario.
+	return res.StatusCode == http.StatusGone
 }

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -96,20 +96,12 @@ func HTTPProbe(config HTTPProbeConfigOptions) error {
 
 // IsHTTPProbeReady checks whether we received a successful Response
 func IsHTTPProbeReady(res *http.Response) bool {
-	if res == nil {
-		return false
-	}
-
 	// response status code between 200-399 indicates success
 	return res.StatusCode >= 200 && res.StatusCode < 400
 }
 
 // IsHTTPProbeShuttingDown checks whether the Response indicates the prober is shutting down.
 func IsHTTPProbeShuttingDown(res *http.Response) bool {
-	if res == nil {
-		return false
-	}
-
 	// status 410 (Gone) indicates the probe returned a shutdown scenario.
 	return res.StatusCode == http.StatusGone
 }

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -103,3 +103,13 @@ func IsHTTPProbeReady(res *http.Response) bool {
 	// response status code between 200-399 indicates success
 	return res.StatusCode >= 200 && res.StatusCode < 400
 }
+
+// IsHTTPProbeShuttingDown checks whether the Response indicates the prober is shutting down.
+func IsHTTPProbeShuttingDown(res *http.Response) bool {
+	if res == nil {
+		return false
+	}
+
+	// status 409 indicates the probe returned a shutdown scenario.
+	return res.StatusCode == http.StatusConflict
+}

--- a/pkg/queue/health/probe_test.go
+++ b/pkg/queue/health/probe_test.go
@@ -166,6 +166,41 @@ func TestHTTPProbeResponseErrorFailure(t *testing.T) {
 	}
 }
 
+func TestIsHTTPProbeShuttingDown(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantResult bool
+	}{{
+		name:       "statusCode: 409",
+		statusCode: 409,
+		wantResult: true,
+	}, {
+		name:       "statusCode: 503",
+		statusCode: 503,
+		wantResult: false,
+	}, {
+		name:       "statusCode: 200",
+		statusCode: 200,
+		wantResult: false,
+	}, {
+		name:       "statusCode: 301",
+		statusCode: 301,
+		wantResult: false,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := http.Response{StatusCode: test.statusCode}
+			result := IsHTTPProbeShuttingDown(&response)
+			if result != test.wantResult {
+				t.Errorf("IsHTTPProbeShuttingDown returned unexpected result: got %v want %v",
+					result, test.wantResult)
+			}
+		})
+	}
+}
+
 func newHTTPGetAction(t *testing.T, serverURL string) *corev1.HTTPGetAction {
 	urlParsed, err := url.Parse(serverURL)
 	if err != nil {

--- a/pkg/queue/health/probe_test.go
+++ b/pkg/queue/health/probe_test.go
@@ -172,8 +172,8 @@ func TestIsHTTPProbeShuttingDown(t *testing.T) {
 		statusCode int
 		wantResult bool
 	}{{
-		name:       "statusCode: 409",
-		statusCode: 409,
+		name:       "statusCode: 410",
+		statusCode: 410,
 		wantResult: true,
 	}, {
 		name:       "statusCode: 503",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #8151

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Makes health_state return a different error code (currently 410 Gone) when it's shutting down. After some discussion with @mattmoor he suggested using a 4xx code. I'm open to suggestions if there's a better option :).
* Makes shutting down fail fast (like preferPodForScaleDown).
* Unit tests to validate behavior.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
