### PR TITLE
Allow more than 1000 concurrent revisions when CC!=0

### DIFF
--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -49,18 +49,23 @@ import (
 )
 
 const (
-
 	// The number of requests that are queued on the breaker before the 503s are sent.
 	// The value must be adjusted depending on the actual production requirements.
 	breakerQueueDepth = 10000
 
 	// The upper bound for concurrent requests sent to the revision.
-	// As new endpoints show up, the Breakers concurrency increases up to this value.
-	breakerMaxConcurrency = 1000
+	// As new endpoints show up, the revisionThrottler's concurrency increases up
+	// to this value.  We need to set some value here since the breaker requires
+	// an explicit buffer size (it's backed by a chan struct{}), but it can
+	// safely be quite large.
+	breakerMaxConcurrency = 100000
 )
 
 var (
-	breakerParams = queue.BreakerParams{
+	// These params are used to build the breaker that throttles across the entire revision.
+	// This is used when CC!=0 because we need to queue requests in case no
+	// individual podTracker is free.
+	revisionBreakerParams = queue.BreakerParams{
 		QueueDepth:      breakerQueueDepth,
 		MaxConcurrency:  breakerMaxConcurrency,
 		InitialCapacity: 0,
@@ -293,11 +298,11 @@ func (rt *revisionThrottler) updateCapacity(backendCount int) {
 	if numTrackers > 0 {
 		// Capacity is computed based off of number of trackers,
 		// when using pod direct routing.
-		capacity = rt.calculateCapacity(len(rt.podTrackers), ac, breakerParams.MaxConcurrency)
+		capacity = rt.calculateCapacity(len(rt.podTrackers), ac, revisionBreakerParams.MaxConcurrency)
 	} else {
 		// Capacity is computed off of number of ready backends,
 		// when we are using clusterIP routing.
-		capacity = rt.calculateCapacity(backendCount, ac, breakerParams.MaxConcurrency)
+		capacity = rt.calculateCapacity(backendCount, ac, revisionBreakerParams.MaxConcurrency)
 	}
 	rt.logger.Infof("Set capacity to %d (backends: %d, index: %d/%d)",
 		capacity, backendCount, ai, ac)
@@ -416,7 +421,7 @@ func (rt *revisionThrottler) handleUpdate(throttler *Throttler, update revisionD
 					tracker = &podTracker{
 						dest: newDest,
 						b: queue.NewBreaker(queue.BreakerParams{
-							QueueDepth:      breakerParams.QueueDepth,
+							QueueDepth:      revisionBreakerParams.QueueDepth,
 							MaxConcurrency:  rt.containerConcurrency,
 							InitialCapacity: rt.containerConcurrency, // Presume full unused capacity.
 						}),
@@ -533,7 +538,7 @@ func (t *Throttler) getOrCreateRevisionThrottler(revID types.NamespacedName) (*r
 			return nil, err
 		}
 		revThrottler = newRevisionThrottler(revID, int(rev.Spec.GetContainerConcurrency()),
-			networking.ServicePortName(rev.GetProtocol()), breakerParams, t.logger)
+			networking.ServicePortName(rev.GetProtocol()), revisionBreakerParams, t.logger)
 		t.revisionThrottlers[revID] = revThrottler
 	}
 	return revThrottler, nil

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -56,9 +56,9 @@ const (
 	// The upper bound for concurrent requests sent to the revision.
 	// As new endpoints show up, the revisionThrottler's concurrency increases up
 	// to this value.  We need to set some value here since the breaker requires
-	// an explicit buffer size (it's backed by a chan struct{}), but it can
-	// safely be quite large.
-	breakerMaxConcurrency = 100000
+	// an explicit buffer size (it's backed by a chan struct{}), but
+	// queue.MaxBreakerCapacity is very large.
+	breakerMaxConcurrency = queue.MaxBreakerCapacity
 )
 
 var (

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -81,8 +81,8 @@ func TestThrottlerUpdateCapacity(t *testing.T) {
 	}
 
 	// temporarily lower MaxConcurrency since the default value is math.MaxInt32
-	// and that will cause very, very slow tests as we try to create huge numbers
-	// of podTrackers in updateCapacity below.
+	// and we want to test calling updateCapacity() below with the same value
+	// as MaxConcurrency. This will be very, very slow if MaxConcurrency is very large.
 	bmp := revisionBreakerParams.MaxConcurrency
 	revisionBreakerParams.MaxConcurrency = 1000
 	defer func() { revisionBreakerParams.MaxConcurrency = bmp }()

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -85,7 +85,7 @@ func TestThrottlerUpdateCapacity(t *testing.T) {
 	// as MaxConcurrency. This will be very, very slow if MaxConcurrency is very large.
 	bmp := revisionBreakerParams.MaxConcurrency
 	revisionBreakerParams.MaxConcurrency = 1000
-	defer func() { revisionBreakerParams.MaxConcurrency = bmp }()
+	t.Cleanup(func() { revisionBreakerParams.MaxConcurrency = bmp })
 
 	rt.updateCapacity(1)
 	if got, want := rt.breaker.Capacity(), 10; got != want {

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"sync/atomic"
 )
@@ -32,6 +33,10 @@ var (
 	// ErrRequestQueueFull indicates the breaker queue depth was exceeded.
 	ErrRequestQueueFull = errors.New("pending request queue full")
 )
+
+// MaxBreakerCapacity is the largest valid value for the MaxConcurrency value of BreakerParams.
+// This is limited by the maximum size of a chan struct{} in the current implementation.
+const MaxBreakerCapacity = math.MaxInt32
 
 // BreakerParams defines the parameters of the breaker.
 type BreakerParams struct {


### PR DESCRIPTION
We need to set some sort of limit on the revision throttler because the breaker is backed by a chan struct{}, but it can and should be higher than 1000 concurrent requests.

Also added some more comments and renamed `breakerParams` to `revisionBreakerParams` since this was super-confusing to me, but this file could probably do with some more cleanup.

/assign @markusthoemmes @vagababov 

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->