### PR TITLE
Test Protobuf HTTP Handler directly and remove error case

### DIFF
--- a/pkg/queue/protobuf_stats_reporter_test.go
+++ b/pkg/queue/protobuf_stats_reporter_test.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -45,7 +44,7 @@ func TestProtobufStatsReporterReport(t *testing.T) {
 			// Make the value slightly more interesting, rather than microseconds.
 			reporter.startTime = reporter.startTime.Add(-5 * time.Second)
 			reporter.Report(test.report)
-			got := reporter.stat.Load().(metrics.Stat)
+			got := scrapeProtobufStat(t, reporter)
 			test.want.PodName = pod
 			if !cmp.Equal(test.want, got, ignoreStatFields) {
 				t.Errorf("Scraped stat mismatch; diff(-want,+got):\n%s", cmp.Diff(test.want, got))
@@ -57,59 +56,38 @@ func TestProtobufStatsReporterReport(t *testing.T) {
 	}
 }
 
-func TestProtoHandler(t *testing.T) {
-	metricsStat := atomic.Value{}
-	metricsStat.Store(testStat)
-
-	tests := []struct {
-		name     string
-		reporter ProtobufStatsReporter
-		errorMsg string
-	}{{
-		name:     "No metrics available",
-		reporter: ProtobufStatsReporter{},
-		errorMsg: "An error has occurred while serving metrics:\n\nno metrics available yet",
-	}, {
-		name: "Metrics available",
-		reporter: ProtobufStatsReporter{
-			reportingPeriodSeconds: 1,
-			startTime:              time.Now(),
-			stat:                   metricsStat,
-			podName:                "testPod"},
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-			rr := httptest.NewRecorder()
-			test.reporter.ServeHTTP(rr, req)
-			if test.errorMsg != "" { // error case
-				expected := test.errorMsg + "\n"
-				if status := rr.Code; status != http.StatusInternalServerError {
-					t.Errorf("StatusCode = %d want %d",
-						status, http.StatusInternalServerError)
-				}
-				if rr.Body.String() != expected {
-					t.Errorf("Body = %q want %q",
-						rr.Body.String(), expected)
-				}
-			} else { // good case, data received
-				bodyBytes, err := ioutil.ReadAll(rr.Body)
-				if err != nil {
-					t.Errorf("Reading body failed: %v", err)
-				}
-				stat := metrics.Stat{}
-				err = stat.Unmarshal(bodyBytes)
-				if err != nil {
-					t.Errorf("Unmarshalling failed: %v", err)
-				}
-				if diff := cmp.Diff(stat, testStat); diff != "" {
-					t.Errorf("Handler returned wrong stat data: (-want, +got):\n%v", diff)
-				}
-			}
-		})
+func TestInitialProtobufStateValid(t *testing.T) {
+	r := NewProtobufStatsReporter(pod, 1*time.Second)
+	emptyStat := metrics.Stat{
+		PodName: pod,
 	}
+
+	// test that scraping before we called Report returns an empty
+	// stat rather than an error. We don't want to accidentally fall
+	// back to mesh mode or something if we manage to scrape too early.
+	got := scrapeProtobufStat(t, r)
+	if !cmp.Equal(emptyStat, got) {
+		t.Errorf("Scraped stat mismatch; diff(-want,+got):\n%s", cmp.Diff(emptyStat, got))
+	}
+}
+
+func scrapeProtobufStat(t *testing.T, r *ProtobufStatsReporter) metrics.Stat {
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, nil)
+	result := w.Result()
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("Expected ServeHTTP status %d but was %d", http.StatusOK, result.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(result.Body)
+	if err != nil {
+		t.Fatal("Expected Read to succeed, got", err)
+	}
+
+	var stat metrics.Stat
+	if err := stat.Unmarshal(b); err != nil {
+		t.Fatal("Expected Unmarshal to succeed, got", err)
+	}
+
+	return stat
 }


### PR DESCRIPTION
Make tests in protobuf_stats_reporter test via the HTTP handler rather than relying on reading the internal atomic.Value. 

Also, set an initial value for the atomic so we don't have to check for nils in ServeHTTP (which avoids a very small edge case where we return an error if we scrape before stats have been reported, and matches the prometheus path).

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

/assign @vagababov @yanweiguo 
