### PR TITLE
Clear map rather than re-allocating

### DIFF
--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -158,7 +158,13 @@ func (cr *ConcurrencyReporter) report(now time.Time) []asmetrics.StatMessage {
 			},
 		})
 	}
-	cr.reportedFirstRequest = make(map[types.NamespacedName]float64)
+
+	// We've now accounted for any cases where we immediately reported seeing the
+	// first request for a revision in handleEvent by subtracting them from this
+	// report.
+	for k := range cr.reportedFirstRequest {
+		delete(cr.reportedFirstRequest, k)
+	}
 
 	return messages
 }


### PR DESCRIPTION
This is a pretty small little optimisation, but Report gets called every second so might as well remove a little allocation since it's equally clear either way (especially since we already have the benchmark handy now!). Go [optimises a straight map delete loop to a memclr](https://go-review.googlesource.com/c/go/+/110055/) under the covers, so it's more efficient than creating a whole new map each time anyway. This does mean the map memory won't ever shrink, but I don't think we'd want it to since we'd only have to re-expand it on the next load peak.

Benchmark comparison:

~~~~
BenchmarkConcurrencyReporterReport/revs-1-16       279           237           -15.05%
BenchmarkConcurrencyReporterReport/revs-5-16       617           544           -11.83%
BenchmarkConcurrencyReporterReport/revs-10-16      1036          987           -4.73%
BenchmarkConcurrencyReporterReport/revs-50-16      4370          4287          -1.90%
BenchmarkConcurrencyReporterReport/revs-100-16     8482          8363          -1.40%
BenchmarkConcurrencyReporterReport/revs-200-16     16773         16260         -3.06%

benchmark                                          old allocs     new allocs     delta
BenchmarkConcurrencyReporterReport/revs-1-16       2              1              -50.00%
BenchmarkConcurrencyReporterReport/revs-5-16       2              1              -50.00%
BenchmarkConcurrencyReporterReport/revs-10-16      2              1              -50.00%
BenchmarkConcurrencyReporterReport/revs-50-16      2              1              -50.00%
BenchmarkConcurrencyReporterReport/revs-100-16     2              1              -50.00%
BenchmarkConcurrencyReporterReport/revs-200-16     2              1              -50.00%

benchmark                                          old bytes     new bytes     delta
BenchmarkConcurrencyReporterReport/revs-1-16       144           96            -33.33%
BenchmarkConcurrencyReporterReport/revs-5-16       496           448           -9.68%
BenchmarkConcurrencyReporterReport/revs-10-16      944           896           -5.08%
BenchmarkConcurrencyReporterReport/revs-50-16      4913          4865          -0.98%
BenchmarkConcurrencyReporterReport/revs-100-16     9526          9479          -0.49%
BenchmarkConcurrencyReporterReport/revs-200-16     18507         18459         -0.26%
~~~~

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

/assign @markusthoemmes @vagababov 
