### PR TITLE
Refactor the concurrency reporter into callable functions.

### DIFF
--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -92,10 +92,11 @@ func (cr *ConcurrencyReporter) handleEvent(event network.ReqEvent) {
 // If absent it creates a new one and returns it, potentially returning a StatMessage too
 // to trigger an immediate scale-from-0.
 func (cr *ConcurrencyReporter) getOrCreateStat(event network.ReqEvent) (*network.RequestStats, *asmetrics.StatMessage) {
-	cr.mux.RLock()
-	stat := cr.stats[event.Key]
-	cr.mux.RUnlock()
-
+	stat := func() *network.RequestStats {
+		cr.mux.RLock()
+		defer cr.mux.RUnlock()
+		return cr.stats[event.Key]
+	}()
 	if stat != nil {
 		return stat, nil
 	}

--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -19,6 +19,7 @@ package handler
 import (
 	"context"
 	"math"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -49,6 +50,17 @@ type ConcurrencyReporter struct {
 	statCh chan []asmetrics.StatMessage
 
 	rl servinglisters.RevisionLister
+
+	mux sync.RWMutex
+	// This map holds the concurrency and request count accounting across revisions.
+	stats map[types.NamespacedName]*network.RequestStats
+	// This map holds whether during this reporting period we reported "first" request
+	// for the revision. Our reporting period is 1s, so there is a high chance that
+	// they will end up in the same metrics bucket and values in the same bucket are
+	// summed.
+	// This is important because for small concurrencies, e.g. 1, autoscaler might cause
+	// noticeable overprovisioning.
+	reportedFirstRequest map[types.NamespacedName]float64
 }
 
 // NewConcurrencyReporter creates a ConcurrencyReporter which listens to incoming
@@ -61,7 +73,104 @@ func NewConcurrencyReporter(ctx context.Context, podName string,
 		reqCh:   reqCh,
 		statCh:  statCh,
 		rl:      revisioninformer.Get(ctx).Lister(),
+
+		stats:                make(map[types.NamespacedName]*network.RequestStats),
+		reportedFirstRequest: make(map[types.NamespacedName]float64),
 	}
+}
+
+// handleEvent handles request events (in, out) and updates the respective stats.
+func (cr *ConcurrencyReporter) handleEvent(event network.ReqEvent) {
+	stats, msgs := cr.getOrCreateStat(event)
+	if len(msgs) > 0 {
+		cr.statCh <- msgs
+	}
+	stats.HandleEvent(event)
+}
+
+// getOrCreateStat gets a stat from the state if present.
+// If absent it creates a new one and returns it, potentially returning a StatMessage too
+// to trigger an immediate scale-from-0.
+func (cr *ConcurrencyReporter) getOrCreateStat(event network.ReqEvent) (*network.RequestStats, []asmetrics.StatMessage) {
+	cr.mux.RLock()
+	stat := cr.stats[event.Key]
+	cr.mux.RUnlock()
+
+	if stat != nil {
+		return stat, nil
+	}
+
+	// Doubly checked locking.
+	cr.mux.Lock()
+	defer cr.mux.Unlock()
+
+	stat = cr.stats[event.Key]
+	if stat != nil {
+		return stat, nil
+	}
+
+	stat = network.NewRequestStats(event.Time)
+	cr.stats[event.Key] = stat
+
+	if event.Type == network.ReqIn {
+		// Return a StatMessage if this is an incoming request.
+		cr.reportedFirstRequest[event.Key] = 1
+		return stat, []asmetrics.StatMessage{{
+			Key: event.Key,
+			Stat: asmetrics.Stat{
+				// Stat time is unset by design. Will be set by receiver.
+				PodName:                   cr.podName,
+				AverageConcurrentRequests: 1,
+				// The way the checks are written, this cannot ever be
+				// anything else but 1. The stats map key is only deleted
+				// after a reporting period, so we see this code path at most
+				// once per period.
+				RequestCount: 1,
+			},
+		}}
+	}
+	return stat, nil
+}
+
+// report cuts a report from all collected statistics and sends the respective messages
+// via the statsCh and reports the concurrency metrics to prometheus.
+func (cr *ConcurrencyReporter) report(now time.Time) {
+	cr.mux.Lock()
+	defer cr.mux.Unlock()
+
+	messages := make([]asmetrics.StatMessage, 0, len(cr.stats))
+	for key, stat := range cr.stats {
+		report := stat.Report(now)
+		firstAdj := cr.reportedFirstRequest[key]
+
+		// This is only 0 if we have seen no activity for the entire reporting
+		// period at all.
+		if report.AverageConcurrency == 0 {
+			delete(cr.stats, key)
+		}
+
+		// Subtract the request we already reported when first seeing the
+		// revision. We report a min of 0 here because the initial report is
+		// always a concurrency of 1 and the actual concurrency reported over
+		// the reporting period might be < 1.
+		adjustedConcurrency := math.Max(report.AverageConcurrency-firstAdj, 0)
+		adjustedCount := report.RequestCount - firstAdj
+		messages = append(messages, asmetrics.StatMessage{
+			Key: key,
+			Stat: asmetrics.Stat{
+				// Stat time is unset by design. The receiver will set the time.
+				PodName:                   cr.podName,
+				AverageConcurrentRequests: adjustedConcurrency,
+				RequestCount:              adjustedCount,
+			},
+		})
+		cr.reportToMetricsBackend(key, report.AverageConcurrency)
+	}
+	if len(messages) > 0 {
+		cr.statCh <- messages
+	}
+
+	cr.reportedFirstRequest = make(map[types.NamespacedName]float64)
 }
 
 func (cr *ConcurrencyReporter) reportToMetricsBackend(key types.NamespacedName, concurrency float64) {
@@ -87,78 +196,12 @@ func (cr *ConcurrencyReporter) Run(stopCh <-chan struct{}) {
 }
 
 func (cr *ConcurrencyReporter) run(stopCh <-chan struct{}, reportCh <-chan time.Time) {
-	// This map holds the concurrency and request count accounting across revisions.
-	stats := make(map[types.NamespacedName]*network.RequestStats)
-	// This map holds whether during this reporting period we reported "first" request
-	// for the revision. Our reporting period is 1s, so there is a high chance that
-	// they will end up in the same metrics bucket and values in the same bucket are
-	// summed.
-	// This is important because for small concurrencies, e.g. 1, autoscaler might cause
-	// noticeable overprovisioning.
-	reportedFirstRequest := make(map[types.NamespacedName]float64)
-
 	for {
 		select {
 		case event := <-cr.reqCh:
-			stat := stats[event.Key]
-			if stat == nil {
-				stat = network.NewRequestStats(event.Time)
-				stats[event.Key] = stat
-
-				// Only generate a from 0 event if this is an incoming request.
-				if event.Type == network.ReqIn {
-					reportedFirstRequest[event.Key] = 1
-					cr.statCh <- []asmetrics.StatMessage{{
-						Key: event.Key,
-						Stat: asmetrics.Stat{
-							// Stat time is unset by design. Will be set by receiver.
-							PodName:                   cr.podName,
-							AverageConcurrentRequests: 1,
-							// The way the check above is written, this cannot ever be
-							// anything else but 1. The stats map key is only deleted
-							// after a reporting period, so we see this code path at most
-							// once per period.
-							RequestCount: 1,
-						},
-					}}
-				}
-			}
-
-			stat.HandleEvent(event)
+			cr.handleEvent(event)
 		case now := <-reportCh:
-			messages := make([]asmetrics.StatMessage, 0, len(stats))
-			for key, stat := range stats {
-				report := stat.Report(now)
-				firstAdj := reportedFirstRequest[key]
-
-				// This is only 0 if we have seen no activity for the entire reporting
-				// period at all.
-				if report.AverageConcurrency == 0 {
-					delete(stats, key)
-				}
-
-				// Subtract the request we already reported when first seeing the
-				// revision. We report a min of 0 here because the initial report is
-				// always a concurrency of 1 and the actual concurrency reported over
-				// the reporting period might be < 1.
-				adjustedConcurrency := math.Max(report.AverageConcurrency-firstAdj, 0)
-				adjustedCount := report.RequestCount - firstAdj
-				messages = append(messages, asmetrics.StatMessage{
-					Key: key,
-					Stat: asmetrics.Stat{
-						// Stat time is unset by design. The receiver will set the time.
-						PodName:                   cr.podName,
-						AverageConcurrentRequests: adjustedConcurrency,
-						RequestCount:              adjustedCount,
-					},
-				})
-				cr.reportToMetricsBackend(key, report.AverageConcurrency)
-			}
-			if len(messages) > 0 {
-				cr.statCh <- messages
-			}
-
-			reportedFirstRequest = make(map[types.NamespacedName]float64)
+			cr.report(now)
 		case <-stopCh:
 			return
 		}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This is a step towards surfacing the handleEvent function to an http handler directly rather than relying on channel operations to propagate those signals.

## Benchmarks results

```
goos: linux
goarch: amd64
pkg: knative.dev/serving/pkg/activator/handler
BenchmarkConcurrencyReporter/sequential-direct-16         	 5104186	       232 ns/op	       0 B/op	       0 allocs/op
BenchmarkConcurrencyReporter/sequential-channel-16        	 1837940	       656 ns/op	       0 B/op	       0 allocs/op
BenchmarkConcurrencyReporter/parallel-direct-16           	14167513	        81.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkConcurrencyReporter/parallel-channel-16          	  909164	      1332 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	knative.dev/serving/pkg/activator/handler	5.790s
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
