### PR TITLE
Change cleanup func to take pointer to names

### DIFF
--- a/test/cleanup.go
+++ b/test/cleanup.go
@@ -60,7 +60,7 @@ func CleanupOnInterrupt(cleanup func()) {
 }
 
 // TearDown will delete created names using clients.
-func TearDown(clients *Clients, names ResourceNames) {
+func TearDown(clients *Clients, names *ResourceNames) {
 	if clients != nil && clients.ServingClient != nil {
 		clients.ServingClient.Delete(
 			[]string{names.Route},
@@ -79,6 +79,6 @@ func EnsureCleanup(t *testing.T, cleanup func()) {
 
 // EnsureTearDown will delete created names when the test ends, either via
 // t.Cleanup, or on interrupt via CleanupOnInterrupt.
-func EnsureTearDown(t *testing.T, clients *Clients, names ResourceNames) {
+func EnsureTearDown(t *testing.T, clients *Clients, names *ResourceNames) {
 	EnsureCleanup(t, func() { TearDown(clients, names) })
 }

--- a/test/conformance/api/v1/blue_green_test.go
+++ b/test/conformance/api/v1/blue_green_test.go
@@ -61,7 +61,7 @@ func TestBlueGreenRoute(t *testing.T) {
 		Image:   test.PizzaPlanet1,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")

--- a/test/conformance/api/v1/configuration_test.go
+++ b/test/conformance/api/v1/configuration_test.go
@@ -38,7 +38,7 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 		Image:  test.PizzaPlanet1,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Logf("Creating new configuration %s", names.Config)
 	if _, err := v1test.CreateConfiguration(t, clients, names); err != nil {

--- a/test/conformance/api/v1/errorcondition_test.go
+++ b/test/conformance/api/v1/errorcondition_test.go
@@ -54,7 +54,7 @@ func TestContainerErrorMsg(t *testing.T) {
 		Image:   test.InvalidHelloWorld,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Specify an invalid image path
 	// A valid DockerRepo is still needed, otherwise will get UNAUTHORIZED instead of container missing error
@@ -164,7 +164,7 @@ func TestContainerExitingMsg(t *testing.T) {
 				Image:  test.Failing,
 			}
 
-			test.EnsureTearDown(t, clients, names)
+			test.EnsureTearDown(t, clients, &names)
 
 			t.Logf("Creating a new Configuration %s", names.Config)
 

--- a/test/conformance/api/v1/generatename_test.go
+++ b/test/conformance/api/v1/generatename_test.go
@@ -120,7 +120,7 @@ func TestServiceGenerateName(t *testing.T) {
 	}
 
 	// Cleanup on test failure.
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Create the service using the generate name field. If the service does not become ready this will fail.
 	t.Log("Creating new service with generateName", generateName)
@@ -155,7 +155,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 		Image: test.HelloWorld,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating new configuration with generateName", generateName)
 	config, err := v1test.CreateConfiguration(t, clients, names, setConfigurationGenerateName(generateName))

--- a/test/conformance/api/v1/migration_test.go
+++ b/test/conformance/api/v1/migration_test.go
@@ -44,7 +44,7 @@ func TestTranslation(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Service")
 	// Create a legacy RunLatest service.  This should perform conversion during the webhook
@@ -87,7 +87,7 @@ func TestV1beta1Rejection(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Service")
 	// Create a legacy RunLatest service, but give it the TypeMeta of v1.

--- a/test/conformance/api/v1/resources_test.go
+++ b/test/conformance/api/v1/resources_test.go
@@ -53,7 +53,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 		Image:   test.Autoscale,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	objects, err := v1test.CreateServiceReady(t, clients, &names, withResources)
 	if err != nil {

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -105,7 +105,7 @@ func TestRevisionTimeout(t *testing.T) {
 				Image:   test.Timeout,
 			}
 
-			test.EnsureTearDown(t, clients, names)
+			test.EnsureTearDown(t, clients, &names)
 
 			t.Log("Creating a new Service ")
 			resources, err := v1test.CreateServiceReady(t, clients, &names, WithRevisionTimeoutSeconds(tc.timeoutSeconds))

--- a/test/conformance/api/v1/route_test.go
+++ b/test/conformance/api/v1/route_test.go
@@ -107,7 +107,7 @@ func TestRouteCreation(t *testing.T) {
 		Image:         test.PizzaPlanet1,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Route and Configuration")
 	config, err := v1test.CreateConfiguration(t, clients, names)

--- a/test/conformance/api/v1/service_account_test.go
+++ b/test/conformance/api/v1/service_account_test.go
@@ -40,7 +40,7 @@ func TestServiceAccountValidation(t *testing.T) {
 		Image:   test.PizzaPlanet1,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Logf("Creating a new Service %s", names.Service)
 	service := v1test.Service(names, WithServiceAccountName(invalidServiceAccountName))

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -50,7 +50,7 @@ func TestService(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Setup initial Service
 	objects, err := v1test.CreateServiceReady(t, clients, &names)
@@ -189,7 +189,7 @@ func TestServiceBYOName(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	revName := names.Service + "-byoname"
 
@@ -252,7 +252,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   test.PizzaPlanet1,
 	}
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Expected Text for different revisions.
 	const (
@@ -490,7 +490,7 @@ func TestAnnotationPropagation(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Setup initial Service
 	objects, err := v1test.CreateServiceReady(t, clients, &names)

--- a/test/conformance/api/v1/single_threaded_test.go
+++ b/test/conformance/api/v1/single_threaded_test.go
@@ -43,7 +43,7 @@ func TestSingleConcurrency(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   test.SingleThreadedImage,
 	}
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	objects, err := v1test.CreateServiceReady(t, clients, &names, rtesting.WithContainerConcurrency(1))
 	if err != nil {

--- a/test/conformance/api/v1/volumes_test.go
+++ b/test/conformance/api/v1/volumes_test.go
@@ -62,7 +62,7 @@ func TestConfigMapVolume(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	test.EnsureCleanup(t, func() {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(configMap.Name, nil); err != nil {
 			t.Errorf("ConfigMaps().Delete() = %v", err)
 		}
@@ -129,7 +129,7 @@ func TestProjectedConfigMapVolume(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	test.EnsureCleanup(t, func() {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(configMap.Name, nil); err != nil {
 			t.Errorf("ConfigMaps().Delete() = %v", err)
 		}
@@ -198,7 +198,7 @@ func TestSecretVolume(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	test.EnsureCleanup(t, func() {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
@@ -261,7 +261,7 @@ func TestProjectedSecretVolume(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	test.EnsureCleanup(t, func() {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
@@ -345,7 +345,7 @@ func TestProjectedComplex(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	test.EnsureCleanup(t, func() {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}

--- a/test/conformance/api/v1alpha1/blue_green_test.go
+++ b/test/conformance/api/v1alpha1/blue_green_test.go
@@ -61,7 +61,7 @@ func TestBlueGreenRoute(t *testing.T) {
 		Image:   test.PizzaPlanet1,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")

--- a/test/conformance/api/v1alpha1/configuration_test.go
+++ b/test/conformance/api/v1alpha1/configuration_test.go
@@ -38,7 +38,7 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 		Image:  test.PizzaPlanet1,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Logf("Creating new configuration %s", names.Config)
 	if _, err := v1a1test.CreateConfiguration(t, clients, names); err != nil {

--- a/test/conformance/api/v1alpha1/errorcondition_test.go
+++ b/test/conformance/api/v1alpha1/errorcondition_test.go
@@ -53,7 +53,7 @@ func TestContainerErrorMsg(t *testing.T) {
 		Image:   test.InvalidHelloWorld,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Specify an invalid image path
 	// A valid DockerRepo is still needed, otherwise will get UNAUTHORIZED instead of container missing error
@@ -162,8 +162,7 @@ func TestContainerExitingMsg(t *testing.T) {
 				Image:  test.Failing,
 			}
 
-			test.EnsureTearDown(t, clients, names)
-
+			test.EnsureTearDown(t, clients, &names)
 			t.Logf("Creating a new Configuration %s", names.Config)
 
 			if _, err := v1a1test.CreateConfiguration(t, clients, names, v1a1opts.WithConfigReadinessProbe(tt.ReadinessProbe)); err != nil {

--- a/test/conformance/api/v1alpha1/generatename_test.go
+++ b/test/conformance/api/v1alpha1/generatename_test.go
@@ -120,7 +120,7 @@ func TestServiceGenerateName(t *testing.T) {
 	}
 
 	// Cleanup on test failure.
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Create the service using the generate name field. If the service does not become ready this will fail.
 	t.Log("Creating new service with generateName", generateName)
@@ -156,7 +156,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 		Image: test.HelloWorld,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating new configuration with generateName", generateName)
 	config, err := v1a1test.CreateConfiguration(t, clients, names, setConfigurationGenerateName(generateName))

--- a/test/conformance/api/v1alpha1/resources_test.go
+++ b/test/conformance/api/v1alpha1/resources_test.go
@@ -52,7 +52,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 		Image:   test.Autoscale,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
 		v1a1opts.WithResourceRequirements(resources))

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -104,7 +104,7 @@ func TestRevisionTimeout(t *testing.T) {
 				Image:   test.Timeout,
 			}
 
-			test.EnsureTearDown(t, clients, names)
+			test.EnsureTearDown(t, clients, &names)
 
 			t.Log("Creating a new Service ")
 			resources, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names, WithRevisionTimeoutSeconds(tc.timeoutSeconds))

--- a/test/conformance/api/v1alpha1/route_test.go
+++ b/test/conformance/api/v1alpha1/route_test.go
@@ -104,7 +104,7 @@ func TestRouteCreation(t *testing.T) {
 		Image:         test.PizzaPlanet1,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Route and Configuration")
 	config, err := v1a1test.CreateConfiguration(t, clients, names)

--- a/test/conformance/api/v1alpha1/service_test.go
+++ b/test/conformance/api/v1alpha1/service_test.go
@@ -49,7 +49,7 @@ func TestRunLatestService(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Setup initial Service
 	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)
@@ -189,7 +189,7 @@ func TestRunLatestServiceBYOName(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	revName := names.Service + "-byoname"
 
@@ -253,7 +253,7 @@ func TestReleaseService(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   test.PizzaPlanet1,
 	}
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Expected Text for different revisions.
 	const (
@@ -523,7 +523,7 @@ func TestAnnotationPropagation(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Setup initial Service
 	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)

--- a/test/conformance/api/v1alpha1/single_threaded_test.go
+++ b/test/conformance/api/v1alpha1/single_threaded_test.go
@@ -42,7 +42,7 @@ func TestSingleConcurrency(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   test.SingleThreadedImage,
 	}
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	objects, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names,
 		v1a1opts.WithContainerConcurrency(1))

--- a/test/conformance/api/v1alpha1/volumes_test.go
+++ b/test/conformance/api/v1alpha1/volumes_test.go
@@ -62,7 +62,7 @@ func TestConfigMapVolume(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	test.EnsureCleanup(t, func() {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(configMap.Name, nil); err != nil {
 			t.Errorf("ConfigMaps().Delete() = %v", err)
 		}
@@ -130,7 +130,7 @@ func TestProjectedConfigMapVolume(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	test.EnsureCleanup(t, func() {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(configMap.Name, nil); err != nil {
 			t.Errorf("ConfigMaps().Delete() = %v", err)
 		}
@@ -200,7 +200,7 @@ func TestSecretVolume(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	test.EnsureCleanup(t, func() {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
@@ -264,7 +264,7 @@ func TestProjectedSecretVolume(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	test.EnsureCleanup(t, func() {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
@@ -349,7 +349,7 @@ func TestProjectedComplex(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	test.EnsureCleanup(t, func() {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}

--- a/test/conformance/api/v1beta1/blue_green_test.go
+++ b/test/conformance/api/v1beta1/blue_green_test.go
@@ -61,7 +61,7 @@ func TestBlueGreenRoute(t *testing.T) {
 		Image:   test.PizzaPlanet1,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")

--- a/test/conformance/api/v1beta1/configuration_test.go
+++ b/test/conformance/api/v1beta1/configuration_test.go
@@ -38,7 +38,7 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 		Image:  test.PizzaPlanet1,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Logf("Creating new configuration %s", names.Config)
 	if _, err := v1b1test.CreateConfiguration(t, clients, names); err != nil {

--- a/test/conformance/api/v1beta1/errorcondition_test.go
+++ b/test/conformance/api/v1beta1/errorcondition_test.go
@@ -54,7 +54,7 @@ func TestContainerErrorMsg(t *testing.T) {
 		Image:   test.InvalidHelloWorld,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Specify an invalid image path
 	// A valid DockerRepo is still needed, otherwise will get UNAUTHORIZED instead of container missing error
@@ -164,7 +164,7 @@ func TestContainerExitingMsg(t *testing.T) {
 				Image:  test.Failing,
 			}
 
-			test.EnsureTearDown(t, clients, names)
+			test.EnsureTearDown(t, clients, &names)
 
 			t.Logf("Creating a new Configuration %s", names.Config)
 

--- a/test/conformance/api/v1beta1/generatename_test.go
+++ b/test/conformance/api/v1beta1/generatename_test.go
@@ -120,7 +120,7 @@ func TestServiceGenerateName(t *testing.T) {
 	}
 
 	// Cleanup on test failure.
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Create the service using the generate name field. If the serivce does not become ready this will fail.
 	t.Log("Creating new service with generateName", generateName)
@@ -155,7 +155,7 @@ func TestRouteAndConfigGenerateName(t *testing.T) {
 		Image: test.HelloWorld,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating new configuration with generateName", generateName)
 	config, err := v1b1test.CreateConfiguration(t, clients, names, setConfigurationGenerateName(generateName))

--- a/test/conformance/api/v1beta1/migration_test.go
+++ b/test/conformance/api/v1beta1/migration_test.go
@@ -44,7 +44,7 @@ func TestTranslation(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Service")
 	// Create a legacy RunLatest service.  This should perform conversion during the webhook
@@ -87,7 +87,7 @@ func TestV1beta1Rejection(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Service")
 	// Create a legacy RunLatest service, but give it the TypeMeta of v1beta1.

--- a/test/conformance/api/v1beta1/resources_test.go
+++ b/test/conformance/api/v1beta1/resources_test.go
@@ -53,7 +53,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 		Image:   test.Autoscale,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	objects, err := v1b1test.CreateServiceReady(t, clients, &names, withResources)
 	if err != nil {

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -104,7 +104,7 @@ func TestRevisionTimeout(t *testing.T) {
 				Image:   test.Timeout,
 			}
 
-			test.EnsureTearDown(t, clients, names)
+			test.EnsureTearDown(t, clients, &names)
 
 			t.Log("Creating a new Service ")
 			resources, err := v1b1test.CreateServiceReady(t, clients, &names, WithRevisionTimeoutSeconds(tc.timeoutSeconds))

--- a/test/conformance/api/v1beta1/route_test.go
+++ b/test/conformance/api/v1beta1/route_test.go
@@ -107,7 +107,7 @@ func TestRouteCreation(t *testing.T) {
 		Image:         test.PizzaPlanet1,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Route and Configuration")
 	config, err := v1b1test.CreateConfiguration(t, clients, names)

--- a/test/conformance/api/v1beta1/service_account_test.go
+++ b/test/conformance/api/v1beta1/service_account_test.go
@@ -40,7 +40,7 @@ func TestServiceAccountValidation(t *testing.T) {
 		Image:   test.PizzaPlanet1,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Logf("Creating a new Service %s", names.Service)
 	service := v1b1test.Service(names, WithServiceAccountName(invalidServiceAccountName))

--- a/test/conformance/api/v1beta1/service_test.go
+++ b/test/conformance/api/v1beta1/service_test.go
@@ -51,7 +51,7 @@ func TestService(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Setup initial Service
 	objects, err := v1b1test.CreateServiceReady(t, clients, &names)
@@ -190,7 +190,7 @@ func TestServiceBYOName(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	revName := names.Service + "-byoname"
 
@@ -253,7 +253,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   test.PizzaPlanet1,
 	}
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Expected Text for different revisions.
 	const (
@@ -491,7 +491,7 @@ func TestAnnotationPropagation(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Setup initial Service
 	objects, err := v1b1test.CreateServiceReady(t, clients, &names)

--- a/test/conformance/api/v1beta1/single_threaded_test.go
+++ b/test/conformance/api/v1beta1/single_threaded_test.go
@@ -43,7 +43,7 @@ func TestSingleConcurrency(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   test.SingleThreadedImage,
 	}
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	objects, err := v1b1test.CreateServiceReady(t, clients, &names, rtesting.WithContainerConcurrency(1))
 	if err != nil {

--- a/test/conformance/api/v1beta1/volumes_test.go
+++ b/test/conformance/api/v1beta1/volumes_test.go
@@ -62,7 +62,7 @@ func TestConfigMapVolume(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	test.EnsureCleanup(t, func() {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(configMap.Name, nil); err != nil {
 			t.Errorf("ConfigMaps().Delete() = %v", err)
 		}
@@ -129,7 +129,7 @@ func TestProjectedConfigMapVolume(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	test.EnsureCleanup(t, func() {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		if err := clients.KubeClient.Kube.CoreV1().ConfigMaps(test.ServingNamespace).Delete(configMap.Name, nil); err != nil {
 			t.Errorf("ConfigMaps().Delete() = %v", err)
 		}
@@ -198,7 +198,7 @@ func TestSecretVolume(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	test.EnsureCleanup(t, func() {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
@@ -261,7 +261,7 @@ func TestProjectedSecretVolume(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	test.EnsureCleanup(t, func() {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}
@@ -345,7 +345,7 @@ func TestProjectedComplex(t *testing.T) {
 
 	// Clean up on test failure or interrupt
 	test.EnsureCleanup(t, func() {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		if err := clients.KubeClient.Kube.CoreV1().Secrets(test.ServingNamespace).Delete(secret.Name, nil); err != nil {
 			t.Errorf("Secrets().Delete() = %v", err)
 		}

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -73,7 +73,7 @@ func TestProbeRuntime(t *testing.T) {
 				Image:   test.Runtime,
 			}
 
-			test.EnsureTearDown(t, clients, names)
+			test.EnsureTearDown(t, clients, &names)
 
 			t.Log("Creating a new Service")
 			resources, err := v1test.CreateServiceReady(t, clients, &names,

--- a/test/conformance/runtime/util.go
+++ b/test/conformance/runtime/util.go
@@ -41,7 +41,7 @@ func fetchRuntimeInfo(
 	t.Helper()
 	names.Service = test.ObjectNameForTest(t)
 
-	test.EnsureTearDown(t, clients, *names)
+	test.EnsureTearDown(t, clients, names)
 
 	serviceOpts, reqOpts, err := splitOpts(opts...)
 	if err != nil {

--- a/test/e2e/activator_test.go
+++ b/test/e2e/activator_test.go
@@ -53,7 +53,7 @@ func TestActivatorOverload(t *testing.T) {
 		Image:   "timeout",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a service with run latest configuration.")
 	// Create a service with concurrency 1 that sleeps for N ms.

--- a/test/e2e/autoscale.go
+++ b/test/e2e/autoscale.go
@@ -190,7 +190,7 @@ func setup(t *testing.T, class, metric string, target int, targetUtilization flo
 		Service: test.ObjectNameForTest(t),
 		Image:   image,
 	}
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 	resources, err := v1test.CreateServiceReady(t, clients, &names,
 		append([]rtesting.ServiceOption{
 			rtesting.WithConfigAnnotations(map[string]string{
@@ -211,7 +211,7 @@ func setup(t *testing.T, class, metric string, target int, targetUtilization flo
 			}),
 		}, fopts...)...)
 	if err != nil {
-		test.TearDown(clients, names)
+		test.TearDown(clients, &names)
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
 

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -74,7 +74,7 @@ func TestAutoscaleSustaining(t *testing.T) {
 	defer cancel()
 
 	ctx := setup(t, autoscaling.KPA, autoscaling.Concurrency, containerConcurrency, targetUtilization, autoscaleTestImageName, validateEndpoint)
-	defer test.TearDown(ctx.clients, ctx.names)
+	defer test.TearDown(ctx.clients, &ctx.names)
 
 	assertAutoscaleUpToNumPods(ctx, 1, 10, 2*time.Minute, false)
 }

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -65,7 +65,7 @@ func testAutoTLS(t *testing.T) {
 	if len(env.TLSServiceName) != 0 {
 		names.Service = env.TLSServiceName
 	}
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	objects, err := v1test.CreateServiceReady(t, clients, &names)
 	if err != nil {

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -60,7 +60,7 @@ func TestDestroyPodInflight(t *testing.T) {
 		Route:  svcName,
 		Image:  "timeout",
 	}
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Route and Configuration")
 	if _, err := v1test.CreateConfiguration(t, clients, names, rtesting.WithConfigRevisionTimeoutSeconds(revisionTimeoutSeconds)); err != nil {
@@ -169,7 +169,7 @@ func TestDestroyPodTimely(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	objects, err := v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))
@@ -253,7 +253,7 @@ func TestDestroyPodWithRequests(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   "autoscale",
 	}
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	objects, err := v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithRevisionTimeoutSeconds(int64(revisionTimeout.Seconds())))

--- a/test/e2e/egress_traffic_test.go
+++ b/test/e2e/egress_traffic_test.go
@@ -41,7 +41,7 @@ func TestEgressTraffic(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   "httpproxy",
 	}
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	service, err := v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithEnv(corev1.EnvVar{

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -337,7 +337,7 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 
 	fopts = append(fopts, rtesting.WithNamedPort("h2c"))
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 	resources, err := v1test.CreateServiceReady(t, clients, &names, fopts...)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -46,7 +46,7 @@ func TestHelloWorld(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Service")
 
@@ -97,7 +97,7 @@ func TestQueueSideCarResourceLimit(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Service")
 	resources, err := v1test.CreateServiceReady(t, clients, &names,

--- a/test/e2e/image_pull_error_test.go
+++ b/test/e2e/image_pull_error_test.go
@@ -41,7 +41,7 @@ func TestImagePullError(t *testing.T) {
 		Image: "ubuntu@sha256:0000000000000000000000000000000000000000000000000000000000000000",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Logf("Creating a new Service %s", names.Image)
 	var (

--- a/test/e2e/initial_scale_test.go
+++ b/test/e2e/initial_scale_test.go
@@ -48,7 +48,7 @@ func TestInitScaleZero(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Service with initial scale zero and verifying that no pods are created")
 	createAndVerifyInitialScaleService(t, clients, names, 0)
@@ -67,7 +67,7 @@ func TestInitScalePositive(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   "helloworld",
 	}
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Service with initialScale 3 and verifying that pods are created")
 	createAndVerifyInitialScaleService(t, clients, names, 3)

--- a/test/e2e/istio/authorization_test.go
+++ b/test/e2e/istio/authorization_test.go
@@ -52,7 +52,7 @@ func TestClusterLocalAuthorization(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	withInternalVisibility := rtesting.WithServiceLabel(
 		serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
@@ -90,7 +90,7 @@ func TestClusterLocalAuthorization(t *testing.T) {
 		Image:   "httpproxy",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	resources, err = v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithEnv(envVars...),

--- a/test/e2e/istio/probing_test.go
+++ b/test/e2e/istio/probing_test.go
@@ -86,8 +86,7 @@ func TestIstioProbing(t *testing.T) {
 			Service: test.ObjectNameForTest(t),
 			Image:   "helloworld",
 		}
-		test.CleanupOnInterrupt(func() { test.TearDown(clients, names) })
-		defer test.TearDown(clients, names)
+		test.EnsureTearDown(t, clients, &names)
 		objects, err := v1test.CreateServiceReady(t, clients, &names)
 		if err != nil {
 			t.Fatalf("Failed to create Service %s: %v", names.Service, err)
@@ -261,7 +260,7 @@ func TestIstioProbing(t *testing.T) {
 			setupGateway(t, clients, names, domain, namespace, c.servers)
 
 			// Create the service and wait for it to be ready
-			test.EnsureTearDown(t, clients, names)
+			test.EnsureTearDown(t, clients, &names)
 			_, err = v1test.CreateServiceReady(t, clients, &names)
 			if err != nil {
 				t.Fatalf("Failed to create Service %s: %v", names.Service, err)

--- a/test/e2e/logging_test.go
+++ b/test/e2e/logging_test.go
@@ -50,7 +50,7 @@ func TestRequestLogs(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Service")
 

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -52,7 +52,7 @@ func TestMinScale(t *testing.T) {
 		Image:  "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating route")
 	if _, err := v1test.CreateRoute(t, clients, names); err != nil {

--- a/test/e2e/multicontainer/multicontainer_test.go
+++ b/test/e2e/multicontainer/multicontainer_test.go
@@ -51,7 +51,7 @@ func TestMultiContainer(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 	t.Log("Creating a new Service")
 
 	resources, err := v1test.CreateServiceReadyForMultiContainer(t, clients, &names, func(svc *v1.Service) {

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -62,7 +62,7 @@ func TestMultipleNamespace(t *testing.T) {
 		Service: serviceName,
 		Image:   test.PizzaPlanet1,
 	}
-	test.EnsureTearDown(t, defaultClients, defaultResources)
+	test.EnsureTearDown(t, defaultClients, &defaultResources)
 	if _, err := v1test.CreateServiceReady(t, defaultClients, &defaultResources); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", defaultResources.Service, test.ServingNamespace, err)
 	}
@@ -71,7 +71,7 @@ func TestMultipleNamespace(t *testing.T) {
 		Service: serviceName,
 		Image:   test.PizzaPlanet2,
 	}
-	test.EnsureTearDown(t, altClients, altResources)
+	test.EnsureTearDown(t, altClients, &altResources)
 	if _, err := v1test.CreateServiceReady(t, altClients, &altResources); err != nil {
 		t.Fatalf("Failed to create Service %v in namespace %v: %v", altResources.Service, test.AlternativeServingNamespace, err)
 	}
@@ -120,7 +120,7 @@ func TestConflictingRouteService(t *testing.T) {
 
 	clients := Setup(t)
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 	if _, err := v1test.CreateServiceReady(t, clients, &names); err != nil {
 		t.Errorf("Failed to create Service %v in namespace %v: %v", names.Service, test.ServingNamespace, err)
 	}

--- a/test/e2e/pod_schedule_error_test.go
+++ b/test/e2e/pod_schedule_error_test.go
@@ -49,7 +49,7 @@ func TestPodScheduleError(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Logf("Creating a new Service %s", names.Image)
 	resources := corev1.ResourceRequirements{

--- a/test/e2e/probe_whitelist_test.go
+++ b/test/e2e/probe_whitelist_test.go
@@ -47,7 +47,7 @@ func TestProbeWhitelist(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Service")
 	resources, err := v1test.CreateServiceReady(t, clients, &names)

--- a/test/e2e/rollback_byo_test.go
+++ b/test/e2e/rollback_byo_test.go
@@ -44,7 +44,7 @@ func TestRollbackBYOName(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	withTrafficSpecOld := rtesting.WithRouteSpec(v1.RouteSpec{
 		Traffic: []v1.TrafficTarget{{

--- a/test/e2e/route_service_test.go
+++ b/test/e2e/route_service_test.go
@@ -47,7 +47,7 @@ func TestRoutesNotReady(t *testing.T) {
 		Image:   test.PizzaPlanet1,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	withTrafficSpec := rtesting.WithRouteSpec(v1.RouteSpec{
 		Traffic: []v1.TrafficTarget{
@@ -146,7 +146,7 @@ func TestRouteVisibilityChanges(t *testing.T) {
 				Image:   test.PizzaPlanet1,
 			}
 
-			test.EnsureTearDown(t, clients, names)
+			test.EnsureTearDown(t, clients, &names)
 
 			st.Log("Creating a new Service")
 			svc, err := v1test.CreateService(st, clients, names, testCase.withTrafficSpec)

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -189,7 +189,7 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 		select {
 		case names := <-cleanupCh:
 			t.Logf("Added %v to cleanup routine.", names)
-			test.EnsureTearDown(t, clients, names)
+			test.EnsureTearDown(t, clients, &names)
 
 		case err := <-doneCh:
 			if err != nil {

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -114,7 +114,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 		Image:   "httpproxy",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	resources, err := v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithEnv(envVars...),
@@ -179,7 +179,7 @@ func TestServiceToServiceCall(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	withInternalVisibility := rtesting.WithServiceLabel(
 		serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
@@ -226,7 +226,7 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 	withInternalVisibility := rtesting.WithServiceLabel(
 		serving.VisibilityLabelKey, serving.VisibilityClusterLocal)
 
-	test.EnsureTearDown(t, clients, testNames)
+	test.EnsureTearDown(t, clients, &testNames)
 
 	resources, err := v1test.CreateServiceReady(t, clients, &testNames,
 		rtesting.WithConfigAnnotations(map[string]string{
@@ -280,7 +280,7 @@ func TestCallToPublicService(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	resources, err := v1test.CreateServiceReady(t, clients, &names)
 	if err != nil {

--- a/test/e2e/service_validation_test.go
+++ b/test/e2e/service_validation_test.go
@@ -45,7 +45,7 @@ func TestServiceValidationWithInvalidPodSpec(t *testing.T) {
 	}
 
 	// Clean up on test failure or interrupt
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Setup Service
 	t.Logf("Creating a new Service %s", names.Service)

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -57,7 +57,7 @@ func TestSubrouteLocalSTS(t *testing.T) { // We can't use a longer more descript
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	tag := "current"
 
@@ -102,7 +102,7 @@ func TestSubrouteVisibilityPublicToPrivate(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	subrouteTag1 := "my-tag"
 	subrouteTag2 := "my-tag2"
@@ -217,7 +217,7 @@ func TestSubrouteVisibilityPrivateToPublic(t *testing.T) {
 		Image:   "helloworld",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	subrouteTag1 := "my-tag"
 	subrouteTag2 := "my-tag2"

--- a/test/e2e/tagheader/tag_header_based_routing_test.go
+++ b/test/e2e/tagheader/tag_header_based_routing_test.go
@@ -57,7 +57,7 @@ func TestTagHeaderBasedRouting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	revision1 := names.Revision
 

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -134,7 +134,7 @@ func TestWebSocket(t *testing.T) {
 	}
 
 	// Clean up in both abnormal and normal exits.
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	if _, err := v1test.CreateServiceReady(t, clients, &names); err != nil {
 		t.Fatal("Failed to create WebSocket server:", err)
@@ -160,7 +160,7 @@ func TestWebSocketViaActivator(t *testing.T) {
 	}
 
 	// Clean up in both abnormal and normal exits.
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	resources, err := v1test.CreateServiceReady(t, clients, &names,
 		rtesting.WithConfigAnnotations(map[string]string{
@@ -190,7 +190,7 @@ func TestWebSocketBlueGreenRoute(t *testing.T) {
 		Image:   wsServerTestImageName,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -81,7 +81,7 @@ func testActivatorHA(t *testing.T, gracePeriod *int64, slo float64) {
 			autoscaling.TargetBurstCapacityKey: "-1", // Make sure all requests go through the activator.
 		}),
 	)
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	// Create second service that will be scaled to zero and after stopping the activator we'll
 	// ensure it can be scaled back from zero.
@@ -91,7 +91,7 @@ func testActivatorHA(t *testing.T, gracePeriod *int64, slo float64) {
 			autoscaling.TargetBurstCapacityKey: "-1",                           // Make sure all requests go through the activator.
 		}),
 	)
-	test.EnsureTearDown(t, clients, namesScaleToZero)
+	test.EnsureTearDown(t, clients, &namesScaleToZero)
 
 	t.Logf("Waiting for %s to scale to zero", namesScaleToZero.Revision)
 	if err := e2e.WaitForScaleToZero(t, revisionresourcenames.Deployment(resourcesScaleToZero.Revision), clients); err != nil {

--- a/test/ha/autoscalerhpa_test.go
+++ b/test/ha/autoscalerhpa_test.go
@@ -60,7 +60,7 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 			autoscaling.TargetAnnotationKey: "70",
 		}))
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	if err := clients.KubeClient.Kube.CoreV1().Pods(system.Namespace()).Delete(leaderController,
 		&metav1.DeleteOptions{}); err != nil {

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -48,7 +48,7 @@ func TestControllerHA(t *testing.T) {
 	}
 
 	service1Names, resources := createPizzaPlanetService(t)
-	test.EnsureTearDown(t, clients, service1Names)
+	test.EnsureTearDown(t, clients, &service1Names)
 
 	if err := clients.KubeClient.Kube.CoreV1().Pods(system.Namespace()).Delete(leaderController,
 		&metav1.DeleteOptions{}); err != nil {
@@ -68,5 +68,5 @@ func TestControllerHA(t *testing.T) {
 
 	// Verify that after changing the leader we can still create a new kservice
 	service2Names, _ := createPizzaPlanetService(t)
-	test.EnsureTearDown(t, clients, service2Names)
+	test.EnsureTearDown(t, clients, &service2Names)
 }

--- a/test/performance/benchmarks/scale-from-zero/continuous/main.go
+++ b/test/performance/benchmarks/scale-from-zero/continuous/main.go
@@ -84,7 +84,7 @@ func createServices(clients *test.Clients, count int) ([]*v1test.ResourceObjects
 
 	cleanupNames := func() {
 		for i := 0; i < count; i++ {
-			test.TearDown(clients, *testNames[i])
+			test.TearDown(clients, testNames[i])
 		}
 	}
 

--- a/test/performance/latency_test.go
+++ b/test/performance/latency_test.go
@@ -59,7 +59,7 @@ func timeToServe(t *testing.T, img, query string, reqTimeout time.Duration) {
 		Image:   img,
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Service")
 	objs, err := v1a1test.CreateRunLatestServiceReady(t, clients, &names)

--- a/test/performance/observed_concurency_test.go
+++ b/test/performance/observed_concurency_test.go
@@ -147,7 +147,7 @@ func testConcurrencyN(t *testing.T, concurrency int) []junit.TestCase {
 		Image:   "observed-concurrency",
 	}
 
-	test.EnsureTearDown(t, clients, names)
+	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Service")
 	objs, err := v1test.CreateServiceReady(t, clients, &names,

--- a/test/upgrade/probe_test.go
+++ b/test/upgrade/probe_test.go
@@ -31,9 +31,7 @@ import (
 	v1test "knative.dev/serving/test/v1"
 )
 
-var (
-	successFraction = flag.Float64("probe.success_fraction", 1.0, "Fraction of probes required to pass during upgrade.")
-)
+var successFraction = flag.Float64("probe.success_fraction", 1.0, "Fraction of probes required to pass during upgrade.")
 
 const pipe = "/tmp/prober-signal"
 

--- a/test/upgrade/probe_test.go
+++ b/test/upgrade/probe_test.go
@@ -54,7 +54,7 @@ func TestProbe(t *testing.T) {
 		Service: "upgrade-probe",
 		Image:   test.PizzaPlanet1,
 	}
-	defer test.TearDown(clients, names)
+	defer test.TearDown(clients, &names)
 
 	objects, err := v1test.CreateServiceReady(t, clients, &names)
 	if err != nil {


### PR DESCRIPTION
if the names change, it will still cleanup the proper resource.
Fixes #8560

/assign @tcnghia @nak3 