### PR TITLE
allow enableServiceLinks to be set

### DIFF
--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -148,6 +148,7 @@ func PodSpecMask(in *corev1.PodSpec) *corev1.PodSpec {
 	out.Containers = in.Containers
 	out.Volumes = in.Volumes
 	out.ImagePullSecrets = in.ImagePullSecrets
+	out.EnableServiceLinks = in.EnableServiceLinks
 
 	// Disallowed fields
 	// This list is unnecessary, but added here for clarity
@@ -175,7 +176,6 @@ func PodSpecMask(in *corev1.PodSpec) *corev1.PodSpec {
 	out.DNSConfig = nil
 	out.ReadinessGates = nil
 	out.RuntimeClassName = nil
-	// TODO(mattmoor): Coming in 1.13: out.EnableServiceLinks = nil
 
 	return out
 }

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -166,13 +166,11 @@ func makeServingContainer(servingContainer corev1.Container, rev *v1.Revision) c
 
 // BuildPodSpec creates a PodSpec from the given revision and containers.
 func BuildPodSpec(rev *v1.Revision, containers []corev1.Container) *corev1.PodSpec {
-	return &corev1.PodSpec{
-		Containers:                    containers,
-		Volumes:                       append([]corev1.Volume{varLogVolume}, rev.Spec.Volumes...),
-		ServiceAccountName:            rev.Spec.ServiceAccountName,
-		TerminationGracePeriodSeconds: rev.Spec.TimeoutSeconds,
-		ImagePullSecrets:              rev.Spec.ImagePullSecrets,
-	}
+	pod := rev.Spec.PodSpec.DeepCopy()
+	pod.Containers = containers
+	pod.Volumes = append([]corev1.Volume{varLogVolume}, rev.Spec.Volumes...)
+	pod.TerminationGracePeriodSeconds = rev.Spec.TimeoutSeconds
+	return pod
 }
 
 func getUserPort(rev *v1.Revision) int32 {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #6074 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Allow service links to be disabled (the property defaults to `true`)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
enableServiceLinks can be set on the PodSpec template
```
