### PR TITLE
[master] Update net-certmanager nightly

### DIFF
--- a/third_party/cert-manager-0.12.0/net-certmanager.yaml
+++ b/third_party/cert-manager-0.12.0/net-certmanager.yaml
@@ -18,7 +18,7 @@ metadata:
   # These are the permissions needed by the `cert-manager` `Certificate` implementation.
   name: knative-serving-certmanager
   labels:
-    serving.knative.dev/release: "v20200612-92e2c6a"
+    serving.knative.dev/release: "v20200616-e96c1a1"
     serving.knative.dev/controller: "true"
     networking.knative.dev/certificate-provider: cert-manager
 rules:
@@ -49,7 +49,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.net-certmanager.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v20200612-92e2c6a"
+    serving.knative.dev/release: "v20200616-e96c1a1"
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -86,7 +86,7 @@ metadata:
   name: net-certmanager-webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200612-92e2c6a"
+    serving.knative.dev/release: "v20200616-e96c1a1"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -109,7 +109,7 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200612-92e2c6a"
+    serving.knative.dev/release: "v20200616-e96c1a1"
     networking.knative.dev/certificate-provider: cert-manager
 data:
   _example: |
@@ -156,7 +156,7 @@ metadata:
   name: networking-certmanager
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200612-92e2c6a"
+    serving.knative.dev/release: "v20200616-e96c1a1"
     networking.knative.dev/certificate-provider: cert-manager
 spec:
   selector:
@@ -168,14 +168,14 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: networking-certmanager
-        serving.knative.dev/release: "v20200612-92e2c6a"
+        serving.knative.dev/release: "v20200616-e96c1a1"
     spec:
       serviceAccountName: controller
       containers:
       - name: networking-certmanager
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/controller@sha256:24ebbe5c305ec3f36ff987ce330dabcd62c37e76b77b0c5f4cc77783eb6de2b6
+        image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/controller@sha256:ec59261bf095f2bab7c86a30fe43e5928aa366181a89304db0f4f36c9126a63c
         resources:
           requests:
             cpu: 30m
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   labels:
     app: networking-certmanager
-    serving.knative.dev/release: "v20200612-92e2c6a"
+    serving.knative.dev/release: "v20200616-e96c1a1"
     networking.knative.dev/certificate-provider: cert-manager
   name: networking-certmanager
   namespace: knative-serving
@@ -245,7 +245,7 @@ metadata:
   name: net-certmanager-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200612-92e2c6a"
+    serving.knative.dev/release: "v20200616-e96c1a1"
 spec:
   selector:
     matchLabels:
@@ -258,14 +258,14 @@ spec:
       labels:
         app: net-certmanager-webhook
         role: net-certmanager-webhook
-        serving.knative.dev/release: "v20200612-92e2c6a"
+        serving.knative.dev/release: "v20200616-e96c1a1"
     spec:
       serviceAccountName: controller
       containers:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/webhook@sha256:8a388a83088ebd3e397b7e81252c8ae4ba8e0a531e2b406ad62eb1f0037127b9
+        image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/webhook@sha256:4fbdcaa4ccd801cc053f5c3cfa57524e5bb32fd28eb472f77c4526c9c3a12185
         resources:
           requests:
             cpu: 20m
@@ -319,7 +319,7 @@ metadata:
   namespace: knative-serving
   labels:
     role: net-certmanager-webhook
-    serving.knative.dev/release: "v20200612-92e2c6a"
+    serving.knative.dev/release: "v20200616-e96c1a1"
 spec:
   ports:
   - # Define metrics and profiling for them to be accessible within service meshes.


### PR DESCRIPTION
<!--[master] Update net-certmanager nightly-->
<!---->
Produced via:
  `curl https://storage.googleapis.com/knative-nightly/net-certmanager/latest/$x > /workspace/source/./third_party/cert-manager-0.12.0/$x`
/assign tcnghia ZhiminXiang
/cc tcnghia ZhiminXiang
/test pull-knative-serving-autotls-tests
