### PR TITLE
Use buffer pool in request log handler

### DIFF
--- a/pkg/activator/handler/probe_handler.go
+++ b/pkg/activator/handler/probe_handler.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 
 	"knative.dev/serving/pkg/activator"
@@ -37,7 +38,7 @@ func (h *ProbeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("unexpected probe header value: %q", val), http.StatusBadRequest)
 			return
 		}
-		w.Write([]byte(activator.Name))
+		io.WriteString(w, activator.Name)
 		return
 	}
 


### PR DESCRIPTION
This is quite a heavily used code path and currently creates a temporary buffer each time. Using a buffer pool avoids a few allocations without much of a downside.

Also tidied up a Write([]byte) into an io.WriteString because why not (saves an alloc & consistent with [queue probe handler](https://github.com/knative/serving/blob/ff28b2ea7a8e6c41eb6d1c46c2f9f233dff84e4f/pkg/queue/health/health_state.go#L92)).

Before/After benchmarks:
~~~~
benchmark                                                   old ns/op     new ns/op     delta
BenchmarkRequestLogHandlerDefaultTemplate/sequential-16     11842         11567         -2.32%
BenchmarkRequestLogHandlerDefaultTemplate/parallel-16       3102          2695          -13.12%

benchmark                                                   old allocs     new allocs     delta
BenchmarkRequestLogHandlerDefaultTemplate/sequential-16     87             83             -4.60%
BenchmarkRequestLogHandlerDefaultTemplate/parallel-16       87             83             -4.60%

benchmark                                                   old bytes     new bytes     delta
BenchmarkRequestLogHandlerDefaultTemplate/sequential-16     2643          2052          -22.36%
BenchmarkRequestLogHandlerDefaultTemplate/parallel-16       2644          2053          -22.35%
~~~~