### PR TITLE
 Optimize pod counting in KPA

### DIFF
--- a/pkg/resources/pods_test.go
+++ b/pkg/resources/pods_test.go
@@ -121,7 +121,6 @@ func TestPodReadyUnreadyCount(t *testing.T) {
 			if want := len(tc.pods) - tc.want; got != want {
 				t.Errorf("NotReadyCount = %d, want: %d", got, want)
 			}
-
 		})
 	}
 }

--- a/pkg/resources/pods_test.go
+++ b/pkg/resources/pods_test.go
@@ -121,6 +121,7 @@ func TestPodReadyUnreadyCount(t *testing.T) {
 			if want := len(tc.pods) - tc.want; got != want {
 				t.Errorf("NotReadyCount = %d, want: %d", got, want)
 			}
+
 		})
 	}
 }


### PR DESCRIPTION
Currently in KPA we make 3 calls iterating all the pods 3 times (and 3 list calls, which are mostly in memory copying and slice allocations).
With this we can reduce this to 1 (which would come in the next PR).
I didn't add specific tests, since I implemented the other functions via this one and have virtually the same code coverage


/hold 
for the precursor PR #8760 to land...