### PR TITLE
Test that initScale revisions eventually scale down

### DIFF
--- a/test/e2e/initial_scale_test.go
+++ b/test/e2e/initial_scale_test.go
@@ -67,8 +67,9 @@ func TestInitScalePositive(t *testing.T) {
 	}
 	test.EnsureTearDown(t, clients, &names)
 
-	t.Log("Creating a new Service with initialScale 3 and verifying that pods are created")
-	createAndVerifyInitialScaleService(t, clients, names, 3)
+	const initialScale = 3
+	t.Logf("Creating a new Service with initialScale %d and verifying that pods are created", initialScale)
+	createAndVerifyInitialScaleService(t, clients, names, initialScale)
 
 	t.Logf("Waiting for Service %q to scale back below initialScale", names.Service)
 	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, func(s *v1.Service) (b bool, e error) {
@@ -78,7 +79,7 @@ func TestInitScalePositive(t *testing.T) {
 			FieldSelector: "status.phase!=Terminating",
 		})
 
-		return len(podList.Items) < 3, err
+		return len(podList.Items) < initialScale, err
 	}, "ServiceScaledBelowInitial"); err != nil {
 		t.Fatal("Service did not scale back below initialScale:", err)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Given we regressed once (https://github.com/knative/serving/issues/8878), seems worth extending the e2e test to check initialScale>1 revisions eventually scale back down after the initial scale is done.

/assign @markusthoemmes @vagababov @taragu 