### PR TITLE
Set pending state first (before annotation modification)

### DIFF
--- a/pkg/reconciler/configuration/resources/revision.go
+++ b/pkg/reconciler/configuration/resources/revision.go
@@ -42,13 +42,13 @@ func MakeRevision(ctx context.Context, config *v1.Configuration, clock clock.Clo
 		rev.GenerateName = config.Name + "-"
 	}
 
-	updateRevisionLabels(rev, config)
-	updateRevisionAnnotations(rev, config)
-
 	// Pending tells the labeler that we have not processed this revision.
-	if cfgMap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC == cfgMap.Enabled {
+	if cfgMap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC != cfgMap.Disabled {
 		rev.SetRoutingState(v1.RoutingStatePending, clock)
 	}
+
+	updateRevisionLabels(rev, config)
+	updateRevisionAnnotations(rev, config)
 
 	// Populate OwnerReferences so that deletes cascade.
 	rev.OwnerReferences = append(rev.OwnerReferences, *kmeta.NewControllerRef(config))

--- a/pkg/reconciler/configuration/resources/revision_test.go
+++ b/pkg/reconciler/configuration/resources/revision_test.go
@@ -201,7 +201,8 @@ func TestMakeRevisions(t *testing.T) {
 			},
 		},
 	}, {
-		name: "with creator annotation from config",
+		name:         "with creator annotation from config",
+		responsiveGC: true,
 		configuration: &v1.Configuration{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "anno",
@@ -230,8 +231,9 @@ func TestMakeRevisions(t *testing.T) {
 				Namespace:    "anno",
 				GenerateName: "config-",
 				Annotations: map[string]string{
-					"serving.knative.dev/creator": "someone",
-					serving.RoutesAnnotationKey:   "route",
+					"serving.knative.dev/creator":             "someone",
+					serving.RoutesAnnotationKey:               "route",
+					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(clock),
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1.SchemeGroupVersion.String(),

--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -47,7 +47,7 @@ func MakeConfigurationFromExisting(service *v1.Service, existing *v1.Configurati
 		labels[serving.RouteLabelKey] = routeName
 	}
 
-	if gc == cfgmap.Enabled || gc == cfgmap.Allowed {
+	if gc != cfgmap.Disabled {
 		set := labelerv2.GetListAnnValue(existing.Annotations, serving.RoutesAnnotationKey)
 		if !set.Has(routeName) {
 			set.Insert(routeName)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* The labeler "fixes" this but can result in test flake if the test tries to assert the routingState before the labeler finishes

Was investigating: https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_serving/8964/pull-knative-serving-integration-tests/1291853455568146432
