### PR TITLE
Rename Autoscaler to be a private type

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -57,7 +57,7 @@ type autoscaler struct {
 	podCounter  resources.EndpointsCounter
 }
 
-// New creates a new instance of autoscaler
+// New creates a new instance of default autoscaler implementation.
 func New(
 	namespace string,
 	revision string,
@@ -71,6 +71,17 @@ func New(
 	if reporterCtx == nil {
 		return nil, errors.New("stats reporter must not be nil")
 	}
+	return newAutoscaler(namespace, revision, metricClient,
+		lister, deciderSpec, reporterCtx), nil
+}
+
+func newAutoscaler(
+	namespace string,
+	revision string,
+	metricClient metrics.MetricClient,
+	lister corev1listers.EndpointsLister,
+	deciderSpec *DeciderSpec,
+	reporterCtx context.Context) *autoscaler {
 
 	// We always start in the panic mode, if the deployment is scaled up over 1 pod.
 	// If the scale is 0 or 1, normal Autoscaler behavior is fine.
@@ -107,7 +118,7 @@ func New(
 
 		panicTime:    pt,
 		maxPanicPods: int32(curC),
-	}, nil
+	}
 }
 
 // Update reconfigures the UniScaler according to the DeciderSpec.

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -573,11 +573,7 @@ func TestStartInPanicMode(t *testing.T) {
 	l := fake.KubeInformer.Core().V1().Endpoints().Lister()
 	for i := 0; i < 2; i++ {
 		fake.Endpoints(i, fake.TestService)
-		us, err := New(fake.TestNamespace, fake.TestRevision, metrics, l, deciderSpec, context.Background())
-		if err != nil {
-			t.Fatal("Error creating test autoscaler:", err)
-		}
-		a := us.(*autoscaler)
+		a := newAutoscaler(fake.TestNamespace, fake.TestRevision, metrics, l, deciderSpec, context.Background())
 		if !a.panicTime.IsZero() {
 			t.Errorf("Create at scale %d had panic mode on", i)
 		}
@@ -588,11 +584,7 @@ func TestStartInPanicMode(t *testing.T) {
 
 	// Now start with 2 and make sure we're in panic mode.
 	fake.Endpoints(2, fake.TestService)
-	us, err := New(fake.TestNamespace, fake.TestRevision, metrics, l, deciderSpec, context.Background())
-	if err != nil {
-		t.Fatal("Error creating test autoscaler:", err)
-	}
-	a := us.(*autoscaler)
+	a := newAutoscaler(fake.TestNamespace, fake.TestRevision, metrics, l, deciderSpec, context.Background())
 	if a.panicTime.IsZero() {
 		t.Error("Create at scale 2 had panic mode off")
 	}
@@ -616,11 +608,7 @@ func TestNewFail(t *testing.T) {
 	}
 
 	l := fake.KubeInformer.Core().V1().Endpoints().Lister()
-	us, err := New(fake.TestNamespace, fake.TestRevision, metrics, l, deciderSpec, context.Background())
-	if err != nil {
-		t.Errorf("No endpoints should succeed, err = %v", err)
-	}
-	a := us.(*autoscaler)
+	a := newAutoscaler(fake.TestNamespace, fake.TestRevision, metrics, l, deciderSpec, context.Background())
 	if got, want := int(a.maxPanicPods), 0; got != want {
 		t.Errorf("maxPanicPods = %d, want: 0", got)
 	}

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -75,7 +75,7 @@ func expectedEBC(totCap, targetBC, recordedConcurrency, numPods float64) int32 {
 	return int32(math.Floor(float64(totCap/targetUtilization*numPods) - targetBC - recordedConcurrency))
 }
 
-func expectedNA(a *Autoscaler, numP float64) int32 {
+func expectedNA(a *autoscaler, numP float64) int32 {
 	return int32(math.Max(MinActivators,
 		math.Ceil(
 			(a.deciderSpec.TotalValue*numP+a.deciderSpec.TargetBurstCapacity)/a.deciderSpec.ActivatorCapacity)))
@@ -314,8 +314,8 @@ func TestAutoscalerPanicModeExponentialTrackAndStablize(t *testing.T) {
 func TestAutoscalerScale(t *testing.T) {
 	tests := []struct {
 		label       string
-		as          *Autoscaler
-		prepFunc    func(as *Autoscaler)
+		as          *autoscaler
+		prepFunc    func(as *autoscaler)
 		baseScale   int
 		wantScale   int32
 		wantEBC     int32
@@ -353,7 +353,7 @@ func TestAutoscalerScale(t *testing.T) {
 	}, {
 		label: "AutoscalerPanicStableLargerThanPanic",
 		as:    newTestAutoscaler(t, 1, 100, &fake.MetricClient{StableConcurrency: 50, PanicConcurrency: 30}),
-		prepFunc: func(a *Autoscaler) {
+		prepFunc: func(a *autoscaler) {
 			a.panicTime = time.Now().Add(-5 * time.Second)
 			a.maxPanicPods = 5
 		},
@@ -363,7 +363,7 @@ func TestAutoscalerScale(t *testing.T) {
 	}, {
 		label: "AutoscalerPanicStableLessThanPanic",
 		as:    newTestAutoscaler(t, 1, 100, &fake.MetricClient{StableConcurrency: 20, PanicConcurrency: 30}),
-		prepFunc: func(a *Autoscaler) {
+		prepFunc: func(a *autoscaler) {
 			a.panicTime = time.Now().Add(-5 * time.Second)
 			a.maxPanicPods = 5
 		},
@@ -383,7 +383,7 @@ func TestAutoscalerScale(t *testing.T) {
 			PanicConcurrency:  3.1,
 		}),
 		baseScale: 2,
-		prepFunc: func(a *Autoscaler) {
+		prepFunc: func(a *autoscaler) {
 			a.deciderSpec.MaxScaleUpRate = 1.1
 		},
 		wantScale: 3,
@@ -392,7 +392,7 @@ func TestAutoscalerScale(t *testing.T) {
 		label:     "AutoscalerStableModeIncreaseWithSmallScaleDownRate",
 		as:        newTestAutoscaler(t, 10 /* target */, 1982 /* TBC */, &fake.MetricClient{StableConcurrency: 1, PanicConcurrency: 1}),
 		baseScale: 100,
-		prepFunc: func(a *Autoscaler) {
+		prepFunc: func(a *autoscaler) {
 			a.deciderSpec.MaxScaleDownRate = 1.1
 		},
 		wantScale: 90,
@@ -510,12 +510,12 @@ func TestAutoscalerUpdateTarget(t *testing.T) {
 	expectScale(t, a, time.Now(), ScaleResult{100, expectedEBC(1, 71, 101, 10), na, true})
 }
 
-func newTestAutoscaler(t *testing.T, targetValue, targetBurstCapacity float64, metrics metrics.MetricClient) *Autoscaler {
+func newTestAutoscaler(t *testing.T, targetValue, targetBurstCapacity float64, metrics metrics.MetricClient) *autoscaler {
 	return newTestAutoscalerWithScalingMetric(t, targetValue, targetBurstCapacity,
 		metrics, "concurrency", false /*panic*/)
 }
 
-func newTestAutoscalerWithScalingMetric(t *testing.T, targetValue, targetBurstCapacity float64, metrics metrics.MetricClient, metric string, startInPanic bool) *Autoscaler {
+func newTestAutoscalerWithScalingMetric(t *testing.T, targetValue, targetBurstCapacity float64, metrics metrics.MetricClient, metric string, startInPanic bool) *autoscaler {
 	t.Helper()
 	deciderSpec := &DeciderSpec{
 		ScalingMetric:       metric,
@@ -546,7 +546,7 @@ func newTestAutoscalerWithScalingMetric(t *testing.T, targetValue, targetBurstCa
 		t.Fatal("Error creating test autoscaler:", err)
 	}
 	fake.Endpoints(1, fake.TestService)
-	return a
+	return a.(*autoscaler)
 }
 
 func expectScale(t *testing.T, a UniScaler, now time.Time, want ScaleResult) {
@@ -573,10 +573,11 @@ func TestStartInPanicMode(t *testing.T) {
 	l := fake.KubeInformer.Core().V1().Endpoints().Lister()
 	for i := 0; i < 2; i++ {
 		fake.Endpoints(i, fake.TestService)
-		a, err := New(fake.TestNamespace, fake.TestRevision, metrics, l, deciderSpec, context.Background())
+		us, err := New(fake.TestNamespace, fake.TestRevision, metrics, l, deciderSpec, context.Background())
 		if err != nil {
 			t.Fatal("Error creating test autoscaler:", err)
 		}
+		a := us.(*autoscaler)
 		if !a.panicTime.IsZero() {
 			t.Errorf("Create at scale %d had panic mode on", i)
 		}
@@ -587,10 +588,11 @@ func TestStartInPanicMode(t *testing.T) {
 
 	// Now start with 2 and make sure we're in panic mode.
 	fake.Endpoints(2, fake.TestService)
-	a, err := New(fake.TestNamespace, fake.TestRevision, metrics, l, deciderSpec, context.Background())
+	us, err := New(fake.TestNamespace, fake.TestRevision, metrics, l, deciderSpec, context.Background())
 	if err != nil {
 		t.Fatal("Error creating test autoscaler:", err)
 	}
+	a := us.(*autoscaler)
 	if a.panicTime.IsZero() {
 		t.Error("Create at scale 2 had panic mode off")
 	}
@@ -614,10 +616,11 @@ func TestNewFail(t *testing.T) {
 	}
 
 	l := fake.KubeInformer.Core().V1().Endpoints().Lister()
-	a, err := New(fake.TestNamespace, fake.TestRevision, metrics, l, deciderSpec, context.Background())
+	us, err := New(fake.TestNamespace, fake.TestRevision, metrics, l, deciderSpec, context.Background())
 	if err != nil {
 		t.Errorf("No endpoints should succeed, err = %v", err)
 	}
+	a := us.(*autoscaler)
 	if got, want := int(a.maxPanicPods), 0; got != want {
 		t.Errorf("maxPanicPods = %d, want: 0", got)
 	}


### PR DESCRIPTION
Since there's no need for it to be public, given we have the UniScaler interface.

/assign @julz