### PR TITLE
Disable lastPinned patching when v2 GC enabled

### DIFF
--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -114,7 +114,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconcil
 		return err
 	}
 
-	if cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC == cfgmap.Enabled {
+	if cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC != cfgmap.Enabled {
 		// In all cases we will add annotations to the referred targets.  This is so that when they become
 		// routable we can know (through a listener) and attempt traffic configuration again.
 		if err := c.reconcileTargetRevisions(ctx, traffic, r); err != nil {

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -114,7 +114,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconcil
 		return err
 	}
 
-	if cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC != cfgmap.Disabled {
+	if cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC == cfgmap.Enabled {
 		// In all cases we will add annotations to the referred targets.  This is so that when they become
 		// routable we can know (through a listener) and attempt traffic configuration again.
 		if err := c.reconcileTargetRevisions(ctx, traffic, r); err != nil {

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -114,10 +114,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconcil
 		return err
 	}
 
-	if cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC == cfgmap.Disabled {
-		logger.Info("ResponsiveGC enabled. Skipping LastPinned updates.")
-	} else {
-		logger.Info("Updating targeted revisions.")
+	if cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC != cfgmap.Disabled {
 		// In all cases we will add annotations to the referred targets.  This is so that when they become
 		// routable we can know (through a listener) and attempt traffic configuration again.
 		if err := c.reconcileTargetRevisions(ctx, traffic, r); err != nil {

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -1814,7 +1814,7 @@ func TestReconcile(t *testing.T) {
 func TestReconcile_ResponsiveGC(t *testing.T) {
 	table := TableTest{{
 		Name: "Update stale lastPinned",
-		Ctx:  setResponsiveGCFeature(context.Background(), cfgmap.Enabled),
+		Ctx:  setResponsiveGCFeature(context.Background(), cfgmap.Disabled),
 		Objects: []runtime.Object{
 			Route("default", "stale-lastpinned", WithConfigTarget("config"),
 				WithURL, WithAddress, WithRouteConditionsAutoTLSDisabled,
@@ -1857,7 +1857,7 @@ func TestReconcile_ResponsiveGC(t *testing.T) {
 		Key: "default/stale-lastpinned",
 	}, {
 		Name: "lastPinned update disabled",
-		Ctx:  setResponsiveGCFeature(context.Background(), cfgmap.Disabled),
+		Ctx:  setResponsiveGCFeature(context.Background(), cfgmap.Enabled),
 		Objects: []runtime.Object{
 			Route("default", "stale-lastpinned", WithConfigTarget("config"),
 				WithURL, WithAddress, WithRouteConditionsAutoTLSDisabled,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/8740

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Disable updates to lastPinned annotation when the v2 GC is enabled

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
When enabled, the ResponsiveGC feature flag disables lastPinned annotation timestamp refreshes
```
