### PR TITLE
Disable chaos for networking components.

### DIFF
--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -77,6 +77,13 @@ spec:
         # and substituted here.
         image: ko://knative.dev/pkg/leaderelection/chaosduck
 
+        args:
+        # Disable chaos on the Istio components.
+        - "-disable=istio-webhook"
+        - "-disable=networking-istio"
+        # Disable chaos on the Contour components.
+        - "-disable=contour-ingress-controller"
+
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:


### PR DESCRIPTION
net-istio and net-contour run in the serving namespace, and their latest nightly updates pull in versions that enable HA by default.

This automatically pulls them into scope for chaos testing, which they haven't been provisioned for.

