### PR TITLE
Propagate the Routes annotation from Service to Configuration

### DIFF
--- a/pkg/reconciler/labeler/v2/accessors.go
+++ b/pkg/reconciler/labeler/v2/accessors.go
@@ -111,7 +111,7 @@ func markRoutingState(
 // or removes the annotation if routeName is nil.
 // Returns true if the entire annotation is newly added or removed, which signifies a state change.
 func updateRouteAnnotation(acc kmeta.Accessor, routeName string, diffAnn map[string]interface{}, remove bool) bool {
-	valSet := getListAnnValue(acc.GetAnnotations(), serving.RoutesAnnotationKey)
+	valSet := GetListAnnValue(acc.GetAnnotations(), serving.RoutesAnnotationKey)
 	has := valSet.Has(routeName)
 	switch {
 	case has && remove:
@@ -141,7 +141,7 @@ func (r *Revision) list(ns, routeName string, state v1.RoutingState) ([]kmeta.Ac
 	kl := make([]kmeta.Accessor, 0, 1)
 	filter := func(m interface{}) {
 		r := m.(*v1.Revision)
-		if getListAnnValue(r.Annotations, serving.RoutesAnnotationKey).Has(routeName) {
+		if GetListAnnValue(r.Annotations, serving.RoutesAnnotationKey).Has(routeName) {
 			kl = append(kl, r)
 		}
 	}
@@ -202,7 +202,7 @@ func (c *Configuration) list(ns, routeName string, state v1.RoutingState) ([]kme
 	kl := make([]kmeta.Accessor, 0, 1)
 	filter := func(m interface{}) {
 		c := m.(*v1.Configuration)
-		if getListAnnValue(c.Annotations, serving.RoutesAnnotationKey).Has(routeName) {
+		if GetListAnnValue(c.Annotations, serving.RoutesAnnotationKey).Has(routeName) {
 			kl = append(kl, c)
 		}
 	}
@@ -213,9 +213,9 @@ func (c *Configuration) list(ns, routeName string, state v1.RoutingState) ([]kme
 	return kl, nil
 }
 
-// getListAnnValue finds a given value in a comma-separated annotation.
+// GetListAnnValue finds a given value in a comma-separated annotation.
 // returns the entire annotation value and true if found.
-func getListAnnValue(annotations map[string]string, key string) sets.String {
+func GetListAnnValue(annotations map[string]string, key string) sets.String {
 	l := annotations[key]
 	if l == "" {
 		return sets.String{}

--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -30,14 +30,18 @@ import (
 )
 
 // MakeConfiguration creates a Configuration from a Service object.
-func MakeConfiguration(service *v1.Service, existing *v1.Configuration, gc cfgmap.Flag) (*v1.Configuration, error) {
+func MakeConfiguration(service *v1.Service) (*v1.Configuration, error) {
+	return MakeConfigurationFromExisting(service, &v1.Configuration{}, cfgmap.Disabled)
+}
+
+func MakeConfigurationFromExisting(service *v1.Service, existing *v1.Configuration, gc cfgmap.Flag) (*v1.Configuration, error) {
 	labels := map[string]string{serving.ServiceLabelKey: service.Name}
 	anns := kmeta.FilterMap(service.GetAnnotations(), func(key string) bool {
 		return key == corev1.LastAppliedConfigAnnotation
 	})
 
 	routeName := names.Route(service)
-	if gc == cfgmap.Enabled {
+	if gc != cfgmap.Enabled {
 		labels[serving.RouteLabelKey] = routeName
 	}
 

--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -17,8 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -48,8 +46,8 @@ func MakeConfigurationFromExisting(service *v1.Service, existing *v1.Configurati
 	}
 
 	if gc == cfgmap.Enabled || gc == cfgmap.Allowed {
-		if set := labelerv2.GetListAnnValue(anns, serving.RoutesAnnotationKey); set.Has(routeName) {
-			anns[serving.RoutesAnnotationKey] = strings.Join(set.UnsortedList(), ",")
+		if set := labelerv2.GetListAnnValue(existing.Annotations, serving.RoutesAnnotationKey); set.Has(routeName) {
+			anns[serving.RoutesAnnotationKey] = existing.Annotations[serving.RoutesAnnotationKey]
 		} else {
 			anns[serving.RoutesAnnotationKey] = routeName
 		}

--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -48,12 +48,11 @@ func MakeConfigurationFromExisting(service *v1.Service, existing *v1.Configurati
 	}
 
 	if gc == cfgmap.Enabled || gc == cfgmap.Allowed {
-		if set := labelerv2.GetListAnnValue(existing.Annotations, serving.RoutesAnnotationKey); set.Has(routeName) {
-			anns[serving.RoutesAnnotationKey] = existing.Annotations[serving.RoutesAnnotationKey]
-		} else {
+		set := labelerv2.GetListAnnValue(existing.Annotations, serving.RoutesAnnotationKey)
+		if !set.Has(routeName) {
 			set.Insert(routeName)
-			anns[serving.RoutesAnnotationKey] = strings.Join(set.UnsortedList(), ",")
 		}
+		anns[serving.RoutesAnnotationKey] = strings.Join(set.UnsortedList(), ",")
 	}
 
 	return &v1.Configuration{

--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resources
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -49,7 +51,8 @@ func MakeConfigurationFromExisting(service *v1.Service, existing *v1.Configurati
 		if set := labelerv2.GetListAnnValue(existing.Annotations, serving.RoutesAnnotationKey); set.Has(routeName) {
 			anns[serving.RoutesAnnotationKey] = existing.Annotations[serving.RoutesAnnotationKey]
 		} else {
-			anns[serving.RoutesAnnotationKey] = routeName
+			set.Insert(routeName)
+			anns[serving.RoutesAnnotationKey] = strings.Join(set.UnsortedList(), ",")
 		}
 	}
 

--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -17,17 +17,38 @@ limitations under the License.
 package resources
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/kmeta"
+	cfgmap "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler/service/resources/names"
 )
 
 // MakeConfiguration creates a Configuration from a Service object.
-func MakeConfiguration(service *v1.Service) (*v1.Configuration, error) {
+func MakeConfiguration(service *v1.Service, existing *v1.Configuration, gc cfgmap.Flag) (*v1.Configuration, error) {
+	labels := map[string]string{serving.ServiceLabelKey: service.Name}
+	anns := kmeta.FilterMap(service.GetAnnotations(), func(key string) bool {
+		return key == corev1.LastAppliedConfigAnnotation
+	})
+
+	routeName := names.Route(service)
+	if gc == cfgmap.Enabled {
+		labels[serving.RouteLabelKey] = routeName
+	}
+
+	if gc == cfgmap.Enabled || gc == cfgmap.Allowed {
+		if val, has := existing.Annotations[serving.RoutesAnnotationKey]; has && strings.Contains(val, routeName) {
+			anns[serving.RoutesAnnotationKey] = val
+		} else {
+			anns[serving.RoutesAnnotationKey] = routeName
+		}
+	}
+
 	return &v1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.Configuration(service),
@@ -35,13 +56,8 @@ func MakeConfiguration(service *v1.Service) (*v1.Configuration, error) {
 			OwnerReferences: []metav1.OwnerReference{
 				*kmeta.NewControllerRef(service),
 			},
-			Labels: kmeta.UnionMaps(service.GetLabels(), map[string]string{
-				serving.RouteLabelKey:   names.Route(service),
-				serving.ServiceLabelKey: service.Name,
-			}),
-			Annotations: kmeta.FilterMap(service.GetAnnotations(), func(key string) bool {
-				return key == corev1.LastAppliedConfigAnnotation
-			}),
+			Labels:      kmeta.UnionMaps(service.GetLabels(), labels),
+			Annotations: anns,
 		},
 		Spec: service.Spec.ConfigurationSpec,
 	}, nil

--- a/pkg/reconciler/service/resources/configuration_test.go
+++ b/pkg/reconciler/service/resources/configuration_test.go
@@ -21,7 +21,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	cfgmap "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/reconciler/service/resources/names"
 )
 
 func TestConfigurationSpec(t *testing.T) {
@@ -43,6 +46,31 @@ func TestConfigurationSpec(t *testing.T) {
 	}
 	if got, want := c.Labels[serving.ServiceLabelKey], testServiceName; got != want {
 		t.Errorf("expected %q labels got %q", want, got)
+	}
+}
+
+func TestConfigurationSpecGCAllowed(t *testing.T) {
+	s := createService()
+	c, _ := MakeConfigurationFromExisting(s, &v1.Configuration{}, cfgmap.Allowed)
+	if got, want := c.Name, testServiceName; got != want {
+		t.Errorf("expected %q for service name got %q", want, got)
+	}
+	if got, want := c.Namespace, testServiceNamespace; got != want {
+		t.Errorf("expected %q for service namespace got %q", want, got)
+	}
+	if got, want := c.Spec.GetTemplate().Spec.GetContainer().Name, testContainerName; got != want {
+		t.Errorf("expected %q for container name got %q", want, got)
+	}
+	expectOwnerReferencesSetCorrectly(t, c.OwnerReferences)
+
+	if got, want := len(c.Labels), 2; got != want {
+		t.Errorf("expected %d labels got %d", want, got)
+	}
+	if got, want := c.Labels[serving.ServiceLabelKey], testServiceName; got != want {
+		t.Errorf("expected %q labels got %q", want, got)
+	}
+	if got, want := c.Annotations[serving.RoutesAnnotationKey], names.Route(s); got != want {
+		t.Errorf("expected %q route annotation got %q", want, got)
 	}
 }
 

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -189,7 +189,7 @@ func (c *Reconciler) checkRoutesNotReady(config *v1.Configuration, logger *zap.S
 
 func (c *Reconciler) createConfiguration(ctx context.Context, service *v1.Service) (*v1.Configuration, error) {
 	gc := cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC
-	cfg, err := resources.MakeConfiguration(service, &v1.Configuration{}, gc)
+	cfg, err := resources.MakeConfigurationFromExisting(service, &v1.Configuration{}, gc)
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +217,7 @@ func (c *Reconciler) reconcileConfiguration(ctx context.Context, service *v1.Ser
 	// diff is the new default values.
 	existing.SetDefaults(ctx)
 	gc := cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC
-	desiredConfig, err := resources.MakeConfiguration(service, existing, gc)
+	desiredConfig, err := resources.MakeConfigurationFromExisting(service, existing, gc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -34,6 +34,7 @@ import (
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
+	cfgmap "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	listers "knative.dev/serving/pkg/client/listers/serving/v1"
@@ -214,7 +215,8 @@ func (c *Reconciler) reconcileConfiguration(ctx context.Context, service *v1.Ser
 	// We are setting the up-to-date default values here so an update won't be triggered if the only
 	// diff is the new default values.
 	existing.SetDefaults(ctx)
-	desiredConfig, err := resources.MakeConfiguration(service)
+	gc := cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC
+	desiredConfig, err := resources.MakeConfiguration(service, existing, gc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -34,8 +34,11 @@ import (
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
+	"knative.dev/pkg/system"
+	cfgmap "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	autoscalercfg "knative.dev/serving/pkg/autoscaler/config"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	ksvcreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/service"
 	configresources "knative.dev/serving/pkg/reconciler/configuration/resources"
@@ -790,7 +793,27 @@ func TestReconcile(t *testing.T) {
 func TestNew(t *testing.T) {
 	ctx, _ := SetupFakeContext(t)
 
-	c := NewController(ctx, configmap.NewStaticWatcher())
+	configMapWatcher := configmap.NewStaticWatcher(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfgmap.FeaturesConfigName,
+			Namespace: system.Namespace(),
+		},
+		Data: map[string]string{},
+	}, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cfgmap.DefaultsConfigName,
+			Namespace: system.Namespace(),
+		},
+		Data: map[string]string{},
+	}, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      autoscalercfg.ConfigName,
+			Namespace: system.Namespace(),
+		},
+		Data: map[string]string{},
+	})
+
+	c := NewController(ctx, configMapWatcher)
 
 	if c == nil {
 		t.Fatal("Expected NewController to return a non-nil value")

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -34,6 +34,7 @@ import (
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
+	cfgmap "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
@@ -800,7 +801,7 @@ func TestNew(t *testing.T) {
 func config(name, namespace string, so ServiceOption, co ...ConfigOption) *v1.Configuration {
 	s := DefaultService(name, namespace, so)
 	s.SetDefaults(context.Background())
-	cfg, err := resources.MakeConfiguration(s)
+	cfg, err := resources.MakeConfiguration(s, &v1.Configuration{}, cfgmap.Disabled)
 	if err != nil {
 		panic(fmt.Sprint("MakeConfiguration() = ", err))
 	}

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -34,7 +34,6 @@ import (
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
-	cfgmap "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
@@ -801,7 +800,7 @@ func TestNew(t *testing.T) {
 func config(name, namespace string, so ServiceOption, co ...ConfigOption) *v1.Configuration {
 	s := DefaultService(name, namespace, so)
 	s.SetDefaults(context.Background())
-	cfg, err := resources.MakeConfiguration(s, &v1.Configuration{}, cfgmap.Disabled)
+	cfg, err := resources.MakeConfiguration(s)
 	if err != nil {
 		panic(fmt.Sprint("MakeConfiguration() = ", err))
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Issue https://github.com/knative/serving/issues/8791

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*  Consider the new GC flag when creating a new Configuration from Service to add the Routes annotation.
    * Currently the Service clobbers on any diff for its route/config. This can cause a battle with the labeler.
