### PR TITLE
Explicitly set the CC=0

### DIFF
--- a/test/performance/benchmarks/dataplane-probe/continuous/dataplane-probe-setup.yaml
+++ b/test/performance/benchmarks/dataplane-probe/continuous/dataplane-probe-setup.yaml
@@ -97,7 +97,6 @@ spec:
       - image: ko://knative.dev/serving/test/test_images/autoscale
       containerConcurrency: 0 # Explicitly set the default, since it might be overridden in CM.
 ---
----
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:

--- a/test/performance/benchmarks/dataplane-probe/continuous/dataplane-probe-setup.yaml
+++ b/test/performance/benchmarks/dataplane-probe/continuous/dataplane-probe-setup.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       containers:
       - image: ko://knative.dev/serving/test/test_images/autoscale
+      containerConcurrency: 0 # Explicitly set the default, since it might be overridden in CM.
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -94,6 +95,8 @@ spec:
     spec:
       containers:
       - image: ko://knative.dev/serving/test/test_images/autoscale
+      containerConcurrency: 0 # Explicitly set the default, since it might be overridden in CM.
+---
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service

--- a/test/performance/benchmarks/load-test/continuous/load-test-setup.yaml
+++ b/test/performance/benchmarks/load-test/continuous/load-test-setup.yaml
@@ -27,7 +27,6 @@ spec:
       - image: ko://knative.dev/serving/test/test_images/autoscale
       containerConcurrency: 0 # Explicitly set the default, since it might be overridden in CM.
 ---
----
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
@@ -42,7 +41,6 @@ spec:
       containers:
       - image: ko://knative.dev/serving/test/test_images/autoscale
       containerConcurrency: 0 # Explicitly set the default, since it might be overridden in CM.
----
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service

--- a/test/performance/benchmarks/load-test/continuous/load-test-setup.yaml
+++ b/test/performance/benchmarks/load-test/continuous/load-test-setup.yaml
@@ -25,6 +25,8 @@ spec:
     spec:
       containers:
       - image: ko://knative.dev/serving/test/test_images/autoscale
+      containerConcurrency: 0 # Explicitly set the default, since it might be overridden in CM.
+---
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -39,6 +41,8 @@ spec:
     spec:
       containers:
       - image: ko://knative.dev/serving/test/test_images/autoscale
+      containerConcurrency: 0 # Explicitly set the default, since it might be overridden in CM.
+---
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -53,3 +57,5 @@ spec:
     spec:
       containers:
       - image: ko://knative.dev/serving/test/test_images/autoscale
+      containerConcurrency: 0 # Explicitly set the default, since it might be overridden in CM.
+---


### PR DESCRIPTION
My cluster had an override for the default CC and the numbers where awful. And it took me quite a while
to check the service to see if something's fishy there.

/assign @chizhg mattmoor