### PR TITLE
Switch stats counter to use pod counter for pod counts

### DIFF
--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -128,7 +128,6 @@ type serviceScraper struct {
 	directClient scrapeClient
 	meshClient   scrapeClient
 
-	counter  resources.EndpointsCounter
 	url      string
 	statsCtx context.Context
 	logger   *zap.SugaredLogger
@@ -139,8 +138,8 @@ type serviceScraper struct {
 
 // NewStatsScraper creates a new StatsScraper for the Revision which
 // the given Metric is responsible for.
-func NewStatsScraper(metric *av1alpha1.Metric, counter resources.EndpointsCounter,
-	podAccessor resources.PodAccessor, logger *zap.SugaredLogger) (StatsScraper, error) {
+func NewStatsScraper(metric *av1alpha1.Metric, podAccessor resources.PodAccessor,
+	logger *zap.SugaredLogger) (StatsScraper, error) {
 	directClient, err := newHTTPScrapeClient(client)
 	if err != nil {
 		return nil, err
@@ -149,20 +148,16 @@ func NewStatsScraper(metric *av1alpha1.Metric, counter resources.EndpointsCounte
 	if err != nil {
 		return nil, err
 	}
-	return newServiceScraperWithClient(metric, counter, podAccessor, directClient, meshClient, logger)
+	return newServiceScraperWithClient(metric, podAccessor, directClient, meshClient, logger)
 }
 
 func newServiceScraperWithClient(
 	metric *av1alpha1.Metric,
-	counter resources.EndpointsCounter,
 	podAccessor resources.PodAccessor,
 	directClient, meshClient scrapeClient,
 	logger *zap.SugaredLogger) (*serviceScraper, error) {
 	if metric == nil {
 		return nil, errors.New("metric must not be nil")
-	}
-	if counter == nil {
-		return nil, errors.New("counter must not be nil")
 	}
 	revName := metric.Labels[serving.RevisionLabelKey]
 	if revName == "" {
@@ -179,7 +174,6 @@ func newServiceScraperWithClient(
 	return &serviceScraper{
 		directClient:    directClient,
 		meshClient:      meshClient,
-		counter:         counter,
 		url:             urlFromTarget(metric.Spec.ScrapeTarget, metric.ObjectMeta.Namespace),
 		podAccessor:     podAccessor,
 		podsAddressable: true,
@@ -197,7 +191,7 @@ func urlFromTarget(t, ns string) string {
 // Scrape calls the destination service then sends it
 // to the given stats channel.
 func (s *serviceScraper) Scrape(window time.Duration) (Stat, error) {
-	readyPodsCount, err := s.counter.ReadyCount()
+	readyPodsCount, err := s.podAccessor.ReadyCount()
 	if err != nil {
 		return emptyStat, ErrFailedGetEndpoints
 	}

--- a/pkg/autoscaler/metrics/stats_scraper_test.go
+++ b/pkg/autoscaler/metrics/stats_scraper_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"sync"
@@ -27,14 +28,18 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeinformers "k8s.io/client-go/informers"
-	fakek8s "k8s.io/client-go/kubernetes/fake"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 
+	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
+	fakepodsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
+
+	"knative.dev/pkg/controller"
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/autoscaler/fake"
 	"knative.dev/serving/pkg/resources"
+
+	. "knative.dev/pkg/reconciler/testing"
 )
 
 var (
@@ -82,13 +87,10 @@ func testStatsWithTime(n int, youngestSecs float64) []Stat {
 
 func TestNewServiceScraperWithClientHappyCase(t *testing.T) {
 	metric := testMetric()
-	counter := resources.NewScopedEndpointsCounter(
-		fake.KubeInformer.Core().V1().Endpoints().Lister(),
-		fake.TestNamespace, fake.TestService)
 	accessor := resources.NewPodAccessor(
 		fake.KubeInformer.Core().V1().Pods().Lister(),
 		fake.TestNamespace, fake.TestRevision)
-	sc, err := NewStatsScraper(metric, counter, accessor, logtesting.TestLogger(t))
+	sc, err := NewStatsScraper(metric, accessor, logtesting.TestLogger(t))
 	if err != nil {
 		t.Fatal("NewServiceScraper =", err)
 	}
@@ -122,13 +124,10 @@ func checkBaseStat(t *testing.T, got Stat) {
 }
 
 func TestNewServiceScraperWithClientErrorCases(t *testing.T) {
-	metric := testMetric()
 	invalidMetric := testMetric()
 	invalidMetric.Labels = map[string]string{}
 	client := newTestScrapeClient(testStats, []error{nil})
-	lister := fake.KubeInformer.Core().V1().Endpoints().Lister()
 	podLister := fake.KubeInformer.Core().V1().Pods().Lister()
-	counter := resources.NewScopedEndpointsCounter(lister, fake.TestNamespace, fake.TestService)
 	podAccessor := resources.NewPodAccessor(podLister, fake.TestNamespace, fake.TestRevision)
 	logger := logtesting.TestLogger(t)
 
@@ -142,28 +141,19 @@ func TestNewServiceScraperWithClientErrorCases(t *testing.T) {
 	}{{
 		name:        "Empty Decider",
 		client:      client,
-		counter:     counter,
 		accessor:    podAccessor,
 		expectedErr: "metric must not be nil",
 	}, {
 		name:        "Missing revision label in Decider",
 		metric:      invalidMetric,
 		client:      client,
-		counter:     counter,
 		accessor:    podAccessor,
 		expectedErr: "no Revision label found for Metric test-revision",
-	}, {
-		name:        "Empty counter",
-		metric:      metric,
-		client:      client,
-		accessor:    podAccessor,
-		counter:     nil,
-		expectedErr: "counter must not be nil",
 	}}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			if _, err := newServiceScraperWithClient(test.metric, test.counter,
+			if _, err := newServiceScraperWithClient(test.metric,
 				test.accessor, test.client, test.client, logger); err != nil {
 				got := err.Error()
 				want := test.expectedErr
@@ -178,17 +168,23 @@ func TestNewServiceScraperWithClientErrorCases(t *testing.T) {
 }
 
 func TestPodDirectScrapeSuccess(t *testing.T) {
-	// Easier to reset, than to delete pods.
-	fake.KubeClient = fakek8s.NewSimpleClientset()
-	fake.KubeInformer = kubeinformers.NewSharedInformerFactory(fake.KubeClient, 0)
+	ctx, cancel, informers := SetupFakeContextWithCancel(t)
+	wf, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
+		cancel()
+		t.Fatal("StartInformers() =", err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		wf()
+	})
+	makePods(ctx, 3)
 
 	client := newTestScrapeClient(testStats, []error{nil})
-	scraper, err := serviceScraperForTest(t, client, nil /* mesh not used */, true)
+	scraper, err := serviceScraperForTest(ctx, t, client, nil /* mesh not used */, true)
 	if err != nil {
 		t.Fatal("serviceScraperForTest:", err)
 	}
-	fake.Endpoints(3, fake.TestService)
-	makePods(3)
 
 	if _, err := scraper.Scrape(defaultMetric.Spec.StableWindow); err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
@@ -200,18 +196,24 @@ func TestPodDirectScrapeSuccess(t *testing.T) {
 }
 
 func TestPodDirectScrapeSomeFailButSuccess(t *testing.T) {
-	fake.KubeClient = fakek8s.NewSimpleClientset()
-	fake.KubeInformer = kubeinformers.NewSharedInformerFactory(fake.KubeClient, 0)
-
 	// For 5 pods, we need 4 successes.
+	ctx, cancel, informers := SetupFakeContextWithCancel(t)
+	wf, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
+		cancel()
+		t.Fatal("StartInformers() =", err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		wf()
+	})
+	makePods(ctx, 5)
+
 	client := newTestScrapeClient(testStats, []error{nil, nil, errors.New("okay"), nil, nil})
-	scraper, err := serviceScraperForTest(t, client, nil /* mesh not used */, true)
+	scraper, err := serviceScraperForTest(ctx, t, client, nil /* mesh not used */, true)
 	if err != nil {
 		t.Fatal("serviceScraperForTest:", err)
 	}
-	fake.Endpoints(5, fake.TestService)
-	makePods(5)
-
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
@@ -229,9 +231,6 @@ func TestPodDirectScrapeSomeFailButSuccess(t *testing.T) {
 }
 
 func TestPodDirectScrapeNoneSucceed(t *testing.T) {
-	fake.KubeClient = fakek8s.NewSimpleClientset()
-	fake.KubeInformer = kubeinformers.NewSharedInformerFactory(fake.KubeClient, 0)
-
 	testStats := testStatsWithTime(4, youngPodCutOffDuration.Seconds() /*youngest*/)
 	direct := newTestScrapeClient(testStats, []error{
 		// Pods fail.
@@ -241,13 +240,22 @@ func TestPodDirectScrapeNoneSucceed(t *testing.T) {
 		// Service succeeds.
 		nil, nil, nil, nil,
 	})
-	scraper, err := serviceScraperForTest(t, direct, mesh, true)
+	ctx, cancel, informers := SetupFakeContextWithCancel(t)
+	wf, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
+		cancel()
+		t.Fatal("StartInformers() =", err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		wf()
+	})
+	makePods(ctx, 4)
+
+	scraper, err := serviceScraperForTest(ctx, t, direct, mesh, true)
 	if err != nil {
 		t.Fatal("serviceScraperForTest:", err)
 	}
-	fake.Endpoints(4, fake.TestService)
-	makePods(4)
-
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
@@ -265,17 +273,23 @@ func TestPodDirectScrapeNoneSucceed(t *testing.T) {
 }
 
 func TestPodDirectScrapePodsExhausted(t *testing.T) {
-	fake.KubeClient = fakek8s.NewSimpleClientset()
-	fake.KubeInformer = kubeinformers.NewSharedInformerFactory(fake.KubeClient, 0)
+	ctx, cancel, informers := SetupFakeContextWithCancel(t)
+	wf, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
+		cancel()
+		t.Fatal("StartInformers() =", err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		wf()
+	})
+	makePods(ctx, 4)
 
 	client := newTestScrapeClient(testStats, []error{nil, nil, errors.New("okay"), nil})
-	scraper, err := serviceScraperForTest(t, client, nil /* mesh not used */, true)
+	scraper, err := serviceScraperForTest(ctx, t, client, nil /* mesh not used */, true)
 	if err != nil {
 		t.Fatal("serviceScraperForTest:", err)
 	}
-	fake.Endpoints(4, fake.TestService)
-	makePods(4)
-
 	_, err = scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err == nil {
 		t.Fatal("Expected an error")
@@ -287,14 +301,24 @@ func TestPodDirectScrapePodsExhausted(t *testing.T) {
 }
 
 func TestScrapeReportStatWhenAllCallsSucceed(t *testing.T) {
+	ctx, cancel, informers := SetupFakeContextWithCancel(t)
+	wf, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
+		cancel()
+		t.Fatal("StartInformers() =", err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		wf()
+	})
+	makePods(ctx, 3)
+
+	// Scrape will set a timestamp bigger than this.
 	client := newTestScrapeClient(testStats, []error{nil})
-	scraper, err := serviceScraperForTest(t, client, client, false)
+	scraper, err := serviceScraperForTest(ctx, t, client, client, false)
 	if err != nil {
 		t.Fatal("serviceScraperForTest:", err)
 	}
-
-	// Make an Endpoints with 3 pods.
-	fake.Endpoints(3, fake.TestService)
 
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
@@ -316,13 +340,23 @@ func TestScrapeAllPodsYoungPods(t *testing.T) {
 
 	direct := newTestScrapeClient(testStats, []error{errNoPodsScraped}) // fall back to service scrape
 	mesh := newTestScrapeClient(testStats, []error{nil})
-	scraper, err := serviceScraperForTest(t, direct, mesh, false)
+
+	ctx, cancel, informers := SetupFakeContextWithCancel(t)
+	wf, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
+		cancel()
+		t.Fatal("StartInformers() =", err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		wf()
+	})
+	makePods(ctx, numP)
+
+	scraper, err := serviceScraperForTest(ctx, t, direct, mesh, false)
 	if err != nil {
 		t.Fatalf("serviceScraperForTest=%v, want no error", err)
 	}
-
-	fake.Endpoints(numP, fake.TestService)
-
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
@@ -342,15 +376,23 @@ func TestScrapeAllPodsOldPods(t *testing.T) {
 	// All pods are at least cutoff time old, so first 5 stats will be picked.
 	testStats := testStatsWithTime(numP, youngPodCutOffDuration.Seconds() /*youngest*/)
 
+	ctx, cancel, informers := SetupFakeContextWithCancel(t)
+	wf, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
+		cancel()
+		t.Fatal("StartInformers() =", err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		wf()
+	})
+	makePods(ctx, numP)
 	direct := newTestScrapeClient(testStats, []error{errNoPodsScraped}) // fall back to service scrape
 	mesh := newTestScrapeClient(testStats, []error{nil})
-	scraper, err := serviceScraperForTest(t, direct, mesh, false)
+	scraper, err := serviceScraperForTest(ctx, t, direct, mesh, false)
 	if err != nil {
 		t.Fatalf("serviceScraperForTest=%v, want no error", err)
 	}
-
-	fake.Endpoints(numP, fake.TestService)
-
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
@@ -371,14 +413,25 @@ func TestScrapeSomePodsOldPods(t *testing.T) {
 	// So pods 3-10 qualify (for 11 total sample is 7).
 	testStats := testStatsWithTime(numP, youngPodCutOffDuration.Seconds()/2 /*youngest*/)
 
+	ctx, cancel, informers := SetupFakeContextWithCancel(t)
+	wf, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
+		cancel()
+		t.Fatal("StartInformers() =", err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		wf()
+	})
+	makePods(ctx, numP)
+
+	// Scrape will set a timestamp bigger than this.
 	direct := newTestScrapeClient(testStats, []error{errNoPodsScraped}) // fall back to service scrape
 	mesh := newTestScrapeClient(testStats, []error{nil})
-	scraper, err := serviceScraperForTest(t, direct, mesh, false)
+	scraper, err := serviceScraperForTest(ctx, t, direct, mesh, false)
 	if err != nil {
 		t.Fatalf("serviceScraperForTest=%v, want no error", err)
 	}
-
-	fake.Endpoints(numP, fake.TestService)
 
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
@@ -395,14 +448,23 @@ func TestScrapeSomePodsOldPods(t *testing.T) {
 }
 
 func TestScrapeReportErrorCannotFindEnoughPods(t *testing.T) {
+	ctx, cancel, informers := SetupFakeContextWithCancel(t)
+	wf, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
+		cancel()
+		t.Fatal("StartInformers() =", err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		wf()
+	})
+	makePods(ctx, 2)
+
 	client := newTestScrapeClient(testStats[2:], []error{nil})
-	scraper, err := serviceScraperForTest(t, client, client, false)
+	scraper, err := serviceScraperForTest(ctx, t, client, client, false)
 	if err != nil {
 		t.Fatalf("serviceScraperForTest=%v, want no error", err)
 	}
-
-	// Make an Endpoints with 2 pods.
-	fake.Endpoints(2, fake.TestService)
 
 	_, err = scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err == nil {
@@ -413,16 +475,25 @@ func TestScrapeReportErrorCannotFindEnoughPods(t *testing.T) {
 func TestScrapeReportErrorIfAnyFails(t *testing.T) {
 	errTest := errors.New("test")
 
+	ctx, cancel, informers := SetupFakeContextWithCancel(t)
+	wf, err := controller.RunInformers(ctx.Done(), informers...)
+	if err != nil {
+		cancel()
+		t.Fatal("StartInformers() =", err)
+	}
+	t.Cleanup(func() {
+		cancel()
+		wf()
+	})
+	makePods(ctx, 2)
+
 	// 1 success and 10 failures so one scrape fails permanently through retries.
 	client := newTestScrapeClient(testStats, []error{nil, errTest, errTest,
 		errTest, errTest, errTest, errTest, errTest, errTest, errTest, errTest})
-	scraper, err := serviceScraperForTest(t, client, client, false)
+	scraper, err := serviceScraperForTest(ctx, t, client, client, false)
 	if err != nil {
 		t.Fatalf("serviceScraperForTest=%v, want no error", err)
 	}
-
-	// Make an Endpoints with 2 pods.
-	fake.Endpoints(2, fake.TestService)
 
 	_, err = scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if !errors.Is(err, errTest) {
@@ -431,14 +502,13 @@ func TestScrapeReportErrorIfAnyFails(t *testing.T) {
 }
 
 func TestScrapeDoNotScrapeIfNoPodsFound(t *testing.T) {
+	ctx, cancel, _ := SetupFakeContextWithCancel(t)
+	t.Cleanup(cancel)
 	client := newTestScrapeClient(testStats, nil)
-	scraper, err := serviceScraperForTest(t, client, client, false)
+	scraper, err := serviceScraperForTest(ctx, t, client, client, false)
 	if err != nil {
 		t.Fatalf("serviceScraperForTest=%v, want no error", err)
 	}
-
-	// Make an Endpoints with 0 pods.
-	fake.Endpoints(0, fake.TestService)
 
 	stat, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
@@ -449,16 +519,13 @@ func TestScrapeDoNotScrapeIfNoPodsFound(t *testing.T) {
 	}
 }
 
-func serviceScraperForTest(t *testing.T, directClient, meshClient scrapeClient, podsAddressable bool) (*serviceScraper, error) {
+func serviceScraperForTest(ctx context.Context, t *testing.T, directClient, meshClient scrapeClient, podsAddressable bool) (*serviceScraper, error) {
 	metric := testMetric()
-	counter := resources.NewScopedEndpointsCounter(
-		fake.KubeInformer.Core().V1().Endpoints().Lister(),
-		fake.TestNamespace, fake.TestService)
 	accessor := resources.NewPodAccessor(
-		fake.KubeInformer.Core().V1().Pods().Lister(),
+		fakepodsinformer.Get(ctx).Lister(),
 		fake.TestNamespace, fake.TestRevision)
 	logger := logtesting.TestLogger(t)
-	ss, err := newServiceScraperWithClient(metric, counter, accessor, directClient, meshClient, logger)
+	ss, err := newServiceScraperWithClient(metric, accessor, directClient, meshClient, logger)
 	if ss != nil {
 		ss.podsAddressable = podsAddressable
 	}
@@ -511,7 +578,7 @@ func TestURLFromTarget(t *testing.T) {
 	}
 }
 
-func makePods(n int) {
+func makePods(ctx context.Context, n int) {
 	for i := 0; i < n; i++ {
 		p := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -521,11 +588,15 @@ func makePods(n int) {
 			},
 			Status: corev1.PodStatus{
 				Phase: corev1.PodRunning,
-				PodIP: "1.2.3.4",
+				PodIP: "1.2.3." + strconv.Itoa(4+i),
+				Conditions: []corev1.PodCondition{{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				}},
 			},
 		}
 
-		fake.KubeClient.CoreV1().Pods(fake.TestNamespace).Create(p)
-		fake.KubeInformer.Core().V1().Pods().Informer().GetIndexer().Add(p)
+		fakekubeclient.Get(ctx).CoreV1().Pods(fake.TestNamespace).Create(p)
+		fakepodsinformer.Get(ctx).Informer().GetIndexer().Add(p)
 	}
 }

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	. "knative.dev/pkg/logging/testing"
@@ -467,12 +466,6 @@ func TestAutoscalerRateLimitScaleDown(t *testing.T) {
 	pc.readyCount = 10
 	// Scale ÷10 again.
 	expectScale(t, a, time.Now(), ScaleResult{1, expectedEBC(10, 61, 1, 10), na, true})
-}
-
-func eraseEndpoints() {
-	ep, _ := fake.KubeClient.CoreV1().Endpoints(fake.TestNamespace).Get(fake.TestService, metav1.GetOptions{})
-	fake.KubeClient.CoreV1().Endpoints(fake.TestNamespace).Delete(fake.TestService, nil)
-	fake.KubeInformer.Core().V1().Endpoints().Informer().GetIndexer().Delete(ep)
 }
 
 func TestCantCountPods(t *testing.T) {


### PR DESCRIPTION
This is is the next steps in this epos. 
The change itself is mostly trivial, but lots of test shenanigans came out.
I switched everything to use ctx based informers, which are easy to clean and separate from test to test.

Next steps I will look at:
- cleaning autoscaler/fake package. May be even ditch it
- changing autoscaler/main to thread the rest of the things. 

/hold
Waiting for #8407 to merge, since it contains changes from there.