### PR TITLE
Add HA label to ha deployments

### DIFF
--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
+    knative.dev/high-availability: "true"
 spec:
   selector:
     matchLabels:

--- a/config/hpa-autoscaling/controller.yaml
+++ b/config/hpa-autoscaling/controller.yaml
@@ -20,6 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
     autoscaling.knative.dev/autoscaler-provider: hpa
+    knative.dev/high-availability: "true"
 spec:
   selector:
     matchLabels:

--- a/config/namespace-wildcard-certs/controller.yaml
+++ b/config/namespace-wildcard-certs/controller.yaml
@@ -20,6 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
     networking.knative.dev/wildcard-certificate-provider: nscert
+    knative.dev/high-availability: "true"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Similar to eventing's https://github.com/knative/eventing/pull/3311

As per https://github.com/knative/operator/issues/73, indicate the HA deployments that the operator is configuring

## Proposed Changes
- Indicate the HA deployments

Operator PR that will allow the operator to read the label: https://github.com/knative/operator/pull/134