### PR TITLE
Implement power of 2 choices LB for cc=0

### DIFF
--- a/pkg/activator/net/lb_policy.go
+++ b/pkg/activator/net/lb_policy.go
@@ -36,7 +36,7 @@ func randomLBPolicy(_ context.Context, targets []*podTracker) (func(), *podTrack
 	return noop, targets[rand.Intn(len(targets))]
 }
 
-// randomChoice2 implementes the Power of 2 choices LB algorithm
+// randomChoice2 implements the Power of 2 choices LB algorithm
 func randomChoice2(_ context.Context, targets []*podTracker) (func(), *podTracker) {
 	// Avoid random if possible.
 	l := len(targets)

--- a/pkg/activator/net/lb_policy.go
+++ b/pkg/activator/net/lb_policy.go
@@ -36,6 +36,39 @@ func randomLBPolicy(_ context.Context, targets []*podTracker) (func(), *podTrack
 	return noop, targets[rand.Intn(len(targets))]
 }
 
+// randomChoice2 implementes the Power of 2 choices LB algorithm
+func randomChoice2(_ context.Context, targets []*podTracker) (func(), *podTracker) {
+	// Avoid random if possible.
+	l := len(targets)
+	// One tracker = no choice.
+	if l == 1 {
+		targets[0].addWeight(1)
+		return func() {
+			targets[0].addWeight(-1)
+		}, targets[0]
+	}
+	r1, r2 := 0, 1
+	// Two trackers - we know the both contestants,
+	// otherwise pick 2 random unequal integers.
+	if l > 2 {
+		r1, r2 = rand.Intn(l), rand.Intn(l)
+		for r1 == r2 {
+			r2 = rand.Intn(l)
+		}
+	}
+
+	t1, t2 := targets[r1], targets[r2]
+	// Possible race here, but this policy is for CC=0,
+	// so fine.
+	if t1.getWeight() > t2.getWeight() {
+		t1, t2 = t2, t1
+	}
+	t1.addWeight(1)
+	return func() {
+		t1.addWeight(-1)
+	}, t1
+}
+
 // firstAvailableLBPolicy is a load balancer policy, that picks the first target
 // that has capacity to serve the request right now.
 func firstAvailableLBPolicy(ctx context.Context, targets []*podTracker) (func(), *podTracker) {


### PR DESCRIPTION
For #7664
This does the power of 2 choices LB policy for CC=0.
Running benchmarks showed practically identical latency (~1ms improvement, depending on the run), but significant improvement in the StdDev (>40% smaller) and slight improvement in MAD.

* Old
	* https://mako.dev/run?run_key=5862154496376832&~a=1&scatter=1 p99=0.106689
	* https://mako.dev/run?run_key=6109803485069312&~a=1&scatter=1 p99=0.107967
	* https://mako.dev/run?run_key=6379497869803520&~a=1&scatter=1 p99=0.107479
* New
	* https://mako.dev/run?run_key=6003847312965632&~a=1&scatter=1 p99=0.105786
	* https://mako.dev/run?run_key=6562307012296704&~a=1&scatter=1 p99=0.106092
	* https://mako.dev/run?run_key=4681701760434176&~a=1 p99=0.105926


/assign @yanweiguo @julz 
/cc mattmoor