### PR TITLE
Remove the pointer return from makeIngressSpec

### DIFF
--- a/pkg/reconciler/route/resources/ingress.go
+++ b/pkg/reconciler/route/resources/ingress.go
@@ -114,7 +114,7 @@ func MakeIngressSpec(
 			if err != nil {
 				return netv1alpha1.IngressSpec{}, err
 			}
-			rule := *makeIngressRule([]string{domain}, r.Namespace, visibility, targets[name])
+			rule := makeIngressRule([]string{domain}, r.Namespace, visibility, targets[name])
 			if networkConfig.TagHeaderBasedRouting {
 				if rule.HTTP.Paths[0].AppendHeaders == nil {
 					rule.HTTP.Paths[0].AppendHeaders = make(map[string]string)
@@ -203,8 +203,9 @@ func makeACMEIngressPaths(challenges map[string]netv1alpha1.HTTP01Challenge, dom
 	return paths
 }
 
-func makeIngressRule(domains []string, ns string, visibility netv1alpha1.IngressVisibility, targets traffic.RevisionTargets) *netv1alpha1.IngressRule {
-	return &netv1alpha1.IngressRule{
+func makeIngressRule(domains []string, ns string,
+	visibility netv1alpha1.IngressVisibility, targets traffic.RevisionTargets) netv1alpha1.IngressRule {
+	return netv1alpha1.IngressRule{
 		Hosts:      domains,
 		Visibility: visibility,
 		HTTP: &netv1alpha1.HTTPIngressRuleValue{

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -50,7 +50,7 @@ const (
 	testIngressClass    = "test-ingress"
 )
 
-func TestMakeIngress_CorrectMetadata(t *testing.T) {
+func TestMakeIngressCorrectMetadata(t *testing.T) {
 	targets := map[string]traffic.RevisionTargets{}
 	ingressClass := "ng-ingress"
 	passdownIngressClass := "ok-ingress"
@@ -515,8 +515,8 @@ func TestMakeIngressRule_Vanilla(t *testing.T) {
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
 	}
 
-	if !cmp.Equal(&expected, rule) {
-		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(&expected, rule))
+	if !cmp.Equal(expected, rule) {
+		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(expected, rule))
 	}
 }
 
@@ -561,8 +561,8 @@ func TestMakeIngressRule_ZeroPercentTarget(t *testing.T) {
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
 	}
 
-	if !cmp.Equal(&expected, rule) {
-		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(&expected, rule))
+	if !cmp.Equal(expected, rule) {
+		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(expected, rule))
 	}
 }
 
@@ -607,8 +607,8 @@ func TestMakeIngressRule_NilPercentTarget(t *testing.T) {
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
 	}
 
-	if !cmp.Equal(&expected, rule) {
-		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(&expected, rule))
+	if !cmp.Equal(expected, rule) {
+		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(expected, rule))
 	}
 }
 
@@ -665,8 +665,8 @@ func TestMakeIngressRule_TwoTargets(t *testing.T) {
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
 	}
 
-	if !cmp.Equal(&expected, rule) {
-		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(&expected, rule))
+	if !cmp.Equal(expected, rule) {
+		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(expected, rule))
 	}
 }
 
@@ -706,8 +706,8 @@ func TestMakeIngressRule_InactiveTarget(t *testing.T) {
 		},
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
 	}
-	if !cmp.Equal(&expected, rule) {
-		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(&expected, rule))
+	if !cmp.Equal(expected, rule) {
+		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(expected, rule))
 	}
 }
 
@@ -766,8 +766,8 @@ func TestMakeIngressRule_TwoInactiveTargets(t *testing.T) {
 		},
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
 	}
-	if !cmp.Equal(&expected, rule) {
-		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(&expected, rule))
+	if !cmp.Equal(expected, rule) {
+		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(expected, rule))
 	}
 }
 
@@ -811,8 +811,8 @@ func TestMakeIngressRule_ZeroPercentTargetInactive(t *testing.T) {
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
 	}
 
-	if !cmp.Equal(&expected, rule) {
-		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(&expected, rule))
+	if !cmp.Equal(expected, rule) {
+		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(expected, rule))
 	}
 }
 
@@ -856,12 +856,12 @@ func TestMakeIngressRule_NilPercentTargetInactive(t *testing.T) {
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
 	}
 
-	if !cmp.Equal(&expected, rule) {
-		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(&expected, rule))
+	if !cmp.Equal(expected, rule) {
+		t.Errorf("Unexpected rule (-want, +got): %s", cmp.Diff(expected, rule))
 	}
 }
 
-func TestMakeIngress_WithTLS(t *testing.T) {
+func TestMakeIngressWithTLS(t *testing.T) {
 	targets := map[string]traffic.RevisionTargets{}
 	ingressClass := "foo-ingress"
 	r := Route(ns, "test-route", WithRouteUID("1234-5678"), WithURL)
@@ -920,7 +920,7 @@ func TestMakeIngressTLS(t *testing.T) {
 	}
 }
 
-func TestMakeIngress_ACMEChallenges(t *testing.T) {
+func TestMakeIngressACMEChallenges(t *testing.T) {
 	targets := map[string]traffic.RevisionTargets{
 		traffic.DefaultTarget: {{
 			TrafficTarget: v1.TrafficTarget{
@@ -1022,7 +1022,7 @@ func TestMakeIngress_ACMEChallenges(t *testing.T) {
 
 }
 
-func TestMakeIngress_FailToGenerateDomain(t *testing.T) {
+func TestMakeIngressFailToGenerateDomain(t *testing.T) {
 	targets := map[string]traffic.RevisionTargets{
 		traffic.DefaultTarget: {{
 			TrafficTarget: v1.TrafficTarget{
@@ -1055,7 +1055,7 @@ func TestMakeIngress_FailToGenerateDomain(t *testing.T) {
 	}
 }
 
-func TestMakeIngress_FailToGenerateTagHost(t *testing.T) {
+func TestMakeIngressFailToGenerateTagHost(t *testing.T) {
 	targets := map[string]traffic.RevisionTargets{
 		traffic.DefaultTarget: {{
 			TrafficTarget: v1.TrafficTarget{

--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -188,7 +188,7 @@ func GetDesiredServiceNames(ctx context.Context, route *v1.Route) (sets.String, 
 	for _, t := range traffic {
 		serviceName, err := domains.HostnameFromTemplate(ctx, route.Name, t.Tag)
 		if err != nil {
-			return sets.String{}, err
+			return nil, err
 		}
 		names.Insert(serviceName)
 	}

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -22,10 +22,12 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving"


### PR DESCRIPTION
There's no reason to return a pointer since it's deref'd immideately.
Also gives a chance not to escape (though it will anyway outside tests).
Other minor nits.

/assign @tcnghia @ZhiminXiang 