### PR TITLE
Fix a few little nits in kpa test

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -186,11 +186,6 @@ func (pas *PodAutoscalerStatus) MarkScaleTargetInitialized() {
 	podCondSet.Manage(pas).MarkTrue(PodAutoscalerConditionScaleTargetInitialized)
 }
 
-// IsSKSReady returns true if the PodAutoscaler's SKS is ready.
-func (pas *PodAutoscalerStatus) IsSKSReady() bool {
-	return pas.GetCondition(PodAutoscalerSKSReady).IsTrue()
-}
-
 // MarkSKSReady marks the PA condition denoting that SKS is ready.
 func (pas *PodAutoscalerStatus) MarkSKSReady() {
 	podCondSet.Manage(pas).MarkTrue(PodAutoscalerSKSReady)

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -186,7 +186,7 @@ func (pas *PodAutoscalerStatus) MarkScaleTargetInitialized() {
 	podCondSet.Manage(pas).MarkTrue(PodAutoscalerConditionScaleTargetInitialized)
 }
 
-// IsSKSReady returns true if the PA condition denoting that SKS is ready.
+// IsSKSReady returns true if the PodAutoscaler's SKS is ready.
 func (pas *PodAutoscalerStatus) IsSKSReady() bool {
 	return pas.GetCondition(PodAutoscalerSKSReady).IsTrue()
 }

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -1212,18 +1212,3 @@ func TestIsScaleTargetInitialized(t *testing.T) {
 		t.Errorf("after marking initially active: got: %v, want: %v", got, want)
 	}
 }
-
-func TestIsSKSReady(t *testing.T) {
-	p := PodAutoscaler{}
-	if got, want := p.Status.IsSKSReady(), false; got != want {
-		t.Errorf("before marking SKS ready: got: %v, want: %v", got, want)
-	}
-	p.Status.MarkSKSReady()
-	if got, want := p.Status.IsSKSReady(), true; got != want {
-		t.Errorf("after marking SKS ready: got: %v, want: %v", got, want)
-	}
-	p.Status.MarkSKSNotReady("not ready")
-	if got, want := p.Status.IsSKSReady(), false; got != want {
-		t.Errorf("after marking SKS not ready: got: %v, want: %v", got, want)
-	}
-}


### PR DESCRIPTION
 - Comment fix for grammar.
 - Rename `initialScaleZeroConfigMap() -> initialScaleZeroASConfig()` for
 consistency with `defaultConfig()` (and bc this returns a `Config` not a config map :)).
 - Remove `metricWithASConfig()` since it's not needed any more.
 - Use `struct{}` context keys for both `asConfigKey` and `deciderKey` for consistency. 
 - Since context keys work via == tests, the structs need to be typed (anonymous empty structs are == to each other), so use as `deciderKey{}`, `asConfigKey{}`.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

/assign @vagababov @taragu

