### PR TITLE
Add a benchmark for the concurrency reporter.

### DIFF
--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -461,19 +461,23 @@ func BenchmarkConcurrencyReporter(b *testing.B) {
 		})
 	}
 
+	request := func(key types.NamespacedName) {
+		reqCh <- network.ReqEvent{
+			Time: time.Now(),
+			Type: network.ReqIn,
+			Key:  key,
+		}
+		reqCh <- network.ReqEvent{
+			Time: time.Now(),
+			Type: network.ReqOut,
+			Key:  key,
+		}
+	}
+
 	b.Run("sequential", func(b *testing.B) {
 		for j := 0; j < b.N; j++ {
 			key := keys[j%len(keys)]
-			reqCh <- network.ReqEvent{
-				Time: time.Now(),
-				Type: network.ReqIn,
-				Key:  key,
-			}
-			reqCh <- network.ReqEvent{
-				Time: time.Now(),
-				Type: network.ReqOut,
-				Key:  key,
-			}
+			request(key)
 		}
 	})
 
@@ -482,16 +486,7 @@ func BenchmarkConcurrencyReporter(b *testing.B) {
 			var j int
 			for pb.Next() {
 				key := keys[j%len(keys)]
-				reqCh <- network.ReqEvent{
-					Time: time.Now(),
-					Type: network.ReqIn,
-					Key:  key,
-				}
-				reqCh <- network.ReqEvent{
-					Time: time.Now(),
-					Type: network.ReqOut,
-					Key:  key,
-				}
+				request(key)
 				j++
 			}
 		})

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -19,6 +19,7 @@ package handler
 import (
 	"context"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	rtesting "knative.dev/pkg/reconciler/testing"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler/metrics"
+	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
 	"knative.dev/serving/pkg/network"
@@ -424,4 +426,62 @@ func revisionInformer(ctx context.Context, revs ...*v1.Revision) {
 		fake.ServingV1().Revisions(rev.Namespace).Create(rev)
 		revisions.Informer().GetIndexer().Add(rev)
 	}
+}
+
+func BenchmarkConcurrencyReporter(b *testing.B) {
+	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(b)
+	defer cancel()
+
+	// Buffer equal to the activator.
+	reqCh := make(chan network.ReqEvent, 100)
+	cr := NewConcurrencyReporter(ctx, activatorPodName, reqCh, make(chan []asmetrics.StatMessage, 1000))
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go cr.Run(stopCh)
+
+	// Spread the load across 100 revisions.
+	keys := make([]types.NamespacedName, 0, 100)
+	for i := 0; i < cap(keys); i++ {
+		keys = append(keys, types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      testRevName + strconv.Itoa(i),
+		})
+	}
+
+	b.Run("sequential", func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			key := keys[j%len(keys)]
+			reqCh <- network.ReqEvent{
+				Time: time.Now(),
+				Type: network.ReqIn,
+				Key:  key,
+			}
+			reqCh <- network.ReqEvent{
+				Time: time.Now(),
+				Type: network.ReqOut,
+				Key:  key,
+			}
+		}
+	})
+
+	b.Run("parallel", func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			var j int
+			for pb.Next() {
+				key := keys[j%len(keys)]
+				reqCh <- network.ReqEvent{
+					Time: time.Now(),
+					Type: network.ReqIn,
+					Key:  key,
+				}
+				reqCh <- network.ReqEvent{
+					Time: time.Now(),
+					Type: network.ReqOut,
+					Key:  key,
+				}
+				j++
+			}
+		})
+	})
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This is to draw a baseline to compare against. The benchmark aims at simulating "real" load, so we're sending constant requests for 100 revisions (to test horizontal scalability) and setup the reporting code like it's used in the production setup.

## Results

```
goos: linux
goarch: amd64
pkg: knative.dev/serving/pkg/activator/handler
BenchmarkConcurrencyReporter/sequential-16         	 1871007	       655 ns/op	       0 B/op	       0 allocs/op
BenchmarkConcurrencyReporter/parallel-16           	  903354	      1313 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	knative.dev/serving/pkg/activator/handler	3.099s
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz 
