### PR TITLE
Change transport of direct client for customized MaxIdleConns

### DIFF
--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -33,7 +33,6 @@ import (
 
 	"knative.dev/networking/pkg/apis/networking"
 	pkgmetrics "knative.dev/pkg/metrics"
-	pkgnet "knative.dev/pkg/network"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/metrics"
@@ -118,8 +117,11 @@ var noKeepaliveClient = &http.Client{
 // to take advantage of HTTP Keep-Alive to avoid connection creation overhead
 // between scrapes of the same pod.
 var client = &http.Client{
-	Timeout:   httpClientTimeout,
-	Transport: pkgnet.NewAutoTransport(),
+	Timeout: httpClientTimeout,
+	Transport: &http.Transport{
+		MaxIdleConns:    1000,
+		IdleConnTimeout: 90 * time.Second,
+	},
 }
 
 // serviceScraper scrapes Revision metrics via a K8S service by sampling. Which

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -33,6 +33,7 @@ import (
 
 	"knative.dev/networking/pkg/apis/networking"
 	pkgmetrics "knative.dev/pkg/metrics"
+	pkgnet "knative.dev/pkg/network"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/metrics"
@@ -117,7 +118,8 @@ var noKeepaliveClient = &http.Client{
 // to take advantage of HTTP Keep-Alive to avoid connection creation overhead
 // between scrapes of the same pod.
 var client = &http.Client{
-	Timeout: httpClientTimeout,
+	Timeout:   httpClientTimeout,
+	Transport: pkgnet.NewAutoTransport(),
 }
 
 // serviceScraper scrapes Revision metrics via a K8S service by sampling. Which


### PR DESCRIPTION
Currently we noticed the CPU usage for autoscaler is high when there are hundreds of pods running in cluster. From the CPU profling we can tell that it is spending on dialing for connections.
```
      flat  flat%   sum%        cum   cum%
         0     0%     0%      0.81s 19.61%  net/http.(*Transport).dialConn
         0     0%     0%      0.81s 19.61%  net/http.(*Transport).dialConnFor
         0     0%     0%      0.75s 18.16%  runtime.mcall
         0     0%     0%      0.74s 17.92%  net.(*Dialer).DialContext
         0     0%     0%      0.74s 17.92%  net/http.(*Transport).dial
     0.01s  0.24%  0.24%      0.74s 17.92%  runtime.schedule
         0     0%  0.24%      0.72s 17.43%  golang.org/x/sync/errgroup.(*Group).Go.func1
     0.70s 16.95% 17.19%      0.72s 17.43%  syscall.Syscall
         0     0% 17.19%      0.70s 16.95%  knative.dev/serving/pkg/autoscaler/metrics.(*serviceScraper).scrapePods.func1
         0     0% 17.19%      0.68s 16.46%  knative.dev/serving/pkg/autoscaler/metrics.(*httpScrapeClient).Scrape
```

The optimization in https://github.com/knative/serving/pull/8367 of @julz works but the default value 100 of `MaxIdleConns` is too small for pod scraping. The customized transport config from pkg/network with 1000 of `MaxIdleConns` should works better. After applying this change  I see a significant CPU drop ( 54% -> 36%) with 300 pods running in cluster.

![image](https://user-images.githubusercontent.com/62631896/86768456-31ad2880-c080-11ea-837f-36d4cb3c56d8.png)


**Release Note**

```release-note
None
```
