### PR TITLE
Bypass scaledown when the revision is not reachable

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -180,7 +180,10 @@ func (a *autoscaler) Scale(ctx context.Context, now time.Time) ScaleResult {
 	// 3 pods. See the unit test for this scenario in action.
 	maxScaleUp := math.Ceil(spec.MaxScaleUpRate * readyPodsCount)
 	// Same logic, opposite math applies here.
-	maxScaleDown := math.Floor(readyPodsCount / spec.MaxScaleDownRate)
+	maxScaleDown := 0.
+	if spec.Reachable {
+		maxScaleDown = math.Floor(readyPodsCount / spec.MaxScaleDownRate)
+	}
 
 	dspc := math.Ceil(observedStableValue / spec.TargetValue)
 	dppc := math.Ceil(observedPanicValue / spec.TargetValue)

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -445,20 +445,6 @@ func TestAutoscalerRateLimitScaleUp(t *testing.T) {
 	expectScale(t, a, time.Now(), ScaleResult{100, expectedEBC(10, 61, 1001, 10), na, true})
 }
 
-func TestAutoscalerScaleDownNoLimitWhenNonReachable(t *testing.T) {
-	metrics := &fake.MetricClient{StableConcurrency: 1, PanicConcurrency: 1}
-	a := newTestAutoscaler(t, 10, 61, metrics)
-
-	// Need 1 pods but can only scale down ten times, to 10.
-	fake.Endpoints(100, fake.TestService)
-	na := expectedNA(a, 100)
-	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 61, 1, 100), na, true})
-
-	na = expectedNA(a, 10)
-	fake.Endpoints(10, fake.TestService)
-	// Scale ÷10 again.
-	expectScale(t, a, time.Now(), ScaleResult{1, expectedEBC(10, 61, 1, 10), na, true})
-}
 func TestAutoscalerRateLimitScaleDown(t *testing.T) {
 	metrics := &fake.MetricClient{StableConcurrency: 1, PanicConcurrency: 1}
 	a := newTestAutoscaler(t, 10, 61, metrics)


### PR DESCRIPTION
If the revision is not reachable, then no reason to slowly scale it down
but rather scale with the speed that the requests are vacating the system

/assign @yanweiguo mattmoor
/lint
