### PR TITLE
Add conformance test for RewriteHost KIngress feature

### DIFF
--- a/test/conformance/ingress/rewrite.go
+++ b/test/conformance/ingress/rewrite.go
@@ -56,7 +56,7 @@ func TestRewriteHost(t *testing.T) {
 	// Now create a RewriteHost ingress to point a custom Host at the Service
 	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
 		Rules: []v1alpha1.IngressRule{{
-			Hosts:      []string{"vanity.ismy.name"},
+			Hosts:      []string{"vanity.ismy.name", "vanity.isalsomy.number"},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -68,4 +68,5 @@ func TestRewriteHost(t *testing.T) {
 	defer cancel()
 
 	RuntimeRequest(t, client, "http://vanity.ismy.name")
+	RuntimeRequest(t, client, "http://vanity.isalsomy.number")
 }

--- a/test/conformance/ingress/rewrite.go
+++ b/test/conformance/ingress/rewrite.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/networking/pkg/apis/networking"
+	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+)
+
+// TestRewriteHost verifies that a RewriteHost rule can be used to implement vanity URLs.
+func TestRewriteHost(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	// Create a simple Ingress over the Service.
+	_, _, cancel = CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Visibility: v1alpha1.IngressVisibilityClusterLocal,
+			Hosts:      []string{name + ".example.com"},
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	// Now create a RewriteHost ingress to point a custom Host at the Service
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{"vanity.ismy.name"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					RewriteHost: name + ".example.com",
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	RuntimeRequest(t, client, "http://vanity.ismy.name")
+}

--- a/test/conformance/ingress/run.go
+++ b/test/conformance/ingress/run.go
@@ -68,5 +68,6 @@ func RunConformance(t *testing.T) {
 	if test.ServingFlags.EnableAlphaFeatures {
 		// Add your conformance test for alpha features
 		t.Run("headers/tags", TestTagHeaders)
+		t.Run("rewrite", TestRewriteHost)
 	}
 }

--- a/test/conformance/ingress/run.go
+++ b/test/conformance/ingress/run.go
@@ -68,6 +68,6 @@ func RunConformance(t *testing.T) {
 	if test.ServingFlags.EnableAlphaFeatures {
 		// Add your conformance test for alpha features
 		t.Run("headers/tags", TestTagHeaders)
-		t.Run("rewrite", TestRewriteHost)
+		t.Run("host-rewrite", TestRewriteHost)
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Conformance test for https://github.com/knative/serving/issues/7748. Implementation for net-istio here: https://github.com/knative/net-istio/pull/174

/assign @tcnghia @mattmoor 

~~/hold because we need to wait for https://github.com/knative/net-istio/pull/174 to land before merging this.~~  https://github.com/knative/net-istio/pull/174 is merged.