### PR TITLE
Use type-safe atomics where possible

### DIFF
--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -22,8 +22,8 @@ import (
 	"math/rand"
 	"sort"
 	"sync"
-	"sync/atomic"
 
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
 	corev1 "k8s.io/api/core/v1"
@@ -66,15 +66,15 @@ type podTracker struct {
 	dest string
 	b    breaker
 	// weight is used for LB policy implementations.
-	weight int32
+	weight atomic.Int32
 }
 
 func (p *podTracker) addWeight(w int32) {
-	atomic.AddInt32(&p.weight, w)
+	p.weight.Add(w)
 }
 
 func (p *podTracker) getWeight() int32 {
-	return atomic.LoadInt32(&p.weight)
+	return p.weight.Load()
 }
 
 func (p *podTracker) String() string {
@@ -120,12 +120,12 @@ type revisionThrottler struct {
 
 	// These are used in slicing to infer which pods to assign
 	// to this activator.
-	numActivators int32
+	numActivators atomic.Int32
 	// If -1, it is presumed that this activator should not receive requests
 	// for the revision. But due to the system being distributed it might take
 	// time for everything to propagate. Thus when this is -1 we assign all the
 	// pod trackers.
-	activatorIndex int32
+	activatorIndex atomic.Int32
 	protocol       string
 
 	// Holds the current number of backends. This is used for when we get an activatorCount update and
@@ -181,7 +181,7 @@ func newRevisionThrottler(revID types.NamespacedName,
 		breaker:              revBreaker,
 		logger:               logger,
 		protocol:             proto,
-		activatorIndex:       -1, // Start with unknown.
+		activatorIndex:       *atomic.NewInt32(-1), // Start with unknown.
 		lbPolicy:             lbp,
 	}
 }
@@ -263,7 +263,7 @@ func (rt *revisionThrottler) resetTrackers() {
 func (rt *revisionThrottler) updateCapacity(backendCount int) {
 	// We have to make assignments on each updateCapacity, since if number
 	// of activators changes, then we need to rebalance the assignedTrackers.
-	ac, ai := int(atomic.LoadInt32(&rt.numActivators)), int(atomic.LoadInt32(&rt.activatorIndex))
+	ac, ai := int(rt.numActivators.Load()), int(rt.activatorIndex.Load())
 	numTrackers := func() int {
 		// We do not have to process the `podTrackers` under lock, since
 		// updateCapacity is guaranteed to be executed by a single goroutine.
@@ -624,14 +624,14 @@ func (rt *revisionThrottler) handlePubEpsUpdate(eps *corev1.Endpoints, selfIP st
 		return
 	}
 
-	na, ai := atomic.LoadInt32(&rt.numActivators), atomic.LoadInt32(&rt.activatorIndex)
+	na, ai := rt.numActivators.Load(), rt.activatorIndex.Load()
 	if na == newNA && ai == newAI {
 		// The state didn't change, do nothing
 		return
 	}
 
-	atomic.StoreInt32(&rt.numActivators, newNA)
-	atomic.StoreInt32(&rt.activatorIndex, newAI)
+	rt.numActivators.Store(newNA)
+	rt.activatorIndex.Store(newAI)
 	rt.logger.Infof("This activator index is %d/%d was %d/%d",
 		rt.activatorIndex, rt.numActivators, newAI, newNA)
 	rt.updateCapacity(rt.backendCount)
@@ -691,8 +691,7 @@ type infiniteBreaker struct {
 	// 0 (no downstream capacity) and 1 (infinite downstream capacity).
 	// `Maybe` checks this value to determine whether to proxy the request
 	// immediately or wait for capacity to appear.
-	// `concurrency` should only be manipulated by `sync/atomic` methods.
-	concurrency int32
+	concurrency atomic.Int32
 
 	logger *zap.SugaredLogger
 }
@@ -707,7 +706,7 @@ func newInfiniteBreaker(logger *zap.SugaredLogger) *infiniteBreaker {
 
 // Capacity returns the current capacity of the breaker
 func (ib *infiniteBreaker) Capacity() int {
-	return int(atomic.LoadInt32(&ib.concurrency))
+	return int(ib.concurrency.Load())
 }
 
 func zeroOrOne(x int) int32 {
@@ -724,7 +723,7 @@ func (ib *infiniteBreaker) UpdateConcurrency(cc int) error {
 	// stomp on each other's feet.
 	ib.mu.Lock()
 	defer ib.mu.Unlock()
-	old := atomic.SwapInt32(&ib.concurrency, rcc)
+	old := ib.concurrency.Swap(rcc)
 
 	// Scale up/down event.
 	if old != rcc {

--- a/pkg/http/response_recorder.go
+++ b/pkg/http/response_recorder.go
@@ -20,7 +20,8 @@ import (
 	"bufio"
 	"net"
 	"net/http"
-	"sync/atomic"
+
+	"go.uber.org/atomic"
 
 	"knative.dev/pkg/websocket"
 )
@@ -41,9 +42,7 @@ type ResponseRecorder struct {
 	// hijacked is whether this connection has been hijacked
 	// by a Handler with the Hijacker interface.
 	// This is guarded by a mutex in the default implementation.
-	// To emulate the same behavior, we will use an int32 and
-	// access to this field only through atomic calls.
-	hijacked int32
+	hijacked atomic.Bool
 }
 
 // NewResponseRecorder creates an http.ResponseWriter that captures the response code and size.
@@ -65,7 +64,7 @@ func (rr *ResponseRecorder) Flush() {
 func (rr *ResponseRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	c, rw, err := websocket.HijackIfPossible(rr.writer)
 	if err != nil {
-		atomic.StoreInt32(&rr.hijacked, 1)
+		rr.hijacked.Store(true)
 	}
 	return c, rw, err
 }
@@ -83,7 +82,7 @@ func (rr *ResponseRecorder) Write(p []byte) (int, error) {
 
 // WriteHeader sends an HTTP response header with the provided status code.
 func (rr *ResponseRecorder) WriteHeader(code int) {
-	if rr.wroteHeader || atomic.LoadInt32(&rr.hijacked) == 1 {
+	if rr.wroteHeader || rr.hijacked.Load() {
 		return
 	}
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

We already use [this library](https://github.com/uber-go/atomic) in [some tests](https://github.com/knative/serving/blob/44d8d27ce736d908bedbec7bd5674839dbba4d52/pkg/reconciler/autoscaling/kpa/kpa_test.go#L1594), so it's in go.mod already, and it's generally just as fast and more type-safe/harder to mess up accidentally.

Just to double-check, before/after of BenchmarkBreakerReserve:

~~~~
benchmark                                 old ns/op     new ns/op     delta
BenchmarkBreakerReserve/sequential-16     94.6          90.7          -4.12%
BenchmarkBreakerReserve/parallel-16       174           162           -6.90%

benchmark                                 old allocs     new allocs     delta
BenchmarkBreakerReserve/sequential-16     0              0              +0.00%
BenchmarkBreakerReserve/parallel-16       0              0              +0.00%

benchmark                                 old bytes     new bytes     delta
BenchmarkBreakerReserve/sequential-16     0             0             +0.00%
BenchmarkBreakerReserve/parallel-16       0             0             +0.00%
~~~~

/assign @markusthoemmes @vagababov 
