### PR TITLE
Allow setting Queue Proxy resources in ConfigMap

### DIFF
--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: 3d5b261a
+    knative.dev/example-checksum: 1de882eb
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -47,3 +47,29 @@ data:
     # ProgressDeadline is the duration we wait for the deployment to
     # be ready before considering it failed.
     progressDeadline: "120s"
+
+    # queueSidecarCPURequest is the requests.cpu to set for the queue proxy sidecar container.
+    # If omitted, a default value (currently "25m"), is used.
+    queueSidecarCPURequest: "25m"
+
+    # queueSidecarCPULimit is the limits.cpu to set for the queue proxy sidecar container.
+    # If omitted, no value is specified and the system default is used.
+    queueSidecarCPULimit: "1000m"
+
+    # queueSidecarMemoryRequest is the requests.memory to set for the queue proxy container.
+    # If omitted, no value is specified and the system default is used.
+    queueSidecarMemoryRequest: "400m"
+
+    # queueSidecarMemoryLimit is the limits.memory to set for the queue proxy container.
+    # If omitted, no value is specified and the system default is used.
+    queueSidecarMemoryLimit: "800m"
+
+    # queueSidecarEphemeralStorageRequest is the requests.ephemeral-storage to
+    # set for the queue proxy sidecar container.
+    # If omitted, no value is specified and the system default is used.
+    queueSidecarEphemeralStorageRequest: "512m"
+
+    # queueSidecarEphemeralStorageLimit is the limits.ephemeral-storage to set
+    # for the queue proxy sidecar container.
+    # If omitted, no value is specified and the system default is used.
+    queueSidecarEphemeralStorageLimit: "1024m"

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	cm "knative.dev/pkg/configmap"
@@ -38,16 +39,36 @@ const (
 	// ProgressDeadlineSeconds. This does not match the K8s default value of 600s.
 	ProgressDeadlineDefault = 120 * time.Second
 
-	registriesSkippingTagResolvingKey = "registriesSkippingTagResolving"
-
 	// ProgressDeadlineKey is the key to configure deployment progress deadline.
 	ProgressDeadlineKey = "progressDeadline"
+
+	// registriesSkippingTagResolvingKey is the config map key for the set of registries
+	// (e.g. ko.local) where tags should not be resolved to digests.
+	registriesSkippingTagResolvingKey = "registriesSkippingTagResolving"
+
+	// queueSidecar resource request keys.
+	queueSidecarCPURequestKey              = "queueSidecarCPURequest"
+	queueSidecarMemoryRequestKey           = "queueSidecarMemoryRequest"
+	queueSidecarEphemeralStorageRequestKey = "queueSidecarEphemeralStorageRequest"
+
+	// queueSidecar resource limit keys.
+	queueSidecarCPULimitKey              = "queueSidecarCPULimit"
+	queueSidecarMemoryLimitKey           = "queueSidecarMemoryLimit"
+	queueSidecarEphemeralStorageLimitKey = "queueSidecarEphemeralStorageLimit"
+)
+
+var (
+	// QueueSidecarCPURequestDefault is the default request.cpu to set for the
+	// queue sidecar. It is set at 25m for backwards-compatibility since this was
+	// the historic default before the field was operator-settable.
+	QueueSidecarCPURequestDefault = resource.MustParse("25m")
 )
 
 func defaultConfig() *Config {
 	return &Config{
 		ProgressDeadline:               ProgressDeadlineDefault,
 		RegistriesSkippingTagResolving: sets.NewString("ko.local", "dev.local"),
+		QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 	}
 }
 
@@ -59,6 +80,13 @@ func NewConfigFromMap(configMap map[string]string) (*Config, error) {
 		cm.AsString(QueueSidecarImageKey, &nc.QueueSidecarImage),
 		cm.AsDuration(ProgressDeadlineKey, &nc.ProgressDeadline),
 		cm.AsStringSet(registriesSkippingTagResolvingKey, &nc.RegistriesSkippingTagResolving),
+
+		cm.AsQuantity(queueSidecarCPURequestKey, &nc.QueueSidecarCPURequest),
+		cm.AsQuantity(queueSidecarMemoryRequestKey, &nc.QueueSidecarMemoryRequest),
+		cm.AsQuantity(queueSidecarEphemeralStorageRequestKey, &nc.QueueSidecarEphemeralStorageRequest),
+		cm.AsQuantity(queueSidecarCPULimitKey, &nc.QueueSidecarCPULimit),
+		cm.AsQuantity(queueSidecarMemoryLimitKey, &nc.QueueSidecarMemoryLimit),
+		cm.AsQuantity(queueSidecarEphemeralStorageLimitKey, &nc.QueueSidecarEphemeralStorageLimit),
 	); err != nil {
 		return nil, err
 	}
@@ -91,4 +119,24 @@ type Config struct {
 	// ProgressDeadline is the time in seconds we wait for the deployment to
 	// be ready before considering it failed.
 	ProgressDeadline time.Duration
+
+	// QueueSidecarCPURequest is the CPU Request to set for the queue proxy sidecar container
+	QueueSidecarCPURequest *resource.Quantity
+
+	// QueueSidecarCPULimit is the CPU Limit to set for the queue proxy sidecar container
+	QueueSidecarCPULimit *resource.Quantity
+
+	// QueueSidecarMemoryRequest is the Memory Request to set for the queue proxy sidecar container
+	QueueSidecarMemoryRequest *resource.Quantity
+
+	// QueueSidecarMemoryLimit is the Memory Limit to set for the queue proxy sidecar container
+	QueueSidecarMemoryLimit *resource.Quantity
+
+	// QueueSidecarEphemeralStorageRequest is the Ephemeral Storage Request to
+	// set for the queue proxy sidecar container
+	QueueSidecarEphemeralStorageRequest *resource.Quantity
+
+	// QueueSidecarEphemeralStorageLimit is the Ephemeral Storage Limit to set
+	// for the queue proxy sidecar container
+	QueueSidecarEphemeralStorageLimit *resource.Quantity
 }

--- a/pkg/deployment/zz_generated.deepcopy.go
+++ b/pkg/deployment/zz_generated.deepcopy.go
@@ -34,6 +34,36 @@ func (in *Config) DeepCopyInto(out *Config) {
 			(*out)[key] = val
 		}
 	}
+	if in.QueueSidecarCPURequest != nil {
+		in, out := &in.QueueSidecarCPURequest, &out.QueueSidecarCPURequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.QueueSidecarCPULimit != nil {
+		in, out := &in.QueueSidecarCPULimit, &out.QueueSidecarCPULimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.QueueSidecarMemoryRequest != nil {
+		in, out := &in.QueueSidecarMemoryRequest, &out.QueueSidecarMemoryRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.QueueSidecarMemoryLimit != nil {
+		in, out := &in.QueueSidecarMemoryLimit, &out.QueueSidecarMemoryLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.QueueSidecarEphemeralStorageRequest != nil {
+		in, out := &in.QueueSidecarEphemeralStorageRequest, &out.QueueSidecarEphemeralStorageRequest
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.QueueSidecarEphemeralStorageLimit != nil {
+		in, out := &in.QueueSidecarEphemeralStorageLimit, &out.QueueSidecarEphemeralStorageLimit
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -83,7 +83,7 @@ var (
 
 	defaultQueueContainer = &corev1.Container{
 		Name:      QueueContainerName,
-		Resources: createQueueResources(make(map[string]string), &corev1.Container{}),
+		Resources: createQueueResources(&deploymentConfig, make(map[string]string), &corev1.Container{}),
 		Ports:     append(queueNonServingPorts, queueHTTPPort),
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


Fixes #8012.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

- defaults request.cpu to 25m for backwards compatibility
- all other requests and limits also maintain current defaults 
  (i.e. nil/unspecified/inherit kubernetes)
- annotation continues to work to override based on user container resources

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Operators can now set Queue Proxy resource requests/limits in the config-deployment.yaml config map
```
