### PR TITLE
Limit the number of concurrent builds when uploading test images.

### DIFF
--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -30,7 +30,8 @@ function upload_test_images() {
 
   # ko resolve is being used for the side-effect of publishing images,
   # so the resulting yaml produced is ignored.
-  ko resolve ${tag_option} -RBf "${image_dir}" > /dev/null
+  # We limit the number of concurrent builds (jobs) to avoid OOMs.
+  ko resolve --jobs=4 ${tag_option} -RBf "${image_dir}" > /dev/null
 }
 
 : ${KO_DOCKER_REPO:?"You must set 'KO_DOCKER_REPO', see DEVELOPMENT.md"}


### PR DESCRIPTION
This limits the number of concurrent jobs used when uploading test
images to try and reduce the peak memory used.  We are seeing these
builds getting OOM killed periodically, and keep raising memory
because of them.

