### PR TITLE
Extract and add comments to standalone exec probe flow

### DIFF
--- a/cmd/queue/execprobe.go
+++ b/cmd/queue/execprobe.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/cmd/queue/execprobe.go
+++ b/cmd/queue/execprobe.go
@@ -32,11 +32,20 @@ import (
 	"knative.dev/serving/pkg/queue/readiness"
 )
 
+const (
+	healthURLPrefix = "http://127.0.0.1:"
+
+	// The 25 millisecond retry interval is an unscientific compromise between wanting to get
+	// started as early as possible while still wanting to give the container some breathing
+	// room to get up and running.
+	aggressivePollInterval = 25 * time.Millisecond
+)
+
 // As well as running as a long-running proxy server, the Queue Proxy can be
 // run as an exec probe if the `--probe-period` flag is passed.
 //
 // In this mode, the exec probe (repeatedly) sends an HTTP request to the Queue
-// Proxy server with a Probe header.  The handler for this probe request
+// Proxy server with a Probe header. The handler for this probe request
 // (knativeProbeHandler) then performs the actual health check against the user
 // container. The exec probe binary exits 0 (success) if it eventually gets a
 // 200 status code back from the knativeProbeHandler, or 1 (fail) if it never

--- a/cmd/queue/execprobe.go
+++ b/cmd/queue/execprobe.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/serving/pkg/network"
+	"knative.dev/serving/pkg/queue"
+	"knative.dev/serving/pkg/queue/health"
+	"knative.dev/serving/pkg/queue/readiness"
+)
+
+// As well as running as a long-running proxy server, the Queue Proxy can be
+// run as an exec probe if the `--probe-period` flag is passed.
+//
+// In this mode, the exec probe (repeatedly) sends an HTTP request to the Queue
+// Proxy server with a Probe header.  The handler for this probe request
+// (knativeProbeHandler) then performs the actual health check against the user
+// container. The exec probe binary exits 0 (success) if it eventually gets a
+// 200 status code back from the knativeProbeHandler, or 1 (fail) if it never
+// does.
+//
+// The reason we use an exec probe to hit an HTTP endpoint on the Queue
+// Proxy to then run the actual probe against the user container rather than
+// using an HTTP probe directly is because an exec probe can be launched
+// immediately after the container starts, whereas an HTTP probe would
+// initially race with the server starting up and fail. The minimum retry
+// period after this failure in upstream kubernetes is a second. The exec
+// probe, on the other hand, automatically polls on an aggressivePollInterval
+// until the HTTP endpoint responds with success. This allows us to get an
+// initial readiness result much faster than the effective upstream Kubernetes
+// minimum of 1 second.
+func standaloneProbeMain(timeout int) (exitCode int) {
+	queueServingPort, err := strconv.Atoi(os.Getenv("QUEUE_SERVING_PORT"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "parse queue port:", err)
+		return 1
+	}
+
+	if err := probeQueueHealthPath(timeout, queueServingPort); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	return 0
+}
+
+func probeQueueHealthPath(timeoutSeconds, queueServingPort int) error {
+	if queueServingPort <= 0 {
+		return fmt.Errorf("port must be a positive value, got %d", queueServingPort)
+	}
+
+	url := healthURLPrefix + strconv.Itoa(queueServingPort)
+	timeoutDuration := readiness.PollTimeout
+	if timeoutSeconds != 0 {
+		timeoutDuration = time.Duration(timeoutSeconds) * time.Second
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("probe failed: error creating request: %w", err)
+	}
+
+	// Add the header to indicate this is a probe request.
+	req.Header.Add(network.ProbeHeaderName, queue.Name)
+	req.Header.Add(network.UserAgentKey, network.QueueProxyUserAgent)
+
+	httpClient := &http.Client{
+		Timeout: timeoutDuration,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
+	defer cancel()
+
+	var lastErr error
+	// Using PollImmediateUntil instead of PollImmediate because if timeout is reached while waiting for first
+	// invocation of conditionFunc, it exits immediately without trying for a second time.
+	timeoutErr := wait.PollImmediateUntil(aggressivePollInterval, func() (bool, error) {
+		res, lastErr := httpClient.Do(req)
+		if lastErr != nil {
+			// Return nil error for retrying
+			return false, nil
+		}
+		defer res.Body.Close()
+
+		// fail readiness immediately rather than retrying if we get a header indicating we're shutting down.
+		if health.IsHTTPProbeShuttingDown(res) {
+			return false, errors.New("failing probe deliberately for shutdown")
+		}
+
+		return health.IsHTTPProbeReady(res), nil
+	}, ctx.Done())
+
+	if lastErr != nil {
+		return fmt.Errorf("failed to probe: %w", lastErr)
+	}
+
+	// An http.StatusOK was never returned during probing
+	if timeoutErr != nil {
+		return errors.New("probe returned not ready")
+	}
+
+	return nil
+}

--- a/cmd/queue/execprobe_test.go
+++ b/cmd/queue/execprobe_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/cmd/queue/execprobe_test.go
+++ b/cmd/queue/execprobe_test.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/network"
+)
+
+func TestProbeQueueInvalidPort(t *testing.T) {
+	if err := probeQueueHealthPath(1, 0); err == nil {
+		t.Error("Expected error, got nil")
+	} else if diff := cmp.Diff(err.Error(), "port must be a positive value, got 0"); diff != "" {
+		t.Errorf("Unexpected not ready message: %s", diff)
+	}
+}
+
+func TestProbeQueueConnectionFailure(t *testing.T) {
+	if err := probeQueueHealthPath(1, 12345); err == nil {
+		t.Error("Expected error, got nil")
+	}
+}
+
+func TestProbeQueueNotReady(t *testing.T) {
+	queueProbed := ptr.Int32(0)
+	ts := newProbeTestServer(func(w http.ResponseWriter) {
+		atomic.AddInt32(queueProbed, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	})
+
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
+	}
+
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("Failed to convert port(%s) to int: %v", u.Port(), err)
+	}
+
+	err = probeQueueHealthPath(1, port)
+
+	if diff := cmp.Diff(err.Error(), "probe returned not ready"); diff != "" {
+		t.Errorf("Unexpected not ready message: %s", diff)
+	}
+
+	if atomic.LoadInt32(queueProbed) == 0 {
+		t.Error("Expected the queue proxy server to be probed")
+	}
+}
+
+func TestProbeQueueShuttingDownFailsFast(t *testing.T) {
+	ts := newProbeTestServer(func(w http.ResponseWriter) {
+		w.WriteHeader(http.StatusGone)
+	})
+
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
+	}
+
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("Failed to convert port(%s) to int: %v", u.Port(), err)
+	}
+
+	start := time.Now()
+	if err = probeQueueHealthPath(1, port); err == nil {
+		t.Error("probeQueueHealthPath did not fail")
+	}
+
+	// if fails due to timeout and not cancelation, then it took too long
+	if time.Since(start) >= 1*time.Second {
+		t.Error("took too long to fail")
+	}
+}
+
+func TestProbeQueueReady(t *testing.T) {
+	queueProbed := ptr.Int32(0)
+	ts := newProbeTestServer(func(w http.ResponseWriter) {
+		atomic.AddInt32(queueProbed, 1)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
+	}
+
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("Failed to convert port(%s) to int: %v", u.Port(), err)
+	}
+
+	if err = probeQueueHealthPath(1, port); err != nil {
+		t.Errorf("probeQueueHealthPath(%d, 1s) = %s", port, err)
+	}
+
+	if atomic.LoadInt32(queueProbed) == 0 {
+		t.Error("Expected the queue proxy server to be probed")
+	}
+}
+
+func TestProbeQueueTimeout(t *testing.T) {
+	queueProbed := ptr.Int32(0)
+	ts := newProbeTestServer(func(w http.ResponseWriter) {
+		atomic.AddInt32(queueProbed, 1)
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
+	}
+
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("failed to convert port(%s) to int", u.Port())
+	}
+
+	timeout := 1
+	if err = probeQueueHealthPath(timeout, port); err == nil {
+		t.Errorf("Expected probeQueueHealthPath(%d, %v) to return timeout error", port, timeout)
+	}
+
+	ts.Close()
+
+	if atomic.LoadInt32(queueProbed) == 0 {
+		t.Error("Expected the queue proxy server to be probed")
+	}
+}
+
+func TestProbeQueueDelayedReady(t *testing.T) {
+	count := ptr.Int32(0)
+	ts := newProbeTestServer(func(w http.ResponseWriter) {
+		if atomic.AddInt32(count, 1) < 9 {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
+	}
+
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("Failed to convert port(%s) to int: %v", u.Port(), err)
+	}
+
+	timeout := 0
+	if err := probeQueueHealthPath(timeout, port); err != nil {
+		t.Errorf("probeQueueHealthPath(%d) = %s", port, err)
+	}
+}
+
+func newProbeTestServer(f func(w http.ResponseWriter)) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(network.UserAgentKey) == network.QueueProxyUserAgent {
+			f(w)
+		}
+	}))
+}

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -59,11 +59,6 @@ import (
 const (
 	badProbeTemplate = "unexpected probe header value: %s"
 
-	healthURLPrefix = "http://127.0.0.1:"
-	// The 25 millisecond retry interval is an unscientific compromise between wanting to get
-	// started as early as possible while still wanting to give the container some breathing
-	// room to get up and running.
-	aggressivePollInterval = 25 * time.Millisecond
 	// reportingPeriod is the interval of time between reporting stats by queue proxy.
 	reportingPeriod = 1 * time.Second
 )

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -22,16 +22,13 @@ import (
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
-	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"go.opencensus.io/plugin/ochttp"
 	pkgnet "knative.dev/pkg/network"
-	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/tracing"
 	tracingconfig "knative.dev/pkg/tracing/config"
 	tracetesting "knative.dev/pkg/tracing/testing"
@@ -146,166 +143,6 @@ func TestProbeHandler(t *testing.T) {
 				t.Errorf("probe body = %q, want: %q, diff: %s", got, want, cmp.Diff(got, want))
 			}
 		})
-	}
-}
-
-func TestProbeQueueInvalidPort(t *testing.T) {
-	if err := probeQueueHealthPath(1, 0); err == nil {
-		t.Error("Expected error, got nil")
-	} else if diff := cmp.Diff(err.Error(), "port must be a positive value, got 0"); diff != "" {
-		t.Errorf("Unexpected not ready message: %s", diff)
-	}
-}
-
-func TestProbeQueueConnectionFailure(t *testing.T) {
-	if err := probeQueueHealthPath(1, 12345); err == nil {
-		t.Error("Expected error, got nil")
-	}
-}
-
-func TestProbeQueueNotReady(t *testing.T) {
-	queueProbed := ptr.Int32(0)
-	ts := newProbeTestServer(func(w http.ResponseWriter) {
-		atomic.AddInt32(queueProbed, 1)
-		w.WriteHeader(http.StatusBadRequest)
-	})
-
-	defer ts.Close()
-
-	u, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
-	}
-
-	port, err := strconv.Atoi(u.Port())
-	if err != nil {
-		t.Fatalf("Failed to convert port(%s) to int: %v", u.Port(), err)
-	}
-
-	err = probeQueueHealthPath(1, port)
-
-	if diff := cmp.Diff(err.Error(), "probe returned not ready"); diff != "" {
-		t.Errorf("Unexpected not ready message: %s", diff)
-	}
-
-	if atomic.LoadInt32(queueProbed) == 0 {
-		t.Error("Expected the queue proxy server to be probed")
-	}
-}
-
-func TestProbeQueueShuttingDownFailsFast(t *testing.T) {
-	ts := newProbeTestServer(func(w http.ResponseWriter) {
-		w.WriteHeader(http.StatusGone)
-	})
-
-	defer ts.Close()
-
-	u, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
-	}
-
-	port, err := strconv.Atoi(u.Port())
-	if err != nil {
-		t.Fatalf("Failed to convert port(%s) to int: %v", u.Port(), err)
-	}
-
-	start := time.Now()
-	if err = probeQueueHealthPath(1, port); err == nil {
-		t.Error("probeQueueHealthPath did not fail")
-	}
-
-	// if fails due to timeout and not cancelation, then it took too long
-	if time.Since(start) >= 1*time.Second {
-		t.Error("took too long to fail")
-	}
-}
-
-func TestProbeQueueReady(t *testing.T) {
-	queueProbed := ptr.Int32(0)
-	ts := newProbeTestServer(func(w http.ResponseWriter) {
-		atomic.AddInt32(queueProbed, 1)
-		w.WriteHeader(http.StatusOK)
-	})
-
-	defer ts.Close()
-
-	u, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
-	}
-
-	port, err := strconv.Atoi(u.Port())
-	if err != nil {
-		t.Fatalf("Failed to convert port(%s) to int: %v", u.Port(), err)
-	}
-
-	if err = probeQueueHealthPath(1, port); err != nil {
-		t.Errorf("probeQueueHealthPath(%d, 1s) = %s", port, err)
-	}
-
-	if atomic.LoadInt32(queueProbed) == 0 {
-		t.Error("Expected the queue proxy server to be probed")
-	}
-}
-
-func TestProbeQueueTimeout(t *testing.T) {
-	queueProbed := ptr.Int32(0)
-	ts := newProbeTestServer(func(w http.ResponseWriter) {
-		atomic.AddInt32(queueProbed, 1)
-		time.Sleep(2 * time.Second)
-		w.WriteHeader(http.StatusOK)
-	})
-
-	defer ts.Close()
-
-	u, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
-	}
-
-	port, err := strconv.Atoi(u.Port())
-	if err != nil {
-		t.Fatalf("failed to convert port(%s) to int", u.Port())
-	}
-
-	timeout := 1
-	if err = probeQueueHealthPath(timeout, port); err == nil {
-		t.Errorf("Expected probeQueueHealthPath(%d, %v) to return timeout error", port, timeout)
-	}
-
-	ts.Close()
-
-	if atomic.LoadInt32(queueProbed) == 0 {
-		t.Error("Expected the queue proxy server to be probed")
-	}
-}
-
-func TestProbeQueueDelayedReady(t *testing.T) {
-	count := ptr.Int32(0)
-	ts := newProbeTestServer(func(w http.ResponseWriter) {
-		if atomic.AddInt32(count, 1) < 9 {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-	})
-
-	defer ts.Close()
-
-	u, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
-	}
-
-	port, err := strconv.Atoi(u.Port())
-	if err != nil {
-		t.Fatalf("Failed to convert port(%s) to int: %v", u.Port(), err)
-	}
-
-	timeout := 0
-	if err := probeQueueHealthPath(timeout, port); err != nil {
-		t.Errorf("probeQueueHealthPath(%d) = %s", port, err)
 	}
 }
 
@@ -508,12 +345,4 @@ func BenchmarkProxyHandler(b *testing.B) {
 			})
 		})
 	}
-}
-
-func newProbeTestServer(f func(w http.ResponseWriter)) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get(network.UserAgentKey) == network.QueueProxyUserAgent {
-			f(w)
-		}
-	}))
 }

--- a/pkg/network/stats.go
+++ b/pkg/network/stats.go
@@ -130,8 +130,8 @@ func (s *RequestStats) HandleEvent(event ReqEvent) {
 	}
 }
 
-// Report returns averageConcurrency, averageProxiedConcurrency, requestCount and proxiedCount
-// relative to the given time. The state will be reset for another reporting cycle afterwards.
+// Report returns a RequestStatsReport relative to the given time. The state
+// will be reset for another reporting cycle afterwards.
 func (s *RequestStats) Report(now time.Time) RequestStatsReport {
 	s.mux.Lock()
 	defer s.mux.Unlock()


### PR DESCRIPTION
The fact that the Queue Proxy's main.go actually has a standalone exec probe mode, and what it does (and why :)), is pretty confusing to new readers (or it was to me, anyway).

This just makes it a bit clearer by adding some clarifying comments and pulling the standalone-exec-probe stuff (and corresponding tests) out to their own file alongside the existing main.go.

/assign @vagababov 

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->