### PR TITLE
Fail test immediately when important setup failed

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -648,18 +648,18 @@ function toggle_feature() {
 function scale_controlplane() {
   for deployment in "$@"; do
     # Make sure all pods run in leader-elected mode.
-    kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "$deployment" --replicas=0 || failed=1
+    kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "$deployment" --replicas=0 || fail_test
     # Give it time to kill the pods.
     sleep 5
     # Scale up components for HA tests
-    kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "$deployment" --replicas="${REPLICAS}" || failed=1
+    kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "$deployment" --replicas="${REPLICAS}" || fail_test
   done
 }
 
 function disable_chaosduck() {
-  kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "chaosduck" --replicas=0 || failed=1
+  kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "chaosduck" --replicas=0 || fail_test
 }
 
 function enable_chaosduck() {
-  kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "chaosduck" --replicas=1 || failed=1
+  kubectl -n "${SYSTEM_NAMESPACE}" scale deployment "chaosduck" --replicas=1 || fail_test
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -62,15 +62,15 @@ if (( HTTPS )); then
 fi
 
 # Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go)
-kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch='{"data":{"allow-zero-initial-scale":"true"}}' || failed=1
+kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch='{"data":{"allow-zero-initial-scale":"true"}}' || fail_test
 
 # Keep the bucket count in sync with test/ha/ha.go
 kubectl -n "${SYSTEM_NAMESPACE}" patch configmap/config-leader-election --type=merge \
-  --patch='{"data":{"buckets": "'${BUCKETS}'"}}' || failed=1
+  --patch='{"data":{"buckets": "'${BUCKETS}'"}}' || fail_test
 
 kubectl patch hpa activator -n "${SYSTEM_NAMESPACE}" \
   --type "merge" \
-  --patch '{"spec": {"minReplicas": '${REPLICAS}', "maxReplicas": '${REPLICAS}'}}' || failed=1
+  --patch '{"spec": {"minReplicas": '${REPLICAS}', "maxReplicas": '${REPLICAS}'}}' || fail_test
 
 # Scale up all of the HA components in knative-serving.
 scale_controlplane "${HA_COMPONENTS[@]}"
@@ -80,7 +80,7 @@ scale_controlplane "${HA_COMPONENTS[@]}"
 kubectl -n ${SYSTEM_NAMESPACE} delete leases --all
 
 # Wait for a new leader Controller to prevent race conditions during service reconciliation
-wait_for_leader_controller || failed=1
+wait_for_leader_controller || fail_test
 
 # Dump the leases post-setup.
 header "Leaders"


### PR DESCRIPTION
This patch replaces failed=1 with fail_test in the setup phase in tests.

Currently even when setup phase (e.g. scale up, wait for leader controller, etc...) failed, e2e test continues.
So it happens the strange status all tests "Passed" but the status is "Failed".

This patch fixes it.

```release-note
NONE
```

/cc @chaodaiG @peterfeifanchen 