### PR TITLE
Fix network probing for kingress conformance.

### DIFF
--- a/test/test_images/runtime/handlers/handler.go
+++ b/test/test_images/runtime/handlers/handler.go
@@ -28,9 +28,10 @@ import (
 
 // InitHandlers initializes all handlers.
 func InitHandlers(mux *http.ServeMux) {
-	h := network.NewProbeHandler(withHeaders(withRequestLog(runtimeHandler)))
-	mux.HandleFunc("/", h.ServeHTTP)
-	mux.HandleFunc(network.ProbePath, withRequestLog(withKubeletProbeHeaderCheck))
+	mux.HandleFunc("/", withHeaders(withRequestLog(runtimeHandler)))
+
+	h := network.NewProbeHandler(withRequestLog(withKubeletProbeHeaderCheck))
+	mux.HandleFunc(network.ProbePath, h.ServeHTTP)
 }
 
 // withRequestLog logs each request before handling it.


### PR DESCRIPTION
Much of kingress conformance uses the "runtime" image to test things because it
echos back headers and other fun stuff.  However, to make this work without the
queue-proxy it has to properly respond to network probes itself as well.  There
was already a probe handler registered at `/healthz` that looked for the kubelet
probe header and replied with a 400 when that wasn't present.  So when we added
`network.ProbePath` to the network probing we actually make things follow a
different request path through the runtime image, and started serving 400s.

You might be wondering why probing didn't fail.

Well, a while back we added logic to the prober to abandon requests that don't
fail with very specific status codes.  If it is a 404 or a 503 we keep trying.
When we get a 400; however, we abandon the probing and return success.

I've been debugging things with an instrumented copy of the probing logic, and I
will try to upstream that in a subsequent PR, but I wanted to land the fix first.