### PR TITLE
Replace hooks with active waits

### DIFF
--- a/pkg/reconciler/serverlessservice/global_resync_test.go
+++ b/pkg/reconciler/serverlessservice/global_resync_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/sync/errgroup"
 
-	"knative.dev/networking/pkg/apis/networking"
 	fakenetworkingclient "knative.dev/networking/pkg/client/injection/client/fake"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	fakeendpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
@@ -31,13 +31,13 @@ import (
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	"knative.dev/serving/pkg/client/injection/ducks/autoscaling/v1alpha1/podscalable"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	_ "knative.dev/pkg/metrics/testing"
 	. "knative.dev/pkg/reconciler/testing"
+	"knative.dev/serving/pkg/reconciler/serverlessservice/resources"
 	. "knative.dev/serving/pkg/reconciler/testing/v1"
 	. "knative.dev/serving/pkg/testing"
 )
@@ -94,25 +94,6 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 		return ctrl.Run(1, ctx.Done())
 	})
 
-	// Due to the fact that registering reactors is not guarded by locks in k8s
-	// fake clients we need to pre-register those.
-	updateHooks := NewHooks()
-	updateHooks.OnUpdate(&kubeClnt.Fake, "endpoints", func(obj runtime.Object) HookResult {
-		eps := obj.(*corev1.Endpoints)
-		if eps.Name == sks1 {
-			t.Logf("Registering expected hook update for endpoints %s", eps.Name)
-			return HookComplete
-		}
-		if eps.Name == networking.ActivatorServiceName {
-			// Expected, but not the one we're waiting for.
-			t.Log("Registering activator endpoint update")
-		} else {
-			// Something's broken.
-			t.Errorf("Unexpected endpoint update for %s", eps.Name)
-		}
-		return HookIncomplete
-	})
-
 	// Inactive, will reconcile.
 	sksObj1 := SKS(ns1, sks1, WithPrivateService, WithPubService, WithDeployRef(sks1), WithProxyMode)
 	// Active, should not visibly reconcile.
@@ -140,7 +121,17 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 		t.Fatal("Error creating activator endpoints:", err)
 	}
 
-	if err := updateHooks.WaitForHooks(3 * time.Second); err != nil {
-		t.Fatal("Hooks timed out:", err)
+	// Actively wait for the endpoints to change their value.
+	if err := wait.PollImmediate(10*time.Millisecond, 3*time.Second, func() (bool, error) {
+		ep, err := eps.Endpoints(ns1).Get(sks1)
+		if err != nil {
+			return false, err
+		}
+		if cmp.Equal(ep.Subsets, resources.FilterSubsetPorts(sksObj1, aEps.Subsets)) {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatal("Failed to see Public Endpoints propagation:", err)
 	}
 }


### PR DESCRIPTION
We have seen in many tests, that hooks are not very reliable (including in this test where we had 2 hooks objects
and now we are down to to one. In many places we actively wait for the actual situation to happen, and then wait for the
hook to succeed.
But it doesn't make sense.
Hooks are also prone to registration ordering, etc.
So get rid of he hooks in the sks tests.

In general I will be looking at other tests one by one trying to get rid of the hooks usage in serving tests.

/assign @JRBANCEL @markusthoemmes mattmoor