### PR TITLE
we don't need to delete the migration job since it uses generateName now

### DIFF
--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -54,8 +54,6 @@ function install_latest_release() {
       || fail_test "Knative latest release installation failed"
   wait_until_pods_running ${SYSTEM_NAMESPACE}
   wait_until_batch_job_complete ${SYSTEM_NAMESPACE}
-  # TODO - delete this once 0.16 lands and we use generateName
-  kubectl delete jobs -n ${SYSTEM_NAMESPACE} -l app=storage-version-migration
 }
 
 function install_head() {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* The job switched from name to generateName with the 0.16 release so we no longer need to clean up old jobs prior to upgrading

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
