### PR TITLE
Enable request log flag support

### DIFF
--- a/cmd/activator/request_log.go
+++ b/cmd/activator/request_log.go
@@ -30,12 +30,15 @@ import (
 
 func updateRequestLogFromConfigMap(logger *zap.SugaredLogger, h *pkghttp.RequestLogHandler) func(configMap *corev1.ConfigMap) {
 	return func(configMap *corev1.ConfigMap) {
+		var newTemplate string
 		obsconfig, err := metrics.NewObservabilityConfigFromConfigMap(configMap)
 		if err != nil {
 			logger.Errorw("Failed to get observability configmap.", zap.Error(err), "configmap", configMap)
 			return
 		}
-		newTemplate := obsconfig.RequestLogTemplate
+		if obsconfig.EnableRequestLog {
+			newTemplate = obsconfig.RequestLogTemplate
+		}
 		if err := h.SetTemplate(newTemplate); err != nil {
 			logger.Errorw("Failed to update the request log template.", zap.Error(err), "template", newTemplate)
 		} else {

--- a/cmd/activator/request_log.go
+++ b/cmd/activator/request_log.go
@@ -36,6 +36,7 @@ func updateRequestLogFromConfigMap(logger *zap.SugaredLogger, h *pkghttp.Request
 			logger.Errorw("Failed to get observability configmap.", zap.Error(err), "configmap", configMap)
 			return
 		}
+
 		if obsconfig.EnableRequestLog {
 			newTemplate = obsconfig.RequestLogTemplate
 		}

--- a/cmd/activator/request_log.go
+++ b/cmd/activator/request_log.go
@@ -30,15 +30,11 @@ import (
 
 func updateRequestLogFromConfigMap(logger *zap.SugaredLogger, h *pkghttp.RequestLogHandler) func(configMap *corev1.ConfigMap) {
 	return func(configMap *corev1.ConfigMap) {
-		var newTemplate string // default is an empty template, disables logging
 		obsconfig, err := metrics.NewObservabilityConfigFromConfigMap(configMap)
 		if err != nil {
 			logger.Errorw("Failed to get observability configmap.", zap.Error(err), "configmap", configMap)
 		} else {
-			if obsconfig.EnableRequestLog {
-				newTemplate = obsconfig.RequestLogTemplate
-			}
-			// set this in any case to disable logging if the previous flag is false
+			newTemplate := obsconfig.RequestLogTemplate
 			if err := h.SetTemplate(newTemplate); err != nil {
 				logger.Errorw("Failed to update the request log template.", zap.Error(err), "template", newTemplate)
 			} else {

--- a/cmd/activator/request_log.go
+++ b/cmd/activator/request_log.go
@@ -30,13 +30,13 @@ import (
 
 func updateRequestLogFromConfigMap(logger *zap.SugaredLogger, h *pkghttp.RequestLogHandler) func(configMap *corev1.ConfigMap) {
 	return func(configMap *corev1.ConfigMap) {
-		var newTemplate string
 		obsconfig, err := metrics.NewObservabilityConfigFromConfigMap(configMap)
 		if err != nil {
 			logger.Errorw("Failed to get observability configmap.", zap.Error(err), "configmap", configMap)
 			return
 		}
 
+		var newTemplate string
 		if obsconfig.EnableRequestLog {
 			newTemplate = obsconfig.RequestLogTemplate
 		}

--- a/cmd/activator/request_log.go
+++ b/cmd/activator/request_log.go
@@ -33,13 +33,13 @@ func updateRequestLogFromConfigMap(logger *zap.SugaredLogger, h *pkghttp.Request
 		obsconfig, err := metrics.NewObservabilityConfigFromConfigMap(configMap)
 		if err != nil {
 			logger.Errorw("Failed to get observability configmap.", zap.Error(err), "configmap", configMap)
+			return
+		}
+		newTemplate := obsconfig.RequestLogTemplate
+		if err := h.SetTemplate(newTemplate); err != nil {
+			logger.Errorw("Failed to update the request log template.", zap.Error(err), "template", newTemplate)
 		} else {
-			newTemplate := obsconfig.RequestLogTemplate
-			if err := h.SetTemplate(newTemplate); err != nil {
-				logger.Errorw("Failed to update the request log template.", zap.Error(err), "template", newTemplate)
-			} else {
-				logger.Infow("Updated the request log template.", "template", newTemplate)
-			}
+			logger.Infow("Updated the request log template.", "template", newTemplate)
 		}
 	}
 }

--- a/cmd/activator/request_log_test.go
+++ b/cmd/activator/request_log_test.go
@@ -61,8 +61,8 @@ func TestUpdateRequestLogFromConfigMap(t *testing.T) {
 		url              string
 		body             string
 		template         string
-		enableRequestLog *bool
 		want             string
+		enableRequestLog *bool
 	}{{
 		name:     "empty template",
 		url:      "http://example.com/testpage",

--- a/cmd/activator/request_log_test.go
+++ b/cmd/activator/request_log_test.go
@@ -65,31 +65,41 @@ func TestUpdateRequestLogFromConfigMap(t *testing.T) {
 		name: "empty template",
 		url:  "http://example.com/testpage",
 		body: "test",
-		data: map[string]string{"logging.request-log-template": ""},
+		data: map[string]string{
+			"logging.request-log-template": "",
+		},
 		want: "",
 	}, {
 		name: "template with new line",
 		url:  "http://example.com/testpage",
 		body: "test",
-		data: map[string]string{"logging.request-log-template": "{{.Request.URL}}\n"},
+		data: map[string]string{
+			"logging.request-log-template": "{{.Request.URL}}\n",
+		},
 		want: "http://example.com/testpage\n",
 	}, {
 		name: "invalid template",
 		url:  "http://example.com",
 		body: "test",
-		data: map[string]string{"logging.request-log-template": "{{}}"},
+		data: map[string]string{
+			"logging.request-log-template": "{{}}",
+		},
 		want: "http://example.com\n",
 	}, {
 		name: "revision info",
 		url:  "http://example.com",
 		body: "test",
-		data: map[string]string{"logging.request-log-template": "{{.Revision.Name}}, {{.Revision.Namespace}}, {{.Revision.Service}}, {{.Revision.Configuration}}, {{.Revision.PodName}}, {{.Revision.PodIP}}"},
+		data: map[string]string{
+			"logging.request-log-template": "{{.Revision.Name}}, {{.Revision.Namespace}}, {{.Revision.Service}}, {{.Revision.Configuration}}, {{.Revision.PodName}}, {{.Revision.PodIP}}",
+		},
 		want: "testRevision, testNs, testSvc, testConfig, , \n",
 	}, {
 		name: "empty template 2",
 		url:  "http://example.com/testpage",
 		body: "test",
-		data: map[string]string{"logging.request-log-template": ""},
+		data: map[string]string{
+			"logging.request-log-template": "",
+		},
 		want: "",
 	}, {
 		name: "explicitly enable request logging",

--- a/cmd/activator/request_log_test.go
+++ b/cmd/activator/request_log_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	testing2 "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/ptr"
 	rtesting "knative.dev/pkg/reconciler/testing"
 	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/serving"
@@ -99,21 +100,21 @@ func TestUpdateRequestLogFromConfigMap(t *testing.T) {
 		body:             "test",
 		template:         "{{.Request.URL}}\n",
 		want:             "http://example.com/testpage\n",
-		enableRequestLog: getBoolPtr(true),
+		enableRequestLog: ptr.Bool(true),
 	}, {
 		name:             "explicitly disable request logging",
 		url:              "http://example.com/testpage",
 		body:             "test",
 		template:         "disable_request_log",
 		want:             "",
-		enableRequestLog: getBoolPtr(false),
+		enableRequestLog: ptr.Bool(false),
 	}, {
 		name:             "explicitly enable request logging with empty template",
 		url:              "http://example.com/testpage",
 		body:             "test",
 		template:         "",
 		want:             "",
-		enableRequestLog: getBoolPtr(true),
+		enableRequestLog: ptr.Bool(true),
 	}}
 
 	for _, test := range tests {
@@ -138,12 +139,6 @@ func TestUpdateRequestLogFromConfigMap(t *testing.T) {
 			}
 		})
 	}
-}
-
-func getBoolPtr(val bool) *bool {
-	ptr := new(bool)
-	*ptr = val
-	return ptr
 }
 
 func TestRequestLogTemplateInputGetter(t *testing.T) {

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -82,6 +82,7 @@ type config struct {
 	ServingLoggingConfig         string `split_words:"true" required:"true"`
 	ServingLoggingLevel          string `split_words:"true" required:"true"`
 	ServingRequestLogTemplate    string `split_words:"true"` // optional
+	ServingEnableRequestLog      bool   `split_words:"true"` // optional
 	ServingEnableProbeRequestLog bool   `split_words:"true"` // optional
 
 	// Metrics configuration
@@ -432,7 +433,7 @@ func buildMetricsServer(promStatReporter *queue.PrometheusStatsReporter, protobu
 }
 
 func pushRequestLogHandler(currentHandler http.Handler, env config) http.Handler {
-	if env.ServingRequestLogTemplate == "" {
+	if !env.ServingEnableRequestLog {
 		return currentHandler
 	}
 

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -136,6 +136,9 @@ var (
 			Name:  "SERVING_REQUEST_LOG_TEMPLATE",
 			Value: "",
 		}, {
+			Name:  "SERVING_ENABLE_REQUEST_LOG",
+			Value: "false",
+		}, {
 			Name:  "SERVING_REQUEST_METRICS_BACKEND",
 			Value: "",
 		}, {

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -312,6 +312,9 @@ func makeQueueContainer(rev *v1.Revision, loggingConfig *logging.Config, tracing
 			Name:  "SERVING_REQUEST_LOG_TEMPLATE",
 			Value: observabilityConfig.RequestLogTemplate,
 		}, {
+			Name:  "SERVING_ENABLE_REQUEST_LOG",
+			Value: strconv.FormatBool(observabilityConfig.EnableRequestLog),
+		}, {
 			Name:  "SERVING_REQUEST_METRICS_BACKEND",
 			Value: observabilityConfig.RequestMetricsBackend,
 		}, {

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -756,6 +756,7 @@ var defaultEnv = map[string]string{
 	"TRACING_CONFIG_SAMPLE_RATE":            "0",
 	"TRACING_CONFIG_DEBUG":                  "false",
 	"SERVING_REQUEST_LOG_TEMPLATE":          "",
+	"SERVING_ENABLE_REQUEST_LOG":            "false",
 	"SERVING_REQUEST_METRICS_BACKEND":       "",
 	"USER_PORT":                             strconv.Itoa(v1.DefaultUserPort),
 	"SYSTEM_NAMESPACE":                      system.Namespace(),

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -200,6 +200,23 @@ func TestMakeQueueContainer(t *testing.T) {
 			})
 		}),
 	}, {
+		name: "disabled request log configuration as env var",
+		rev: revision("bar", "foo",
+			withContainers(containers),
+			withContainerConcurrency(1)),
+		oc: metrics.ObservabilityConfig{
+			RequestLogTemplate:    "test template",
+			EnableProbeRequestLog: false,
+			EnableRequestLog:      false,
+		},
+		want: queueContainer(func(c *corev1.Container) {
+			c.Env = env(map[string]string{
+				"SERVING_REQUEST_LOG_TEMPLATE":     "test template",
+				"SERVING_ENABLE_REQUEST_LOG":       "false",
+				"SERVING_ENABLE_PROBE_REQUEST_LOG": "false",
+			})
+		}),
+	}, {
 		name: "request metrics backend as env var",
 		rev: revision("bar", "foo",
 			withContainers(containers),


### PR DESCRIPTION
Fixes #8644 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* According to the discussion in #8644 we check in activator and queue proxy if we should enable request logging
based on a new flag. 


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE

```

/assign @vagababov 