### PR TITLE
Explain reasoning behind pool implementation to avoid future confusion.

### DIFF
--- a/pkg/network/bufferpool.go
+++ b/pkg/network/bufferpool.go
@@ -21,18 +21,25 @@ import (
 	"sync"
 )
 
-// bufferPool implements the BufferPool interface to be used in
-// httputil.ReverseProxy. It stores pointers to to slices to
-// further avoid allocations, see https://staticcheck.io/docs/checks#SA6002.
+// bufferPool implements the BufferPool interface to be used in httputil.ReverseProxy.
+//
+// Sadly, because of the httputil.BufferPool interface, we cannot avoid an allocation
+// when returning the slice to the pool. We could choose to not use use pointers of
+// slices and use straight slices instead, but that'd cause an allocation likewise
+// because of the interface{} API. It'd also trigger a staticcheck warning.
+// See https://staticcheck.io/docs/checks#SA6002.
 type bufferPool struct {
 	pool *sync.Pool
 }
 
-// NewBufferPool creates a new BytePool. This is only safe to use in the context
+// NewBufferPool creates a new BufferPool. This is only safe to use in the context
 // of a httputil.ReverseProxy, as the buffers returned via Put are not cleaned
 // explicitly.
 func NewBufferPool() httputil.BufferPool {
 	return &bufferPool{
+		// We don't use the New function of sync.Pool here to avoid an unnecessary
+		// allocation when creating the slices. They are implicitly created in the
+		// Get function below.
 		pool: &sync.Pool{},
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

@julz and I discussed this and we both had to remind ourselves why the implementation is like this and why it can't be improved (allocation-wise) currently. This should avoid the manual brain-cache rebuild the next time.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz 
