### PR TITLE
Use loggers with keys.

### DIFF
--- a/pkg/network/status/status_test.go
+++ b/pkg/network/status/status_test.go
@@ -539,6 +539,12 @@ func TestProbeVerifier(t *testing.T) {
 	prober := NewProber(zaptest.NewLogger(t).Sugar(), nil, nil)
 	verifier := prober.probeVerifier(&workItem{
 		ingressState: &ingressState{
+			ing: &v1alpha1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+				},
+			},
 			hash: hash,
 		},
 		podState: nil,


### PR DESCRIPTION
This makes the logger invocations in the status prober add keys so that logstream can properly extract the relevant probe lines for a particular key and show them alongside the pertinent test output (e.g. failures!).

Fixes: https://github.com/knative/serving/issues/8767

/assign @tcnghia @vagababov 