### PR TITLE
Accept both B3 and TraceContext style tracing

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -45,6 +45,7 @@ import (
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/tracing"
 	tracingconfig "knative.dev/pkg/tracing/config"
+	"knative.dev/pkg/tracing/propagation/tracecontextb3"
 	"knative.dev/serving/pkg/activator"
 	activatorutil "knative.dev/serving/pkg/activator/util"
 	pkghttp "knative.dev/serving/pkg/http"
@@ -372,7 +373,8 @@ func buildTransport(env config, logger *zap.SugaredLogger) http.RoundTripper {
 	})
 
 	return &ochttp.Transport{
-		Base: pkgnet.AutoTransport,
+		Base:        pkgnet.AutoTransport,
+		Propagation: tracecontextb3.B3Egress,
 	}
 }
 

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -31,6 +31,7 @@ import (
 	pkgnet "knative.dev/pkg/network"
 	"knative.dev/pkg/tracing"
 	tracingconfig "knative.dev/pkg/tracing/config"
+	"knative.dev/pkg/tracing/propagation/tracecontextb3"
 	tracetesting "knative.dev/pkg/tracing/testing"
 	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/network"
@@ -252,7 +253,8 @@ func TestQueueTraceSpans(t *testing.T) {
 					breaker = queue.NewBreaker(params)
 				}
 				proxy.Transport = &ochttp.Transport{
-					Base: pkgnet.AutoTransport,
+					Base:        pkgnet.AutoTransport,
+					Propagation: tracecontextb3.B3Egress,
 				}
 
 				h := proxyHandler(breaker, network.NewRequestStats(time.Now()), true /*tracingEnabled*/, proxy)

--- a/go.mod
+++ b/go.mod
@@ -39,8 +39,8 @@ require (
 	k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29
 	knative.dev/caching v0.0.0-20200606210318-787aec80f71c
 	knative.dev/networking v0.0.0-20200622163826-421cd312c651
-	knative.dev/pkg v0.0.0-20200623024526-fb0320d9287e
-	knative.dev/test-infra v0.0.0-20200623005026-1f7e5f05c52b
+	knative.dev/pkg v0.0.0-20200623173527-5658d93fb07e
+	knative.dev/test-infra v0.0.0-20200623145727-e9ff5263be06
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -1394,6 +1394,8 @@ knative.dev/pkg v0.0.0-20200619020725-7df8fc5d7743/go.mod h1:DquzK0hsLDcg2q63Sn+
 knative.dev/pkg v0.0.0-20200622135826-98f8a949a106/go.mod h1:DquzK0hsLDcg2q63Sn+CngAyRwv4cKMpt5F19YzBfb0=
 knative.dev/pkg v0.0.0-20200623024526-fb0320d9287e h1:fmsw4i/We4S9yyaZadL2z8DKDIz7XzcY/v4yPGUmUA4=
 knative.dev/pkg v0.0.0-20200623024526-fb0320d9287e/go.mod h1:DquzK0hsLDcg2q63Sn+CngAyRwv4cKMpt5F19YzBfb0=
+knative.dev/pkg v0.0.0-20200623173527-5658d93fb07e h1:MhQNsqYZ5BuDyZT/Q5MQMTMYTmkLcwq6MY+gGvPkymY=
+knative.dev/pkg v0.0.0-20200623173527-5658d93fb07e/go.mod h1:DquzK0hsLDcg2q63Sn+CngAyRwv4cKMpt5F19YzBfb0=
 knative.dev/sample-controller v0.0.0-20200510050845-bf7c19498b7e/go.mod h1:D2ZDLrR9Dq9LiiVN7TatzI7WMcEPgk1MHbbhgBKE6W8=
 knative.dev/test-infra v0.0.0-20200407185800-1b88cb3b45a5/go.mod h1:xcdUkMJrLlBswIZqL5zCuBFOC22WIPMQoVX1L35i0vQ=
 knative.dev/test-infra v0.0.0-20200505052144-5ea2f705bb55/go.mod h1:WqF1Azka+FxPZ20keR2zCNtiQA1MP9ZB4BH4HuI+SIU=
@@ -1406,8 +1408,8 @@ knative.dev/test-infra v0.0.0-20200522180958-6a0a9b9d893a/go.mod h1:n9eQkzmSNj8B
 knative.dev/test-infra v0.0.0-20200606045118-14ebc4a42974/go.mod h1://I6IZIF0QDgs5wotU243ZZ5cTpm6/GthayjUenBBc0=
 knative.dev/test-infra v0.0.0-20200617235125-6382dba95484/go.mod h1:+BfrTJpc++rH30gX/C0QY6NT2eYVzycll52uw6CrQnc=
 knative.dev/test-infra v0.0.0-20200619200026-0b0587234302/go.mod h1:H8QEB2Y35+vAuVtDbn7QBD+NQr9zQbbxNiovCLNH7F4=
-knative.dev/test-infra v0.0.0-20200623005026-1f7e5f05c52b h1:qQTd9xCiV3/PVt2LsmELMVL2gT4eAScMaFrPqiQnt1I=
-knative.dev/test-infra v0.0.0-20200623005026-1f7e5f05c52b/go.mod h1:H8QEB2Y35+vAuVtDbn7QBD+NQr9zQbbxNiovCLNH7F4=
+knative.dev/test-infra v0.0.0-20200623145727-e9ff5263be06 h1:6LNkyjc5iPk+Q47wwixmc9CL/0GIL40wZWGlwHXTDRc=
+knative.dev/test-infra v0.0.0-20200623145727-e9ff5263be06/go.mod h1:qKM6vO6hD6aa0ZYGDdyr5YiXPQMhbix1K8UWPUvVlIE=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -29,6 +29,7 @@ import (
 	"knative.dev/pkg/logging"
 	pkgnet "knative.dev/pkg/network"
 	tracingconfig "knative.dev/pkg/tracing/config"
+	"knative.dev/pkg/tracing/propagation/tracecontextb3"
 	"knative.dev/serving/pkg/activator"
 	activatorconfig "knative.dev/serving/pkg/activator/config"
 	"knative.dev/serving/pkg/activator/util"
@@ -54,10 +55,13 @@ type activationHandler struct {
 func New(ctx context.Context, t Throttler) http.Handler {
 	defaultTransport := pkgnet.AutoTransport
 	return &activationHandler{
-		transport:        defaultTransport,
-		tracingTransport: &ochttp.Transport{Base: defaultTransport},
-		throttler:        t,
-		bufferPool:       network.NewBufferPool(),
+		transport: defaultTransport,
+		tracingTransport: &ochttp.Transport{
+			Base:        defaultTransport,
+			Propagation: tracecontextb3.B3Egress,
+		},
+		throttler:  t,
+		bufferPool: network.NewBufferPool(),
 	}
 }
 

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -37,6 +37,7 @@ import (
 	rtesting "knative.dev/pkg/reconciler/testing"
 	"knative.dev/pkg/tracing"
 	tracingconfig "knative.dev/pkg/tracing/config"
+	"knative.dev/pkg/tracing/propagation/tracecontextb3"
 	tracetesting "knative.dev/pkg/tracing/testing"
 	"knative.dev/serving/pkg/activator"
 	activatorconfig "knative.dev/serving/pkg/activator/config"
@@ -253,7 +254,10 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 
 			handler := (New(ctx, fakeThrottler{})).(*activationHandler)
 			handler.transport = rt
-			handler.tracingTransport = &ochttp.Transport{Base: rt}
+			handler.tracingTransport = &ochttp.Transport{
+				Base:        rt,
+				Propagation: tracecontextb3.B3Egress,
+			}
 
 			// Set up config store to populate context.
 			configStore := setupConfigStore(t, logging.FromContext(ctx))

--- a/vendor/go.opencensus.io/plugin/ochttp/propagation/tracecontext/propagation.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/propagation/tracecontext/propagation.go
@@ -1,0 +1,187 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tracecontext contains HTTP propagator for TraceContext standard.
+// See https://github.com/w3c/distributed-tracing for more information.
+package tracecontext // import "go.opencensus.io/plugin/ochttp/propagation/tracecontext"
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/textproto"
+	"regexp"
+	"strings"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+	"go.opencensus.io/trace/tracestate"
+)
+
+const (
+	supportedVersion  = 0
+	maxVersion        = 254
+	maxTracestateLen  = 512
+	traceparentHeader = "traceparent"
+	tracestateHeader  = "tracestate"
+	trimOWSRegexFmt   = `^[\x09\x20]*(.*[^\x20\x09])[\x09\x20]*$`
+)
+
+var trimOWSRegExp = regexp.MustCompile(trimOWSRegexFmt)
+
+var _ propagation.HTTPFormat = (*HTTPFormat)(nil)
+
+// HTTPFormat implements the TraceContext trace propagation format.
+type HTTPFormat struct{}
+
+// SpanContextFromRequest extracts a span context from incoming requests.
+func (f *HTTPFormat) SpanContextFromRequest(req *http.Request) (sc trace.SpanContext, ok bool) {
+	h, ok := getRequestHeader(req, traceparentHeader, false)
+	if !ok {
+		return trace.SpanContext{}, false
+	}
+	sections := strings.Split(h, "-")
+	if len(sections) < 4 {
+		return trace.SpanContext{}, false
+	}
+
+	if len(sections[0]) != 2 {
+		return trace.SpanContext{}, false
+	}
+	ver, err := hex.DecodeString(sections[0])
+	if err != nil {
+		return trace.SpanContext{}, false
+	}
+	version := int(ver[0])
+	if version > maxVersion {
+		return trace.SpanContext{}, false
+	}
+
+	if version == 0 && len(sections) != 4 {
+		return trace.SpanContext{}, false
+	}
+
+	if len(sections[1]) != 32 {
+		return trace.SpanContext{}, false
+	}
+	tid, err := hex.DecodeString(sections[1])
+	if err != nil {
+		return trace.SpanContext{}, false
+	}
+	copy(sc.TraceID[:], tid)
+
+	if len(sections[2]) != 16 {
+		return trace.SpanContext{}, false
+	}
+	sid, err := hex.DecodeString(sections[2])
+	if err != nil {
+		return trace.SpanContext{}, false
+	}
+	copy(sc.SpanID[:], sid)
+
+	opts, err := hex.DecodeString(sections[3])
+	if err != nil || len(opts) < 1 {
+		return trace.SpanContext{}, false
+	}
+	sc.TraceOptions = trace.TraceOptions(opts[0])
+
+	// Don't allow all zero trace or span ID.
+	if sc.TraceID == [16]byte{} || sc.SpanID == [8]byte{} {
+		return trace.SpanContext{}, false
+	}
+
+	sc.Tracestate = tracestateFromRequest(req)
+	return sc, true
+}
+
+// getRequestHeader returns a combined header field according to RFC7230 section 3.2.2.
+// If commaSeparated is true, multiple header fields with the same field name using be
+// combined using ",".
+// If no header was found using the given name, "ok" would be false.
+// If more than one headers was found using the given name, while commaSeparated is false,
+// "ok" would be false.
+func getRequestHeader(req *http.Request, name string, commaSeparated bool) (hdr string, ok bool) {
+	v := req.Header[textproto.CanonicalMIMEHeaderKey(name)]
+	switch len(v) {
+	case 0:
+		return "", false
+	case 1:
+		return v[0], true
+	default:
+		return strings.Join(v, ","), commaSeparated
+	}
+}
+
+// TODO(rghetia): return an empty Tracestate when parsing tracestate header encounters an error.
+// Revisit to return additional boolean value to indicate parsing error when following issues
+// are resolved.
+// https://github.com/w3c/distributed-tracing/issues/172
+// https://github.com/w3c/distributed-tracing/issues/175
+func tracestateFromRequest(req *http.Request) *tracestate.Tracestate {
+	h, _ := getRequestHeader(req, tracestateHeader, true)
+	if h == "" {
+		return nil
+	}
+
+	var entries []tracestate.Entry
+	pairs := strings.Split(h, ",")
+	hdrLenWithoutOWS := len(pairs) - 1 // Number of commas
+	for _, pair := range pairs {
+		matches := trimOWSRegExp.FindStringSubmatch(pair)
+		if matches == nil {
+			return nil
+		}
+		pair = matches[1]
+		hdrLenWithoutOWS += len(pair)
+		if hdrLenWithoutOWS > maxTracestateLen {
+			return nil
+		}
+		kv := strings.Split(pair, "=")
+		if len(kv) != 2 {
+			return nil
+		}
+		entries = append(entries, tracestate.Entry{Key: kv[0], Value: kv[1]})
+	}
+	ts, err := tracestate.New(nil, entries...)
+	if err != nil {
+		return nil
+	}
+
+	return ts
+}
+
+func tracestateToRequest(sc trace.SpanContext, req *http.Request) {
+	var pairs = make([]string, 0, len(sc.Tracestate.Entries()))
+	if sc.Tracestate != nil {
+		for _, entry := range sc.Tracestate.Entries() {
+			pairs = append(pairs, strings.Join([]string{entry.Key, entry.Value}, "="))
+		}
+		h := strings.Join(pairs, ",")
+
+		if h != "" && len(h) <= maxTracestateLen {
+			req.Header.Set(tracestateHeader, h)
+		}
+	}
+}
+
+// SpanContextToRequest modifies the given request to include traceparent and tracestate headers.
+func (f *HTTPFormat) SpanContextToRequest(sc trace.SpanContext, req *http.Request) {
+	h := fmt.Sprintf("%x-%x-%x-%x",
+		[]byte{supportedVersion},
+		sc.TraceID[:],
+		sc.SpanID[:],
+		[]byte{byte(sc.TraceOptions)})
+	req.Header.Set(traceparentHeader, h)
+	tracestateToRequest(sc, req)
+}

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/packages.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/packages.go
@@ -201,7 +201,7 @@ func isKRShaped(tags map[string]map[string]string) bool {
 	if !has {
 		return false
 	}
-	return vals["krshapedlogic"] == "true"
+	return vals["krshapedlogic"] != "false"
 }
 
 func isNonNamespaced(tags map[string]map[string]string) bool {

--- a/vendor/knative.dev/pkg/test/spoof/spoof.go
+++ b/vendor/knative.dev/pkg/test/spoof/spoof.go
@@ -34,9 +34,9 @@ import (
 	"knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/pkg/test/zipkin"
+	"knative.dev/pkg/tracing/propagation/tracecontextb3"
 
 	"go.opencensus.io/plugin/ochttp"
-	"go.opencensus.io/plugin/ochttp/propagation/b3"
 	"go.opencensus.io/trace"
 )
 
@@ -135,7 +135,7 @@ func New(
 	// Enable Zipkin tracing
 	roundTripper := &ochttp.Transport{
 		Base:        transport,
-		Propagation: &b3.HTTPFormat{},
+		Propagation: tracecontextb3.TraceContextEgress,
 	}
 
 	sc := SpoofingClient{

--- a/vendor/knative.dev/pkg/tracing/http.go
+++ b/vendor/knative.dev/pkg/tracing/http.go
@@ -22,6 +22,7 @@ import (
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/trace"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/pkg/tracing/propagation/tracecontextb3"
 )
 
 var (
@@ -50,6 +51,7 @@ func HTTPSpanIgnoringPaths(pathsToIgnore ...string) func(http.Handler) http.Hand
 				}
 				return underlyingSampling
 			},
+			Propagation: tracecontextb3.TraceContextEgress,
 		}
 	}
 }

--- a/vendor/knative.dev/pkg/tracing/propagation/http_format_sequence.go
+++ b/vendor/knative.dev/pkg/tracing/propagation/http_format_sequence.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package propagation
+
+import (
+	"net/http"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+// HTTPFormatSequence is a propagation.HTTPFormat that applies multiple other propagation formats.
+// For incoming requests, it will use the first SpanContext it can find, checked in the order of
+// HTTPFormatSequence.Ingress.
+// For outgoing requests, it will apply all the formats to the outgoing request, in the order of
+// HTTPFormatSequence.Egress.
+type HTTPFormatSequence struct {
+	Ingress []propagation.HTTPFormat
+	Egress  []propagation.HTTPFormat
+}
+
+var _ propagation.HTTPFormat = (*HTTPFormatSequence)(nil)
+
+// SpanContextFromRequest satisfies the propagation.HTTPFormat interface.
+func (h *HTTPFormatSequence) SpanContextFromRequest(req *http.Request) (trace.SpanContext, bool) {
+	for _, format := range h.Ingress {
+		if sc, ok := format.SpanContextFromRequest(req); ok {
+			return sc, true
+		}
+	}
+	return trace.SpanContext{}, false
+}
+
+// SpanContextToRequest satisfies the propagation.HTTPFormat interface.
+func (h *HTTPFormatSequence) SpanContextToRequest(sc trace.SpanContext, req *http.Request) {
+	for _, format := range h.Egress {
+		format.SpanContextToRequest(sc, req)
+	}
+}

--- a/vendor/knative.dev/pkg/tracing/propagation/tracecontextb3/http_format.go
+++ b/vendor/knative.dev/pkg/tracing/propagation/tracecontextb3/http_format.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracecontextb3
+
+import (
+	"go.opencensus.io/plugin/ochttp/propagation/b3"
+	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
+	ocpropagation "go.opencensus.io/trace/propagation"
+	"knative.dev/pkg/tracing/propagation"
+)
+
+// TraceContextB3Egress is a propagation.HTTPFormat that reads both TraceContext and B3 tracing
+// formats, preferring TraceContext. It always writes both formats.
+var TraceContextB3Egress = &propagation.HTTPFormatSequence{
+	Ingress: []ocpropagation.HTTPFormat{
+		&tracecontext.HTTPFormat{},
+		&b3.HTTPFormat{},
+	},
+	Egress: []ocpropagation.HTTPFormat{
+		&tracecontext.HTTPFormat{},
+		&b3.HTTPFormat{},
+	},
+}
+
+// TraceContextEgress is a propagation.HTTPFormat that reads both TraceContext and B3 tracing
+// formats, preferring TraceContext. It always writes TraceContext format exclusively.
+var TraceContextEgress = &propagation.HTTPFormatSequence{
+	Ingress: []ocpropagation.HTTPFormat{
+		&tracecontext.HTTPFormat{},
+		&b3.HTTPFormat{},
+	},
+	Egress: []ocpropagation.HTTPFormat{
+		&tracecontext.HTTPFormat{},
+	},
+}
+
+// B3Egress is a propagation.HTTPFormat that reads both TraceContext and B3 tracing formats,
+// preferring TraceContext. It always writes B3 format exclusively.
+var B3Egress = &propagation.HTTPFormatSequence{
+	Ingress: []ocpropagation.HTTPFormat{
+		&tracecontext.HTTPFormat{},
+		&b3.HTTPFormat{},
+	},
+	Egress: []ocpropagation.HTTPFormat{
+		&b3.HTTPFormat{},
+	},
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -321,6 +321,7 @@ go.opencensus.io/metric/metricproducer
 go.opencensus.io/plugin/ocgrpc
 go.opencensus.io/plugin/ochttp
 go.opencensus.io/plugin/ochttp/propagation/b3
+go.opencensus.io/plugin/ochttp/propagation/tracecontext
 go.opencensus.io/resource
 go.opencensus.io/resource/resourcekeys
 go.opencensus.io/stats
@@ -1032,7 +1033,7 @@ knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/server
 knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice
 knative.dev/networking/pkg/client/istio/listers/networking/v1alpha3
 knative.dev/networking/pkg/client/listers/networking/v1alpha1
-# knative.dev/pkg v0.0.0-20200623024526-fb0320d9287e
+# knative.dev/pkg v0.0.0-20200623173527-5658d93fb07e
 ## explicit
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate
@@ -1137,6 +1138,8 @@ knative.dev/pkg/testutils/clustermanager/perf-tests
 knative.dev/pkg/testutils/clustermanager/perf-tests/pkg
 knative.dev/pkg/tracing
 knative.dev/pkg/tracing/config
+knative.dev/pkg/tracing/propagation
+knative.dev/pkg/tracing/propagation/tracecontextb3
 knative.dev/pkg/tracing/testing
 knative.dev/pkg/tracker
 knative.dev/pkg/version
@@ -1149,7 +1152,7 @@ knative.dev/pkg/webhook/resourcesemantics/conversion
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
 knative.dev/pkg/websocket
-# knative.dev/test-infra v0.0.0-20200623005026-1f7e5f05c52b
+# knative.dev/test-infra v0.0.0-20200623145727-e9ff5263be06
 ## explicit
 knative.dev/test-infra/scripts
 # sigs.k8s.io/yaml v1.2.0


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Accept both B3 and TraceContext style tracing
* Only B3 style tracing is egressed.
    * This was done for backwards compatibility with the existing system, which sends via B3 style. We could output both formats, but it was determined that the additional overhead of ~70 bytes per message was too high for the potential benefit. See [here](https://github.com/knative/pkg/pull/1429#pullrequestreview-435062580) for more discussion.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Serving components now recognize both B3 and TraceContext style tracing.
```
