### PR TITLE
[release-0.15] update knative.dev/pkg which includes webhook fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
 	k8s.io/metrics v0.17.2
 	knative.dev/caching v0.0.0-20200521155757-e78d17bc250e
-	knative.dev/pkg v0.0.0-20200528142800-1c6815d7e4c9
+	knative.dev/pkg v0.0.0-20200625173728-dfb81cf04a7c
 	knative.dev/test-infra v0.0.0-20200519161858-554a95a37986
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1441,8 +1441,8 @@ knative.dev/pkg v0.0.0-20200505191044-3da93ebb24c2/go.mod h1:Q6sL35DdGs8hIQZKdaC
 knative.dev/pkg v0.0.0-20200515002500-16d7b963416f/go.mod h1:tMOHGbxtRz8zYFGEGpV/bpoTEM1o89MwYFC4YJXl3GY=
 knative.dev/pkg v0.0.0-20200519155757-14eb3ae3a5a7 h1:9S2r59HZJF9nKvoRLg5zJzx6XpVlVyvVRqz/C/h6h2s=
 knative.dev/pkg v0.0.0-20200519155757-14eb3ae3a5a7/go.mod h1:QgNZTxnwpB/oSpNcfnLVlw+WpEwwyKAvJlvR3hgeltA=
-knative.dev/pkg v0.0.0-20200528142800-1c6815d7e4c9 h1:bN9gghp5Osuw1bgKrvMaA+oiAvPuYmzSbRo54/EFSxI=
-knative.dev/pkg v0.0.0-20200528142800-1c6815d7e4c9/go.mod h1:QgNZTxnwpB/oSpNcfnLVlw+WpEwwyKAvJlvR3hgeltA=
+knative.dev/pkg v0.0.0-20200625173728-dfb81cf04a7c h1:QZYml0nrYQFvfDDSUV+J2PKcPuI3EisK3ePoe1Qdvq0=
+knative.dev/pkg v0.0.0-20200625173728-dfb81cf04a7c/go.mod h1:QgNZTxnwpB/oSpNcfnLVlw+WpEwwyKAvJlvR3hgeltA=
 knative.dev/test-infra v0.0.0-20200407185800-1b88cb3b45a5/go.mod h1:xcdUkMJrLlBswIZqL5zCuBFOC22WIPMQoVX1L35i0vQ=
 knative.dev/test-infra v0.0.0-20200505052144-5ea2f705bb55/go.mod h1:WqF1Azka+FxPZ20keR2zCNtiQA1MP9ZB4BH4HuI+SIU=
 knative.dev/test-infra v0.0.0-20200513011557-d03429a76034 h1:JxqONCZVS7or+Fv3ebVQoipuIBH7Ig3Qbx170hgIF+A=

--- a/vendor/knative.dev/pkg/webhook/admission.go
+++ b/vendor/knative.dev/pkg/webhook/admission.go
@@ -88,7 +88,13 @@ func admissionHandler(rootLogger *zap.SugaredLogger, stats StatsReporter, c Admi
 
 		ctx := logging.WithLogger(r.Context(), logger)
 
-		var response admissionv1beta1.AdmissionReview
+		response := admissionv1beta1.AdmissionReview{
+			// Use the same type meta as the request - this is required by the K8s API
+			// note: v1beta1 & v1 AdmissionReview shapes are identical so even though
+			// we're using v1 types we still support v1beta1 admission requests
+			TypeMeta: review.TypeMeta,
+		}
+
 		reviewResponse := c.Admit(ctx, review.Request)
 		var patchType string
 		if reviewResponse.PatchType != nil {

--- a/vendor/knative.dev/pkg/webhook/conversion.go
+++ b/vendor/knative.dev/pkg/webhook/conversion.go
@@ -54,6 +54,10 @@ func conversionHandler(rootLogger *zap.SugaredLogger, stats StatsReporter, c Con
 
 		ctx := logging.WithLogger(r.Context(), logger)
 		response := apixv1beta1.ConversionReview{
+			// Use the same type meta as the request - this is required by the K8s API
+			// note: v1beta1 & v1 ConversionReview shapes are identical so even though
+			// we're using v1 types we still support v1beta1 conversion requests
+			TypeMeta: review.TypeMeta,
 			Response: c.Convert(ctx, review.Request),
 		}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1169,7 +1169,7 @@ knative.dev/caching/pkg/client/injection/informers/caching/v1alpha1/image/fake
 knative.dev/caching/pkg/client/injection/informers/factory
 knative.dev/caching/pkg/client/injection/informers/factory/fake
 knative.dev/caching/pkg/client/listers/caching/v1alpha1
-# knative.dev/pkg v0.0.0-20200528142800-1c6815d7e4c9
+# knative.dev/pkg v0.0.0-20200625173728-dfb81cf04a7c
 ## explicit
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* This includes webhook fixes that should make upgrading from 0.15 to 0.16 smooth

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Webhook responses now return TypeMeta which would interrupt serving upgrades 
```
