### PR TITLE
[WIP/POC] Use TraceContextB3Egress for spoof client to test `x-b3-spanid` and `x-b3-traceid` in TestShouldHaveHeadersSet

### DIFF
--- a/vendor/knative.dev/pkg/test/spoof/spoof.go
+++ b/vendor/knative.dev/pkg/test/spoof/spoof.go
@@ -135,7 +135,7 @@ func New(
 	// Enable Zipkin tracing
 	roundTripper := &ochttp.Transport{
 		Base:        transport,
-		Propagation: tracecontextb3.TraceContextEgress,
+		Propagation: tracecontextb3.TraceContextB3Egress,
 	}
 
 	sc := SpoofingClient{


### PR DESCRIPTION
/hold

This is a POC for https://github.com/knative/pkg/pull/1447.
