### PR TITLE
Harden activator HA test.

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -144,68 +144,59 @@ sleep 30
 
 # Run conformance and e2e tests.
 
-#go_test_e2e -timeout=30m \
-#  $(go list ./test/conformance/... | grep -v 'certificate\|ingress' ) \
-#  ./test/e2e \
-#  ${parallelism} \
-#  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
+go_test_e2e -timeout=30m \
+  $(go list ./test/conformance/... | grep -v 'certificate\|ingress' ) \
+  ./test/e2e \
+  ${parallelism} \
+  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 
 # We run KIngress conformance ingress separately, to make it easier to skip some tests.
-#go_test_e2e -timeout=20m ./test/conformance/ingress ${parallelism}  \
-#  `# Skip TestUpdate due to excessive flaking https://github.com/knative/serving/issues/8032` \
-#  -run="TestIngressConformance/^[^u]" \
-#  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
+go_test_e2e -timeout=20m ./test/conformance/ingress ${parallelism}  \
+  `# Skip TestUpdate due to excessive flaking https://github.com/knative/serving/issues/8032` \
+  -run="TestIngressConformance/^[^u]" \
+  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 
-#if (( HTTPS )); then
-#  kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found
-#  turn_off_auto_tls
-#fi
+if (( HTTPS )); then
+  kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found
+  turn_off_auto_tls
+fi
 
-#enable_tag_header_based_routing
-#add_trap "disable_tag_header_based_routing" SIGKILL SIGTERM SIGQUIT
-#go_test_e2e -timeout=2m ./test/e2e/tagheader || failed=1
-#disable_tag_header_based_routing
+enable_tag_header_based_routing
+add_trap "disable_tag_header_based_routing" SIGKILL SIGTERM SIGQUIT
+go_test_e2e -timeout=2m ./test/e2e/tagheader || failed=1
+disable_tag_header_based_routing
 
-#enable_multi_container_feature
-#add_trap "disable_multi_container_feature" SIGKILL SIGTERM SIGQUIT
-#go_test_e2e -timeout=2m ./test/e2e/multicontainer || failed=1
-#disable_multi_container_feature
+enable_multi_container_feature
+add_trap "disable_multi_container_feature" SIGKILL SIGTERM SIGQUIT
+go_test_e2e -timeout=2m ./test/e2e/multicontainer || failed=1
+disable_multi_container_feature
 
 # Certificate conformance tests must be run separately
 # because they need cert-manager specific configurations.
-#kubectl apply -f ${TMP_DIR}/test/config/autotls/certmanager/selfsigned/
-#add_trap "kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/selfsigned/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
-#go_test_e2e -timeout=10m ./test/conformance/certificate/nonhttp01 "$(certificate_class)" || failed=1
-#kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/selfsigned/
+kubectl apply -f ${TMP_DIR}/test/config/autotls/certmanager/selfsigned/
+add_trap "kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/selfsigned/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
+go_test_e2e -timeout=10m ./test/conformance/certificate/nonhttp01 "$(certificate_class)" || failed=1
+kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/selfsigned/
 
-#kubectl apply -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
-#add_trap "kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
-#go_test_e2e -timeout=10m ./test/conformance/certificate/http01 "$(certificate_class)" || failed=1
-#kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
+kubectl apply -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
+add_trap "kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
+go_test_e2e -timeout=10m ./test/conformance/certificate/http01 "$(certificate_class)" || failed=1
+kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
 
 # Run scale tests.
-#go_test_e2e -timeout=10m ${parallelism} ./test/scale || failed=1
+go_test_e2e -timeout=10m ${parallelism} ./test/scale || failed=1
 
 # Istio E2E tests mutate the cluster and must be ran separately
-#if [[ -n "${ISTIO_VERSION}" ]]; then
-#  kubectl apply -f ${TMP_DIR}/test/config/security/authorization_ingress.yaml || return 1
-#  add_trap "kubectl delete -f ${TMP_DIR}/test/config/security/authorization_ingress.yaml --ignore-not-found" SIGKILL SIGTERM SIGQUIT
-#  go_test_e2e -timeout=10m ./test/e2e/istio "--resolvabledomain=$(use_resolvable_domain)" || failed=1
-#  kubectl delete -f ${TMP_DIR}/test/config/security/authorization_ingress.yaml
-#fi
+if [[ -n "${ISTIO_VERSION}" ]]; then
+  kubectl apply -f ${TMP_DIR}/test/config/security/authorization_ingress.yaml || return 1
+  add_trap "kubectl delete -f ${TMP_DIR}/test/config/security/authorization_ingress.yaml --ignore-not-found" SIGKILL SIGTERM SIGQUIT
+  go_test_e2e -timeout=10m ./test/e2e/istio "--resolvabledomain=$(use_resolvable_domain)" || failed=1
+  kubectl delete -f ${TMP_DIR}/test/config/security/authorization_ingress.yaml
+fi
 
 # Run HA tests separately as they're stopping core Knative Serving pods
 # Define short -spoofinterval to ensure frequent probing while stopping pods
-go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
-go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
-go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
-go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
-go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
-go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
-go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
-go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
-go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
-go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
+go_test_e2e -timeout=15m -failfast -parallel=1 ./test/ha -spoofinterval="10ms" || failed=1
 
 (( failed )) && fail_test
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -196,7 +196,16 @@ sleep 30
 
 # Run HA tests separately as they're stopping core Knative Serving pods
 # Define short -spoofinterval to ensure frequent probing while stopping pods
-go_test_e2e -timeout=40m --count=10 -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
+go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
+go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
+go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
+go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
+go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
+go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
+go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
+go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
+go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
+go_test_e2e -timeout=10m -parallel=1 ./test/ha -run "^(TestActivatorHAGraceful|TestActivatorHANonGraceful)$" -spoofinterval="10ms" || failed=1
 
 (( failed )) && fail_test
 

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -110,7 +110,7 @@ func testActivatorHA(t *testing.T, gracePeriod *int64, slo float64) {
 		}
 
 		// Wait for the killed activator to disappear from the knative service's endpoints.
-		if err := waitForEndpointsState(clients.KubeClient, resourcesScaleToZero.Revision.Name, test.ServingNamespace, endpointsDoNotContain(activator.Status.PodIP)); err != nil {
+		if err := waitForEndpointsState(clients.KubeClient, resourcesScaleToZero.Revision.Name, test.ServingNamespace, readyEndpointsDoNotContain(activator.Status.PodIP)); err != nil {
 			t.Fatal("Failed to wait for the service to update its endpoints:", err)
 		}
 		if gracePeriod != nil && *gracePeriod == 0 {

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -28,6 +28,7 @@ import (
 	"knative.dev/pkg/test/logstream"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgnet "knative.dev/pkg/network"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
@@ -114,7 +115,7 @@ func testActivatorHA(t *testing.T, gracePeriod *int64, slo float64) {
 		}
 		if gracePeriod != nil && *gracePeriod == 0 {
 			t.Log("Allow the network to notice the missing endpoint")
-			time.Sleep(5 * time.Second)
+			time.Sleep(pkgnet.DefaultDrainTimeout)
 		}
 
 		t.Log("Test if service still works")
@@ -129,7 +130,7 @@ func testActivatorHA(t *testing.T, gracePeriod *int64, slo float64) {
 		}
 		if gracePeriod != nil && *gracePeriod == 0 {
 			t.Log("Allow the network to notice the new endpoint")
-			time.Sleep(5 * time.Second)
+			time.Sleep(pkgnet.DefaultDrainTimeout)
 		}
 	}
 }

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -19,7 +19,6 @@ package ha
 import (
 	"net/url"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,7 +72,7 @@ func assertServiceEventuallyWorks(t *testing.T, clients *test.Clients, names tes
 func waitForEndpointsState(client *pkgTest.KubeClient, svcName, svcNamespace string, inState func(*corev1.Endpoints) (bool, error)) error {
 	endpointsService := client.Kube.CoreV1().Endpoints(svcNamespace)
 
-	return wait.PollImmediate(1*time.Second, 8*time.Minute, func() (bool, error) {
+	return wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
 		endpoint, err := endpointsService.Get(svcName, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -82,7 +82,7 @@ func waitForEndpointsState(client *pkgTest.KubeClient, svcName, svcNamespace str
 	})
 }
 
-func endpointsDoNotContain(ip string) func(*corev1.Endpoints) (bool, error) {
+func readyEndpointsDoNotContain(ip string) func(*corev1.Endpoints) (bool, error) {
 	return func(eps *corev1.Endpoints) (bool, error) {
 		for _, subset := range eps.Subsets {
 			for _, ready := range subset.Addresses {

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -47,6 +47,7 @@ func createPizzaPlanetService(t *testing.T, fopt ...rtesting.ServiceOption) (tes
 	if err != nil {
 		t.Fatal("Failed to create Service:", err)
 	}
+	test.EnsureTearDown(t, clients, names)
 
 	assertServiceEventuallyWorks(t, clients, names, resources.Service.Status.URL.URL(), test.PizzaPlanetText1)
 	return names, resources

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -47,7 +47,6 @@ func createPizzaPlanetService(t *testing.T, fopt ...rtesting.ServiceOption) (tes
 	if err != nil {
 		t.Fatal("Failed to create Service:", err)
 	}
-	test.EnsureTearDown(t, clients, names)
 
 	assertServiceEventuallyWorks(t, clients, names, resources.Service.Status.URL.URL(), test.PizzaPlanetText1)
 	return names, resources


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

- Narrow down checks on the endpoint resources.
- Allow the network to repogram itself between pod deletes/recreations if the grace period is 0.
- Fetch activator pods only once.
- Add extensive logging for increased debuggability.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
