### PR TITLE
Remove unnecessary nil pointer check.

### DIFF
--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -893,29 +893,27 @@ func RuntimeRequestWithExpectations(t *testing.T, client *http.Client, url strin
 
 	defer resp.Body.Close()
 
-	if resp != nil {
-		for _, e := range responseExpectations {
-			if err := e(resp); err != nil {
-				t.Errorf("Error meeting response expectations: %v", err)
-				DumpResponse(t, resp)
-				return nil
-			}
+	for _, e := range responseExpectations {
+		if err := e(resp); err != nil {
+			t.Errorf("Error meeting response expectations: %v", err)
+			DumpResponse(t, resp)
+			return nil
 		}
+	}
 
-		if resp.StatusCode == http.StatusOK {
-			b, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				t.Errorf("Unable to read response body: %v", err)
-				DumpResponse(t, resp)
-				return nil
-			}
-			ri := &types.RuntimeInfo{}
-			if err := json.Unmarshal(b, ri); err != nil {
-				t.Errorf("Unable to parse runtime image's response payload: %v", err)
-				return nil
-			}
-			return ri
+	if resp.StatusCode == http.StatusOK {
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Errorf("Unable to read response body: %v", err)
+			DumpResponse(t, resp)
+			return nil
 		}
+		ri := &types.RuntimeInfo{}
+		if err := json.Unmarshal(b, ri); err != nil {
+			t.Errorf("Unable to parse runtime image's response payload: %v", err)
+			return nil
+		}
+		return ri
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As per title, the additional `nil` check isn't necessary because we check for errors already and the `defer` would panic anyway.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
