### PR TITLE
Make sorting consistent in GC test.

### DIFF
--- a/pkg/reconciler/gc/v2/gc_test.go
+++ b/pkg/reconciler/gc/v2/gc_test.go
@@ -54,6 +54,7 @@ var revisionSpec = v1.RevisionSpec{
 
 func TestCollect(t *testing.T) {
 	now := time.Now()
+	nineMinutesAgo := now.Add(-9 * time.Minute)
 	tenMinutesAgo := now.Add(-10 * time.Minute)
 
 	old := now.Add(-11 * time.Minute)
@@ -164,7 +165,7 @@ func TestCollect(t *testing.T) {
 			rev("keep-recent-last-pinned", "foo", 5555, MarkRevisionReady,
 				WithRevName("5555"),
 				WithCreationTimestamp(older),
-				WithLastPinned(tenMinutesAgo)),
+				WithLastPinned(nineMinutesAgo)),
 			rev("keep-recent-last-pinned", "foo", 5556, MarkRevisionReady,
 				WithRevName("5556"),
 				WithCreationTimestamp(old),


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #8605 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

One of the tests ("keep recent lastPinned") failed fairly often because it used two revisions with the same LastPinned timestamp. Sorting a slice is unstable so in a lot of occasions, the given order was flipped and revision 5555 was tried to be deleted, even though it shouldn't even have been considered to be deleted.

Note: sort.SliceStable doesn't help because the incoming list's order is already non-consistent.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @whaught
