### PR TITLE
[master] Update net-certmanager nightly

### DIFF
--- a/third_party/cert-manager-0.12.0/net-certmanager.yaml
+++ b/third_party/cert-manager-0.12.0/net-certmanager.yaml
@@ -18,7 +18,7 @@ metadata:
   # These are the permissions needed by the `cert-manager` `Certificate` implementation.
   name: knative-serving-certmanager
   labels:
-    serving.knative.dev/release: "v20200727-2db31aa"
+    serving.knative.dev/release: "v20200804-9aa1fe7"
     serving.knative.dev/controller: "true"
     networking.knative.dev/certificate-provider: cert-manager
 rules:
@@ -49,7 +49,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.net-certmanager.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v20200727-2db31aa"
+    serving.knative.dev/release: "v20200804-9aa1fe7"
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -86,7 +86,7 @@ metadata:
   name: net-certmanager-webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200727-2db31aa"
+    serving.knative.dev/release: "v20200804-9aa1fe7"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -109,7 +109,7 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200727-2db31aa"
+    serving.knative.dev/release: "v20200804-9aa1fe7"
     networking.knative.dev/certificate-provider: cert-manager
 data:
   _example: |
@@ -156,7 +156,7 @@ metadata:
   name: networking-certmanager
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200727-2db31aa"
+    serving.knative.dev/release: "v20200804-9aa1fe7"
     networking.knative.dev/certificate-provider: cert-manager
 spec:
   selector:
@@ -168,14 +168,14 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: networking-certmanager
-        serving.knative.dev/release: "v20200727-2db31aa"
+        serving.knative.dev/release: "v20200804-9aa1fe7"
     spec:
       serviceAccountName: controller
       containers:
       - name: networking-certmanager
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/controller@sha256:af969f13741e49b5805941685c87bacf558028a30ad1426e54b408cf2e641730
+        image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/controller@sha256:45ac4b3137007a040f7b41f88e91fd0b7ac650f3a1c8c0e6e1c498858285863f
         resources:
           requests:
             cpu: 30m
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   labels:
     app: networking-certmanager
-    serving.knative.dev/release: "v20200727-2db31aa"
+    serving.knative.dev/release: "v20200804-9aa1fe7"
     networking.knative.dev/certificate-provider: cert-manager
   name: networking-certmanager
   namespace: knative-serving
@@ -245,7 +245,7 @@ metadata:
   name: net-certmanager-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200727-2db31aa"
+    serving.knative.dev/release: "v20200804-9aa1fe7"
 spec:
   selector:
     matchLabels:
@@ -258,14 +258,14 @@ spec:
       labels:
         app: net-certmanager-webhook
         role: net-certmanager-webhook
-        serving.knative.dev/release: "v20200727-2db31aa"
+        serving.knative.dev/release: "v20200804-9aa1fe7"
     spec:
       serviceAccountName: controller
       containers:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/webhook@sha256:4f2999810ce81b12da4c8ec358a7832e59377a5b00009f9b96152c138f5206d7
+        image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/webhook@sha256:5161e5d064390c6418d83118721be491044e29024f297912edb96c2bf19b0c39
         resources:
           requests:
             cpu: 20m
@@ -319,7 +319,7 @@ metadata:
   namespace: knative-serving
   labels:
     role: net-certmanager-webhook
-    serving.knative.dev/release: "v20200727-2db31aa"
+    serving.knative.dev/release: "v20200804-9aa1fe7"
 spec:
   ports:
   - # Define metrics and profiling for them to be accessible within service meshes.


### PR DESCRIPTION
<!--[master] Update net-certmanager nightly-->
<!---->
Produced via:
  `curl https://storage.googleapis.com/knative-nightly/net-certmanager/latest/$x > /workspace/source/./third_party/cert-manager-0.12.0/$x`
/assign tcnghia ZhiminXiang
/cc tcnghia ZhiminXiang
/test pull-knative-serving-autotls-tests
