### PR TITLE
Add helpers to approx equate the int32.

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -264,8 +264,7 @@ func (a *autoscaler) Scale(ctx context.Context, now time.Time) ScaleResult {
 	case a.deciderSpec.TargetBurstCapacity > 0:
 		// Extra float64 cast disables fused multiply-subtract to force identical behavior on
 		// all platforms. See floating point section in https://golang.org/ref/spec#Operators.
-		// nolint:unconvert
-		totCap := float64(float64(originalReadyPodsCount) * a.deciderSpec.TotalValue)
+		totCap := float64(originalReadyPodsCount) * a.deciderSpec.TotalValue
 		excessBCF = math.Floor(totCap - a.deciderSpec.TargetBurstCapacity - observedPanicValue)
 		numAct = int32(math.Max(MinActivators,
 			math.Ceil((totCap+a.deciderSpec.TargetBurstCapacity)/a.deciderSpec.ActivatorCapacity)))

--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -262,8 +262,6 @@ func (a *autoscaler) Scale(ctx context.Context, now time.Time) ScaleResult {
 		excessBCF = 0
 		// numAct stays at MinActivators, only needed to scale from 0.
 	case a.deciderSpec.TargetBurstCapacity > 0:
-		// Extra float64 cast disables fused multiply-subtract to force identical behavior on
-		// all platforms. See floating point section in https://golang.org/ref/spec#Operators.
 		totCap := float64(originalReadyPodsCount) * a.deciderSpec.TotalValue
 		excessBCF = math.Floor(totCap - a.deciderSpec.TargetBurstCapacity - observedPanicValue)
 		numAct = int32(math.Max(MinActivators,

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -93,8 +93,6 @@ func TestAutoscalerNoDataNoAutoscale(t *testing.T) {
 }
 
 func expectedEBC(totCap, targetBC, recordedConcurrency, numPods float64) int32 {
-	// Extra float64 cast disables fused multiply-subtract to force identical behavior on
-	// all platforms. See floating point section in https://golang.org/ref/spec#Operators.
 	ebcF := totCap/targetUtilization*numPods - targetBC - recordedConcurrency
 	// We need to floor for negative values.
 	return int32(math.Floor(ebcF))
@@ -546,17 +544,13 @@ func newTestAutoscalerWithScalingMetric(t *testing.T, targetValue, targetBurstCa
 		metrics, pc, deciderSpec, ctx), pc
 }
 
-// equateInt32 equates int32s with given path with ±-1 tolerance.
+// approxEquateInt32 equates int32s with given path with ±-1 tolerance.
 // This is needed due to rounding errors across various platforms.
-func equateInt32(field string) cmp.Option {
-	eqOpt := cmp.Options{
-		cmp.FilterValues(
-			func(a, b int32) bool { return true },
-			cmp.Comparer(func(a, b int32) bool {
-				d := a - b
-				return d <= 1 && d >= -1
-			})),
-	}
+func approxEquateInt32(field string) cmp.Option {
+	eqOpt := cmp.Comparer(func(a, b int32) bool {
+		d := a - b
+		return d <= 1 && d >= -1
+	})
 	return cmp.FilterPath(func(p cmp.Path) bool {
 		return p.String() == field
 	}, eqOpt)
@@ -565,7 +559,7 @@ func equateInt32(field string) cmp.Option {
 func expectScale(t *testing.T, a UniScaler, now time.Time, want ScaleResult) {
 	t.Helper()
 	got := a.Scale(TestContextWithLogger(t), now)
-	if !cmp.Equal(got, want, equateInt32("ExcessBurstCapacity")) {
+	if !cmp.Equal(got, want, approxEquateInt32("ExcessBurstCapacity")) {
 		t.Error("ScaleResult mismatch(-want,+got):\n", cmp.Diff(want, got))
 	}
 }


### PR DESCRIPTION
In case of various platforms the ebc calculations can be one-off.
Which is not ideal, but in the grand scheme of things probably not as important as long as it's consistent (given the arbitrary choice of how we compute it anyway).
So add helpers to equate ±1.

/assign @julz 