### PR TITLE
Enable chaos for net-contour controller.

### DIFF
--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -81,8 +81,6 @@ spec:
         # Disable chaos on the Istio components.
         - "-disable=istio-webhook"
         - "-disable=networking-istio"
-        # Disable chaos on the Contour components.
-        - "-disable=contour-ingress-controller"
 
         env:
         - name: SYSTEM_NAMESPACE

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -54,6 +54,7 @@ SYSTEM_NAMESPACE=$(uuidgen | tr 'A-Z' 'a-z')
 # Keep this in sync with test/ha/ha.go
 readonly REPLICAS=3
 readonly BUCKETS=10
+HA_COMPONENTS=()
 
 
 # Parse our custom flags.
@@ -277,6 +278,7 @@ function install_contour() {
   kubectl apply -f ${INSTALL_CONTOUR_YAML} || return 1
 
   UNINSTALL_LIST+=( "${INSTALL_CONTOUR_YAML}" )
+  HA_COMPONENTS+=( "contour-ingress-controller" )
 
   local NET_CONTOUR_YAML_NAME=${TMP_DIR}/${INSTALL_NET_CONTOUR_YAML##*/}
   sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${INSTALL_NET_CONTOUR_YAML} > ${NET_CONTOUR_YAML_NAME}
@@ -370,6 +372,7 @@ function install_knative_serving_standard() {
   UNINSTALL_LIST+=( "${CERT_YAML_NAME}" )
 
   echo ">> Installing Knative serving"
+  HA_COMPONENTS+=( "controller" "webhook" "autoscaler-hpa" )
   if [[ "$1" == "HEAD" ]]; then
     local CORE_YAML_NAME=${TMP_DIR}/${SERVING_CORE_YAML##*/}
     sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${SERVING_CORE_YAML} > ${CORE_YAML_NAME}

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -72,7 +72,8 @@ kubectl patch hpa activator -n "${SYSTEM_NAMESPACE}" \
   --type "merge" \
   --patch '{"spec": {"minReplicas": '${REPLICAS}', "maxReplicas": '${REPLICAS}'}}' || failed=1
 
-scale_controlplane controller autoscaler-hpa webhook
+# Scale up all of the HA components in knative-serving.
+scale_controlplane "${HA_COMPONENTS[@]}"
 
 # Changing the bucket count and cycling the controllers will leave around stale
 # lease resources at the old sharding factor, so clean these up.


### PR DESCRIPTION
Opening this now to test the non-Contour changes, but it won't work for Contour until https://github.com/knative/serving/pull/8716 lands.

I also need to remove the `-disable` still

/hold