### PR TITLE
Change update-codegen and run it.

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -38,8 +38,12 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 $(dirname $0)/../vend
 
 KNATIVE_CODEGEN_PKG=${KNATIVE_CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 $(dirname $0)/../vendor/knative.dev/pkg 2>/dev/null || echo ../pkg)}
 
+# Make sure our codegen tool's dependencies are up-to-date
+${REPO_ROOT_DIR}/hack/update-deps.sh
+
 chmod +x ${CODEGEN_PKG}/generate-groups.sh
 chmod +x ${KNATIVE_CODEGEN_PKG}/hack/generate-knative.sh
+
 
 # generate the code with:
 # --output-base    because this script should also be able to run inside the vendor dir of
@@ -85,5 +89,6 @@ ${GOPATH}/bin/deepcopy-gen \
   -i knative.dev/serving/pkg/metrics \
   -i knative.dev/serving/pkg/network
 
-# Make sure our dependencies are up-to-date
+# Make sure our generated code's dependencies are updated.
 ${REPO_ROOT_DIR}/hack/update-deps.sh
+


### PR DESCRIPTION
This change adds the update-deps command to the beginning of update-codegen.
This is done specifically to prevent a situation in which our codegen dependencies
are updated, but are not used, which could theoretically cause inconsistencies
or even build failures.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
