### PR TITLE
Tidy up globals and generally clean up throttler

### DIFF
--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -129,10 +129,10 @@ func TestThrottlerUpdateCapacity(t *testing.T) {
 		t.Errorf("Capacity = %d, want: %d", got, want)
 	}
 
-	// shouldn't really happen since queue.MaxBreakerCapacity is very, very large,
+	// shouldn't really happen since revisionMaxConcurrency is very, very large,
 	// but check that we behave reasonably if it's exceeded.
-	capacity := rt.calculateCapacity(queue.MaxBreakerCapacity+5, 1, queue.MaxBreakerCapacity)
-	if got, want := capacity, queue.MaxBreakerCapacity; got != want {
+	capacity := rt.calculateCapacity(revisionMaxConcurrency+5, 1)
+	if got, want := capacity, revisionMaxConcurrency; got != want {
 		t.Errorf("calculateCapacity = %d, want: %d", got, want)
 	}
 


### PR DESCRIPTION
Got rid of the `revisionBreakerParams` global (which was confusingly shadowed in the constructor but used directly as a global elsewhere).

Also, updated comments a bit and gave the tests a bit of a scrub:

 - removed the defer cleanups in the tests which are no longer needed since the global `revisionBreakerParams` is gone.
 - updated `updateCapacity` test to test capacity with `infiniteBreaker` in place when CC=0 to match actual reality and behaviour in this case.
 - out of an abundance of caution, test exceeding `MaxBreakerCapacity` via `calculateCapacity` since we can no longer directly lower the global to a reasonable value to test this via `updateCapacity` (in practice this case can't really occur any more anyway 🤷🏼).
 - used e.g. 10*10 rather than just 100 in a couple of places in `TestUpdateCapacity` where (I think) that explains the logic of the test a little bit better.
 - renamed `defaultParams` to `testBreakerParams` since the `defaultParams`, slightly confusingly, do not actually represent the defaults in the code.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

/assign @vagababov @markusthoemmes @taragu 

