### PR TITLE
Increase test timeout second for TestRevisionTimeout

### DIFF
--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -75,7 +75,7 @@ func sendRequest(t *testing.T, clients *test.Clients, endpoint *url.URL,
 
 	t.Logf("Response status code: %v, expected: %v", resp.StatusCode, expectedResponseCode)
 	if expectedResponseCode != resp.StatusCode {
-		return fmt.Errorf("response status code = %v, want: %v", resp.StatusCode, expectedResponseCode)
+		return fmt.Errorf("response status code = %v, want = %v, response = %v", resp.StatusCode, expectedResponseCode, resp)
 	}
 	return nil
 }
@@ -94,13 +94,13 @@ func TestRevisionTimeout(t *testing.T) {
 	}{{
 		name:           "when scaling up from 0 and does not exceed timeout seconds",
 		shouldScaleTo0: true,
-		timeoutSeconds: 10,
+		timeoutSeconds: 20,
 		expectedStatus: http.StatusOK,
 	}, {
 		name:           "when scaling up from 0 and it writes first byte before timeout",
 		shouldScaleTo0: true,
-		timeoutSeconds: 10,
-		sleep:          15 * time.Second,
+		timeoutSeconds: 20,
+		sleep:          25 * time.Second,
 		expectedStatus: http.StatusOK,
 	}, {
 		name:           "when scaling up from 0 and it does exceed timeout seconds",

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -74,7 +74,7 @@ func sendRequest(t *testing.T, clients *test.Clients, endpoint *url.URL,
 
 	t.Logf("Response status code: %v, expected: %v", resp.StatusCode, expectedResponseCode)
 	if expectedResponseCode != resp.StatusCode {
-		return fmt.Errorf("response status code = %v, want: %v", resp.StatusCode, expectedResponseCode)
+		return fmt.Errorf("response status code = %v, want = %v, response = %v", resp.StatusCode, expectedResponseCode, resp)
 	}
 	return nil
 }
@@ -93,13 +93,13 @@ func TestRevisionTimeout(t *testing.T) {
 	}{{
 		name:           "when scaling up from 0 and does not exceed timeout seconds",
 		shouldScaleTo0: true,
-		timeoutSeconds: 10,
+		timeoutSeconds: 20,
 		expectedStatus: http.StatusOK,
 	}, {
 		name:           "when scaling up from 0 and it writes first byte before timeout",
 		shouldScaleTo0: true,
-		timeoutSeconds: 10,
-		sleep:          15 * time.Second,
+		timeoutSeconds: 20,
+		sleep:          25 * time.Second,
 		expectedStatus: http.StatusOK,
 	}, {
 		name:           "when scaling up from 0 and it does exceed timeout seconds",

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -74,7 +74,7 @@ func sendRequest(t *testing.T, clients *test.Clients, endpoint *url.URL,
 
 	t.Logf("Response status code: %v, expected: %v", resp.StatusCode, expectedResponseCode)
 	if expectedResponseCode != resp.StatusCode {
-		return fmt.Errorf("response status code = %v, want: %v", resp.StatusCode, expectedResponseCode)
+		return fmt.Errorf("response status code = %v, want = %v, response = %v", resp.StatusCode, expectedResponseCode, resp)
 	}
 	return nil
 }
@@ -93,13 +93,13 @@ func TestRevisionTimeout(t *testing.T) {
 	}{{
 		name:           "when scaling up from 0 and does not exceed timeout seconds",
 		shouldScaleTo0: true,
-		timeoutSeconds: 10,
+		timeoutSeconds: 20,
 		expectedStatus: http.StatusOK,
 	}, {
 		name:           "when scaling up from 0 and it writes first byte before timeout",
 		shouldScaleTo0: true,
-		timeoutSeconds: 10,
-		sleep:          15 * time.Second,
+		timeoutSeconds: 20,
+		sleep:          25 * time.Second,
 		expectedStatus: http.StatusOK,
 	}, {
 		name:           "when scaling up from 0 and it does exceed timeout seconds",


### PR DESCRIPTION
Following two tests very frequnetly fails on mesh mode:

- "when scaling up from 0 and does not exceed timeout seconds"
- "when scaling up from 0 and it writes first byte before timeout"

see: https://testgrid.knative.dev/serving#istio-1.5-mesh&include-filter-by-regex=TestRevisionTimeout

This is because `10s` is usually too short to scale up pod with side-car container.

Hence this patch increases the test timeout to 20s.

/lint

**Release Note**

```release-note
NONE
```
