### PR TITLE
Encode stats as protobuf in the activator.

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -88,12 +88,12 @@ func statReporter(statSink *websocket.ManagedConnection, statChan <-chan []asmet
 			wsms := asmetrics.ToWireStatMessages(sms)
 			b, err := wsms.Marshal()
 			if err != nil {
-				logger.Errorw("Error while marshaling stat", zap.Error(err))
+				logger.Errorw("Error while marshaling stats", zap.Error(err))
 				return
 			}
 
 			if err := statSink.SendRaw(gorillawebsocket.BinaryMessage, b); err != nil {
-				logger.Errorw("Error while sending stat", zap.Error(err))
+				logger.Errorw("Error while sending stats", zap.Error(err))
 			}
 		}(sms)
 	}

--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -84,19 +83,19 @@ var (
 
 func statReporter(statSink *websocket.ManagedConnection, statChan <-chan []asmetrics.StatMessage,
 	logger *zap.SugaredLogger) {
-	for sm := range statChan {
-		go func(msgs []asmetrics.StatMessage) {
-			for _, msg := range msgs {
-				b, err := json.Marshal(msg)
-				if err != nil {
-					logger.Errorw("Error while marshaling stat", zap.Error(err))
-					continue
-				}
-				if err := statSink.SendRaw(gorillawebsocket.TextMessage, b); err != nil {
-					logger.Errorw("Error while sending stat", zap.Error(err))
-				}
+	for sms := range statChan {
+		go func(sms []asmetrics.StatMessage) {
+			wsms := asmetrics.ToWireStatMessages(sms)
+			b, err := wsms.Marshal()
+			if err != nil {
+				logger.Errorw("Error while marshaling stat", zap.Error(err))
+				return
 			}
-		}(sm)
+
+			if err := statSink.SendRaw(gorillawebsocket.BinaryMessage, b); err != nil {
+				logger.Errorw("Error while sending stat", zap.Error(err))
+			}
+		}(sms)
 	}
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As the title says, this should complete the "migration".

I'll review our usage of goroutines vs. buffered channels here next.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
