### PR TITLE
Disable service links for the deployment probe

### DIFF
--- a/test/performance/benchmarks/deployment-probe/continuous/kodata/basic-template.yaml
+++ b/test/performance/benchmarks/deployment-probe/continuous/kodata/basic-template.yaml
@@ -20,6 +20,7 @@ metadata:
 spec:
   template:
     spec:
+      enableServiceLinks: false
       containers:
       - image: gcr.io/knative-samples/autoscale-go:0.1
         # Limit resources so that we can pack more on-cluster.


### PR DESCRIPTION
Let's see if we can see a meaningful reduction in latency on the tests.
Probably not a big one, given we scale to 25.

/assign @chizhg @mattmoor 