### PR TITLE
Probe all hosts instead of stopping after one successful probe.

### DIFF
--- a/pkg/network/status/status.go
+++ b/pkg/network/status/status.go
@@ -253,10 +253,10 @@ func (m *Prober) IsReady(ctx context.Context, ing *v1alpha1.Ingress) (bool, erro
 			}
 		}()
 
-		// Update the states when probing is successful or cancelled
+		// Update the states when probing is cancelled
 		go func() {
 			<-podCtx.Done()
-			m.updateStates(ingressState, podState)
+			m.onProbingCancellation(ingressState, podState)
 		}()
 
 		for _, wi := range ipWorkItems {
@@ -396,19 +396,39 @@ func (m *Prober) processWorkItem() bool {
 		logger.Errorf("Probing of %s failed, IP: %s:%s, ready: %t, error: %v (depth: %d)",
 			item.url, item.podIP, item.podPort, ok, err, m.workQueue.Len())
 	} else {
-		m.updateStates(item.ingressState, item.podState)
+		m.onProbingSuccess(item.ingressState, item.podState)
 	}
 	return true
 }
 
-func (m *Prober) updateStates(ingressState *ingressState, podState *podState) {
-	// This is the last probe call for the pod, the pod is ready
+func (m *Prober) onProbingSuccess(ingressState *ingressState, podState *podState) {
+	// The last probe call for the Pod succeeded, the Pod is ready
 	if atomic.AddInt32(&podState.pendingCount, -1) == 0 {
+		// Unlock the goroutine blocked on <-podCtx.Done()
 		podState.cancel()
 
 		// This is the last pod being successfully probed, the Ingress is ready
 		if atomic.AddInt32(&ingressState.pendingCount, -1) == 0 {
 			m.readyCallback(ingressState.ing)
+		}
+	}
+}
+
+func (m *Prober) onProbingCancellation(ingressState *ingressState, podState *podState) {
+	for {
+		pendingCount := atomic.LoadInt32(&podState.pendingCount)
+		if pendingCount <= 0 {
+			// Probing succeeded, nothing to do
+			return
+		}
+
+		// Attempt to set pendingCount to 0
+		if atomic.CompareAndSwapInt32(&podState.pendingCount, pendingCount, 0) {
+			// This is the last pod being successfully probed, the Ingress is ready
+			if atomic.AddInt32(&ingressState.pendingCount, -1) == 0 {
+				m.readyCallback(ingressState.ing)
+			}
+			return
 		}
 	}
 }

--- a/pkg/network/status/status_test.go
+++ b/pkg/network/status/status_test.go
@@ -162,7 +162,8 @@ func TestProbeAllHosts(t *testing.T) {
 
 	// Just drain the requests in the channel to not block the handler
 	go func() {
-		for range probeRequests {}
+		for range probeRequests {
+		}
 	}()
 
 	// Wait for the probing to eventually succeed

--- a/pkg/network/status/status_test.go
+++ b/pkg/network/status/status_test.go
@@ -57,8 +57,8 @@ var (
 )
 
 func TestProbeAllHosts(t *testing.T) {
-	hostA := "foo.bar.com"
-	hostB := "ksvc.test.dev"
+	const hostA = "foo.bar.com"
+	const hostB = "ksvc.test.dev"
 	hostBEnabled := int32(0)
 
 	ing := ingTemplate.DeepCopy()
@@ -162,9 +162,7 @@ func TestProbeAllHosts(t *testing.T) {
 
 	// Just drain the requests in the channel to not block the handler
 	go func() {
-		for {
-			<-probeRequests
-		}
+		for range probeRequests {}
 	}()
 
 	// Wait for the probing to eventually succeed

--- a/pkg/network/status/status_test.go
+++ b/pkg/network/status/status_test.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -54,6 +55,121 @@ var (
 		},
 	}
 )
+
+func TestProbeAllHosts(t *testing.T) {
+	hostA := "foo.bar.com"
+	hostB := "ksvc.test.dev"
+	hostBEnabled := int32(0)
+
+	ing := ingTemplate.DeepCopy()
+	ing.Spec.Rules[0].Hosts = append(ing.Spec.Rules[0].Hosts, hostB)
+	hash, err := ingress.InsertProbe(ing)
+	if err != nil {
+		t.Fatal("Failed to insert probe:", err)
+	}
+
+	// Dummy handler returning HTTP 500 (it should never be called during probing)
+	dummyRequests := make(chan *http.Request)
+	dummyHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dummyRequests <- r
+		w.WriteHeader(500)
+	})
+
+	// Actual probe handler used in Activator and Queue-Proxy
+	probeHandler := network.NewProbeHandler(dummyHandler)
+
+	// Probes to hostA always succeed and probes to hostB only succeed if hostBEnabled is true
+	probeRequests := make(chan *http.Request)
+	finalHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probeRequests <- r
+		if !strings.HasPrefix(r.Host, hostA) &&
+			(atomic.LoadInt32(&hostBEnabled) == 0 || !strings.HasPrefix(r.Host, hostB)) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		r.Header.Set(network.HashHeaderName, hash)
+		probeHandler.ServeHTTP(w, r)
+	})
+
+	ts := httptest.NewServer(finalHandler)
+	defer ts.Close()
+	tsURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse URL %q: %v", ts.URL, err)
+	}
+	port, err := strconv.Atoi(tsURL.Port())
+	if err != nil {
+		t.Fatalf("Failed to parse port %q: %v", tsURL.Port(), err)
+	}
+	hostname := tsURL.Hostname()
+
+	ready := make(chan *v1alpha1.Ingress)
+	prober := NewProber(
+		zaptest.NewLogger(t).Sugar(),
+		fakeProbeTargetLister{{
+			PodIPs:  sets.NewString(hostname),
+			PodPort: strconv.Itoa(port),
+			URLs:    []*url.URL{tsURL},
+		}},
+		func(ing *v1alpha1.Ingress) {
+			ready <- ing
+		})
+
+	done := make(chan struct{})
+	cancelled := prober.Start(done)
+	defer func() {
+		close(done)
+		<-cancelled
+	}()
+
+	// The first call to IsReady must succeed and return false
+	ok, err := prober.IsReady(context.Background(), ing)
+	if err != nil {
+		t.Fatal("IsReady failed:", err)
+	}
+	if ok {
+		t.Fatal("IsReady() returned true")
+	}
+
+	// Wait for both hosts to be probed
+	hostASeen, hostBSeen := false, false
+	for req := range probeRequests {
+		if req.Host == hostA {
+			hostASeen = true
+		} else if req.Host == hostB {
+			hostBSeen = true
+		} else {
+			t.Fatalf("Host header = %q, want %q or %q", req.Host, hostA, hostB)
+		}
+
+		if hostASeen && hostBSeen {
+			break
+		}
+	}
+
+	select {
+	case <-ready:
+		// Since HostB doesn't return 200, the prober shouldn't be ready
+		t.Fatal("Prober shouldn't be ready")
+	case <-time.After(1 * time.Second):
+		// Not ideal but it gives time to the prober to write to ready
+		break
+	}
+
+	// Make probes to hostB succeed
+	atomic.StoreInt32(&hostBEnabled, 1)
+
+	// Just drain the requests in the channel to not block the handler
+	go func() {
+		for {
+			<-probeRequests
+		}
+	}()
+
+	// Wait for the probing to eventually succeed
+	<-ready
+}
 
 func TestProbeLifecycle(t *testing.T) {
 	ing := ingTemplate.DeepCopy()
@@ -630,9 +746,11 @@ func (l fakeProbeTargetLister) ListProbeTargets(ctx context.Context, ing *v1alph
 			Port:    target.Port,
 		}
 		for _, url := range target.URLs {
-			newURL := *url
-			newURL.Host = ing.Spec.Rules[0].Hosts[0]
-			newTarget.URLs = append(newTarget.URLs, &newURL)
+			for _, host := range ing.Spec.Rules[0].Hosts {
+				newURL := *url
+				newURL.Host = host
+				newTarget.URLs = append(newTarget.URLs, &newURL)
+			}
 		}
 		targets = append(targets, newTarget)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #8765.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
* Instead of considering a single probe success as a signal that the Pod is ready, require all probes to succeed.

https://github.com/knative-sandbox/net-istio/pull/190 needs to be merged first to not create a regression
/hold
/assign @mattmoor @tcnghia 