### PR TITLE
Ensure all yaml checksums are quoted

### DIFF
--- a/config/core/configmaps/defaults.yaml
+++ b/config/core/configmaps/defaults.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: 2defca8d
+    knative.dev/example-checksum: "2defca8d"
 data:
   _example: |
     ################################

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: 0608517d
+    knative.dev/example-checksum: "0608517d"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.

--- a/config/core/configmaps/domain.yaml
+++ b/config/core/configmaps/domain.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: f8e5beb4
+    knative.dev/example-checksum: "f8e5beb4"
 data:
   _example: |
     ################################

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: 43bdc81c
+    knative.dev/example-checksum: "43bdc81c"
 data:
   _example: |
     ################################

--- a/config/core/configmaps/gc.yaml
+++ b/config/core/configmaps/gc.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: 83219cc3
+    knative.dev/example-checksum: "83219cc3"
 data:
   _example: |
     ################################

--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: b705abde
+    knative.dev/example-checksum: "b705abde"
 data:
   _example: |
     ################################

--- a/config/core/configmaps/logging.yaml
+++ b/config/core/configmaps/logging.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: 23eed3d8
+    knative.dev/example-checksum: "23eed3d8"
 data:
   _example: |
     ################################

--- a/config/core/configmaps/network.yaml
+++ b/config/core/configmaps/network.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: c7f290c9
+    knative.dev/example-checksum: "c7f290c9"
 data:
   _example: |
     ################################

--- a/config/core/configmaps/observability.yaml
+++ b/config/core/configmaps/observability.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: 8acf3b67
+    knative.dev/example-checksum: "8acf3b67"
 data:
   _example: |
     ################################

--- a/config/core/configmaps/tracing.yaml
+++ b/config/core/configmaps/tracing.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: 4002b4c2
+    knative.dev/example-checksum: "4002b4c2"
 data:
   _example: |
     ################################


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* If you win the hashcode lottery and get a checksum that is all numeric, this parses as an int instead of a string and fails.
   * Quotes ensure proper parsing
   * This was mysterious and confusing in: https://github.com/knative/serving/pull/8582

