### PR TITLE
move dry-run back to allowed

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -60,7 +60,7 @@ data:
     # When "allowed", the server will not run the dry-run validation by default.
     #   However, clients may enable the behavior on an individual Service by
     #   attaching the following metadata annotation: "features.knative.dev/podspec-dryrun":"enabled".
-    kubernetes.podspec-dryrun: "enabled"
+    kubernetes.podspec-dryrun: "allowed"
 
     # Indicates whether new responsive garbage collection is enabled. This
     # feature labels revisions in real-time as they become referenced and

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "ba0dd46d"
+    knative.dev/example-checksum: "ab930d35"
 data:
   _example: |
     ################################

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -43,7 +43,7 @@ func defaultFeaturesConfig() *Features {
 		MultiContainer:       Disabled,
 		PodSpecAffinity:      Disabled,
 		PodSpecFieldRef:      Disabled,
-		PodSpecDryRun:        Enabled,
+		PodSpecDryRun:        Allowed,
 		PodSpecNodeSelector:  Disabled,
 		PodSpecTolerations:   Disabled,
 		ResponsiveRevisionGC: Disabled,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Issue https://github.com/knative/pkg/issues/1509

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Move PodSpec Dry Run back to allowed. Will not be run by default while EOF webhook errors are investigated.
