### PR TITLE
Update the mako rollout benchmark to include service restart

### DIFF
--- a/test/performance/benchmarks/rollout-probe/continuous/rollout-probe-setup.yaml
+++ b/test/performance/benchmarks/rollout-probe/continuous/rollout-probe-setup.yaml
@@ -37,7 +37,8 @@ spec:
   template:
     metadata:
       annotations:
-        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/minScale: "100"
+        autoscaling.knative.dev/maxScale: "150"
         # Always hook the activator in.
         autoscaling.knative.dev/targetBurstCapacity: "-1"
     spec:
@@ -77,7 +78,8 @@ spec:
   template:
     metadata:
       annotations:
-        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/minScale: "100"
+        autoscaling.knative.dev/maxScale: "150"
         # Only hook the activator in when scaled to zero.
         autoscaling.knative.dev/targetBurstCapacity: "0"
     spec:


### PR DESCRIPTION
This is a more appropriate benchmark, which actually tests how we response when the
rollout is updated in the mean time.i
https://mako.dev/run?run_key=4649981615013888&~ac=1&~dp=1&~ace=1 — is a good example that shows the hump for latency
and spike for errors after the service is updated in a minute

/assign @chizhg mattmoor