### PR TITLE
 Thread the reachability status to decider.

### DIFF
--- a/pkg/autoscaler/scaling/multiscaler.go
+++ b/pkg/autoscaler/scaling/multiscaler.go
@@ -74,6 +74,8 @@ type DeciderSpec struct {
 	// revision initial scale and cluster initial scale into account. Revision initial
 	// scale overrides cluster initial scale.
 	InitialScale int32
+	// Reachable describes whether the revision is referenced by any route.
+	Reachable bool
 }
 
 // DeciderStatus is the current scale recommendation.

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	asv1a1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/autoscaler/scaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/resources"
@@ -47,7 +47,7 @@ type Deciders interface {
 // MakeDecider constructs a Decider resource from a PodAutoscaler taking
 // into account the PA's ContainerConcurrency and the relevant
 // autoscaling annotation.
-func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autoscalerconfig.Config, svc string) *scaling.Decider {
+func MakeDecider(ctx context.Context, pa *asv1a1.PodAutoscaler, config *autoscalerconfig.Config, svc string) *scaling.Decider {
 	panicThresholdPercentage := config.PanicThresholdPercentage
 	if x, ok := pa.PanicThresholdPercentage(); ok {
 		panicThresholdPercentage = x
@@ -74,6 +74,7 @@ func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autosc
 			StableWindow:        resources.StableWindow(pa, config),
 			ServiceName:         svc,
 			InitialScale:        GetInitialScale(config, pa),
+			Reachable:           pa.Spec.Reachability != asv1a1.ReachabilityUnreachable,
 		},
 	}
 }
@@ -81,7 +82,7 @@ func MakeDecider(ctx context.Context, pa *v1alpha1.PodAutoscaler, config *autosc
 // GetInitialScale returns the calculated initial scale based on the autoscaler
 // ConfigMap and PA initial scale annotation value.
 // TODO(taragu): This function is exported and will be reused in other packages.
-func GetInitialScale(asConfig *autoscalerconfig.Config, pa *v1alpha1.PodAutoscaler) int32 {
+func GetInitialScale(asConfig *autoscalerconfig.Config, pa *asv1a1.PodAutoscaler) int32 {
 	initialScale := asConfig.InitialScale
 	revisionInitialScale, ok := pa.InitialScale()
 	if !ok || (revisionInitialScale == 0 && !asConfig.AllowZeroInitialScale) {

--- a/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
@@ -44,6 +44,20 @@ func TestMakeDecider(t *testing.T) {
 		pa:   pa(),
 		want: decider(withTarget(100.0), withPanicThreshold(2.0), withTotal(100)),
 	}, {
+		name: "unreachable",
+		pa: pa(func(pa *v1alpha1.PodAutoscaler) {
+			pa.Spec.Reachability = v1alpha1.ReachabilityUnreachable
+		}),
+		want: decider(withTarget(100.0), withPanicThreshold(2.0), withTotal(100), func(d *scaling.Decider) {
+			d.Spec.Reachable = false
+		}),
+	}, {
+		name: "explicit reachable",
+		pa: pa(func(pa *v1alpha1.PodAutoscaler) {
+			pa.Spec.Reachability = v1alpha1.ReachabilityReachable
+		}),
+		want: decider(withTarget(100.0), withPanicThreshold(2.0), withTotal(100)),
+	}, {
 		name: "tu < 1", // See #4449 why Target=100
 		pa:   pa(),
 		want: decider(withTarget(80), withPanicThreshold(2.0), withTotal(100)),
@@ -263,6 +277,7 @@ func decider(options ...deciderOption) *scaling.Decider {
 			ActivatorCapacity:   811,
 			StableWindow:        config.StableWindow,
 			InitialScale:        1,
+			Reachable:           true,
 		},
 	}
 	for _, fn := range options {


### PR DESCRIPTION
This permits us to make more aggressive moves in the autoscaler when we know that the revision is no longer
routable.
E.g. ignore scale down rates, when the revision is vacated from all the requests (next PR)

/assign @julz @yanweiguo 