### PR TITLE
Add round robin policy for the cc > 3

### DIFF
--- a/pkg/activator/net/lb_policy.go
+++ b/pkg/activator/net/lb_policy.go
@@ -86,29 +86,27 @@ func firstAvailableLBPolicy(ctx context.Context, targets []*podTracker) (func(),
 	return noop, nil
 }
 
-type roundRobinPolicyT struct {
-	mu  sync.Mutex
-	idx int
-}
-
 func newRoundRobinPolicy() lbPolicy {
-	rrp := roundRobinPolicyT{}
+	var (
+		mu  sync.Mutex
+		idx int
+	)
 	return func(ctx context.Context, targets []*podTracker) (func(), *podTracker) {
-		rrp.mu.Lock()
-		defer rrp.mu.Unlock()
+		mu.Lock()
+		defer mu.Unlock()
 		// The number of trackers might have shrunk, so reset to 0.
 		l := len(targets)
-		if rrp.idx >= l {
-			rrp.idx = 0
+		if idx >= l {
+			idx = 0
 		}
 
 		// Now for |targets| elements and check every next one in
 		// round robin fashion.
 		for i := 0; i < l; i++ {
-			p := (rrp.idx + i) % l
+			p := (idx + i) % l
 			if cb, ok := targets[p].Reserve(ctx); ok {
 				// We want to start with the next index.
-				rrp.idx = p + 1
+				idx = p + 1
 				return cb, targets[p]
 			}
 		}

--- a/pkg/activator/net/lb_policy.go
+++ b/pkg/activator/net/lb_policy.go
@@ -21,6 +21,7 @@ package net
 import (
 	"context"
 	"math/rand"
+	"sync"
 )
 
 // lbPolicy is a functor that selects a target pod from the list, or (noop, nil) if
@@ -83,4 +84,35 @@ func firstAvailableLBPolicy(ctx context.Context, targets []*podTracker) (func(),
 		}
 	}
 	return noop, nil
+}
+
+type roundRobinPolicyT struct {
+	mu  sync.Mutex
+	idx int
+}
+
+func newRoundRobinPolicy() lbPolicy {
+	rrp := roundRobinPolicyT{}
+	return func(ctx context.Context, targets []*podTracker) (func(), *podTracker) {
+		rrp.mu.Lock()
+		defer rrp.mu.Unlock()
+		// The number of trackers might have shrunk, so reset to 0.
+		l := len(targets)
+		if rrp.idx >= l {
+			rrp.idx = 0
+		}
+
+		// Now for |targets| elements and check every next one in
+		// round robin fashion.
+		for i := 0; i < l; i++ {
+			p := (rrp.idx + i) % l
+			if cb, ok := targets[p].Reserve(ctx); ok {
+				// We want to start with the next index.
+				rrp.idx = p + 1
+				return cb, targets[p]
+			}
+		}
+		// We exhausted all the options...
+		return noop, nil
+	}
 }

--- a/pkg/activator/net/lb_policy_test.go
+++ b/pkg/activator/net/lb_policy_test.go
@@ -159,35 +159,79 @@ func TestFirstAvailable(t *testing.T) {
 }
 
 func TestRoundRobin(t *testing.T) {
-	rrp := newRoundRobinPolicy()
-	podTrackers := makeTrackers(3, 1)
-	cb, pt := rrp(context.Background(), podTrackers)
-	t.Cleanup(cb)
-	if got, want := pt, podTrackers[0]; got != want {
-		t.Fatalf("Tracker = %v, want: %v", got, want)
-	}
-	cb, pt = rrp(context.Background(), podTrackers)
-	t.Cleanup(cb)
-	if got, want := pt, podTrackers[1]; got != want {
-		t.Fatalf("Tracker = %v, want: %v", got, want)
-	}
-	cb, pt = rrp(context.Background(), podTrackers)
-	if got, want := pt, podTrackers[2]; got != want {
-		t.Fatalf("Tracker = %v, want: %v", got, want)
-	}
-	_, pt = rrp(context.Background(), podTrackers)
-	t.Cleanup(cb)
-	if pt != nil {
-		t.Fatal("Wanted nil, got: ", pt)
-	}
+	t.Run("with cc=1", func(t *testing.T) {
+		rrp := newRoundRobinPolicy()
+		podTrackers := makeTrackers(3, 1)
+		cb, pt := rrp(context.Background(), podTrackers)
+		t.Cleanup(cb)
+		if got, want := pt, podTrackers[0]; got != want {
+			t.Fatalf("Tracker = %v, want: %v", got, want)
+		}
+		cb, pt = rrp(context.Background(), podTrackers)
+		t.Cleanup(cb)
+		if got, want := pt, podTrackers[1]; got != want {
+			t.Fatalf("Tracker = %v, want: %v", got, want)
+		}
+		// This will make it use shorter array, jump over and start from 0.
+		// But it's occupied already, so will fail to acquire.
+		_, pt = rrp(context.Background(), podTrackers[:1])
+		if pt != nil {
+			t.Fatal("Wanted nil, got: ", pt)
+		}
 
-	// Reset last one.
-	cb()
-	cb, pt = rrp(context.Background(), podTrackers)
-	if got, want := pt, podTrackers[2]; got != want {
-		t.Fatalf("Tracker = %v, want: %v", got, want)
-	}
-	t.Cleanup(cb)
+		cb, pt = rrp(context.Background(), podTrackers)
+		if got, want := pt, podTrackers[2]; got != want {
+			t.Fatalf("Tracker = %v, want: %v", got, want)
+		}
+		_, pt = rrp(context.Background(), podTrackers)
+		if pt != nil {
+			t.Fatal("Wanted nil, got: ", pt)
+		}
+
+		// Reset last one.
+		cb()
+		cb, pt = rrp(context.Background(), podTrackers)
+		if got, want := pt, podTrackers[2]; got != want {
+			t.Fatalf("Tracker = %v, want: %v", got, want)
+		}
+		t.Cleanup(cb)
+	})
+	t.Run("with cc=2", func(t *testing.T) {
+		rrp := newRoundRobinPolicy()
+		podTrackers := makeTrackers(3, 2)
+		cb, pt := rrp(context.Background(), podTrackers)
+		t.Cleanup(cb)
+		if got, want := pt, podTrackers[0]; got != want {
+			t.Fatalf("Tracker = %v, want: %v", got, want)
+		}
+		cb, pt = rrp(context.Background(), podTrackers)
+		t.Cleanup(cb)
+		if got, want := pt, podTrackers[1]; got != want {
+			t.Fatalf("Tracker = %v, want: %v", got, want)
+		}
+		// This will make it use shorter array, jump over and start from 0.
+		cb, pt = rrp(context.Background(), podTrackers[:1])
+		t.Cleanup(cb)
+		if got, want := pt, podTrackers[0]; got != want {
+			t.Fatalf("Tracker = %v, want: %v", got, want)
+		}
+		cb, pt = rrp(context.Background(), podTrackers)
+		t.Cleanup(cb)
+		if got, want := pt, podTrackers[1]; got != want {
+			t.Fatalf("Tracker = %v, want: %v", got, want)
+		}
+		cb, pt = rrp(context.Background(), podTrackers)
+		t.Cleanup(cb)
+		if got, want := pt, podTrackers[2]; got != want {
+			t.Fatalf("Tracker = %v, want: %v", got, want)
+		}
+		// Now index 0 has already 2 slots occupied, so is 1, so we should get 2 again.
+		cb, pt = rrp(context.Background(), podTrackers)
+		t.Cleanup(cb)
+		if got, want := pt, podTrackers[2]; got != want {
+			t.Fatalf("Tracker = %v, want: %v", got, want)
+		}
+	})
 }
 
 func BenchmarkPolicy(b *testing.B) {


### PR DESCRIPTION
Add a round robin policy for the CC > 3.
This is the simply one, i.e not the least loaded. I can iterate over that,
but the preliminary results look quite good as is.

Sample runs with the new policy:
https://mako.dev/run?run_key=5913306583793664&~act=1&scatter=1
With the old:
https://mako.dev/run?run_key=4860661639151616&~act=1&scatter=1
(there's some spurious spike)

/assign @julz @markusthoemmes 
For #7664