### PR TITLE
Add and set InitialScale field in DeciderSpec

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -62,9 +62,8 @@ func (pa *PodAutoscaler) Metric() string {
 
 func (pa *PodAutoscaler) annotationInt32(key string) (int32, bool) {
 	if s, ok := pa.Annotations[key]; ok {
-		// no error check or negative check: relying on validation
-		i, _ := strconv.ParseInt(s, 10, 32)
-		return int32(i), true
+		i, err := strconv.ParseInt(s, 10, 32)
+		return int32(i), err == nil
 	}
 	return 0, false
 }

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -62,11 +62,8 @@ func (pa *PodAutoscaler) Metric() string {
 
 func (pa *PodAutoscaler) annotationInt32(key string) (int32, bool) {
 	if s, ok := pa.Annotations[key]; ok {
-		// no error check: relying on validation
+		// no error check or negative check: relying on validation
 		i, _ := strconv.ParseInt(s, 10, 32)
-		if i < 0 {
-			return 0, false
-		}
 		return int32(i), true
 	}
 	return 0, false

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -1143,3 +1143,37 @@ func TestScaleToZeroPodRetention(t *testing.T) {
 		})
 	}
 }
+
+func TestInitialScale(t *testing.T) {
+	cases := []struct {
+		name   string
+		pa     *PodAutoscaler
+		want   int
+		wantOK bool
+	}{{
+		name: "nil",
+		pa:   pa(nil),
+	}, {
+		name: "not present",
+		pa:   pa(map[string]string{}),
+	}, {
+		name: "present",
+		pa: pa(map[string]string{
+			autoscaling.InitialScaleAnnotationKey: "2",
+		}),
+		want:   2,
+		wantOK: true,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotOK := tc.pa.InitialScale()
+			if got != int32(tc.want) {
+				t.Errorf("ScaleToZeroPodRetention = %v, want: %v", got, tc.want)
+			}
+			if gotOK != tc.wantOK {
+				t.Errorf("OK = %v, want: %v", gotOK, tc.wantOK)
+			}
+		})
+	}
+}

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -667,12 +667,6 @@ func TestScaleBounds(t *testing.T) {
 		max:     "sandwich",
 		wantMin: 0,
 		wantMax: 0,
-	}, {
-		name:    "too small",
-		min:     "-1",
-		max:     "-1",
-		wantMin: 0,
-		wantMax: 0,
 	}}
 
 	for _, tc := range cases {
@@ -1148,7 +1142,7 @@ func TestInitialScale(t *testing.T) {
 	cases := []struct {
 		name   string
 		pa     *PodAutoscaler
-		want   int
+		want   int32
 		wantOK bool
 	}{{
 		name: "nil",
@@ -1168,8 +1162,8 @@ func TestInitialScale(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, gotOK := tc.pa.InitialScale()
-			if got != int32(tc.want) {
-				t.Errorf("ScaleToZeroPodRetention = %v, want: %v", got, tc.want)
+			if got != tc.want {
+				t.Errorf("InitialScale = %v, want: %v", got, tc.want)
 			}
 			if gotOK != tc.wantOK {
 				t.Errorf("OK = %v, want: %v", gotOK, tc.wantOK)

--- a/pkg/autoscaler/scaling/multiscaler.go
+++ b/pkg/autoscaler/scaling/multiscaler.go
@@ -70,6 +70,10 @@ type DeciderSpec struct {
 	StableWindow time.Duration
 	// The name of the k8s service for pod information.
 	ServiceName string
+	// InitialScale is the calculated initial scale of the revision, taking both
+	// revision initial scale and cluster initial scale into account. Revision initial
+	// scale overrides cluster initial scale.
+	InitialScale int32
 }
 
 // DeciderStatus is the current scale recommendation.

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -86,14 +86,12 @@ func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autosc
 func GetInitialScale(asConfig *autoscalerconfig.Config, pa *v1alpha1.PodAutoscaler) int32 {
 	initialScale := asConfig.InitialScale
 	revisionInitialScale, ok := pa.ObjectMeta.Annotations[autoscaling.InitialScaleAnnotationKey]
-	if ok {
-		revInitialScaleInt, err := strconv.Atoi(revisionInitialScale)
-		if err == nil {
-			if revInitialScaleInt == 0 && !asConfig.AllowZeroInitialScale {
-				return initialScale
-			}
-			initialScale = int32(revInitialScaleInt)
-		}
+	if !ok {
+		return initialScale
 	}
-	return initialScale
+	revInitialScaleInt, err := strconv.Atoi(revisionInitialScale)
+	if err != nil || (revInitialScaleInt == 0 && !asConfig.AllowZeroInitialScale) {
+		return initialScale
+	}
+	return int32(revInitialScaleInt)
 }

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -18,10 +18,8 @@ package resources
 
 import (
 	"context"
-	"strconv"
 
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/autoscaler/scaling"
@@ -85,13 +83,9 @@ func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autosc
 // TODO(taragu): This function is exported and will be reused in other packages.
 func GetInitialScale(asConfig *autoscalerconfig.Config, pa *v1alpha1.PodAutoscaler) int32 {
 	initialScale := asConfig.InitialScale
-	revisionInitialScale, ok := pa.ObjectMeta.Annotations[autoscaling.InitialScaleAnnotationKey]
-	if !ok {
+	revisionInitialScale, ok := pa.InitialScale()
+	if !ok || (revisionInitialScale == 0 && !asConfig.AllowZeroInitialScale) {
 		return initialScale
 	}
-	revInitialScaleInt, err := strconv.Atoi(revisionInitialScale)
-	if err != nil || (revInitialScaleInt == 0 && !asConfig.AllowZeroInitialScale) {
-		return initialScale
-	}
-	return int32(revInitialScaleInt)
+	return revisionInitialScale
 }

--- a/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
@@ -130,6 +130,16 @@ func TestMakeDecider(t *testing.T) {
 		name: "with metric annotation",
 		pa:   pa(WithMetricAnnotation("rps")),
 		want: decider(withTarget(100.0), withPanicThreshold(2.0), withTotal(100), withMetric("rps"), withMetricAnnotation("rps")),
+	}, {
+		name: "with initial scale",
+		pa: pa(func(pa *v1alpha1.PodAutoscaler) {
+			pa.ObjectMeta.Annotations[autoscaling.InitialScaleAnnotationKey] = "2"
+		}),
+		want: decider(withTarget(100.0), withPanicThreshold(2.0), withTotal(100),
+			func(d *scaling.Decider) {
+				d.Spec.InitialScale = 2
+				d.ObjectMeta.Annotations[autoscaling.InitialScaleAnnotationKey] = "2"
+			}),
 	}}
 
 	for _, tc := range cases {
@@ -141,6 +151,58 @@ func TestMakeDecider(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want, MakeDecider(context.Background(), tc.pa, cfg, tc.svc)); diff != "" {
 				t.Errorf("%q (-want, +got):\n%v", tc.name, diff)
+			}
+		})
+	}
+}
+
+func TestGetInitialScale(t *testing.T) {
+	tests := []struct {
+		name          string
+		paMutation    func(*v1alpha1.PodAutoscaler)
+		configMutator func(*autoscalerconfig.Config)
+		want          int
+	}{{
+		name: "revision initial scale not set",
+		want: 1,
+	}, {
+		name: "revision initial scale overrides cluster initial scale",
+		paMutation: func(pa *v1alpha1.PodAutoscaler) {
+			pa.ObjectMeta.Annotations[autoscaling.InitialScaleAnnotationKey] = "2"
+		},
+		want: 2,
+	}, {
+		name: "cluster allows initial scale zero",
+		paMutation: func(pa *v1alpha1.PodAutoscaler) {
+			pa.ObjectMeta.Annotations[autoscaling.InitialScaleAnnotationKey] = "0"
+		},
+		configMutator: func(c *autoscalerconfig.Config) {
+			c.AllowZeroInitialScale = true
+		},
+		want: 0,
+	}, {
+		name: "cluster does not allows initial scale zero",
+		paMutation: func(pa *v1alpha1.PodAutoscaler) {
+			pa.ObjectMeta.Annotations[autoscaling.InitialScaleAnnotationKey] = "0"
+		},
+		configMutator: func(c *autoscalerconfig.Config) {
+			c.AllowZeroInitialScale = false
+		},
+		want: 1,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			autoscalerConfig, _ := autoscalerconfig.NewConfigFromMap(map[string]string{})
+			if test.configMutator != nil {
+				test.configMutator(autoscalerConfig)
+			}
+			pa := pa()
+			if test.paMutation != nil {
+				test.paMutation(pa)
+			}
+			got := int(GetInitialScale(autoscalerConfig, pa))
+			if want := test.want; got != want {
+				t.Errorf("got = %v, want: %v", got, want)
 			}
 		})
 	}
@@ -200,6 +262,7 @@ func decider(options ...deciderOption) *scaling.Decider {
 			PanicThreshold:      200,
 			ActivatorCapacity:   811,
 			StableWindow:        config.StableWindow,
+			InitialScale:        1,
 		},
 	}
 	for _, fn := range options {
@@ -288,4 +351,6 @@ var config = &autoscalerconfig.Config{
 	PanicThresholdPercentage:           200,
 	PanicWindowPercentage:              10,
 	ScaleToZeroGracePeriod:             30 * time.Second,
+	InitialScale:                       1,
+	AllowZeroInitialScale:              false,
 }


### PR DESCRIPTION
/lint

Part 4 of #7682

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
* Add InitialScale field to DeciderSpec, so that we are able to access the initial scale in the Autoscaler constructor to determine if we want to start in panic mode.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
/cc @julz @vagababov @markusthoemmes @dprotaso @mattmoor 
