### PR TITLE
Undo #7999: no longer wrap activator in timeout handler

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -60,11 +60,8 @@ import (
 	activatorconfig "knative.dev/serving/pkg/activator/config"
 	activatorhandler "knative.dev/serving/pkg/activator/handler"
 	activatornet "knative.dev/serving/pkg/activator/net"
-	"knative.dev/serving/pkg/activator/util"
-	apiconfig "knative.dev/serving/pkg/apis/config"
 	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
 	pkghttp "knative.dev/serving/pkg/http"
-	"knative.dev/serving/pkg/http/handler"
 	"knative.dev/serving/pkg/logging"
 	"knative.dev/serving/pkg/network"
 )
@@ -208,12 +205,6 @@ func main() {
 	// Create activation handler chain
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first
 	var ah http.Handler = activatorhandler.New(ctx, throttler)
-	ah = handler.NewTimeToFirstByteTimeoutHandler(ah, "activator request timeout", func(r *http.Request) time.Duration {
-		if rev := util.RevisionFrom(r.Context()); rev != nil {
-			return time.Duration(*rev.Spec.TimeoutSeconds) * time.Second
-		}
-		return apiconfig.DefaultRevisionTimeoutSeconds * time.Second
-	})
 	ah = activatorhandler.NewRequestEventHandler(reqCh, ah)
 	ah = tracing.HTTPSpanMiddleware(ah)
 	ah = configStore.HTTPMiddleware(ah)

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -81,22 +81,6 @@ func TestRevisionTimeout(t *testing.T) {
 		sleep          time.Duration
 		expectedStatus int
 	}{{
-		name:           "when scaling up from 0 and does not exceed timeout seconds",
-		shouldScaleTo0: true,
-		timeoutSeconds: 40,
-		expectedStatus: http.StatusOK,
-	}, {
-		name:           "when scaling up from 0 and it writes first byte before timeout",
-		shouldScaleTo0: true,
-		timeoutSeconds: 40,
-		sleep:          45 * time.Second,
-		expectedStatus: http.StatusOK,
-	}, {
-		name:           "when scaling up from 0 and it does exceed timeout seconds",
-		shouldScaleTo0: true,
-		timeoutSeconds: 1, // If the pods come up faster than 1s, this test might fail.
-		expectedStatus: http.StatusGatewayTimeout,
-	}, {
 		name:           "when pods already exist, and it does not exceed timeout seconds",
 		timeoutSeconds: 10,
 		initialSleep:   2 * time.Second,

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -81,22 +81,6 @@ func TestRevisionTimeout(t *testing.T) {
 		sleep          time.Duration
 		expectedStatus int
 	}{{
-		name:           "when scaling up from 0 and does not exceed timeout seconds",
-		shouldScaleTo0: true,
-		timeoutSeconds: 40,
-		expectedStatus: http.StatusOK,
-	}, {
-		name:           "when scaling up from 0 and it writes first byte before timeout",
-		shouldScaleTo0: true,
-		timeoutSeconds: 40,
-		sleep:          45 * time.Second,
-		expectedStatus: http.StatusOK,
-	}, {
-		name:           "when scaling up from 0 and it does exceed timeout seconds",
-		shouldScaleTo0: true,
-		timeoutSeconds: 1, // If the pods come up faster than 1s, this test might fail.
-		expectedStatus: http.StatusGatewayTimeout,
-	}, {
 		name:           "when pods already exist, and it does not exceed timeout seconds",
 		timeoutSeconds: 10,
 		initialSleep:   2 * time.Second,

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -81,22 +81,6 @@ func TestRevisionTimeout(t *testing.T) {
 		sleep          time.Duration
 		expectedStatus int
 	}{{
-		name:           "when scaling up from 0 and does not exceed timeout seconds",
-		shouldScaleTo0: true,
-		timeoutSeconds: 40,
-		expectedStatus: http.StatusOK,
-	}, {
-		name:           "when scaling up from 0 and it writes first byte before timeout",
-		shouldScaleTo0: true,
-		timeoutSeconds: 40,
-		sleep:          45 * time.Second,
-		expectedStatus: http.StatusOK,
-	}, {
-		name:           "when scaling up from 0 and it does exceed timeout seconds",
-		shouldScaleTo0: true,
-		timeoutSeconds: 1, // If the pods come up faster than 1s, this test might fail.
-		expectedStatus: http.StatusGatewayTimeout,
-	}, {
 		name:           "when pods already exist, and it does not exceed timeout seconds",
 		timeoutSeconds: 10,
 		initialSleep:   2 * time.Second,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

We see that RevisionTimeout tests are flaky, and @markusthoemmes also saw some HTTP connection breakage in case of timeout.

Since the change is quite old, there isn't a clean way to revert #7999, so I just undo the logic in cmd/activator/main.go as well as remove related conformance testing.
 
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
