### PR TITLE
Remove serving.yaml from release artifacts.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -217,13 +217,15 @@ You can see things running with:
 
 ```console
 kubectl -n knative-serving get pods
-NAME                                READY   STATUS      RESTARTS   AGE
-activator-5b87795885-f8t7k          2/2     Running     0          18m
-autoscaler-6495f7f79d-86jsr         2/2     Running     0          18m
-controller-5fd7fddc58-klmt4         1/1     Running     0          18m
-default-domain-6hs98                0/1     Completed   0          13s
-networking-istio-6755db495d-wtj4d   1/1     Running     0          18m
-webhook-84b8c9886d-dsqqv            1/1     Running     0          18m
+NAME                                  READY   STATUS    RESTARTS   AGE
+activator-7454cd659f-rrz86            1/1     Running   0          105s
+autoscaler-58cbfd4985-fl5h7           1/1     Running   0          105s
+autoscaler-hpa-77964b9b8c-9sbgq       1/1     Running   0          105s
+controller-847b7cc977-5mvvq           1/1     Running   0          105s
+istio-webhook-69bf66f869-cgc4l        1/1     Running   0          105s
+networking-istio-dcf7944fb-5m25h      1/1     Running   0          105s
+networking-ns-cert-56c58544db-sgstd   1/1     Running   0          105s
+webhook-6b6c77567f-flr59              1/1     Running   0          105s
 ```
 
 You can access the Knative Serving Controller's logs with:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -208,8 +208,8 @@ ko delete -f config/post-install/default-domain.yaml --ignore-not-found
 ko apply -f config/post-install/default-domain.yaml
 ```
 
-The above step is equivalent to applying the `serving.yaml` for released
-versions of Knative Serving.
+The above step is equivalent to applying the `serving-crds.yaml` and
+`serving-core.yaml` for released versions of Knative Serving.
 
 You can see things running with:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -208,8 +208,10 @@ ko delete -f config/post-install/default-domain.yaml --ignore-not-found
 ko apply -f config/post-install/default-domain.yaml
 ```
 
-The above step is equivalent to applying the `serving-crds.yaml` and
-`serving-core.yaml` for released versions of Knative Serving.
+The above step is equivalent to applying the `serving-crds.yaml`,
+`serving-core.yaml`, `serving-hpa.yaml` and `serving-nscert.yaml` for released
+versions of Knative Serving and additionally applying **net-istio** as the
+ingress implementation.
 
 You can see things running with:
 

--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -48,7 +48,6 @@ fi
 rm -fr ${YAML_OUTPUT_DIR}/*.yaml
 
 # Generated Knative component YAML files
-readonly SERVING_YAML=${YAML_OUTPUT_DIR}/serving.yaml
 readonly SERVING_CORE_YAML=${YAML_OUTPUT_DIR}/serving-core.yaml
 readonly SERVING_DEFAULT_DOMAIN_YAML=${YAML_OUTPUT_DIR}/serving-default-domain.yaml
 readonly SERVING_STORAGE_VERSION_MIGRATE_YAML=${YAML_OUTPUT_DIR}/serving-storage-version-migration.yaml
@@ -102,11 +101,6 @@ cat "./third_party/cert-manager-0.12.0/net-certmanager.yaml" > "${SERVING_CERT_M
 # Create nscert related yaml
 ko resolve ${KO_YAML_FLAGS} -f config/namespace-wildcard-certs | "${LABEL_YAML_CMD[@]}" > "${SERVING_NSCERT_YAML}"
 
-# Create serving.yaml with all of the default components
-cat "${SERVING_CORE_YAML}" > "${SERVING_YAML}"
-cat "${SERVING_HPA_YAML}" >> "${SERVING_YAML}"
-cat "./third_party/net-istio.yaml" >> "${SERVING_YAML}"
-
 # Metrics via Prometheus & Grafana
 ko resolve ${KO_YAML_FLAGS} -R \
     -f third_party/config/monitoring/metrics/prometheus \
@@ -149,10 +143,9 @@ ko resolve ${KO_YAML_FLAGS} -R -f config/monitoring/tracing/jaeger/memory -f con
 
 echo "All manifests generated"
 
-# List generated YAML files, with serving.yaml first.
+# List generated YAML files, with serving-core.yaml first.
 
 cat << EOF > ${YAML_LIST_FILE}
-${SERVING_YAML}
 ${SERVING_CORE_YAML}
 ${SERVING_DEFAULT_DOMAIN_YAML}
 ${SERVING_STORAGE_VERSION_MIGRATE_YAML}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #7755

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Stops enumerating `serving.yaml` in our release artifacts and remove all occurrences of it from our scripts.

/assign @mattmoor @chizhg 
