### PR TITLE
Tidy up queue stat reporting a bit

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -435,9 +435,9 @@ func buildMetricsServer(promStatReporter *queue.PrometheusStatsReporter, protobu
 func metricsHTTPHandler(promStatReporter *queue.PrometheusStatsReporter, protobufStatReporter *queue.ProtobufStatsReporter) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.Header.Get("Accept"), network.ProtoAcceptContent) {
-			protobufStatReporter.Handler().ServeHTTP(w, r)
+			protobufStatReporter.ServeHTTP(w, r)
 		} else {
-			promStatReporter.Handler().ServeHTTP(w, r)
+			promStatReporter.ServeHTTP(w, r)
 		}
 	})
 }

--- a/pkg/queue/prometheus_stats_reporter.go
+++ b/pkg/queue/prometheus_stats_reporter.go
@@ -69,9 +69,12 @@ func newGV(n, h string) *prometheus.GaugeVec {
 
 // PrometheusStatsReporter structure represents a prometheus stats reporter.
 type PrometheusStatsReporter struct {
-	handler         http.Handler
-	reportingPeriod time.Duration
-	startTime       time.Time
+	handler   http.Handler
+	startTime time.Time
+
+	// RequestsPerSecond and ProxiedRequestsPerSecond need to be divided by the
+	// reporting period they were collected over to get a "per-second" value.
+	reportingPeriodSeconds float64
 
 	requestsPerSecond                prometheus.Gauge
 	proxiedRequestsPerSecond         prometheus.Gauge
@@ -113,9 +116,10 @@ func NewPrometheusStatsReporter(namespace, config, revision, pod string, reporti
 	}
 
 	return &PrometheusStatsReporter{
-		handler:         promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
-		reportingPeriod: reportingPeriod,
-		startTime:       time.Now(),
+		handler:   promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
+		startTime: time.Now(),
+
+		reportingPeriodSeconds: reportingPeriod.Seconds(),
 
 		requestsPerSecond:                requestsPerSecondGV.With(labels),
 		proxiedRequestsPerSecond:         proxiedRequestsPerSecondGV.With(labels),
@@ -128,16 +132,14 @@ func NewPrometheusStatsReporter(namespace, config, revision, pod string, reporti
 // Report captures request metrics.
 func (r *PrometheusStatsReporter) Report(stats network.RequestStatsReport) {
 	// Requests per second is a rate over time while concurrency is not.
-	rp := r.reportingPeriod.Seconds()
-	r.requestsPerSecond.Set(stats.RequestCount / rp)
-	r.proxiedRequestsPerSecond.Set(stats.ProxiedRequestCount / rp)
+	r.requestsPerSecond.Set(stats.RequestCount / r.reportingPeriodSeconds)
+	r.proxiedRequestsPerSecond.Set(stats.ProxiedRequestCount / r.reportingPeriodSeconds)
 	r.averageConcurrentRequests.Set(stats.AverageConcurrency)
 	r.averageProxiedConcurrentRequests.Set(stats.AverageProxiedConcurrency)
 	r.processUptime.Set(time.Since(r.startTime).Seconds())
 }
 
-// Handler returns an uninstrumented http.Handler used to serve stats registered by this
-// PrometheusStatsReporter.
-func (r *PrometheusStatsReporter) Handler() http.Handler {
-	return r.handler
+// ServeHTTP serves the stats in prometheus format over HTTP.
+func (r *PrometheusStatsReporter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	r.handler.ServeHTTP(w, req)
 }

--- a/pkg/queue/protobuf_stats_reporter_test.go
+++ b/pkg/queue/protobuf_stats_reporter_test.go
@@ -72,10 +72,10 @@ func TestProtoHandler(t *testing.T) {
 	}, {
 		name: "Metrics available",
 		reporter: ProtobufStatsReporter{
-			reportingPeriod: time.Duration(1),
-			startTime:       time.Now(),
-			stat:            metricsStat,
-			podName:         "testPod"},
+			reportingPeriodSeconds: 1,
+			startTime:              time.Now(),
+			stat:                   metricsStat,
+			podName:                "testPod"},
 	}}
 
 	for _, test := range tests {
@@ -85,8 +85,7 @@ func TestProtoHandler(t *testing.T) {
 				t.Fatal(err)
 			}
 			rr := httptest.NewRecorder()
-			handler := test.reporter.Handler()
-			handler.ServeHTTP(rr, req)
+			test.reporter.ServeHTTP(rr, req)
 			if test.errorMsg != "" { // error case
 				expected := test.errorMsg + "\n"
 				if status := rr.Code; status != http.StatusInternalServerError {


### PR DESCRIPTION
Various small improvements.

 - Update comment which was referring to RequestsPerSecond (the prometheus gauge name) rather than RequestCount (the protobuf field name).
 - Calculate reportingPeriodSeconds up-front rather than on every Report.
 - Drop intermediate Handler()s and related closure and just implement ServeHTTP directly.
 - Drop explicit creation of atomic.Value{} since zero-value is fine.

/assign @markusthoemmes @vagababov 

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

