### PR TITLE
Support JSON encoded messages in stat server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,8 +43,8 @@ require (
 	k8s.io/metrics v0.17.6
 	knative.dev/caching v0.0.0-20200606210318-787aec80f71c
 	knative.dev/networking v0.0.0-20200607161819-2086ac6759c2
-	knative.dev/pkg v0.0.0-20200606224418-7ed1d4a552bc
-	knative.dev/test-infra v0.0.0-20200606045118-14ebc4a42974
+	knative.dev/pkg v0.0.0-20200609135932-0c198ddb9228
+	knative.dev/test-infra v0.0.0-20200608183332-3442736aebd0
 )
 
 // pin the older grpc - see: https://github.com/grpc/grpc-go/issues/3180

--- a/go.sum
+++ b/go.sum
@@ -1327,8 +1327,8 @@ knative.dev/pkg v0.0.0-20200603222317-b79e4a24ca50 h1:sbJMCCtOENPgfE5dUSwBUxZtJz
 knative.dev/pkg v0.0.0-20200603222317-b79e4a24ca50/go.mod h1:8IfPj/lpuKHHg82xZCl2wuFZ3BM96To72sN1W8T9wjQ=
 knative.dev/pkg v0.0.0-20200605170718-b7125260dc6f h1:2WVJ2b5Yws8klA2yCNkprY8EaQAR/mCVdV9XeI/4/Y0=
 knative.dev/pkg v0.0.0-20200605170718-b7125260dc6f/go.mod h1:ItJ3UvcHFt7qMoowI2uXfaGMWNGIMYAtzAbdsi+b0Cg=
-knative.dev/pkg v0.0.0-20200606224418-7ed1d4a552bc h1:oBoCkjjSI0Q2H4yWANAi3CgQ5XQAuOkGIgqvfU0Hk+E=
-knative.dev/pkg v0.0.0-20200606224418-7ed1d4a552bc/go.mod h1:ItJ3UvcHFt7qMoowI2uXfaGMWNGIMYAtzAbdsi+b0Cg=
+knative.dev/pkg v0.0.0-20200609135932-0c198ddb9228 h1:J4xAugpm7d1OdCPNdGC8lBM7JsOPRTooz1rhqpHAvg8=
+knative.dev/pkg v0.0.0-20200609135932-0c198ddb9228/go.mod h1:Ap/HE9hVqeI+/TtEmeClB61c6SFs6923AsU/juovj3w=
 knative.dev/sample-controller v0.0.0-20200510050845-bf7c19498b7e/go.mod h1:D2ZDLrR9Dq9LiiVN7TatzI7WMcEPgk1MHbbhgBKE6W8=
 knative.dev/test-infra v0.0.0-20200407185800-1b88cb3b45a5/go.mod h1:xcdUkMJrLlBswIZqL5zCuBFOC22WIPMQoVX1L35i0vQ=
 knative.dev/test-infra v0.0.0-20200505052144-5ea2f705bb55/go.mod h1:WqF1Azka+FxPZ20keR2zCNtiQA1MP9ZB4BH4HuI+SIU=
@@ -1346,6 +1346,8 @@ knative.dev/test-infra v0.0.0-20200605033518-4b5d9e1bbdbe h1:8jvsC2cS3Xc/KOPnCOJ
 knative.dev/test-infra v0.0.0-20200605033518-4b5d9e1bbdbe/go.mod h1:wsGme3loBZjSjhuaTUhejJ34EOwKZ5KXkweKL0zSKhM=
 knative.dev/test-infra v0.0.0-20200606045118-14ebc4a42974 h1:CrZmlbB+j3ZF/aTrfyypY5ulX2w7XrkfeXKQsbkqzTg=
 knative.dev/test-infra v0.0.0-20200606045118-14ebc4a42974/go.mod h1://I6IZIF0QDgs5wotU243ZZ5cTpm6/GthayjUenBBc0=
+knative.dev/test-infra v0.0.0-20200608183332-3442736aebd0 h1:4vtwMZF9yw+onnENJC1IETToafDFuF/pEdPx3IyNz1w=
+knative.dev/test-infra v0.0.0-20200608183332-3442736aebd0/go.mod h1://I6IZIF0QDgs5wotU243ZZ5cTpm6/GthayjUenBBc0=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"encoding/json"
 	"net"
 	"net/http"
 	"sync"
@@ -154,17 +155,26 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 			close(handlerCh)
 			return
 		}
-		if messageType != websocket.BinaryMessage {
-			s.logger.Error("Dropping non-binary message.")
+
+		// we accept either GOB-encoded or JSON-encoded messages depending on the
+		// message type to ensure safe upgrades.
+		var dec decoder
+		switch messageType {
+		case websocket.BinaryMessage:
+			dec = gob.NewDecoder(bytes.NewBuffer(msg))
+		case websocket.TextMessage:
+			dec = json.NewDecoder(bytes.NewBuffer(msg))
+		default:
+			s.logger.Error("Dropping unknown message type.")
 			continue
 		}
-		dec := gob.NewDecoder(bytes.NewBuffer(msg))
+
 		var sm metrics.StatMessage
-		err = dec.Decode(&sm)
-		if err != nil {
+		if err = dec.Decode(&sm); err != nil {
 			s.logger.Error(err)
 			continue
 		}
+
 		sm.Stat.Time = time.Now()
 
 		s.logger.Debugf("Received stat message: %+v", sm)
@@ -202,4 +212,9 @@ func (s *Server) Shutdown(timeout time.Duration) {
 	case <-ctx.Done():
 		s.logger.Warn("Shutdown timed out")
 	}
+}
+
+// decoder is the interface implemented by json.Decoder and gob.Decoder
+type decoder interface {
+	Decode(interface{}) error
 }

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -175,12 +175,7 @@ func TestServerDoesNotLeakGoroutines(t *testing.T) {
 }
 
 func BenchmarkStatServer(b *testing.B) {
-	encodingName := map[bool]string{
-		false: "gob",
-		true:  "json",
-	}
-
-	for _, jsonEncoding := range []bool{false, true} {
+	for encoding, jsonEncoding := range map[string]bool{"json": true, "gob": false} {
 		for _, numMsgs := range []int{1, 5, 100} {
 			statsCh := make(chan metrics.StatMessage, numMsgs)
 			server := newTestServer(statsCh)
@@ -196,7 +191,7 @@ func BenchmarkStatServer(b *testing.B) {
 				msgs[i] = newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision"}, "activator1", 2.1, 51)
 			}
 
-			b.Run(fmt.Sprintf("%d-msgs-%s-encoding-sequential", numMsgs, encodingName[jsonEncoding]), func(b *testing.B) {
+			b.Run(fmt.Sprintf("%d-msgs-%s-encoding-sequential", numMsgs, encoding), func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					for _, msg := range msgs {
 						if err := send(statSink, msg, jsonEncoding); err != nil {

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -19,6 +19,7 @@ package statserver
 import (
 	"bytes"
 	"encoding/gob"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -85,8 +86,13 @@ func TestStatsReceived(t *testing.T) {
 
 	statSink := dialOK(server.listenAddr(), t)
 
-	assertReceivedOK(newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision"}, "activator1", 2.1, 51), statSink, statsCh, t)
-	assertReceivedOK(newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision2"}, "activator2", 2.2, 30), statSink, statsCh, t)
+	// gob encoding
+	assertReceivedOK(t, newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision"}, "activator1", 2.1, 51), statSink, statsCh, false)
+	assertReceivedOK(t, newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision2"}, "activator2", 2.2, 30), statSink, statsCh, false)
+
+	// json encoding
+	assertReceivedOK(t, newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision"}, "activator1", 2.1, 51), statSink, statsCh, true)
+	assertReceivedOK(t, newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision2"}, "activator2", 2.2, 30), statSink, statsCh, true)
 
 	closeSink(statSink, t)
 }
@@ -100,14 +106,16 @@ func TestServerShutdown(t *testing.T) {
 	listenAddr := server.listenAddr()
 	statSink := dialOK(listenAddr, t)
 
-	assertReceivedOK(newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision"}, "activator1", 2.1, 51), statSink, statsCh, t)
+	assertReceivedOK(t, newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision"}, "activator1", 2.1, 51), statSink, statsCh, false)
 
 	server.Shutdown(time.Second)
 	// We own the channel.
 	close(statsCh)
 
 	// Send a statistic to the server
-	send(statSink, newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision2"}, "activator2", 2.2, 30), t)
+	if err := send(statSink, newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision2"}, "activator2", 2.2, 30), false); err != nil {
+		t.Fatal("Expected send to succeed, got:", err)
+	}
 
 	// Check the statistic was not received
 	_, ok := <-statsCh
@@ -129,7 +137,7 @@ func TestServerShutdown(t *testing.T) {
 	}
 
 	// Check that new connections are refused with some error
-	if _, err := dial(listenAddr, t); err == nil {
+	if _, err := dial(listenAddr); err == nil {
 		t.Fatal("Connection not refused")
 	}
 
@@ -147,7 +155,7 @@ func TestServerDoesNotLeakGoroutines(t *testing.T) {
 	listenAddr := server.listenAddr()
 	statSink := dialOK(listenAddr, t)
 
-	assertReceivedOK(newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision"}, "activator1", 2.1, 51), statSink, statsCh, t)
+	assertReceivedOK(t, newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision"}, "activator1", 2.1, 51), statSink, statsCh, false)
 
 	closeSink(statSink, t)
 
@@ -166,6 +174,49 @@ func TestServerDoesNotLeakGoroutines(t *testing.T) {
 	server.Shutdown(time.Second)
 }
 
+func BenchmarkStatServer(b *testing.B) {
+	encodingName := map[bool]string{
+		false: "gob",
+		true:  "json",
+	}
+
+	for _, jsonEncoding := range []bool{false, true} {
+		for _, numMsgs := range []int{1, 5, 100} {
+			statsCh := make(chan metrics.StatMessage, numMsgs)
+			server := newTestServer(statsCh)
+			go server.listenAndServe()
+
+			statSink, err := dial(server.listenAddr())
+			if err != nil {
+				b.Fatal("Dial failed:", err)
+			}
+
+			msgs := make([]metrics.StatMessage, numMsgs)
+			for i := 0; i < numMsgs; i++ {
+				msgs[i] = newStatMessage(types.NamespacedName{Namespace: "test-namespace", Name: "test-revision"}, "activator1", 2.1, 51)
+			}
+
+			b.Run(fmt.Sprintf("%d-msgs-%s-encoding-sequential", numMsgs, encodingName[jsonEncoding]), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					for _, msg := range msgs {
+						if err := send(statSink, msg, jsonEncoding); err != nil {
+							b.Fatal("Expected send to succeed, but got:", err)
+						}
+					}
+
+					for range msgs {
+						if _, ok := <-statsCh; !ok {
+							b.Fatal("Statistic not received")
+						}
+					}
+				}
+			})
+
+			server.Shutdown(time.Second)
+		}
+	}
+}
+
 func newStatMessage(revKey types.NamespacedName, podName string, averageConcurrentRequests float64, requestCount float64) metrics.StatMessage {
 	return metrics.StatMessage{
 		Key: revKey,
@@ -177,14 +228,17 @@ func newStatMessage(revKey types.NamespacedName, podName string, averageConcurre
 	}
 }
 
-func assertReceivedOK(sm metrics.StatMessage, statSink *websocket.Conn, statsCh <-chan metrics.StatMessage, t *testing.T) bool {
-	send(statSink, sm, t)
+func assertReceivedOK(t *testing.T, sm metrics.StatMessage, statSink *websocket.Conn, statsCh <-chan metrics.StatMessage, jsonEncoding bool) bool {
+	if err := send(statSink, sm, jsonEncoding); err != nil {
+		t.Fatal("Expected send to succeed, got:", err)
+	}
+
 	recv, ok := <-statsCh
 	if !ok {
-		t.Fatalf("statistic not received")
+		t.Fatal("Statistic not received")
 	}
 	if recv.Stat.Time == (time.Time{}) {
-		t.Fatalf("Stat time is nil")
+		t.Fatal("Stat time is nil")
 	}
 	ignoreTimeField := cmpopts.IgnoreFields(metrics.StatMessage{}, "Stat.Time")
 	if !cmp.Equal(sm, recv, ignoreTimeField) {
@@ -194,17 +248,17 @@ func assertReceivedOK(sm metrics.StatMessage, statSink *websocket.Conn, statsCh 
 }
 
 func dialOK(serverURL string, t *testing.T) *websocket.Conn {
-	statSink, err := dial(serverURL, t)
+	statSink, err := dial(serverURL)
 	if err != nil {
 		t.Fatal("Dial failed:", err)
 	}
 	return statSink
 }
 
-func dial(serverURL string, t *testing.T) (*websocket.Conn, error) {
+func dial(serverURL string) (*websocket.Conn, error) {
 	u, err := url.Parse(serverURL)
 	if err != nil {
-		t.Fatal(err)
+		return nil, err
 	}
 	u.Scheme = "ws"
 
@@ -215,16 +269,26 @@ func dial(serverURL string, t *testing.T) (*websocket.Conn, error) {
 	return statSink, err
 }
 
-func send(statSink *websocket.Conn, sm metrics.StatMessage, t *testing.T) {
+func send(statSink *websocket.Conn, sm metrics.StatMessage, jsonEncoding bool) error {
 	var b bytes.Buffer
-	enc := gob.NewEncoder(&b)
+
+	var enc encoder = gob.NewEncoder(&b)
+	messageType := websocket.BinaryMessage
+
+	if jsonEncoding {
+		enc = json.NewEncoder(&b)
+		messageType = websocket.TextMessage
+	}
 
 	if err := enc.Encode(sm); err != nil {
-		t.Fatal("Failed to encode data from stats channel:", err)
+		return fmt.Errorf("failed to encode data from stats channel: %w", err)
 	}
-	if err := statSink.WriteMessage(websocket.BinaryMessage, b.Bytes()); err != nil {
-		t.Fatal("Failed to write to stat sink:", err)
+
+	if err := statSink.WriteMessage(messageType, b.Bytes()); err != nil {
+		return fmt.Errorf("failed to write to stat sink: %w", err)
 	}
+
+	return nil
 }
 
 func closeSink(statSink *websocket.Conn, t *testing.T) {
@@ -268,4 +332,9 @@ type testListener struct {
 func (t *testListener) Accept() (net.Conn, error) {
 	t.listenAddr <- "http://" + t.Listener.Addr().String()
 	return t.Listener.Accept()
+}
+
+// encoder is the interface implemented by gob.Encoder and json.Encoder
+type encoder interface {
+	Encode(interface{}) error
 }

--- a/vendor/knative.dev/pkg/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
+++ b/vendor/knative.dev/pkg/client/injection/kube/reconciler/core/v1/namespace/reconciler.go
@@ -294,10 +294,11 @@ func (r *reconcilerImpl) updateFinalizersFiltered(ctx context.Context, resource 
 
 	patcher := r.Client.CoreV1().Namespaces()
 
-	resource, err = patcher.Patch(resource.Name, types.MergePatchType, patch)
+	resourceName := resource.Name
+	resource, err = patcher.Patch(resourceName, types.MergePatchType, patch)
 	if err != nil {
 		r.Recorder.Eventf(resource, v1.EventTypeWarning, "FinalizerUpdateFailed",
-			"Failed to update finalizers for %q: %v", resource.Name, err)
+			"Failed to update finalizers for %q: %v", resourceName, err)
 	} else {
 		r.Recorder.Eventf(resource, v1.EventTypeNormal, "FinalizerUpdate",
 			"Updated %q finalizers", resource.GetName())

--- a/vendor/knative.dev/pkg/websocket/connection.go
+++ b/vendor/knative.dev/pkg/websocket/connection.go
@@ -312,6 +312,11 @@ func (c *ManagedConnection) Send(msg interface{}) error {
 	return c.write(websocket.BinaryMessage, b.Bytes())
 }
 
+// SendRaw sends a message over the websocket connection without performing any encoding.
+func (c *ManagedConnection) SendRaw(messageType int, msg []byte) error {
+	return c.write(messageType, msg)
+}
+
 // Shutdown closes the websocket connection.
 func (c *ManagedConnection) Shutdown() error {
 	c.closeOnce.Do(func() {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1227,7 +1227,7 @@ knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/server
 knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice
 knative.dev/networking/pkg/client/istio/listers/networking/v1alpha3
 knative.dev/networking/pkg/client/listers/networking/v1alpha1
-# knative.dev/pkg v0.0.0-20200606224418-7ed1d4a552bc
+# knative.dev/pkg v0.0.0-20200609135932-0c198ddb9228
 ## explicit
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate
@@ -1344,7 +1344,7 @@ knative.dev/pkg/webhook/resourcesemantics/conversion
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
 knative.dev/pkg/websocket
-# knative.dev/test-infra v0.0.0-20200606045118-14ebc4a42974
+# knative.dev/test-infra v0.0.0-20200608183332-3442736aebd0
 ## explicit
 knative.dev/test-infra/scripts
 # sigs.k8s.io/structured-merge-diff/v2 v2.0.1


### PR DESCRIPTION
Because of how websockets work (message rather than byte-stream based), GOB needs to send type information with every message. This means gob actually ends up sending more data (~350 bytes rather than ~250 for json). Benchmark (see below) demonstrates JSON is (quite a lot) better in this case. 

(Even better would likely be to avoid web sockets for this use case and use something like grpc - or figure out how to use the same gob encoder/decoder for multiple messages - but that's A Lot More Work and this is a pretty small change that makes things better in the meantime).

~~~~
BenchmarkStatServer/1-msgs-gob-encoding-sequential-16              12194             96940 ns/op           14829 B/op        316 allocs/op
BenchmarkStatServer/5-msgs-gob-encoding-sequential-16               6087            206672 ns/op           74116 B/op       1580 allocs/op
BenchmarkStatServer/100-msgs-gob-encoding-sequential-16              364           3286541 ns/op         1482205 B/op      31606 allocs/op
BenchmarkStatServer/1-msgs-json-encoding-sequential-16             31862             37636 ns/op            3973 B/op         26 allocs/op
BenchmarkStatServer/5-msgs-json-encoding-sequential-16             16504             72378 ns/op           19863 B/op        130 allocs/op
BenchmarkStatServer/100-msgs-json-encoding-sequential-16            1425            783149 ns/op          397062 B/op       2604 allocs/op
~~~~

This PR adds a benchmark and teaches the server to speak both GOB and JSON temporarily (to avoid problems during upgrade). Will PR the client side to use JSON in a follow-on PR after adding the ability to do that to the WebSocket client in `pkg`.

/assign @markusthoemmes @vagababov 