### PR TITLE
Update the autoscaler interface in terms of counter

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -218,7 +218,10 @@ func uniScalerFactoryFunc(endpointsInformer corev1informers.EndpointsInformer,
 			return nil, err
 		}
 
-		return scaling.New(decider.Namespace, decider.Name, metricClient, endpointsInformer.Lister(), &decider.Spec, ctx)
+		pc := resources.NewScopedEndpointsCounter(endpointsInformer.Lister(),
+			decider.Namespace, decider.Name)
+		return scaling.New(decider.Namespace, decider.Name, metricClient,
+			pc, &decider.Spec, ctx)
 	}
 }
 

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -219,7 +219,7 @@ func uniScalerFactoryFunc(endpointsInformer corev1informers.EndpointsInformer,
 		}
 
 		pc := resources.NewScopedEndpointsCounter(endpointsInformer.Lister(),
-			decider.Namespace, decider.Name)
+			decider.Namespace, decider.Spec.ServiceName)
 		return scaling.New(decider.Namespace, decider.Name, metricClient,
 			pc, &decider.Spec, ctx)
 	}

--- a/pkg/resources/endpoints.go
+++ b/pkg/resources/endpoints.go
@@ -39,9 +39,10 @@ func NotReadyAddressCount(endpoints *corev1.Endpoints) int {
 	return notReady
 }
 
-// EndpointsCounter provides a count of currently ready and notReady pods. This
-// information is used by UniScaler implementations to make scaling
-// decisions. The interface prevents the UniScaler from needing to
+// EndpointsCounter provides a count of currently ready and notReady pods.
+// This information, among other places, is used by UniScaler implementations
+// to make scaling decisions.
+// The interface prevents the UniScaler from needing to
 // know how counts are performed.
 // The int return value represents the number of pods that are ready
 // to handle incoming requests.


### PR DESCRIPTION
- We were using lister to pass into the autoscaler and instantiate the counter.
- There was a moment when we were using random names for private serice (k8s name template), but no longer
  so no need for this anymore
- So remove the update counter, since service is constant rev-private

/lint
/assign @yanweiguo @markusthoemmes mattmoor