### PR TITLE
Avoid recompiling hash-gen to speed up codegen script

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,8 +43,8 @@ require (
 	k8s.io/metrics v0.17.6
 	knative.dev/caching v0.0.0-20200606210318-787aec80f71c
 	knative.dev/networking v0.0.0-20200611155523-bd13675bcf70
-	knative.dev/pkg v0.0.0-20200611204322-2ddcfef739a2
-	knative.dev/test-infra v0.0.0-20200612005123-35b61c499a41
+	knative.dev/pkg v0.0.0-20200614232523-aec2008e6656
+	knative.dev/test-infra v0.0.0-20200612191923-a4dd434e085b
 )
 
 // pin the older grpc - see: https://github.com/grpc/grpc-go/issues/3180

--- a/go.sum
+++ b/go.sum
@@ -1358,6 +1358,8 @@ knative.dev/pkg v0.0.0-20200609184032-fef70cc2616b h1:L25RYK4WW4kVVUQHl6JA3oacGT
 knative.dev/pkg v0.0.0-20200609184032-fef70cc2616b/go.mod h1:rA+FklsrVahwF4a+D63NyHJlzDoAFH81K4J5CYuE3bA=
 knative.dev/pkg v0.0.0-20200611204322-2ddcfef739a2 h1:GMCS1McFzXLs+Q5jj/iKyue+Gbx4BytNZAhRpLamdz8=
 knative.dev/pkg v0.0.0-20200611204322-2ddcfef739a2/go.mod h1:rA+FklsrVahwF4a+D63NyHJlzDoAFH81K4J5CYuE3bA=
+knative.dev/pkg v0.0.0-20200614232523-aec2008e6656 h1:DHmOWuH1kfJnk4q/ZNZPbDR5dzpWDpHWh5IP9sCbvdE=
+knative.dev/pkg v0.0.0-20200614232523-aec2008e6656/go.mod h1:rA+FklsrVahwF4a+D63NyHJlzDoAFH81K4J5CYuE3bA=
 knative.dev/sample-controller v0.0.0-20200510050845-bf7c19498b7e/go.mod h1:D2ZDLrR9Dq9LiiVN7TatzI7WMcEPgk1MHbbhgBKE6W8=
 knative.dev/test-infra v0.0.0-20200407185800-1b88cb3b45a5/go.mod h1:xcdUkMJrLlBswIZqL5zCuBFOC22WIPMQoVX1L35i0vQ=
 knative.dev/test-infra v0.0.0-20200505052144-5ea2f705bb55/go.mod h1:WqF1Azka+FxPZ20keR2zCNtiQA1MP9ZB4BH4HuI+SIU=
@@ -1374,8 +1376,8 @@ knative.dev/test-infra v0.0.0-20200522180958-6a0a9b9d893a/go.mod h1:n9eQkzmSNj8B
 knative.dev/test-infra v0.0.0-20200606045118-14ebc4a42974 h1:CrZmlbB+j3ZF/aTrfyypY5ulX2w7XrkfeXKQsbkqzTg=
 knative.dev/test-infra v0.0.0-20200606045118-14ebc4a42974/go.mod h1://I6IZIF0QDgs5wotU243ZZ5cTpm6/GthayjUenBBc0=
 knative.dev/test-infra v0.0.0-20200610141822-fd009ecf10fe/go.mod h1:vyiP+4ospN/PJgwVzHkjnhlNP4uBPnvwkgb9dPCFSj4=
-knative.dev/test-infra v0.0.0-20200612005123-35b61c499a41 h1:KJMDpNdLRN39P/U6rspOTLorWEKcUZfy09gkLmWB0Ik=
-knative.dev/test-infra v0.0.0-20200612005123-35b61c499a41/go.mod h1:vyiP+4ospN/PJgwVzHkjnhlNP4uBPnvwkgb9dPCFSj4=
+knative.dev/test-infra v0.0.0-20200612191923-a4dd434e085b h1:QF1luh24SFfO3llKMl3i1drC6hBBqXCO1D8QV13gkNY=
+knative.dev/test-infra v0.0.0-20200612191923-a4dd434e085b/go.mod h1:+BfrTJpc++rH30gX/C0QY6NT2eYVzycll52uw6CrQnc=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -29,11 +29,8 @@ fi
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/library.sh
 
 # Compute _example checksum for all configmaps.
-go install "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen"
-for file in "${REPO_ROOT_DIR}"/config/core/configmaps/*.yaml
-do
-  ${GOPATH}/bin/hash-gen "$file"
-done
+echo "Generating checksums for configmap _example keys"
+go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/config/core/configmaps/*.yaml
 
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 $(dirname $0)/../vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -29,9 +29,10 @@ fi
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/library.sh
 
 # Compute _example checksum for all configmaps.
+go install "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen"
 for file in "${REPO_ROOT_DIR}"/config/core/configmaps/*.yaml
 do
-  go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "$file"
+  ${GOPATH}/bin/hash-gen "$file"
 done
 
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 $(dirname $0)/../vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}

--- a/vendor/knative.dev/pkg/configmap/hash-gen/main.go
+++ b/vendor/knative.dev/pkg/configmap/hash-gen/main.go
@@ -29,9 +29,10 @@ import (
 )
 
 func main() {
-	fileName := os.Args[1]
-	if err := processFile(fileName); err != nil {
-		log.Fatal(err)
+	for _, fileName := range os.Args[1:] {
+		if err := processFile(fileName); err != nil {
+			log.Fatal(err)
+		}
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1227,7 +1227,7 @@ knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/server
 knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice
 knative.dev/networking/pkg/client/istio/listers/networking/v1alpha3
 knative.dev/networking/pkg/client/listers/networking/v1alpha1
-# knative.dev/pkg v0.0.0-20200611204322-2ddcfef739a2
+# knative.dev/pkg v0.0.0-20200614232523-aec2008e6656
 ## explicit
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate
@@ -1344,7 +1344,7 @@ knative.dev/pkg/webhook/resourcesemantics/conversion
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
 knative.dev/pkg/websocket
-# knative.dev/test-infra v0.0.0-20200612005123-35b61c499a41
+# knative.dev/test-infra v0.0.0-20200612191923-a4dd434e085b
 ## explicit
 knative.dev/test-infra/scripts
 # sigs.k8s.io/structured-merge-diff/v2 v2.0.1


### PR DESCRIPTION
Before:

~~~~
$ time ./hack/update-checksums.sh # just the checksum part of -codegen
       18.28 real        27.86 user        12.29 sys
~~~~

After:
~~~~
$ time ./hack/update-checksums.sh # just the checksum part of -codegen
        0.85 real         1.03 user         0.95 sys
~~~~

Note: [we already rely](https://github.com/knative/serving/blob/master/hack/update-codegen.sh#L71) on being able to `go install` deepcopy-gen to `${GOPATH}/bin` [on L71](https://github.com/knative/serving/blob/master/hack/update-codegen.sh#L71), so seems fine to do the same with `hash-gen`.

/assign @markusthoemmes 