### PR TITLE
Relax validation for visibility label.

### DIFF
--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -111,14 +111,6 @@ func ValidateContainerConcurrency(ctx context.Context, containerConcurrency *int
 	return nil
 }
 
-// ValidateClusterVisibilityLabel function validates the visibility label on a Route
-func ValidateClusterVisibilityLabel(label string) (errs *apis.FieldError) {
-	if label != VisibilityClusterLocal {
-		errs = apis.ErrInvalidValue(label, VisibilityLabelKey)
-	}
-	return
-}
-
 // SetUserInfo sets creator and updater annotations
 func SetUserInfo(ctx context.Context, oldSpec, newSpec, resource interface{}) {
 	if ui := apis.GetUserInfo(ctx); ui != nil {

--- a/pkg/apis/serving/metadata_validation_test.go
+++ b/pkg/apis/serving/metadata_validation_test.go
@@ -354,35 +354,6 @@ func TestValidateContainerConcurrency(t *testing.T) {
 	}
 }
 
-func TestValidateClusterVisibilityLabel(t *testing.T) {
-	tests := []struct {
-		name      string
-		label     string
-		expectErr *apis.FieldError
-	}{{
-		name:      "empty label",
-		label:     "",
-		expectErr: apis.ErrInvalidValue("", VisibilityLabelKey),
-	}, {
-		name:  "valid label",
-		label: VisibilityClusterLocal,
-	}, {
-		name:      "invalid label",
-		label:     "not-cluster-local",
-		expectErr: apis.ErrInvalidValue("not-cluster-local", VisibilityLabelKey),
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			err := ValidateClusterVisibilityLabel(test.label)
-			if got, want := err.Error(), test.expectErr.Error(); got != want {
-				t.Errorf("\nGot:  %q\nwant: %q", got, want)
-			}
-		})
-	}
-
-}
-
 type withPod struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/serving/v1/configuration_validation.go
+++ b/pkg/apis/serving/v1/configuration_validation.go
@@ -71,6 +71,8 @@ func (csf *ConfigurationStatusFields) Validate(ctx context.Context) *apis.FieldE
 }
 
 // validateLabels function validates configuration labels
+// Any label with prefix serving.knative.dev is not allowed except
+// serving.knative.dev/visibility , serving.knative.dev/service, serving.knative.dev/route label.
 func (c *Configuration) validateLabels() (errs *apis.FieldError) {
 	for key, val := range c.GetLabels() {
 		switch {

--- a/pkg/apis/serving/v1/configuration_validation.go
+++ b/pkg/apis/serving/v1/configuration_validation.go
@@ -75,7 +75,6 @@ func (c *Configuration) validateLabels() (errs *apis.FieldError) {
 	for key, val := range c.GetLabels() {
 		switch {
 		case key == serving.VisibilityLabelKey:
-			errs = errs.Also(validateClusterVisibilityLabel(val))
 		case key == serving.RouteLabelKey:
 		case key == serving.ServiceLabelKey:
 			errs = errs.Also(verifyLabelOwnerRef(val, serving.ServiceLabelKey, "Service", c.GetOwnerReferences()))

--- a/pkg/apis/serving/v1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1/configuration_validation_test.go
@@ -268,29 +268,17 @@ func TestConfigurationLabelValidation(t *testing.T) {
 		c    *Configuration
 		want *apis.FieldError
 	}{{
-		name: "valid visibility name",
+		name: "visibility label specified",
 		c: &Configuration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "byo-name",
 				Labels: map[string]string{
-					serving.VisibilityLabelKey: "cluster-local",
+					serving.VisibilityLabelKey: "my-realm",
 				},
 			},
 			Spec: validConfigSpec,
 		},
 		want: nil,
-	}, {
-		name: "invalid visibility name",
-		c: &Configuration{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "byo-name",
-				Labels: map[string]string{
-					serving.VisibilityLabelKey: "bad-value",
-				},
-			},
-			Spec: validConfigSpec,
-		},
-		want: apis.ErrInvalidValue("bad-value", "metadata.labels.serving.knative.dev/visibility"),
 	}, {
 		name: "valid route name",
 		c: &Configuration{

--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -206,19 +206,11 @@ func (rsf *RouteStatusFields) Validate(ctx context.Context) *apis.FieldError {
 	return nil
 }
 
-func validateClusterVisibilityLabel(label string) (errs *apis.FieldError) {
-	if label != serving.VisibilityClusterLocal {
-		errs = apis.ErrInvalidValue(label, serving.VisibilityLabelKey)
-	}
-	return
-}
-
 // validateLabels function validates route labels.
 func (r *Route) validateLabels() (errs *apis.FieldError) {
 	for key, val := range r.GetLabels() {
 		switch {
 		case key == serving.VisibilityLabelKey:
-			errs = errs.Also(validateClusterVisibilityLabel(val))
 		case key == serving.ServiceLabelKey:
 			errs = errs.Also(verifyLabelOwnerRef(val, serving.ServiceLabelKey, "Service", r.GetOwnerReferences()))
 		case strings.HasPrefix(key, serving.GroupNamePrefix):

--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -207,6 +207,8 @@ func (rsf *RouteStatusFields) Validate(ctx context.Context) *apis.FieldError {
 }
 
 // validateLabels function validates route labels.
+// Any label with prefix serving.knative.dev is not allowed except
+// serving.knative.dev/visibility , serving.knative.dev/service label.
 func (r *Route) validateLabels() (errs *apis.FieldError) {
 	for key, val := range r.GetLabels() {
 		switch {

--- a/pkg/apis/serving/v1/route_validation_test.go
+++ b/pkg/apis/serving/v1/route_validation_test.go
@@ -534,29 +534,17 @@ func TestRouteLabelValidation(t *testing.T) {
 		r    *Route
 		want *apis.FieldError
 	}{{
-		name: "valid visibility name",
+		name: "visibility label specified",
 		r: &Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "byo-name",
 				Labels: map[string]string{
-					serving.VisibilityLabelKey: "cluster-local",
+					serving.VisibilityLabelKey: "my-realm",
 				},
 			},
 			Spec: validRouteSpec,
 		},
 		want: nil,
-	}, {
-		name: "invalid visibility name",
-		r: &Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "byo-name",
-				Labels: map[string]string{
-					serving.VisibilityLabelKey: "bad-value",
-				},
-			},
-			Spec: validRouteSpec,
-		},
-		want: apis.ErrInvalidValue("bad-value", "metadata.labels.serving.knative.dev/visibility"),
 	}, {
 		name: "valid knative service name",
 		r: &Route{

--- a/pkg/apis/serving/v1/service_validation.go
+++ b/pkg/apis/serving/v1/service_validation.go
@@ -66,10 +66,9 @@ func (ss *ServiceStatus) Validate(ctx context.Context) *apis.FieldError {
 
 // validateLabels function validates service labels
 func (s *Service) validateLabels() (errs *apis.FieldError) {
-	for key, val := range s.GetLabels() {
+	for key := range s.GetLabels() {
 		switch {
 		case key == serving.VisibilityLabelKey:
-			errs = errs.Also(validateClusterVisibilityLabel(val))
 		case strings.HasPrefix(key, serving.GroupNamePrefix):
 			errs = errs.Also(apis.ErrInvalidKeyName(key, apis.CurrentField))
 		}

--- a/pkg/apis/serving/v1/service_validation.go
+++ b/pkg/apis/serving/v1/service_validation.go
@@ -65,6 +65,8 @@ func (ss *ServiceStatus) Validate(ctx context.Context) *apis.FieldError {
 }
 
 // validateLabels function validates service labels
+// Any label with prefix serving.knative.dev is not allowed except
+// serving.knative.dev/visibility label.
 func (s *Service) validateLabels() (errs *apis.FieldError) {
 	for key := range s.GetLabels() {
 		switch {

--- a/pkg/apis/serving/v1/service_validation_test.go
+++ b/pkg/apis/serving/v1/service_validation_test.go
@@ -70,12 +70,12 @@ func TestServiceValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		name: "valid visibility label",
+		name: "visibility label specified",
 		r: &Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "valid",
 				Labels: map[string]string{
-					serving.VisibilityLabelKey: "cluster-local",
+					serving.VisibilityLabelKey: "my-realm",
 				},
 			},
 			Spec: ServiceSpec{
@@ -114,21 +114,6 @@ func TestServiceValidation(t *testing.T) {
 			},
 		},
 		want: nil,
-	}, {
-		name: "invalid visibility label value",
-		r: &Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "valid",
-				Labels: map[string]string{
-					serving.VisibilityLabelKey: "bad-label",
-				},
-			},
-			Spec: ServiceSpec{
-				ConfigurationSpec: goodConfigSpec,
-				RouteSpec:         goodRouteSpec,
-			},
-		},
-		want: apis.ErrInvalidValue("bad-label", "metadata.labels.serving.knative.dev/visibility"),
 	}, {
 		name: "valid release",
 		r: &Service{

--- a/pkg/apis/serving/v1beta1/configuration_validation.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation.go
@@ -60,7 +60,6 @@ func (c *Configuration) validateLabels() (errs *apis.FieldError) {
 	for key, val := range c.GetLabels() {
 		switch {
 		case key == serving.VisibilityLabelKey:
-			errs = errs.Also(serving.ValidateClusterVisibilityLabel(val))
 		case key == serving.RouteLabelKey:
 		case key == serving.ServiceLabelKey:
 			errs = errs.Also(verifyLabelOwnerRef(val, serving.ServiceLabelKey, "Service", c.GetOwnerReferences()))

--- a/pkg/apis/serving/v1beta1/configuration_validation.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation.go
@@ -56,6 +56,8 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 }
 
 // validateLabels function validates configuration labels
+// Any label with prefix serving.knative.dev is not allowed except
+// serving.knative.dev/visibility , serving.knative.dev/service, serving.knative.dev/route label.
 func (c *Configuration) validateLabels() (errs *apis.FieldError) {
 	for key, val := range c.GetLabels() {
 		switch {

--- a/pkg/apis/serving/v1beta1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1beta1/configuration_validation_test.go
@@ -246,29 +246,17 @@ func TestConfigurationLabelValidation(t *testing.T) {
 		c    *Configuration
 		want *apis.FieldError
 	}{{
-		name: "valid visibility name",
+		name: "visibility label specified",
 		c: &Configuration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "byo-name",
 				Labels: map[string]string{
-					serving.VisibilityLabelKey: "cluster-local",
+					serving.VisibilityLabelKey: "my-realm",
 				},
 			},
 			Spec: validConfigSpec,
 		},
 		want: nil,
-	}, {
-		name: "invalid visibility name",
-		c: &Configuration{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "byo-name",
-				Labels: map[string]string{
-					serving.VisibilityLabelKey: "bad-value",
-				},
-			},
-			Spec: validConfigSpec,
-		},
-		want: apis.ErrInvalidValue("bad-value", "metadata.labels.serving.knative.dev/visibility"),
 	}, {
 		name: "valid route name",
 		c: &Configuration{

--- a/pkg/apis/serving/v1beta1/route_validation.go
+++ b/pkg/apis/serving/v1beta1/route_validation.go
@@ -48,7 +48,6 @@ func (r *Route) validateLabels() (errs *apis.FieldError) {
 	for key, val := range r.GetLabels() {
 		switch {
 		case key == serving.VisibilityLabelKey:
-			errs = errs.Also(serving.ValidateClusterVisibilityLabel(val))
 		case key == serving.ServiceLabelKey:
 			errs = errs.Also(verifyLabelOwnerRef(val, serving.ServiceLabelKey, "Service", r.GetOwnerReferences()))
 		case strings.HasPrefix(key, serving.GroupNamePrefix):

--- a/pkg/apis/serving/v1beta1/route_validation.go
+++ b/pkg/apis/serving/v1beta1/route_validation.go
@@ -44,6 +44,8 @@ func (r *Route) Validate(ctx context.Context) *apis.FieldError {
 }
 
 // validateLabels function validates route labels.
+// Any label with prefix serving.knative.dev is not allowed except
+// serving.knative.dev/visibility , serving.knative.dev/service label.
 func (r *Route) validateLabels() (errs *apis.FieldError) {
 	for key, val := range r.GetLabels() {
 		switch {

--- a/pkg/apis/serving/v1beta1/route_validation_test.go
+++ b/pkg/apis/serving/v1beta1/route_validation_test.go
@@ -502,29 +502,17 @@ func TestRouteLabelValidation(t *testing.T) {
 		r    *Route
 		want *apis.FieldError
 	}{{
-		name: "valid visibility name",
+		name: "visibility label specified",
 		r: &Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "byo-name",
 				Labels: map[string]string{
-					serving.VisibilityLabelKey: "cluster-local",
+					serving.VisibilityLabelKey: "my-realm",
 				},
 			},
 			Spec: validRouteSpec,
 		},
 		want: nil,
-	}, {
-		name: "invalid visibility name",
-		r: &Route{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "byo-name",
-				Labels: map[string]string{
-					serving.VisibilityLabelKey: "bad-value",
-				},
-			},
-			Spec: validRouteSpec,
-		},
-		want: apis.ErrInvalidValue("bad-value", "metadata.labels.serving.knative.dev/visibility"),
 	}, {
 		name: "valid knative service name",
 		r: &Route{

--- a/pkg/apis/serving/v1beta1/service_validation.go
+++ b/pkg/apis/serving/v1beta1/service_validation.go
@@ -50,7 +50,9 @@ func (s *Service) Validate(ctx context.Context) (errs *apis.FieldError) {
 	return errs
 }
 
-// validateLabels function validates service labels
+// validateLabels function validates service labels.
+// Any label with prefix serving.knative.dev is not allowed except
+// serving.knative.dev/visibility label.
 func (s *Service) validateLabels() (errs *apis.FieldError) {
 	for key := range s.GetLabels() {
 		switch {

--- a/pkg/apis/serving/v1beta1/service_validation.go
+++ b/pkg/apis/serving/v1beta1/service_validation.go
@@ -52,10 +52,9 @@ func (s *Service) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 // validateLabels function validates service labels
 func (s *Service) validateLabels() (errs *apis.FieldError) {
-	for key, val := range s.GetLabels() {
+	for key := range s.GetLabels() {
 		switch {
 		case key == serving.VisibilityLabelKey:
-			errs = errs.Also(serving.ValidateClusterVisibilityLabel(val))
 		case strings.HasPrefix(key, serving.GroupNamePrefix):
 			errs = errs.Also(apis.ErrInvalidKeyName(key, apis.CurrentField))
 		}

--- a/pkg/apis/serving/v1beta1/service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/service_validation_test.go
@@ -72,12 +72,12 @@ func TestServiceValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		name: "valid visibility label",
+		name: "visibility label specified",
 		r: &Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "valid",
 				Labels: map[string]string{
-					serving.VisibilityLabelKey: "cluster-local",
+					serving.VisibilityLabelKey: "my-realm",
 				},
 			},
 			Spec: v1.ServiceSpec{
@@ -116,21 +116,6 @@ func TestServiceValidation(t *testing.T) {
 			},
 		},
 		want: nil,
-	}, {
-		name: "invalid visibility label value",
-		r: &Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "valid",
-				Labels: map[string]string{
-					serving.VisibilityLabelKey: "bad-label",
-				},
-			},
-			Spec: v1.ServiceSpec{
-				ConfigurationSpec: goodConfigSpec,
-				RouteSpec:         goodRouteSpec,
-			},
-		},
-		want: apis.ErrInvalidValue("bad-label", "metadata.labels.serving.knative.dev/visibility"),
 	}, {
 		name: "valid release",
 		r: &Service{


### PR DESCRIPTION
Issue: https://github.com/knative/serving/issues/8185

This is in preparation for work on changing ingress visibility. We want to start allowing any strings to be passed in as the names of the realms can be any string. Not restricting it to `cluster-local`

/cc @shashwathi 