### PR TITLE
Pull the new pkg that fixes the update of the CM example hashing with spaces

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -21,7 +21,7 @@ metadata:
     serving.knative.dev/release: devel
     knative.dev/example-checksum: "b2d0685a"
   annotations:
-    knative.dev/example-checksum: b2d0685a
+    knative.dev/example-checksum: "62090295"
 data:
   _example: |
     ################################

--- a/config/core/configmaps/defaults.yaml
+++ b/config/core/configmaps/defaults.yaml
@@ -21,7 +21,7 @@ metadata:
     serving.knative.dev/release: devel
     knative.dev/example-checksum: "7610427c"
   annotations:
-    knative.dev/example-checksum: 7610427c
+    knative.dev/example-checksum: c3699c6c
 data:
   _example: |
     ################################

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -21,7 +21,7 @@ metadata:
     serving.knative.dev/release: devel
     knative.dev/example-checksum: "cf88a4cf"
   annotations:
-    knative.dev/example-checksum: cf88a4cf
+    knative.dev/example-checksum: 3d5b261a
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.

--- a/config/core/configmaps/domain.yaml
+++ b/config/core/configmaps/domain.yaml
@@ -21,7 +21,7 @@ metadata:
     serving.knative.dev/release: devel
     knative.dev/example-checksum: "327d2082"
   annotations:
-    knative.dev/example-checksum: 327d2082
+    knative.dev/example-checksum: aa261100
 data:
   _example: |
     ################################

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -21,7 +21,7 @@ metadata:
     serving.knative.dev/release: devel
     knative.dev/example-checksum: "303e565f"
   annotations:
-    knative.dev/example-checksum: 303e565f
+    knative.dev/example-checksum: 84c3c6c3
 data:
   _example: |
     ################################

--- a/config/core/configmaps/gc.yaml
+++ b/config/core/configmaps/gc.yaml
@@ -21,7 +21,7 @@ metadata:
     serving.knative.dev/release: devel
     knative.dev/example-checksum: "7a8e5402"
   annotations:
-    knative.dev/example-checksum: 7a8e5402
+    knative.dev/example-checksum: eb64daa7
 data:
   _example: |
     ################################

--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -21,7 +21,7 @@ metadata:
     serving.knative.dev/release: devel
     knative.dev/example-checksum: "82c28949"
   annotations:
-    knative.dev/example-checksum: 82c28949
+    knative.dev/example-checksum: c517f87a
 data:
   _example: |
     ################################

--- a/config/core/configmaps/logging.yaml
+++ b/config/core/configmaps/logging.yaml
@@ -21,7 +21,7 @@ metadata:
     serving.knative.dev/release: devel
     knative.dev/example-checksum: "3199de9f"
   annotations:
-    knative.dev/example-checksum: 3199de9f
+    knative.dev/example-checksum: f83a0082
 data:
   _example: |
     ################################

--- a/config/core/configmaps/network.yaml
+++ b/config/core/configmaps/network.yaml
@@ -21,7 +21,7 @@ metadata:
     serving.knative.dev/release: devel
     knative.dev/example-checksum: "8b4ff3d6"
   annotations:
-    knative.dev/example-checksum: 8b4ff3d6
+    knative.dev/example-checksum: fe214c76
 data:
   _example: |
     ################################

--- a/config/core/configmaps/observability.yaml
+++ b/config/core/configmaps/observability.yaml
@@ -21,7 +21,7 @@ metadata:
     serving.knative.dev/release: devel
     knative.dev/example-checksum: "26889b7b"
   annotations:
-    knative.dev/example-checksum: 26889b7b
+    knative.dev/example-checksum: 5ec1a71c
 data:
   _example: |
     ################################

--- a/config/core/configmaps/tracing.yaml
+++ b/config/core/configmaps/tracing.yaml
@@ -21,7 +21,7 @@ metadata:
     serving.knative.dev/release: devel
     knative.dev/example-checksum: "e359bd08"
   annotations:
-    knative.dev/example-checksum: e359bd08
+    knative.dev/example-checksum: 35dc6aa4
 data:
   _example: |
     ################################

--- a/go.mod
+++ b/go.mod
@@ -43,8 +43,8 @@ require (
 	k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29
 	k8s.io/metrics v0.17.6
 	knative.dev/caching v0.0.0-20200604203019-a5bd4f5d0e4f
-	knative.dev/pkg v0.0.0-20200605112617-7b4093b435c0
-	knative.dev/test-infra v0.0.0-20200605033518-4b5d9e1bbdbe
+	knative.dev/pkg v0.0.0-20200605170718-b7125260dc6f
+	knative.dev/test-infra v0.0.0-20200605173118-26a648be867f
 )
 
 // pin the older grpc - see: https://github.com/grpc/grpc-go/issues/3180

--- a/go.sum
+++ b/go.sum
@@ -1322,8 +1322,8 @@ knative.dev/pkg v0.0.0-20200519155757-14eb3ae3a5a7/go.mod h1:QgNZTxnwpB/oSpNcfnL
 knative.dev/pkg v0.0.0-20200520073958-94316e20e860/go.mod h1:QgNZTxnwpB/oSpNcfnLVlw+WpEwwyKAvJlvR3hgeltA=
 knative.dev/pkg v0.0.0-20200603222317-b79e4a24ca50 h1:sbJMCCtOENPgfE5dUSwBUxZtJzhfqORhExyWFX7L0Fk=
 knative.dev/pkg v0.0.0-20200603222317-b79e4a24ca50/go.mod h1:8IfPj/lpuKHHg82xZCl2wuFZ3BM96To72sN1W8T9wjQ=
-knative.dev/pkg v0.0.0-20200605112617-7b4093b435c0 h1:DV9r7l21aS/KdO+fcAlkvQr5Clct6WM2VQ3Q8tdRm2g=
-knative.dev/pkg v0.0.0-20200605112617-7b4093b435c0/go.mod h1:8IfPj/lpuKHHg82xZCl2wuFZ3BM96To72sN1W8T9wjQ=
+knative.dev/pkg v0.0.0-20200605170718-b7125260dc6f h1:2WVJ2b5Yws8klA2yCNkprY8EaQAR/mCVdV9XeI/4/Y0=
+knative.dev/pkg v0.0.0-20200605170718-b7125260dc6f/go.mod h1:ItJ3UvcHFt7qMoowI2uXfaGMWNGIMYAtzAbdsi+b0Cg=
 knative.dev/test-infra v0.0.0-20200407185800-1b88cb3b45a5/go.mod h1:xcdUkMJrLlBswIZqL5zCuBFOC22WIPMQoVX1L35i0vQ=
 knative.dev/test-infra v0.0.0-20200505052144-5ea2f705bb55/go.mod h1:WqF1Azka+FxPZ20keR2zCNtiQA1MP9ZB4BH4HuI+SIU=
 knative.dev/test-infra v0.0.0-20200513011557-d03429a76034 h1:JxqONCZVS7or+Fv3ebVQoipuIBH7Ig3Qbx170hgIF+A=
@@ -1336,6 +1336,8 @@ knative.dev/test-infra v0.0.0-20200522180958-6a0a9b9d893a h1:c0qTABRcNoxZVu5gsry
 knative.dev/test-infra v0.0.0-20200522180958-6a0a9b9d893a/go.mod h1:n9eQkzmSNj8BiqNFl1lzoz68D09uMeJfyOjc132Gbik=
 knative.dev/test-infra v0.0.0-20200605033518-4b5d9e1bbdbe h1:8jvsC2cS3Xc/KOPnCOJSpxtQqgx8ZoDPEgaoRrNq8Uk=
 knative.dev/test-infra v0.0.0-20200605033518-4b5d9e1bbdbe/go.mod h1:wsGme3loBZjSjhuaTUhejJ34EOwKZ5KXkweKL0zSKhM=
+knative.dev/test-infra v0.0.0-20200605173118-26a648be867f h1:VEhKLxXX9vhijAquw8I8sr0PhgsLQmZdwVqQ27h0oW8=
+knative.dev/test-infra v0.0.0-20200605173118-26a648be867f/go.mod h1://I6IZIF0QDgs5wotU243ZZ5cTpm6/GthayjUenBBc0=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/knative.dev/pkg/configmap/example.go
+++ b/vendor/knative.dev/pkg/configmap/example.go
@@ -19,6 +19,7 @@ package configmap
 import (
 	"fmt"
 	"hash/crc32"
+	"strings"
 )
 
 const (
@@ -29,7 +30,9 @@ const (
 	ExampleChecksumAnnotation = "knative.dev/example-checksum"
 )
 
-// Checksum generates a checksum for the example value to be compared against a respective annotation.
+// Checksum generates a checksum for the example value to be compared against
+// a respective annotation.
+// Leading and trailing spaces are ignored.
 func Checksum(value string) string {
-	return fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(value)))
+	return fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(strings.TrimSpace(value))))
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1199,7 +1199,7 @@ knative.dev/caching/pkg/client/injection/informers/caching/v1alpha1/image/fake
 knative.dev/caching/pkg/client/injection/informers/factory
 knative.dev/caching/pkg/client/injection/informers/factory/fake
 knative.dev/caching/pkg/client/listers/caching/v1alpha1
-# knative.dev/pkg v0.0.0-20200605112617-7b4093b435c0
+# knative.dev/pkg v0.0.0-20200605170718-b7125260dc6f
 ## explicit
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate
@@ -1316,7 +1316,7 @@ knative.dev/pkg/webhook/resourcesemantics/conversion
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
 knative.dev/pkg/websocket
-# knative.dev/test-infra v0.0.0-20200605033518-4b5d9e1bbdbe
+# knative.dev/test-infra v0.0.0-20200605173118-26a648be867f
 ## explicit
 knative.dev/test-infra/scripts
 # sigs.k8s.io/structured-merge-diff/v2 v2.0.1


### PR DESCRIPTION
Fixes #8211 in serving
Verified manually.
/assign @markusthoemmes @julz mattmoor