### PR TITLE
Disable fused multiply-subtract optimizations on activator calculations

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -254,9 +254,10 @@ func (a *Autoscaler) Scale(ctx context.Context, now time.Time) ScaleResult {
 		excessBCF = 0
 		// numAct stays 1, only needed to scale from 0.
 	case a.deciderSpec.TargetBurstCapacity > 0:
-		totCap := float64(originalReadyPodsCount) * a.deciderSpec.TotalValue
-		excessBCF = math.Floor(totCap - observedPanicValue -
-			a.deciderSpec.TargetBurstCapacity)
+		// Extra float64 cast disables fused multiply-subtract to force identical behavior on
+		// all platforms. See floating point section in https://golang.org/ref/spec#Operators.
+		totCap := float64(float64(originalReadyPodsCount) * a.deciderSpec.TotalValue)
+		excessBCF = math.Floor(totCap - a.deciderSpec.TargetBurstCapacity - observedPanicValue)
 		numAct = int32(math.Max(MinActivators,
 			math.Ceil((totCap+a.deciderSpec.TargetBurstCapacity)/a.deciderSpec.ActivatorCapacity)))
 	case a.deciderSpec.TargetBurstCapacity == -1:

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -70,7 +70,9 @@ func TestAutoscalerNoDataNoAutoscale(t *testing.T) {
 }
 
 func expectedEBC(totCap, targetBC, recordedConcurrency, numPods float64) int32 {
-	return int32(math.Floor(totCap/targetUtilization*numPods - targetBC - recordedConcurrency))
+	// Extra float64 cast disables fused multiply-subtract to force identical behavior on
+	// all platforms. See floating point section in https://golang.org/ref/spec#Operators.
+	return int32(math.Floor(float64(totCap/targetUtilization*numPods) - targetBC - recordedConcurrency))
 }
 
 func expectedNA(a *Autoscaler, numP float64) int32 {


### PR DESCRIPTION
Fixes TestAutoscalerPanicModeExponentialTrackAndStablize on arm64, ppc64le and s390x. These platforms aren't currently supported by Knative but it can be built from source on them and fixing this test will help any future porting efforts smoother. This is especially true since it is the only unit test that appears to fail on these platforms.

This change won't affect amd64 at all, except when using a compiler that supports fused multiply-subtract operations (e.g. gccgo or gollvm with -Ofast).

Ideally we'd make the tests and/or calculations more tolerant of minor variations in the output of individual floating point operations. Here the test failure is caused by a tiny numerical difference that is magnified by rounding down: `math.Floor(330.999...)` vs. `math.Floor(331.000...)`. I'm not certain of the best way to do that though and it would certainly be a much larger and more invasive change.

Thanks for taking a look!