### PR TITLE
Revert 8933

### DIFF
--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -191,8 +191,7 @@ func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *av1alpha1.PodAutoscalerS
 		// See #8922 for details. When we try to scale to 0, we force the Deployment's
 		// Progress status to become `true`, since successful scale down means
 		// progress has been achieved.
-		// If the ResourcesAvailable is already false, don't override the message.
-		if !ps.IsScaleTargetInitialized() && !rs.GetCondition(RevisionConditionResourcesAvailable).IsFalse() {
+		if !ps.IsScaleTargetInitialized() {
 			rs.MarkResourcesAvailableFalse(ReasonProgressDeadlineExceeded,
 				"Initial scale was never achieved")
 		}

--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -182,19 +182,6 @@ func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *av1alpha1.PodAutoscalerS
 	case corev1.ConditionUnknown:
 		rs.MarkActiveUnknown(cond.Reason, cond.Message)
 	case corev1.ConditionFalse:
-		// Here we have 2 things coming together at the same time:
-		// 1. The ready is False, meaning the revision is scaled to 0
-		// 2. Initial scale was never achieved, which means we failed to progress
-		//    towards initial scale during the progress deadline period and scaled to 0
-		//		failing to activate.
-		// So mark the revision as failed at that point.
-		// See #8922 for details. When we try to scale to 0, we force the Deployment's
-		// Progress status to become `true`, since successful scale down means
-		// progress has been achieved.
-		if !ps.IsScaleTargetInitialized() {
-			rs.MarkResourcesAvailableFalse(ReasonProgressDeadlineExceeded,
-				"Initial scale was never achieved")
-		}
 		rs.MarkActiveFalse(cond.Reason, cond.Message)
 	case corev1.ConditionTrue:
 		rs.MarkActiveTrue()

--- a/pkg/apis/serving/v1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1/revision_lifecycle_test.go
@@ -575,31 +575,6 @@ func TestPropagateAutoscalerStatus(t *testing.T) {
 	apistest.CheckConditionSucceeded(r, RevisionConditionResourcesAvailable, t)
 }
 
-func TestPropagateAutoscalerStatusNoProgress(t *testing.T) {
-	r := &RevisionStatus{}
-	r.InitializeConditions()
-	apistest.CheckConditionOngoing(r, RevisionConditionReady, t)
-
-	// PodAutoscaler is not ready and initial scale was never attained.
-	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
-		Status: duckv1.Status{
-			Conditions: duckv1.Conditions{{
-				Type:   av1alpha1.PodAutoscalerConditionReady,
-				Status: corev1.ConditionFalse,
-			}, {
-				Type:   av1alpha1.PodAutoscalerConditionScaleTargetInitialized,
-				Status: corev1.ConditionUnknown,
-			}},
-		},
-	})
-	apistest.CheckConditionFailed(r, RevisionConditionActive, t)
-	apistest.CheckConditionFailed(r, RevisionConditionResourcesAvailable, t)
-	cond := r.GetCondition(RevisionConditionResourcesAvailable)
-	if got, want := cond.Reason, ReasonProgressDeadlineExceeded; got != want {
-		t.Errorf("Reason = %q, want: %q", got, want)
-	}
-}
-
 func TestPropagateAutoscalerStatusRace(t *testing.T) {
 	r := &RevisionStatus{}
 	r.InitializeConditions()

--- a/pkg/apis/serving/v1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1/revision_lifecycle_test.go
@@ -598,27 +598,6 @@ func TestPropagateAutoscalerStatusNoProgress(t *testing.T) {
 	if got, want := cond.Reason, ReasonProgressDeadlineExceeded; got != want {
 		t.Errorf("Reason = %q, want: %q", got, want)
 	}
-
-	// Set a different reason/message
-	r.MarkResourcesAvailableFalse("another-one", "bit-the-dust")
-
-	// And apply the status.
-	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
-		Status: duckv1.Status{
-			Conditions: duckv1.Conditions{{
-				Type:   av1alpha1.PodAutoscalerConditionReady,
-				Status: corev1.ConditionFalse,
-			}, {
-				Type:   av1alpha1.PodAutoscalerConditionScaleTargetInitialized,
-				Status: corev1.ConditionUnknown,
-			}},
-		},
-	})
-	// Verify it did not alter the reason/message.
-	cond = r.GetCondition(RevisionConditionResourcesAvailable)
-	if got, want := cond.Reason, ReasonProgressDeadlineExceeded; got == want {
-		t.Errorf("Reason = %q should have not overridden a different status", got)
-	}
 }
 
 func TestPropagateAutoscalerStatusRace(t *testing.T) {

--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -175,7 +175,7 @@ func (c *Reconciler) reconcilePA(ctx context.Context, rev *v1.Revision) error {
 func hasDeploymentTimedOut(deployment *appsv1.Deployment) bool {
 	// as per https://kubernetes.io/docs/concepts/workloads/controllers/deployment
 	for _, cond := range deployment.Status.Conditions {
-		// Look for a condition with status False
+		// Look for Deployment with status False
 		if cond.Status != corev1.ConditionFalse {
 			continue
 		}

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -237,8 +237,7 @@ func TestReconcile(t *testing.T) {
 				MarkInactive("NoTraffic", "This thing is inactive."),
 				withDefaultContainerStatuses(), withObservedGeneration(1)),
 			pa("foo", "stable-deactivation",
-				WithNoTraffic("NoTraffic", "This thing is inactive."), WithReachabilityUnreachable,
-				WithScaleTargetInitialized),
+				WithNoTraffic("NoTraffic", "This thing is inactive."), WithReachabilityUnreachable),
 			deploy(t, "foo", "stable-deactivation"),
 			image("foo", "stable-deactivation"),
 		},
@@ -298,7 +297,6 @@ func TestReconcile(t *testing.T) {
 				MarkRevisionReady, withObservedGeneration(1)),
 			pa("foo", "pa-inactive",
 				WithNoTraffic("NoTraffic", "This thing is inactive."),
-				WithScaleTargetInitialized,
 				WithReachabilityUnreachable),
 			readyDeploy(deploy(t, "foo", "pa-inactive")),
 			image("foo", "pa-inactive"),
@@ -312,28 +310,6 @@ func TestReconcile(t *testing.T) {
 		}},
 		Key: "foo/pa-inactive",
 	}, {
-		Name: "pa inactive II",
-		// Test propagating the inactivity signal from the pa to the Revision.
-		Objects: []runtime.Object{
-			rev("foo", "pa-inactive",
-				withK8sServiceName("something-in-the-way"), WithLogURL,
-				withObservedGeneration(1)),
-			pa("foo", "pa-inactive",
-				WithNoTraffic("NoTraffic", "This thing is inactive.")),
-			readyDeploy(deploy(t, "foo", "pa-inactive")),
-			image("foo", "pa-inactive"),
-		},
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "pa-inactive",
-				WithLogURL, withDefaultContainerStatuses(), MarkDeploying(""),
-				// When we reconcile an "all ready" revision when the PA
-				// is inactive, we should see the following change.
-				MarkInactive("NoTraffic", "This thing is inactive."), withObservedGeneration(1),
-				MarkResourcesUnavailable(v1.ReasonProgressDeadlineExceeded,
-					"Initial scale was never achieved")),
-		}},
-		Key: "foo/pa-inactive",
-	}, {
 		Name: "pa inactive, but has service",
 		// Test propagating the inactivity signal from the pa to the Revision.
 		// But propagate the service name.
@@ -344,7 +320,6 @@ func TestReconcile(t *testing.T) {
 			pa("foo", "pa-inactive",
 				WithNoTraffic("NoTraffic", "This thing is inactive."),
 				WithPAStatusService("pa-inactive-svc"),
-				WithScaleTargetInitialized,
 				WithReachabilityUnreachable),
 			readyDeploy(deploy(t, "foo", "pa-inactive")),
 			image("foo", "pa-inactive"),


### PR DESCRIPTION
TestContainerExitingMsg got significantly less stable after this change.  Biasing towards a revert while we investigate.

The two commits in this change are via `git revert <sha>` in reverse order.

/assign @vagababov 