### PR TITLE
Remove duplicate helpers and simplify one

### DIFF
--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -272,7 +272,7 @@ func TestReconcile(t *testing.T) {
 				MarkRevisionReady, withObservedGeneration(1)),
 			pa("foo", "pa-not-ready",
 				WithPAStatusService("its-not-confidential"),
-				WithBufferedTraffic("Something", "This is something longer"),
+				WithBufferedTraffic,
 				WithReachabilityUnreachable),
 			readyDeploy(deploy(t, "foo", "pa-not-ready")),
 			image("foo", "pa-not-ready"),
@@ -283,7 +283,7 @@ func TestReconcile(t *testing.T) {
 				withK8sServiceName("its-not-confidential"),
 				// When we reconcile a ready state and our pa is in an activating
 				// state, we should see the following mutation.
-				MarkActivating("Something", "This is something longer"),
+				MarkActivating("Queued", "Requests to the target are being buffered as resources are provisioned."),
 				withObservedGeneration(1),
 			),
 		}},

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -118,10 +118,9 @@ func WithPAMetricsService(svc string) PodAutoscalerOption {
 
 // WithBufferedTraffic updates the PA to reflect that it has received
 // and buffered traffic while it is being activated.
-func WithBufferedTraffic(reason, message string) PodAutoscalerOption {
-	return func(pa *asv1a1.PodAutoscaler) {
-		pa.Status.MarkActivating(reason, message)
-	}
+func WithBufferedTraffic(pa *asv1a1.PodAutoscaler) {
+	pa.Status.MarkActivating("Queued",
+		"Requests to the target are being buffered as resources are provisioned.")
 }
 
 // WithNoTraffic updates the PA to reflect the fact that it is not


### PR DESCRIPTION
- there's only way this value is set right now, so let's make it simple
- remove duplicate helpers from kpa_test.go

/assign mattmoor @markusthoemmes 