### PR TITLE
Scale to 1 immediately, if unroutable.

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -87,9 +87,11 @@ func (pa *PodAutoscaler) annotationFloat64(key string) (float64, bool) {
 func (pa *PodAutoscaler) ScaleBounds() (min, max int32) {
 	if pa.Spec.Reachability != ReachabilityUnreachable {
 		min = pa.annotationInt32(autoscaling.MinScaleAnnotationKey)
+		max = pa.annotationInt32(autoscaling.MaxScaleAnnotationKey)
+	} else {
+		// Unreachable, so let's immediately scale the revision to 1.
+		max = 1
 	}
-	max = pa.annotationInt32(autoscaling.MaxScaleAnnotationKey)
-
 	return
 }
 

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -660,7 +660,7 @@ func TestScaleBounds(t *testing.T) {
 		max:          "100",
 		reachability: ReachabilityUnreachable,
 		wantMin:      0,
-		wantMax:      100,
+		wantMax:      1,
 	}, {
 		name:    "malformed",
 		min:     "ham",

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -559,6 +559,7 @@ func TestDisableScaleToZero(t *testing.T) {
 func newKPA(t *testing.T, servingClient clientset.Interface, revision *v1.Revision) *pav1alpha1.PodAutoscaler {
 	t.Helper()
 	pa := revisionresources.MakePA(revision)
+	WithReachabilityReachable(pa)
 	pa.Status.InitializeConditions()
 	_, err := servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(pa)
 	if err != nil {


### PR DESCRIPTION
During my benchmarking, I noticed that due to scaledown multiplier of 2 it takes close to a minute to
scale from large scale to 1 and then 0.
But if the revision is not routable, there's no reason we cannot scale directly to 1.
So report maxScale=1 for unroutable revisions.

/hold
/assign @markusthoemmes mattmoor