### PR TITLE
Remove chaosduck before running HA tests.

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -169,6 +169,10 @@ if [[ -n "${ISTIO_VERSION}" ]]; then
   kubectl delete -f ${TMP_DIR}/test/config/security/authorization_ingress.yaml
 fi
 
+# Remove chaosduck before running HA tests as they expect to be in control of what gets
+# killed when.
+kubectl delete -f "${TMP_DIR}/test/config/chaosduck.yaml"
+
 # Run HA tests separately as they're stopping core Knative Serving pods
 # Define short -spoofinterval to ensure frequent probing while stopping pods
 go_test_e2e -timeout=15m -failfast -parallel=1 ./test/ha \


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

These tests generally assume they are in charge of what gets deleted when.

In addition: Should we just remove all of the HA tests of the controllers themselves and trust the chaosduck to surface the relevant failures through the "normal" suite :thinking:.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor 
