### PR TITLE
Use t.Cleanup to dry up e2e tests

### DIFF
--- a/test/cleanup.go
+++ b/test/cleanup.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"testing"
 )
 
 func init() {
@@ -67,4 +68,17 @@ func TearDown(clients *Clients, names ResourceNames) {
 			[]string{names.Service},
 		)
 	}
+}
+
+// EnsureCleanup will run the provided cleanup function when the test ends,
+// either via t.Cleanup or on interrupt via CleanupOnInterrupt.
+func EnsureCleanup(t *testing.T, cleanup func()) {
+	t.Cleanup(cleanup)
+	CleanupOnInterrupt(cleanup)
+}
+
+// EnsureTearDown will delete created names when the test ends, either via
+// t.Cleanup, or on interrupt via EnsureCleanup.
+func EnsureTearDown(t *testing.T, clients *Clients, names ResourceNames) {
+	EnsureCleanup(t, func() { TearDown(clients, names) })
 }

--- a/test/cleanup.go
+++ b/test/cleanup.go
@@ -78,7 +78,7 @@ func EnsureCleanup(t *testing.T, cleanup func()) {
 }
 
 // EnsureTearDown will delete created names when the test ends, either via
-// t.Cleanup, or on interrupt via EnsureCleanup.
+// t.Cleanup, or on interrupt via CleanupOnInterrupt.
 func EnsureTearDown(t *testing.T, clients *Clients, names ResourceNames) {
 	EnsureCleanup(t, func() { TearDown(clients, names) })
 }

--- a/test/clients.go
+++ b/test/clients.go
@@ -200,8 +200,8 @@ func newServingClients(cfg *rest.Config, namespace string) (*ServingClients, err
 	}, nil
 }
 
-// Delete will delete all Routes and Configs with the names routes and configs, if clients
-// has been successfully initialized.
+// Delete will delete all Routes and Configs with the named routes and configs, if clients
+// have been successfully initialized.
 func (clients *ServingClients) Delete(routes []string, configs []string, services []string) []error {
 	deletions := []struct {
 		client interface {

--- a/test/conformance/api/v1/blue_green_test.go
+++ b/test/conformance/api/v1/blue_green_test.go
@@ -61,8 +61,7 @@ func TestBlueGreenRoute(t *testing.T) {
 		Image:   test.PizzaPlanet1,
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")

--- a/test/conformance/api/v1/configuration_test.go
+++ b/test/conformance/api/v1/configuration_test.go
@@ -38,8 +38,7 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 		Image:  test.PizzaPlanet1,
 	}
 
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	t.Logf("Creating new configuration %s", names.Config)
 	if _, err := v1test.CreateConfiguration(t, clients, names); err != nil {

--- a/test/conformance/api/v1/errorcondition_test.go
+++ b/test/conformance/api/v1/errorcondition_test.go
@@ -54,8 +54,7 @@ func TestContainerErrorMsg(t *testing.T) {
 		Image:   test.InvalidHelloWorld,
 	}
 
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	// Specify an invalid image path
 	// A valid DockerRepo is still needed, otherwise will get UNAUTHORIZED instead of container missing error
@@ -165,8 +164,7 @@ func TestContainerExitingMsg(t *testing.T) {
 				Image:  test.Failing,
 			}
 
-			defer test.TearDown(clients, names)
-			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+			test.EnsureTearDown(t, clients, names)
 
 			t.Logf("Creating a new Configuration %s", names.Config)
 

--- a/test/conformance/api/v1/generatename_test.go
+++ b/test/conformance/api/v1/generatename_test.go
@@ -120,8 +120,7 @@ func TestServiceGenerateName(t *testing.T) {
 	}
 
 	// Cleanup on test failure.
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer func() { test.TearDown(clients, names) }()
+	test.EnsureTearDown(t, clients, names)
 
 	// Create the service using the generate name field. If the service does not become ready this will fail.
 	t.Log("Creating new service with generateName", generateName)
@@ -156,8 +155,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 		Image: test.HelloWorld,
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer func() { test.TearDown(clients, names) }()
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating new configuration with generateName", generateName)
 	config, err := v1test.CreateConfiguration(t, clients, names, setConfigurationGenerateName(generateName))

--- a/test/conformance/api/v1/migration_test.go
+++ b/test/conformance/api/v1/migration_test.go
@@ -44,8 +44,7 @@ func TestTranslation(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Service")
 	// Create a legacy RunLatest service.  This should perform conversion during the webhook
@@ -88,8 +87,7 @@ func TestV1beta1Rejection(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Service")
 	// Create a legacy RunLatest service, but give it the TypeMeta of v1.

--- a/test/conformance/api/v1/resources_test.go
+++ b/test/conformance/api/v1/resources_test.go
@@ -53,8 +53,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 		Image:   test.Autoscale,
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	objects, err := v1test.CreateServiceReady(t, clients, &names, withResources)
 	if err != nil {

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -132,8 +132,7 @@ func TestRevisionTimeout(t *testing.T) {
 				Image:   test.Timeout,
 			}
 
-			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-			defer test.TearDown(clients, names)
+			test.EnsureTearDown(t, clients, names)
 
 			t.Log("Creating a new Service ")
 			_, err := createService(t, clients, names, tc.timeoutSeconds)

--- a/test/conformance/api/v1/route_test.go
+++ b/test/conformance/api/v1/route_test.go
@@ -107,8 +107,7 @@ func TestRouteCreation(t *testing.T) {
 		Image:         test.PizzaPlanet1,
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Route and Configuration")
 	config, err := v1test.CreateConfiguration(t, clients, names)

--- a/test/conformance/api/v1/service_account_test.go
+++ b/test/conformance/api/v1/service_account_test.go
@@ -40,8 +40,7 @@ func TestServiceAccountValidation(t *testing.T) {
 		Image:   test.PizzaPlanet1,
 	}
 
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	t.Logf("Creating a new Service %s", names.Service)
 	service := v1test.Service(names, WithServiceAccountName(invalidServiceAccountName))

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -50,8 +50,7 @@ func TestService(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	// Setup initial Service
 	objects, err := v1test.CreateServiceReady(t, clients, &names)
@@ -190,8 +189,7 @@ func TestServiceBYOName(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	revName := names.Service + "-byoname"
 
@@ -254,8 +252,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   test.PizzaPlanet1,
 	}
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	// Expected Text for different revisions.
 	const (
@@ -493,8 +490,7 @@ func TestAnnotationPropagation(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	// Setup initial Service
 	objects, err := v1test.CreateServiceReady(t, clients, &names)

--- a/test/conformance/api/v1/single_threaded_test.go
+++ b/test/conformance/api/v1/single_threaded_test.go
@@ -43,8 +43,7 @@ func TestSingleConcurrency(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   test.SingleThreadedImage,
 	}
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	objects, err := v1test.CreateServiceReady(t, clients, &names, rtesting.WithContainerConcurrency(1))
 	if err != nil {

--- a/test/conformance/api/v1/volumes_test.go
+++ b/test/conformance/api/v1/volumes_test.go
@@ -60,16 +60,13 @@ func TestConfigMapVolume(t *testing.T) {
 	}
 	t.Log("Successfully created configMap:", configMap)
 
-	cleanup := func() {
+	// Clean up on test failure or interrupt
+	test.EnsureCleanup(t, func() {
 		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(configMap.Name, nil); err != nil {
 			t.Errorf("ConfigMaps().Delete() = %v", err)
 		}
-	}
-
-	// Clean up on test failure or interrupt
-	defer cleanup()
-	test.CleanupOnInterrupt(cleanup)
+	})
 
 	withVolume := WithVolume("asdf", filepath.Dir(test.HelloVolumePath), corev1.VolumeSource{
 		ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -130,16 +127,13 @@ func TestProjectedConfigMapVolume(t *testing.T) {
 	}
 	t.Log("Successfully created configMap:", configMap)
 
-	cleanup := func() {
+	// Clean up on test failure or interrupt
+	test.EnsureCleanup(t, func() {
 		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(configMap.Name, nil); err != nil {
 			t.Errorf("ConfigMaps().Delete() = %v", err)
 		}
-	}
-
-	// Clean up on test failure or interrupt
-	defer cleanup()
-	test.CleanupOnInterrupt(cleanup)
+	})
 
 	withVolume := WithVolume("asdf", filepath.Dir(test.HelloVolumePath), corev1.VolumeSource{
 		Projected: &corev1.ProjectedVolumeSource{
@@ -202,16 +196,13 @@ func TestSecretVolume(t *testing.T) {
 	}
 	t.Log("Successfully created secret:", secret)
 
-	cleanup := func() {
+	// Clean up on test failure or interrupt
+	test.EnsureCleanup(t, func() {
 		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
-	}
-
-	// Clean up on test failure or interrupt
-	defer cleanup()
-	test.CleanupOnInterrupt(cleanup)
+	})
 
 	withVolume := WithVolume("asdf", filepath.Dir(test.HelloVolumePath), corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
@@ -268,16 +259,13 @@ func TestProjectedSecretVolume(t *testing.T) {
 	}
 	t.Log("Successfully created secret:", secret)
 
-	cleanup := func() {
+	// Clean up on test failure or interrupt
+	test.EnsureCleanup(t, func() {
 		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
-	}
-
-	// Clean up on test failure or interrupt
-	defer cleanup()
-	test.CleanupOnInterrupt(cleanup)
+	})
 
 	withVolume := WithVolume("asdf", filepath.Dir(test.HelloVolumePath), corev1.VolumeSource{
 		Projected: &corev1.ProjectedVolumeSource{
@@ -355,16 +343,13 @@ func TestProjectedComplex(t *testing.T) {
 	}
 	t.Log("Successfully created secret:", secret)
 
-	cleanup := func() {
+	// Clean up on test failure or interrupt
+	test.EnsureCleanup(t, func() {
 		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
-	}
-
-	// Clean up on test failure or interrupt
-	defer cleanup()
-	test.CleanupOnInterrupt(cleanup)
+	})
 
 	withVolume := WithVolume("asdf", filepath.Dir(test.HelloVolumePath), corev1.VolumeSource{
 		Projected: &corev1.ProjectedVolumeSource{

--- a/test/conformance/api/v1alpha1/blue_green_test.go
+++ b/test/conformance/api/v1alpha1/blue_green_test.go
@@ -61,8 +61,7 @@ func TestBlueGreenRoute(t *testing.T) {
 		Image:   test.PizzaPlanet1,
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")

--- a/test/conformance/api/v1alpha1/configuration_test.go
+++ b/test/conformance/api/v1alpha1/configuration_test.go
@@ -38,8 +38,7 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 		Image:  test.PizzaPlanet1,
 	}
 
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	t.Logf("Creating new configuration %s", names.Config)
 	if _, err := v1a1test.CreateConfiguration(t, clients, names); err != nil {

--- a/test/conformance/api/v1alpha1/errorcondition_test.go
+++ b/test/conformance/api/v1alpha1/errorcondition_test.go
@@ -53,8 +53,7 @@ func TestContainerErrorMsg(t *testing.T) {
 		Image:   test.InvalidHelloWorld,
 	}
 
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	// Specify an invalid image path
 	// A valid DockerRepo is still needed, otherwise will get UNAUTHORIZED instead of container missing error
@@ -163,8 +162,7 @@ func TestContainerExitingMsg(t *testing.T) {
 				Image:  test.Failing,
 			}
 
-			defer test.TearDown(clients, names)
-			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+			test.EnsureTearDown(t, clients, names)
 
 			t.Logf("Creating a new Configuration %s", names.Config)
 

--- a/test/conformance/api/v1alpha1/generatename_test.go
+++ b/test/conformance/api/v1alpha1/generatename_test.go
@@ -120,8 +120,7 @@ func TestServiceGenerateName(t *testing.T) {
 	}
 
 	// Cleanup on test failure.
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer func() { test.TearDown(clients, names) }()
+	test.EnsureTearDown(t, clients, names)
 
 	// Create the service using the generate name field. If the service does not become ready this will fail.
 	t.Log("Creating new service with generateName", generateName)
@@ -157,8 +156,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 		Image: test.HelloWorld,
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer func() { test.TearDown(clients, names) }()
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating new configuration with generateName", generateName)
 	config, err := v1a1test.CreateConfiguration(t, clients, names, setConfigurationGenerateName(generateName))

--- a/test/conformance/api/v1alpha1/resources_test.go
+++ b/test/conformance/api/v1alpha1/resources_test.go
@@ -52,8 +52,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 		Image:   test.Autoscale,
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
 		v1a1opts.WithResourceRequirements(resources))

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -130,8 +130,7 @@ func TestRevisionTimeout(t *testing.T) {
 				Image:   test.Timeout,
 			}
 
-			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-			defer test.TearDown(clients, names)
+			test.EnsureTearDown(t, clients, names)
 
 			t.Log("Creating a new Service ")
 			_, err := createLatestService(t, clients, names, tc.timeoutSeconds)

--- a/test/conformance/api/v1alpha1/route_test.go
+++ b/test/conformance/api/v1alpha1/route_test.go
@@ -104,8 +104,7 @@ func TestRouteCreation(t *testing.T) {
 		Image:         test.PizzaPlanet1,
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Route and Configuration")
 	config, err := v1a1test.CreateConfiguration(t, clients, names)

--- a/test/conformance/api/v1alpha1/service_test.go
+++ b/test/conformance/api/v1alpha1/service_test.go
@@ -49,8 +49,7 @@ func TestRunLatestService(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	// Setup initial Service
 	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)
@@ -190,8 +189,7 @@ func TestRunLatestServiceBYOName(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	revName := names.Service + "-byoname"
 
@@ -255,8 +253,7 @@ func TestReleaseService(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   test.PizzaPlanet1,
 	}
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	// Expected Text for different revisions.
 	const (
@@ -526,8 +523,7 @@ func TestAnnotationPropagation(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	// Setup initial Service
 	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)

--- a/test/conformance/api/v1alpha1/single_threaded_test.go
+++ b/test/conformance/api/v1alpha1/single_threaded_test.go
@@ -42,8 +42,7 @@ func TestSingleConcurrency(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   test.SingleThreadedImage,
 	}
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
 		v1a1opts.WithContainerConcurrency(1))

--- a/test/conformance/api/v1alpha1/volumes_test.go
+++ b/test/conformance/api/v1alpha1/volumes_test.go
@@ -60,16 +60,13 @@ func TestConfigMapVolume(t *testing.T) {
 	}
 	t.Log("Successfully created configMap:", configMap)
 
-	cleanup := func() {
+	// Clean up on test failure or interrupt
+	test.EnsureCleanup(t, func() {
 		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(configMap.Name, nil); err != nil {
 			t.Errorf("ConfigMaps().Delete() = %v", err)
 		}
-	}
-
-	// Clean up on test failure or interrupt
-	defer cleanup()
-	test.CleanupOnInterrupt(cleanup)
+	})
 
 	withVolume := WithVolume("asdf", filepath.Dir(test.HelloVolumePath), corev1.VolumeSource{
 		ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -131,16 +128,13 @@ func TestProjectedConfigMapVolume(t *testing.T) {
 	}
 	t.Log("Successfully created configMap:", configMap)
 
-	cleanup := func() {
+	// Clean up on test failure or interrupt
+	test.EnsureCleanup(t, func() {
 		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(configMap.Name, nil); err != nil {
 			t.Errorf("ConfigMaps().Delete() = %v", err)
 		}
-	}
-
-	// Clean up on test failure or interrupt
-	defer cleanup()
-	test.CleanupOnInterrupt(cleanup)
+	})
 
 	withVolume := WithVolume("asdf", filepath.Dir(test.HelloVolumePath), corev1.VolumeSource{
 		Projected: &corev1.ProjectedVolumeSource{
@@ -204,16 +198,13 @@ func TestSecretVolume(t *testing.T) {
 	}
 	t.Log("Successfully created secret:", secret)
 
-	cleanup := func() {
+	// Clean up on test failure or interrupt
+	test.EnsureCleanup(t, func() {
 		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
-	}
-
-	// Clean up on test failure or interrupt
-	defer cleanup()
-	test.CleanupOnInterrupt(cleanup)
+	})
 
 	withVolume := WithVolume("asdf", filepath.Dir(test.HelloVolumePath), corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
@@ -271,16 +262,13 @@ func TestProjectedSecretVolume(t *testing.T) {
 	}
 	t.Log("Successfully created secret:", secret)
 
-	cleanup := func() {
+	// Clean up on test failure or interrupt
+	test.EnsureCleanup(t, func() {
 		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
-	}
-
-	// Clean up on test failure or interrupt
-	defer cleanup()
-	test.CleanupOnInterrupt(cleanup)
+	})
 
 	withVolume := WithVolume("asdf", filepath.Dir(test.HelloVolumePath), corev1.VolumeSource{
 		Projected: &corev1.ProjectedVolumeSource{
@@ -359,16 +347,13 @@ func TestProjectedComplex(t *testing.T) {
 	}
 	t.Log("Successfully created secret:", secret)
 
-	cleanup := func() {
+	// Clean up on test failure or interrupt
+	test.EnsureCleanup(t, func() {
 		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
-	}
-
-	// Clean up on test failure or interrupt
-	defer cleanup()
-	test.CleanupOnInterrupt(cleanup)
+	})
 
 	withVolume := WithVolume("asdf", filepath.Dir(test.HelloVolumePath), corev1.VolumeSource{
 		Projected: &corev1.ProjectedVolumeSource{

--- a/test/conformance/api/v1beta1/blue_green_test.go
+++ b/test/conformance/api/v1beta1/blue_green_test.go
@@ -61,8 +61,7 @@ func TestBlueGreenRoute(t *testing.T) {
 		Image:   test.PizzaPlanet1,
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")

--- a/test/conformance/api/v1beta1/configuration_test.go
+++ b/test/conformance/api/v1beta1/configuration_test.go
@@ -38,8 +38,7 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 		Image:  test.PizzaPlanet1,
 	}
 
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	t.Logf("Creating new configuration %s", names.Config)
 	if _, err := v1b1test.CreateConfiguration(t, clients, names); err != nil {

--- a/test/conformance/api/v1beta1/errorcondition_test.go
+++ b/test/conformance/api/v1beta1/errorcondition_test.go
@@ -54,8 +54,7 @@ func TestContainerErrorMsg(t *testing.T) {
 		Image:   test.InvalidHelloWorld,
 	}
 
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	// Specify an invalid image path
 	// A valid DockerRepo is still needed, otherwise will get UNAUTHORIZED instead of container missing error
@@ -165,8 +164,7 @@ func TestContainerExitingMsg(t *testing.T) {
 				Image:  test.Failing,
 			}
 
-			defer test.TearDown(clients, names)
-			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+			test.EnsureTearDown(t, clients, names)
 
 			t.Logf("Creating a new Configuration %s", names.Config)
 

--- a/test/conformance/api/v1beta1/generatename_test.go
+++ b/test/conformance/api/v1beta1/generatename_test.go
@@ -120,8 +120,7 @@ func TestServiceGenerateName(t *testing.T) {
 	}
 
 	// Cleanup on test failure.
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer func() { test.TearDown(clients, names) }()
+	test.EnsureTearDown(t, clients, names)
 
 	// Create the service using the generate name field. If the serivce does not become ready this will fail.
 	t.Log("Creating new service with generateName", generateName)
@@ -156,8 +155,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 		Image: test.HelloWorld,
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer func() { test.TearDown(clients, names) }()
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating new configuration with generateName", generateName)
 	config, err := v1b1test.CreateConfiguration(t, clients, names, setConfigurationGenerateName(generateName))

--- a/test/conformance/api/v1beta1/migration_test.go
+++ b/test/conformance/api/v1beta1/migration_test.go
@@ -44,8 +44,7 @@ func TestTranslation(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Service")
 	// Create a legacy RunLatest service.  This should perform conversion during the webhook
@@ -88,8 +87,7 @@ func TestV1beta1Rejection(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Service")
 	// Create a legacy RunLatest service, but give it the TypeMeta of v1beta1.

--- a/test/conformance/api/v1beta1/resources_test.go
+++ b/test/conformance/api/v1beta1/resources_test.go
@@ -53,8 +53,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 		Image:   test.Autoscale,
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	objects, err := v1b1test.CreateServiceReady(t, clients, &names, withResources)
 	if err != nil {

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -130,8 +130,7 @@ func TestRevisionTimeout(t *testing.T) {
 				Image:   test.Timeout,
 			}
 
-			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-			defer test.TearDown(clients, names)
+			test.EnsureTearDown(t, clients, names)
 
 			t.Log("Creating a new Service ")
 			_, err := createService(t, clients, names, tc.timeoutSeconds)

--- a/test/conformance/api/v1beta1/route_test.go
+++ b/test/conformance/api/v1beta1/route_test.go
@@ -107,8 +107,7 @@ func TestRouteCreation(t *testing.T) {
 		Image:         test.PizzaPlanet1,
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Route and Configuration")
 	config, err := v1b1test.CreateConfiguration(t, clients, names)

--- a/test/conformance/api/v1beta1/service_account_test.go
+++ b/test/conformance/api/v1beta1/service_account_test.go
@@ -40,8 +40,7 @@ func TestServiceAccountValidation(t *testing.T) {
 		Image:   test.PizzaPlanet1,
 	}
 
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	t.Logf("Creating a new Service %s", names.Service)
 	service := v1b1test.Service(names, WithServiceAccountName(invalidServiceAccountName))

--- a/test/conformance/api/v1beta1/service_test.go
+++ b/test/conformance/api/v1beta1/service_test.go
@@ -51,8 +51,7 @@ func TestService(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	// Setup initial Service
 	objects, err := v1b1test.CreateServiceReady(t, clients, &names)
@@ -191,8 +190,7 @@ func TestServiceBYOName(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	revName := names.Service + "-byoname"
 
@@ -255,8 +253,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   test.PizzaPlanet1,
 	}
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	// Expected Text for different revisions.
 	const (
@@ -494,8 +491,7 @@ func TestAnnotationPropagation(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	// Setup initial Service
 	objects, err := v1b1test.CreateServiceReady(t, clients, &names)

--- a/test/conformance/api/v1beta1/single_threaded_test.go
+++ b/test/conformance/api/v1beta1/single_threaded_test.go
@@ -43,8 +43,7 @@ func TestSingleConcurrency(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   test.SingleThreadedImage,
 	}
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	objects, err := v1b1test.CreateServiceReady(t, clients, &names, rtesting.WithContainerConcurrency(1))
 	if err != nil {

--- a/test/conformance/api/v1beta1/volumes_test.go
+++ b/test/conformance/api/v1beta1/volumes_test.go
@@ -60,16 +60,13 @@ func TestConfigMapVolume(t *testing.T) {
 	}
 	t.Log("Successfully created configMap:", configMap)
 
-	cleanup := func() {
+	// Clean up on test failure or interrupt
+	test.EnsureCleanup(t, func() {
 		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(configMap.Name, nil); err != nil {
 			t.Errorf("ConfigMaps().Delete() = %v", err)
 		}
-	}
-
-	// Clean up on test failure or interrupt
-	defer cleanup()
-	test.CleanupOnInterrupt(cleanup)
+	})
 
 	withVolume := WithVolume("asdf", filepath.Dir(test.HelloVolumePath), corev1.VolumeSource{
 		ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -130,16 +127,13 @@ func TestProjectedConfigMapVolume(t *testing.T) {
 	}
 	t.Log("Successfully created configMap:", configMap)
 
-	cleanup := func() {
+	// Clean up on test failure or interrupt
+	test.EnsureCleanup(t, func() {
 		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(configMap.Name, nil); err != nil {
 			t.Errorf("ConfigMaps().Delete() = %v", err)
 		}
-	}
-
-	// Clean up on test failure or interrupt
-	defer cleanup()
-	test.CleanupOnInterrupt(cleanup)
+	})
 
 	withVolume := WithVolume("asdf", filepath.Dir(test.HelloVolumePath), corev1.VolumeSource{
 		Projected: &corev1.ProjectedVolumeSource{
@@ -202,16 +196,13 @@ func TestSecretVolume(t *testing.T) {
 	}
 	t.Log("Successfully created secret:", secret)
 
-	cleanup := func() {
+	// Clean up on test failure or interrupt
+	test.EnsureCleanup(t, func() {
 		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
-	}
-
-	// Clean up on test failure or interrupt
-	defer cleanup()
-	test.CleanupOnInterrupt(cleanup)
+	})
 
 	withVolume := WithVolume("asdf", filepath.Dir(test.HelloVolumePath), corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
@@ -268,16 +259,13 @@ func TestProjectedSecretVolume(t *testing.T) {
 	}
 	t.Log("Successfully created secret:", secret)
 
-	cleanup := func() {
+	// Clean up on test failure or interrupt
+	test.EnsureCleanup(t, func() {
 		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
-	}
-
-	// Clean up on test failure or interrupt
-	defer cleanup()
-	test.CleanupOnInterrupt(cleanup)
+	})
 
 	withVolume := WithVolume("asdf", filepath.Dir(test.HelloVolumePath), corev1.VolumeSource{
 		Projected: &corev1.ProjectedVolumeSource{
@@ -355,16 +343,13 @@ func TestProjectedComplex(t *testing.T) {
 	}
 	t.Log("Successfully created secret:", secret)
 
-	cleanup := func() {
+	// Clean up on test failure or interrupt
+	test.EnsureCleanup(t, func() {
 		test.TearDown(clients, names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
-	}
-
-	// Clean up on test failure or interrupt
-	defer cleanup()
-	test.CleanupOnInterrupt(cleanup)
+	})
 
 	withVolume := WithVolume("asdf", filepath.Dir(test.HelloVolumePath), corev1.VolumeSource{
 		Projected: &corev1.ProjectedVolumeSource{

--- a/test/conformance/certificate/http01/certificate.go
+++ b/test/conformance/certificate/http01/certificate.go
@@ -36,8 +36,7 @@ func TestHTTP01Challenge(t *testing.T) {
 	}
 
 	for _, domains := range certDomains {
-		cert, cancel := utils.CreateCertificate(t, clients, domains)
-		defer cancel()
+		cert := utils.CreateCertificate(t, clients, domains)
 
 		if err := utils.WaitForCertificateState(clients.NetworkingClient, cert.Name,
 			func(c *v1alpha1.Certificate) (bool, error) {

--- a/test/conformance/certificate/nonhttp01/certificate.go
+++ b/test/conformance/certificate/nonhttp01/certificate.go
@@ -28,8 +28,7 @@ func TestSecret(t *testing.T) {
 	clients := test.Setup(t)
 	certName := test.ObjectNameForTest(t) + ".example.com"
 
-	cert, cancel := utils.CreateCertificate(t, clients, []string{certName})
-	defer cancel()
+	cert := utils.CreateCertificate(t, clients, []string{certName})
 
 	t.Logf("Waiting for Certificate %q to transition to Ready", cert.Name)
 	if err := utils.WaitForCertificateState(clients.NetworkingClient, cert.Name, utils.IsCertificateReady, "CertificateIsReady"); err != nil {

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -73,8 +73,7 @@ func TestProbeRuntime(t *testing.T) {
 				Image:   test.Runtime,
 			}
 
-			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-			defer test.TearDown(clients, names)
+			test.EnsureTearDown(t, clients, names)
 
 			t.Log("Creating a new Service")
 			resources, err := v1test.CreateServiceReady(t, clients, &names,

--- a/test/conformance/runtime/util.go
+++ b/test/conformance/runtime/util.go
@@ -41,8 +41,7 @@ func fetchRuntimeInfo(
 	t.Helper()
 	names.Service = test.ObjectNameForTest(t)
 
-	defer test.TearDown(clients, *names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, *names) })
+	test.EnsureTearDown(t, clients, *names)
 
 	serviceOpts, reqOpts, err := splitOpts(opts...)
 	if err != nil {

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -54,8 +54,7 @@ func TestActivatorOverload(t *testing.T) {
 		Image:   "timeout",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a service with run latest configuration.")
 	// Create a service with concurrency 1 that sleeps for N ms.

--- a/test/e2e/autoscale.go
+++ b/test/e2e/autoscale.go
@@ -179,8 +179,8 @@ func toPercentageString(f float64) string {
 // setup creates a new service, with given service options.
 // It returns a testContext that has resources, K8s clients and other needed
 // data points.
-// It sets up CleanupOnInterrupt as well that will destroy the resources
-// when the test terminates.
+// It sets up EnsureTearDown to ensure that resources are cleaned up when the
+// test terminates.
 func setup(t *testing.T, class, metric string, target int, targetUtilization float64, image string, validate validationFunc, fopts ...rtesting.ServiceOption) *testContext {
 	t.Helper()
 	clients := Setup(t)
@@ -190,7 +190,7 @@ func setup(t *testing.T, class, metric string, target int, targetUtilization flo
 		Service: test.ObjectNameForTest(t),
 		Image:   image,
 	}
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 	resources, err := v1test.CreateServiceReady(t, clients, &names,
 		append([]rtesting.ServiceOption{
 			rtesting.WithConfigAnnotations(map[string]string{
@@ -378,7 +378,6 @@ func RunAutoscaleUpCountPods(t *testing.T, class, metric string) {
 	}
 
 	ctx := setup(t, class, metric, target, targetUtilization, autoscaleTestImageName, validateEndpoint)
-	defer test.TearDown(ctx.clients, ctx.names)
 
 	ctx.t.Log("The autoscaler spins up additional replicas when traffic increases.")
 	// note: without the warm-up / gradual increase of load the test is retrieving a 503 (overload) from the envoy

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -43,7 +43,6 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 	defer cancel()
 
 	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency, containerConcurrency, targetUtilization, autoscaleTestImageName, validateEndpoint)
-	defer test.TearDown(ctx.clients, ctx.names)
 
 	assertAutoscaleUpToNumPods(ctx, 1, 2, 60*time.Second, true)
 	assertScaleDown(ctx)
@@ -95,7 +94,6 @@ func TestTargetBurstCapacity(t *testing.T) {
 			autoscaling.TargetBurstCapacityKey:                "7",
 			autoscaling.PanicThresholdPercentageAnnotationKey: "200", // makes panicking rare
 		}))
-	defer test.TearDown(ctx.clients, ctx.names)
 
 	cfg, err := autoscalerCM(ctx.clients)
 	if err != nil {
@@ -162,7 +160,6 @@ func TestTargetBurstCapacityMinusOne(t *testing.T) {
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 		}))
-	defer test.TearDown(ctx.clients, ctx.names)
 
 	_, err := autoscalerCM(ctx.clients)
 	if err != nil {
@@ -191,7 +188,6 @@ func TestFastScaleToZero(t *testing.T) {
 			autoscaling.TargetBurstCapacityKey: "-1",
 			autoscaling.WindowAnnotationKey:    autoscaling.WindowMin.String(),
 		}))
-	defer test.TearDown(ctx.clients, ctx.names)
 
 	cfg, err := autoscalerCM(ctx.clients)
 	if err != nil {

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -65,8 +65,7 @@ func testAutoTLS(t *testing.T) {
 	if len(env.TLSServiceName) != 0 {
 		names.Service = env.TLSServiceName
 	}
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	objects, err := v1test.CreateServiceReady(t, clients, &names)
 	if err != nil {

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -60,8 +60,7 @@ func TestDestroyPodInflight(t *testing.T) {
 		Route:  svcName,
 		Image:  "timeout",
 	}
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Route and Configuration")
 	if _, err := v1test.CreateConfiguration(t, clients, names, rtesting.WithConfigRevisionTimeoutSeconds(revisionTimeoutSeconds)); err != nil {
@@ -170,8 +169,7 @@ func TestDestroyPodTimely(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	objects, err := v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
@@ -255,8 +253,7 @@ func TestDestroyPodWithRequests(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   "autoscale",
 	}
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	objects, err := v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))

--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -42,8 +42,7 @@ func TestEgressTraffic(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   "httpproxy",
 	}
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	service, err := v1.CreateServiceReady(t, clients, &names,
 		rtesting.WithEnv(corev1.EnvVar{

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -337,8 +337,7 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 
 	fopts = append(fopts, rtesting.WithNamedPort("h2c"))
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 	resources, err := v1test.CreateServiceReady(t, clients, &names, fopts...)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -46,8 +46,7 @@ func TestHelloWorld(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Service")
 
@@ -98,8 +97,7 @@ func TestQueueSideCarResourceLimit(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Service")
 	resources, err := v1test.CreateServiceReady(t, clients, &names,

--- a/test/e2e/image_pull_error_test.go
+++ b/test/e2e/image_pull_error_test.go
@@ -41,8 +41,7 @@ func TestImagePullError(t *testing.T) {
 		Image: "ubuntu@sha256:0000000000000000000000000000000000000000000000000000000000000000",
 	}
 
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	t.Logf("Creating a new Service %s", names.Image)
 	var (

--- a/test/e2e/initial_scale_test.go
+++ b/test/e2e/initial_scale_test.go
@@ -47,8 +47,8 @@ func TestInitScaleZero(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   "helloworld",
 	}
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Service with initial scale zero and verifying that no pods are created")
 	createAndVerifyInitialScaleService(t, clients, names, 0)
@@ -67,8 +67,7 @@ func TestInitScalePositive(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   "helloworld",
 	}
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Service with initialScale 3 and verifying that pods are created")
 	createAndVerifyInitialScaleService(t, clients, names, 3)

--- a/test/e2e/istio/authorization_test.go
+++ b/test/e2e/istio/authorization_test.go
@@ -52,8 +52,7 @@ func TestClusterLocalAuthorization(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	withInternalVisibility := rtesting.WithServiceLabel(
 		serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
@@ -91,8 +90,7 @@ func TestClusterLocalAuthorization(t *testing.T) {
 		Image:   "httpproxy",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	resources, err = v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithEnv(envVars...),

--- a/test/e2e/istio/probing_test.go
+++ b/test/e2e/istio/probing_test.go
@@ -60,12 +60,15 @@ func TestIstioProbing(t *testing.T) {
 
 	clients := e2e.Setup(t)
 	namespace := system.Namespace()
+
 	// Save the current Gateway to restore it after the test
 	oldGateway, err := clients.IstioClient.NetworkingV1alpha3().Gateways(namespace).Get(networking.KnativeIngressGateway, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get Gateway %s/%s", namespace, networking.KnativeIngressGateway)
 	}
-	restore := func() {
+
+	// After the test ends, restore the old gateway
+	test.EnsureCleanup(t, func() {
 		curGateway, err := clients.IstioClient.NetworkingV1alpha3().Gateways(namespace).Get(networking.KnativeIngressGateway, metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("Failed to get Gateway %s/%s", namespace, networking.KnativeIngressGateway)
@@ -74,9 +77,7 @@ func TestIstioProbing(t *testing.T) {
 		if _, err := clients.IstioClient.NetworkingV1alpha3().Gateways(namespace).Update(curGateway); err != nil {
 			t.Fatalf("Failed to restore Gateway %s/%s: %v", namespace, networking.KnativeIngressGateway, err)
 		}
-	}
-	test.CleanupOnInterrupt(restore)
-	defer restore()
+	})
 
 	// Create a dummy service to get the domain name
 	var domain string
@@ -260,8 +261,7 @@ func TestIstioProbing(t *testing.T) {
 			setupGateway(t, clients, names, domain, namespace, c.servers)
 
 			// Create the service and wait for it to be ready
-			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-			defer test.TearDown(clients, names)
+			test.EnsureTearDown(t, clients, names)
 			_, err = v1test.CreateServiceReady(t, clients, &names)
 			if err != nil {
 				t.Fatalf("Failed to create Service %s: %v", names.Service, err)

--- a/test/e2e/logging_test.go
+++ b/test/e2e/logging_test.go
@@ -51,11 +51,7 @@ func TestRequestLogs(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	cleanup := func() {
-		test.TearDown(clients, names)
-	}
-	test.CleanupOnInterrupt(cleanup)
-	t.Cleanup(cleanup)
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Service")
 

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -52,8 +52,7 @@ func TestMinScale(t *testing.T) {
 		Image:  "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating route")
 	if _, err := v1test.CreateRoute(t, clients, names); err != nil {

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -62,8 +62,7 @@ func TestMultipleNamespace(t *testing.T) {
 		Service: serviceName,
 		Image:   test.PizzaPlanet1,
 	}
-	test.CleanupOnInterrupt(func() { test.TearDown(defaultClients, defaultResources) })
-	defer test.TearDown(defaultClients, defaultResources)
+	test.EnsureTearDown(t, defaultClients, defaultResources)
 	if _, err := v1test.CreateServiceReady(t, defaultClients, &defaultResources); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", defaultResources.Service, test.ServingNamespace, err)
 	}
@@ -72,8 +71,7 @@ func TestMultipleNamespace(t *testing.T) {
 		Service: serviceName,
 		Image:   test.PizzaPlanet2,
 	}
-	test.CleanupOnInterrupt(func() { test.TearDown(altClients, altResources) })
-	defer test.TearDown(altClients, altResources)
+	test.EnsureTearDown(t, altClients, altResources)
 	if _, err := v1test.CreateServiceReady(t, altClients, &altResources); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", altResources.Service, test.AlternativeServingNamespace, err)
 	}
@@ -116,16 +114,13 @@ func TestConflictingRouteService(t *testing.T) {
 
 	altClients := SetupAlternativeNamespace(t)
 	altClients.KubeClient.Kube.CoreV1().Services(test.AlternativeServingNamespace).Create(svc)
-	cleanup := func() {
+	test.EnsureCleanup(t, func() {
 		altClients.KubeClient.Kube.CoreV1().Services(test.AlternativeServingNamespace).Delete(svc.Name, &metav1.DeleteOptions{})
-	}
-	test.CleanupOnInterrupt(cleanup)
-	defer cleanup()
+	})
 
 	clients := Setup(t)
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 	if _, err := v1test.CreateServiceReady(t, clients, &names); err != nil {
 		t.Errorf("Failed to create Service %v in namespace %v: %v", names.Service, test.ServingNamespace, err)
 	}

--- a/test/e2e/pod_schedule_error_test.go
+++ b/test/e2e/pod_schedule_error_test.go
@@ -49,8 +49,7 @@ func TestPodScheduleError(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	t.Logf("Creating a new Service %s", names.Image)
 	resources := corev1.ResourceRequirements{

--- a/test/e2e/probe_whitelist_test.go
+++ b/test/e2e/probe_whitelist_test.go
@@ -47,8 +47,7 @@ func TestProbeWhitelist(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Service")
 	resources, err := v1test.CreateServiceReady(t, clients, &names)

--- a/test/e2e/rollback_byo_test.go
+++ b/test/e2e/rollback_byo_test.go
@@ -44,8 +44,7 @@ func TestRollbackBYOName(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	withTrafficSpecOld := rtesting.WithRouteSpec(v1.RouteSpec{
 		Traffic: []v1.TrafficTarget{{

--- a/test/e2e/route_service_test.go
+++ b/test/e2e/route_service_test.go
@@ -47,8 +47,7 @@ func TestRoutesNotReady(t *testing.T) {
 		Image:   test.PizzaPlanet1,
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	withTrafficSpec := rtesting.WithRouteSpec(v1.RouteSpec{
 		Traffic: []v1.TrafficTarget{
@@ -147,8 +146,7 @@ func TestRouteVisibilityChanges(t *testing.T) {
 				Image:   test.PizzaPlanet1,
 			}
 
-			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-			defer test.TearDown(clients, names)
+			test.EnsureTearDown(t, clients, names)
 
 			st.Log("Creating a new Service")
 			svc, err := v1test.CreateService(st, clients, names, testCase.withTrafficSpec)

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -185,8 +185,7 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 		select {
 		case names := <-cleanupCh:
 			t.Logf("Added %v to cleanup routine.", names)
-			test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-			defer test.TearDown(clients, names)
+			test.EnsureTearDown(t, clients, names)
 
 		case err := <-doneCh:
 			if err != nil {

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -114,8 +114,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 		Image:   "httpproxy",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	resources, err := v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithEnv(envVars...),
@@ -180,8 +179,7 @@ func TestServiceToServiceCall(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	withInternalVisibility := rtesting.WithServiceLabel(
 		serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
@@ -228,8 +226,7 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 	withInternalVisibility := rtesting.WithServiceLabel(
 		serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, testNames) })
-	defer test.TearDown(clients, testNames)
+	test.EnsureTearDown(t, clients, testNames)
 
 	resources, err := v1test.CreateServiceReady(t, clients, &testNames,
 		rtesting.WithConfigAnnotations(map[string]string{
@@ -283,8 +280,7 @@ func TestCallToPublicService(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	resources, err := v1test.CreateServiceReady(t, clients, &names)
 	if err != nil {

--- a/test/e2e/service_validation_test.go
+++ b/test/e2e/service_validation_test.go
@@ -45,8 +45,7 @@ func TestServiceValidationWithInvalidPodSpec(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	// Setup Service
 	t.Logf("Creating a new Service %s", names.Service)

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -57,8 +57,7 @@ func TestSubrouteLocalSTS(t *testing.T) { // We can't use a longer more descript
 		Image:   "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	tag := "current"
 
@@ -103,8 +102,7 @@ func TestSubrouteVisibilityPublicToPrivate(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	subrouteTag1 := "my-tag"
 	subrouteTag2 := "my-tag2"
@@ -219,8 +217,7 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	subrouteTag1 := "my-tag"
 	subrouteTag2 := "my-tag2"

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -134,8 +134,7 @@ func TestWebSocket(t *testing.T) {
 	}
 
 	// Clean up in both abnormal and normal exits.
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	if _, err := v1test.CreateServiceReady(t, clients, &names); err != nil {
 		t.Fatal("Failed to create WebSocket server:", err)
@@ -161,8 +160,7 @@ func TestWebSocketViaActivator(t *testing.T) {
 	}
 
 	// Clean up in both abnormal and normal exits.
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	resources, err := v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithConfigAnnotations(map[string]string{
@@ -192,8 +190,7 @@ func TestWebSocketBlueGreenRoute(t *testing.T) {
 		Image:   wsServerTestImageName,
 	}
 
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -74,8 +74,7 @@ func testActivatorHA(t *testing.T, gracePeriod *int64, slo float64) {
 			autoscaling.TargetBurstCapacityKey: "-1", // Make sure all requests go through the activator.
 		}),
 	)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+	test.EnsureTearDown(t, clients, names)
 
 	// Create second service that will be scaled to zero and after stopping the activator we'll
 	// ensure it can be scaled back from zero.
@@ -85,8 +84,7 @@ func testActivatorHA(t *testing.T, gracePeriod *int64, slo float64) {
 			autoscaling.TargetBurstCapacityKey: "-1",                           // Make sure all requests go through the activator.
 		}),
 	)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, namesScaleToZero) })
-	defer test.TearDown(clients, namesScaleToZero)
+	test.EnsureTearDown(t, clients, namesScaleToZero)
 
 	if err := e2e.WaitForScaleToZero(t, revisionresourcenames.Deployment(resourcesScaleToZero.Revision), clients); err != nil {
 		t.Fatal("Failed to scale to zero:", err)

--- a/test/ha/autoscalerhpa_test.go
+++ b/test/ha/autoscalerhpa_test.go
@@ -59,8 +59,8 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 			autoscaling.MetricAnnotationKey: autoscaling.CPU,
 			autoscaling.TargetAnnotationKey: "70",
 		}))
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-	defer test.TearDown(clients, names)
+
+	test.EnsureTearDown(t, clients, names)
 
 	if err := clients.KubeClient.Kube.CoreV1().Pods(system.Namespace()).Delete(leaderController,
 		&metav1.DeleteOptions{}); err != nil {

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -48,8 +48,7 @@ func TestControllerHA(t *testing.T) {
 	}
 
 	service1Names, resources := createPizzaPlanetService(t)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, service1Names) })
-	defer test.TearDown(clients, service1Names)
+	test.EnsureTearDown(t, clients, service1Names)
 
 	if err := clients.KubeClient.Kube.CoreV1().Pods(system.Namespace()).Delete(leaderController,
 		&metav1.DeleteOptions{}); err != nil {
@@ -69,6 +68,5 @@ func TestControllerHA(t *testing.T) {
 
 	// Verify that after changing the leader we can still create a new kservice
 	service2Names, _ := createPizzaPlanetService(t)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, service2Names) })
-	test.TearDown(clients, service2Names)
+	test.EnsureTearDown(t, clients, service2Names)
 }

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -59,8 +59,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 		Image:   img,
 	}
 
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Service")
 	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -147,8 +147,7 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 		Image:   "observed-concurrency",
 	}
 
-	defer test.TearDown(clients, names)
-	test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
+	test.EnsureTearDown(t, clients, names)
 
 	t.Log("Creating a new Service")
 	objs, err := v1test.CreateServiceReady(t, clients, &names,


### PR DESCRIPTION
Try out replacing repetitive defer/CleanupOnInterrupt pairs using the new t.Cleanup function.