### PR TITLE
Fix script to grep correct leader in e2e-common.sh

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -621,7 +621,7 @@ function dump_extra_cluster_state() {
 function wait_for_leader_controller() {
   echo -n "Waiting for a leader Controller"
   for i in {1..150}; do  # timeout after 5 minutes
-    local leader=$(kubectl get lease -n "${SYSTEM_NAMESPACE}" -ojsonpath='{.items[*].spec.holderIdentity}'  | cut -d"_" -f1 | grep "^controller-" | head -1)
+    local leader=$(kubectl get lease -n "${SYSTEM_NAMESPACE}" -ojsonpath='{range .items[*].spec}{"\n"}{.holderIdentity}' | cut -d"_" -f1 | grep "^controller-" | head -1)
     # Make sure the leader pod exists.
     if [ -n "${leader}" ] && kubectl get pod "${leader}" -n "${SYSTEM_NAMESPACE}"  >/dev/null 2>&1; then
       echo -e "\nNew leader Controller has been elected"


### PR DESCRIPTION
This patch adds break line to "grep" controller's leader name correctly.

It fixes https://github.com/knative/serving/pull/8715 's e2e error.

**Release Note**

```release-note
NONE
```

/cc @mattmoor @vagababov @ZhiminXiang