### PR TITLE
Disable service links in the scale to N test

### DIFF
--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"knative.dev/pkg/pool"
+	"knative.dev/pkg/ptr"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -89,6 +90,9 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 			defer latencies.Add("time-to-done", start)
 
 			svc, err := v1test.CreateService(t, clients, names,
+				func(svc *v1.Service) {
+					svc.Spec.Template.Spec.EnableServiceLinks = ptr.Bool(false)
+				},
 				rtesting.WithResourceRequirements(corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("50m"),


### PR DESCRIPTION
We create up to 100 services right now.
It would be beneficial if those were faster, nimbler to start and run.

/assign mattmoor