### PR TITLE
Ensure new GC is run for allowed state

### DIFF
--- a/pkg/reconciler/gc/reconciler.go
+++ b/pkg/reconciler/gc/reconciler.go
@@ -43,10 +43,10 @@ var _ configreconciler.Interface = (*reconciler)(nil)
 func (c *reconciler) ReconcileKind(ctx context.Context, config *v1.Configuration) pkgreconciler.Event {
 	switch cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC {
 
-	case cfgmap.Enabled: // v2 logic
-		return gcv2.Collect(ctx, c.client, c.revisionLister, config)
-
-	default: // v1 logic
+	case cfgmap.Disabled: // v1 logic
 		return gcv1.Collect(ctx, c.client, c.revisionLister, config)
+
+	default: // v2 logic
+		return gcv2.Collect(ctx, c.client, c.revisionLister, config)
 	}
 }

--- a/pkg/reconciler/labeler/labeler.go
+++ b/pkg/reconciler/labeler/labeler.go
@@ -51,29 +51,30 @@ var _ routereconciler.Finalizer = (*Reconciler)(nil)
 func (c *Reconciler) FinalizeKind(ctx context.Context, r *v1.Route) pkgreconciler.Event {
 	switch cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC {
 
-	case cfgmap.Enabled: // v2 logic
-		cacc := labelerv2.NewConfigurationAccessor(c.client, c.tracker, c.configurationLister, c.clock)
-		racc := labelerv2.NewRevisionAccessor(c.client, c.tracker, c.revisionLister, c.clock)
-		return labelerv2.ClearLabels(r.Namespace, r.Name, cacc, racc)
-
-	default: // v1 logic
+	case cfgmap.Disabled: // v2 logic
 		cacc := labelerv1.NewConfigurationAccessor(c.client, c.tracker, c.configurationLister)
 		racc := labelerv1.NewRevisionAccessor(c.client, c.tracker, c.revisionLister)
 		return labelerv1.ClearLabels(r.Namespace, r.Name, cacc, racc)
+
+	default: // v1 logic
+		cacc := labelerv2.NewConfigurationAccessor(c.client, c.tracker, c.configurationLister, c.clock)
+		racc := labelerv2.NewRevisionAccessor(c.client, c.tracker, c.revisionLister, c.clock)
+		return labelerv2.ClearLabels(r.Namespace, r.Name, cacc, racc)
 	}
 }
 
 func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconciler.Event {
 	switch cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC {
 
-	case cfgmap.Enabled: // v2 logic
+	case cfgmap.Disabled: // v1 logic
+		cacc := labelerv1.NewConfigurationAccessor(c.client, c.tracker, c.configurationLister)
+		racc := labelerv1.NewRevisionAccessor(c.client, c.tracker, c.revisionLister)
+		return labelerv1.SyncLabels(r, cacc, racc)
+
+	default: // v2 logic
 		cacc := labelerv2.NewConfigurationAccessor(c.client, c.tracker, c.configurationLister, c.clock)
 		racc := labelerv2.NewRevisionAccessor(c.client, c.tracker, c.revisionLister, c.clock)
 		return labelerv2.SyncLabels(r, cacc, racc)
 
-	default: // v1 logic
-		cacc := labelerv1.NewConfigurationAccessor(c.client, c.tracker, c.configurationLister)
-		racc := labelerv1.NewRevisionAccessor(c.client, c.tracker, c.revisionLister)
-		return labelerv1.SyncLabels(r, cacc, racc)
 	}
 }

--- a/pkg/reconciler/labeler/labeler.go
+++ b/pkg/reconciler/labeler/labeler.go
@@ -51,12 +51,12 @@ var _ routereconciler.Finalizer = (*Reconciler)(nil)
 func (c *Reconciler) FinalizeKind(ctx context.Context, r *v1.Route) pkgreconciler.Event {
 	switch cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC {
 
-	case cfgmap.Disabled: // v2 logic
+	case cfgmap.Disabled: // v1 logic
 		cacc := labelerv1.NewConfigurationAccessor(c.client, c.tracker, c.configurationLister)
 		racc := labelerv1.NewRevisionAccessor(c.client, c.tracker, c.revisionLister)
 		return labelerv1.ClearLabels(r.Namespace, r.Name, cacc, racc)
 
-	default: // v1 logic
+	default: // v2 logic
 		cacc := labelerv2.NewConfigurationAccessor(c.client, c.tracker, c.configurationLister, c.clock)
 		racc := labelerv2.NewRevisionAccessor(c.client, c.tracker, c.revisionLister, c.clock)
 		return labelerv2.ClearLabels(r.Namespace, r.Name, cacc, racc)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/8744

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Ensure that in state 'allowed' the v2 GC and Labeler are run
    * We will only disable the LastPinned functionality when Enabled, so Allowed can test the new GC without discarding the old data.
