### PR TITLE
Add StaticTimeoutFunc handler and speed up timeout handler tests.

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -340,9 +340,7 @@ func buildServer(env config, healthState *health.State, rp *readiness.Probe, sta
 	}
 	composedHandler = proxyHandler(breaker, stats, tracingEnabled, composedHandler)
 	composedHandler = queue.ForwardedShimHandler(composedHandler)
-	composedHandler = handler.NewTimeToFirstByteTimeoutHandler(composedHandler, "request timeout", func(*http.Request) time.Duration {
-		return timeout
-	})
+	composedHandler = handler.NewTimeToFirstByteTimeoutHandler(composedHandler, "request timeout", handler.StaticTimeoutFunc(timeout))
 
 	if metricsSupported {
 		composedHandler = requestMetricsHandler(composedHandler, env)

--- a/pkg/http/handler/timeout.go
+++ b/pkg/http/handler/timeout.go
@@ -32,7 +32,7 @@ import (
 type TimeoutFunc func(req *http.Request) time.Duration
 
 // StaticTimeoutFunc returns a TimeoutFunc that always returns the same duration.
-func StaticTimeoutFunc(timeout time.Duration) func(req *http.Request) time.Duration {
+func StaticTimeoutFunc(timeout time.Duration) TimeoutFunc {
 	return func(req *http.Request) time.Duration {
 		return timeout
 	}

--- a/pkg/http/handler/timeout.go
+++ b/pkg/http/handler/timeout.go
@@ -31,6 +31,13 @@ import (
 // TimeoutFunc returns the timeout duration to be used by the timeout handler.
 type TimeoutFunc func(req *http.Request) time.Duration
 
+// StaticTimeoutFunc returns a TimeoutFunc that always returns the same duration.
+func StaticTimeoutFunc(timeout time.Duration) func(req *http.Request) time.Duration {
+	return func(req *http.Request) time.Duration {
+		return timeout
+	}
+}
+
 type timeToFirstByteTimeoutHandler struct {
 	handler     http.Handler
 	timeoutFunc TimeoutFunc


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

- Add a `StaticTimeoutFunc` helper to easily return static timeouts.
- Clean up the tests to make them quicker (used to take 10s, now < 10ms).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @JRBANCEL 

You've added the sleep in the test. Would you elaborate on why that's needed or can we ditch it?
