### PR TITLE
Move common functions to e2e-common.sh

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -68,13 +68,13 @@ function setup_auto_tls_common() {
 
   setup_custom_domain
 
-  turn_on_auto_tls
+  toggle_feature autoTLS Enabled config-network
 }
 
 function cleanup_auto_tls_common() {
   cleanup_custom_domain
 
-  turn_off_auto_tls
+  toggle_feature autoTLS Disabled config-network
   kubectl delete kcert --all -n serving-tests
 }
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -607,10 +607,29 @@ function dump_extra_cluster_state() {
   kubectl get serverlessservices -o yaml --all-namespaces
 }
 
-function turn_on_auto_tls() {
-  kubectl patch configmap config-network -n ${SYSTEM_NAMESPACE} -p '{"data":{"autoTLS":"Enabled"}}'
+function wait_for_leader_controller() {
+  echo -n "Waiting for a leader Controller"
+  for i in {1..150}; do  # timeout after 5 minutes
+    local leader=$(kubectl get lease -n "${SYSTEM_NAMESPACE}" -ojsonpath='{.items[*].spec.holderIdentity}'  | cut -d"_" -f1 | grep "^controller-" | head -1)
+    # Make sure the leader pod exists.
+    if [ -n "${leader}" ] && kubectl get pod "${leader}" -n "${SYSTEM_NAMESPACE}"  >/dev/null 2>&1; then
+      echo -e "\nNew leader Controller has been elected"
+      return 0
+    fi
+    echo -n "."
+    sleep 2
+  done
+  echo -e "\n\nERROR: timeout waiting for leader controller"
+  return 1
 }
 
-function turn_off_auto_tls() {
-  kubectl patch configmap config-network -n ${SYSTEM_NAMESPACE} -p '{"data":{"autoTLS":"Disabled"}}'
+function toggle_feature() {
+  local FEATURE="$1"
+  local STATE="$2"
+  local CONFIG="${3:-config-features}"
+  echo -n "Setting feature ${FEATURE} to ${STATE}"
+  kubectl patch cm "${CONFIG}" -n "${SYSTEM_NAMESPACE}" -p '{"data":{"'${FEATURE}'":"'${STATE}'"}}'
+  # We don't have a good mechanism for positive handoff so sleep :(
+  echo "Waiting 10s for change to get picked up."
+  sleep 10
 }


### PR DESCRIPTION
This patch changes test scripts to:
- move  `wait_for_leader_controller()` and `toggle_feature()` to e2e-common.sh
- use `toggle_feature()` instead of `turn_on_auto_tls`.

**Release Note**

```release-note
NONE
```
