### PR TITLE
Bump activator terminationGracePeriodSeconds to match DefaultMaxRevisionTimeoutSeconds

### DIFF
--- a/config/core/configmaps/defaults.yaml
+++ b/config/core/configmaps/defaults.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "2defca8d"
+    knative.dev/example-checksum: "b44360b5"
 data:
   _example: |
     ################################
@@ -47,6 +47,9 @@ data:
     # seconds that can be used for revision-timeout-seconds.
     # This value must be greater than or equal to revision-timeout-seconds.
     # If omitted, the system default is used (600 seconds).
+    #
+    # If this value is increased, the activator's terminationGraceTimeSeconds
+    # should also be increased to prevent in-flight requests being disrupted.
     max-revision-timeout-seconds: "600"  # 10 minutes
 
     # revision-cpu-request contains the cpu allocation to assign

--- a/config/core/deployments/activator.yaml
+++ b/config/core/deployments/activator.yaml
@@ -103,7 +103,7 @@ spec:
       # should be at least as large as the upper bound on the Revision's
       # timeoutSeconds property to avoid servicing events disrupting
       # connections.
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 600
 
 ---
 apiVersion: v1


### PR DESCRIPTION
The previous default could lead to active in-flight requests getting killed half-way if the user increased RevisionTimeoutSeconds (since [DefaultMaxRevisionTimeoutSeconds is 10 minutes](https://github.com/knative/serving/blob/ac91f264dc1826eafa42729b0b968a6e59245cb9/pkg/apis/config/defaults.go#L46), not 5 minutes).

Note that an operator could still increase max-revision-timeout-seconds in the defaults configmap, 
in which case this value would be too low again, but at least this makes the out-of-the-box behaviour
reasonable.

Also added a comment to defaults configmap to ensure an operator knows to bump this timeout
when increasing max-revision-timeout-seconds.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Increases terminationGracePeriodSeconds for activator components to 10 minutes to prevent
possibility of disruption to in-flight requests if RevisionTimeoutSeconds is increased up to the
out-of-the-box limit.
```
