### PR TITLE
Add autoscaler class verification for values with `.knative.dev` suffix

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"knative.dev/pkg/apis"
@@ -49,9 +50,18 @@ func ValidateAnnotations(allowInitScaleZero bool, anns map[string]string) *apis.
 	if len(anns) == 0 {
 		return nil
 	}
-	return validateMinMaxScale(anns).Also(validateFloats(anns)).
+	return validateClass(anns).Also(validateMinMaxScale(anns)).Also(validateFloats(anns)).
 		Also(validateWindow(anns).Also(validateLastPodRetention(anns)).
 			Also(validateMetric(anns).Also(validateInitialScale(allowInitScaleZero, anns))))
+}
+
+func validateClass(annotations map[string]string) *apis.FieldError {
+	if c, ok := annotations[ClassAnnotationKey]; ok {
+		if strings.HasSuffix(c, domain) && c != KPA && c != HPA {
+			return apis.ErrInvalidValue(c, ClassAnnotationKey)
+		}
+	}
+	return nil
 }
 
 func validateFloats(annotations map[string]string) *apis.FieldError {

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -37,6 +37,13 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 		name:        "empty annotations",
 		annotations: map[string]string{},
 	}, {
+		name:        "invalid class",
+		annotations: map[string]string{ClassAnnotationKey: "unsupport.knative.dev"},
+		expectErr:   "invalid value: unsupport.knative.dev: " + ClassAnnotationKey,
+	}, {
+		name:        "non-knative.dev domain class",
+		annotations: map[string]string{ClassAnnotationKey: "some.other.domain"},
+	}, {
 		name:        "minScale is 0",
 		annotations: map[string]string{MinScaleAnnotationKey: "0"},
 	}, {

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -38,8 +38,8 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 		annotations: map[string]string{},
 	}, {
 		name:        "invalid class",
-		annotations: map[string]string{ClassAnnotationKey: "unsupport.knative.dev"},
-		expectErr:   "invalid value: unsupport.knative.dev: " + ClassAnnotationKey,
+		annotations: map[string]string{ClassAnnotationKey: "unsupported.knative.dev"},
+		expectErr:   "invalid value: unsupported.knative.dev: " + ClassAnnotationKey,
 	}, {
 		name:        "non-knative.dev domain class",
 		annotations: map[string]string{ClassAnnotationKey: "some.other.domain"},

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -19,6 +19,8 @@ package autoscaling
 import "time"
 
 const (
+	domain = ".knative.dev"
+
 	// InternalGroupName is the internal autoscaling group name. This is used for CRDs.
 	InternalGroupName = "autoscaling.internal.knative.dev"
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

For #5403

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Verify values of `autoscaling.knative.dev/class` annotation with `*.knative.dev` suffix. Only `kpa.autoscaling.knative.dev` and `hpa.autoscaling.knative.dev` are supported values.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Added validations for `autoscaling.knative.dev/class` annotation. If the value has `*.knative.dev` suffix, only `kpa.autoscaling.knative.dev` and `hpa.autoscaling.knative.dev` are valid.
```
