### PR TITLE
Use `.` as scope separator in config-features keys.

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: 11fc2bce
+    knative.dev/example-checksum: e0eb3d80
 data:
   _example: |
     ################################
@@ -43,7 +43,7 @@ data:
 
 
     # Indicates whether Kubernetes FieldRef support is enabled
-    kubernetes/podspec-fieldref: "disabled"
+    kubernetes.podspec-fieldref: "disabled"
 
 
     # This feature validates PodSpecs from the validating webhook
@@ -52,4 +52,4 @@ data:
     # When "allowed", the client may enable the behavior with the
     # 'features.knative.dev/podspec-dryrun':'enabled' annotation.
     # When "enabled"  the server will always run the extra validation.
-    kubernetes/podspec-dryrun: "allowed"
+    kubernetes.podspec-dryrun: "allowed"

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -52,8 +52,8 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 
 	if err := cm.Parse(data,
 		asFlag("multi-container", &nc.MultiContainer),
-		asFlag("kubernetes/podspec-fieldref", &nc.PodSpecFieldRef),
-		asFlag("kubernetes/podspec-dryrun", &nc.PodSpecDryRun)); err != nil {
+		asFlag("kubernetes.podspec-fieldref", &nc.PodSpecFieldRef),
+		asFlag("kubernetes.podspec-dryrun", &nc.PodSpecDryRun)); err != nil {
 		return nil, err
 	}
 	return nc, nil

--- a/pkg/apis/config/features_test.go
+++ b/pkg/apis/config/features_test.go
@@ -74,7 +74,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 		}),
 		data: map[string]string{
 			"multi-container":           "Enabled",
-			"kubernetes/podspec-dryrun": "Enabled",
+			"kubernetes.podspec-dryrun": "Enabled",
 		},
 	}, {
 		name:    "multi-container Disabled",
@@ -86,31 +86,31 @@ func TestFeaturesConfiguration(t *testing.T) {
 			"multi-container": "Disabled",
 		},
 	}, {
-		name:    "kubernetes/podspec-fieldref Allowed",
+		name:    "kubernetes.podspec-fieldref Allowed",
 		wantErr: false,
 		wantFeatures: defaultWith(&Features{
 			PodSpecFieldRef: Allowed,
 		}),
 		data: map[string]string{
-			"kubernetes/podspec-fieldref": "Allowed",
+			"kubernetes.podspec-fieldref": "Allowed",
 		},
 	}, {
-		name:    "kubernetes/podspec-fieldref Enabled",
+		name:    "kubernetes.podspec-fieldref Enabled",
 		wantErr: false,
 		wantFeatures: defaultWith(&Features{
 			PodSpecFieldRef: Enabled,
 		}),
 		data: map[string]string{
-			"kubernetes/podspec-fieldref": "Enabled",
+			"kubernetes.podspec-fieldref": "Enabled",
 		},
 	}, {
-		name:    "kubernetes/podspec-fieldref Disabled",
+		name:    "kubernetes.podspec-fieldref Disabled",
 		wantErr: false,
 		wantFeatures: defaultWith(&Features{
 			PodSpecFieldRef: Disabled,
 		}),
 		data: map[string]string{
-			"kubernetes/podspec-fieldref": "Disabled",
+			"kubernetes.podspec-fieldref": "Disabled",
 		},
 	}}
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #8468.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
`/` is not allowed in a ConfigMap key.
Let's use `.` as scope separator.

## TODO
:exclamation: :exclamation: :exclamation: I need to add E2E tests for this, my bad :sad:

/assign @mattmoor @whaught @dprotaso 
