### PR TITLE
Final touches to remove fake constants

### DIFF
--- a/cmd/autoscaler/main_test.go
+++ b/cmd/autoscaler/main_test.go
@@ -24,15 +24,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeinformers "k8s.io/client-go/informers"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
+
 	"knative.dev/serving/pkg/apis/serving"
-	autoscalerfake "knative.dev/serving/pkg/autoscaler/fake"
 	"knative.dev/serving/pkg/autoscaler/scaling"
 )
 
-var (
-	kubeClient   = fakek8s.NewSimpleClientset()
-	kubeInformer = kubeinformers.NewSharedInformerFactory(kubeClient, 0)
-)
+var kubeInformer = kubeinformers.NewSharedInformerFactory(fakek8s.NewSimpleClientset(), 0)
 
 func TestUniscalerFactoryFailures(t *testing.T) {
 	tests := []struct {
@@ -74,8 +71,8 @@ func TestUniscalerFactoryFailures(t *testing.T) {
 	uniScalerFactory := testUniScalerFactory()
 	decider := &scaling.Decider{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: autoscalerfake.TestNamespace,
-			Name:      autoscalerfake.TestRevision,
+			Namespace: "a-cool-namespace",
+			Name:      "very-nice-revision-name",
 		},
 		Spec: scaling.DeciderSpec{},
 	}
@@ -100,10 +97,10 @@ func TestUniScalerFactoryFunc(t *testing.T) {
 	for _, srv := range []string{"some", ""} {
 		decider := &scaling.Decider{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: autoscalerfake.TestNamespace,
-				Name:      autoscalerfake.TestRevision,
+				Namespace: "ome-more-namespace",
+				Name:      "astounding-revision",
 				Labels: map[string]string{
-					serving.RevisionLabelKey:      autoscalerfake.TestRevision,
+					serving.RevisionLabelKey:      "astrounding-revision",
 					serving.ServiceLabelKey:       srv,
 					serving.ConfigurationLabelKey: "test-config",
 				},

--- a/pkg/autoscaler/fake/fakes.go
+++ b/pkg/autoscaler/fake/fakes.go
@@ -16,20 +16,7 @@ limitations under the License.
 
 package fake
 
-import (
-	"time"
-)
-
-const (
-	// TestRevision is the name used for the revision.
-	TestRevision = "test-revision"
-	// TestService is the name used for the service.
-	TestService = "test-revision-metrics"
-	// TestNamespace is the name used for the namespace.
-	TestNamespace = "test-namespace"
-	// TestConfig is the name used for the config.
-	TestConfig = "test-config"
-)
+import "time"
 
 // A ManualTickProvider holds a channel that delivers `ticks' of a clock at intervals.
 type ManualTickProvider struct {

--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -395,14 +395,14 @@ func TestDoubleWatch(t *testing.T) {
 func TestMetricCollectorError(t *testing.T) {
 	testMetric := &av1alpha1.Metric{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: fake.TestNamespace,
-			Name:      fake.TestRevision,
+			Namespace: testNamespace,
+			Name:      testRevision,
 			Labels: map[string]string{
-				serving.RevisionLabelKey: fake.TestRevision,
+				serving.RevisionLabelKey: testRevision,
 			},
 		},
 		Spec: av1alpha1.MetricSpec{
-			ScrapeTarget: fake.TestRevision + "-zhudex",
+			ScrapeTarget: testRevision + "-zhudex",
 		},
 	}
 

--- a/pkg/autoscaler/scaling/multiscaler_test.go
+++ b/pkg/autoscaler/scaling/multiscaler_test.go
@@ -451,8 +451,8 @@ func (u *fakeUniScaler) Update(*DeciderSpec) error {
 func newDecider() *Decider {
 	return &Decider{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: fake.TestNamespace,
-			Name:      fake.TestRevision,
+			Namespace: "a-ns",
+			Name:      "a-rev",
 		},
 		Spec: DeciderSpec{
 			TargetValue: 1,


### PR DESCRIPTION
Usage of same constants across tests was kind of required when we were using a shared fake
but no more and in effect it might hide bugs by 'happy councidence' because names matched.
So I introduced some variation in naming, though not complete

/assign @markusthoemmes @yanweiguo 