### PR TITLE
Add a benchmark for report and optimize it further.

### DIFF
--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -152,13 +152,11 @@ func (cr *ConcurrencyReporter) report(now time.Time) []asmetrics.StatMessage {
 		messages = append(messages, asmetrics.StatMessage{
 			Key: key,
 			Stat: asmetrics.Stat{
-				// Stat time is unset by design. The receiver will set the time.
 				PodName:                   cr.podName,
 				AverageConcurrentRequests: adjustedConcurrency,
 				RequestCount:              adjustedCount,
 			},
 		})
-		cr.reportToMetricsBackend(key, report.AverageConcurrency)
 	}
 	cr.reportedFirstRequest = make(map[types.NamespacedName]float64)
 
@@ -192,6 +190,9 @@ func (cr *ConcurrencyReporter) run(stopCh <-chan struct{}, reportCh <-chan time.
 		select {
 		case now := <-reportCh:
 			msgs := cr.report(now)
+			for _, msg := range msgs {
+				cr.reportToMetricsBackend(msg.Key, msg.Stat.AverageConcurrentRequests)
+			}
 			if len(msgs) > 0 {
 				cr.statCh <- msgs
 			}

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -461,14 +462,23 @@ func TestConcurrencyReporterHandler(t *testing.T) {
 
 func TestMetricsReported(t *testing.T) {
 	reset()
-	cr, _, cancel := newTestReporter(t)
+	cr, ctx, cancel := newTestReporter(t)
 	defer cancel()
+
+	reportCh := make(chan time.Time)
+	go func() {
+		cr.run(ctx.Done(), reportCh)
+		close(reportCh)
+	}()
 
 	cr.handleEvent(network.ReqEvent{Key: rev1, Type: network.ReqIn})
 	cr.handleEvent(network.ReqEvent{Key: rev1, Type: network.ReqIn})
 	cr.handleEvent(network.ReqEvent{Key: rev1, Type: network.ReqIn})
 	cr.handleEvent(network.ReqEvent{Key: rev1, Type: network.ReqIn})
-	cr.report(time.Time{}.Add(1 * time.Millisecond))
+
+	reportCh <- time.Now()
+	<-cr.statCh
+	<-cr.statCh
 
 	wantTags := map[string]string{
 		metricskey.LabelRevisionName:      rev1.Name,
@@ -478,6 +488,11 @@ func TestMetricsReported(t *testing.T) {
 		metricskey.PodName:                "the-best-activator",
 		metricskey.ContainerName:          "activator",
 	}
+	metricstest.CheckLastValueData(t, "request_concurrency", wantTags, 3)
+
+	reportCh <- time.Now()
+	<-cr.statCh
+
 	metricstest.CheckLastValueData(t, "request_concurrency", wantTags, 4)
 }
 
@@ -525,13 +540,22 @@ func BenchmarkConcurrencyReporter(b *testing.B) {
 		}
 	}()
 
+	fake := fakeservingclient.Get(ctx)
+	revisions := fakerevisioninformer.Get(ctx)
+
 	// Spread the load across 100 revisions.
 	keys := make([]types.NamespacedName, 0, 100)
 	for i := 0; i < cap(keys); i++ {
-		keys = append(keys, types.NamespacedName{
+		key := types.NamespacedName{
 			Namespace: testNamespace,
 			Name:      testRevName + strconv.Itoa(i),
-		})
+		}
+		keys = append(keys, key)
+
+		// Create revisions in the fake clients to trigger report logic.
+		rev := revision(key.Namespace, key.Name)
+		fake.ServingV1().Revisions(rev.Namespace).Create(rev)
+		revisions.Informer().GetIndexer().Add(rev)
 	}
 
 	request := func(key types.NamespacedName) {
@@ -564,4 +588,54 @@ func BenchmarkConcurrencyReporter(b *testing.B) {
 			}
 		})
 	})
+}
+
+// BenchmarkConcurrencyReporterReport benchmarks the report function specifically
+// to get a feeling for how expensive it is as it'll lock the mutex and thus block
+// requests for the respective time too.
+func BenchmarkConcurrencyReporterReport(b *testing.B) {
+	for _, revs := range []int{1, 5, 10, 50, 100, 200} {
+		b.Run(fmt.Sprintf("revs-%d", revs), func(b *testing.B) {
+			ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(b)
+			defer cancel()
+
+			// Buffer equal to the activator.
+			statCh := make(chan []asmetrics.StatMessage)
+			cr := NewConcurrencyReporter(ctx, activatorPodName, statCh)
+
+			// Just read and ignore all stat messages.
+			go func() {
+				for {
+					select {
+					case <-statCh:
+					}
+				}
+			}()
+
+			fake := fakeservingclient.Get(ctx)
+			revisions := fakerevisioninformer.Get(ctx)
+			for i := 0; i < revs; i++ {
+				key := types.NamespacedName{
+					Namespace: testNamespace,
+					Name:      testRevName + strconv.Itoa(i),
+				}
+
+				// Create revisions in the fake clients to trigger report logic.
+				rev := revision(key.Namespace, key.Name)
+				fake.ServingV1().Revisions(rev.Namespace).Create(rev)
+				revisions.Informer().GetIndexer().Add(rev)
+
+				// Send a dummy request for reach revision to make sure it's reported.
+				cr.handleEvent(network.ReqEvent{
+					Time: time.Now(),
+					Type: network.ReqIn,
+					Key:  key,
+				})
+			}
+
+			for j := 0; j < b.N; j++ {
+				cr.report(time.Now())
+			}
+		})
+	}
 }

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -625,7 +625,7 @@ func BenchmarkConcurrencyReporterReport(b *testing.B) {
 				fake.ServingV1().Revisions(rev.Namespace).Create(rev)
 				revisions.Informer().GetIndexer().Add(rev)
 
-				// Send a dummy request for reach revision to make sure it's reported.
+				// Send a dummy request for each revision to make sure it's reported.
 				cr.handleEvent(network.ReqEvent{
 					Time: time.Now(),
 					Type: network.ReqIn,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This might be slightly controversial. As per the test change, the semantics of the stats reported via Prometheus slightly change in that if a scale from 0 request was part of the current reporting period, the prometheus metrics will actually contain the discounted metrics for 1 second. I figured that's not too harmful seeing as the performance gains to the report function are quite high and the scrape interval on prometheus endpoints is kinda low usually anyway, so the chance that anybody sees the wrong value is fairly low anyway.

## Benchmark before dropping the prometheus reporting from hot path

```
goos: linux
goarch: amd64
pkg: knative.dev/serving/pkg/activator/handler
BenchmarkConcurrencyReporterReport/revs-1-16         	  712749	      1623 ns/op	     960 B/op	      17 allocs/op
BenchmarkConcurrencyReporterReport/revs-5-16         	  156891	      7566 ns/op	    4576 B/op	      77 allocs/op
BenchmarkConcurrencyReporterReport/revs-10-16        	   79693	     14943 ns/op	    9105 B/op	     152 allocs/op
BenchmarkConcurrencyReporterReport/revs-50-16        	   15901	     76126 ns/op	   46385 B/op	     752 allocs/op
BenchmarkConcurrencyReporterReport/revs-100-16       	    6978	    152694 ns/op	   92706 B/op	    1502 allocs/op
BenchmarkConcurrencyReporterReport/revs-200-16       	    3963	    305022 ns/op	  188425 B/op	    3004 allocs/op
PASS
```

## Benchmark with the reporting dropped from hot path

```
goos: linux
goarch: amd64
pkg: knative.dev/serving/pkg/activator/handler
BenchmarkConcurrencyReporterReport/revs-1-16         	 4048651	       294 ns/op	     144 B/op	       2 allocs/op
BenchmarkConcurrencyReporterReport/revs-5-16         	 1632193	       728 ns/op	     496 B/op	       2 allocs/op
BenchmarkConcurrencyReporterReport/revs-10-16        	  918271	      1251 ns/op	     944 B/op	       2 allocs/op
BenchmarkConcurrencyReporterReport/revs-50-16        	  206355	      5550 ns/op	    4914 B/op	       2 allocs/op
BenchmarkConcurrencyReporterReport/revs-100-16       	  112792	     10861 ns/op	    9528 B/op	       2 allocs/op
BenchmarkConcurrencyReporterReport/revs-200-16       	   57441	     20658 ns/op	   18514 B/op	       2 allocs/op
PASS
```

## Compare

```
benchmark                                          old ns/op     new ns/op     delta
BenchmarkConcurrencyReporterReport/revs-1-16       1623          294           -81.89%
BenchmarkConcurrencyReporterReport/revs-5-16       7566          728           -90.38%
BenchmarkConcurrencyReporterReport/revs-10-16      14943         1251          -91.63%
BenchmarkConcurrencyReporterReport/revs-50-16      76126         5550          -92.71%
BenchmarkConcurrencyReporterReport/revs-100-16     152694        10861         -92.89%
BenchmarkConcurrencyReporterReport/revs-200-16     305022        20658         -93.23%

benchmark                                          old allocs     new allocs     delta
BenchmarkConcurrencyReporterReport/revs-1-16       17             2              -88.24%
BenchmarkConcurrencyReporterReport/revs-5-16       77             2              -97.40%
BenchmarkConcurrencyReporterReport/revs-10-16      152            2              -98.68%
BenchmarkConcurrencyReporterReport/revs-50-16      752            2              -99.73%
BenchmarkConcurrencyReporterReport/revs-100-16     1502           2              -99.87%
BenchmarkConcurrencyReporterReport/revs-200-16     3004           2              -99.93%

benchmark                                          old bytes     new bytes     delta
BenchmarkConcurrencyReporterReport/revs-1-16       960           144           -85.00%
BenchmarkConcurrencyReporterReport/revs-5-16       4576          496           -89.16%
BenchmarkConcurrencyReporterReport/revs-10-16      9105          944           -89.63%
BenchmarkConcurrencyReporterReport/revs-50-16      46385         4914          -89.41%
BenchmarkConcurrencyReporterReport/revs-100-16     92706         9528          -89.72%
BenchmarkConcurrencyReporterReport/revs-200-16     188425        18514         -90.17%
```

And yes: The prometheus stuff is **really** too expensive imo.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
