### PR TITLE
Remove time from stat struct as it's never sent anyway.

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -165,7 +165,7 @@ func main() {
 
 	go func() {
 		for sm := range statsCh {
-			collector.Record(sm.Key, sm.Stat)
+			collector.Record(sm.Key, time.Now(), sm.Stat)
 			multiScaler.Poke(sm.Key, sm.Stat)
 		}
 	}()

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -297,7 +297,6 @@ func (s *serviceScraper) scrapePods(readyPods int) (Stat, error) {
 
 func computeAverages(results <-chan Stat, sample, total float64) Stat {
 	ret := Stat{
-		Time:    time.Now(),
 		PodName: scraperPodName,
 	}
 
@@ -379,7 +378,6 @@ func (s *serviceScraper) scrapeService(window time.Duration, readyPods int) (Sta
 	close(youngStatCh)
 
 	ret := Stat{
-		Time:    time.Now(),
 		PodName: scraperPodName,
 	}
 

--- a/pkg/autoscaler/metrics/stats_scraper_test.go
+++ b/pkg/autoscaler/metrics/stats_scraper_test.go
@@ -189,16 +189,11 @@ func TestPodDirectScrapeSuccess(t *testing.T) {
 	}
 	fake.Endpoints(3, fake.TestService)
 	makePods(3)
-	now := time.Now()
 
-	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
-	if err != nil {
+	if _, err := scraper.Scrape(defaultMetric.Spec.StableWindow); err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
 	}
 
-	if got.Time.Before(now) {
-		t.Errorf("stat.Time=%v, want greater than %v", got.Time, now)
-	}
 	if !scraper.podsAddressable {
 		t.Error("PodAddressable switched to false")
 	}
@@ -216,16 +211,12 @@ func TestPodDirectScrapeSomeFailButSuccess(t *testing.T) {
 	}
 	fake.Endpoints(5, fake.TestService)
 	makePods(5)
-	now := time.Now()
 
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
 	}
 
-	if got.Time.Before(now) {
-		t.Errorf("stat.Time=%v, want greater than %v", got.Time, now)
-	}
 	// Checking one of the metrics is enough here.
 	if got.AverageConcurrentRequests != 20.0 {
 		t.Errorf("stat.AverageConcurrentRequests=%v, want %v",
@@ -256,16 +247,12 @@ func TestPodDirectScrapeNoneSucceed(t *testing.T) {
 	}
 	fake.Endpoints(4, fake.TestService)
 	makePods(4)
-	now := time.Now()
 
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
 	}
 
-	if got.Time.Before(now) {
-		t.Errorf("stat.Time=%v, want greater than %v", got.Time, now)
-	}
 	// Checking one of the metrics is enough here.
 	if got.AverageConcurrentRequests != 20.0 {
 		t.Errorf("stat.AverageConcurrentRequests=%v, want %v",
@@ -309,16 +296,11 @@ func TestScrapeReportStatWhenAllCallsSucceed(t *testing.T) {
 	// Make an Endpoints with 3 pods.
 	fake.Endpoints(3, fake.TestService)
 
-	// Scrape will set a timestamp bigger than this.
-	now := time.Now()
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
 	}
 
-	if got.Time.Before(now) {
-		t.Errorf("stat.Time=%v, want greater than %v", got.Time, now)
-	}
 	checkBaseStat(t, got)
 }
 
@@ -341,16 +323,11 @@ func TestScrapeAllPodsYoungPods(t *testing.T) {
 
 	fake.Endpoints(numP, fake.TestService)
 
-	// Scrape will set a timestamp bigger than this.
-	now := time.Now()
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
 	}
 
-	if got.Time.Before(now) {
-		t.Errorf("stat.Time=%v, want bigger than %v", got.Time, now)
-	}
 	if got.PodName != scraperPodName {
 		t.Errorf("stat.PodName=%v, want %v", got.PodName, scraperPodName)
 	}
@@ -374,16 +351,11 @@ func TestScrapeAllPodsOldPods(t *testing.T) {
 
 	fake.Endpoints(numP, fake.TestService)
 
-	// Scrape will set a timestamp bigger than this.
-	now := time.Now()
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
 	}
 
-	if got.Time.Before(now) {
-		t.Errorf("stat.Time=%v, want bigger than %v", got.Time, now)
-	}
 	if got.PodName != scraperPodName {
 		t.Errorf("stat.PodName=%v, want %v", got.PodName, scraperPodName)
 	}
@@ -408,16 +380,11 @@ func TestScrapeSomePodsOldPods(t *testing.T) {
 
 	fake.Endpoints(numP, fake.TestService)
 
-	// Scrape will set a timestamp bigger than this.
-	now := time.Now()
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
 	}
 
-	if got.Time.Before(now) {
-		t.Errorf("stat.Time=%v, want bigger than %v", got.Time, now)
-	}
 	if got.PodName != scraperPodName {
 		t.Errorf("stat.PodName=%v, want %v", got.PodName, scraperPodName)
 	}

--- a/pkg/autoscaler/scaling/multiscaler_test.go
+++ b/pkg/autoscaler/scaling/multiscaler_test.go
@@ -354,7 +354,6 @@ func TestMultiScalerScaleFromZero(t *testing.T) {
 	}
 
 	testStat := metrics.Stat{
-		Time:                      time.Now(),
 		PodName:                   "test-pod",
 		AverageConcurrentRequests: 1,
 		RequestCount:              1,

--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -175,8 +175,6 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		sm.Stat.Time = time.Now()
-
 		s.logger.Debugf("Received stat message: %+v", sm)
 		s.statsCh <- sm
 	}

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gorilla/websocket"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -220,12 +219,8 @@ func assertReceivedOK(t *testing.T, sm metrics.StatMessage, statSink *websocket.
 	if !ok {
 		t.Fatal("Statistic not received")
 	}
-	if recv.Stat.Time == (time.Time{}) {
-		t.Fatal("Stat time is nil")
-	}
-	ignoreTimeField := cmpopts.IgnoreFields(metrics.StatMessage{}, "Stat.Time")
-	if !cmp.Equal(sm, recv, ignoreTimeField) {
-		t.Fatalf("StatMessage mismatch: diff (-got, +want) %s", cmp.Diff(recv, sm, ignoreTimeField))
+	if !cmp.Equal(sm, recv) {
+		t.Fatalf("StatMessage mismatch: diff (-got, +want) %s", cmp.Diff(recv, sm))
 	}
 	return true
 }

--- a/pkg/reconciler/metric/metric_test.go
+++ b/pkg/reconciler/metric/metric_test.go
@@ -276,7 +276,7 @@ func (c *testCollector) CreateOrUpdate(metric *av1alpha1.Metric) error {
 	return c.createOrUpdateError
 }
 
-func (c *testCollector) Record(key types.NamespacedName, stat metrics.Stat) {
+func (c *testCollector) Record(key types.NamespacedName, now time.Time, stat metrics.Stat) {
 	if c.recordCalls != nil {
 		c.recordCalls <- struct{}{}
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

We always set the time of the stat when we receive it anyway (the scraper does and the websocket server does too), so we should be able to safely remove it from the struct and thus not confuse the wire protocol with this field.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
