### PR TITLE
Print friendly validation error for autoscaling.knative.dev/target annotation

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -85,7 +85,7 @@ func validateFloats(annotations map[string]string) *apis.FieldError {
 
 	if v, ok := annotations[TargetAnnotationKey]; ok {
 		if fv, err := strconv.ParseFloat(v, 64); err != nil || fv < TargetMin {
-			errs = errs.Also(apis.ErrOutOfBoundsValue(v, TargetMin, math.MaxFloat64, TargetAnnotationKey))
+			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("target %s should be at least %g", v, TargetMin), TargetAnnotationKey))
 		}
 	}
 

--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -85,7 +85,7 @@ func validateFloats(annotations map[string]string) *apis.FieldError {
 
 	if v, ok := annotations[TargetAnnotationKey]; ok {
 		if fv, err := strconv.ParseFloat(v, 64); err != nil || fv < TargetMin {
-			errs = errs.Also(apis.ErrInvalidValue(v, TargetAnnotationKey))
+			errs = errs.Also(apis.ErrOutOfBoundsValue(v, TargetMin, math.MaxFloat64, TargetAnnotationKey))
 		}
 	}
 

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -18,12 +18,10 @@ package autoscaling
 
 import (
 	"fmt"
-	"math"
 	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"knative.dev/pkg/apis"
 )
 
 func TestValidateScaleBoundAnnotations(t *testing.T) {
@@ -124,11 +122,11 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "target negative",
 		annotations: map[string]string{TargetAnnotationKey: "-11"},
-		expectErr:   apis.ErrOutOfBoundsValue(-11, TargetMin, math.MaxFloat64, TargetAnnotationKey).Error(),
+		expectErr:   "target -11 should be at least 0.01: " + TargetAnnotationKey,
 	}, {
 		name:        "target 0",
 		annotations: map[string]string{TargetAnnotationKey: "0"},
-		expectErr:   apis.ErrOutOfBoundsValue(0, TargetMin, math.MaxFloat64, TargetAnnotationKey).Error(),
+		expectErr:   "target 0 should be at least 0.01: " + TargetAnnotationKey,
 	}, {
 		name:        "target okay",
 		annotations: map[string]string{TargetAnnotationKey: "11"},

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -18,10 +18,12 @@ package autoscaling
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"knative.dev/pkg/apis"
 )
 
 func TestValidateScaleBoundAnnotations(t *testing.T) {
@@ -122,11 +124,11 @@ func TestValidateScaleBoundAnnotations(t *testing.T) {
 	}, {
 		name:        "target negative",
 		annotations: map[string]string{TargetAnnotationKey: "-11"},
-		expectErr:   "invalid value: -11: " + TargetAnnotationKey,
+		expectErr:   apis.ErrOutOfBoundsValue(-11, TargetMin, math.MaxFloat64, TargetAnnotationKey).Error(),
 	}, {
 		name:        "target 0",
 		annotations: map[string]string{TargetAnnotationKey: "0"},
-		expectErr:   "invalid value: 0: " + TargetAnnotationKey,
+		expectErr:   apis.ErrOutOfBoundsValue(0, TargetMin, math.MaxFloat64, TargetAnnotationKey).Error(),
 	}, {
 		name:        "target okay",
 		annotations: map[string]string{TargetAnnotationKey: "11"},


### PR DESCRIPTION
When `autoscaling.knative.dev/target` annotation is configured, the
error message is not friendly as it does not say what is the valid
value.
This patch changes the error message by using `apis.ErrGeneric` error.

e.g. configure following annotation in ksvc

```
      annotations:
        autoscaling.knative.dev/target: "0"
```

- Current error

```
$ kubectl edit ksvc
error: services.serving.knative.dev "hello-example" could not be patched: admission webhook "validation.webhook.serving.knative.dev" denied the request: validation failed: invalid value: 0: spec.template.metadata.annotations.autoscaling.knative.dev/target
You can run `kubectl replace -f /tmp/kubectl-edit-8fytg.yaml` to try this update again.
```

- After this PR

```
$ kubectl edit ksvc
error: services.serving.knative.dev "hello-example" could not be patched: admission webhook "validation.webhook.serving.knative.dev" denied the request: validation failed: target 0 should be at least 0.01: spec.template.metadata.annotations.autoscaling.knative.dev/target
You can run `kubectl replace -f /tmp/kubectl-edit-6wcyy.yaml` to try this update again.
```


/lint

**Release Note**

```release-note
NONE
```
