### PR TITLE
Accept protobuf encoded messages in the statserver.

### DIFF
--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -155,7 +155,7 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// we accept either protobuf-encoded or JSON-encoded messages depending on the
+		// We accept either protobuf-encoded or JSON-encoded messages depending on the
 		// message type to ensure safe upgrades.
 		switch messageType {
 		case websocket.BinaryMessage:

--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -166,7 +166,7 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 			}
 
 			for _, wsm := range wsms.Messages {
-				if wsm == nil || wsm.Stat == nil {
+				if wsm.Stat == nil {
 					// To allow for future protobuf schema changes.
 					continue
 				}

--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -161,7 +161,7 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 		case websocket.BinaryMessage:
 			var wsms metrics.WireStatMessages
 			if err := wsms.Unmarshal(msg); err != nil {
-				s.logger.Errorw("Failed to unmarshal message", zap.Error(err))
+				s.logger.Errorw("Failed to unmarshal the object", zap.Error(err))
 				continue
 			}
 

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -237,6 +237,8 @@ func BenchmarkStatServer(b *testing.B) {
 }
 
 func assertReceivedJSON(t *testing.T, sm metrics.StatMessage, statSink *websocket.Conn, statsCh <-chan metrics.StatMessage) {
+	t.Helper()
+
 	if err := sendJSON(statSink, sm); err != nil {
 		t.Fatal("Expected send to succeed, got:", err)
 	}
@@ -248,6 +250,8 @@ func assertReceivedJSON(t *testing.T, sm metrics.StatMessage, statSink *websocke
 }
 
 func assertReceivedProto(t *testing.T, sms []metrics.StatMessage, statSink *websocket.Conn, statsCh <-chan metrics.StatMessage) {
+	t.Helper()
+
 	if err := sendProto(statSink, sms); err != nil {
 		t.Fatal("Expected send to succeed, got:", err)
 	}
@@ -262,6 +266,8 @@ func assertReceivedProto(t *testing.T, sms []metrics.StatMessage, statSink *webs
 }
 
 func dialOK(t *testing.T, serverURL string) *websocket.Conn {
+	t.Helper()
+
 	statSink, err := dial(serverURL)
 	if err != nil {
 		t.Fatal("Dial failed:", err)
@@ -311,6 +317,8 @@ func sendProto(statSink *websocket.Conn, sms []metrics.StatMessage) error {
 }
 
 func closeSink(t *testing.T, statSink *websocket.Conn) {
+	t.Helper()
+
 	if err := statSink.Close(); err != nil {
 		t.Fatal("Failed to close", err)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This further improves the efficiency of the statserver by allowing it to receive a slice of StatMessages, binary-encoded via protobufs. The protobufs are already quite an improvement over using JSON, both in terms of density and serdes performance. Collapsing all stats into a single message further reduces the overhead of the surrounding protocols, making for a much more efficient protocol overall.

## Benchmark results

```
goos: linux
goarch: amd64
pkg: knative.dev/serving/pkg/autoscaler/statserver
BenchmarkStatServer/json-encoding-1-msgs-16         	   37719	     32458 ns/op	    3661 B/op	      23 allocs/op
BenchmarkStatServer/proto-encoding-1-msgs-16        	   53277	     22843 ns/op	    2600 B/op	      15 allocs/op
BenchmarkStatServer/json-encoding-2-msgs-16         	   23275	     50602 ns/op	    7322 B/op	      46 allocs/op
BenchmarkStatServer/proto-encoding-2-msgs-16        	   50244	     24294 ns/op	    3088 B/op	      24 allocs/op
BenchmarkStatServer/json-encoding-5-msgs-16         	   14947	     83316 ns/op	   18308 B/op	     115 allocs/op
BenchmarkStatServer/proto-encoding-5-msgs-16        	   43286	     28117 ns/op	    4624 B/op	      50 allocs/op
BenchmarkStatServer/json-encoding-10-msgs-16        	    9296	    130637 ns/op	   36618 B/op	     230 allocs/op
BenchmarkStatServer/proto-encoding-10-msgs-16       	   42984	     28248 ns/op	    7136 B/op	      91 allocs/op
BenchmarkStatServer/json-encoding-20-msgs-16        	    5286	    228309 ns/op	   73225 B/op	     460 allocs/op
BenchmarkStatServer/proto-encoding-20-msgs-16       	   28622	     41278 ns/op	   16272 B/op	     173 allocs/op
BenchmarkStatServer/json-encoding-50-msgs-16        	    2389	    490206 ns/op	  183048 B/op	    1151 allocs/op
BenchmarkStatServer/proto-encoding-50-msgs-16       	   16401	     72992 ns/op	   39280 B/op	     415 allocs/op
BenchmarkStatServer/json-encoding-100-msgs-16       	    1308	    938296 ns/op	  366103 B/op	    2302 allocs/op
BenchmarkStatServer/proto-encoding-100-msgs-16      	   10000	    121983 ns/op	   63856 B/op	     816 allocs/op
PASS
ok  	knative.dev/serving/pkg/autoscaler/statserver	21.040s
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @julz 
