### PR TITLE
Remove the Autoscaling config from revision reconciler

### DIFF
--- a/pkg/reconciler/revision/config/store.go
+++ b/pkg/reconciler/revision/config/store.go
@@ -35,7 +35,6 @@ type cfgKey struct{}
 // +k8s:deepcopy-gen=false
 // Config contains the configmaps requires for revision reconciliation.
 type Config struct {
-	Autoscaler    *autoscalerconfig.Config
 	Defaults      *config.Defaults
 	Deployment    *deployment.Config
 	Logging       *logging.Config
@@ -88,7 +87,6 @@ func (s *Store) ToContext(ctx context.Context) context.Context {
 // Load returns the config from the store.
 func (s *Store) Load() *Config {
 	return &Config{
-		Autoscaler:    s.UntypedLoad(autoscalerconfig.ConfigName).(*autoscalerconfig.Config).DeepCopy(),
 		Defaults:      s.UntypedLoad(config.DefaultsConfigName).(*config.Defaults).DeepCopy(),
 		Deployment:    s.UntypedLoad(deployment.ConfigName).(*deployment.Config).DeepCopy(),
 		Logging:       s.UntypedLoad((logging.ConfigMapName())).(*logging.Config).DeepCopy(),

--- a/pkg/reconciler/revision/config/store_test.go
+++ b/pkg/reconciler/revision/config/store_test.go
@@ -127,13 +127,6 @@ func TestStoreLoadWithContext(t *testing.T) {
 			t.Error("Unexpected defaults config (-want, +got):", diff)
 		}
 	})
-
-	t.Run("autoscaler", func(t *testing.T) {
-		expected, _ := autoscalerconfig.NewConfigFromConfigMap(autoscalerConfig)
-		if diff := cmp.Diff(expected, config.Autoscaler); diff != "" {
-			t.Error("Unexpected autoscaler config (-want, +got):", diff)
-		}
-	})
 }
 
 func TestStoreImmutableConfig(t *testing.T) {
@@ -153,8 +146,6 @@ func TestStoreImmutableConfig(t *testing.T) {
 	config.Logging.LoggingConfig = "mutated"
 	ccMutated := int64(4)
 	config.Defaults.ContainerConcurrency = ccMutated
-	scaleupMutated := float64(4)
-	config.Autoscaler.MaxScaleUpRate = scaleupMutated
 
 	newConfig := store.Load()
 
@@ -166,8 +157,5 @@ func TestStoreImmutableConfig(t *testing.T) {
 	}
 	if newConfig.Defaults.ContainerConcurrency == ccMutated {
 		t.Error("Defaults config is not immutable")
-	}
-	if newConfig.Autoscaler.MaxScaleUpRate == scaleupMutated {
-		t.Error("Autoscaler config is not immutable")
 	}
 }

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -22,6 +22,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+
 	caching "knative.dev/caching/pkg/apis/caching/v1alpha1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/kmp"
@@ -41,7 +42,6 @@ func (c *Reconciler) createDeployment(ctx context.Context, rev *v1.Revision) (*a
 		cfgs.Tracing,
 		cfgs.Network,
 		cfgs.Observability,
-		cfgs.Autoscaler,
 		cfgs.Deployment,
 	)
 
@@ -62,7 +62,6 @@ func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1.Revis
 		cfgs.Tracing,
 		cfgs.Network,
 		cfgs.Observability,
-		cfgs.Autoscaler,
 		cfgs.Deployment,
 	)
 
@@ -111,12 +110,10 @@ func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1.Revis
 
 func (c *Reconciler) createImageCache(rev *v1.Revision, containerName, imageDigest string) (*caching.Image, error) {
 	image := resources.MakeImageCache(rev, containerName, imageDigest)
-
 	return c.cachingclient.CachingV1alpha1().Images(image.Namespace).Create(image)
 }
 
 func (c *Reconciler) createPA(ctx context.Context, rev *v1.Revision) (*autoscaling.PodAutoscaler, error) {
 	pa := resources.MakePA(rev)
-
 	return c.client.AutoscalingV1alpha1().PodAutoscalers(pa.Namespace).Create(pa)
 }

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -28,7 +28,6 @@ import (
 	tracingconfig "knative.dev/pkg/tracing/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/queue"
@@ -90,8 +89,8 @@ func rewriteUserProbe(p *corev1.Probe, userPort int) {
 	}
 }
 
-func makePodSpec(rev *v1.Revision, loggingConfig *logging.Config, tracingConfig *tracingconfig.Config, observabilityConfig *metrics.ObservabilityConfig, autoscalerConfig *autoscalerconfig.Config, deploymentConfig *deployment.Config) (*corev1.PodSpec, error) {
-	queueContainer, err := makeQueueContainer(rev, loggingConfig, tracingConfig, observabilityConfig, autoscalerConfig, deploymentConfig)
+func makePodSpec(rev *v1.Revision, loggingConfig *logging.Config, tracingConfig *tracingconfig.Config, observabilityConfig *metrics.ObservabilityConfig, deploymentConfig *deployment.Config) (*corev1.PodSpec, error) {
+	queueContainer, err := makeQueueContainer(rev, loggingConfig, tracingConfig, observabilityConfig, deploymentConfig)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create queue-proxy container: %w", err)
@@ -218,14 +217,13 @@ func buildUserPortEnv(userPort string) corev1.EnvVar {
 
 // MakeDeployment constructs a K8s Deployment resource from a revision.
 func MakeDeployment(rev *v1.Revision,
-	loggingConfig *logging.Config, tracingConfig *tracingconfig.Config, networkConfig *network.Config, observabilityConfig *metrics.ObservabilityConfig,
-	autoscalerConfig *autoscalerconfig.Config, deploymentConfig *deployment.Config) (*appsv1.Deployment, error) {
+	loggingConfig *logging.Config, tracingConfig *tracingconfig.Config, networkConfig *network.Config, observabilityConfig *metrics.ObservabilityConfig, deploymentConfig *deployment.Config) (*appsv1.Deployment, error) {
 
 	podTemplateAnnotations := kmeta.FilterMap(rev.GetAnnotations(), func(k string) bool {
 		return k == serving.RevisionLastPinnedAnnotationKey
 	})
 
-	podSpec, err := makePodSpec(rev, loggingConfig, tracingConfig, observabilityConfig, autoscalerConfig, deploymentConfig)
+	podSpec, err := makePodSpec(rev, loggingConfig, tracingConfig, observabilityConfig, deploymentConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create PodSpec: %w", err)
 	}

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -37,7 +37,6 @@ import (
 	_ "knative.dev/pkg/system/testing"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
 
@@ -468,7 +467,6 @@ func TestMakePodSpec(t *testing.T) {
 		name string
 		rev  *v1.Revision
 		oc   metrics.ObservabilityConfig
-		ac   autoscalerconfig.Config
 		want *corev1.PodSpec
 	}{{
 		name: "user-defined user port, queue proxy have PORT env",
@@ -928,7 +926,7 @@ func TestMakePodSpec(t *testing.T) {
 			quantityComparer := cmp.Comparer(func(x, y resource.Quantity) bool {
 				return x.Cmp(y) == 0
 			})
-			got, err := makePodSpec(test.rev, &logConfig, &traceConfig, &test.oc, &test.ac, &deploymentConfig)
+			got, err := makePodSpec(test.rev, &logConfig, &traceConfig, &test.oc, &deploymentConfig)
 			if err != nil {
 				t.Fatal("makePodSpec returned error:", err)
 			}
@@ -941,7 +939,7 @@ func TestMakePodSpec(t *testing.T) {
 
 func TestMissingProbeError(t *testing.T) {
 	if _, err := MakeDeployment(revision("bar", "foo"), &logConfig, &traceConfig,
-		&network.Config{}, &obsConfig, &asConfig, &deploymentConfig); err == nil {
+		&network.Config{}, &obsConfig, &deploymentConfig); err == nil {
 		t.Error("expected error from MakeDeployment")
 	}
 }
@@ -1031,13 +1029,13 @@ func TestMakeDeployment(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// Tested above so that we can rely on it here for brevity.
 			podSpec, err := makePodSpec(test.rev, &logConfig, &traceConfig,
-				&obsConfig, &asConfig, &deploymentConfig)
+				&obsConfig, &deploymentConfig)
 			if err != nil {
 				t.Fatal("makePodSpec returned error:", err)
 			}
 			test.want.Spec.Template.Spec = *podSpec
 			got, err := MakeDeployment(test.rev, &logConfig, &traceConfig,
-				&network.Config{}, &obsConfig, &asConfig, &test.dc)
+				&network.Config{}, &obsConfig, &test.dc)
 			if err != nil {
 				t.Fatal("got unexpected error:", err)
 			}

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -34,7 +34,6 @@ import (
 	tracingconfig "knative.dev/pkg/tracing/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/queue"
@@ -220,8 +219,7 @@ func makeQueueProbe(in *corev1.Probe) *corev1.Probe {
 }
 
 // makeQueueContainer creates the container spec for the queue sidecar.
-func makeQueueContainer(rev *v1.Revision, loggingConfig *logging.Config, tracingConfig *tracingconfig.Config, observabilityConfig *metrics.ObservabilityConfig,
-	autoscalerConfig *autoscalerconfig.Config, deploymentConfig *deployment.Config) (*corev1.Container, error) {
+func makeQueueContainer(rev *v1.Revision, loggingConfig *logging.Config, tracingConfig *tracingconfig.Config, observabilityConfig *metrics.ObservabilityConfig, deploymentConfig *deployment.Config) (*corev1.Container, error) {
 	configName := ""
 	if owner := metav1.GetControllerOf(rev); owner != nil && owner.Kind == "Configuration" {
 		configName = owner.Name

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -42,7 +42,6 @@ import (
 	tracingconfig "knative.dev/pkg/tracing/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
 )
@@ -66,7 +65,6 @@ var (
 	logConfig        logging.Config
 	traceConfig      tracingconfig.Config
 	obsConfig        metrics.ObservabilityConfig
-	asConfig         autoscalerconfig.Config
 	deploymentConfig deployment.Config
 )
 
@@ -277,7 +275,7 @@ func TestMakeQueueContainer(t *testing.T) {
 					}},
 				}
 			}
-			got, err := makeQueueContainer(test.rev, &test.lc, &traceConfig, &test.oc, &asConfig, &test.dc)
+			got, err := makeQueueContainer(test.rev, &test.lc, &traceConfig, &test.oc, &test.dc)
 			if err != nil {
 				t.Fatal("makeQueueContainer returned error:", err)
 			}
@@ -413,7 +411,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := makeQueueContainer(test.rev, &logConfig, &traceConfig, &obsConfig, &asConfig, &test.dc)
+			got, err := makeQueueContainer(test.rev, &logConfig, &traceConfig, &obsConfig, &test.dc)
 			if err != nil {
 				t.Fatal("makeQueueContainer returned error:", err)
 			}
@@ -485,7 +483,7 @@ func TestProbeGenerationHTTPDefaults(t *testing.T) {
 		}
 	})
 
-	got, err := makeQueueContainer(rev, &logConfig, &traceConfig, &obsConfig, &asConfig, &deploymentConfig)
+	got, err := makeQueueContainer(rev, &logConfig, &traceConfig, &obsConfig, &deploymentConfig)
 	if err != nil {
 		t.Fatal("makeQueueContainer returned error")
 	}
@@ -557,7 +555,7 @@ func TestProbeGenerationHTTP(t *testing.T) {
 		}
 	})
 
-	got, err := makeQueueContainer(rev, &logConfig, &traceConfig, &obsConfig, &asConfig, &deploymentConfig)
+	got, err := makeQueueContainer(rev, &logConfig, &traceConfig, &obsConfig, &deploymentConfig)
 	if err != nil {
 		t.Fatal("makeQueueContainer returned error")
 	}
@@ -724,7 +722,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 				Value: string(wantProbeJSON),
 			})
 
-			got, err := makeQueueContainer(testRev, &logConfig, &traceConfig, &obsConfig, &asConfig, &deploymentConfig)
+			got, err := makeQueueContainer(testRev, &logConfig, &traceConfig, &obsConfig, &deploymentConfig)
 			if err != nil {
 				t.Fatal("makeQueueContainer returned error")
 			}

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -39,7 +39,6 @@ import (
 	asv1a1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	defaultconfig "knative.dev/serving/pkg/apis/config"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	revisionreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/revision"
 	"knative.dev/serving/pkg/reconciler/revision/config"
@@ -703,8 +702,7 @@ func deploy(t *testing.T, namespace, name string, opts ...interface{}) *appsv1.D
 	// before calling MakeDeployment within Reconcile.
 	rev.SetDefaults(context.Background())
 	deployment, err := resources.MakeDeployment(rev, cfg.Logging, cfg.Tracing, cfg.Network,
-		cfg.Observability, cfg.Autoscaler, cfg.Deployment,
-	)
+		cfg.Observability, cfg.Deployment)
 	if err != nil {
 		t.Fatal("failed to create deployment")
 	}
@@ -764,9 +762,8 @@ func ReconcilerTestConfig() *config.Config {
 		Observability: &metrics.ObservabilityConfig{
 			LoggingURLTemplate: "http://logger.io/${REVISION_UID}",
 		},
-		Logging:    &logging.Config{},
-		Tracing:    &tracingconfig.Config{},
-		Autoscaler: &autoscalerconfig.Config{},
-		Defaults:   &defaultconfig.Defaults{},
+		Logging:  &logging.Config{},
+		Tracing:  &tracingconfig.Config{},
+		Defaults: &defaultconfig.Defaults{},
 	}
 }


### PR DESCRIPTION
It is no longer required and we can remove it now.

/assign @dprotaso mattmoor