### PR TITLE
Add a byte pool for scraping

### DIFF
--- a/pkg/autoscaler/metrics/http_scrape_client.go
+++ b/pkg/autoscaler/metrics/http_scrape_client.go
@@ -107,13 +107,13 @@ func (c *httpScrapeClient) Scrape(url string) (Stat, error) {
 		return emptyStat, fmt.Errorf("GET request for URL %q returned HTTP status %v", url, resp.StatusCode)
 	}
 	if resp.Header.Get("Content-Type") == network.ProtoAcceptContent {
-		return statFromProtoOptimized(resp.Body, resp.ContentLength)
+		return statFromProto(resp.Body, resp.ContentLength)
 	}
 
 	return statFromPrometheus(resp.Body)
 }
 
-func statFromProtoOptimized(body io.Reader, l int64) (Stat, error) {
+func statFromProto(body io.Reader, l int64) (Stat, error) {
 	var stat Stat
 	if l <= 0 {
 		return emptyStat, fmt.Errorf("no data received, data size unknown")
@@ -136,7 +136,6 @@ func statFromProtoOptimized(body io.Reader, l int64) (Stat, error) {
 	if err != nil {
 		return emptyStat, fmt.Errorf("unmarshalling failed: %w", err)
 	}
-	// fmt.Printf("stat:%v\n", stat)
 	return stat, nil
 }
 

--- a/pkg/autoscaler/metrics/http_scrape_client.go
+++ b/pkg/autoscaler/metrics/http_scrape_client.go
@@ -130,7 +130,7 @@ func statFromProto(body io.Reader, l int64) (Stat, error) {
 		n += nn
 	}
 	if err != nil {
-		return emptyStat, fmt.Errorf("reading body failed: %w - %d", err, n)
+		return emptyStat, fmt.Errorf("reading body failed: %w", err)
 	}
 	err = stat.Unmarshal(b[0:l])
 	if err != nil {

--- a/pkg/autoscaler/metrics/http_scrape_client_test.go
+++ b/pkg/autoscaler/metrics/http_scrape_client_test.go
@@ -252,7 +252,6 @@ func newTestHTTPClient(response *http.Response, err error) *http.Client {
 
 func BenchmarkUnmarshallingProtoData(b *testing.B) {
 	stat := Stat{}
-	stat.PodName = podName
 	stat.ProcessUptime = 12.2
 	stat.ProxiedRequestCount = 122
 	stat.AverageConcurrentRequests = 2.3

--- a/pkg/autoscaler/metrics/http_scrape_client_test.go
+++ b/pkg/autoscaler/metrics/http_scrape_client_test.go
@@ -251,12 +251,14 @@ func newTestHTTPClient(response *http.Response, err error) *http.Client {
 }
 
 func BenchmarkUnmarshallingProtoData(b *testing.B) {
-	stat := Stat{}
-	stat.ProcessUptime = 12.2
-	stat.ProxiedRequestCount = 122
-	stat.AverageConcurrentRequests = 2.3
-	stat.AverageProxiedConcurrentRequests = 100.2
-	stat.ProxiedRequestCount = 100
+	stat := Stat{
+		ProcessUptime:                    12.2,
+		AverageConcurrentRequests:        2.3,
+		AverageProxiedConcurrentRequests: 100.2,
+		RequestCount:                     122,
+		ProxiedRequestCount:              122,
+	}
+
 	benchmarks := []struct {
 		name    string
 		podName string

--- a/pkg/autoscaler/metrics/http_scrape_client_test.go
+++ b/pkg/autoscaler/metrics/http_scrape_client_test.go
@@ -288,13 +288,13 @@ func BenchmarkUnmarshallingProtoData(b *testing.B) {
 	}}
 
 	for _, bm := range benchmarks {
-		rawBody, err := ioutil.ReadAll(bm.resp.Body)
+		bodyBytes, err := ioutil.ReadAll(bm.resp.Body)
 		if err != nil {
 			b.Error(err)
 		}
 		b.Run(bm.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, err = statFromProto(bytes.NewReader(rawBody))
+				_, err = statFromProto(bytes.NewReader(bodyBytes))
 				if err != nil {
 					b.Error(err)
 				}

--- a/pkg/autoscaler/metrics/http_scrape_client_test.go
+++ b/pkg/autoscaler/metrics/http_scrape_client_test.go
@@ -21,11 +21,9 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"knative.dev/serving/pkg/network"
@@ -234,13 +232,6 @@ func makeProtoResponse(statusCode int, stat Stat, contentType string) *http.Resp
 	res.Header.Set("Content-Type", contentType)
 	res.ContentLength = int64(len(buffer))
 	return res
-}
-
-func randInt() int {
-	rand.Seed(time.Now().UnixNano())
-	min := 1
-	max := 254 // Kubernetes object name max is 253
-	return rand.Intn(max-min+1) + min
 }
 
 func makeProtoResponseForBenchmarking(statusCode int, dataType benchmarkingDataType, contentType string) *http.Response {

--- a/pkg/autoscaler/metrics/http_scrape_client_test.go
+++ b/pkg/autoscaler/metrics/http_scrape_client_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -232,7 +233,7 @@ func makeProtoResponse(statusCode int, stat Stat, contentType string) *http.Resp
 	}
 	res.Header = http.Header{}
 	res.Header.Set("Content-Type", contentType)
-	res.ContentLength = int64(len(buffer))
+	res.Header.Set("Content-Length", strconv.Itoa(len(buffer)))
 	return res
 }
 
@@ -258,7 +259,7 @@ func makeProtoResponseForBenchmarking(statusCode int, stat Stat, contentType str
 	}
 	res.Header = http.Header{}
 	res.Header.Set("Content-Type", contentType)
-	res.ContentLength = int64(len(buffer))
+	res.Header.Set("Content-Length", strconv.Itoa(len(buffer)))
 	return res
 }
 

--- a/pkg/queue/protobuf_stats_reporter.go
+++ b/pkg/queue/protobuf_stats_reporter.go
@@ -18,7 +18,6 @@ package queue
 
 import (
 	"net/http"
-	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -29,8 +28,7 @@ import (
 )
 
 const (
-	contentTypeHeader   = "Content-Type"
-	contentLengthHeader = "Content-Length"
+	contentTypeHeader = "Content-Type"
 )
 
 // PrometheusStatsReporter structure represents a prometheus stats reporter.
@@ -82,7 +80,6 @@ func (r *ProtobufStatsReporter) Handler() http.Handler {
 			return
 		}
 		header.Set(contentTypeHeader, network.ProtoAcceptContent)
-		header.Set(contentLengthHeader, strconv.Itoa(len(buffer)))
 		rsp.Write(buffer)
 	})
 }

--- a/pkg/queue/protobuf_stats_reporter.go
+++ b/pkg/queue/protobuf_stats_reporter.go
@@ -18,6 +18,7 @@ package queue
 
 import (
 	"net/http"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -28,7 +29,8 @@ import (
 )
 
 const (
-	contentTypeHeader = "Content-Type"
+	contentTypeHeader   = "Content-Type"
+	contentLengthHeader = "Content-Length"
 )
 
 // PrometheusStatsReporter structure represents a prometheus stats reporter.
@@ -80,6 +82,7 @@ func (r *ProtobufStatsReporter) Handler() http.Handler {
 			return
 		}
 		header.Set(contentTypeHeader, network.ProtoAcceptContent)
+		header.Set(contentLengthHeader, strconv.Itoa(len(buffer)))
 		rsp.Write(buffer)
 	})
 }


### PR DESCRIPTION
Optimizes #8556 as discussed in that PR.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds a multi-size byte slice pool, replacing the `readAll` call which suffers from [certain issues](https://www.openmymind.net/Go-Slices-And-The-Case-Of-The-Missing-Memory/). 
* It sets an upper limit to each slice allocation[ avoiding using a byte buffer](https://github.com/golang/go/issues/23199) and follows [the multi-size pool](https://github.com/golang/go/blob/7e394a2/src/net/http/h2_bundle.go#L998-L1043) approach.
* Benchmarking this with random data shows a significant reduction in memory allocation.
`ReadAll` costs around 750MB while the pool only 18MB.
![normal](https://user-images.githubusercontent.com/7945591/87281340-ca69fb00-c4fb-11ea-8013-d010b3300c27.png)
![opt](https://user-images.githubusercontent.com/7945591/87281348-cccc5500-c4fb-11ea-98d8-6639ec94fe37.png)
```
BenchmarkUnmarshalling-8   	  354242	      3326 ns/op	    3463 B/op	      13 allocs/op  <- current
BenchmarkUnmarshalling-8   	  405806	      2911 ns/op	    1452 B/op	      13 allocs/op  <- optimized
```
Allocation is optimized as shown above.
Ideally we could re-slice buffers to optimize what we add back to the pool but that should not add much.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```
NONE
```
/assign @markusthoemmes @julz @vagababov