### PR TITLE
Dry up exec probe tests with t.Cleanup

### DIFF
--- a/cmd/queue/execprobe.go
+++ b/cmd/queue/execprobe.go
@@ -115,7 +115,7 @@ func probeQueueHealthPath(timeout time.Duration, queueServingPort int) error {
 	timeoutErr := wait.PollImmediateUntil(aggressivePollInterval, func() (bool, error) {
 		res, lastErr = httpClient.Do(req)
 		if lastErr != nil {
-			// Return nil error for retrying
+			// Return nil error for retrying.
 			return false, nil
 		}
 
@@ -138,7 +138,7 @@ func probeQueueHealthPath(timeout time.Duration, queueServingPort int) error {
 		return fmt.Errorf("failed to probe: %w", lastErr)
 	}
 
-	// An http.StatusOK was never returned during probing
+	// An http.StatusOK was never returned during probing.
 	if timeoutErr != nil {
 		return errors.New("probe returned not ready")
 	}

--- a/cmd/queue/execprobe_test.go
+++ b/cmd/queue/execprobe_test.go
@@ -117,9 +117,9 @@ func TestProbeQueueReady(t *testing.T) {
 }
 
 func TestProbeQueueTimeout(t *testing.T) {
-	queueProbed := 0
+	probed := make(chan struct{})
 	port := newProbeTestServer(t, func(w http.ResponseWriter) {
-		queueProbed++
+		close(probed)
 		time.Sleep(2 * time.Second)
 		w.WriteHeader(http.StatusOK)
 	})
@@ -132,7 +132,9 @@ func TestProbeQueueTimeout(t *testing.T) {
 		t.Error("Unexpected return value from standaloneProbeMain:", rv)
 	}
 
-	if queueProbed == 0 {
+	select {
+	case <-probed:
+	default:
 		t.Error("Expected the queue proxy server to be probed")
 	}
 }

--- a/cmd/queue/execprobe_test.go
+++ b/cmd/queue/execprobe_test.go
@@ -47,24 +47,12 @@ func TestProbeQueueConnectionFailure(t *testing.T) {
 
 func TestProbeQueueNotReady(t *testing.T) {
 	queueProbed := 0
-	ts := newProbeTestServer(func(w http.ResponseWriter) {
+	port := newProbeTestServer(t, func(w http.ResponseWriter) {
 		queueProbed++
 		w.WriteHeader(http.StatusBadRequest)
 	})
 
-	defer ts.Close()
-
-	u, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
-	}
-
-	port, err := strconv.Atoi(u.Port())
-	if err != nil {
-		t.Fatalf("Failed to convert port(%s) to int: %v", u.Port(), err)
-	}
-
-	err = probeQueueHealthPath(time.Second, port)
+	err := probeQueueHealthPath(time.Second, port)
 
 	if err == nil || err.Error() != "probe returned not ready" {
 		t.Error("Unexpected not ready error:", err)
@@ -77,24 +65,12 @@ func TestProbeQueueNotReady(t *testing.T) {
 
 func TestProbeShuttingDown(t *testing.T) {
 	queueProbed := 0
-	ts := newProbeTestServer(func(w http.ResponseWriter) {
+	port := newProbeTestServer(t, func(w http.ResponseWriter) {
 		queueProbed++
 		w.WriteHeader(http.StatusGone)
 	})
 
-	defer ts.Close()
-
-	u, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
-	}
-
-	port, err := strconv.Atoi(u.Port())
-	if err != nil {
-		t.Fatalf("Failed to convert port(%s) to int: %v", u.Port(), err)
-	}
-
-	err = probeQueueHealthPath(time.Second, port)
+	err := probeQueueHealthPath(time.Second, port)
 
 	if err == nil || err.Error() != "failed to probe: failing probe deliberately for shutdown" {
 		t.Error("Unexpected error:", err)
@@ -106,28 +82,16 @@ func TestProbeShuttingDown(t *testing.T) {
 }
 
 func TestProbeQueueShuttingDownFailsFast(t *testing.T) {
-	ts := newProbeTestServer(func(w http.ResponseWriter) {
+	port := newProbeTestServer(t, func(w http.ResponseWriter) {
 		w.WriteHeader(http.StatusGone)
 	})
 
-	defer ts.Close()
-
-	u, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
-	}
-
-	port, err := strconv.Atoi(u.Port())
-	if err != nil {
-		t.Fatalf("Failed to convert port(%s) to int: %v", u.Port(), err)
-	}
-
 	start := time.Now()
-	if err = probeQueueHealthPath(1, port); err == nil {
+	if err := probeQueueHealthPath(1, port); err == nil {
 		t.Error("probeQueueHealthPath did not fail")
 	}
 
-	// if fails due to timeout and not cancelation, then it took too long
+	// if fails due to timeout and not cancelation, then it took too long.
 	if time.Since(start) >= 1*time.Second {
 		t.Error("took too long to fail")
 	}
@@ -135,20 +99,13 @@ func TestProbeQueueShuttingDownFailsFast(t *testing.T) {
 
 func TestProbeQueueReady(t *testing.T) {
 	queueProbed := 0
-	ts := newProbeTestServer(func(w http.ResponseWriter) {
+	port := newProbeTestServer(t, func(w http.ResponseWriter) {
 		queueProbed++
 		w.WriteHeader(http.StatusOK)
 	})
 
-	defer ts.Close()
-
-	u, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
-	}
-
 	t.Cleanup(func() { os.Unsetenv(queuePortEnvVar) })
-	os.Setenv(queuePortEnvVar, u.Port())
+	os.Setenv(queuePortEnvVar, strconv.Itoa(port))
 
 	if rv := standaloneProbeMain(0 /*use default*/); rv != 0 {
 		t.Error("Unexpected return value from standaloneProbeMain:", rv)
@@ -161,28 +118,19 @@ func TestProbeQueueReady(t *testing.T) {
 
 func TestProbeQueueTimeout(t *testing.T) {
 	queueProbed := 0
-	ts := newProbeTestServer(func(w http.ResponseWriter) {
+	port := newProbeTestServer(t, func(w http.ResponseWriter) {
 		queueProbed++
 		time.Sleep(2 * time.Second)
 		w.WriteHeader(http.StatusOK)
 	})
 
-	defer ts.Close()
-
-	u, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
-	}
-
 	t.Cleanup(func() { os.Unsetenv(queuePortEnvVar) })
-	os.Setenv(queuePortEnvVar, u.Port())
+	os.Setenv(queuePortEnvVar, strconv.Itoa(port))
 
 	const timeout = time.Second
 	if rv := standaloneProbeMain(timeout); rv == 0 {
 		t.Error("Unexpected return value from standaloneProbeMain:", rv)
 	}
-
-	ts.Close()
 
 	if queueProbed == 0 {
 		t.Error("Expected the queue proxy server to be probed")
@@ -191,7 +139,7 @@ func TestProbeQueueTimeout(t *testing.T) {
 
 func TestProbeQueueDelayedReady(t *testing.T) {
 	count := 0
-	ts := newProbeTestServer(func(w http.ResponseWriter) {
+	port := newProbeTestServer(t, func(w http.ResponseWriter) {
 		count++
 		if count < 9 {
 			w.WriteHeader(http.StatusBadRequest)
@@ -200,27 +148,28 @@ func TestProbeQueueDelayedReady(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	defer ts.Close()
+	if err := probeQueueHealthPath(readiness.PollTimeout, port); err != nil {
+		t.Errorf("probeQueueHealthPath(%d) = %s", port, err)
+	}
+}
+
+func newProbeTestServer(t *testing.T, f func(w http.ResponseWriter)) (port int) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(network.UserAgentKey) == network.QueueProxyUserAgent {
+			f(w)
+		}
+	}))
+	t.Cleanup(ts.Close)
 
 	u, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatalf("%s is not a valid URL: %v", ts.URL, err)
 	}
 
-	port, err := strconv.Atoi(u.Port())
+	port, err = strconv.Atoi(u.Port())
 	if err != nil {
 		t.Fatalf("Failed to convert port(%s) to int: %v", u.Port(), err)
 	}
 
-	if err := probeQueueHealthPath(readiness.PollTimeout, port); err != nil {
-		t.Errorf("probeQueueHealthPath(%d) = %s", port, err)
-	}
-}
-
-func newProbeTestServer(f func(w http.ResponseWriter)) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get(network.UserAgentKey) == network.QueueProxyUserAgent {
-			f(w)
-		}
-	}))
+	return port
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Remove all the repetitive url/port parsing and defer ts.Close calls via the nice new t.Cleanup stuff.

/assign @markusthoemmes @taragu 