### PR TITLE
Add scaling from/to zero e2e test during upgrade/downgrade

### DIFF
--- a/test/upgrade/autoscaler_test.go
+++ b/test/upgrade/autoscaler_test.go
@@ -37,13 +37,11 @@ import (
 	v1test "knative.dev/serving/test/v1"
 )
 
-const scaleToZeroPipe = "/tmp/scale-to-zero-signal"
-
 func TestScaleToZero(t *testing.T) {
 	t.Parallel()
 	// Create a named pipe and wait for the upgrade script to write to it
 	// to signal that we should stop testing.
-	createPipe(t)
+	createPipe(pipe, t)
 
 	clients := e2e.Setup(t)
 	names := test.ResourceNames{

--- a/test/upgrade/autoscaler_test.go
+++ b/test/upgrade/autoscaler_test.go
@@ -1,0 +1,81 @@
+// +build probe
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"syscall"
+	"testing"
+
+	"knative.dev/serving/test"
+	"knative.dev/serving/test/e2e"
+	v1test "knative.dev/serving/test/v1"
+)
+
+var successFraction = flag.Float64("probe.success_fraction", 1.0, "Fraction of probes required to pass during upgrade.")
+
+const pipe = "/tmp/scale-to-zero-signal"
+
+func TestScaleToZero(t *testing.T) {
+	// We run the prober as a golang test because it fits in nicely with
+	// the rest of our integration tests, and AssertProberDefault needs
+	// a *testing.T. Unfortunately, "go test" intercepts signals, so we
+	// can't coordinate with the test by just sending e.g. SIGCONT, so we
+	// create a named pipe and wait for the upgrade script to write to it
+	// to signal that we should stop probing.
+	if err := syscall.Mkfifo(pipe, 0666); err != nil {
+		t.Fatal("Failed to create pipe:", err)
+	}
+	defer os.Remove(pipe)
+
+	clients := e2e.Setup(t)
+	names := test.ResourceNames{
+		Service: "scale-to-zero",
+		Image:   test.PizzaPlanet1,
+	}
+	defer test.TearDown(clients, &names)
+
+	objects, err := v1test.CreateServiceReady(t, clients, &names,
+		append([]rtesting.ServiceOption{
+			rtesting.WithConfigAnnotations(map[string]string{
+				// Scale to zero as quick as possible
+				autoscaling.WindowAnnotationKey: "6s",
+				autoscaling.TargetBurstCapacityKey: "-1",
+			})
+		})
+	if err != nil {
+		t.Fatal("Failed to create Service:", err)
+	}
+	url := objects.Service.Status.URL.URL()
+
+	// This polls until we get a 200 with the right body.
+	assertServiceResourcesUpdated(t, clients, names, url, test.PizzaPlanetText1)
+
+	// Use log.Printf instead of t.Logf because we want to see failures
+	// inline with other logs instead of buffered until the end.
+	prober := test.RunRouteProber(log.Printf, clients, url, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
+	defer test.CheckSLO(*successFraction, t.Name(), prober)
+
+	// e2e-upgrade-test.sh will close this pipe to signal the upgrade is
+	// over, at which point we will finish the test and check the prober.
+	ioutil.ReadFile(pipe)
+}

--- a/test/upgrade/autoscaler_test.go
+++ b/test/upgrade/autoscaler_test.go
@@ -1,7 +1,7 @@
 // +build probe
 
 /*
-Copyright 2019 The Knative Authors
+Copyright 2020 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -41,12 +41,8 @@ const scaleToZeroPipe = "/tmp/scale-to-zero-signal"
 
 func TestScaleToZero(t *testing.T) {
 	t.Parallel()
-	// We run the prober as a golang test because it fits in nicely with
-	// the rest of our integration tests, and AssertProberDefault needs
-	// a *testing.T. Unfortunately, "go test" intercepts signals, so we
-	// can't coordinate with the test by just sending e.g. SIGCONT, so we
-	// create a named pipe and wait for the upgrade script to write to it
-	// to signal that we should stop probing.
+	// Create a named pipe and wait for the upgrade script to write to it
+	// to signal that we should stop testing.
 	createPipe(t)
 
 	clients := e2e.Setup(t)
@@ -114,7 +110,7 @@ func TestScaleToZero(t *testing.T) {
 		stop := false
 		// TODO(yanweiguo): In normal scaling to zero e2e test, we use 45 seconds as timeout.
 		// Need to tweak the value both here and there.
-		if err := wait.PollImmediate(500*time.Millisecond, 30*time.Second, func() (bool, error) {
+		if err := wait.PollImmediate(500*time.Millisecond, 45*time.Second, func() (bool, error) {
 			select {
 			case <-stopCh:
 				t.Log("Received stop signal")

--- a/test/upgrade/autoscaler_test.go
+++ b/test/upgrade/autoscaler_test.go
@@ -19,63 +19,124 @@ limitations under the License.
 package upgrade
 
 import (
-	"flag"
+	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
-	"syscall"
 	"testing"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/networking/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/autoscaling"
+	"knative.dev/serving/pkg/apis/serving"
+	"knative.dev/serving/pkg/resources"
+	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"
 	v1test "knative.dev/serving/test/v1"
 )
 
-var successFraction = flag.Float64("probe.success_fraction", 1.0, "Fraction of probes required to pass during upgrade.")
-
-const pipe = "/tmp/scale-to-zero-signal"
+const scaleToZeroPipe = "/tmp/scale-to-zero-signal"
 
 func TestScaleToZero(t *testing.T) {
+	t.Parallel()
 	// We run the prober as a golang test because it fits in nicely with
 	// the rest of our integration tests, and AssertProberDefault needs
 	// a *testing.T. Unfortunately, "go test" intercepts signals, so we
 	// can't coordinate with the test by just sending e.g. SIGCONT, so we
 	// create a named pipe and wait for the upgrade script to write to it
 	// to signal that we should stop probing.
-	if err := syscall.Mkfifo(pipe, 0666); err != nil {
-		t.Fatal("Failed to create pipe:", err)
-	}
-	defer os.Remove(pipe)
+	createPipe(t)
 
 	clients := e2e.Setup(t)
 	names := test.ResourceNames{
 		Service: "scale-to-zero",
 		Image:   test.PizzaPlanet1,
 	}
-	defer test.TearDown(clients, &names)
+	cleanup := func() {
+		test.TearDown(clients, &names)
+		os.Remove(pipe)
+	}
+	t.Cleanup(cleanup)
+	test.CleanupOnInterrupt(cleanup)
 
 	objects, err := v1test.CreateServiceReady(t, clients, &names,
-		append([]rtesting.ServiceOption{
-			rtesting.WithConfigAnnotations(map[string]string{
-				// Scale to zero as quick as possible
-				autoscaling.TargetBurstCapacityKey: "-1",
-				autoscaling.WindowAnnotationKey:    autoscaling.WindowMin.String(),
-			})
-		})
+		rtesting.WithConfigAnnotations(map[string]string{
+			// Scale to zero as quick as possible
+			autoscaling.TargetBurstCapacityKey: "-1",
+			autoscaling.WindowAnnotationKey:    autoscaling.WindowMin.String(),
+		}))
 	if err != nil {
 		t.Fatal("Failed to create Service:", err)
 	}
 	url := objects.Service.Status.URL.URL()
 
+	epsL, err := clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace).List(metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s,%s=%s",
+			serving.RevisionLabelKey, objects.Revision.Name,
+			networking.ServiceTypeKey, networking.ServiceTypePrivate,
+		),
+	})
+	if err != nil || len(epsL.Items) == 0 {
+		t.Fatal("No endpoints or error:", err)
+	}
+
+	epsN := epsL.Items[0].Name
+
 	// This polls until we get a 200 with the right body.
 	assertServiceResourcesUpdated(t, clients, names, url, test.PizzaPlanetText1)
 
-	// Use log.Printf instead of t.Logf because we want to see failures
-	// inline with other logs instead of buffered until the end.
-	prober := test.RunRouteProber(log.Printf, clients, url, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
-	defer test.CheckSLO(*successFraction, t.Name(), prober)
+	stopCh := make(chan struct{})
+	go func() {
+		// e2e-upgrade-test.sh will close this pipe to signal the upgrade is
+		// over, at which point we will finish the test and check the prober.
+		ioutil.ReadFile(pipe)
+		close(stopCh)
+	}()
 
-	// e2e-upgrade-test.sh will close this pipe to signal the upgrade is
-	// over, at which point we will finish the test and check the prober.
-	ioutil.ReadFile(pipe)
+	for {
+		t.Log("Waiting for ready pods")
+		// There're some delays to populate the IP to the endpoints of private Service
+		// after the pod is up to serve.
+		if err := wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+			eps, err := clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace).Get(epsN, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			return resources.ReadyAddressCount(eps) > 0, nil
+		}); err != nil {
+			t.Fatalf("Did not observe %q to have ready IPs", epsN)
+		}
+
+		t.Log("Waiting for scaling to zero")
+		st := time.Now()
+		stop := false
+		// TODO(yanweiguo): In normal scaling to zero e2e test, we use 45 seconds as timeout.
+		// Need to tweak the value both here and there.
+		if err := wait.PollImmediate(500*time.Millisecond, 30*time.Second, func() (bool, error) {
+			select {
+			case <-stopCh:
+				t.Log("Received stop signal")
+				stop = true
+				return true, nil
+			default:
+				eps, err := clients.KubeClient.Kube.CoreV1().Endpoints(test.ServingNamespace).Get(epsN, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				return resources.ReadyAddressCount(eps) == 0, nil
+			}
+		}); err != nil {
+			t.Fatalf("Did not observe %q to actually be emptied", epsN)
+		}
+
+		if stop {
+			break
+		}
+
+		t.Logf("Total time to scale down: %v", time.Since(st))
+		t.Log("Waiting for scaling from zero")
+		assertServiceResourcesUpdated(t, clients, names, url, test.PizzaPlanetText1)
+	}
 }

--- a/test/upgrade/autoscaler_test.go
+++ b/test/upgrade/autoscaler_test.go
@@ -58,8 +58,8 @@ func TestScaleToZero(t *testing.T) {
 		append([]rtesting.ServiceOption{
 			rtesting.WithConfigAnnotations(map[string]string{
 				// Scale to zero as quick as possible
-				autoscaling.WindowAnnotationKey: "6s",
 				autoscaling.TargetBurstCapacityKey: "-1",
+				autoscaling.WindowAnnotationKey:    autoscaling.WindowMin.String(),
 			})
 		})
 	if err != nil {

--- a/test/upgrade/probe_test.go
+++ b/test/upgrade/probe_test.go
@@ -38,7 +38,10 @@ func TestProbe(t *testing.T) {
 	t.Parallel()
 	// We run the prober as a golang test because it fits in nicely with
 	// the rest of our integration tests, and AssertProberDefault needs
-	// a *testing.T.
+	// a *testing.T. Unfortunately, "go test" intercepts signals, so we
+	// can't coordinate with the test by just sending e.g. SIGCONT, so we
+	// create a named pipe and wait for the upgrade script to write to it
+	// to signal that we should stop probing.
 	createPipe(t)
 
 	clients := e2e.Setup(t)

--- a/test/upgrade/probe_test.go
+++ b/test/upgrade/probe_test.go
@@ -32,8 +32,6 @@ import (
 
 var successFraction = flag.Float64("probe.success_fraction", 1.0, "Fraction of probes required to pass during upgrade.")
 
-const pipe = "/tmp/prober-signal"
-
 func TestProbe(t *testing.T) {
 	t.Parallel()
 	// We run the prober as a golang test because it fits in nicely with
@@ -42,7 +40,7 @@ func TestProbe(t *testing.T) {
 	// can't coordinate with the test by just sending e.g. SIGCONT, so we
 	// create a named pipe and wait for the upgrade script to write to it
 	// to signal that we should stop probing.
-	createPipe(t)
+	createPipe(pipe, t)
 
 	clients := e2e.Setup(t)
 	names := test.ResourceNames{

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -42,6 +42,8 @@ const (
 	scaleToZeroServiceName   = "scale-to-zero-upgrade-service"
 	byoServiceName           = "byo-revision-name-upgrade-test"
 	byoRevName               = byoServiceName + "-" + "rev1"
+
+	pipe = "/tmp/prober-signal"
 )
 
 // Shamelessly cribbed from conformance/service_test.
@@ -77,8 +79,8 @@ func createNewService(serviceName string, t *testing.T) {
 
 // createPipe create a named pipe. It fails the test if any error except
 // already exist happens.
-func createPipe(t *testing.T) {
-	if err := syscall.Mkfifo(pipe, 0666); err != nil {
+func createPipe(name string, t *testing.T) {
+	if err := syscall.Mkfifo(name, 0666); err != nil {
 		if err.Error() != "file exists" {
 			t.Fatal("Failed to create pipe:", err)
 		}

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -19,6 +19,7 @@ package upgrade
 import (
 	"fmt"
 	"net/url"
+	"syscall"
 	"testing"
 
 	// Mysteriously required to support GCP auth (required by k8s libs).
@@ -72,4 +73,15 @@ func createNewService(serviceName string, t *testing.T) {
 	}
 	url := resources.Service.Status.URL.URL()
 	assertServiceResourcesUpdated(t, clients, names, url, test.PizzaPlanetText1)
+}
+
+// createPipe create a named pipe. It fails the test if any error except
+// already exist happens.
+func createPipe(t *testing.T) {
+	if err := syscall.Mkfifo(pipe, 0666); err != nil {
+		if err.Error() != "file exists" {
+			t.Fatal("Failed to create pipe:", err)
+		}
+
+	}
 }

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -82,6 +82,5 @@ func createPipe(t *testing.T) {
 		if err.Error() != "file exists" {
 			t.Fatal("Failed to create pipe:", err)
 		}
-
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

For #8909

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add a scaling from/to zero e2e test running in parallel with the probing test.
* Use the same pipe to send the signal to the newly added test that the downgrade process is done.

