### PR TITLE
Remove unused flag enable-multi-container

### DIFF
--- a/config/core/configmaps/defaults.yaml
+++ b/config/core/configmaps/defaults.yaml
@@ -108,6 +108,3 @@ data:
     # allow-container-concurrency-zero controls whether users can
     # specify 0 (i.e. unbounded) for containerConcurrency.
     allow-container-concurrency-zero: "true"
-
-    # feature flag indicates whether to enable multi container support or not
-    enable-multi-container: "false"

--- a/config/core/configmaps/defaults.yaml
+++ b/config/core/configmaps/defaults.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: 699f11f8
+    knative.dev/example-checksum: a63d266d
 data:
   _example: |
     ################################

--- a/pkg/apis/config/defaults_test.go
+++ b/pkg/apis/config/defaults_test.go
@@ -87,19 +87,6 @@ func TestDefaultsConfiguration(t *testing.T) {
 			"allow-container-concurrency-zero": "false",
 		},
 	}, {
-		name:    "invalid multi container flag value",
-		wantErr: false,
-		wantDefaults: &Defaults{
-			RevisionTimeoutSeconds:        DefaultRevisionTimeoutSeconds,
-			MaxRevisionTimeoutSeconds:     DefaultMaxRevisionTimeoutSeconds,
-			UserContainerNameTemplate:     DefaultUserContainerName,
-			ContainerConcurrencyMaxLimit:  DefaultMaxRevisionContainerConcurrency,
-			AllowContainerConcurrencyZero: DefaultAllowContainerConcurrencyZero,
-		},
-		data: map[string]string{
-			"enable-multi-container": "invalid",
-		},
-	}, {
 		name:    "invalid allow container concurrency zero flag value",
 		wantErr: false,
 		wantDefaults: &Defaults{


### PR DESCRIPTION

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Removed `enable-multi-container` which is handled by `config-features` configmap by `multi-container` flag