### PR TITLE
Remove old checksum labels

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-    knative.dev/example-checksum: "b2d0685a"
   annotations:
     knative.dev/example-checksum: "62090295"
 data:

--- a/config/core/configmaps/defaults.yaml
+++ b/config/core/configmaps/defaults.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-    knative.dev/example-checksum: "7610427c"
   annotations:
     knative.dev/example-checksum: c3699c6c
 data:

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-    knative.dev/example-checksum: "cf88a4cf"
   annotations:
     knative.dev/example-checksum: 3d5b261a
 data:

--- a/config/core/configmaps/domain.yaml
+++ b/config/core/configmaps/domain.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-    knative.dev/example-checksum: "327d2082"
   annotations:
     knative.dev/example-checksum: aa261100
 data:

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-    knative.dev/example-checksum: "303e565f"
   annotations:
     knative.dev/example-checksum: 84c3c6c3
 data:

--- a/config/core/configmaps/gc.yaml
+++ b/config/core/configmaps/gc.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-    knative.dev/example-checksum: "7a8e5402"
   annotations:
     knative.dev/example-checksum: eb64daa7
 data:

--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-    knative.dev/example-checksum: "82c28949"
   annotations:
     knative.dev/example-checksum: c517f87a
 data:

--- a/config/core/configmaps/logging.yaml
+++ b/config/core/configmaps/logging.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-    knative.dev/example-checksum: "3199de9f"
   annotations:
     knative.dev/example-checksum: f83a0082
 data:

--- a/config/core/configmaps/network.yaml
+++ b/config/core/configmaps/network.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-    knative.dev/example-checksum: "8b4ff3d6"
   annotations:
     knative.dev/example-checksum: fe214c76
 data:

--- a/config/core/configmaps/observability.yaml
+++ b/config/core/configmaps/observability.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-    knative.dev/example-checksum: "26889b7b"
   annotations:
     knative.dev/example-checksum: 5ec1a71c
 data:

--- a/config/core/configmaps/tracing.yaml
+++ b/config/core/configmaps/tracing.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-    knative.dev/example-checksum: "e359bd08"
   annotations:
     knative.dev/example-checksum: 35dc6aa4
 data:


### PR DESCRIPTION
These are ignored now that we use [annotations rather than labels](https://github.com/knative/pkg/pull/1380).

/assign @vagababov 