### PR TITLE
Remove decider service name

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -90,7 +90,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 	}
 
 	pa.Status.MetricsServiceName = sks.Status.PrivateServiceName
-	decider, err := c.reconcileDecider(ctx, pa, pa.Status.MetricsServiceName)
+	decider, err := c.reconcileDecider(ctx, pa)
 	if err != nil {
 		return fmt.Errorf("error reconciling Decider: %w", err)
 	}
@@ -169,8 +169,8 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 	return computeStatus(pa, pc, logger)
 }
 
-func (c *Reconciler) reconcileDecider(ctx context.Context, pa *pav1alpha1.PodAutoscaler, k8sSvc string) (*scaling.Decider, error) {
-	desiredDecider := resources.MakeDecider(ctx, pa, config.FromContext(ctx).Autoscaler, k8sSvc)
+func (c *Reconciler) reconcileDecider(ctx context.Context, pa *pav1alpha1.PodAutoscaler) (*scaling.Decider, error) {
+	desiredDecider := resources.MakeDecider(ctx, pa, config.FromContext(ctx).Autoscaler)
 	decider, err := c.deciders.Get(ctx, desiredDecider.Namespace, desiredDecider.Name)
 	if errors.IsNotFound(err) {
 		decider, err = c.deciders.Create(ctx, desiredDecider)

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1017,7 +1017,7 @@ func TestReconcile(t *testing.T) {
 		// Make new decider if it's not in the context
 		if d := ctx.Value(deciderKey); d == nil {
 			decider := resources.MakeDecider(
-				ctx, kpa(testNamespace, testRevision), defaultConfig().Autoscaler, "trying-hard-to-care-in-this-test")
+				ctx, kpa(testNamespace, testRevision), defaultConfig().Autoscaler)
 			decider.Status.DesiredScale = defaultScale
 			decider.Status.NumActivators = scaling.MinActivators
 			decider.Generation = 2112
@@ -1271,7 +1271,7 @@ func TestUpdate(t *testing.T) {
 	fakenetworkingclient.Get(ctx).NetworkingV1alpha1().ServerlessServices(testNamespace).Create(sks)
 	fakesksinformer.Get(ctx).Informer().GetIndexer().Add(sks)
 
-	decider := resources.MakeDecider(context.Background(), kpa, defaultConfig().Autoscaler, sks.Status.PrivateServiceName)
+	decider := resources.MakeDecider(context.Background(), kpa, defaultConfig().Autoscaler)
 
 	// The Reconciler won't do any work until it becomes the leader.
 	if la, ok := ctl.Reconciler.(reconciler.LeaderAware); ok {

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -47,7 +47,7 @@ type Deciders interface {
 // MakeDecider constructs a Decider resource from a PodAutoscaler taking
 // into account the PA's ContainerConcurrency and the relevant
 // autoscaling annotation.
-func MakeDecider(ctx context.Context, pa *asv1a1.PodAutoscaler, config *autoscalerconfig.Config, svc string) *scaling.Decider {
+func MakeDecider(ctx context.Context, pa *asv1a1.PodAutoscaler, config *autoscalerconfig.Config) *scaling.Decider {
 	panicThresholdPercentage := config.PanicThresholdPercentage
 	if x, ok := pa.PanicThresholdPercentage(); ok {
 		panicThresholdPercentage = x
@@ -72,7 +72,6 @@ func MakeDecider(ctx context.Context, pa *asv1a1.PodAutoscaler, config *autoscal
 			ActivatorCapacity:   config.ActivatorCapacity,
 			PanicThreshold:      panicThreshold,
 			StableWindow:        resources.StableWindow(pa, config),
-			ServiceName:         svc,
 			InitialScale:        GetInitialScale(config, pa),
 			Reachable:           pa.Spec.Reachability != asv1a1.ReachabilityUnreachable,
 		},

--- a/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
@@ -36,7 +36,6 @@ func TestMakeDecider(t *testing.T) {
 	cases := []struct {
 		name   string
 		pa     *v1alpha1.PodAutoscaler
-		svc    string
 		want   *scaling.Decider
 		cfgOpt func(autoscalerconfig.Config) *autoscalerconfig.Config
 	}{{
@@ -133,14 +132,6 @@ func TestMakeDecider(t *testing.T) {
 			withTarget(10.0), withPanicThreshold(4.0), withTotal(10),
 			withTargetAnnotation("10"), withPanicThresholdPercentageAnnotation("400")),
 	}, {
-		name: "with service name",
-		pa:   pa(WithTargetAnnotation("10"), WithPanicThresholdPercentageAnnotation("400")),
-		svc:  "rock-solid",
-		want: decider(
-			withService("rock-solid"),
-			withTarget(10.0), withPanicThreshold(4.0), withTotal(10.0),
-			withTargetAnnotation("10"), withPanicThresholdPercentageAnnotation("400")),
-	}, {
 		name: "with metric annotation",
 		pa:   pa(WithMetricAnnotation("rps")),
 		want: decider(withTarget(100.0), withPanicThreshold(2.0), withTotal(100), withMetric("rps"), withMetricAnnotation("rps")),
@@ -163,7 +154,7 @@ func TestMakeDecider(t *testing.T) {
 				cfg = tc.cfgOpt(*config)
 			}
 
-			if diff := cmp.Diff(tc.want, MakeDecider(context.Background(), tc.pa, cfg, tc.svc)); diff != "" {
+			if diff := cmp.Diff(tc.want, MakeDecider(context.Background(), tc.pa, cfg)); diff != "" {
 				t.Errorf("%q (-want, +got):\n%v", tc.name, diff)
 			}
 		})
@@ -320,12 +311,6 @@ func withTotal(total float64) deciderOption {
 func withTarget(target float64) deciderOption {
 	return func(decider *scaling.Decider) {
 		decider.Spec.TargetValue = target
-	}
-}
-
-func withService(s string) deciderOption {
-	return func(d *scaling.Decider) {
-		d.Spec.ServiceName = s
 	}
 }
 


### PR DESCRIPTION
No longer required since it was used for endpoints counter
and we no longer do that

/assign @yanweiguo mattmoor @markusthoemmes 