### PR TITLE
Track referenced traffic targets with tracker in the labeler.

### DIFF
--- a/pkg/reconciler/labeler/labeler.go
+++ b/pkg/reconciler/labeler/labeler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	pkgreconciler "knative.dev/pkg/reconciler"
+	"knative.dev/pkg/tracker"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
 	routereconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/route"
@@ -29,6 +30,9 @@ import (
 // Reconciler implements controller.Reconciler for Route resources.
 type Reconciler struct {
 	client clientset.Interface
+
+	// tracker to track revisions and configurations
+	tracker tracker.Interface
 
 	// Listers index properties about resources
 	configurationLister listers.ConfigurationLister

--- a/pkg/reconciler/labeler/labeler_test.go
+++ b/pkg/reconciler/labeler/labeler_test.go
@@ -308,6 +308,7 @@ func TestReconcile(t *testing.T) {
 			client:              servingclient.Get(ctx),
 			configurationLister: listers.GetConfigurationLister(),
 			revisionLister:      listers.GetRevisionLister(),
+			tracker:             &NullTracker{},
 		}
 
 		return routereconciler.NewReconciler(ctx, logging.FromContext(ctx), servingclient.Get(ctx),

--- a/pkg/reconciler/labeler/labels.go
+++ b/pkg/reconciler/labeler/labels.go
@@ -63,7 +63,7 @@ func (c *Reconciler) syncLabels(ctx context.Context, r *v1.Route) error {
 		}
 
 		if configName != "" {
-			if err := c.tracker.TrackReference(ref(r.Namespace, revName, "Configuration"), r); err != nil {
+			if err := c.tracker.TrackReference(ref(r.Namespace, configName, "Configuration"), r); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

The labeler currently fails reconcilation if a revision is not (yet) there (likewise for a configuration). It then retries in a loop, with increasing backoffs. That's entirely unnecessary, as we can just as well watch revisions and configurations and be informed if a change happened to them.

I'm not super happy with the fallback tracker on error, especially about the hardcoded apiversion there. Copied that from the route reconciler.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor @dprotaso 
