### PR TITLE
Fix flake in canServeRequests

### DIFF
--- a/test/conformance/api/v1/generatename_test.go
+++ b/test/conformance/api/v1/generatename_test.go
@@ -83,7 +83,7 @@ func canServeRequests(t *testing.T, clients *test.Clients, route *v1.Route) erro
 		route.Name,
 		func(r *v1.Route) (bool, error) {
 			url = r.Status.URL.URL()
-			return url != nil, nil
+			return url.String() != "", nil
 		},
 		"RouteDomain",
 	)

--- a/test/conformance/api/v1alpha1/generatename_test.go
+++ b/test/conformance/api/v1alpha1/generatename_test.go
@@ -83,7 +83,7 @@ func canServeRequests(t *testing.T, clients *test.Clients, route *v1alpha1.Route
 		route.Name,
 		func(r *v1alpha1.Route) (bool, error) {
 			url = r.Status.URL.URL()
-			return url != nil, nil
+			return url.String() != "", nil
 		},
 		"RouteDomain",
 	)

--- a/test/conformance/api/v1beta1/generatename_test.go
+++ b/test/conformance/api/v1beta1/generatename_test.go
@@ -83,7 +83,7 @@ func canServeRequests(t *testing.T, clients *test.Clients, route *v1beta1.Route)
 		route.Name,
 		func(r *v1beta1.Route) (bool, error) {
 			url = r.Status.URL.URL()
-			return url != nil, nil
+			return url.String() != "", nil
 		},
 		"RouteDomain",
 	)


### PR DESCRIPTION
`Status.URL.URL()` is never nil because `Status.URL.URL()` [returns an empty URL if the receiver is nil](https://github.com/knative/pkg/blob/master/apis/url.go#L109), so `WaitForRouteState` always immediately succeeds here, even if the URL isn't updated yet. Use `String()` for comparison instead.

Fixes #8327.
