### PR TITLE
Move queue metrics handler in to its own file and add tests

### DIFF
--- a/pkg/queue/stats_handler.go
+++ b/pkg/queue/stats_handler.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"net/http"
+	"strings"
+
+	"knative.dev/serving/pkg/network"
+)
+
+type statsHandler struct {
+	prom  http.Handler
+	proto http.Handler
+}
+
+// NewStatsHandler returns a new StatHandler.
+func NewStatsHandler(prom, proto http.Handler) http.Handler {
+	return &statsHandler{
+		prom:  prom,
+		proto: proto,
+	}
+}
+
+// ServeHTTP serves the stats over HTTP. Either protobuf or prometheus stats
+// are served, depending on the Accept header.
+func (reporter *statsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.Contains(r.Header.Get("Accept"), network.ProtoAcceptContent) {
+		reporter.proto.ServeHTTP(w, r)
+	} else {
+		reporter.prom.ServeHTTP(w, r)
+	}
+}

--- a/pkg/queue/stats_handler_test.go
+++ b/pkg/queue/stats_handler_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"knative.dev/serving/pkg/network"
+)
+
+func TestStatsHandler(t *testing.T) {
+	prom := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("served-by", "prometheus")
+	})
+
+	proto := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("served-by", "protobuf")
+	})
+
+	reporter := NewStatsHandler(prom, proto)
+
+	tests := []struct {
+		name    string
+		headers http.Header
+		expect  string
+	}{{
+		name:   "no headers",
+		expect: "prometheus",
+	}, {
+		name: "some other accept header",
+		headers: http.Header{
+			"Accept": []string{"something-else"},
+		},
+		expect: "prometheus",
+	}, {
+		name: "protobuf in second Accept header still serves prometheus",
+		headers: http.Header{
+			"Accept": []string{"", network.ProtoAcceptContent},
+		},
+		expect: "prometheus",
+	}, {
+		name: "protobuf accept header",
+		headers: http.Header{
+			"Accept": []string{network.ProtoAcceptContent},
+		},
+		expect: "protobuf",
+	}, {
+		name: "protobuf accept header as part of CSV",
+		headers: http.Header{
+			"Accept": []string{"something/else, application/protobuf"},
+		},
+		expect: "protobuf",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+			r.Header = test.headers
+
+			w := httptest.NewRecorder()
+			reporter.ServeHTTP(w, r)
+
+			if got, want := w.Header().Get("served-by"), test.expect; got != want {
+				t.Errorf("Expected to be served %s but was served %s", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Spun out of https://github.com/knative/serving/pull/8864. Might end up redundant if we drop the prometheus stat serving, but no harm having it extracted and tested in the mean-time.

/assign @vagababov @yanweiguo 
