### PR TITLE
Drop env parsing in readiness probe

### DIFF
--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -150,7 +150,7 @@ func TestProbeHandler(t *testing.T) {
 }
 
 func TestProbeQueueInvalidPort(t *testing.T) {
-	if err := probeQueueHealthPath(1, probeConfig{QueueServingPort: 0}); err == nil {
+	if err := probeQueueHealthPath(1, 0); err == nil {
 		t.Error("Expected error, got nil")
 	} else if diff := cmp.Diff(err.Error(), "port must be a positive value, got 0"); diff != "" {
 		t.Errorf("Unexpected not ready message: %s", diff)
@@ -158,7 +158,7 @@ func TestProbeQueueInvalidPort(t *testing.T) {
 }
 
 func TestProbeQueueConnectionFailure(t *testing.T) {
-	if err := probeQueueHealthPath(1, probeConfig{QueueServingPort: 12345}); err == nil {
+	if err := probeQueueHealthPath(1, 12345); err == nil {
 		t.Error("Expected error, got nil")
 	}
 }
@@ -182,7 +182,7 @@ func TestProbeQueueNotReady(t *testing.T) {
 		t.Fatalf("Failed to convert port(%s) to int: %v", u.Port(), err)
 	}
 
-	err = probeQueueHealthPath(1, probeConfig{QueueServingPort: port})
+	err = probeQueueHealthPath(1, port)
 
 	if diff := cmp.Diff(err.Error(), "probe returned not ready"); diff != "" {
 		t.Errorf("Unexpected not ready message: %s", diff)
@@ -211,7 +211,7 @@ func TestProbeQueueShuttingDownFailsFast(t *testing.T) {
 	}
 
 	start := time.Now()
-	if err = probeQueueHealthPath(1, probeConfig{QueueServingPort: port}); err == nil {
+	if err = probeQueueHealthPath(1, port); err == nil {
 		t.Error("probeQueueHealthPath did not fail")
 	}
 
@@ -240,7 +240,7 @@ func TestProbeQueueReady(t *testing.T) {
 		t.Fatalf("Failed to convert port(%s) to int: %v", u.Port(), err)
 	}
 
-	if err = probeQueueHealthPath(1, probeConfig{QueueServingPort: port}); err != nil {
+	if err = probeQueueHealthPath(1, port); err != nil {
 		t.Errorf("probeQueueHealthPath(%d, 1s) = %s", port, err)
 	}
 
@@ -270,7 +270,7 @@ func TestProbeQueueTimeout(t *testing.T) {
 	}
 
 	timeout := 1
-	if err = probeQueueHealthPath(timeout, probeConfig{QueueServingPort: port}); err == nil {
+	if err = probeQueueHealthPath(timeout, port); err == nil {
 		t.Errorf("Expected probeQueueHealthPath(%d, %v) to return timeout error", port, timeout)
 	}
 
@@ -304,7 +304,7 @@ func TestProbeQueueDelayedReady(t *testing.T) {
 	}
 
 	timeout := 0
-	if err := probeQueueHealthPath(timeout, probeConfig{QueueServingPort: port}); err != nil {
+	if err := probeQueueHealthPath(timeout, port); err != nil {
 		t.Errorf("probeQueueHealthPath(%d) = %s", port, err)
 	}
 }


### PR DESCRIPTION
Now that there's only one env var anyway (after dropping selective destroy), might as well drop the struct and the envconfig-based parsing (which we wanted to do anyway to shave a few cpu cycles from the readiness probes).

/assign @vagababov 