### PR TITLE
Increase prometheus mem limit to prevent crashing

### DIFF
--- a/config/monitoring/metrics/prometheus/300-prometheus.yaml
+++ b/config/monitoring/metrics/prometheus/300-prometheus.yaml
@@ -285,7 +285,7 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            memory: 1000Mi
+            memory: 1300Mi
           requests:
             memory: 400Mi
         terminationMessagePath: /dev/termination-log

--- a/config/monitoring/metrics/prometheus/300-prometheus.yaml
+++ b/config/monitoring/metrics/prometheus/300-prometheus.yaml
@@ -285,7 +285,7 @@ spec:
           timeoutSeconds: 3
         resources:
           limits:
-            memory: 1300Mi
+            memory: 2000Mi
           requests:
             memory: 400Mi
         terminationMessagePath: /dev/termination-log

--- a/config/monitoring/metrics/prometheus/300-prometheus.yaml
+++ b/config/monitoring/metrics/prometheus/300-prometheus.yaml
@@ -261,7 +261,7 @@ spec:
         - --storage.tsdb.no-lockfile
         - --web.enable-lifecycle
         - --web.route-prefix=/
-        image: prom/prometheus:v2.2.1
+        image: prom/prometheus:v2.3.0
         imagePullPolicy: IfNotPresent
         name: prometheus
         ports:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
/area monitoring

Fixes #5457

<!-- Please include the 'why' behind your changes if no issue exists -->
Prometheus pods are failing with `out-of-memory` error, since the 1GB memory limit introduced by #3332 is not enough for it to initiate:

```
❯ k get pods -n knative-monitoring -l app=prometheus
NAME                                  READY   STATUS             RESTARTS   AGE                                                                                                                                                                                                 
prometheus-system-0                   0/1     CrashLoopBackOff   7683       28d
prometheus-system-1                   0/1     CrashLoopBackOff   3819       13d
```


```
❯ k describe pod prometheus-system-1 -n knative-monitoring
...
    State:
    Terminated
      Reason:       OOMKilled                             
      Exit Code:    137
      Started:      Fri, 03 Jul 2020 15:09:10 +0200
      Finished:     Fri, 03 Jul 2020 15:09:23 +0200
```


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Increased Prometheus memory limit to prevent it from crashing
```
