### PR TITLE
Set a high terminationGracePeriodSeconds on webhook

### DIFF
--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -85,6 +85,10 @@ spec:
               value: "webhook"
         livenessProbe: *probe
 
+      # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
+      # high value that we respect whatever value it has configured for the lame duck grace period.
+      terminationGracePeriodSeconds: 300
+
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
When our webhook drains, it sleeps for `network.DefaultDrainTimeout` after failing readiness probes before exiting, see [here](https://github.com/knative/pkg/blob/4419e613c133505ea5109380102765a7699b9bf8/webhook/webhook.go#L229-L234) which is configured to [this value](https://github.com/knative/pkg/blob/4419e613c133505ea5109380102765a7699b9bf8/network/network.go#L39-L43).

I suspect that the default `terminationGracePeriodSeconds` (of `30`) is clipping this sleep already (due to the coordination involved), but I am also thinking about raising this value due to seeing a non-zero number of EOF messages running chaos during our e2e testing.

I plan to make similar changes to eventing and our sample controller (cc @vaikas @grantr @lionelvillard )