### PR TITLE
Various nits around the code.

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -99,7 +99,7 @@ type revisionWatcher struct {
 
 	// Stores the list of pods that have been successfully probed.
 	healthyPods sets.String
-	// Stores whether the service ClusterIP has been seen as healthy
+	// Stores whether the service ClusterIP has been seen as healthy.
 	clusterIPHealthy bool
 
 	transport     http.RoundTripper
@@ -124,7 +124,6 @@ func newRevisionWatcher(ctx context.Context, rev types.NamespacedName, protocol 
 		protocol:        protocol,
 		updateCh:        updateCh,
 		done:            make(chan struct{}),
-		healthyPods:     sets.NewString(),
 		transport:       transport,
 		destsCh:         destsCh,
 		serviceLister:   serviceLister,
@@ -256,7 +255,7 @@ func (rw *revisionWatcher) checkDests(curDests, prevDests dests) {
 	if len(curDests.ready) == 0 && len(curDests.notReady) == 0 {
 		// We must have scaled down.
 		rw.clusterIPHealthy = false
-		rw.healthyPods = sets.NewString()
+		rw.healthyPods = nil
 		rw.logger.Debug("ClusterIP is no longer healthy.")
 		// Send update that we are now inactive (both params invalid).
 		rw.sendUpdate("", nil)

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -74,7 +74,7 @@ var (
 )
 
 func ValidateVolumes(vs []corev1.Volume, mountedVolumes sets.String) (sets.String, *apis.FieldError) {
-	volumes := sets.NewString()
+	volumes := make(sets.String, len(vs))
 	var errs *apis.FieldError
 	for i, volume := range vs {
 		if volumes.Has(volume.Name) {
@@ -308,6 +308,7 @@ func validateContainers(ctx context.Context, containers []corev1.Container, volu
 	return errs
 }
 
+// AllMountedVolumes returns all the mounted volumes in all the containers.
 func AllMountedVolumes(containers []corev1.Container) sets.String {
 	volumeNames := sets.NewString()
 	for _, c := range containers {
@@ -445,8 +446,8 @@ func validateVolumeMounts(mounts []corev1.VolumeMount, volumes sets.String) *api
 	var errs *apis.FieldError
 	// Check that volume mounts match names in "volumes", that "volumes" has 100%
 	// coverage, and the field restrictions.
-	seenName := sets.NewString()
-	seenMountPath := sets.NewString()
+	seenName := make(sets.String, len(mounts))
+	seenMountPath := make(sets.String, len(mounts))
 	for i, vm := range mounts {
 		errs = errs.Also(apis.CheckDisallowedFields(vm, *VolumeMountMask(&vm)).ViaIndex(i))
 		// This effectively checks that Name is non-empty because Volume name must be non-empty.

--- a/pkg/autoscaler/metrics/stat.pb.go
+++ b/pkg/autoscaler/metrics/stat.pb.go
@@ -39,7 +39,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// Stat defines a single measurement at a point in time
+// Stat defines a single measurement at a point in time.
 type Stat struct {
 	// The unique identity of this pod.  Used to count how many pods
 	// are contributing to the metrics.

--- a/pkg/autoscaler/metrics/stat.proto
+++ b/pkg/autoscaler/metrics/stat.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 
 package metrics;
 
-// Stat defines a single measurement at a point in time
+// Stat defines a single measurement at a point in time.
 message Stat {
   // The unique identity of this pod.  Used to count how many pods
   // are contributing to the metrics.

--- a/pkg/autoscaler/metrics/stat_conversions.go
+++ b/pkg/autoscaler/metrics/stat_conversions.go
@@ -19,8 +19,8 @@ package metrics
 import "k8s.io/apimachinery/pkg/types"
 
 // ToWireStatMessage converts the StatMessage to a WireStatMessage.
-func (sm StatMessage) ToWireStatMessage() WireStatMessage {
-	return WireStatMessage{
+func (sm StatMessage) ToWireStatMessage() *WireStatMessage {
+	return &WireStatMessage{
 		Namespace: sm.Key.Namespace,
 		Name:      sm.Key.Name,
 		Stat:      &sm.Stat,
@@ -43,11 +43,10 @@ func (wsm WireStatMessage) ToStatMessage() StatMessage {
 // struct, ready to be sent off.
 func ToWireStatMessages(sms []StatMessage) WireStatMessages {
 	wsms := WireStatMessages{
-		Messages: make([]*WireStatMessage, 0, len(sms)),
+		Messages: make([]*WireStatMessage, len(sms)),
 	}
-	for _, sm := range sms {
-		wsm := sm.ToWireStatMessage()
-		wsms.Messages = append(wsms.Messages, &wsm)
+	for i, sm := range sms {
+		wsms.Messages[i] = sm.ToWireStatMessage()
 	}
 	return wsms
 }

--- a/pkg/autoscaler/metrics/stat_conversions_test.go
+++ b/pkg/autoscaler/metrics/stat_conversions_test.go
@@ -39,7 +39,7 @@ func TestStatMessageConversion(t *testing.T) {
 		},
 	}
 
-	wsm := WireStatMessage{
+	wsm := &WireStatMessage{
 		Namespace: sm.Key.Namespace,
 		Name:      sm.Key.Name,
 		Stat:      &sm.Stat,
@@ -86,7 +86,7 @@ func TestStatMessageSliceConversion(t *testing.T) {
 
 	wsm1 := sm1.ToWireStatMessage()
 	wsm2 := sm2.ToWireStatMessage()
-	wsms := WireStatMessages{Messages: []*WireStatMessage{&wsm1, &wsm2}}
+	wsms := WireStatMessages{Messages: []*WireStatMessage{wsm1, wsm2}}
 
 	if got, want := ToWireStatMessages(sms), wsms; !cmp.Equal(got, want) {
 		t.Fatalf("WireStatMessages mismatch: diff (-got, +want) %s", cmp.Diff(got, want))

--- a/pkg/network/ingress/ingress.go
+++ b/pkg/network/ingress/ingress.go
@@ -68,12 +68,12 @@ func InsertProbe(ing *v1alpha1.Ingress) (string, error) {
 // HostsPerVisibility takes an Ingress and a map from visibility levels to a set of string keys,
 // it then returns a map from that key space to the hosts under that visibility.
 func HostsPerVisibility(ing *v1alpha1.Ingress, visibilityToKey map[v1alpha1.IngressVisibility]sets.String) map[string]sets.String {
-	output := make(map[string]sets.String)
+	output := make(map[string]sets.String, 2) // We currently have public and internal.
 	for _, rule := range ing.Spec.Rules {
 		for host := range ExpandedHosts(sets.NewString(rule.Hosts...)) {
 			for key := range visibilityToKey[rule.Visibility] {
 				if _, ok := output[key]; !ok {
-					output[key] = sets.NewString()
+					output[key] = make(sets.String, 1)
 				}
 				output[key].Insert(host)
 			}
@@ -84,12 +84,13 @@ func HostsPerVisibility(ing *v1alpha1.Ingress, visibilityToKey map[v1alpha1.Ingr
 
 // ExpandedHosts sets up hosts for the short-names for cluster DNS names.
 func ExpandedHosts(hosts sets.String) sets.String {
-	expanded := sets.NewString()
 	allowedSuffixes := []string{
 		"",
 		"." + network.GetClusterDomainName(),
 		".svc." + network.GetClusterDomainName(),
 	}
+	// Optimistically pre-alloc.
+	expanded := make(sets.String, len(hosts)*len(allowedSuffixes))
 	for _, h := range hosts.List() {
 		for _, suffix := range allowedSuffixes {
 			if strings.HasSuffix(h, suffix) {

--- a/pkg/network/ingress/ingress.go
+++ b/pkg/network/ingress/ingress.go
@@ -73,7 +73,7 @@ func HostsPerVisibility(ing *v1alpha1.Ingress, visibilityToKey map[v1alpha1.Ingr
 		for host := range ExpandedHosts(sets.NewString(rule.Hosts...)) {
 			for key := range visibilityToKey[rule.Visibility] {
 				if _, ok := output[key]; !ok {
-					output[key] = make(sets.String, 1)
+					output[key] = make(sets.String, len(rule.Hosts))
 				}
 				output[key].Insert(host)
 			}

--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -96,7 +96,7 @@ func (c *Reconciler) reconcilePlaceholderServices(ctx context.Context, route *v1
 
 	ns := route.Namespace
 
-	names := sets.NewString()
+	names := make(sets.String, len(targets))
 	for name := range targets {
 		names.Insert(name)
 	}

--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -38,7 +38,7 @@ var errLoadBalancerNotFound = errors.New("failed to fetch loadbalancer domain/IP
 
 // GetNames returns a set of service names.
 func GetNames(services []*corev1.Service) sets.String {
-	names := sets.NewString()
+	names := make(sets.String, len(services))
 
 	for i := range services {
 		names.Insert(services[i].Name)

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -423,7 +423,7 @@ func findMatchingWildcardCert(ctx context.Context, domains []string, certs []*ne
 }
 
 func wildcardCertMatches(ctx context.Context, domains []string, cert *netv1alpha1.Certificate) bool {
-	dnsNames := sets.NewString()
+	dnsNames := make(sets.String, len(cert.Spec.DNSNames))
 	logger := logging.FromContext(ctx)
 
 	for _, dns := range cert.Spec.DNSNames {

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -134,7 +134,7 @@ func subsetEndpoints(eps *corev1.Endpoints, target string, n int) *corev1.Endpoi
 		return eps
 	}
 
-	addrs := sets.NewString()
+	addrs := make(sets.String, len(eps.Subsets[0].Addresses))
 	for _, ss := range eps.Subsets {
 		for _, addr := range ss.Addresses {
 			addrs.Insert(addr.IP)

--- a/test/conformance/ingress/headers.go
+++ b/test/conformance/ingress/headers.go
@@ -205,7 +205,7 @@ func TestPostSplitSetHeaders(t *testing.T) {
 	)
 
 	backends := make([]v1alpha1.IngressBackendSplit, 0, splits)
-	names := sets.NewString()
+	names := make(sets.String, splits)
 	for i := 0; i < splits; i++ {
 		name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
 		defer cancel()
@@ -244,7 +244,7 @@ func TestPostSplitSetHeaders(t *testing.T) {
 		// Make enough requests that the likelihood of us seeing each variation is high,
 		// but don't check the distribution of requests, as that isn't the point of this
 		// particular test.
-		seen := sets.NewString()
+		seen := make(sets.String, len(names))
 		for i := 0; i < maxRequests; i++ {
 			ri := RuntimeRequest(t, client, "http://"+name+".example.com")
 			if ri == nil {
@@ -265,7 +265,7 @@ func TestPostSplitSetHeaders(t *testing.T) {
 		// Make enough requests that the likelihood of us seeing each variation is high,
 		// but don't check the distribution of requests, as that isn't the point of this
 		// particular test.
-		seen := sets.NewString()
+		seen := make(sets.String, len(names))
 		for i := 0; i < maxRequests; i++ {
 			ri := RuntimeRequest(t, client, "http://"+name+".example.com", func(req *http.Request) {
 				// Specify a value for the header to verify that implementations

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -134,7 +134,7 @@ func waitForActivatorEndpoints(resources *v1test.ResourceObjects, clients *test.
 		if presources.ReadyAddressCount(svcEps) != wantAct {
 			return false, nil
 		}
-		aset := sets.NewString()
+		aset := make(sets.String, wantAct)
 		for _, ss := range svcEps.Subsets {
 			for i := 0; i < len(ss.Addresses); i++ {
 				aset.Insert(ss.Addresses[i].IP)


### PR DESCRIPTION
- preallocate sets
- comments
- change the stats conversion to return a pointer, since we always take the pointer anyway, which simplifies the assignment.

/assign @julz @tcnghia 