### PR TITLE
Eliminate array allocations

### DIFF
--- a/pkg/reconciler/gc/v2/gc.go
+++ b/pkg/reconciler/gc/v2/gc.go
@@ -102,15 +102,16 @@ func Collect(
 	return nil
 }
 
+// nonactiveRevisions swaps active revisions to the end and omits them in new slice
 func nonactiveRevisions(revs []*v1.Revision, config *v1.Configuration) []*v1.Revision {
-	nonactive, count := make([]*v1.Revision, len(revs)), 0
-	for _, rev := range revs {
-		if !isRevisionActive(rev, config) {
-			nonactive[count] = rev
-			count++
+	swap := len(revs)
+	for i := len(revs) - 1; i >= 0; i-- {
+		if isRevisionActive(revs[i], config) {
+			swap--
+			revs[swap], revs[i] = revs[i], revs[swap]
 		}
 	}
-	return nonactive[:count]
+	return revs[:swap]
 }
 
 func isRevisionActive(rev *v1.Revision, config *v1.Configuration) bool {

--- a/pkg/reconciler/gc/v2/gc.go
+++ b/pkg/reconciler/gc/v2/gc.go
@@ -86,7 +86,7 @@ func Collect(
 			}
 		}
 	}
-	nonstale := revs[swap:] // nonstale revisions are moved to the end, but now in reverse-order
+	nonstale := revs[swap:] // reslice to include the nonstale revisions, but now in reverse-order
 
 	if max == gc.Disabled || len(nonstale) <= max {
 		return nil
@@ -103,7 +103,7 @@ func Collect(
 	return nil
 }
 
-// nonactiveRevisions swaps active revisions to the end and omits them in new slice
+// nonactiveRevisions swaps active revisions to the end and reslices to omit them
 func nonactiveRevisions(revs []*v1.Revision, config *v1.Configuration) []*v1.Revision {
 	swap := len(revs)
 	for i := 0; i < swap; {

--- a/pkg/reconciler/gc/v2/gc.go
+++ b/pkg/reconciler/gc/v2/gc.go
@@ -92,7 +92,7 @@ func Collect(
 		return nil
 	}
 
-	// Delete extra revisions past max, but iterate backwards for oldest ordering
+	// Delete extra revisions past max
 	for _, rev := range revs[max:] {
 		logger.Infof("Maximum(%d) reached. Deleting oldest non-active revision %q", max, rev.ObjectMeta.Name)
 		if err := client.ServingV1().Revisions(rev.Namespace).Delete(rev.Name, &metav1.DeleteOptions{}); err != nil {

--- a/pkg/reconciler/gc/v2/gc.go
+++ b/pkg/reconciler/gc/v2/gc.go
@@ -65,7 +65,7 @@ func Collect(
 		return a.Before(b)
 	})
 
-	// Delete stale revisions while more than min remain
+	// Delete stale revisions while more than min remain, swap nonstale revisions to the end
 	swap := len(revs)
 	for i := 0; i < swap; {
 		rev := revs[i]
@@ -80,7 +80,7 @@ func Collect(
 
 		default:
 			i++
-			logger.Info("Deleting stale revision: ", revs[i].ObjectMeta.Name)
+			logger.Info("Deleting stale revision: ", rev.ObjectMeta.Name)
 			if err := client.ServingV1().Revisions(rev.Namespace).Delete(rev.Name, &metav1.DeleteOptions{}); err != nil {
 				logger.With(zap.Error(err)).Error("Failed to GC revision: ", rev.Name)
 			}

--- a/pkg/reconciler/gc/v2/gc.go
+++ b/pkg/reconciler/gc/v2/gc.go
@@ -67,7 +67,7 @@ func Collect(
 
 	// Delete stale revisions while more than min remain
 	count, remaining := 0, len(revs)
-	nonstale := make([]*v1.Revision, remaining)
+	nonstale := make([]*v1.Revision, remaining) // TODO: use the swap trick again?
 	for _, rev := range revs {
 		switch {
 		case remaining <= min:
@@ -105,10 +105,12 @@ func Collect(
 // nonactiveRevisions swaps active revisions to the end and omits them in new slice
 func nonactiveRevisions(revs []*v1.Revision, config *v1.Configuration) []*v1.Revision {
 	swap := len(revs)
-	for i := len(revs) - 1; i >= 0; i-- {
+	for i := 0; i < swap; {
 		if isRevisionActive(revs[i], config) {
 			swap--
 			revs[swap], revs[i] = revs[i], revs[swap]
+		} else {
+			i++
 		}
 	}
 	return revs[:swap]

--- a/pkg/reconciler/gc/v2/gc.go
+++ b/pkg/reconciler/gc/v2/gc.go
@@ -86,13 +86,13 @@ func Collect(
 			}
 		}
 	}
-	nonstale := revs[swap:] // reslice to include the nonstale revisions, but now in reverse-order
+	nonstale := revs[swap:] // Reslice to include the nonstale revisions, which are now in reverse order
 
 	if max == gc.Disabled || len(nonstale) <= max {
 		return nil
 	}
 
-	// Delete extra revisions past max, but iterate backwards for oldest ordering.
+	// Delete extra revisions past max, but iterate backwards for oldest ordering
 	for i := len(nonstale) - 1; i >= max; i-- {
 		rev := revs[i]
 		logger.Infof("Maximum(%d) reached. Deleting oldest non-active revision %q", max, rev.ObjectMeta.Name)

--- a/pkg/reconciler/gc/v2/gc.go
+++ b/pkg/reconciler/gc/v2/gc.go
@@ -86,15 +86,14 @@ func Collect(
 			}
 		}
 	}
-	nonstale := revs[swap:] // Reslice to include the nonstale revisions, which are now in reverse order
+	revs = revs[swap:] // Reslice to include the nonstale revisions, which are now in reverse order
 
-	if max == gc.Disabled || len(nonstale) <= max {
+	if max == gc.Disabled || len(revs) <= max {
 		return nil
 	}
 
 	// Delete extra revisions past max, but iterate backwards for oldest ordering
-	for i := len(nonstale) - 1; i >= max; i-- {
-		rev := revs[i]
+	for _, rev := range revs[max:] {
 		logger.Infof("Maximum(%d) reached. Deleting oldest non-active revision %q", max, rev.ObjectMeta.Name)
 		if err := client.ServingV1().Revisions(rev.Namespace).Delete(rev.Name, &metav1.DeleteOptions{}); err != nil {
 			logger.With(zap.Error(err)).Error("Failed to GC revision: ", rev.Name)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Never allocate new arrays, just swap elements to the end of the existing one and reslice
* Optimizes memory, but definitely is a readability loss: reviewers let me know what you think