### PR TITLE
fix the incorrect memory and storage setting

### DIFF
--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "0608517d"
+    knative.dev/example-checksum: "a409bec7"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -58,18 +58,18 @@ data:
 
     # queueSidecarMemoryRequest is the requests.memory to set for the queue proxy container.
     # If omitted, no value is specified and the system default is used.
-    queueSidecarMemoryRequest: "400m"
+    queueSidecarMemoryRequest: "400Mi"
 
     # queueSidecarMemoryLimit is the limits.memory to set for the queue proxy container.
     # If omitted, no value is specified and the system default is used.
-    queueSidecarMemoryLimit: "800m"
+    queueSidecarMemoryLimit: "800Mi"
 
     # queueSidecarEphemeralStorageRequest is the requests.ephemeral-storage to
     # set for the queue proxy sidecar container.
     # If omitted, no value is specified and the system default is used.
-    queueSidecarEphemeralStorageRequest: "512m"
+    queueSidecarEphemeralStorageRequest: "512Mi"
 
     # queueSidecarEphemeralStorageLimit is the limits.ephemeral-storage to set
     # for the queue proxy sidecar container.
     # If omitted, no value is specified and the system default is used.
-    queueSidecarEphemeralStorageLimit: "1024m"
+    queueSidecarEphemeralStorageLimit: "1024Mi"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* The previous example inside config-deployment configmap  includes the incorrect value for memory and storage. 
*  When I set "memorylimit" according to previous example,  the pods can't be created at all .. It crashed due to the following error: 
```
   lastState:
      terminated:
        containerID: containerd://6303980ea8192751b256c1fdee76fceb46597edd30493947ed8ca03918d2f24b
        exitCode: 128
        finishedAt: "2020-08-04T14:47:05Z"
        message: 'failed to create containerd task: OCI runtime create failed: container_linux.go:349:
          starting container process caused "process_linux.go:449: container init
          caused \"process_linux.go:415: setting cgroup config for procHooks process
          caused \\\"failed to write \\\\\\\"1\\\\\\\" to \\\\\\\"/sys/fs/cgroup/memory/kubepods/burstable/pod86fa2113-e4da-4c53-bd09-9b8082122b92/6303980ea8192751b256c1fdee76fceb46597edd30493947ed8ca03918d2f24b/memory.limit_in_bytes\\\\\\\":
          write /sys/fs/cgroup/memory/kubepods/burstable/pod86fa2113-e4da-4c53-bd09-9b8082122b92/6303980ea8192751b256c1fdee76fceb46597edd30493947ed8ca03918d2f24b/memory.limit_in_bytes:
          device or resource busy\\\"\"": unknown'
        reason: StartError
        startedAt: "1970-01-01T00:00:00Z"
```
with resources setting:
```
    resources:
      limits:
        cpu: 100m
        memory: 200m
      requests:
        cpu: 25m
        memory: 100m
```
*  Then, I fixed it by correcting the memory representation.  I think others will meet the similar situation with me by referring to the example directly. 


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
