### PR TITLE
Add Benchmark and slightly improve worst-case performance for power of 2 policy

### DIFF
--- a/pkg/activator/net/lb_policy.go
+++ b/pkg/activator/net/lb_policy.go
@@ -38,8 +38,8 @@ func randomLBPolicy(_ context.Context, targets []*podTracker) (func(), *podTrack
 	return noop, targets[rand.Intn(len(targets))]
 }
 
-// randomChoice2 implements the Power of 2 choices LB algorithm
-func randomChoice2(_ context.Context, targets []*podTracker) (func(), *podTracker) {
+// randomChoice2Policy implements the Power of 2 choices LB algorithm
+func randomChoice2Policy(_ context.Context, targets []*podTracker) (func(), *podTracker) {
 	// Avoid random if possible.
 	l := len(targets)
 	// One tracker = no choice.
@@ -50,12 +50,12 @@ func randomChoice2(_ context.Context, targets []*podTracker) (func(), *podTracke
 		}, targets[0]
 	}
 	r1, r2 := 0, 1
-	// Two trackers - we know the both contestants,
+	// Two trackers - we know both contestants,
 	// otherwise pick 2 random unequal integers.
 	if l > 2 {
-		r1, r2 = rand.Intn(l), rand.Intn(l)
-		for r1 == r2 {
-			r2 = rand.Intn(l)
+		r1, r2 = rand.Intn(l), rand.Intn(l-1)
+		if r2 >= r1 {
+			r2++
 		}
 	}
 

--- a/pkg/activator/net/lb_policy.go
+++ b/pkg/activator/net/lb_policy.go
@@ -54,6 +54,9 @@ func randomChoice2Policy(_ context.Context, targets []*podTracker) (func(), *pod
 	// otherwise pick 2 random unequal integers.
 	if l > 2 {
 		r1, r2 = rand.Intn(l), rand.Intn(l-1)
+		// shift second half of second rand.Intn down so we're picking
+		// from range of numbers other than r1.
+		// i.e. rand.Intn(l-1) range is now from range [0,r1),[r1+1,l).
 		if r2 >= r1 {
 			r2++
 		}

--- a/pkg/activator/net/lb_policy_test.go
+++ b/pkg/activator/net/lb_policy_test.go
@@ -18,6 +18,7 @@ package net
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -27,7 +28,7 @@ import (
 func TestRandomChoice2(t *testing.T) {
 	t.Run("1 tracker", func(t *testing.T) {
 		podTrackers := makeTrackers(1, 0)
-		cb, pt := randomChoice2(context.Background(), podTrackers)
+		cb, pt := randomChoice2Policy(context.Background(), podTrackers)
 		t.Cleanup(cb)
 		if got, want := pt.dest, podTrackers[0].dest; got != want {
 			t.Errorf("pt.dest = %s, want: %s", got, want)
@@ -36,7 +37,7 @@ func TestRandomChoice2(t *testing.T) {
 		if got, want := pt.getWeight(), wantW; got != want {
 			t.Errorf("pt.weight = %d, want: %d", got, want)
 		}
-		cb, pt = randomChoice2(context.Background(), podTrackers)
+		cb, pt = randomChoice2Policy(context.Background(), podTrackers)
 		if got, want := pt.dest, podTrackers[0].dest; got != want {
 			t.Errorf("pt.dest = %s, want: %s", got, want)
 		}
@@ -50,21 +51,21 @@ func TestRandomChoice2(t *testing.T) {
 	})
 	t.Run("2 trackers", func(t *testing.T) {
 		podTrackers := makeTrackers(2, 0)
-		cb, pt := randomChoice2(context.Background(), podTrackers)
+		cb, pt := randomChoice2Policy(context.Background(), podTrackers)
 		t.Cleanup(cb)
 		wantW := int32(1) // to avoid casting on every check.
 		if got, want := pt.getWeight(), wantW; got != want {
 			t.Errorf("pt.weight = %d, want: %d", got, want)
 		}
 		// Must return a different one.
-		cb, pt = randomChoice2(context.Background(), podTrackers)
+		cb, pt = randomChoice2Policy(context.Background(), podTrackers)
 		dest := pt.dest
 		if got, want := pt.getWeight(), wantW; got != want {
 			t.Errorf("pt.weight = %d, want: %d", got, want)
 		}
 		cb()
 		// Should return the same one.
-		_, pt = randomChoice2(context.Background(), podTrackers)
+		_, pt = randomChoice2Policy(context.Background(), podTrackers)
 		if got, want := pt.getWeight(), wantW; got != want {
 			t.Errorf("pt.weight = %d, want: %d", got, want)
 		}
@@ -74,20 +75,20 @@ func TestRandomChoice2(t *testing.T) {
 	})
 	t.Run("3 trackers", func(t *testing.T) {
 		podTrackers := makeTrackers(3, 0)
-		cb, pt := randomChoice2(context.Background(), podTrackers)
+		cb, pt := randomChoice2Policy(context.Background(), podTrackers)
 		t.Cleanup(cb)
 		wantW := int32(1) // to avoid casting on every check.
 		if got, want := pt.getWeight(), wantW; got != want {
 			t.Errorf("pt.weight = %d, want: %d", got, want)
 		}
 		// Must return a different one.
-		cb, pt = randomChoice2(context.Background(), podTrackers)
+		cb, pt = randomChoice2Policy(context.Background(), podTrackers)
 		if got, want := pt.getWeight(), wantW; got != want {
 			t.Errorf("pt.weight = %d, want: %d", got, want)
 		}
 		cb()
 		// Should return same or the other unsued one.
-		_, pt = randomChoice2(context.Background(), podTrackers)
+		_, pt = randomChoice2Policy(context.Background(), podTrackers)
 		if got, want := pt.getWeight(), wantW; got != want {
 			t.Errorf("pt.weight = %d, want: %d", got, want)
 		}
@@ -155,4 +156,40 @@ func TestFirstAvailable(t *testing.T) {
 			t.Errorf("Tracker = %s, want: %s", got, want)
 		}
 	})
+}
+
+func BenchmarkPolicy(b *testing.B) {
+	for _, test := range []struct {
+		name   string
+		policy lbPolicy
+	}{{
+		name:   "random",
+		policy: randomLBPolicy,
+	}, {
+		name:   "random-power-of-2-choice",
+		policy: randomChoice2Policy,
+	}, {
+		name:   "first-available",
+		policy: firstAvailableLBPolicy,
+	}} {
+		for _, n := range []int{1, 2, 3, 10, 100} {
+			b.Run(fmt.Sprintf("%s-%d-trackers-sequential", test.name, n), func(b *testing.B) {
+				targets := makeTrackers(n, 0)
+				for i := 0; i < b.N; i++ {
+					cb, _ := test.policy(nil, targets)
+					cb()
+				}
+			})
+
+			b.Run(fmt.Sprintf("%s-%d-trackers-parallel", test.name, n), func(b *testing.B) {
+				targets := makeTrackers(n, 0)
+				b.RunParallel(func(pb *testing.PB) {
+					for pb.Next() {
+						cb, _ := test.policy(nil, targets)
+						cb()
+					}
+				})
+			})
+		}
+	}
 }

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -165,7 +165,7 @@ func newRevisionThrottler(revID types.NamespacedName,
 	)
 	if containerConcurrency == 0 {
 		revBreaker = newInfiniteBreaker(logger)
-		lbp = randomChoice2
+		lbp = randomChoice2Policy
 	} else {
 		revBreaker = queue.NewBreaker(breakerParams)
 		lbp = firstAvailableLBPolicy


### PR DESCRIPTION
Since we have a few now and they're on the request path so performance is important, introduce some micro-benchmarks for the load balancer policy functions.

Also:

- Add 'Policy' suffix for consistency with other two -Policys.
- Avoid loop when picking distinct random numbers.

Initial benchmark numbers for posterity

~~~~
BenchmarkPolicy/random-1-trackers-sequential-16                 54945710                20.0 ns/op             0 B/op          0 allocs/op
BenchmarkPolicy/random-1-trackers-parallel-16                   15525848                75.3 ns/op             0 B/op          0 allocs/op
BenchmarkPolicy/random-2-trackers-sequential-16                 56466338                19.8 ns/op             0 B/op          0 allocs/op
BenchmarkPolicy/random-2-trackers-parallel-16                   15696794                77.3 ns/op             0 B/op          0 allocs/op
BenchmarkPolicy/random-3-trackers-sequential-16                 54863163                21.0 ns/op             0 B/op          0 allocs/op
BenchmarkPolicy/random-3-trackers-parallel-16                   13449475                80.2 ns/op             0 B/op          0 allocs/op
BenchmarkPolicy/random-10-trackers-sequential-16                56106998                20.7 ns/op             0 B/op          0 allocs/op
BenchmarkPolicy/random-10-trackers-parallel-16                  12795628                83.5 ns/op             0 B/op          0 allocs/op
BenchmarkPolicy/random-100-trackers-sequential-16               52572321                20.6 ns/op             0 B/op          0 allocs/op
BenchmarkPolicy/random-100-trackers-parallel-16                 12091090                82.9 ns/op             0 B/op          0 allocs/op
BenchmarkPolicy/random-power-of-2-choice-1-trackers-sequential-16               23132274                45.6 ns/op            32 B/op          1 allocs/op
BenchmarkPolicy/random-power-of-2-choice-1-trackers-parallel-16                 21438214                58.1 ns/op            32 B/op          1 allocs/op
BenchmarkPolicy/random-power-of-2-choice-2-trackers-sequential-16               26966349                38.5 ns/op            16 B/op          1 allocs/op
BenchmarkPolicy/random-power-of-2-choice-2-trackers-parallel-16                 26447814                47.8 ns/op            16 B/op          1 allocs/op
BenchmarkPolicy/random-power-of-2-choice-3-trackers-sequential-16               15077157                73.8 ns/op            16 B/op          1 allocs/op
BenchmarkPolicy/random-power-of-2-choice-3-trackers-parallel-16                  4660580               234 ns/op              16 B/op          1 allocs/op
BenchmarkPolicy/random-power-of-2-choice-10-trackers-sequential-16              13648172                80.5 ns/op            16 B/op          1 allocs/op
BenchmarkPolicy/random-power-of-2-choice-10-trackers-parallel-16                 4620370               244 ns/op              16 B/op          1 allocs/op
BenchmarkPolicy/random-power-of-2-choice-100-trackers-sequential-16             13741285                76.2 ns/op            16 B/op          1 allocs/op
BenchmarkPolicy/random-power-of-2-choice-100-trackers-parallel-16                4362265               255 ns/op              16 B/op          1 allocs/op
BenchmarkPolicy/first-available-1-trackers-sequential-16                        279202359                4.29 ns/op            0 B/op          0 allocs/op
BenchmarkPolicy/first-available-1-trackers-parallel-16                          507425887                2.36 ns/op            0 B/op          0 allocs/op
BenchmarkPolicy/first-available-2-trackers-sequential-16                        268484088                4.23 ns/op            0 B/op          0 allocs/op
BenchmarkPolicy/first-available-2-trackers-parallel-16                          594320574                2.34 ns/op            0 B/op          0 allocs/op
BenchmarkPolicy/first-available-3-trackers-sequential-16                        278901487                4.26 ns/op            0 B/op          0 allocs/op
BenchmarkPolicy/first-available-3-trackers-parallel-16                          344830414                3.76 ns/op            0 B/op          0 allocs/op
BenchmarkPolicy/first-available-10-trackers-sequential-16                       281508778                4.42 ns/op            0 B/op          0 allocs/op
BenchmarkPolicy/first-available-10-trackers-parallel-16                         613140248                1.96 ns/op            0 B/op          0 allocs/op
BenchmarkPolicy/first-available-100-trackers-sequential-16                      261077210                4.58 ns/op            0 B/op          0 allocs/op
BenchmarkPolicy/first-available-100-trackers-parallel-16                        640696489                2.08 ns/op            0 B/op          0 allocs/op
~~~~

/assign @markusthoemmes @vagababov 