### PR TITLE
Do not propagate the visibility label from Route

### DIFF
--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -112,11 +112,11 @@ func makeK8sService(ctx context.Context, route *v1.Route, targetName string) (*c
 				// This service is owned by the Route.
 				*kmeta.NewControllerRef(route),
 			},
-			Labels: kmeta.FilterMap(kmeta.UnionMaps(route.GetLabels(), svcLabels), func(key string) bool {
+			Labels: kmeta.UnionMaps(kmeta.FilterMap(route.GetLabels(), func(key string) bool {
 				// Do not propagate the visibility label from Route as users may want to set the label
 				// in the specific k8s svc for subroute. see https://github.com/knative/serving/pull/4560.
 				return key == serving.VisibilityLabelKey
-			}),
+			}), svcLabels),
 			Annotations: route.GetAnnotations(),
 		},
 	}, nil

--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -112,7 +112,11 @@ func makeK8sService(ctx context.Context, route *v1.Route, targetName string) (*c
 				// This service is owned by the Route.
 				*kmeta.NewControllerRef(route),
 			},
-			Labels:      kmeta.UnionMaps(route.GetLabels(), svcLabels),
+			Labels: kmeta.FilterMap(kmeta.UnionMaps(route.GetLabels(), svcLabels), func(key string) bool {
+				// Do not propagate the visibility label from Route as users may want to set the label
+				// in the specific k8s svc for subroute. see https://github.com/knative/serving/pull/4560.
+				return key == serving.VisibilityLabelKey
+			}),
 			Annotations: route.GetAnnotations(),
 		},
 	}, nil

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -293,8 +293,7 @@ func TestMakeK8sPlaceholderService(t *testing.T) {
 			SessionAffinity: corev1.ServiceAffinityNone,
 		},
 		expectedLabels: map[string]string{
-			serving.RouteLabelKey:      "test-route",
-			serving.VisibilityLabelKey: serving.VisibilityClusterLocal,
+			serving.RouteLabelKey: "test-route",
 		},
 	}}
 	for _, tt := range tests {


### PR DESCRIPTION
This patch stops propagating the visibility label from Route.

When users want to set visibility to a specific subroute, they want to
add the label to the specific k8s.
Hence, the label should not be propagated from the Route.

/lint

**Release Note**

```release-note
NONE
```
