### PR TITLE
Remove the unused method.

### DIFF
--- a/pkg/resources/pods.go
+++ b/pkg/resources/pods.go
@@ -44,13 +44,6 @@ func NewPodAccessor(lister corev1listers.PodLister, namespace, revisionName stri
 	}
 }
 
-// PendingTerminatingCount returns the number of pods in a Pending or
-// Terminating state.
-func (pa PodAccessor) PendingTerminatingCount() (pending, terminating int, err error) {
-	_, _, p, t, err := pa.PodCountsByState()
-	return p, t, err
-}
-
 // PodCountsByState returns number of pods for the revision grouped by their state, that is
 // of interest to knative (e.g. ignoring failed or terminated pods).
 func (pa PodAccessor) PodCountsByState() (ready, notReady, pending, terminating int, err error) {

--- a/pkg/resources/pods_test.go
+++ b/pkg/resources/pods_test.go
@@ -226,7 +226,7 @@ func TestPodIPsSortedByAge(t *testing.T) {
 	}
 }
 
-func TestScopedPodsCounter(t *testing.T) {
+func TestPendingTerminatingCounts(t *testing.T) {
 	kubeClient := fakek8s.NewSimpleClientset()
 	podsClient := kubeinformers.NewSharedInformerFactory(kubeClient, 0).Core().V1().Pods()
 	createPods := func(pods []*corev1.Pod) {
@@ -269,7 +269,7 @@ func TestScopedPodsCounter(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			createPods(test.pods)
 
-			pending, terminating, err := podCounter.PendingTerminatingCount()
+			_, _, pending, terminating, err := podCounter.PodCountsByState()
 			if got, want := (err != nil), test.wantErr; got != want {
 				t.Errorf("WantErr = %v, want: %v, err: %v", got, want, err)
 			}


### PR DESCRIPTION
Remove the ununsed method, but keep its test to test the functionality.
We now use PodCountsByState in kpa, instead of this.
The ready counter is used in collector and non-ready one I kept for far to ensure counter interface
implementation.

/assign @yanweiguo @markusthoemmes 