### PR TITLE
Optimise initial startup readiness probing

### DIFF
--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -121,7 +121,6 @@ func TestProbeHandler(t *testing.T) {
 		name:          "false probe function",
 		prober:        func() bool { return false },
 		wantCode:      http.StatusServiceUnavailable,
-		wantBody:      "queue not ready",
 		requestHeader: queue.Name,
 	}}
 

--- a/pkg/queue/health/health_state.go
+++ b/pkg/queue/health/health_state.go
@@ -20,15 +20,8 @@ import (
 	"io"
 	"net/http"
 	"sync"
-)
 
-const (
-	// Return `queue` as body for 200 responses to indicate the response is from queue-proxy.
-	aliveBody = "queue"
-	// Return `queue not ready` as body for 503 response for queue not yet ready.
-	notAliveBody = "queue not ready"
-	// Return `shutting down` as body for 410 response if the queue got a shutdown request.
-	shuttingDownBody = "shutting down"
+	"knative.dev/serving/pkg/queue"
 )
 
 // State holds state about the current healthiness of the component.
@@ -92,21 +85,19 @@ func (h *State) drainFinished() {
 
 // HandleHealthProbe handles the probe according to the current state of the
 // health server. If isAggressive is false and prober has succeeded previously,
-// the function return success without probing user-container again (until
+// the function returns success without probing user-container again (until
 // shutdown).
 func (h *State) HandleHealthProbe(prober func() bool, isAggressive bool, w http.ResponseWriter) {
 	sendAlive := func() {
-		io.WriteString(w, aliveBody)
+		io.WriteString(w, queue.Name)
 	}
 
 	sendNotAlive := func() {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		io.WriteString(w, notAliveBody)
 	}
 
 	sendShuttingDown := func() {
 		w.WriteHeader(http.StatusGone)
-		io.WriteString(w, shuttingDownBody)
 	}
 
 	switch {

--- a/pkg/queue/health/health_state_test.go
+++ b/pkg/queue/health/health_state_test.go
@@ -21,6 +21,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"knative.dev/serving/pkg/queue"
 )
 
 func TestHealthStateSetsState(t *testing.T) {
@@ -72,74 +74,68 @@ func TestHealthStateHealthHandler(t *testing.T) {
 		state:        &State{alive: true},
 		isAggressive: false,
 		wantStatus:   http.StatusOK,
-		wantBody:     aliveBody,
+		wantBody:     queue.Name,
 	}, {
 		name:         "alive: false, prober: true, K-Probe",
 		state:        &State{alive: false},
 		prober:       func() bool { return true },
 		isAggressive: false,
 		wantStatus:   http.StatusOK,
-		wantBody:     aliveBody,
+		wantBody:     queue.Name,
 	}, {
 		name:         "alive: false, prober: false, K-Probe",
 		state:        &State{alive: false},
 		prober:       func() bool { return false },
 		isAggressive: false,
 		wantStatus:   http.StatusServiceUnavailable,
-		wantBody:     notAliveBody,
 	}, {
 		name:         "alive: false, no prober, K-Probe",
 		state:        &State{alive: false},
 		isAggressive: false,
 		wantStatus:   http.StatusOK,
-		wantBody:     aliveBody,
+		wantBody:     queue.Name,
 	}, {
 		name:         "shuttingDown: true, K-Probe",
 		state:        &State{shuttingDown: true},
 		isAggressive: false,
 		wantStatus:   http.StatusGone,
-		wantBody:     shuttingDownBody,
 	}, {
 		name:         "no prober, shuttingDown: false",
 		state:        &State{},
 		isAggressive: true,
 		wantStatus:   http.StatusOK,
-		wantBody:     aliveBody,
+		wantBody:     queue.Name,
 	}, {
 		name:         "prober: true, shuttingDown: true",
 		state:        &State{shuttingDown: true},
 		prober:       func() bool { return true },
 		isAggressive: true,
 		wantStatus:   http.StatusGone,
-		wantBody:     shuttingDownBody,
 	}, {
 		name:         "prober: true, shuttingDown: false",
 		state:        &State{},
 		prober:       func() bool { return true },
 		isAggressive: true,
 		wantStatus:   http.StatusOK,
-		wantBody:     aliveBody,
+		wantBody:     queue.Name,
 	}, {
 		name:         "prober: false, shuttingDown: false",
 		state:        &State{},
 		prober:       func() bool { return false },
 		isAggressive: true,
 		wantStatus:   http.StatusServiceUnavailable,
-		wantBody:     notAliveBody,
 	}, {
 		name:         "prober: false, shuttingDown: true",
 		state:        &State{},
 		prober:       func() bool { return false },
 		isAggressive: true,
 		wantStatus:   http.StatusServiceUnavailable,
-		wantBody:     notAliveBody,
 	}, {
 		name:         "alive: true, prober: false, shuttingDown: false",
 		state:        &State{alive: true},
 		prober:       func() bool { return false },
 		isAggressive: true,
 		wantStatus:   http.StatusServiceUnavailable,
-		wantBody:     notAliveBody,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
The probe response body is completely ignored in non-success cases.  Since we aggressively poll the server up to 40 times a second on startup, it's nice to shave off a little bit of network stack load if we can. Additionally, the Golang default transport disables connection re-use via keep-alives if the response body is not closed _and_ read to EOF, so always read to completion to avoid a lot of unnecessary connection creation overhead at startup-time.

Also, use `queue.Name` constant rather than `aliveBody` since this is the constant
actually used in the corresponding check in [revision_backends.go](https://github.com/knative/serving/blob/master/pkg/activator/net/revision_backends.go#L167).

/assign @markusthoemmes @vagababov 

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
