### PR TITLE
Another attempt at flaky route test

### DIFF
--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -1389,6 +1389,12 @@ func TestUpdateDomainConfigMap(t *testing.T) {
 				t.Fatal("Failed to see route initial reconcile propagation:", err)
 			}
 
+			// Ensure we're operating on a copy, to make sure the update below
+			// generates an actual diff. Otherwise the value in the
+			// fake cache is going to be changed. Now, this update sometimes races with
+			// the CM update and since the update below is a noop (the same object
+			// is applied), noting happens and the test fails.
+			route = route.DeepCopy()
 			tc.apply(route, watcher)
 			fakerouteinformer.Get(ctx).Informer().GetIndexer().Add(route)
 			if _, err := routeClient.Update(route); err != nil {


### PR DESCRIPTION
Fixes #8056
Make sure to clone the object before modifying. Otherwise the update below generates a noop.
And if global resync already finished (i.e race with CM update), then the test will fail.
This happens since we jitter in the global resync code and if random returns 0 (or another small number), the test fails.
Hence very rare occurrence of flakes.

/assign @dprotaso @tcnghia mattmoor