### PR TITLE
Move labeler patch creation behind Accessor implementations

### DIFF
--- a/pkg/reconciler/labeler/labelerv2_test.go
+++ b/pkg/reconciler/labeler/labelerv2_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/reconciler/labeler/labelerv2_test.go
+++ b/pkg/reconciler/labeler/labelerv2_test.go
@@ -167,7 +167,7 @@ func TestV2Reconcile(t *testing.T) {
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError",
-				`failed to add route label to Namespace=default "the-config-dbnfd": inducing failure for patch revisions`),
+				`failed to add route label to Namespace=default Name="the-config-dbnfd": inducing failure for patch revisions`),
 		},
 		Key: "default/add-label-failure",
 	}, {
@@ -189,7 +189,7 @@ func TestV2Reconcile(t *testing.T) {
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError",
-				`failed to add route label to Namespace=default "the-config": inducing failure for patch configurations`),
+				`failed to add route label to Namespace=default Name="the-config": inducing failure for patch configurations`),
 		},
 		Key: "default/add-label-failure",
 	}, {
@@ -205,7 +205,7 @@ func TestV2Reconcile(t *testing.T) {
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError",
-				`failed to add route label to Namespace=default "the-config-dbnfd": `+
+				`failed to add route label to Namespace=default Name="the-config-dbnfd": `+
 					`resource already has route label "another-route", and cannot be referenced by "the-route"`),
 		},
 		Key: "default/the-route",

--- a/pkg/reconciler/labeler/labelerv2_test.go
+++ b/pkg/reconciler/labeler/labelerv2_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -167,7 +167,7 @@ func TestV2Reconcile(t *testing.T) {
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError",
-				`failed to add route label to /, Kind= "the-config-dbnfd": inducing failure for patch revisions`),
+				`failed to add route label to Namespace=default "the-config-dbnfd": inducing failure for patch revisions`),
 		},
 		Key: "default/add-label-failure",
 	}, {
@@ -189,7 +189,7 @@ func TestV2Reconcile(t *testing.T) {
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError",
-				`failed to add route label to /, Kind= "the-config": inducing failure for patch configurations`),
+				`failed to add route label to Namespace=default "the-config": inducing failure for patch configurations`),
 		},
 		Key: "default/add-label-failure",
 	}, {
@@ -205,7 +205,8 @@ func TestV2Reconcile(t *testing.T) {
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError",
-				`/, Kind= "the-config-dbnfd" is already in use by "another-route", and cannot be used by "the-route"`),
+				`failed to add route label to Namespace=default "the-config-dbnfd": `+
+					`resource already has route label "another-route", and cannot be referenced by "the-route"`),
 		},
 		Key: "default/the-route",
 	}, {

--- a/pkg/reconciler/labeler/v2/accessors.go
+++ b/pkg/reconciler/labeler/v2/accessors.go
@@ -61,9 +61,8 @@ func NewRevisionAccessor(
 
 // makeMetadataPatch makes a metadata map to be patched or nil if no changes are needed.
 func makeMetadataPatch(acc kmeta.Accessor, routeName string) (map[string]interface{}, error) {
-	labels := map[string]interface{}{}
-
-	if err := addRouteLabel(acc, labels, routeName); err != nil {
+	labels, err := addRouteLabel(acc, routeName)
+	if err != nil {
 		return nil, err
 	}
 
@@ -80,7 +79,9 @@ func makeMetadataPatch(acc kmeta.Accessor, routeName string) (map[string]interfa
 
 // addRouteLabel appends the route label to the list of labels if needed
 // or removes the label if routeName is nil.
-func addRouteLabel(acc kmeta.Accessor, diffLabels map[string]interface{}, routeName string) error {
+func addRouteLabel(acc kmeta.Accessor, routeName string) (map[string]interface{}, error) {
+	diffLabels := map[string]interface{}{}
+
 	oldLabels := acc.GetLabels()
 	if routeName == "" { // remove the label
 		if len(oldLabels) != 0 && oldLabels[serving.RouteLabelKey] != "" {
@@ -95,12 +96,12 @@ func addRouteLabel(acc kmeta.Accessor, diffLabels map[string]interface{}, routeN
 			} else if oldLabel != routeName {
 				// TODO(whaught): this restricts us to only one route -> revision
 				// We can move this to a comma separated list annotation and use the new routingState label.
-				return fmt.Errorf("resource already has route label %q, and cannot be referenced by %q", oldLabel, routeName)
+				return nil, fmt.Errorf("resource already has route label %q, and cannot be referenced by %q", oldLabel, routeName)
 			}
 		}
 	}
 
-	return nil
+	return diffLabels, nil
 }
 
 // list implements Accessor

--- a/pkg/reconciler/labeler/v2/accessors.go
+++ b/pkg/reconciler/labeler/v2/accessors.go
@@ -80,15 +80,13 @@ func makeMetadataPatch(acc kmeta.Accessor, routeName string) (map[string]interfa
 // addRouteLabel appends the route label to the list of labels if needed
 // or removes the label if routeName is nil.
 func addRouteLabel(acc kmeta.Accessor, routeName string) (map[string]interface{}, error) {
-	diffLabels := map[string]interface{}{}
-
 	if routeName == "" { // remove the label
 		if acc.GetLabels()[serving.RouteLabelKey] != "" {
-			diffLabels[serving.RouteLabelKey] = nil
+			return map[string]interface{}{serving.RouteLabelKey: nil}, nil
 		}
 	} else { // add the label
 		if oldLabel := acc.GetLabels()[serving.RouteLabelKey]; oldLabel == "" {
-			diffLabels[serving.RouteLabelKey] = routeName
+			return map[string]interface{}{serving.RouteLabelKey: routeName}, nil
 		} else if oldLabel != routeName {
 			// TODO(whaught): this restricts us to only one route -> revision
 			// We can move this to a comma separated list annotation and use the new routingState label.
@@ -96,7 +94,7 @@ func addRouteLabel(acc kmeta.Accessor, routeName string) (map[string]interface{}
 		}
 	}
 
-	return diffLabels, nil
+	return nil, nil
 }
 
 // list implements Accessor

--- a/pkg/reconciler/labeler/v2/accessors.go
+++ b/pkg/reconciler/labeler/v2/accessors.go
@@ -84,17 +84,17 @@ func addRouteLabel(acc kmeta.Accessor, diffLabels map[string]interface{}, routeN
 	oldLabels := acc.GetLabels()
 	if routeName == nil { // remove the label
 		if len(oldLabels) != 0 && oldLabels[serving.RouteLabelKey] != "" {
-			diffLabels[serving.RouteLabelKey] = nil
+			diffLabels[serving.RouteLabelKey] = routeName
 		}
 	} else { // add the label
 		if len(oldLabels) == 0 {
 			diffLabels[serving.RouteLabelKey] = routeName
 		} else {
-			// TODO(whaught): this restricts us to only one route -> revision
-			// We can move this to a comma separated list annotation and use the new routingState label.
 			if oldLabel := oldLabels[serving.RouteLabelKey]; oldLabel == "" {
 				diffLabels[serving.RouteLabelKey] = routeName
 			} else if oldLabel != *routeName {
+				// TODO(whaught): this restricts us to only one route -> revision
+				// We can move this to a comma separated list annotation and use the new routingState label.
 				return fmt.Errorf("resource already has route label %q, and cannot be referenced by %q", oldLabel, *routeName)
 			}
 		}

--- a/pkg/reconciler/labeler/v2/accessors.go
+++ b/pkg/reconciler/labeler/v2/accessors.go
@@ -85,6 +85,8 @@ func addRouteLabel(acc kmeta.Accessor, labels map[string]interface{}, routeName 
 	} else if oldLabel := oldLabels[serving.RouteLabelKey]; routeName == nil && oldLabel != "" {
 		labels[serving.RouteLabelKey] = routeName
 	} else if routeName != nil && oldLabel != *routeName {
+		// TODO(whaught): this restricts us to only one route -> revision
+		// We can move this to a comma separated list annotation and use the new routingState label.
 		return fmt.Errorf("resource already has route label %q, and cannot be referenced by %q", oldLabel, *routeName)
 	}
 	return nil

--- a/pkg/reconciler/labeler/v2/accessors.go
+++ b/pkg/reconciler/labeler/v2/accessors.go
@@ -84,20 +84,16 @@ func addRouteLabel(acc kmeta.Accessor, routeName string) (map[string]interface{}
 
 	oldLabels := acc.GetLabels()
 	if routeName == "" { // remove the label
-		if len(oldLabels) != 0 && oldLabels[serving.RouteLabelKey] != "" {
+		if oldLabels[serving.RouteLabelKey] != "" {
 			diffLabels[serving.RouteLabelKey] = nil
 		}
 	} else { // add the label
-		if len(oldLabels) == 0 {
+		if oldLabel := oldLabels[serving.RouteLabelKey]; oldLabel == "" {
 			diffLabels[serving.RouteLabelKey] = routeName
-		} else {
-			if oldLabel := oldLabels[serving.RouteLabelKey]; oldLabel == "" {
-				diffLabels[serving.RouteLabelKey] = routeName
-			} else if oldLabel != routeName {
-				// TODO(whaught): this restricts us to only one route -> revision
-				// We can move this to a comma separated list annotation and use the new routingState label.
-				return nil, fmt.Errorf("resource already has route label %q, and cannot be referenced by %q", oldLabel, routeName)
-			}
+		} else if oldLabel != routeName {
+			// TODO(whaught): this restricts us to only one route -> revision
+			// We can move this to a comma separated list annotation and use the new routingState label.
+			return nil, fmt.Errorf("resource already has route label %q, and cannot be referenced by %q", oldLabel, routeName)
 		}
 	}
 

--- a/pkg/reconciler/labeler/v2/accessors.go
+++ b/pkg/reconciler/labeler/v2/accessors.go
@@ -78,7 +78,8 @@ func makeMetadataPatch(acc kmeta.Accessor, routeName *string) (map[string]interf
 	return nil, nil
 }
 
-// addRouteLabel appends the route label to the list of labels if needed.
+// addRouteLabel appends the route label to the list of labels if needed
+// or removes the label if routeName is nil.
 func addRouteLabel(acc kmeta.Accessor, diffLabels map[string]interface{}, routeName *string) error {
 	oldLabels := acc.GetLabels()
 	if routeName == nil { // remove the label

--- a/pkg/reconciler/labeler/v2/accessors.go
+++ b/pkg/reconciler/labeler/v2/accessors.go
@@ -82,13 +82,12 @@ func makeMetadataPatch(acc kmeta.Accessor, routeName string) (map[string]interfa
 func addRouteLabel(acc kmeta.Accessor, routeName string) (map[string]interface{}, error) {
 	diffLabels := map[string]interface{}{}
 
-	oldLabels := acc.GetLabels()
 	if routeName == "" { // remove the label
-		if oldLabels[serving.RouteLabelKey] != "" {
+		if acc.GetLabels()[serving.RouteLabelKey] != "" {
 			diffLabels[serving.RouteLabelKey] = nil
 		}
 	} else { // add the label
-		if oldLabel := oldLabels[serving.RouteLabelKey]; oldLabel == "" {
+		if oldLabel := acc.GetLabels()[serving.RouteLabelKey]; oldLabel == "" {
 			diffLabels[serving.RouteLabelKey] = routeName
 		} else if oldLabel != routeName {
 			// TODO(whaught): this restricts us to only one route -> revision

--- a/pkg/reconciler/labeler/v2/labels.go
+++ b/pkg/reconciler/labeler/v2/labels.go
@@ -110,7 +110,7 @@ func ClearLabels(ns, name string, accs ...Accessor) error {
 func setLabelForListed(route *v1.Route, acc Accessor, names sets.String) error {
 	for name := range names {
 		if err := setRouteLabel(acc, route.Namespace, name, route.Name); err != nil {
-			return fmt.Errorf("failed to add route label to Namespace=%s %q: %w", route.Namespace, name, err)
+			return fmt.Errorf("failed to add route label to Namespace=%s Name=%q: %w", route.Namespace, name, err)
 		}
 	}
 	return nil

--- a/pkg/reconciler/labeler/v2/labels.go
+++ b/pkg/reconciler/labeler/v2/labels.go
@@ -23,10 +23,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/tracker"
 
-	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -47,7 +45,7 @@ func SyncLabels(r *v1.Route, cacc *Configuration, racc *Revision) error {
 				return err
 			}
 
-			rev, err := racc.get(r.Namespace, revName)
+			rev, err := racc.revisionLister.Revisions(r.Namespace).Get(revName)
 			if err != nil {
 				// The revision might not exist (yet). The informers will notify if it gets created.
 				continue
@@ -111,45 +109,32 @@ func ClearLabels(ns, name string, accs ...Accessor) error {
 // listed within "names" in the same namespace.
 func setLabelForListed(route *v1.Route, acc Accessor, names sets.String) error {
 	for name := range names {
-		elt, err := acc.get(route.Namespace, name)
-		if err != nil {
-			return err
-		}
-		routeName, ok := elt.GetLabels()[serving.RouteLabelKey]
-		if ok {
-			if routeName != route.Name {
-				return fmt.Errorf("%s %q is already in use by %q, and cannot be used by %q",
-					elt.GroupVersionKind(), elt.GetName(), routeName, route.Name)
-			}
-		} else {
-			if err := setRouteLabel(acc, elt, &route.Name); err != nil {
-				return fmt.Errorf("failed to add route label to %s %q: %w",
-					elt.GroupVersionKind(), elt.GetName(), err)
-			}
+		if err := setRouteLabel(acc, route.Namespace, name, &route.Name); err != nil {
+			return fmt.Errorf("failed to add route label to Namespace=%s %q: %w", route.Namespace, name, err)
 		}
 	}
-
 	return nil
 }
 
 // deleteLabelForNotListed uses the accessor to delete the label from any listable entity that is
 // not named within our list.  Unlike setLabelForListed, this function takes ns/name instead of a
 // Route so that it can clean things up when a Route ceases to exist.
-func deleteLabelForNotListed(ns, name string, acc Accessor, names sets.String) error {
-	oldList, err := acc.list(ns, name)
+func deleteLabelForNotListed(ns, routeName string, acc Accessor, names sets.String) error {
+	oldList, err := acc.list(ns, routeName)
 	if err != nil {
 		return err
 	}
 
 	// Delete label for newly removed traffic targets.
 	for _, elt := range oldList {
-		if names.Has(elt.GetName()) {
+		name := elt.GetName()
+		if names.Has(name) {
 			continue
 		}
 
-		if err := setRouteLabel(acc, elt, nil); err != nil {
+		if err := setRouteLabel(acc, ns, name, nil); err != nil {
 			return fmt.Errorf("failed to remove route label to %s %q: %w",
-				elt.GroupVersionKind(), elt.GetName(), err)
+				elt.GroupVersionKind(), name, err)
 		}
 	}
 
@@ -159,21 +144,18 @@ func deleteLabelForNotListed(ns, name string, acc Accessor, names sets.String) e
 // setRouteLabel toggles the route label on the specified element through the provided accessor.
 // a nil route name will cause the route label to be deleted, and a non-nil route will cause
 // that route name to be attached to the element.
-func setRouteLabel(acc Accessor, elt kmeta.Accessor, routeName *string) error {
-	mergePatch := map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels": map[string]interface{}{
-				serving.RouteLabelKey: routeName,
-			},
-		},
-	}
-
-	patch, err := json.Marshal(mergePatch)
-	if err != nil {
+func setRouteLabel(acc Accessor, ns, name string, routeName *string) error {
+	if mergePatch, err := acc.makeMetadataPatch(ns, name, routeName); err != nil {
 		return err
+	} else if mergePatch != nil {
+		patch, err := json.Marshal(mergePatch)
+		if err != nil {
+			return err
+		}
+		return acc.patch(ns, name, types.MergePatchType, patch)
 	}
 
-	return acc.patch(elt.GetNamespace(), elt.GetName(), types.MergePatchType, patch)
+	return nil
 }
 
 func ref(namespace, name, kind string) tracker.Reference {

--- a/pkg/reconciler/labeler/v2/labels.go
+++ b/pkg/reconciler/labeler/v2/labels.go
@@ -109,7 +109,7 @@ func ClearLabels(ns, name string, accs ...Accessor) error {
 // listed within "names" in the same namespace.
 func setLabelForListed(route *v1.Route, acc Accessor, names sets.String) error {
 	for name := range names {
-		if err := setRouteLabel(acc, route.Namespace, name, &route.Name); err != nil {
+		if err := setRouteLabel(acc, route.Namespace, name, route.Name); err != nil {
 			return fmt.Errorf("failed to add route label to Namespace=%s %q: %w", route.Namespace, name, err)
 		}
 	}
@@ -132,7 +132,7 @@ func deleteLabelForNotListed(ns, routeName string, acc Accessor, names sets.Stri
 			continue
 		}
 
-		if err := setRouteLabel(acc, ns, name, nil); err != nil {
+		if err := setRouteLabel(acc, ns, name, ""); err != nil {
 			return fmt.Errorf("failed to remove route label to %s %q: %w",
 				elt.GroupVersionKind(), name, err)
 		}
@@ -144,7 +144,7 @@ func deleteLabelForNotListed(ns, routeName string, acc Accessor, names sets.Stri
 // setRouteLabel toggles the route label on the specified element through the provided accessor.
 // a nil route name will cause the route label to be deleted, and a non-nil route will cause
 // that route name to be attached to the element.
-func setRouteLabel(acc Accessor, ns, name string, routeName *string) error {
+func setRouteLabel(acc Accessor, ns, name string, routeName string) error {
 	if mergePatch, err := acc.makeMetadataPatch(ns, name, routeName); err != nil {
 		return err
 	} else if mergePatch != nil {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Issue #8208

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* This hides the logic for creating a patch to operate on implementations of Accessor
    * Allows Configuration / Revision to have divergent logic (the new timestamp will be rev only)
    * Allows access to all Revision/Configuration fields

*Note: this alternate implementation is behind a feature flag - none of this code is enabled.*
