### PR TITLE
Use common const value for probe path

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -85,7 +85,6 @@ func (d dests) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 const (
 	probeTimeout          time.Duration = 300 * time.Millisecond
 	defaultProbeFrequency time.Duration = 200 * time.Millisecond
-	probePath                           = "/healthz"
 )
 
 // revisionWatcher watches the podIPs and ClusterIP of the service for a revision. It implements the logic
@@ -158,7 +157,7 @@ func (rw *revisionWatcher) probe(ctx context.Context, dest string) (bool, error)
 	httpDest := url.URL{
 		Scheme: "http",
 		Host:   dest,
-		Path:   probePath,
+		Path:   network.ProbePath,
 	}
 	// NOTE: changes below may require changes to testing/roundtripper.go to make unit tests passing.
 	return prober.Do(ctx, rw.transport, httpDest.String(),

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -34,6 +34,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"knative.dev/serving/pkg/autoscaler/metrics"
+	"knative.dev/serving/pkg/network"
 
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -61,7 +62,7 @@ func TestProbe(t *testing.T) {
 
 	defer server.Shutdown(0)
 	go server.listenAndServe()
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/healthz", server.listenAddr()), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", server.listenAddr(), network.ProbePath), nil)
 	if err != nil {
 		t.Fatal("Error creating request:", err)
 	}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -34,6 +34,10 @@ import (
 )
 
 const (
+	// ProbeHeaderName is the name of a path that activator, autoscaler and
+	// prober(used by KIngress generally) use for health check.
+	ProbePath = "/healthz"
+
 	// ProbeHeaderName is the name of a header that can be added to
 	// requests to probe the knative networking layer.  Requests
 	// with this header will not be passed to the user container or

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	// ProbeHeaderName is the name of a path that activator, autoscaler and
+	// ProbePath is the name of a path that activator, autoscaler and
 	// prober(used by KIngress generally) use for health check.
 	ProbePath = "/healthz"
 

--- a/pkg/network/status/status.go
+++ b/pkg/network/status/status.go
@@ -47,7 +47,6 @@ const (
 	probeConcurrency = 15
 	// probeTimeout defines the maximum amount of time a request will wait
 	probeTimeout = 1 * time.Second
-	probePath    = "/healthz"
 	// initialDelay defines the delay before enqueuing a probing request the first time.
 	// It gives times for the change to propagate and prevents unnecessary retries.
 	initialDelay = 200 * time.Millisecond
@@ -368,7 +367,7 @@ func (m *Prober) processWorkItem() bool {
 	}
 
 	probeURL := deepCopy(item.url)
-	probeURL.Path = path.Join(probeURL.Path, probePath)
+	probeURL.Path = path.Join(probeURL.Path, network.ProbePath)
 
 	ctx, cancel := context.WithTimeout(item.context, probeTimeout)
 	defer cancel()

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -117,7 +117,7 @@ func paToProbeTarget(pa *pav1alpha1.PodAutoscaler) string {
 	svc := pkgnet.GetServiceHostname(pa.Status.ServiceName, pa.Namespace)
 	port := networking.ServicePort(pa.Spec.ProtocolType)
 
-	return fmt.Sprintf("http://%s:%d/healthz", svc, port)
+	return fmt.Sprintf("http://%s:%d/%s", svc, port, network.ProbePath)
 }
 
 // activatorProbe returns true if via probe it determines that the

--- a/test/test_images/runtime/handlers/handler.go
+++ b/test/test_images/runtime/handlers/handler.go
@@ -30,7 +30,7 @@ import (
 func InitHandlers(mux *http.ServeMux) {
 	h := network.NewProbeHandler(withHeaders(withRequestLog(runtimeHandler)))
 	mux.HandleFunc("/", h.ServeHTTP)
-	mux.HandleFunc("/healthz", withRequestLog(withKubeletProbeHeaderCheck))
+	mux.HandleFunc(network.ProbePath, withRequestLog(withKubeletProbeHeaderCheck))
 }
 
 // withRequestLog logs each request before handling it.


### PR DESCRIPTION
## Proposed Changes

Autoscaler, activator and KIngres Prober commonly use the probe path
`/healthz`, but they defined it in each package.

This patch adds const value for ProbePath and use it from them.

Related to https://github.com/knative/serving/pull/7445

/lint

**Release Note**

```release-note
NONE
```
