### PR TITLE
Use integer suffixes rather than uuids when generating container names for multiple containers

### DIFF
--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -436,6 +436,71 @@ func TestRevisionDefaulting(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "multiple containers with some names empty",
+		in: &Revision{
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "",
+					}, {
+						Name: "user-container-0",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 8888,
+						}},
+					}, {
+						Name: "user-container-3",
+					}, {
+						Name: "",
+					}, {
+						Name: "user-container-5",
+					}, {
+						Name: "",
+					}, {
+						Name: "",
+					}, {
+						Name: "user-container-4",
+					}},
+				},
+			},
+		},
+		want: &Revision{
+			Spec: RevisionSpec{
+				TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+				ContainerConcurrency: ptr.Int64(config.DefaultContainerConcurrency),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:      "user-container-1",
+						Resources: defaultResources,
+					}, {
+						Name:           "user-container-0",
+						Resources:      defaultResources,
+						ReadinessProbe: defaultProbe,
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 8888,
+						}},
+					}, {
+						Name:      "user-container-3",
+						Resources: defaultResources,
+					}, {
+						Name:      "user-container-2",
+						Resources: defaultResources,
+					}, {
+						Name:      "user-container-5",
+						Resources: defaultResources,
+					}, {
+						Name:      "user-container-6",
+						Resources: defaultResources,
+					}, {
+						Name:      "user-container-7",
+						Resources: defaultResources,
+					}, {
+						Name:      "user-container-4",
+						Resources: defaultResources,
+					}},
+				},
+			},
+		},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
uuid uses crypto/rand (rather than math/rand) which has some performance edge cases on some platforms (not the worst thing in the world, but easy to avoid here). With uuid the resulting names are pretty long, which is a bit of a pain for `kubectl logs`, `kubectl exec` etc. This should perform a bit better, and the resulting names are a little nicer looking (`user-container-1`, `user-container-2` etc). 

Plus, this way the generated names are stable over recreates (useful e.g. for consistent container names in logs for the same ksvc between revisions etc).

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
