### PR TITLE
Disable the chaos duck in upgrade tests.

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -652,3 +652,11 @@ function scale_controlplane() {
     kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "$deployment" --replicas="${REPLICAS}" || failed=1
   done
 }
+
+function disable_chaosduck() {
+  kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "chaosduck" --replicas=0 || failed=1
+}
+
+function enable_chaosduck() {
+  kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "chaosduck" --replicas=1 || failed=1
+}

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -71,6 +71,11 @@ function knative_setup() {
 
 initialize $@ --skip-istio-addon
 
+# We haven't configured these deployments for high-availability,
+# so disable the chaos duck.
+# TODO(mattmoor): Reconsider this after 0.17 cuts.
+disable_chaosduck
+
 # TODO(#2656): Reduce the timeout after we get this test to consistently passing.
 TIMEOUT=10m
 


### PR DESCRIPTION
These legs aren't configured for HA, so there are all assortment of legitimate failures when we start killing replicas of non-HA things!

We should reconsider this post-0.17 cut.

/assign @markusthoemmes @vagababov 