### PR TITLE
Disable chaos on webhook for now.

### DIFF
--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -83,7 +83,7 @@ spec:
         - "-disable=networking-istio"
         # Disable chaos on webhooks until https://github.com/knative/pkg/issues/1509 is
         # sorted out.
-        - "disable=webhook"
+        - "-disable=webhook"
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -81,7 +81,9 @@ spec:
         # Disable chaos on the Istio components.
         - "-disable=istio-webhook"
         - "-disable=networking-istio"
-
+        # Disable chaos on webhooks until https://github.com/knative/pkg/issues/1509 is
+        # sorted out.
+        - "disable=webhook"
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Chaos on webhook currently causes a battery of failures tracked in https://github.com/knative/pkg/issues/1509. I think we should disable it to not hide issues and/or make it unnecessarily hard for contributors to debug their PR test failures.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor 
