### PR TITLE
Remove istio-injection label from knative-serving namespace

### DIFF
--- a/config/core/100-namespace.yaml
+++ b/config/core/100-namespace.yaml
@@ -17,6 +17,4 @@ kind: Namespace
 metadata:
   name: knative-serving
   labels:
-    # TODO(mattmoor): We should not require any istio annotations.
-    istio-injection: enabled
     serving.knative.dev/release: devel


### PR DESCRIPTION
The label was remained because it was necessary for mesh mode test. 
However it is now manually added in the script by:

https://github.com/knative/serving/blob/320e01a596acefca56f025c2ef0e9d394e453267/test/e2e-common.sh#L291

so we should be able to remove it.

Fixes https://github.com/knative/serving/issues/6421


**Release Note**

```release-note
The label istio-injection=enabled for knative-serving namespace was dropped in serving-core.yaml.
```
