### PR TITLE
Fix volume mount validation issues

### DIFF
--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -110,7 +110,7 @@ func (rs *RevisionSpec) Validate(ctx context.Context) *apis.FieldError {
 	case len(rs.PodSpec.Containers) > 0:
 		errs = errs.Also(rs.RevisionSpec.Validate(ctx))
 	case rs.DeprecatedContainer != nil:
-		volumes, err := serving.ValidateVolumes(rs.Volumes)
+		volumes, err := serving.ValidateVolumes(rs.Volumes, serving.AllMountedVolumes(append(rs.PodSpec.Containers, *rs.DeprecatedContainer)))
 		if err != nil {
 			errs = errs.Also(err.ViaField("volumes"))
 		}


### PR DESCRIPTION
Fixes #8393 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Validation of volume mounts requires at least one container to mount a volume for both having a single container
and multiple ones in a revision.

**Release Note**

```
NONE

```
/assign @markusthoemmes @mattmoor 
