### PR TITLE
propagate routes annotation on revision create

### DIFF
--- a/pkg/reconciler/configuration/resources/revision.go
+++ b/pkg/reconciler/configuration/resources/revision.go
@@ -75,7 +75,7 @@ func updateRevisionLabels(rev, config metav1.Object) {
 }
 
 // updateRevisionAnnotations sets the revision's annotation given a Configuration's updater annotation.
-func updateRevisionAnnotations(rev, config metav1.Object) {
+func updateRevisionAnnotations(rev *v1.Revision, config metav1.Object) {
 	annotations := rev.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string, 1)
@@ -85,6 +85,11 @@ func updateRevisionAnnotations(rev, config metav1.Object) {
 	cans := config.GetAnnotations()
 	if c, ok := cans[serving.UpdaterAnnotation]; ok {
 		annotations[serving.CreatorAnnotation] = c
+	}
+
+	if v, ok := cans[serving.RoutesAnnotationKey]; ok {
+		annotations[serving.RoutesAnnotationKey] = v
+		rev.SetRoutingState(v1.RoutingStateActive, clock.RealClock{})
 	}
 
 	rev.SetAnnotations(annotations)

--- a/pkg/reconciler/configuration/resources/revision_test.go
+++ b/pkg/reconciler/configuration/resources/revision_test.go
@@ -209,6 +209,7 @@ func TestMakeRevisions(t *testing.T) {
 				Annotations: map[string]string{
 					"serving.knative.dev/creator":      "admin",
 					"serving.knative.dev/lastModifier": "someone",
+					serving.RoutesAnnotationKey:        "route",
 				},
 				Generation: 10,
 			},
@@ -230,6 +231,7 @@ func TestMakeRevisions(t *testing.T) {
 				GenerateName: "config-",
 				Annotations: map[string]string{
 					"serving.knative.dev/creator": "someone",
+					serving.RoutesAnnotationKey:   "route",
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1.SchemeGroupVersion.String(),
@@ -242,6 +244,7 @@ func TestMakeRevisions(t *testing.T) {
 					serving.ConfigurationLabelKey:           "config",
 					serving.ConfigurationGenerationLabelKey: "10",
 					serving.ServiceLabelKey:                 "",
+					serving.RoutingStateLabelKey:            "active",
 				},
 			},
 			Spec: v1.RevisionSpec{

--- a/pkg/reconciler/gc/v2/gc.go
+++ b/pkg/reconciler/gc/v2/gc.go
@@ -99,7 +99,7 @@ func Collect(
 	logger.Infof("Maximum number of revisions (%d) reached, deleting oldest non-active (%d) revisions",
 		max, len(revs)-max)
 	for _, rev := range revs[max:] {
-		logger.Info("Deleting non-active revision: " + rev.ObjectMeta.Name)
+		logger.Info("Deleting non-active revision: ", rev.ObjectMeta.Name)
 		if err := client.ServingV1().Revisions(rev.Namespace).Delete(rev.Name, &metav1.DeleteOptions{}); err != nil {
 			logger.Errorw("Failed to GC revision: "+rev.Name, zap.Error(err))
 		}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/8791

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Propagate the routes annotation from Configuration to new Revision if present
    * This also sets routingState to active