### PR TITLE
Propagate labels and annotations from Route to placeholder service

### DIFF
--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -112,7 +112,8 @@ func makeK8sService(ctx context.Context, route *v1.Route, targetName string) (*c
 				// This service is owned by the Route.
 				*kmeta.NewControllerRef(route),
 			},
-			Labels: svcLabels,
+			Labels:      kmeta.UnionMaps(route.GetLabels(), svcLabels),
+			Annotations: route.GetAnnotations(),
 		},
 	}, nil
 }


### PR DESCRIPTION
This patch changes to propagate placeholder service's labels and
annotations from Route.

Currently there are no way to add annotation and labels to the
placeholder service except for manual.

/lint

**Release Note**

```release-note
Placeholder service's labels and annotations are propagated from Route.
```
