### PR TITLE
[WIP] Refactor labeler to support per-resource logic

### DIFF
--- a/pkg/reconciler/labeler/accessors.go
+++ b/pkg/reconciler/labeler/accessors.go
@@ -34,6 +34,7 @@ type accessor interface {
 	makeMetadataPatch(ns, name string, routeName *string) (map[string]interface{}, error)
 }
 
+// makeMetadataPatch makes a metadata map to be patched or nil if no changes are needed.
 func makeMetadataPatch(acc kmeta.Accessor, routeName *string) (map[string]interface{}, error) {
 	labels := map[string]interface{}{}
 
@@ -52,6 +53,7 @@ func makeMetadataPatch(acc kmeta.Accessor, routeName *string) (map[string]interf
 	return nil, nil
 }
 
+// addRouteLabel appends the route label to the list of labels if needed.
 func addRouteLabel(acc kmeta.Accessor, labels map[string]interface{}, routeName *string) error {
 	if oldLabels := acc.GetLabels(); oldLabels == nil && routeName != nil {
 		labels[serving.RouteLabelKey] = routeName

--- a/pkg/reconciler/labeler/accessors.go
+++ b/pkg/reconciler/labeler/accessors.go
@@ -60,7 +60,7 @@ func addRouteLabel(acc kmeta.Accessor, labels map[string]interface{}, routeName 
 	} else if oldLabel := oldLabels[serving.RouteLabelKey]; routeName == nil && oldLabel != "" {
 		labels[serving.RouteLabelKey] = routeName
 	} else if routeName != nil && oldLabel != *routeName {
-		return fmt.Errorf("already in use %q, and cannot be used by %q", oldLabel, *routeName)
+		return fmt.Errorf("resource already has route label %q, and cannot be referenced by %q", oldLabel, *routeName)
 	}
 
 	return nil

--- a/pkg/reconciler/labeler/labeler_test.go
+++ b/pkg/reconciler/labeler/labeler_test.go
@@ -195,7 +195,7 @@ func TestReconcile(t *testing.T) {
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError",
 				`failed to add route label to Namespace=default "the-config-dbnfd": `+
-					`already in use "another-route", and cannot be used by "the-route"`),
+					`resource already has route label "another-route", and cannot be referenced by "the-route"`),
 		},
 		Key: "default/the-route",
 	}, {

--- a/pkg/reconciler/labeler/labeler_test.go
+++ b/pkg/reconciler/labeler/labeler_test.go
@@ -158,7 +158,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError",
-				`failed to add route label to /, Kind= "the-config-dbnfd": inducing failure for patch revisions`),
+				`failed to add route label to Namespace=default "the-config-dbnfd": inducing failure for patch revisions`),
 		},
 		Key: "default/add-label-failure",
 	}, {
@@ -179,7 +179,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError",
-				`failed to add route label to /, Kind= "the-config": inducing failure for patch configurations`),
+				`failed to add route label to Namespace=default "the-config": inducing failure for patch configurations`),
 		},
 		Key: "default/add-label-failure",
 	}, {
@@ -194,7 +194,8 @@ func TestReconcile(t *testing.T) {
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError",
-				`/, Kind= "the-config-dbnfd" is already in use by "another-route", and cannot be used by "the-route"`),
+				`failed to add route label to Namespace=default "the-config-dbnfd": `+
+					`already in use "another-route", and cannot be used by "the-route"`),
 		},
 		Key: "default/the-route",
 	}, {

--- a/pkg/reconciler/labeler/labels.go
+++ b/pkg/reconciler/labeler/labels.go
@@ -141,8 +141,8 @@ func setRouteLabel(acc accessor, ns, name string, routeName *string) error {
 	if mergePatch, err := acc.makeMetadataPatch(ns, name, routeName); err != nil {
 		return err
 	} else if mergePatch != nil {
-		if patch, err2 := json.Marshal(mergePatch); err2 != nil {
-			return err2
+		if patch, err := json.Marshal(mergePatch); err != nil {
+			return err
 		} else {
 			return acc.patch(ns, name, types.MergePatchType, patch)
 		}

--- a/pkg/reconciler/labeler/labels.go
+++ b/pkg/reconciler/labeler/labels.go
@@ -141,11 +141,11 @@ func setRouteLabel(acc accessor, ns, name string, routeName *string) error {
 	if mergePatch, err := acc.makeMetadataPatch(ns, name, routeName); err != nil {
 		return err
 	} else if mergePatch != nil {
-		if patch, err := json.Marshal(mergePatch); err != nil {
+		patch, err := json.Marshal(mergePatch)
+		if err != nil {
 			return err
-		} else {
-			return acc.patch(ns, name, types.MergePatchType, patch)
 		}
+		return acc.patch(ns, name, types.MergePatchType, patch)
 	}
 	return nil
 }


### PR DESCRIPTION
Issue #8208

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Switches from`get` to `makeMetadataPatch `behind the `accessor` interface. This will allow us to create logic, for example, that only operates on Revisions or accesses type-specific fields.
    * This will be used in future PRs to add a timestamp to revisions when the route label changes which will be used for GC.

### Alternative
I could fork the labeler and copy these files over. This could help with staging the code, for safety's sake.

I'm considering if for the new labeler & gc if they really need to be separate reconcilers - we could have one that both grooms labels and deletes dead revisions as it goes along listing resources.