### PR TITLE
Support protobuf format in QP's metrics exchange

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -241,8 +241,9 @@ func main() {
 	stats := network.NewRequestStats(time.Now())
 	go func() {
 		for now := range reportTicker.C {
-			promStatReporter.Report(stats.Report(now))
-			protoStatReporter.Report(stats.Report(now))
+			stat := stats.Report(now)
+			promStatReporter.Report(stat)
+			protoStatReporter.Report(stat)
 		}
 	}()
 

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -234,9 +234,6 @@ func main() {
 	}
 
 	protoStatReporter := queue.NewProtobufStatsReporter(env.ServingPod, reportingPeriod)
-	if err != nil {
-		logger.Fatalw("Failed to create stats reporter", zap.Error(err))
-	}
 
 	reportTicker := time.NewTicker(reportingPeriod)
 	defer reportTicker.Stop()
@@ -437,11 +434,11 @@ func buildMetricsServer(promStatReporter *queue.PrometheusStatsReporter, protobu
 }
 
 func metricsHttpHandler(promStatReporter *queue.PrometheusStatsReporter, protobufStatReporter *queue.ProtobufStatsReporter) http.Handler {
-	return http.HandlerFunc(func(rsp http.ResponseWriter, req *http.Request) {
-		if strings.Contains(req.Header.Get("Accept"), network.ProtoAcceptContent) {
-			protobufStatReporter.Handler().ServeHTTP(rsp, req)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept"), network.ProtoAcceptContent) {
+			protobufStatReporter.Handler().ServeHTTP(w, r)
 		} else {
-			promStatReporter.Handler().ServeHTTP(rsp, req)
+			promStatReporter.Handler().ServeHTTP(w, r)
 		}
 	})
 }

--- a/pkg/autoscaler/metrics/http_scrape_client.go
+++ b/pkg/autoscaler/metrics/http_scrape_client.go
@@ -17,27 +17,16 @@ limitations under the License.
 package metrics
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
-	"sync"
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"knative.dev/serving/pkg/network"
 )
-
-// It should hold the value of marshalled Stat which is
-// 8*5 (float64) + 16 (string ref) + 253 (max K8s resource name) = 309
-const bufferSize = 312
-
-var pool = sync.Pool{
-	New: func() interface{} {
-		return bytes.NewBuffer(make([]byte, bufferSize))
-	},
-}
 
 type httpScrapeClient struct {
 	httpClient *http.Client
@@ -76,20 +65,9 @@ func (c *httpScrapeClient) Scrape(url string) (Stat, error) {
 	return statFromPrometheus(resp.Body)
 }
 
-func ioCopy(r io.Reader) ([]byte, error) {
-	buffer := pool.Get().(*bytes.Buffer)
-	buffer.Reset()
-	defer pool.Put(buffer)
-	_, err := io.Copy(buffer, r)
-	if err != nil {
-		return nil, err
-	}
-	return buffer.Bytes(), nil
-}
-
 func statFromProto(body io.Reader) (Stat, error) {
 	var stat Stat
-	bodyBytes, err := ioCopy(body)
+	bodyBytes, err := ioutil.ReadAll(body)
 	if err != nil {
 		return emptyStat, fmt.Errorf("reading body failed: %w", err)
 	}

--- a/pkg/autoscaler/metrics/http_scrape_client_test.go
+++ b/pkg/autoscaler/metrics/http_scrape_client_test.go
@@ -24,36 +24,63 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"knative.dev/serving/pkg/network"
 )
 
 const (
-	testURL = "http://test-revision-zhudex.test-namespace:9090/metrics"
+	queueAverageConcurrentRequests        = 3.0
+	queueRequestsPerSecond                = 5
+	queueAverageProxiedConcurrentRequests = 2.0
+	queueProxiedOperationsPerSecond       = 4
+	processUptime                         = 2937.12
+	zeroProcessUptime                     = 0
+	podName                               = "test-revision-1234"
+)
 
+var (
+	testURL = "http://test-revision-zhudex.test-namespace:9090/metrics"
 	// TODO: Use Prometheus lib to generate the following text instead of using text format directly.
-	testAverageConcurrencyContext = `# HELP queue_average_concurrent_requests Number of requests currently being handled by this pod
+	testAverageConcurrencyContext = fmt.Sprintf(`# HELP queue_average_concurrent_requests Number of requests currently being handled by this pod
 # TYPE queue_average_concurrent_requests gauge
-queue_average_concurrent_requests{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 3.0
-`
-	testQPSContext = `# HELP queue_requests_per_second Number of requests received since last Stat
+queue_average_concurrent_requests{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} %f
+`, queueAverageConcurrentRequests)
+	testQPSContext = fmt.Sprintf(`# HELP queue_requests_per_second Number of requests received since last Stat
 # TYPE queue_requests_per_second gauge
-queue_requests_per_second{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 5
-`
-	testAverageProxiedConcurrenyContext = `# HELP queue_average_proxied_concurrent_requests Number of proxied requests currently being handled by this pod
+queue_requests_per_second{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} %d
+`, queueRequestsPerSecond)
+	testAverageProxiedConcurrenyContext = fmt.Sprintf(`# HELP queue_average_proxied_concurrent_requests Number of proxied requests currently being handled by this pod
 # TYPE queue_average_proxied_concurrent_requests gauge
-queue_average_proxied_concurrent_requests{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 2.0
-`
-	testProxiedQPSContext = `# HELP queue_proxied_operations_per_second Number of proxied requests received since last Stat
+queue_average_proxied_concurrent_requests{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} %f
+`, queueAverageProxiedConcurrentRequests)
+	testProxiedQPSContext = fmt.Sprintf(`# HELP queue_proxied_operations_per_second Number of proxied requests received since last Stat
 # TYPE queue_proxied_operations_per_second gauge
-queue_proxied_operations_per_second{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} 4
-`
+queue_proxied_operations_per_second{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} %d
+`, queueProxiedOperationsPerSecond)
 	testFullContext = testAverageConcurrencyContext + testQPSContext + testAverageProxiedConcurrenyContext + testProxiedQPSContext
 
-	testUptimeContext = `# HELP process_uptime The number of seconds that the process has been up
+	testUptimeContext = fmt.Sprintf(`# HELP process_uptime The number of seconds that the process has been up
 # TYPE process_uptime gauge
-process_uptime{destination_configuration="s1",destination_namespace="default",destination_pod="s1-tdgpn-deployment-86f6459cf8-mc9mw",destination_revision="s1-tdgpn"} 2937.12
-`
-
+process_uptime{destination_configuration="s1",destination_namespace="default",destination_pod="s1-tdgpn-deployment-86f6459cf8-mc9mw",destination_revision="s1-tdgpn"} %f
+`, processUptime)
 	testOptionalContext = testFullContext + testUptimeContext
+
+	statFull = Stat{
+		PodName:                          podName,
+		AverageConcurrentRequests:        queueAverageConcurrentRequests,
+		AverageProxiedConcurrentRequests: queueAverageProxiedConcurrentRequests,
+		RequestCount:                     queueRequestsPerSecond,
+		ProxiedRequestCount:              queueProxiedOperationsPerSecond,
+	}
+
+	statOptional = Stat{
+		PodName:                          podName,
+		AverageConcurrentRequests:        queueAverageConcurrentRequests,
+		AverageProxiedConcurrentRequests: queueAverageProxiedConcurrentRequests,
+		RequestCount:                     queueRequestsPerSecond,
+		ProxiedRequestCount:              queueProxiedOperationsPerSecond,
+		ProcessUptime:                    processUptime,
+	}
 )
 
 func TestNewHTTPScrapeClient_ErrorCases(t *testing.T) {
@@ -82,68 +109,74 @@ func TestNewHTTPScrapeClient_ErrorCases(t *testing.T) {
 }
 
 func TestHTTPScrapeClientScrapeHappyCase(t *testing.T) {
-	hClient := newTestHTTPClient(getHTTPResponse(http.StatusOK, testFullContext), nil)
-	sClient, err := newHTTPScrapeClient(hClient)
-	if err != nil {
-		t.Fatalf("newHTTPScrapeClient = %v, want no error", err)
-	}
-
-	stat, err := sClient.Scrape(testURL)
-	if err != nil {
-		t.Errorf("scrapeViaURL = %v, want no error", err)
-	}
-	if stat.AverageConcurrentRequests != 3.0 {
-		t.Errorf("stat.AverageConcurrentRequests = %v, want 3.0", stat.AverageConcurrentRequests)
-	}
-	if stat.RequestCount != 5 {
-		t.Errorf("stat.RequestCount = %v, want 5", stat.RequestCount)
-	}
-	if stat.AverageProxiedConcurrentRequests != 2.0 {
-		t.Errorf("stat.AverageProxiedConcurrency = %v, want 2.0", stat.AverageProxiedConcurrentRequests)
-	}
-	if stat.ProxiedRequestCount != 4 {
-		t.Errorf("stat.ProxiedCount = %v, want 4", stat.ProxiedRequestCount)
-	}
-	if stat.PodName != "test-revision-1234" {
-		t.Errorf("stat.PodName = %s, want test-revision-1234", stat.PodName)
-	}
-	if stat.ProcessUptime != 0 {
-		t.Errorf("default/missing stat.ProcessUptime = %v, want: 0", stat.ProcessUptime)
+	for _, hClient := range []*http.Client{
+		newTestHTTPClient(makeResponse(http.StatusOK, testFullContext), nil),
+		newTestHTTPClient(makeProtoResponse(http.StatusOK, statFull, network.ProtoAcceptContent), nil),
+	} {
+		sClient, err := newHTTPScrapeClient(hClient)
+		if err != nil {
+			t.Fatalf("newHTTPScrapeClient = %v, want no error", err)
+		}
+		stat, err := sClient.Scrape(testURL)
+		if err != nil {
+			t.Errorf("scrapeViaURL = %v, want no error", err)
+		}
+		if stat.AverageConcurrentRequests != queueAverageConcurrentRequests {
+			t.Errorf("stat.AverageConcurrentRequests = %v, want %v", stat.AverageConcurrentRequests, queueAverageConcurrentRequests)
+		}
+		if stat.RequestCount != queueRequestsPerSecond {
+			t.Errorf("stat.RequestCount = %v, want %v", stat.RequestCount, queueRequestsPerSecond)
+		}
+		if stat.AverageProxiedConcurrentRequests != queueAverageProxiedConcurrentRequests {
+			t.Errorf("stat.AverageProxiedConcurrency = %v, want %v", stat.AverageProxiedConcurrentRequests, queueAverageProxiedConcurrentRequests)
+		}
+		if stat.ProxiedRequestCount != queueProxiedOperationsPerSecond {
+			t.Errorf("stat.ProxiedCount = %v, want %v", stat.ProxiedRequestCount, queueProxiedOperationsPerSecond)
+		}
+		if stat.PodName != podName {
+			t.Errorf("stat.PodName = %s, want %s", stat.PodName, podName)
+		}
+		if stat.ProcessUptime != zeroProcessUptime {
+			t.Errorf("default/missing stat.ProcessUptime = %v, want: %v", stat.ProcessUptime, zeroProcessUptime)
+		}
 	}
 }
 
 func TestHTTPScrapeClientScrapeHappyCaseWithOptionals(t *testing.T) {
-	hClient := newTestHTTPClient(getHTTPResponse(http.StatusOK, testOptionalContext), nil)
-	sClient, err := newHTTPScrapeClient(hClient)
-	if err != nil {
-		t.Fatalf("newHTTPScrapeClient = %v, want no error", err)
-	}
-
-	stat, err := sClient.Scrape(testURL)
-	if err != nil {
-		t.Errorf("scrapeViaURL = %v, want no error", err)
-	}
-	if stat.AverageConcurrentRequests != 3.0 {
-		t.Errorf("stat.AverageConcurrentRequests = %v, want 3.0", stat.AverageConcurrentRequests)
-	}
-	if stat.RequestCount != 5 {
-		t.Errorf("stat.RequestCount = %v, want 5", stat.RequestCount)
-	}
-	if stat.AverageProxiedConcurrentRequests != 2.0 {
-		t.Errorf("stat.AverageProxiedConcurrency = %v, want 2.0", stat.AverageProxiedConcurrentRequests)
-	}
-	if stat.ProxiedRequestCount != 4 {
-		t.Errorf("stat.ProxiedCount = %v, want 4", stat.ProxiedRequestCount)
-	}
-	if stat.PodName != "test-revision-1234" {
-		t.Errorf("stat.PodName = %s, want test-revision-1234", stat.PodName)
-	}
-	if got, want := stat.ProcessUptime, 2937.12; got != want {
-		t.Errorf("stat.ProcessUptime = %v, want: %v", got, want)
+	for _, hClient := range []*http.Client{
+		newTestHTTPClient(makeResponse(http.StatusOK, testOptionalContext), nil),
+		newTestHTTPClient(makeProtoResponse(http.StatusOK, statOptional, network.ProtoAcceptContent), nil),
+	} {
+		sClient, err := newHTTPScrapeClient(hClient)
+		if err != nil {
+			t.Fatalf("newHTTPScrapeClient = %v, want no error", err)
+		}
+		stat, err := sClient.Scrape(testURL)
+		if err != nil {
+			t.Errorf("scrapeViaURL = %v, want no error", err)
+		}
+		if stat.AverageConcurrentRequests != queueAverageConcurrentRequests {
+			t.Errorf("stat.AverageConcurrentRequests = %v, want %v", stat.AverageConcurrentRequests, queueAverageConcurrentRequests)
+		}
+		if stat.RequestCount != queueRequestsPerSecond {
+			t.Errorf("stat.RequestCount = %v, want %d", stat.RequestCount, queueRequestsPerSecond)
+		}
+		if stat.AverageProxiedConcurrentRequests != queueAverageProxiedConcurrentRequests {
+			t.Errorf("stat.AverageProxiedConcurrency = %v, want %v", stat.AverageProxiedConcurrentRequests, queueAverageProxiedConcurrentRequests)
+		}
+		if stat.ProxiedRequestCount != queueProxiedOperationsPerSecond {
+			t.Errorf("stat.ProxiedCount = %v, want %v", stat.ProxiedRequestCount, queueProxiedOperationsPerSecond)
+		}
+		if stat.PodName != podName {
+			t.Errorf("stat.PodName = %s, want %s", stat.PodName, podName)
+		}
+		if got, want := stat.ProcessUptime, processUptime; got != want {
+			t.Errorf("stat.ProcessUptime = %v, want: %v", got, want)
+		}
 	}
 }
 
-func TestHTTPScrapeClient_Scrape_ErrorCases(t *testing.T) {
+func TestHTTPScrapeClientScrapeErrorCases(t *testing.T) {
 	testCases := []struct {
 		name            string
 		responseCode    int
@@ -188,7 +221,7 @@ func TestHTTPScrapeClient_Scrape_ErrorCases(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			hClient := newTestHTTPClient(getHTTPResponse(test.responseCode, test.responseContext), test.responseErr)
+			hClient := newTestHTTPClient(makeResponse(test.responseCode, test.responseContext), test.responseErr)
 			sClient, err := newHTTPScrapeClient(hClient)
 			if err != nil {
 				t.Errorf("newHTTPScrapeClient=%v, want no error", err)
@@ -204,11 +237,58 @@ func TestHTTPScrapeClient_Scrape_ErrorCases(t *testing.T) {
 	}
 }
 
-func getHTTPResponse(statusCode int, context string) *http.Response {
+func TestHTTPScrapeClientScrapeProtoErrorCases(t *testing.T) {
+	testCases := []struct {
+		name         string
+		responseCode int
+		responseErr  error
+		stat         Stat
+		expectedErr  string
+	}{{
+		name:         "Non 200 return code",
+		responseCode: http.StatusForbidden,
+		expectedErr:  fmt.Sprintf(`GET request for URL %q returned HTTP status 403`, testURL),
+	}, {
+		name:         "Error got when sending request",
+		responseCode: http.StatusOK,
+		responseErr:  errors.New("upstream closed"),
+		expectedErr:  "upstream closed",
+	}}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			hClient := newTestHTTPClient(makeProtoResponse(test.responseCode, test.stat, network.ProtoAcceptContent), test.responseErr)
+			sClient, err := newHTTPScrapeClient(hClient)
+			if err != nil {
+				t.Fatalf("newHTTPScrapeClient=%v, want no error", err)
+			}
+			_, err = sClient.Scrape(testURL)
+			if err == nil {
+				t.Fatal("Got no error")
+			}
+			if !strings.Contains(err.Error(), test.expectedErr) {
+				t.Errorf("Error = %q, want to contain: %q", err.Error(), test.expectedErr)
+			}
+		})
+	}
+}
+
+func makeResponse(statusCode int, context string) *http.Response {
 	return &http.Response{
 		StatusCode: statusCode,
 		Body:       ioutil.NopCloser(bytes.NewBufferString(context)),
 	}
+}
+
+func makeProtoResponse(statusCode int, stat Stat, contentType string) *http.Response {
+	buffer, _ := stat.Marshal()
+	res := http.Response{
+		StatusCode: statusCode,
+		Body:       ioutil.NopCloser(bytes.NewBuffer(buffer)),
+	}
+	res.Header = http.Header{}
+	res.Header.Set("Content-Type", contentType)
+	return &res
 }
 
 type fakeRoundTripper struct {

--- a/pkg/autoscaler/metrics/http_scrape_client_test.go
+++ b/pkg/autoscaler/metrics/http_scrape_client_test.go
@@ -308,17 +308,3 @@ func newTestHTTPClient(response *http.Response, err error) *http.Client {
 		},
 	}
 }
-
-func BenchmarkUnmarshalling(b *testing.B) {
-	b.ReportAllocs()
-	hClient := newTestHTTPClient(makeProtoResponse(http.StatusOK, Stat{}, network.ProtoAcceptContent), nil)
-	scrapeClient, err := newHTTPScrapeClient(hClient)
-	if err != nil {
-		b.Fatal(err)
-	}
-	for i := 0; i < b.N; i++ {
-		if _, err := scrapeClient.Scrape(testURL); err != nil {
-			b.Fatal(err)
-		}
-	}
-}

--- a/pkg/autoscaler/metrics/http_scrape_client_test.go
+++ b/pkg/autoscaler/metrics/http_scrape_client_test.go
@@ -312,12 +312,10 @@ func newTestHTTPClient(response *http.Response, err error) *http.Client {
 func BenchmarkUnmarshalling(b *testing.B) {
 	b.ReportAllocs()
 	hClient := newTestHTTPClient(makeProtoResponse(http.StatusOK, Stat{}, network.ProtoAcceptContent), nil)
-
 	scrapeClient, err := newHTTPScrapeClient(hClient)
 	if err != nil {
 		b.Fatal(err)
 	}
-
 	for i := 0; i < b.N; i++ {
 		if _, err := scrapeClient.Scrape(testURL); err != nil {
 			b.Fatal(err)

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -154,6 +154,9 @@ const (
 	// TagHeaderBasedRoutingKey is the name of the configuration entry
 	// that specifies enabling tag header based routing or not.
 	TagHeaderBasedRoutingKey = "tagHeaderBasedRouting"
+
+	// ProtoAcceptContent is the content type to be used when autoscaler scrapes metrics from the QP
+	ProtoAcceptContent = "application/protobuf"
 )
 
 // DomainTemplateValues are the available properties people can choose from

--- a/pkg/queue/prometheus_stats_reporter_test.go
+++ b/pkg/queue/prometheus_stats_reporter_test.go
@@ -34,7 +34,70 @@ const (
 	pod       = "helloworld-go-00001-deployment-8ff587cc9-7g9gc"
 )
 
-func TestNewPrometheusStatsReporter_negative(t *testing.T) {
+var testCases = []struct {
+	name                        string
+	reportingPeriod             time.Duration
+	concurrency                 float64
+	proxiedConcurrency          float64
+	reqCount                    float64
+	proxiedReqCount             float64
+	expectedReqCount            float64
+	expectedProxiedRequestCount float64
+	expectedConcurrency         float64
+	expectedProxiedConcurrency  float64
+}{{
+	name:            "no proxy requests",
+	reportingPeriod: 1 * time.Second,
+
+	reqCount:    39,
+	concurrency: 3,
+
+	expectedReqCount:            39,
+	expectedConcurrency:         3,
+	expectedProxiedRequestCount: 0,
+	expectedProxiedConcurrency:  0,
+}, {
+	name:            "reportingPeriod=10s",
+	reportingPeriod: 10 * time.Second,
+
+	reqCount:           39,
+	concurrency:        3,
+	proxiedReqCount:    15,
+	proxiedConcurrency: 2,
+
+	expectedReqCount:            3.9,
+	expectedConcurrency:         3,
+	expectedProxiedRequestCount: 1.5,
+	expectedProxiedConcurrency:  2,
+}, {
+	name:            "reportingPeriod=2s",
+	reportingPeriod: 2 * time.Second,
+
+	reqCount:           39,
+	concurrency:        3,
+	proxiedReqCount:    15,
+	proxiedConcurrency: 2,
+
+	expectedReqCount:            19.5,
+	expectedConcurrency:         3,
+	expectedProxiedRequestCount: 7.5,
+	expectedProxiedConcurrency:  2,
+}, {
+	name:            "reportingPeriod=1s",
+	reportingPeriod: 1 * time.Second,
+
+	reqCount:           39,
+	concurrency:        3,
+	proxiedReqCount:    15,
+	proxiedConcurrency: 2,
+
+	expectedReqCount:            39,
+	expectedConcurrency:         3,
+	expectedProxiedRequestCount: 15,
+	expectedProxiedConcurrency:  2,
+}}
+
+func TestNewPrometheusStatsReporterNegative(t *testing.T) {
 	tests := []struct {
 		name      string
 		errorMsg  string
@@ -44,37 +107,33 @@ func TestNewPrometheusStatsReporter_negative(t *testing.T) {
 		revision  string
 		pod       string
 	}{{
-		"Empty_Namespace_Value",
-		"Expected namespace empty error",
-		errors.New("namespace must not be empty"),
-		"",
-		config,
-		revision,
-		pod,
+		name:     "Empty_Namespace_Value",
+		errorMsg: "Expected namespace empty error",
+		result:   errors.New("namespace must not be empty"),
+		config:   config,
+		revision: revision,
+		pod:      pod,
 	}, {
-		"Empty_Config_Value",
-		"Expected config empty error",
-		errors.New("config must not be empty"),
-		namespace,
-		"",
-		revision,
-		pod,
+		name:      "Empty_Config_Value",
+		errorMsg:  "Expected config empty error",
+		result:    errors.New("config must not be empty"),
+		namespace: namespace,
+		revision:  revision,
+		pod:       pod,
 	}, {
-		"Empty_Revision_Value",
-		"Expected revision empty error",
-		errors.New("revision must not be empty"),
-		namespace,
-		config,
-		"",
-		pod,
+		name:      "Empty_Revision_Value",
+		errorMsg:  "Expected revision empty error",
+		result:    errors.New("revision must not be empty"),
+		namespace: namespace,
+		config:    config,
+		pod:       pod,
 	}, {
-		"Empty_Pod_Value",
-		"Expected pod empty error",
-		errors.New("pod must not be empty"),
-		namespace,
-		config,
-		revision,
-		"",
+		name:      "Empty_Pod_Value",
+		errorMsg:  "Expected pod empty error",
+		result:    errors.New("pod must not be empty"),
+		namespace: namespace,
+		config:    config,
+		revision:  revision,
 	}}
 
 	for _, test := range tests {
@@ -86,73 +145,8 @@ func TestNewPrometheusStatsReporter_negative(t *testing.T) {
 	}
 }
 
-func TestReporterReport(t *testing.T) {
-	tests := []struct {
-		name            string
-		reportingPeriod time.Duration
-
-		concurrency        float64
-		proxiedConcurrency float64
-		reqCount           float64
-		proxiedReqCount    float64
-
-		expectedReqCount            float64
-		expectedProxiedRequestCount float64
-		expectedConcurrency         float64
-		expectedProxiedConcurrency  float64
-	}{{
-		name:            "no proxy requests",
-		reportingPeriod: 1 * time.Second,
-
-		reqCount:    39,
-		concurrency: 3,
-
-		expectedReqCount:            39,
-		expectedConcurrency:         3,
-		expectedProxiedRequestCount: 0,
-		expectedProxiedConcurrency:  0,
-	}, {
-		name:            "reportingPeriod=10s",
-		reportingPeriod: 10 * time.Second,
-
-		reqCount:           39,
-		concurrency:        3,
-		proxiedReqCount:    15,
-		proxiedConcurrency: 2,
-
-		expectedReqCount:            3.9,
-		expectedConcurrency:         3,
-		expectedProxiedRequestCount: 1.5,
-		expectedProxiedConcurrency:  2,
-	}, {
-		name:            "reportingPeriod=2s",
-		reportingPeriod: 2 * time.Second,
-
-		reqCount:           39,
-		concurrency:        3,
-		proxiedReqCount:    15,
-		proxiedConcurrency: 2,
-
-		expectedReqCount:            19.5,
-		expectedConcurrency:         3,
-		expectedProxiedRequestCount: 7.5,
-		expectedProxiedConcurrency:  2,
-	}, {
-		name:            "reportingPeriod=1s",
-		reportingPeriod: 1 * time.Second,
-
-		reqCount:           39,
-		concurrency:        3,
-		proxiedReqCount:    15,
-		proxiedConcurrency: 2,
-
-		expectedReqCount:            39,
-		expectedConcurrency:         3,
-		expectedProxiedRequestCount: 15,
-		expectedProxiedConcurrency:  2,
-	}}
-
-	for _, test := range tests {
+func TestProtobufStatsReporterReport(t *testing.T) {
+	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			reporter, err := NewPrometheusStatsReporter(namespace, config, revision, pod, test.reportingPeriod)
 			if err != nil {

--- a/pkg/queue/protobuf_stats_reporter.go
+++ b/pkg/queue/protobuf_stats_reporter.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+
+	"knative.dev/serving/pkg/autoscaler/metrics"
+	"knative.dev/serving/pkg/network"
+)
+
+const (
+	contentTypeHeader = "Content-Type"
+)
+
+// PrometheusStatsReporter structure represents a prometheus stats reporter.
+type ProtobufStatsReporter struct {
+	reportingPeriod time.Duration
+	startTime       time.Time
+	stat            atomic.Value
+	podName         string
+}
+
+// NewPrometheusStatsReporter creates a reporter that collects and reports queue metrics.
+func NewProtobufStatsReporter(pod string, reportingPeriod time.Duration) *ProtobufStatsReporter {
+	return &ProtobufStatsReporter{
+		reportingPeriod: reportingPeriod,
+		startTime:       time.Now(),
+		stat:            atomic.Value{},
+		podName:         pod,
+	}
+}
+
+// Report captures request metrics.
+func (r *ProtobufStatsReporter) Report(stats network.RequestStatsReport) {
+	// Requests per second is a rate over time while concurrency is not.
+	rp := r.reportingPeriod.Seconds()
+	r.stat.Store(metrics.Stat{
+		PodName:                          r.podName,
+		RequestCount:                     stats.RequestCount / rp,
+		ProxiedRequestCount:              stats.ProxiedRequestCount / rp,
+		AverageConcurrentRequests:        stats.AverageConcurrency,
+		AverageProxiedConcurrentRequests: stats.AverageProxiedConcurrency,
+		ProcessUptime:                    time.Since(r.startTime).Seconds(),
+	})
+}
+
+// Handler returns an uninstrumented http.Handler used to serve stats registered by this
+// ProtobufStatsReporter.
+func (r *ProtobufStatsReporter) Handler() http.Handler {
+	return http.HandlerFunc(func(rsp http.ResponseWriter, req *http.Request) {
+		stat := r.stat.Load()
+		if stat == nil {
+			httpError(rsp, "no metrics available yet")
+			return
+		}
+		header := rsp.Header()
+		data := stat.(metrics.Stat)
+		buffer, err := proto.Marshal(&data)
+		if err != nil {
+			httpError(rsp, err.Error())
+		}
+		header.Set(contentTypeHeader, network.ProtoAcceptContent)
+		rsp.Write(buffer)
+	})
+}
+
+func httpError(rsp http.ResponseWriter, errMsg string) {
+	http.Error(
+		rsp,
+		"An error has occurred while serving metrics:\n\n"+errMsg,
+		http.StatusInternalServerError,
+	)
+}

--- a/pkg/queue/protobuf_stats_reporter.go
+++ b/pkg/queue/protobuf_stats_reporter.go
@@ -77,6 +77,7 @@ func (r *ProtobufStatsReporter) Handler() http.Handler {
 		buffer, err := proto.Marshal(&data)
 		if err != nil {
 			httpError(rsp, err.Error())
+			return
 		}
 		header.Set(contentTypeHeader, network.ProtoAcceptContent)
 		rsp.Write(buffer)

--- a/pkg/queue/protobuf_stats_reporter_test.go
+++ b/pkg/queue/protobuf_stats_reporter_test.go
@@ -24,28 +24,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp/cmpopts"
-
 	"github.com/google/go-cmp/cmp"
 
 	"knative.dev/serving/pkg/autoscaler/metrics"
 	"knative.dev/serving/pkg/network"
 )
 
-var (
-	testStat = metrics.Stat{
-		PodName:                          "testPod",
-		AverageConcurrentRequests:        5.0,
-		AverageProxiedConcurrentRequests: 5.0,
-		ProxiedRequestCount:              100.0,
-		RequestCount:                     100.0,
-		ProcessUptime:                    20.0,
-	}
-
-	ignoreStuff = cmp.Options{
-		cmpopts.IgnoreFields(testStat, "ProcessUptime"),
-	}
-)
+var testStat = metrics.Stat{
+	PodName:                          "testPod",
+	AverageConcurrentRequests:        5.0,
+	AverageProxiedConcurrentRequests: 5.0,
+	ProxiedRequestCount:              100.0,
+	RequestCount:                     100.0,
+	ProcessUptime:                    20.0,
+}
 
 func TestReporterReport(t *testing.T) {
 	for _, test := range testCases {
@@ -129,7 +121,7 @@ func TestProtoHandler(t *testing.T) {
 				if err != nil {
 					t.Errorf("Unmarshalling failed: %v", err)
 				}
-				if diff := cmp.Diff(stat, testStat, ignoreStuff...); diff != "" {
+				if diff := cmp.Diff(stat, testStat); diff != "" {
 					t.Errorf("Handler returned wrong stat data: (-want, +got):\n%v", diff)
 				}
 			}

--- a/pkg/queue/protobuf_stats_reporter_test.go
+++ b/pkg/queue/protobuf_stats_reporter_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"knative.dev/serving/pkg/autoscaler/metrics"
+	"knative.dev/serving/pkg/network"
+)
+
+var testStat = metrics.Stat{
+	PodName:                          "testPod",
+	AverageConcurrentRequests:        5.0,
+	AverageProxiedConcurrentRequests: 5.0,
+	ProxiedRequestCount:              100.0,
+	RequestCount:                     100.0,
+	ProcessUptime:                    20.0,
+}
+
+func TestReporterReport(t *testing.T) {
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			reporter := NewProtobufStatsReporter(pod, test.reportingPeriod)
+			// Make the value slightly more interesting, rather than microseconds.
+			reporter.startTime = reporter.startTime.Add(-5 * time.Second)
+			reporter.Report(network.RequestStatsReport{
+				AverageConcurrency:        test.concurrency,
+				AverageProxiedConcurrency: test.proxiedConcurrency,
+				RequestCount:              test.reqCount,
+				ProxiedRequestCount:       test.proxiedReqCount,
+			})
+			stat := reporter.stat.Load().(metrics.Stat)
+			if stat.RequestCount != test.expectedReqCount {
+				t.Errorf("stat.RequestCount = %v, want %v", stat.RequestCount, test.expectedReqCount)
+			}
+			if stat.AverageConcurrentRequests != test.expectedConcurrency {
+				t.Errorf("stat.AverageConcurrentRequests = %v, want %v", stat.AverageConcurrentRequests, test.expectedConcurrency)
+			}
+			if stat.ProxiedRequestCount != test.expectedProxiedRequestCount {
+				t.Errorf("stat.ProxiedRequestCount = %v, want %v", stat.ProxiedRequestCount, test.expectedProxiedRequestCount)
+			}
+			if stat.AverageProxiedConcurrentRequests != test.expectedProxiedConcurrency {
+				t.Errorf("stat.AverageProxiedConcurrentRequests = %v, want %v", stat.AverageProxiedConcurrentRequests, test.expectedProxiedConcurrency)
+			}
+			if got := stat.ProcessUptime; got < 5.0 || got > 6.0 {
+				t.Errorf("Got %v for process uptime, wanted 5.0 <= x < 6.0", got)
+			}
+		})
+	}
+}
+
+func TestProtoHandler(t *testing.T) {
+	metricsStat := atomic.Value{}
+	metricsStat.Store(testStat)
+
+	tests := []struct {
+		name     string
+		reporter ProtobufStatsReporter
+		errorMsg string
+	}{{
+		name:     "No metrics available",
+		reporter: ProtobufStatsReporter{},
+		errorMsg: "An error has occurred while serving metrics:\n\nno metrics available yet",
+	}, {
+		name: "Metrics available",
+		reporter: ProtobufStatsReporter{
+			reportingPeriod: time.Duration(1),
+			startTime:       time.Now(),
+			stat:            metricsStat,
+			podName:         "testPod"},
+	},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Accept-content", network.ProtoAcceptContent)
+			rr := httptest.NewRecorder()
+			handler := http.HandlerFunc(test.reporter.Handler().(http.HandlerFunc))
+			handler.ServeHTTP(rr, req)
+			if test.errorMsg != "" { // error case
+				expected := test.errorMsg + "\n"
+				if status := rr.Code; status != http.StatusInternalServerError {
+					t.Errorf("handler returned wrong status code: got %v want %v",
+						status, http.StatusInternalServerError)
+				}
+				if rr.Body.String() != expected {
+					t.Errorf("handler returned unexpected body: got %v want %v",
+						rr.Body.String(), expected)
+				}
+			} else { // good case, data received
+				bodyBytes, err := ioutil.ReadAll(rr.Body)
+				if err != nil {
+					t.Errorf("reading body failed: %w", err)
+				}
+				stat := metrics.Stat{}
+				err = stat.Unmarshal(bodyBytes)
+				if err != nil {
+					t.Errorf("unmarshalling failed: %w", err)
+				}
+				if stat.PodName != testStat.PodName {
+					t.Errorf("handler returned wrong stat data: got stat.PodName = %v want %v",
+						stat.PodName, testStat.PodName)
+				}
+				if stat.RequestCount != testStat.RequestCount {
+					t.Errorf("handler returned wrong stat data: got stat.RequestCount = %v want %v",
+						stat.RequestCount, testStat.RequestCount)
+				}
+				if stat.ProcessUptime != testStat.ProcessUptime {
+					t.Errorf("handler returned wrong stat data: got stat.ProcessUptime = %v want %v",
+						stat.ProcessUptime, testStat.ProcessUptime)
+				}
+				if stat.ProxiedRequestCount != testStat.ProxiedRequestCount {
+					t.Errorf("handler returned wrong stat data: got stat.ProxiedRequestCount = %v want %v",
+						stat.ProxiedRequestCount, testStat.ProxiedRequestCount)
+				}
+				if stat.AverageProxiedConcurrentRequests != testStat.AverageProxiedConcurrentRequests {
+					t.Errorf("handler returned wrong stat data: got AverageProxiedConcurrentRequests = %v want %v",
+						stat.AverageProxiedConcurrentRequests, testStat.AverageProxiedConcurrentRequests)
+				}
+				if stat.AverageConcurrentRequests != testStat.AverageConcurrentRequests {
+					t.Errorf("handler returned wrong stat data: got stat.AverageConcurrentRequests = %v want %v",
+						stat.AverageConcurrentRequests, testStat.AverageConcurrentRequests)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #8378

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* It is based on previous work from here #8396.
* Supports by default the protobuf based format for the QP <-> Autoscaler communication.
* Introduces a proto stat reporter for the QP. Note here that it does not use the Prometheus client model and its related exposition format based on Proto 2, as there is no support for [proto 3](https://github.com/prometheus/docs/issues/549) coming and in general Prometheus and its client libs are [moving away](https://github.com/prometheus/docs/issues/549#issuecomment-559560195) from [protobuf](https://github.com/prometheus/client_model).

* Keeps the current Prometheus text format for migration scenarios.
* It does not do any compression of the proto metrics struct since the are no real benefits unless there is an unlike case where `podName` in `Stat` is highly compressible and contains a lot of repetitions. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```
NONE
```

/assign @markusthoemmes 