### PR TITLE
Populate the routingState label and modified annotation in the Labeler

### DIFF
--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -37,6 +37,7 @@ var (
 		UpdaterAnnotation,
 		CreatorAnnotation,
 		RevisionLastPinnedAnnotationKey,
+		RoutingStateModifiedAnnotationKey,
 		GroupNamePrefix+"forceUpgrade",
 	)
 )

--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
 	net "knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving"
@@ -122,13 +123,13 @@ func (r *Revision) SetRoutingState(state RoutingState) {
 
 	r.Annotations = kmeta.UnionMaps(r.Annotations,
 		map[string]string{
-			serving.RoutingStateModifiedAnnotationKey: RoutingStateModifiedString(),
+			serving.RoutingStateModifiedAnnotationKey: RoutingStateModifiedString(clock.RealClock{}),
 		})
 }
 
 // RoutingStateModifiedString gives a formatted now timestamp.
-func RoutingStateModifiedString() string {
-	return time.Now().UTC().Format(time.RFC3339)
+func RoutingStateModifiedString(clock clock.Clock) string {
+	return clock.Now().UTC().Format(time.RFC3339)
 }
 
 // GetRoutingState retrieves the RoutingState label.

--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -61,14 +61,14 @@ const (
 	// RoutingStatePending is a state after a revision is created, but before
 	// its routing state has been determined. It is treated like active for the purposes
 	// of revision garbage collection.
-	RoutingStatePending RoutingState = "Pending"
+	RoutingStatePending RoutingState = "pending"
 
 	// RoutingStateActive is a state for a revision which are actively referenced by a Route.
-	RoutingStateActive RoutingState = "Active"
+	RoutingStateActive RoutingState = "active"
 
 	// RoutingStateReserve is a state for a revision which is no longer referenced by a Route,
 	// and is scaled down, but may be rapidly pinned to a route to be made active again.
-	RoutingStateReserve RoutingState = "Reserve"
+	RoutingStateReserve RoutingState = "reserve"
 )
 
 type (

--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -60,14 +60,14 @@ const (
 	// RoutingStatePending is a state after a revision is created, but before
 	// its routing state has been determined. It is treated like active for the purposes
 	// of revision garbage collection.
-	RoutingStatePending RoutingState = "pending"
+	RoutingStatePending RoutingState = "Pending"
 
 	// RoutingStateActive is a state for a revision which are actively referenced by a Route.
-	RoutingStateActive RoutingState = "active"
+	RoutingStateActive RoutingState = "Active"
 
 	// RoutingStateReserve is a state for a revision which is no longer referenced by a Route,
 	// and is scaled down, but may be rapidly pinned to a route to be made active again.
-	RoutingStateReserve RoutingState = "reserve"
+	RoutingStateReserve RoutingState = "Reserve"
 )
 
 type (
@@ -122,8 +122,13 @@ func (r *Revision) SetRoutingState(state RoutingState) {
 
 	r.Annotations = kmeta.UnionMaps(r.Annotations,
 		map[string]string{
-			serving.RoutingStateModifiedAnnotationKey: time.Now().UTC().Format(time.RFC3339),
+			serving.RoutingStateModifiedAnnotationKey: RoutingStateModifiedString(),
 		})
+}
+
+// RoutingStateModifiedString gives a formatted now timestamp.
+func RoutingStateModifiedString() string {
+	return time.Now().UTC().Format(time.RFC3339)
 }
 
 // GetRoutingState retrieves the RoutingState label.

--- a/pkg/reconciler/gc/v2/gc_test.go
+++ b/pkg/reconciler/gc/v2/gc_test.go
@@ -143,12 +143,12 @@ func TestCollect(t *testing.T) {
 				WithCreationTimestamp(oldest)),
 			rev("keep-no-last-pinned", "foo", 5555, MarkRevisionReady,
 				WithRevName("5555"),
-				WithCreationTimestamp(older),
-				WithLastPinned(tenMinutesAgo)),
+				WithCreationTimestamp(oldest),
+				WithLastPinned(older)),
 			rev("keep-no-last-pinned", "foo", 5556, MarkRevisionReady,
 				WithRevName("5556"),
-				WithCreationTimestamp(old),
-				WithLastPinned(tenMinutesAgo)),
+				WithCreationTimestamp(oldest),
+				WithLastPinned(old)),
 		},
 	}, {
 		name: "keep recent lastPinned",
@@ -206,7 +206,7 @@ func TestCollect(t *testing.T) {
 			rev("keep-all", "foo", 5554,
 				WithRevName("keep-all"),
 				WithCreationTimestamp(oldest),
-				WithLastPinned(tenMinutesAgo)),
+				WithLastPinned(old)),
 		},
 	}}
 

--- a/pkg/reconciler/labeler/labeler.go
+++ b/pkg/reconciler/labeler/labeler.go
@@ -19,6 +19,7 @@ package labeler
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/util/clock"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/tracker"
 	cfgmap "knative.dev/serving/pkg/apis/config"
@@ -40,6 +41,7 @@ type Reconciler struct {
 	// Listers index properties about resources
 	configurationLister listers.ConfigurationLister
 	revisionLister      listers.RevisionLister
+	clock               clock.Clock
 }
 
 // Check that our Reconciler implements routereconciler.Interface
@@ -50,8 +52,8 @@ func (c *Reconciler) FinalizeKind(ctx context.Context, r *v1.Route) pkgreconcile
 	switch cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC {
 
 	case cfgmap.Enabled: // v2 logic
-		cacc := labelerv2.NewConfigurationAccessor(c.client, c.tracker, c.configurationLister)
-		racc := labelerv2.NewRevisionAccessor(c.client, c.tracker, c.revisionLister)
+		cacc := labelerv2.NewConfigurationAccessor(c.client, c.tracker, c.configurationLister, c.clock)
+		racc := labelerv2.NewRevisionAccessor(c.client, c.tracker, c.revisionLister, c.clock)
 		return labelerv2.ClearLabels(r.Namespace, r.Name, cacc, racc)
 
 	default: // v1 logic
@@ -65,8 +67,8 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconcil
 	switch cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC {
 
 	case cfgmap.Enabled: // v2 logic
-		cacc := labelerv2.NewConfigurationAccessor(c.client, c.tracker, c.configurationLister)
-		racc := labelerv2.NewRevisionAccessor(c.client, c.tracker, c.revisionLister)
+		cacc := labelerv2.NewConfigurationAccessor(c.client, c.tracker, c.configurationLister, c.clock)
+		racc := labelerv2.NewRevisionAccessor(c.client, c.tracker, c.revisionLister, c.clock)
 		return labelerv2.SyncLabels(r, cacc, racc)
 
 	default: // v1 logic

--- a/pkg/reconciler/labeler/labelerv2_test.go
+++ b/pkg/reconciler/labeler/labelerv2_test.go
@@ -447,6 +447,9 @@ func patchAddRouteAndServingStateLabel(namespace, name, routeName string, now ti
 	action.Namespace = namespace
 
 	state := string(v1.RoutingStateReserve)
+
+	// Note: the raw json `"key": null` removes a value, whereas an actual value
+	// called "null" would need quotes to parse as a string `"key":"null"`.
 	if routeName != "null" {
 		state = string(v1.RoutingStateActive)
 		routeName = `"` + routeName + `"`

--- a/pkg/reconciler/labeler/labelerv2_test.go
+++ b/pkg/reconciler/labeler/labelerv2_test.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/clock"
 	clientgotesting "k8s.io/client-go/testing"
 	routereconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/route"
 
@@ -50,6 +51,7 @@ import (
 // This is heavily based on the way the OpenShift Ingress controller tests its reconciliation method.
 func TestV2Reconcile(t *testing.T) {
 	now := metav1.Now()
+	fakeTime := now.Time
 
 	table := TableTest{{
 		Name: "bad workqueue key",
@@ -336,6 +338,7 @@ func TestV2Reconcile(t *testing.T) {
 			configurationLister: listers.GetConfigurationLister(),
 			revisionLister:      listers.GetRevisionLister(),
 			tracker:             &NullTracker{},
+			clock:               clock.NewFakeClock(fakeTime),
 		}
 
 		return routereconciler.NewReconciler(ctx, logging.FromContext(ctx), servingclient.Get(ctx),

--- a/pkg/reconciler/labeler/labelerv2_test.go
+++ b/pkg/reconciler/labeler/labelerv2_test.go
@@ -446,12 +446,10 @@ func patchAddRouteAndServingStateLabel(namespace, name, routeName string, now ti
 	action.Name = name
 	action.Namespace = namespace
 
-	var state string
-	if routeName == "null" {
-		state = "Reserve"
-	} else {
-		state = "Active"
-		routeName = fmt.Sprintf("%q", routeName)
+	state := string(v1.RoutingStateReserve)
+	if routeName != "null" {
+		state = string(v1.RoutingStateActive)
+		routeName = `"` + routeName + `"`
 	}
 
 	patch := fmt.Sprintf(

--- a/pkg/reconciler/labeler/v2/accessors.go
+++ b/pkg/reconciler/labeler/v2/accessors.go
@@ -25,6 +25,7 @@ import (
 
 	"knative.dev/pkg/tracker"
 	"knative.dev/serving/pkg/apis/serving"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
 	listers "knative.dev/serving/pkg/client/listers/serving/v1"
 )
@@ -60,41 +61,64 @@ func NewRevisionAccessor(
 }
 
 // makeMetadataPatch makes a metadata map to be patched or nil if no changes are needed.
-func makeMetadataPatch(acc kmeta.Accessor, routeName string) (map[string]interface{}, error) {
-	labels, err := addRouteLabel(acc, routeName)
-	if err != nil {
+func makeMetadataPatch(acc kmeta.Accessor, routeName string, addRoutingState bool) (map[string]interface{}, error) {
+	labels := map[string]interface{}{}
+	annotations := map[string]interface{}{}
+
+	if err := addRouteLabel(acc, routeName, labels); err != nil {
 		return nil, err
 	}
 
+	if addRoutingState {
+		markRoutingState(acc, routeName != "", labels, annotations)
+	}
+
+	meta := map[string]interface{}{}
 	if len(labels) > 0 {
-		meta := map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"labels": labels,
-			},
-		}
-		return meta, nil
+		meta["labels"] = labels
+	}
+	if len(annotations) > 0 {
+		meta["annotations"] = annotations
+	}
+	if len(meta) > 0 {
+		return map[string]interface{}{"metadata": meta}, nil
 	}
 	return nil, nil
 }
 
+// markRoutingState updates the RoutingStateLabel and bumps the modified time annotation.
+func markRoutingState(acc kmeta.Accessor, hasRoute bool, diffLabels, diffAnn map[string]interface{}) {
+	var wantState string
+	if hasRoute {
+		wantState = string(v1.RoutingStateActive)
+	} else {
+		wantState = string(v1.RoutingStateReserve)
+	}
+
+	if acc.GetLabels()[serving.RoutingStateLabelKey] != wantState {
+		diffLabels[serving.RoutingStateLabelKey] = wantState
+		diffAnn[serving.RoutingStateModifiedAnnotationKey] = v1.RoutingStateModifiedString()
+	}
+}
+
 // addRouteLabel appends the route label to the list of labels if needed
 // or removes the label if routeName is nil.
-func addRouteLabel(acc kmeta.Accessor, routeName string) (map[string]interface{}, error) {
+func addRouteLabel(acc kmeta.Accessor, routeName string, diffLabels map[string]interface{}) error {
 	if routeName == "" { // remove the label
 		if acc.GetLabels()[serving.RouteLabelKey] != "" {
-			return map[string]interface{}{serving.RouteLabelKey: nil}, nil
+			diffLabels[serving.RouteLabelKey] = nil
 		}
 	} else { // add the label
 		if oldLabel := acc.GetLabels()[serving.RouteLabelKey]; oldLabel == "" {
-			return map[string]interface{}{serving.RouteLabelKey: routeName}, nil
+			diffLabels[serving.RouteLabelKey] = routeName
 		} else if oldLabel != routeName {
 			// TODO(whaught): this restricts us to only one route -> revision
 			// We can move this to a comma separated list annotation and use the new routingState label.
-			return nil, fmt.Errorf("resource already has route label %q, and cannot be referenced by %q", oldLabel, routeName)
+			return fmt.Errorf("resource already has route label %q, and cannot be referenced by %q", oldLabel, routeName)
 		}
 	}
 
-	return nil, nil
+	return nil
 }
 
 // list implements Accessor
@@ -124,7 +148,7 @@ func (r *Revision) makeMetadataPatch(ns, name string, routeName string) (map[str
 	if err != nil {
 		return nil, err
 	}
-	return makeMetadataPatch(rev, routeName)
+	return makeMetadataPatch(rev, routeName, true /*addRoutingState*/)
 }
 
 // Configuration is an implementation of Accessor for Configurations.
@@ -176,5 +200,5 @@ func (c *Configuration) makeMetadataPatch(ns, name string, routeName string) (ma
 	if err != nil {
 		return nil, err
 	}
-	return makeMetadataPatch(config, routeName)
+	return makeMetadataPatch(config, routeName, false /*addRoutingState*/)
 }

--- a/pkg/reconciler/labeler/v2/accessors.go
+++ b/pkg/reconciler/labeler/v2/accessors.go
@@ -95,11 +95,9 @@ func makeMetadataPatch(
 func markRoutingState(
 	acc kmeta.Accessor, hasRoute bool, clock clock.Clock,
 	diffLabels, diffAnn map[string]interface{}) {
-	var wantState string
+	wantState := string(v1.RoutingStateReserve)
 	if hasRoute {
 		wantState = string(v1.RoutingStateActive)
-	} else {
-		wantState = string(v1.RoutingStateReserve)
 	}
 
 	if acc.GetLabels()[serving.RoutingStateLabelKey] != wantState {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Issue #8208

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Populate the RoutingState label and RoutingStateModified timestamp annotations in the new labeler
* Use a FakeClock for unit test stability of Now()

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Created a V2 Labeler that populates RoutingState and RoutingStateModified annotations on Revisions
This will be used for revision garbage collection

```
