### PR TITLE
Fix the flake in the revision test

### DIFF
--- a/pkg/reconciler/revision/queueing_test.go
+++ b/pkg/reconciler/revision/queueing_test.go
@@ -25,8 +25,8 @@ import (
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -36,7 +36,6 @@ import (
 	"knative.dev/pkg/tracing"
 	tracingconfig "knative.dev/pkg/tracing/config"
 	tracetesting "knative.dev/pkg/tracing/testing"
-	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -237,15 +236,6 @@ func TestNewRevisionCallsSyncHandler(t *testing.T) {
 	rev := testRevision(getPodSpec())
 	servingClient := fakeservingclient.Get(ctx)
 
-	h := NewHooks()
-
-	// Check for a service created as a signal that syncHandler ran
-	h.OnCreate(&servingClient.Fake, "podautoscalers", func(obj runtime.Object) HookResult {
-		pa := obj.(*autoscalingv1alpha1.PodAutoscaler)
-		t.Logf("PA created: %s", pa.Name)
-		return HookComplete
-	})
-
 	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		t.Fatal("Error starting informers:", err)
@@ -266,7 +256,12 @@ func TestNewRevisionCallsSyncHandler(t *testing.T) {
 		t.Fatal("Error creating revision:", err)
 	}
 
-	if err := h.WaitForHooks(time.Second * 3); err != nil {
-		t.Error(err)
+	// Poll to see PA object to be created.
+	if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
+		pa, _ := servingClient.AutoscalingV1alpha1().PodAutoscalers(rev.Namespace).Get(
+			rev.Name, metav1.GetOptions{})
+		return pa != nil, nil
+	}); err != nil {
+		t.Error("Failed to see PA creation")
 	}
 }


### PR DESCRIPTION
Just poll the PA creation directly from the fake,
rather than wait for hooks to complete

```
gt -run=TestNewRevisionCallsSyncHandler -count=200
PASS
ok      knative.dev/serving/pkg/reconciler/revision     22.736s
```

Fixes #8280