### PR TITLE
Add conformance test for tag header based routing

### DIFF
--- a/test/conformance/ingress/headers.go
+++ b/test/conformance/ingress/headers.go
@@ -119,6 +119,7 @@ func TestTagHeaders(t *testing.T) {
 
 			ri := RuntimeRequest(t, client, "http://"+name+".example.com", ros...)
 			if ri == nil {
+				t.Errorf("Couldn't make request")
 				return
 			}
 

--- a/test/conformance/ingress/headers.go
+++ b/test/conformance/ingress/headers.go
@@ -121,7 +121,7 @@ const(
 
 			ri := RuntimeRequest(t, client, "http://"+name+".example.com", ros...)
 			if ri == nil {
-				t.Errorf("Couldn't make request")
+				t.Error("Couldn't make request")
 				return
 			}
 

--- a/test/conformance/ingress/headers.go
+++ b/test/conformance/ingress/headers.go
@@ -55,7 +55,7 @@ func TestTagHeaders(t *testing.T) {
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
 					Headers: map[string]v1alpha1.HeaderMatch{
-						network.TagHeaderName: v1alpha1.HeaderMatch{
+						network.TagHeaderName: {
 							Exact: tagName,
 						},
 					},

--- a/test/conformance/ingress/headers.go
+++ b/test/conformance/ingress/headers.go
@@ -41,12 +41,12 @@ func TestTagHeaders(t *testing.T) {
 	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 	defer cancel()
 
-	const tagName = "the-tag"
-
-	const backendHeader = "Which-Backend"
-
-	const backendWithTag = "tag"
-	const backendWithoutTag = "no-tag"
+const(
+	tagName = "the-tag"
+	backendHeader = "Which-Backend"
+	backendWithTag = "tag"
+	backendWithoutTag = "no-tag"
+)
 
 	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{

--- a/test/conformance/ingress/headers.go
+++ b/test/conformance/ingress/headers.go
@@ -114,7 +114,9 @@ func TestTagHeaders(t *testing.T) {
 			ros := []RequestOption{}
 
 			if tt.TagHeader != nil {
-				ros = append(ros, tagHeaderOption(*tt.TagHeader))
+				ros = append(ros, func(r *http.Request) {
+					r.Header.Set(network.TagHeaderName, *tt.TagHeader)
+				})
 			}
 
 			ri := RuntimeRequest(t, client, "http://"+name+".example.com", ros...)
@@ -129,12 +131,6 @@ func TestTagHeaders(t *testing.T) {
 		})
 	}
 
-}
-
-func tagHeaderOption(tag string) RequestOption {
-	return func(r *http.Request) {
-		r.Header.Set(network.TagHeaderName, tag)
-	}
 }
 
 // TestPreSplitSetHeaders verifies that an Ingress that specified AppendHeaders pre-split has the appropriate header(s) set.

--- a/test/conformance/ingress/headers.go
+++ b/test/conformance/ingress/headers.go
@@ -39,14 +39,14 @@ func TestTagHeaders(t *testing.T) {
 	clients := test.Setup(t)
 
 	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
-	defer cancel()
+	t.Cleanup(cancel)
 
-const(
-	tagName = "the-tag"
-	backendHeader = "Which-Backend"
-	backendWithTag = "tag"
-	backendWithoutTag = "no-tag"
-)
+	const (
+		tagName           = "the-tag"
+		backendHeader     = "Which-Backend"
+		backendWithTag    = "tag"
+		backendWithoutTag = "no-tag"
+	)
 
 	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
@@ -84,7 +84,7 @@ const(
 			},
 		}},
 	})
-	defer cancel()
+	t.Cleanup(cancel)
 
 	tests := []struct {
 		Name        string

--- a/test/conformance/ingress/headers.go
+++ b/test/conformance/ingress/headers.go
@@ -25,8 +25,116 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/network"
 	"knative.dev/serving/test"
 )
+
+// TestTagHeaders verifies that an Ingress properly dispaches to backends based on the tag header
+//
+// See proposal doc for reference:
+// https://docs.google.com/document/d/12t_3NE4EqvW_l0hfVlQcAGKkwkAM56tTn2wN_JtHbSQ/edit?usp=sharing
+func TestTagHeaders(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	const tagName = "the-tag"
+
+	const backendHeader = "Which-Backend"
+
+	const backendWithTag = "tag"
+	const backendWithoutTag = "no-tag"
+
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{name + ".example.com"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Headers: map[string]v1alpha1.HeaderMatch{
+						network.TagHeaderName: v1alpha1.HeaderMatch{
+							Exact: tagName,
+						},
+					},
+					AppendHeaders: map[string]string{
+						backendHeader: backendWithTag,
+					},
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}, {
+					AppendHeaders: map[string]string{
+						backendHeader: backendWithoutTag,
+					},
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	tests := []struct {
+		Name        string
+		TagHeader   *string
+		WantBackend string
+	}{{
+		Name:        "matching tag header",
+		TagHeader:   ptr.String(tagName),
+		WantBackend: backendWithTag,
+	}, {
+		Name:        "no tag header",
+		WantBackend: backendWithoutTag,
+	}, {
+		// Note: Behavior may change in Phase 2 (see Proposal doc)
+		Name:        "empty tag header",
+		TagHeader:   ptr.String(""),
+		WantBackend: backendWithoutTag,
+	}, {
+		// Note: Behavior may change in Phase 2 (see Proposal doc)
+		Name:        "non-matching tag header",
+		TagHeader:   ptr.String("not-" + tagName),
+		WantBackend: backendWithoutTag,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			ros := []RequestOption{}
+
+			if tt.TagHeader != nil {
+				ros = append(ros, tagHeaderOption(*tt.TagHeader))
+			}
+
+			ri := RuntimeRequest(t, client, "http://"+name+".example.com", ros...)
+			if ri == nil {
+				return
+			}
+
+			if got, want := ri.Request.Headers.Get(backendHeader), tt.WantBackend; got != want {
+				t.Errorf("Header[%q] = %q, wanted %q", backendHeader, got, want)
+			}
+		})
+	}
+
+}
+
+func tagHeaderOption(tag string) RequestOption {
+	return func(r *http.Request) {
+		r.Header.Set(network.TagHeaderName, tag)
+	}
+}
 
 // TestPreSplitSetHeaders verifies that an Ingress that specified AppendHeaders pre-split has the appropriate header(s) set.
 func TestPreSplitSetHeaders(t *testing.T) {

--- a/test/conformance/ingress/run.go
+++ b/test/conformance/ingress/run.go
@@ -27,6 +27,7 @@ func RunConformance(t *testing.T) {
 
 	t.Run("headers/pre-split", TestPreSplitSetHeaders)
 	t.Run("headers/post-split", TestPostSplitSetHeaders)
+	t.Run("headers/tags", TestTagHeaders)
 
 	t.Run("hosts/multiple", TestMultipleHosts)
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #8097 

Verified with [net-contour implementation](https://github.com/knative/net-contour/pull/148)

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add ingress conformance test for tag header based routing

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add ingress conformance test for tag header based routing
```

/assign @ZhiminXiang @tcnghia @igsong 