### PR TITLE
Remove usage of deprecated protobuf library.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/docker/cli v0.0.0-20200210162036-a4bedce16568 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/gogo/protobuf v1.3.1
-	github.com/golang/protobuf v1.4.2
 	github.com/google/go-cmp v0.5.1
 	github.com/google/go-containerregistry v0.1.2-0.20200717224239-a84993334b27
 	github.com/google/gofuzz v1.1.0

--- a/test/performance/benchmarks/dataplane-probe/continuous/sla.go
+++ b/test/performance/benchmarks/dataplane-probe/continuous/sla.go
@@ -20,24 +20,24 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	tpb "github.com/google/mako/clients/proto/analyzers/threshold_analyzer_go_proto"
 	mpb "github.com/google/mako/spec/proto/mako_go_proto"
 	vegeta "github.com/tsenart/vegeta/lib"
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/test/mako"
 )
 
 // This function constructs an analyzer that validates the p95 aggregate value of the given metric.
 func new95PercentileLatency(name, valueKey string, min, max time.Duration) *tpb.ThresholdAnalyzerInput {
 	return &tpb.ThresholdAnalyzerInput{
-		Name: proto.String(name),
+		Name: ptr.String(name),
 		Configs: []*tpb.ThresholdConfig{{
 			Min: bound(min),
 			Max: bound(max),
 			DataFilter: &mpb.DataFilter{
 				DataType:            mpb.DataFilter_METRIC_AGGREGATE_PERCENTILE.Enum(),
-				PercentileMilliRank: proto.Int32(95000),
-				ValueKey:            proto.String(valueKey),
+				PercentileMilliRank: ptr.Int32(95000),
+				ValueKey:            ptr.String(valueKey),
 			},
 		}},
 		CrossRunConfig: mako.NewCrossRunConfig(10),
@@ -182,5 +182,5 @@ var (
 // bound is a helper for making the inline SLOs more readable by expressing
 // them as durations.
 func bound(d time.Duration) *float64 {
-	return proto.Float64(d.Seconds())
+	return ptr.Float64(d.Seconds())
 }

--- a/test/performance/benchmarks/deployment-probe/continuous/sla.go
+++ b/test/performance/benchmarks/deployment-probe/continuous/sla.go
@@ -19,10 +19,10 @@ package main
 import (
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	tpb "github.com/google/mako/clients/proto/analyzers/threshold_analyzer_go_proto"
 	mpb "github.com/google/mako/spec/proto/mako_go_proto"
 
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/test/mako"
 )
 
@@ -30,14 +30,14 @@ import (
 // to 25 seconds.
 func newDeploy95PercentileLatency(tags ...string) *tpb.ThresholdAnalyzerInput {
 	return &tpb.ThresholdAnalyzerInput{
-		Name: proto.String("Deploy p95 latency"),
+		Name: ptr.String("Deploy p95 latency"),
 		Configs: []*tpb.ThresholdConfig{{
 			Min: bound(0 * time.Second),
 			Max: bound(25 * time.Second),
 			DataFilter: &mpb.DataFilter{
 				DataType:            mpb.DataFilter_METRIC_AGGREGATE_PERCENTILE.Enum(),
-				PercentileMilliRank: proto.Int32(95000),
-				ValueKey:            proto.String("dl"),
+				PercentileMilliRank: ptr.Int32(95000),
+				ValueKey:            ptr.String("dl"),
 			},
 		}},
 		CrossRunConfig: mako.NewCrossRunConfig(10, tags...),
@@ -50,13 +50,13 @@ func newDeploy95PercentileLatency(tags ...string) *tpb.ThresholdAnalyzerInput {
 // handful of the trailing deployments, so we relax this to 410.
 func newReadyDeploymentCount(tags ...string) *tpb.ThresholdAnalyzerInput {
 	return &tpb.ThresholdAnalyzerInput{
-		Name: proto.String("Ready deployment count"),
+		Name: ptr.String("Ready deployment count"),
 		Configs: []*tpb.ThresholdConfig{{
-			Min: proto.Float64(410),
-			Max: proto.Float64(420),
+			Min: ptr.Float64(410),
+			Max: ptr.Float64(420),
 			DataFilter: &mpb.DataFilter{
 				DataType: mpb.DataFilter_METRIC_AGGREGATE_COUNT.Enum(),
-				ValueKey: proto.String("dl"),
+				ValueKey: ptr.String("dl"),
 			},
 		}},
 		CrossRunConfig: mako.NewCrossRunConfig(10, tags...),
@@ -66,5 +66,5 @@ func newReadyDeploymentCount(tags ...string) *tpb.ThresholdAnalyzerInput {
 // bound is a helper for making the inline SLOs more readable by expressing
 // them as durations.
 func bound(d time.Duration) *float64 {
-	return proto.Float64(d.Seconds())
+	return ptr.Float64(d.Seconds())
 }

--- a/test/performance/benchmarks/load-test/continuous/sla.go
+++ b/test/performance/benchmarks/load-test/continuous/sla.go
@@ -19,9 +19,9 @@ package main
 import (
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	tpb "github.com/google/mako/clients/proto/analyzers/threshold_analyzer_go_proto"
 	mpb "github.com/google/mako/spec/proto/mako_go_proto"
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/test/mako"
 )
 
@@ -30,14 +30,14 @@ import (
 // state (once the autoscaling decisions have leveled off).
 func newLoadTest95PercentileLatency(tags ...string) *tpb.ThresholdAnalyzerInput {
 	return &tpb.ThresholdAnalyzerInput{
-		Name: proto.String("95p latency"),
+		Name: ptr.String("95p latency"),
 		Configs: []*tpb.ThresholdConfig{{
 			Min: bound(100 * time.Millisecond),
 			Max: bound(115 * time.Millisecond),
 			DataFilter: &mpb.DataFilter{
 				DataType:            mpb.DataFilter_METRIC_AGGREGATE_PERCENTILE.Enum(),
-				PercentileMilliRank: proto.Int32(95000),
-				ValueKey:            proto.String("l"),
+				PercentileMilliRank: ptr.Int32(95000),
+				ValueKey:            ptr.String("l"),
 			},
 		}},
 		CrossRunConfig: mako.NewCrossRunConfig(10, tags...),
@@ -50,13 +50,13 @@ func newLoadTest95PercentileLatency(tags ...string) *tpb.ThresholdAnalyzerInput 
 // of non-cold-start overload requests.
 func newLoadTestMaximumLatency(tags ...string) *tpb.ThresholdAnalyzerInput {
 	return &tpb.ThresholdAnalyzerInput{
-		Name: proto.String("Maximum latency"),
+		Name: ptr.String("Maximum latency"),
 		Configs: []*tpb.ThresholdConfig{{
 			Min: bound(100 * time.Millisecond),
 			Max: bound(100*time.Millisecond + 10*time.Second),
 			DataFilter: &mpb.DataFilter{
 				DataType: mpb.DataFilter_METRIC_AGGREGATE_MAX.Enum(),
-				ValueKey: proto.String("l"),
+				ValueKey: ptr.String("l"),
 			},
 		}},
 		CrossRunConfig: mako.NewCrossRunConfig(10, tags...),
@@ -67,12 +67,12 @@ func newLoadTestMaximumLatency(tags ...string) *tpb.ThresholdAnalyzerInput {
 // stepped burst is 0.
 func newLoadTestMaximumErrorRate(tags ...string) *tpb.ThresholdAnalyzerInput {
 	return &tpb.ThresholdAnalyzerInput{
-		Name: proto.String("Mean error rate"),
+		Name: ptr.String("Mean error rate"),
 		Configs: []*tpb.ThresholdConfig{{
-			Max: proto.Float64(0),
+			Max: ptr.Float64(0),
 			DataFilter: &mpb.DataFilter{
 				DataType: mpb.DataFilter_METRIC_AGGREGATE_MEAN.Enum(),
-				ValueKey: proto.String("es"),
+				ValueKey: ptr.String("es"),
 			},
 		}},
 		CrossRunConfig: mako.NewCrossRunConfig(10, tags...),
@@ -82,5 +82,5 @@ func newLoadTestMaximumErrorRate(tags ...string) *tpb.ThresholdAnalyzerInput {
 // bound is a helper for making the inline SLOs more readable by expressing
 // them as durations.
 func bound(d time.Duration) *float64 {
-	return proto.Float64(d.Seconds())
+	return ptr.Float64(d.Seconds())
 }

--- a/test/performance/benchmarks/rollout-probe/continuous/sla.go
+++ b/test/performance/benchmarks/rollout-probe/continuous/sla.go
@@ -20,24 +20,24 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	tpb "github.com/google/mako/clients/proto/analyzers/threshold_analyzer_go_proto"
 	mpb "github.com/google/mako/spec/proto/mako_go_proto"
 	vegeta "github.com/tsenart/vegeta/lib"
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/test/mako"
 )
 
 // This function constructs an analyzer that validates the p95 aggregate value of the given metric.
 func new95PercentileLatency(name, valueKey string, min, max time.Duration) *tpb.ThresholdAnalyzerInput {
 	return &tpb.ThresholdAnalyzerInput{
-		Name: proto.String(name),
+		Name: ptr.String(name),
 		Configs: []*tpb.ThresholdConfig{{
 			Min: bound(min),
 			Max: bound(max),
 			DataFilter: &mpb.DataFilter{
 				DataType:            mpb.DataFilter_METRIC_AGGREGATE_PERCENTILE.Enum(),
-				PercentileMilliRank: proto.Int32(95000),
-				ValueKey:            proto.String(valueKey),
+				PercentileMilliRank: ptr.Int32(95000),
+				ValueKey:            ptr.String(valueKey),
 			},
 		}},
 		CrossRunConfig: mako.NewCrossRunConfig(10),
@@ -108,5 +108,5 @@ var (
 // bound is a helper for making the inline SLOs more readable by expressing
 // them as durations.
 func bound(d time.Duration) *float64 {
-	return proto.Float64(d.Seconds())
+	return ptr.Float64(d.Seconds())
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -149,7 +149,6 @@ github.com/golang/glog
 # github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 github.com/golang/groupcache/lru
 # github.com/golang/protobuf v1.4.2
-## explicit
 github.com/golang/protobuf/descriptor
 github.com/golang/protobuf/internal/gengogrpc
 github.com/golang/protobuf/jsonpb


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

The library was used to just generated pointers here anyway. We've got our own helpers to do that, so why not just avoid the dependency altogether?

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
