### PR TITLE
Increase timeout to 40s for revision timeout tests

### DIFF
--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -94,13 +94,13 @@ func TestRevisionTimeout(t *testing.T) {
 	}{{
 		name:           "when scaling up from 0 and does not exceed timeout seconds",
 		shouldScaleTo0: true,
-		timeoutSeconds: 20,
+		timeoutSeconds: 40,
 		expectedStatus: http.StatusOK,
 	}, {
 		name:           "when scaling up from 0 and it writes first byte before timeout",
 		shouldScaleTo0: true,
-		timeoutSeconds: 20,
-		sleep:          25 * time.Second,
+		timeoutSeconds: 40,
+		sleep:          45 * time.Second,
 		expectedStatus: http.StatusOK,
 	}, {
 		name:           "when scaling up from 0 and it does exceed timeout seconds",

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -93,13 +93,13 @@ func TestRevisionTimeout(t *testing.T) {
 	}{{
 		name:           "when scaling up from 0 and does not exceed timeout seconds",
 		shouldScaleTo0: true,
-		timeoutSeconds: 20,
+		timeoutSeconds: 40,
 		expectedStatus: http.StatusOK,
 	}, {
 		name:           "when scaling up from 0 and it writes first byte before timeout",
 		shouldScaleTo0: true,
-		timeoutSeconds: 20,
-		sleep:          25 * time.Second,
+		timeoutSeconds: 40,
+		sleep:          45 * time.Second,
 		expectedStatus: http.StatusOK,
 	}, {
 		name:           "when scaling up from 0 and it does exceed timeout seconds",

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -93,13 +93,13 @@ func TestRevisionTimeout(t *testing.T) {
 	}{{
 		name:           "when scaling up from 0 and does not exceed timeout seconds",
 		shouldScaleTo0: true,
-		timeoutSeconds: 20,
+		timeoutSeconds: 40,
 		expectedStatus: http.StatusOK,
 	}, {
 		name:           "when scaling up from 0 and it writes first byte before timeout",
 		shouldScaleTo0: true,
-		timeoutSeconds: 20,
-		sleep:          25 * time.Second,
+		timeoutSeconds: 40,
+		sleep:          45 * time.Second,
 		expectedStatus: http.StatusOK,
 	}, {
 		name:           "when scaling up from 0 and it does exceed timeout seconds",


### PR DESCRIPTION
Fixes: https://github.com/knative/serving/issues/8252

Sometimes the pods seems to take much longer than expected to come up.

If this still causes flakiness we should consider updating the tests to
run multiple times and ensure that at least x% is working as intended.

Testing timeouts are tricky when pod startup times are inconsistent.

/cc @shashwathi 