### PR TITLE
Add more early-exits for GC v2

### DIFF
--- a/pkg/reconciler/gc/v2/gc.go
+++ b/pkg/reconciler/gc/v2/gc.go
@@ -46,7 +46,7 @@ func Collect(
 
 	min, max := int(cfg.MinNonActiveRevisions), int(cfg.MaxNonActiveRevisions)
 	if max == gc.Disabled && cfg.RetainSinceCreateTime == gc.Disabled && cfg.RetainSinceLastActiveTime == gc.Disabled {
-		return nil
+		return nil // all deletion settings are disabled
 	}
 
 	selector := labels.SelectorFromSet(labels.Set{serving.ConfigurationLabelKey: config.Name})

--- a/pkg/reconciler/gc/v2/gc.go
+++ b/pkg/reconciler/gc/v2/gc.go
@@ -44,20 +44,26 @@ func Collect(
 	cfg := configns.FromContext(ctx).RevisionGC
 	logger := logging.FromContext(ctx)
 
+	min, max := int(cfg.MinNonActiveRevisions), int(cfg.MaxNonActiveRevisions)
+	if max == gc.Disabled && cfg.RetainSinceCreateTime == gc.Disabled && cfg.RetainSinceLastActiveTime == gc.Disabled {
+		return nil
+	}
+
 	selector := labels.SelectorFromSet(labels.Set{serving.ConfigurationLabelKey: config.Name})
 	revs, err := revisionLister.Revisions(config.Namespace).List(selector)
 	if err != nil {
 		return err
 	}
-
-	min, max := int(cfg.MinNonActiveRevisions), int(cfg.MaxNonActiveRevisions)
-	if len(revs) <= min ||
-		max == gc.Disabled && cfg.RetainSinceCreateTime == gc.Disabled && cfg.RetainSinceLastActiveTime == gc.Disabled {
-		return nil
+	if len(revs) <= min {
+		return nil // not enough total revs
 	}
 
 	// Filter out active revs
 	revs = nonactiveRevisions(revs, config)
+
+	if len(revs) <= min {
+		return nil // not enough non-active revs
+	}
 
 	// Sort by last active ascending (oldest first)
 	sort.Slice(revs, func(i, j int) bool {

--- a/pkg/reconciler/gc/v2/gc_test.go
+++ b/pkg/reconciler/gc/v2/gc_test.go
@@ -74,6 +74,18 @@ func TestCollectMin(t *testing.T) {
 		revs        []*v1.Revision
 		wantDeletes []clientgotesting.DeleteActionImpl
 	}{{
+		name: "too few revisions",
+		cfg: cfg("none-reserved", "foo", 5556,
+			WithLatestCreated("5556"),
+			WithLatestReady("5556"),
+			WithConfigObservedGen),
+		revs: []*v1.Revision{
+			rev("none-reserved", "foo", 5556, MarkRevisionReady,
+				WithRevName("5556"),
+				WithRoutingState(v1.RoutingStateActive),
+				WithCreationTimestamp(old)),
+		},
+	}, {
 		name: "delete oldest, keep one recent, one active",
 		cfg: cfg("keep-two", "foo", 5556,
 			WithLatestCreated("5556"),


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* For the disabled case we can exit before even listing
* We can also exit early if there are too few both before and after filtering active
