### PR TITLE
Make SKS global resync test more consistent.

### DIFF
--- a/pkg/reconciler/serverlessservice/global_resync_test.go
+++ b/pkg/reconciler/serverlessservice/global_resync_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/sync/errgroup"
 
+	networkingv1alpha1 "knative.dev/networking/pkg/client/clientset/versioned/typed/networking/v1alpha1"
 	fakenetworkingclient "knative.dev/networking/pkg/client/injection/client/fake"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	fakeendpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
@@ -31,7 +32,7 @@ import (
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	"knative.dev/serving/pkg/client/injection/ducks/autoscaling/v1alpha1/podscalable"
 
-	"k8s.io/apimachinery/pkg/labels"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -94,27 +95,27 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 		return ctrl.Run(1, ctx.Done())
 	})
 
+	networking := fakenetworkingclient.Get(ctx).NetworkingV1alpha1()
+
 	// Inactive, will reconcile.
 	sksObj1 := SKS(ns1, sks1, WithPrivateService, WithPubService, WithDeployRef(sks1), WithProxyMode)
+	sksObj1.Generation = 1
 	// Active, should not visibly reconcile.
 	sksObj2 := SKS(ns2, sks2, WithPrivateService, WithPubService, WithDeployRef(sks2), markHappy)
+	sksObj2.Generation = 1
 
-	if _, err := fakenetworkingclient.Get(ctx).NetworkingV1alpha1().ServerlessServices(ns1).Create(sksObj1); err != nil {
+	if _, err := networking.ServerlessServices(ns1).Create(sksObj1); err != nil {
 		t.Fatal("Error creating SKS1:", err)
 	}
-	if _, err := fakenetworkingclient.Get(ctx).NetworkingV1alpha1().ServerlessServices(ns2).Create(sksObj2); err != nil {
+	if _, err := networking.ServerlessServices(ns2).Create(sksObj2); err != nil {
 		t.Fatal("Error creating SKS2:", err)
 	}
 
-	eps := fakeendpointsinformer.Get(ctx).Lister()
-	if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
-		l, err := eps.List(labels.Everything())
-		return len(l) >= 4, err
-	}); err != nil {
-		t.Fatal("Failed to see endpoint creation:", err)
-	}
-	t.Log("Updating the activator endpoints now...")
+	// Wait for the SKSs to be reconciled
+	waitForObservedGen(networking, ns1, sks1, 1)
+	waitForObservedGen(networking, ns2, sks2, 1)
 
+	t.Log("Updating the activator endpoints now...")
 	// Now that we have established the baseline, update the activator endpoints.
 	aEps = activatorEndpoints(withOtherSubsets)
 	if _, err := kubeClnt.CoreV1().Endpoints(aEps.Namespace).Update(aEps); err != nil {
@@ -122,6 +123,7 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 	}
 
 	// Actively wait for the endpoints to change their value.
+	eps := fakeendpointsinformer.Get(ctx).Lister()
 	if err := wait.PollImmediate(10*time.Millisecond, 3*time.Second, func() (bool, error) {
 		ep, err := eps.Endpoints(ns1).Get(sks1)
 		if err != nil {
@@ -134,4 +136,14 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 	}); err != nil {
 		t.Fatal("Failed to see Public Endpoints propagation:", err)
 	}
+}
+
+func waitForObservedGen(client networkingv1alpha1.NetworkingV1alpha1Interface, ns, name string, generation int64) error {
+	return wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
+		sks, err := client.ServerlessServices(ns).Get(name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return sks.Status.ObservedGeneration == 1, nil
+	})
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #8811

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This test used to rely on a number of endpoints being created by a first reconcilation but didn't actually specify how many endpoints it actually was waiting for. This resulted in intermittent failures being possible.

This makes the test more consistent in that it waits for the reconcilation of all resources to be done statically by awaiting for their observed generation to be bumped.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
