### PR TITLE
Revert "Update net-istio from nightly. (#8897)"

### DIFF
--- a/third_party/net-istio.yaml
+++ b/third_party/net-istio.yaml
@@ -18,7 +18,7 @@ metadata:
   # These are the permissions needed by the Istio Ingress implementation.
   name: knative-serving-istio
   labels:
-    serving.knative.dev/release: "v20200804-933aa6c"
+    serving.knative.dev/release: "v20200727-2edfadf"
     serving.knative.dev/controller: "true"
     networking.knative.dev/ingress-provider: istio
 rules:
@@ -48,7 +48,7 @@ metadata:
   name: knative-ingress-gateway
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200804-933aa6c"
+    serving.knative.dev/release: "v20200727-2edfadf"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -85,7 +85,7 @@ metadata:
   name: cluster-local-gateway
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200804-933aa6c"
+    serving.knative.dev/release: "v20200727-2edfadf"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -118,7 +118,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.istio.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v20200804-933aa6c"
+    serving.knative.dev/release: "v20200727-2edfadf"
     networking.knative.dev/ingress-provider: istio
 webhooks:
 - admissionReviewVersions:
@@ -154,7 +154,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.istio.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v20200804-933aa6c"
+    serving.knative.dev/release: "v20200727-2edfadf"
     networking.knative.dev/ingress-provider: istio
 webhooks:
 - admissionReviewVersions:
@@ -192,7 +192,7 @@ metadata:
   name: istio-webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200804-933aa6c"
+    serving.knative.dev/release: "v20200727-2edfadf"
     networking.knative.dev/ingress-provider: istio
 
 ---
@@ -216,7 +216,7 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200804-933aa6c"
+    serving.knative.dev/release: "v20200727-2edfadf"
     networking.knative.dev/ingress-provider: istio
 data:
   _example: |
@@ -286,7 +286,7 @@ metadata:
   name: networking-istio
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200804-933aa6c"
+    serving.knative.dev/release: "v20200727-2edfadf"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -302,14 +302,14 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: networking-istio
-        serving.knative.dev/release: "v20200804-933aa6c"
+        serving.knative.dev/release: "v20200727-2edfadf"
     spec:
       serviceAccountName: controller
       containers:
       - name: networking-istio
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/controller@sha256:db5d363d8f3591f18d3b00bf32848db8ee883efc838efebeb5af2f13b4c937a9
+        image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/controller@sha256:ada2c471e55eeecfaf6a98b0958f5915463186adbdce0e689f1373267d789407
         resources:
           requests:
             cpu: 30m
@@ -361,7 +361,7 @@ metadata:
   name: istio-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200804-933aa6c"
+    serving.knative.dev/release: "v20200727-2edfadf"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -375,14 +375,14 @@ spec:
       labels:
         app: istio-webhook
         role: istio-webhook
-        serving.knative.dev/release: "v20200804-933aa6c"
+        serving.knative.dev/release: "v20200727-2edfadf"
     spec:
       serviceAccountName: controller
       containers:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/webhook@sha256:4d9989433ca197c5376dd7c889918e9ed46293b0d0f6824dfbf3755c12f62784
+        image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/webhook@sha256:e0dd7dcfcdea75d14cfbec37a77fab32089e7bbe451e7e2aa6314ce72fd50cfd
         resources:
           requests:
             cpu: 20m
@@ -436,7 +436,7 @@ metadata:
   namespace: knative-serving
   labels:
     role: istio-webhook
-    serving.knative.dev/release: "v20200804-933aa6c"
+    serving.knative.dev/release: "v20200727-2edfadf"
     networking.knative.dev/ingress-provider: istio
 spec:
   ports:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This reverts commit fd858cbd7930f6d53635003b1547b3db34aaa529.

TestGrid shows a **ton** of ingress failures since this commit so I figured I'd try to verify if it makes things better if we revert it to narrow down the cause.

/hold

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
