### PR TITLE
Pod random shuffle for scraping, pt I

### DIFF
--- a/pkg/resources/pods.go
+++ b/pkg/resources/pods.go
@@ -104,7 +104,7 @@ func (pa PodAccessor) NotReadyCount() (int, error) {
 type PodFilter func(p *corev1.Pod) bool
 
 // PodTransformer provides a way to do something with the pod
-// that has been selected by the filters.
+// that has been selected by all the filters.
 // For example pod transformer may extract a field and store it in
 // internal state.
 type PodTransformer func(p *corev1.Pod)


### PR DESCRIPTION
In this first part of pod random shuffling, we are introducing pod filters and transformers
that permit apply various filtering and final transformation to the pod list.
The current get pod IPs by age is simply re-implemented using this new construct (covering all the testing).

In part II, we will be introducing a possibility to cutoff young pods, if possible, and then random shuffling
the rest, rather than sorting them to increase diversity of pods scraped in the metric collector.

/assign @julz @yanweiguo  @markusthoemmes 