### PR TITLE
Avoid file stat when scaledown feature disabled

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -169,6 +169,11 @@ func proxyHandler(breaker *queue.Breaker, stats *network.RequestStats, tracingEn
 }
 
 func preferPodForScaledown(downwardAPILabelsPath string) (bool, error) {
+	// If downwardAPILabelsPath is empty, feature is disabled.
+	if downwardAPILabelsPath == "" {
+		return false, nil
+	}
+
 	// Short circuit a rejection when no label path file is mounted
 	if _, err := os.Stat(downwardAPILabelsPath); os.IsNotExist(err) {
 		return false, nil

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -174,11 +174,6 @@ func preferPodForScaledown(downwardAPILabelsPath string) (bool, error) {
 		return false, nil
 	}
 
-	// Short circuit a rejection when no label path file is mounted
-	if _, err := os.Stat(downwardAPILabelsPath); os.IsNotExist(err) {
-		return false, nil
-	}
-
 	contentBytes, err := ioutil.ReadFile(downwardAPILabelsPath)
 	if err != nil {
 		return false, err

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -163,7 +163,7 @@ var (
 			Value: metrics.Domain(),
 		}, {
 			Name:  "DOWNWARD_API_LABELS_PATH",
-			Value: fmt.Sprintf("%s/%s", podInfoVolumePath, metadataLabelsPath),
+			Value: "",
 		}, {
 			Name:  "SERVING_READINESS_PROBE",
 			Value: fmt.Sprintf(`{"tcpSocket":{"port":%d,"host":"127.0.0.1"}}`, v1.DefaultUserPort),
@@ -774,13 +774,25 @@ func TestMakePodSpec(t *testing.T) {
 				),
 			}),
 	}, {
+		name: "with graceful scaledown disabled",
+		rev: revision("bar", "foo",
+			withContainers(containers),
+		),
+		ac: autoscalerconfig.Config{
+			EnableGracefulScaledown: false,
+		},
+		want: podSpec(
+			[]corev1.Container{
+				servingContainer(),
+				queueContainer(
+					withEnvVar("DOWNWARD_API_LABELS_PATH", ""),
+				),
+			},
+		),
+	}, {
 		name: "with graceful scaledown enabled",
 		rev: revision("bar", "foo",
-			withContainers([]corev1.Container{{
-				Name:           servingContainerName,
-				Image:          "busybox",
-				ReadinessProbe: withTCPReadinessProbe(v1.DefaultUserPort),
-			}}),
+			withContainers(containers),
 			WithContainerStatuses([]v1.ContainerStatuses{{
 				ImageDigest: "busybox@sha256:deadbeef",
 			}}),

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -226,9 +226,11 @@ func makeQueueContainer(rev *v1.Revision, loggingConfig *logging.Config, tracing
 	}
 	ports = append(ports, servingPort)
 
+	scaleDownLabelPath := ""
 	var volumeMounts []corev1.VolumeMount
 	if autoscalerConfig.EnableGracefulScaledown {
 		volumeMounts = append(volumeMounts, labelVolumeMount)
+		scaleDownLabelPath = fmt.Sprintf("%s/%s", podInfoVolumePath, metadataLabelsPath)
 	}
 
 	container := rev.Spec.GetContainer()
@@ -322,7 +324,7 @@ func makeQueueContainer(rev *v1.Revision, loggingConfig *logging.Config, tracing
 			Value: metrics.Domain(),
 		}, {
 			Name:  "DOWNWARD_API_LABELS_PATH",
-			Value: fmt.Sprintf("%s/%s", podInfoVolumePath, metadataLabelsPath),
+			Value: scaleDownLabelPath,
 		}, {
 			Name:  "SERVING_READINESS_PROBE",
 			Value: probeJSON,

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -727,7 +727,7 @@ var defaultEnv = map[string]string{
 	"SYSTEM_NAMESPACE":                      system.Namespace(),
 	"METRICS_DOMAIN":                        metrics.Domain(),
 	"QUEUE_SERVING_PORT":                    "8012",
-	"DOWNWARD_API_LABELS_PATH":              fmt.Sprintf("%s/%s", podInfoVolumePath, metadataLabelsPath),
+	"DOWNWARD_API_LABELS_PATH":              "",
 	"ENABLE_PROFILING":                      "false",
 	"SERVING_ENABLE_PROBE_REQUEST_LOG":      "false",
 }


### PR DESCRIPTION
The `preferPodForScaledown` function gets called on every health check (which can be pretty frequent, especially at startup) and currently does a `stat` on the labels path even though [when the feature is disabled this is never mounted](https://github.com/knative/serving/blob/2247211/pkg/reconciler/revision/resources/queue.go#L230-L231). Might as well avoid the syscall in that case.

/assign @vagababov @markusthoemmes 