### PR TITLE
Make remaining sync/atomic usages type-safe

### DIFF
--- a/pkg/activator/testing/roundtripper.go
+++ b/pkg/activator/testing/roundtripper.go
@@ -21,7 +21,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
-	"sync/atomic"
+
+	"go.uber.org/atomic"
 
 	network "knative.dev/networking/pkg"
 	"knative.dev/serving/pkg/queue"
@@ -54,7 +55,7 @@ type FakeRoundTripper struct {
 	RequestResponse *FakeResponse
 	responseMux     sync.Mutex
 
-	NumProbes int32
+	NumProbes atomic.Int32
 }
 
 func defaultProbeResponse() *FakeResponse {
@@ -110,7 +111,7 @@ func (rt *FakeRoundTripper) popResponse(host string) *FakeResponse {
 // RT is a RoundTripperFunc
 func (rt *FakeRoundTripper) RT(req *http.Request) (*http.Response, error) {
 	if req.Header.Get(network.ProbeHeaderName) != "" {
-		atomic.AddInt32(&rt.NumProbes, 1)
+		rt.NumProbes.Inc()
 		resp := rt.popResponse(req.URL.Host)
 		if resp.Err != nil {
 			return nil, resp.Err


### PR DESCRIPTION
Missed a few usages in tests in https://github.com/knative/serving/pull/8936. Might as well use it everywhere.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

/assign @markusthoemmes 