### PR TITLE
Add autoscaler ConfigMap to revision reconciler and create deployment with initial scale

### DIFF
--- a/pkg/reconciler/revision/config/store.go
+++ b/pkg/reconciler/revision/config/store.go
@@ -41,7 +41,7 @@ type Config struct {
 	Network       *network.Config
 	Observability *metrics.ObservabilityConfig
 	Tracing       *pkgtracing.Config
-	Autoscaling   *autoscalerconfig.Config
+	Autoscaler    *autoscalerconfig.Config
 }
 
 // FromContext loads the configuration from the context.
@@ -94,6 +94,6 @@ func (s *Store) Load() *Config {
 		Network:       s.UntypedLoad(network.ConfigName).(*network.Config).DeepCopy(),
 		Observability: s.UntypedLoad(metrics.ConfigMapName()).(*metrics.ObservabilityConfig).DeepCopy(),
 		Tracing:       s.UntypedLoad(pkgtracing.ConfigName).(*pkgtracing.Config).DeepCopy(),
-		Autoscaling:   s.UntypedLoad(autoscalerconfig.ConfigName).(*autoscalerconfig.Config).DeepCopy(),
+		Autoscaler:    s.UntypedLoad(autoscalerconfig.ConfigName).(*autoscalerconfig.Config).DeepCopy(),
 	}
 }

--- a/pkg/reconciler/revision/config/store.go
+++ b/pkg/reconciler/revision/config/store.go
@@ -41,6 +41,7 @@ type Config struct {
 	Network       *network.Config
 	Observability *metrics.ObservabilityConfig
 	Tracing       *pkgtracing.Config
+	Autoscaling   *autoscalerconfig.Config
 }
 
 // FromContext loads the configuration from the context.
@@ -93,5 +94,6 @@ func (s *Store) Load() *Config {
 		Network:       s.UntypedLoad(network.ConfigName).(*network.Config).DeepCopy(),
 		Observability: s.UntypedLoad(metrics.ConfigMapName()).(*metrics.ObservabilityConfig).DeepCopy(),
 		Tracing:       s.UntypedLoad(pkgtracing.ConfigName).(*pkgtracing.Config).DeepCopy(),
+		Autoscaling:   s.UntypedLoad(autoscalerconfig.ConfigName).(*autoscalerconfig.Config).DeepCopy(),
 	}
 }

--- a/pkg/reconciler/revision/config/store_test.go
+++ b/pkg/reconciler/revision/config/store_test.go
@@ -127,6 +127,13 @@ func TestStoreLoadWithContext(t *testing.T) {
 			t.Error("Unexpected defaults config (-want, +got):", diff)
 		}
 	})
+
+	t.Run("autoscaler", func(t *testing.T) {
+		expected, _ := autoscalerconfig.NewConfigFromConfigMap(autoscalerConfig)
+		if diff := cmp.Diff(expected, config.Autoscaler); diff != "" {
+			t.Error("Unexpected autoscaler config (-want, +got):", diff)
+		}
+	})
 }
 
 func TestStoreImmutableConfig(t *testing.T) {
@@ -146,6 +153,8 @@ func TestStoreImmutableConfig(t *testing.T) {
 	config.Logging.LoggingConfig = "mutated"
 	ccMutated := int64(4)
 	config.Defaults.ContainerConcurrency = ccMutated
+	scaleupMutated := float64(4)
+	config.Autoscaler.MaxScaleUpRate = scaleupMutated
 
 	newConfig := store.Load()
 
@@ -157,5 +166,8 @@ func TestStoreImmutableConfig(t *testing.T) {
 	}
 	if newConfig.Defaults.ContainerConcurrency == ccMutated {
 		t.Error("Defaults config is not immutable")
+	}
+	if newConfig.Autoscaler.MaxScaleUpRate == scaleupMutated {
+		t.Error("Autoscaler config is not immutable")
 	}
 }

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -43,7 +43,7 @@ func (c *Reconciler) createDeployment(ctx context.Context, rev *v1.Revision) (*a
 		cfgs.Network,
 		cfgs.Observability,
 		cfgs.Deployment,
-		cfgs.Autoscaling,
+		cfgs.Autoscaler,
 	)
 
 	if err != nil {
@@ -64,7 +64,7 @@ func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1.Revis
 		cfgs.Network,
 		cfgs.Observability,
 		cfgs.Deployment,
-		cfgs.Autoscaling,
+		cfgs.Autoscaler,
 	)
 
 	if err != nil {

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -43,6 +43,7 @@ func (c *Reconciler) createDeployment(ctx context.Context, rev *v1.Revision) (*a
 		cfgs.Network,
 		cfgs.Observability,
 		cfgs.Deployment,
+		cfgs.Autoscaling,
 	)
 
 	if err != nil {
@@ -63,6 +64,7 @@ func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1.Revis
 		cfgs.Network,
 		cfgs.Observability,
 		cfgs.Deployment,
+		cfgs.Autoscaling,
 	)
 
 	if err != nil {

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -29,7 +29,7 @@ import (
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
+	asconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/queue"
@@ -221,7 +221,7 @@ func buildUserPortEnv(userPort string) corev1.EnvVar {
 func MakeDeployment(rev *v1.Revision,
 	loggingConfig *logging.Config, tracingConfig *tracingconfig.Config, networkConfig *network.Config,
 	observabilityConfig *metrics.ObservabilityConfig, deploymentConfig *deployment.Config,
-	autoscalerConfig *autoscalerconfig.Config) (*appsv1.Deployment, error) {
+	autoscalerConfig *asconfig.Config) (*appsv1.Deployment, error) {
 
 	podTemplateAnnotations := kmeta.FilterMap(rev.GetAnnotations(), func(k string) bool {
 		return k == serving.RevisionLastPinnedAnnotationKey

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -26,8 +26,10 @@ import (
 	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/ptr"
 	tracingconfig "knative.dev/pkg/tracing/config"
+	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/pkg/queue"
@@ -217,7 +219,9 @@ func buildUserPortEnv(userPort string) corev1.EnvVar {
 
 // MakeDeployment constructs a K8s Deployment resource from a revision.
 func MakeDeployment(rev *v1.Revision,
-	loggingConfig *logging.Config, tracingConfig *tracingconfig.Config, networkConfig *network.Config, observabilityConfig *metrics.ObservabilityConfig, deploymentConfig *deployment.Config) (*appsv1.Deployment, error) {
+	loggingConfig *logging.Config, tracingConfig *tracingconfig.Config, networkConfig *network.Config,
+	observabilityConfig *metrics.ObservabilityConfig, deploymentConfig *deployment.Config,
+	autoscalerConfig *autoscalerconfig.Config) (*appsv1.Deployment, error) {
 
 	podTemplateAnnotations := kmeta.FilterMap(rev.GetAnnotations(), func(k string) bool {
 		return k == serving.RevisionLastPinnedAnnotationKey
@@ -226,6 +230,18 @@ func MakeDeployment(rev *v1.Revision,
 	podSpec, err := makePodSpec(rev, loggingConfig, tracingConfig, observabilityConfig, deploymentConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create PodSpec: %w", err)
+	}
+
+	replicaCount := autoscalerConfig.InitialScale
+	ann, found := rev.ObjectMeta.Annotations[autoscaling.InitialScaleAnnotationKey]
+	if found {
+		initialScale, err := strconv.Atoi(ann)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process initialScale annotation: %w", err)
+		}
+		if initialScale != 0 || autoscalerConfig.AllowZeroInitialScale {
+			replicaCount = int32(initialScale)
+		}
 	}
 
 	return &appsv1.Deployment{
@@ -240,7 +256,7 @@ func MakeDeployment(rev *v1.Revision,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(rev)},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas:                ptr.Int32(1),
+			Replicas:                ptr.Int32(replicaCount),
 			Selector:                makeSelector(rev),
 			ProgressDeadlineSeconds: ptr.Int32(int32(deploymentConfig.ProgressDeadline.Seconds())),
 			Template: corev1.PodTemplateSpec{

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -1063,50 +1063,6 @@ func TestMakeDeployment(t *testing.T) {
 			deploy.Spec.Template.ObjectMeta.Annotations = map[string]string{autoscaling.InitialScaleAnnotationKey: "20"}
 			deploy.ObjectMeta.Annotations = map[string]string{autoscaling.InitialScaleAnnotationKey: "20"}
 		}),
-	}, {
-		name: "cluster initial scale does not allow initial scale zero",
-		acMutator: func(ac *asconfig.Config) {
-			ac.InitialScale = 2
-			ac.AllowZeroInitialScale = false
-		},
-		rev: revision("bar", "foo",
-			withoutLabels,
-			withContainers([]corev1.Container{{
-				Name:           servingContainerName,
-				Image:          "ubuntu",
-				ReadinessProbe: withTCPReadinessProbe(12345),
-			}}),
-			func(revision *v1.Revision) {
-				revision.ObjectMeta.Annotations = map[string]string{autoscaling.InitialScaleAnnotationKey: "0"}
-			},
-		),
-		want: appsv1deployment(func(deploy *appsv1.Deployment) {
-			deploy.Spec.Replicas = ptr.Int32(int32(2))
-			deploy.Spec.Template.ObjectMeta.Annotations = map[string]string{autoscaling.InitialScaleAnnotationKey: "0"}
-			deploy.ObjectMeta.Annotations = map[string]string{autoscaling.InitialScaleAnnotationKey: "0"}
-		}),
-	}, {
-		name: "cluster initial scale allows initial scale zero",
-		acMutator: func(ac *asconfig.Config) {
-			ac.InitialScale = 2
-			ac.AllowZeroInitialScale = true
-		},
-		rev: revision("bar", "foo",
-			withoutLabels,
-			withContainers([]corev1.Container{{
-				Name:           servingContainerName,
-				Image:          "ubuntu",
-				ReadinessProbe: withTCPReadinessProbe(12345),
-			}}),
-			func(revision *v1.Revision) {
-				revision.ObjectMeta.Annotations = map[string]string{autoscaling.InitialScaleAnnotationKey: "0"}
-			},
-		),
-		want: appsv1deployment(func(deploy *appsv1.Deployment) {
-			deploy.Spec.Replicas = ptr.Int32(int32(0))
-			deploy.Spec.Template.ObjectMeta.Annotations = map[string]string{autoscaling.InitialScaleAnnotationKey: "0"}
-			deploy.ObjectMeta.Annotations = map[string]string{autoscaling.InitialScaleAnnotationKey: "0"}
-		}),
 	}}
 
 	for _, test := range tests {

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -42,6 +42,7 @@ import (
 	tracingconfig "knative.dev/pkg/tracing/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
 )
@@ -66,6 +67,10 @@ var (
 	traceConfig      tracingconfig.Config
 	obsConfig        metrics.ObservabilityConfig
 	deploymentConfig deployment.Config
+	asConfig         = autoscalerconfig.Config{
+		InitialScale:          1,
+		AllowZeroInitialScale: false,
+	}
 )
 
 const testProbeJSONTemplate = `{"tcpSocket":{"port":%d,"host":"127.0.0.1"}}`

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -42,7 +42,7 @@ import (
 	tracingconfig "knative.dev/pkg/tracing/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
+	asconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/network"
 )
@@ -67,7 +67,7 @@ var (
 	traceConfig      tracingconfig.Config
 	obsConfig        metrics.ObservabilityConfig
 	deploymentConfig deployment.Config
-	asConfig         = autoscalerconfig.Config{
+	asConfig         = asconfig.Config{
 		InitialScale:          1,
 		AllowZeroInitialScale: false,
 	}

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -39,6 +39,7 @@ import (
 	asv1a1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	defaultconfig "knative.dev/serving/pkg/apis/config"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	revisionreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/revision"
 	"knative.dev/serving/pkg/reconciler/revision/config"
@@ -716,7 +717,7 @@ func deploy(t *testing.T, namespace, name string, opts ...interface{}) *appsv1.D
 	// before calling MakeDeployment within Reconcile.
 	rev.SetDefaults(context.Background())
 	deployment, err := resources.MakeDeployment(rev, cfg.Logging, cfg.Tracing, cfg.Network,
-		cfg.Observability, cfg.Deployment)
+		cfg.Observability, cfg.Deployment, cfg.Autoscaling)
 	if err != nil {
 		t.Fatal("failed to create deployment")
 	}
@@ -779,5 +780,9 @@ func ReconcilerTestConfig() *config.Config {
 		Logging:  &logging.Config{},
 		Tracing:  &tracingconfig.Config{},
 		Defaults: &defaultconfig.Defaults{},
+		Autoscaling: &autoscalerconfig.Config{
+			InitialScale:          1,
+			AllowZeroInitialScale: false,
+		},
 	}
 }

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -39,7 +39,7 @@ import (
 	asv1a1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	defaultconfig "knative.dev/serving/pkg/apis/config"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
+	asconfig "knative.dev/serving/pkg/autoscaler/config"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	revisionreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/revision"
 	"knative.dev/serving/pkg/reconciler/revision/config"
@@ -717,7 +717,7 @@ func deploy(t *testing.T, namespace, name string, opts ...interface{}) *appsv1.D
 	// before calling MakeDeployment within Reconcile.
 	rev.SetDefaults(context.Background())
 	deployment, err := resources.MakeDeployment(rev, cfg.Logging, cfg.Tracing, cfg.Network,
-		cfg.Observability, cfg.Deployment, cfg.Autoscaling)
+		cfg.Observability, cfg.Deployment, cfg.Autoscaler)
 	if err != nil {
 		t.Fatal("failed to create deployment")
 	}
@@ -780,7 +780,7 @@ func ReconcilerTestConfig() *config.Config {
 		Logging:  &logging.Config{},
 		Tracing:  &tracingconfig.Config{},
 		Defaults: &defaultconfig.Defaults{},
-		Autoscaling: &autoscalerconfig.Config{
+		Autoscaler: &asconfig.Config{
 			InitialScale:          1,
 			AllowZeroInitialScale: false,
 		},


### PR DESCRIPTION
/lint

Part 6 of #7682

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
* Adding back the autoscaler ConfigMap to revision reconciler
* Pass in the autoscaler ConfigMap to MakeDeployment in order to create the initial replica count with initial scale

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
/cc @julz @vagababov @markusthoemmes @dprotaso @mattmoor