### PR TITLE
Remove the service name from decider spec

### DIFF
--- a/cmd/autoscaler/main_test.go
+++ b/cmd/autoscaler/main_test.go
@@ -77,9 +77,7 @@ func TestUniscalerFactoryFailures(t *testing.T) {
 			Namespace: autoscalerfake.TestNamespace,
 			Name:      autoscalerfake.TestRevision,
 		},
-		Spec: scaling.DeciderSpec{
-			ServiceName: "wholesome-service",
-		},
+		Spec: scaling.DeciderSpec{},
 	}
 
 	for _, test := range tests {
@@ -110,9 +108,7 @@ func TestUniScalerFactoryFunc(t *testing.T) {
 					serving.ConfigurationLabelKey: "test-config",
 				},
 			},
-			Spec: scaling.DeciderSpec{
-				ServiceName: "magic-services-offered",
-			},
+			Spec: scaling.DeciderSpec{},
 		}
 
 		if _, err := uniScalerFactory(decider); err != nil {

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -54,7 +54,7 @@ func (fpc fakePodCounter) ReadyCount() (int, error) {
 }
 
 func TestNewErrorWhenGivenNilReadyPodCounter(t *testing.T) {
-	if _, err := New(fake.TestNamespace, fake.TestRevision, &metricClient{}, nil, &DeciderSpec{TargetValue: 10, ServiceName: fake.TestService}, context.Background()); err == nil {
+	if _, err := New(fake.TestNamespace, fake.TestRevision, &metricClient{}, nil, &DeciderSpec{TargetValue: 10}, context.Background()); err == nil {
 		t.Error("Expected error when ReadyPodCounter interface is nil, but got none.")
 	}
 }
@@ -62,7 +62,7 @@ func TestNewErrorWhenGivenNilReadyPodCounter(t *testing.T) {
 func TestNewErrorWhenGivenNilStatsReporter(t *testing.T) {
 	pc := &fakePodCounter{}
 	if _, err := New(fake.TestNamespace, fake.TestRevision, &metricClient{}, pc,
-		&DeciderSpec{TargetValue: 10, ServiceName: fake.TestService}, nil); err == nil {
+		&DeciderSpec{TargetValue: 10}, nil); err == nil {
 		t.Error("Expected error when EndpointsInformer interface is nil, but got none.")
 	}
 }
@@ -503,7 +503,6 @@ func TestAutoscalerUpdateTarget(t *testing.T) {
 		MaxScaleDownRate:    10,
 		MaxScaleUpRate:      10,
 		StableWindow:        stableWindow,
-		ServiceName:         fake.TestService,
 	})
 	na = expectedNA(a, 10)
 	expectScale(t, a, time.Now(), ScaleResult{100, expectedEBC(1, 71, 101, 10), na, true})
@@ -534,7 +533,6 @@ func newTestAutoscalerWithScalingMetric(t *testing.T, targetValue, targetBurstCa
 		MaxScaleDownRate:    10,
 		ActivatorCapacity:   activatorCapacity,
 		StableWindow:        stableWindow,
-		ServiceName:         fake.TestService,
 		Reachable:           true,
 	}
 
@@ -569,7 +567,6 @@ func TestStartInPanicMode(t *testing.T) {
 		MaxScaleUpRate:      10,
 		MaxScaleDownRate:    10,
 		StableWindow:        stableWindow,
-		ServiceName:         fake.TestService,
 	}
 
 	pc := &fakePodCounter{}
@@ -605,7 +602,6 @@ func TestNewFail(t *testing.T) {
 		MaxScaleUpRate:      10,
 		MaxScaleDownRate:    10,
 		StableWindow:        stableWindow,
-		ServiceName:         fake.TestService,
 	}
 
 	pc := fakePodCounter{err: errors.New("starlight")}

--- a/pkg/autoscaler/scaling/multiscaler.go
+++ b/pkg/autoscaler/scaling/multiscaler.go
@@ -68,8 +68,6 @@ type DeciderSpec struct {
 	PanicThreshold float64
 	// StableWindow is needed to determine when to exit panic mode.
 	StableWindow time.Duration
-	// The name of the k8s service for pod information.
-	ServiceName string
 	// InitialScale is the calculated initial scale of the revision, taking both
 	// revision initial scale and cluster initial scale into account. Revision initial
 	// scale overrides cluster initial scale.


### PR DESCRIPTION
Somehow I just removed the setting of it 🤦 .
but not the actual thingy on the type.
So remove it now.

/assign @yanweiguo mattmoor