### PR TITLE
Fix flake in TestPodIPsSplitByAge due to non-deterministic lookup.

### DIFF
--- a/pkg/resources/pods_test.go
+++ b/pkg/resources/pods_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -423,6 +424,11 @@ func TestPodIPsSplitByAge(t *testing.T) {
 			if err != nil {
 				t.Fatal("PodIPsByAge failed:", err)
 			}
+
+			// Pod listing is non deterministic so we arbitrarily sort the IPs.
+			sort.Strings(gotOld)
+			sort.Strings(gotNew)
+
 			if !cmp.Equal(gotOld, tc.wantOld, cmpopts.EquateEmpty()) {
 				t.Error("GotOld wrong answer (-want, +got):\n", cmp.Diff(tc.wantOld, gotOld, cmpopts.EquateEmpty()))
 			}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Failed here https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1290649145672994818 (will be a flake today I assume).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @julz
