### PR TITLE
Update rollout benchmark to use cc=1

### DIFF
--- a/test/performance/benchmarks/rollout-probe/continuous/rollout-probe-setup.yaml
+++ b/test/performance/benchmarks/rollout-probe/continuous/rollout-probe-setup.yaml
@@ -32,19 +32,25 @@ spec:
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
-  name: activator-with-cc-50
+  name: activator-with-cc
 spec:
   template:
     metadata:
       annotations:
         autoscaling.knative.dev/minScale: "1"
-        autoscaling.knative.dev/maxScale: "10"
         # Always hook the activator in.
         autoscaling.knative.dev/targetBurstCapacity: "-1"
     spec:
       containers:
       - image: ko://knative.dev/serving/test/test_images/autoscale
-      containerConcurrency: 50
+        resources:
+          requests:
+            cpu: 20m
+            memory: 20Mi
+          limits:
+            cpu: 50m
+            memory: 50Mi
+      containerConcurrency: 1
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -66,17 +72,23 @@ spec:
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
-  name: queue-proxy-with-cc-50
+  name: queue-proxy-with-cc
 spec:
   template:
     metadata:
       annotations:
         autoscaling.knative.dev/minScale: "1"
-        autoscaling.knative.dev/maxScale: "10"
         # Only hook the activator in when scaled to zero.
         autoscaling.knative.dev/targetBurstCapacity: "0"
     spec:
       containers:
       - image: ko://knative.dev/serving/test/test_images/autoscale
-      containerConcurrency: 50
+        resources:
+          requests:
+            cpu: 20m
+            memory: 20Mi
+          limits:
+            cpu: 50m
+            memory: 50Mi
+      containerConcurrency: 1
 ---

--- a/test/performance/benchmarks/rollout-probe/continuous/rollout-probe.yaml
+++ b/test/performance/benchmarks/rollout-probe/continuous/rollout-probe.yaml
@@ -117,7 +117,7 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: rollout-probe-activator-with-cc-50
+  name: rollout-probe-activator-with-cc
 spec:
   # Run every thirty minutes, offset from other jobs.
   schedule: "12,42 * * * *"
@@ -130,7 +130,7 @@ spec:
           containers:
           - name: rollout-probe
             image: ko://knative.dev/serving/test/performance/benchmarks/rollout-probe/continuous
-            args: ["-target=activator-with-cc-50", "--duration=3m"]
+            args: ["-target=activator-with-cc", "--duration=3m"]
             resources:
               requests:
                 cpu: 1000m
@@ -159,7 +159,7 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: rollout-probe-queue-with-cc-50
+  name: rollout-probe-queue-with-cc
 spec:
   # Run every thirty minutes, offset from other jobs.
   schedule: "15,45 * * * *"
@@ -172,7 +172,7 @@ spec:
           containers:
           - name: rollout-probe
             image: ko://knative.dev/serving/test/performance/benchmarks/rollout-probe/continuous
-            args: ["-target=queue-with-cc-50", "--duration=3m"]
+            args: ["-target=queue-with-cc", "--duration=3m"]
             resources:
               requests:
                 cpu: 1000m

--- a/test/performance/benchmarks/rollout-probe/continuous/sla.go
+++ b/test/performance/benchmarks/rollout-probe/continuous/sla.go
@@ -73,10 +73,10 @@ var (
 			estat:     "qe",
 			analyzers: []*tpb.ThresholdAnalyzerInput{newQueue95PercentileLatency("q")},
 		},
-		"queue-with-cc-50": {
+		"queue-with-cc": {
 			target: vegeta.Target{
 				Method: http.MethodGet,
-				URL:    "http://queue-proxy-with-cc-50.default.svc.cluster.local?sleep=100",
+				URL:    "http://queue-proxy-with-cc.default.svc.cluster.local?sleep=100",
 			},
 			stat:  "qc",
 			estat: "qce",
@@ -92,10 +92,10 @@ var (
 			estat:     "ae",
 			analyzers: []*tpb.ThresholdAnalyzerInput{newActivator95PercentileLatency("a")},
 		},
-		"activator-with-cc-50": {
+		"activator-with-cc": {
 			target: vegeta.Target{
 				Method: http.MethodGet,
-				URL:    "http://activator-with-cc-50.default.svc.cluster.local?sleep=100",
+				URL:    "http://activator-with-cc.default.svc.cluster.local?sleep=100",
 			},
 			stat:  "ac",
 			estat: "ace",

--- a/test/performance/benchmarks/rollout-probe/dev.config
+++ b/test/performance/benchmarks/rollout-probe/dev.config
@@ -39,11 +39,11 @@ metric_info_list: {
 }
 metric_info_list: {
   value_key: "qc"
-  label: "queue-proxy-with-cc-50"
+  label: "queue-proxy-with-cc"
 }
 metric_info_list: {
   value_key: "ac"
-  label: "activator-with-cc-50"
+  label: "activator-with-cc"
 }
 
 # error metrics.
@@ -53,7 +53,7 @@ metric_info_list: {
 }
 metric_info_list: {
   value_key: "qce"
-  label: "queue-cc-50-errors"
+  label: "queue-cc-errors"
 }
 metric_info_list: {
   value_key: "ae"
@@ -61,5 +61,15 @@ metric_info_list: {
 }
 metric_info_list: {
   value_key: "ace"
-  label: "activator-cc-50-errors"
+  label: "activator-cc-errors"
+}
+
+# additional metrics
+metric_info_list: {
+  value_key: "dp"
+  label: "desired-pods"
+}
+metric_info_list: {
+  value_key: "ap"
+  label: "available-pods"
 }

--- a/test/performance/benchmarks/rollout-probe/prod.config
+++ b/test/performance/benchmarks/rollout-probe/prod.config
@@ -39,11 +39,11 @@ metric_info_list: {
 }
 metric_info_list: {
   value_key: "qc"
-  label: "queue-proxy-with-cc-50"
+  label: "queue-proxy-with-cc"
 }
 metric_info_list: {
   value_key: "ac"
-  label: "activator-with-cc-50"
+  label: "activator-with-cc"
 }
 
 # error metrics.
@@ -53,7 +53,7 @@ metric_info_list: {
 }
 metric_info_list: {
   value_key: "qce"
-  label: "queue-cc-50-errors"
+  label: "queue-cc-errors"
 }
 metric_info_list: {
   value_key: "ae"
@@ -61,5 +61,15 @@ metric_info_list: {
 }
 metric_info_list: {
   value_key: "ace"
-  label: "activator-cc-50-errors"
+  label: "activator-cc-errors"
+}
+
+# additional metrics
+metric_info_list: {
+  value_key: "dp"
+  label: "desired-pods"
+}
+metric_info_list: {
+  value_key: "ap"
+  label: "available-pods"
 }


### PR DESCRIPTION
- cc=1
- QPS=1k
- also report desired and actual pod count (I am seeing up to 7.5k pods
requested).

An example run: https://mako.dev/run?run_key=5026962756075520&~ac=1&~ace=1&~dp=1&~ap=1

/assign @chizhg mattmoor