### PR TITLE
Do not clean up auto TLS resources before collecting logs and resources

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -189,11 +189,9 @@ go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
 kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
 delete_dns_record
 
+(( failed )) && fail_test
+
 subheader "Cleanup auto tls"
 cleanup_auto_tls_common
-
-# Dump cluster state in case of failure
-(( failed )) && dump_cluster_state
-(( failed )) && fail_test
 
 success

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -168,8 +168,6 @@ fi
 # Define short -spoofinterval to ensure frequent probing while stopping pods
 go_test_e2e -timeout=15m -failfast -parallel=1 ./test/ha -spoofinterval="10ms" || failed=1
 
-# Dump cluster state in case of failure
-(( failed )) && dump_cluster_state
 (( failed )) && fail_test
 
 success


### PR DESCRIPTION
## Proposed Changes

This patch changes following two:

- to call `cleanup_auto_tls_common` after `dump_cluster_state`.

We cannot see auto TLS resources in the dumped resources currently. It should be called only when the test passed actually.

- to remove `dump_cluster_state` because it is called in `fail_test`.

The dump_cluster_state is called in fail_test so we don't need to call it here.

https://github.com/knative/serving/blob/0258654c4657ea95bffc367ef17768ca920a5fec/vendor/knative.dev/test-infra/scripts/e2e-tests.sh#L421

**Release Note**

```release-note
NONE
```
