### PR TITLE
Make sure we don't override existing message on failed resources.

### DIFF
--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -191,7 +191,8 @@ func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *av1alpha1.PodAutoscalerS
 		// See #8922 for details. When we try to scale to 0, we force the Deployment's
 		// Progress status to become `true`, since successful scale down means
 		// progress has been achieved.
-		if !ps.IsScaleTargetInitialized() {
+		// If the ResourcesAvailable is already false, don't override the message.
+		if !ps.IsScaleTargetInitialized() && !rs.GetCondition(RevisionConditionResourcesAvailable).IsFalse() {
 			rs.MarkResourcesAvailableFalse(ReasonProgressDeadlineExceeded,
 				"Initial scale was never achieved")
 		}


### PR DESCRIPTION
It is easy to envision that PA would fail with this message in addition to deployment failing (e.g. with container pull error message).
Usually deployment failures happen much earlier in time, but overtime PA would fail as well and we'd override the message,
which is not strictly right (not totally wrong either, but still).
So don't do it in that case.


/lint
/assign mattmoor