### PR TITLE
Simplify feature flag name.

### DIFF
--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -40,9 +40,9 @@ const (
 
 func defaultFeaturesConfig() *Features {
 	return &Features{
-		MultiContainer:     Disabled,
-		KubernetesFieldRef: Disabled,
-		PodSpecDryRun:      Allowed,
+		MultiContainer: Disabled,
+		FieldRef:       Disabled,
+		PodSpecDryRun:  Allowed,
 	}
 }
 
@@ -52,7 +52,7 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 
 	if err := cm.Parse(data,
 		asFlag("multi-container", &nc.MultiContainer),
-		asFlag("kubernetes/field-ref", &nc.KubernetesFieldRef),
+		asFlag("kubernetes/field-ref", &nc.FieldRef),
 		asFlag("kubernetes/podspec-dryrun", &nc.PodSpecDryRun)); err != nil {
 		return nil, err
 	}
@@ -66,9 +66,9 @@ func NewFeaturesConfigFromConfigMap(config *corev1.ConfigMap) (*Features, error)
 
 // Features specifies which features are allowed by the webhook.
 type Features struct {
-	MultiContainer     Flag
-	KubernetesFieldRef Flag
-	PodSpecDryRun      Flag
+	MultiContainer Flag
+	FieldRef       Flag
+	PodSpecDryRun  Flag
 }
 
 // asFlag parses the value at key as a Flag into the target, if it exists.

--- a/pkg/apis/config/features_test.go
+++ b/pkg/apis/config/features_test.go
@@ -89,7 +89,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 		name:    "kubernetes/field-ref Allowed",
 		wantErr: false,
 		wantFeatures: defaultWith(&Features{
-			KubernetesFieldRef: Allowed,
+			FieldRef: Allowed,
 		}),
 		data: map[string]string{
 			"kubernetes/field-ref": "Allowed",
@@ -98,7 +98,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 		name:    "kubernetes/field-ref Enabled",
 		wantErr: false,
 		wantFeatures: defaultWith(&Features{
-			KubernetesFieldRef: Enabled,
+			FieldRef: Enabled,
 		}),
 		data: map[string]string{
 			"kubernetes/field-ref": "Enabled",
@@ -107,7 +107,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 		name:    "kubernetes/field-ref Disabled",
 		wantErr: false,
 		wantFeatures: defaultWith(&Features{
-			KubernetesFieldRef: Disabled,
+			FieldRef: Disabled,
 		}),
 		data: map[string]string{
 			"kubernetes/field-ref": "Disabled",

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -186,7 +186,7 @@ func validateEnvValueFrom(ctx context.Context, source *corev1.EnvVarSource) *api
 		return nil
 	}
 	features := config.FromContextOrDefaults(ctx).Features
-	return apis.CheckDisallowedFields(*source, *EnvVarSourceMask(source, features.KubernetesFieldRef != config.Disabled))
+	return apis.CheckDisallowedFields(*source, *EnvVarSourceMask(source, features.FieldRef != config.Disabled))
 }
 
 func validateEnvVar(ctx context.Context, env corev1.EnvVar) *apis.FieldError {

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -43,7 +43,7 @@ func withMultiContainer() configOption {
 
 func withFieldRef() configOption {
 	return func(cfg *config.Config) *config.Config {
-		cfg.Features.KubernetesFieldRef = config.Enabled
+		cfg.Features.FieldRef = config.Enabled
 		return cfg
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

The `Kubernetes` scope is useless in the code.
This is more consistent with the `PodSpecDryRun` flag.

/assign @whaught @vagababov 