### PR TITLE
Replace MTP with a fake clock and k8s utility clock

### DIFF
--- a/pkg/autoscaler/fake/fakes.go
+++ b/pkg/autoscaler/fake/fakes.go
@@ -39,15 +39,18 @@ func (mtp *ManualTickProvider) NewTicker(time.Duration) *time.Ticker {
 func (mtp *ManualTickProvider) C() <-chan time.Time {
 	return mtp.Channel
 }
+
+// Stop is nonce here.
 func (mtp *ManualTickProvider) Stop() {}
 
-// FakeClock is K8s clock.FakeClock but it overrides tick provider
+// Clock is K8s clock.Clock but it overrides tick provider
 // with ManualTickProvider above.
-type FakeClock struct {
+type Clock struct {
 	*clock.FakeClock
 	TP *ManualTickProvider
 }
 
-func (fc FakeClock) NewTicker(time.Duration) clock.Ticker {
+// NewTicker returns a NewTicker which is a ManualTickProvider.
+func (fc Clock) NewTicker(time.Duration) clock.Ticker {
 	return fc.TP
 }

--- a/pkg/autoscaler/fake/fakes.go
+++ b/pkg/autoscaler/fake/fakes.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package fake
 
-import "time"
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/clock"
+)
 
 // A ManualTickProvider holds a channel that delivers `ticks' of a clock at intervals.
 type ManualTickProvider struct {
@@ -29,4 +33,21 @@ func (mtp *ManualTickProvider) NewTicker(time.Duration) *time.Ticker {
 	return &time.Ticker{
 		C: mtp.Channel,
 	}
+}
+
+// C returns the tick channel.
+func (mtp *ManualTickProvider) C() <-chan time.Time {
+	return mtp.Channel
+}
+func (mtp *ManualTickProvider) Stop() {}
+
+// FakeClock is K8s clock.FakeClock but it overrides tick provider
+// with ManualTickProvider above.
+type FakeClock struct {
+	*clock.FakeClock
+	TP *ManualTickProvider
+}
+
+func (fc FakeClock) NewTicker(time.Duration) clock.Ticker {
+	return fc.TP
 }

--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -27,6 +27,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	. "knative.dev/pkg/logging/testing"
@@ -116,6 +117,81 @@ func TestMetricCollectorCRUD(t *testing.T) {
 	})
 }
 
+func TestMetricCollectorScraperMovingTime(t *testing.T) {
+	logger := TestLogger(t)
+
+	mtp := &fake.ManualTickProvider{
+		Channel: make(chan time.Time),
+	}
+	now := time.Now()
+	fc := fake.FakeClock{
+		FakeClock: clock.NewFakeClock(now),
+		TP:        mtp,
+	}
+	metricKey := types.NamespacedName{Namespace: defaultNamespace, Name: defaultName}
+	const (
+		reportConcurrency = 10
+		reportRPS         = 20
+		wantConcurrency   = 7 * 10 / 2
+		wantRPS           = 7 * 20 / 2
+		wantPConcurrency  = 7 * 10 / 2
+		wantPRPS          = 7 * 20 / 2
+	)
+	stat := Stat{
+		PodName:                   "testPod",
+		AverageConcurrentRequests: reportConcurrency,
+		RequestCount:              reportRPS,
+	}
+	scraper := &testScraper{
+		s: func() (Stat, error) {
+			return stat, nil
+		},
+	}
+	factory := scraperFactory(scraper, nil)
+
+	coll := NewMetricCollector(factory, logger)
+	coll.clock = fc
+	coll.CreateOrUpdate(&defaultMetric)
+
+	// Tick three times.  Time doesn't matter since we use the time on the Stat.
+	for i := 0; i < 3; i++ {
+		mtp.Channel <- now
+	}
+	now = now.Add(time.Second)
+	fc.SetTime(now)
+	for i := 0; i < 4; i++ {
+		mtp.Channel <- now
+	}
+	var gotRPS, gotConcurrency, panicRPS, panicConcurrency float64
+	// Poll to see that the async loop completed.
+	wait.PollImmediate(10*time.Millisecond, 2*time.Second, func() (bool, error) {
+		gotConcurrency, panicConcurrency, _ = coll.StableAndPanicConcurrency(metricKey, now)
+		gotRPS, panicRPS, _ = coll.StableAndPanicRPS(metricKey, now)
+		return gotConcurrency == wantConcurrency &&
+			panicConcurrency == wantPConcurrency &&
+			gotRPS == wantRPS &&
+			panicRPS == wantPRPS, nil
+	})
+
+	if _, _, err := coll.StableAndPanicConcurrency(metricKey, now); err != nil {
+		t.Errorf("StableAndPanicConcurrency() = %v", err)
+	}
+	if _, _, err := coll.StableAndPanicRPS(metricKey, now); err != nil {
+		t.Errorf("StableAndPanicRPS() = %v", err)
+	}
+	if panicConcurrency != wantPConcurrency {
+		t.Errorf("PanicConcurrency() = %v, want %v", panicConcurrency, wantPConcurrency)
+	}
+	if panicRPS != wantPRPS {
+		t.Errorf("PanicRPS() = %v, want %v", panicRPS, wantPRPS)
+	}
+	if gotConcurrency != wantConcurrency {
+		t.Errorf("StableConcurrency() = %v, want %v", gotConcurrency, wantConcurrency)
+	}
+	if gotRPS != wantRPS {
+		t.Errorf("StableRPS() = %v, want %v", gotRPS, wantRPS)
+	}
+}
 func TestMetricCollectorScraper(t *testing.T) {
 	logger := TestLogger(t)
 
@@ -123,6 +199,10 @@ func TestMetricCollectorScraper(t *testing.T) {
 		Channel: make(chan time.Time),
 	}
 	now := time.Now()
+	fc := fake.FakeClock{
+		FakeClock: clock.NewFakeClock(now),
+		TP:        mtp,
+	}
 	metricKey := types.NamespacedName{Namespace: defaultNamespace, Name: defaultName}
 	const (
 		reportConcurrency = 10
@@ -145,13 +225,13 @@ func TestMetricCollectorScraper(t *testing.T) {
 	factory := scraperFactory(scraper, nil)
 
 	coll := NewMetricCollector(factory, logger)
-	coll.tickProvider = mtp.NewTicker // custom ticker.
+	coll.clock = fc
 	coll.CreateOrUpdate(&defaultMetric)
 
 	// Tick three times.  Time doesn't matter since we use the time on the Stat.
-	mtp.Channel <- now
-	mtp.Channel <- now
-	mtp.Channel <- now
+	for i := 0; i < 3; i++ {
+		mtp.Channel <- now
+	}
 	var gotRPS, gotConcurrency, panicRPS, panicConcurrency float64
 	// Poll to see that the async loop completed.
 	wait.PollImmediate(10*time.Millisecond, 2*time.Second, func() (bool, error) {
@@ -187,11 +267,13 @@ func TestMetricCollectorScraper(t *testing.T) {
 	mtp.Channel <- now
 
 	// Wait for async loop to finish.
-	wait.PollImmediate(10*time.Millisecond, 2*time.Second, func() (bool, error) {
+	if err := wait.PollImmediate(10*time.Millisecond, 2*time.Second, func() (bool, error) {
 		gotConcurrency, _, _ = coll.StableAndPanicConcurrency(metricKey, now.Add(defaultMetric.Spec.StableWindow).Add(-5*time.Second))
 		gotRPS, _, _ = coll.StableAndPanicRPS(metricKey, now.Add(defaultMetric.Spec.StableWindow).Add(-5*time.Second))
 		return gotConcurrency == reportConcurrency*5 && gotRPS == reportRPS*5, nil
-	})
+	}); err != nil {
+		t.Fatalf("Timed out waiting for the expected values to appear: CC = %v, RPS = %v", gotConcurrency, gotRPS)
+	}
 	if gotConcurrency != reportConcurrency*5 {
 		t.Errorf("StableAndPanicConcurrency() = %v, want %v", gotConcurrency, reportConcurrency*5)
 	}
@@ -216,6 +298,10 @@ func TestMetricCollectorNoScraper(t *testing.T) {
 		Channel: make(chan time.Time),
 	}
 	now := time.Now()
+	fc := fake.FakeClock{
+		FakeClock: clock.NewFakeClock(now),
+		TP:        mtp,
+	}
 	metricKey := types.NamespacedName{Namespace: defaultNamespace, Name: defaultName}
 	const wantStat = 0.
 	stat := Stat{
@@ -226,15 +312,17 @@ func TestMetricCollectorNoScraper(t *testing.T) {
 	factory := scraperFactory(nil, nil)
 
 	coll := NewMetricCollector(factory, logger)
-	coll.tickProvider = mtp.NewTicker // custom ticker.
+	coll.clock = fc
 
 	noTargetMetric := defaultMetric
 	noTargetMetric.Spec.ScrapeTarget = ""
 	coll.CreateOrUpdate(&noTargetMetric)
 	// Tick three times.  Time doesn't matter since we use the time on the Stat.
-	mtp.Channel <- now
-	mtp.Channel <- now
-	mtp.Channel <- now
+	for i := 0; i < 3; i++ {
+		mtp.Channel <- now
+		now = now.Add(time.Second)
+		fc.SetTime(now)
+	}
 
 	gotConcurrency, panicConcurrency, errCon := coll.StableAndPanicConcurrency(metricKey, now)
 	gotRPS, panicRPS, errRPS := coll.StableAndPanicRPS(metricKey, now)
@@ -341,7 +429,11 @@ func TestMetricCollectorRecord(t *testing.T) {
 	mtp := &fake.ManualTickProvider{
 		Channel: make(chan time.Time),
 	}
-	coll.tickProvider = mtp.NewTicker // This will ensure time based scraping won't interfere.
+	fc := fake.FakeClock{
+		FakeClock: clock.NewFakeClock(now),
+		TP:        mtp,
+	}
+	coll.clock = fc
 
 	// Freshly created collection does not contain any metrics and should return an error.
 	coll.CreateOrUpdate(&defaultMetric)
@@ -444,8 +536,13 @@ func TestMetricCollectorError(t *testing.T) {
 			mtp := &fake.ManualTickProvider{
 				Channel: make(chan time.Time),
 			}
+			now := time.Now()
+			fc := fake.FakeClock{
+				FakeClock: clock.NewFakeClock(now),
+				TP:        mtp,
+			}
 			coll := NewMetricCollector(factory, logger)
-			coll.tickProvider = mtp.NewTicker
+			coll.clock = fc
 
 			watchCh := make(chan types.NamespacedName)
 			coll.Watch(func(key types.NamespacedName) {
@@ -454,7 +551,7 @@ func TestMetricCollectorError(t *testing.T) {
 
 			// Create a collection and immediately tick.
 			coll.CreateOrUpdate(testMetric)
-			mtp.Channel <- time.Now()
+			mtp.Channel <- now
 
 			// Expect an event to be propagated because we're erroring.
 			key := types.NamespacedName{Namespace: testMetric.Namespace, Name: testMetric.Name}

--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -124,7 +124,7 @@ func TestMetricCollectorScraperMovingTime(t *testing.T) {
 		Channel: make(chan time.Time),
 	}
 	now := time.Now()
-	fc := fake.FakeClock{
+	fc := fake.Clock{
 		FakeClock: clock.NewFakeClock(now),
 		TP:        mtp,
 	}
@@ -199,7 +199,7 @@ func TestMetricCollectorScraper(t *testing.T) {
 		Channel: make(chan time.Time),
 	}
 	now := time.Now()
-	fc := fake.FakeClock{
+	fc := fake.Clock{
 		FakeClock: clock.NewFakeClock(now),
 		TP:        mtp,
 	}
@@ -298,7 +298,7 @@ func TestMetricCollectorNoScraper(t *testing.T) {
 		Channel: make(chan time.Time),
 	}
 	now := time.Now()
-	fc := fake.FakeClock{
+	fc := fake.Clock{
 		FakeClock: clock.NewFakeClock(now),
 		TP:        mtp,
 	}
@@ -429,7 +429,7 @@ func TestMetricCollectorRecord(t *testing.T) {
 	mtp := &fake.ManualTickProvider{
 		Channel: make(chan time.Time),
 	}
-	fc := fake.FakeClock{
+	fc := fake.Clock{
 		FakeClock: clock.NewFakeClock(now),
 		TP:        mtp,
 	}
@@ -537,7 +537,7 @@ func TestMetricCollectorError(t *testing.T) {
 				Channel: make(chan time.Time),
 			}
 			now := time.Now()
-			fc := fake.FakeClock{
+			fc := fake.Clock{
 				FakeClock: clock.NewFakeClock(now),
 				TP:        mtp,
 			}

--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -192,6 +192,7 @@ func TestMetricCollectorScraperMovingTime(t *testing.T) {
 		t.Errorf("StableRPS() = %v, want %v", gotRPS, wantRPS)
 	}
 }
+
 func TestMetricCollectorScraper(t *testing.T) {
 	logger := TestLogger(t)
 


### PR DESCRIPTION
- This permits controlling time as well as ticker
- With that we can remove the flakes on the heavily loaded test clusters
  when the time is guaranteed to shift between clusters and in general,
  this can happen if the test timing is particularly bad (e.g. started on millisecond 999 of a second)
- Add a test to cover time movements and expected division.
/lint
/assign @yanweiguo @julz 