### PR TITLE
Fix race condition between Revision and PodAutoscaler readiness.

### DIFF
--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -171,6 +171,13 @@ func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *av1alpha1.PodAutoscalerS
 		return
 	}
 
+	if ps.IsScaleTargetInitialized() {
+		// Precondition for PA being initialized is SKS being active and
+		// that entices that |service.endpoints| > 0.
+		rs.MarkResourcesAvailableTrue()
+		rs.MarkContainerHealthyTrue()
+	}
+
 	switch cond.Status {
 	case corev1.ConditionUnknown:
 		rs.MarkActiveUnknown(cond.Reason, cond.Message)
@@ -181,6 +188,9 @@ func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *av1alpha1.PodAutoscalerS
 
 		// Precondition for PA being active is SKS being active and
 		// that entices that |service.endpoints| > 0.
+		//
+		// Note: This is needed for backwards compatibility as we're adding the new
+		// ScaleTargetInitialized condition to gate readiness.
 		rs.MarkResourcesAvailableTrue()
 		rs.MarkContainerHealthyTrue()
 	}

--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -173,7 +173,7 @@ func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *av1alpha1.PodAutoscalerS
 
 	if ps.IsScaleTargetInitialized() {
 		// Precondition for PA being initialized is SKS being active and
-		// that entices that |service.endpoints| > 0.
+		// that implies that |service.endpoints| > 0.
 		rs.MarkResourcesAvailableTrue()
 		rs.MarkContainerHealthyTrue()
 	}
@@ -187,7 +187,7 @@ func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *av1alpha1.PodAutoscalerS
 		rs.MarkActiveTrue()
 
 		// Precondition for PA being active is SKS being active and
-		// that entices that |service.endpoints| > 0.
+		// that implies that |service.endpoints| > 0.
 		//
 		// Note: This is needed for backwards compatibility as we're adding the new
 		// ScaleTargetInitialized condition to gate readiness.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #8539

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This fixes a race condition where the revision reconciler might never be able to observe a PodAutoscaler while it's ready and only see it non-ready if the PA scales down to 0 before the revision reconciler saw PA's readiness.

While the desire is to make PA's readiness more fitting with K8s APIs in general (i.e. make it be ready even if scaled to 0) this at least fixes the major painpoint we're having with the current state.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @julz
