### PR TITLE
Update the job name and label into storage-version-migration-serving

### DIFF
--- a/config/post-install/storage-version-migration.yaml
+++ b/config/post-install/storage-version-migration.yaml
@@ -15,10 +15,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: storage-version-migration-
+  generateName: storage-version-migration-serving-
   namespace: knative-serving
   labels:
-    app: "storage-version-migration"
+    app: "storage-version-migration-serving"
     serving.knative.dev/release: devel
 spec:
   ttlSecondsAfterFinished: 600
@@ -28,7 +28,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
       labels:
-        app: "storage-version-migration"
+        app: "storage-version-migration-serving"
     spec:
       serviceAccountName: controller
       restartPolicy: OnFailure


### PR DESCRIPTION


<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* This PR changed the name storage-version-migration into storage-version-migration-serving to differentiate from the job name in eventing.