### PR TITLE
PodSpec dry-run for unparented Configurations

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -77,12 +77,18 @@ var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 }
 
 var serviceValidation = validation.NewCallback(
-	extravalidation.ValidateRevisionTemplate, webhook.Create, webhook.Update)
+	extravalidation.ValidateService, webhook.Create, webhook.Update)
+
+var configValidation = validation.NewCallback(
+	extravalidation.ValidateConfiguration, webhook.Create, webhook.Update)
 
 var callbacks = map[schema.GroupVersionKind]validation.Callback{
-	servingv1alpha1.SchemeGroupVersion.WithKind("Service"): serviceValidation,
-	servingv1beta1.SchemeGroupVersion.WithKind("Service"):  serviceValidation,
-	servingv1.SchemeGroupVersion.WithKind("Service"):       serviceValidation,
+	servingv1alpha1.SchemeGroupVersion.WithKind("Service"):       serviceValidation,
+	servingv1beta1.SchemeGroupVersion.WithKind("Service"):        serviceValidation,
+	servingv1.SchemeGroupVersion.WithKind("Service"):             serviceValidation,
+	servingv1alpha1.SchemeGroupVersion.WithKind("Configuration"): configValidation,
+	servingv1beta1.SchemeGroupVersion.WithKind("Configuration"):  configValidation,
+	servingv1.SchemeGroupVersion.WithKind("Configuration"):       configValidation,
 }
 
 func newDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {

--- a/pkg/webhook/validate_unstructured.go
+++ b/pkg/webhook/validate_unstructured.go
@@ -26,6 +26,7 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	"knative.dev/serving/pkg/apis/config"
+	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -43,8 +44,22 @@ const (
 	DryRunStrict DryRunMode = "strict"
 )
 
-// ValidateRevisionTemplate runs extra validation on Service resources
-func ValidateRevisionTemplate(ctx context.Context, uns *unstructured.Unstructured) error {
+// ValidateService runs extra validation on Service resources
+func ValidateService(ctx context.Context, uns *unstructured.Unstructured) error {
+	return validateRevisionTemplate(ctx, uns)
+}
+
+// ValidateConfiguration runs extra validation on Configurationresources
+func ValidateConfiguration(ctx context.Context, uns *unstructured.Unstructured) error {
+	// If owned by a service, skip validation for Configuration.
+	if uns.GetLabels()[serving.ServiceLabelKey] != "" {
+		return nil
+	}
+
+	return validateRevisionTemplate(ctx, uns)
+}
+
+func validateRevisionTemplate(ctx context.Context, uns *unstructured.Unstructured) error {
 	content := uns.UnstructuredContent()
 
 	var mode DryRunMode

--- a/pkg/webhook/validate_unstructured.go
+++ b/pkg/webhook/validate_unstructured.go
@@ -49,7 +49,7 @@ func ValidateService(ctx context.Context, uns *unstructured.Unstructured) error 
 	return validateRevisionTemplate(ctx, uns)
 }
 
-// ValidateConfiguration runs extra validation on Configurationresources
+// ValidateConfiguration runs extra validation on Configuration resources
 func ValidateConfiguration(ctx context.Context, uns *unstructured.Unstructured) error {
 	// If owned by a service, skip validation for Configuration.
 	if uns.GetLabels()[serving.ServiceLabelKey] != "" {

--- a/pkg/webhook/validate_unstructured_test.go
+++ b/pkg/webhook/validate_unstructured_test.go
@@ -45,7 +45,7 @@ var (
 	}
 )
 
-func TestServiceValidation(t *testing.T) {
+func TestUnstructuredValidation(t *testing.T) {
 	newCreateWithOptions = newTestPods
 
 	tests := []struct {
@@ -104,7 +104,7 @@ func TestServiceValidation(t *testing.T) {
 			unstruct := &unstructured.Unstructured{}
 			unstruct.SetUnstructuredContent(test.data)
 
-			got := ValidateRevisionTemplate(ctx, unstruct)
+			got := ValidateService(ctx, unstruct)
 			if got == nil {
 				if test.want != "" {
 					t.Errorf("Validate got=nil, want=%q", test.want)
@@ -150,7 +150,7 @@ func TestDryRunFeatureFlag(t *testing.T) {
 			unstruct := &unstructured.Unstructured{}
 			unstruct.SetUnstructuredContent(data)
 
-			got := ValidateRevisionTemplate(ctx, unstruct)
+			got := ValidateService(ctx, unstruct)
 			if got == nil {
 				if test.want != "" {
 					t.Errorf("Validate got=nil, want=%q", test.want)
@@ -219,7 +219,7 @@ func TestSkipUpdate(t *testing.T) {
 			unstruct := &unstructured.Unstructured{}
 			unstruct.SetUnstructuredContent(test.new)
 
-			got := ValidateRevisionTemplate(ctx, unstruct)
+			got := ValidateService(ctx, unstruct)
 			if got == nil {
 				if test.want != "" {
 					t.Errorf("Validate got=nil, want=%q", test.want)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/8730

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* If a Configuration has no parent Service, we apply dry-run on PodSpec during validation

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
PodSpec DryRun also validates unparented (service-less) Configurations 
```
