### PR TITLE
Temporarily remove routetags for queue metrics

### DIFF
--- a/pkg/queue/request_metric.go
+++ b/pkg/queue/request_metric.go
@@ -81,7 +81,7 @@ type appRequestMetricsHandler struct {
 // NewRequestMetricsHandler creates an http.Handler that emits request metrics.
 func NewRequestMetricsHandler(next http.Handler,
 	ns, service, config, rev, pod string) (http.Handler, error) {
-	keys := []tag.Key{metrics.PodTagKey, metrics.ContainerTagKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey, metrics.RouteTagKey}
+	keys := []tag.Key{metrics.PodTagKey, metrics.ContainerTagKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey /*, metrics.RouteTagKey*/}
 	if err := pkgmetrics.RegisterResourceView(
 		&view.View{
 			Description: "The number of requests that are routed to queue-proxy",
@@ -123,16 +123,18 @@ func (h *requestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		// If ServeHTTP panics, recover, record the failure and panic again.
 		err := recover()
 		latency := time.Since(startTime)
-		routeTag := GetRouteTagNameFromRequest(r)
+		// routeTag := GetRouteTagNameFromRequest(r)
 		if err != nil {
-			ctx := metrics.AugmentWithResponseAndRouteTag(h.statsCtx,
-				http.StatusInternalServerError, routeTag)
+			ctx := metrics.AugmentWithResponse(h.statsCtx, http.StatusInternalServerError)
+			// ctx := metrics.AugmentWithResponseAndRouteTag(h.statsCtx,
+			// http.StatusInternalServerError, routeTag)
 			pkgmetrics.RecordBatch(ctx, requestCountM.M(1),
 				responseTimeInMsecM.M(float64(latency.Milliseconds())))
 			panic(err)
 		}
-		ctx := metrics.AugmentWithResponseAndRouteTag(h.statsCtx,
-			rr.ResponseCode, routeTag)
+		ctx := metrics.AugmentWithResponse(h.statsCtx, rr.ResponseCode)
+		// ctx := metrics.AugmentWithResponseAndRouteTag(h.statsCtx,
+		// rr.ResponseCode, routeTag)
 		pkgmetrics.RecordBatch(ctx, requestCountM.M(1),
 			responseTimeInMsecM.M(float64(latency.Milliseconds())))
 	}()

--- a/pkg/queue/request_metric.go
+++ b/pkg/queue/request_metric.go
@@ -208,7 +208,7 @@ func (h *appRequestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 }
 
 // GetRouteTagNameFromRequest extracts the value of the tag header from http.Request
-func GetRouteTagNameFromRequest(r *http.Request) string {
+/*func GetRouteTagNameFromRequest(r *http.Request) string {
 	name := r.Header.Get(network.TagHeaderName)
 	isDefaultRoute := r.Header.Get(network.DefaultRouteHeaderName)
 
@@ -227,4 +227,4 @@ func GetRouteTagNameFromRequest(r *http.Request) string {
 	}
 	// Otherwise, returns the value of the tag header.
 	return name
-}
+}*/

--- a/pkg/queue/request_metric.go
+++ b/pkg/queue/request_metric.go
@@ -126,6 +126,8 @@ func (h *requestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		// routeTag := GetRouteTagNameFromRequest(r)
 		if err != nil {
 			ctx := metrics.AugmentWithResponse(h.statsCtx, http.StatusInternalServerError)
+			// TODO: add the routeTag back after stackdriver adds support for it.
+			// https://github.com/knative/serving/issues/8970
 			// ctx := metrics.AugmentWithResponseAndRouteTag(h.statsCtx,
 			// http.StatusInternalServerError, routeTag)
 			pkgmetrics.RecordBatch(ctx, requestCountM.M(1),
@@ -133,6 +135,8 @@ func (h *requestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 			panic(err)
 		}
 		ctx := metrics.AugmentWithResponse(h.statsCtx, rr.ResponseCode)
+		// TODO: add the routeTag back after stackdriver adds support for it.
+		// https://github.com/knative/serving/issues/8970
 		// ctx := metrics.AugmentWithResponseAndRouteTag(h.statsCtx,
 		// rr.ResponseCode, routeTag)
 		pkgmetrics.RecordBatch(ctx, requestCountM.M(1),

--- a/pkg/queue/request_metric_test.go
+++ b/pkg/queue/request_metric_test.go
@@ -54,7 +54,7 @@ func TestRequestMetricsHandler(t *testing.T) {
 		metricskey.ContainerName:          "queue-proxy",
 		metricskey.LabelResponseCode:      "200",
 		metricskey.LabelResponseCodeClass: "2xx",
-		"tag":                             disabledTagName,
+		//"tag":                             disabledTagName,
 	}
 	wantResource := &resource.Resource{
 		Type: "knative_revision",
@@ -76,7 +76,7 @@ func TestRequestMetricsHandler(t *testing.T) {
 	metricstest.AssertMetric(t, metricstest.DistributionCountOnlyMetric("request_latencies", 1, wantTags).WithResource(wantResource))
 }
 
-func TestRequestMetricsHandlerWithEnablingTagOnRequestMetrics(t *testing.T) {
+/* func TestRequestMetricsHandlerWithEnablingTagOnRequestMetrics(t *testing.T) {
 	defer reset()
 	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	handler, err := NewRequestMetricsHandler(baseHandler, "ns", "svc", "cfg", "rev", "pod")
@@ -133,7 +133,7 @@ func TestRequestMetricsHandlerWithEnablingTagOnRequestMetrics(t *testing.T) {
 	handler.ServeHTTP(resp, req)
 	wantTags["tag"] = "test-tag"
 	metricstest.AssertMetric(t, metricstest.IntMetric("request_count", 1, wantTags).WithResource(wantResource))
-}
+} */
 
 func reset() {
 	metricstest.Unregister(
@@ -163,7 +163,7 @@ func TestRequestMetricsHandlerPanickingHandler(t *testing.T) {
 			metricskey.ContainerName:          "queue-proxy",
 			metricskey.LabelResponseCode:      "500",
 			metricskey.LabelResponseCodeClass: "5xx",
-			"tag":                             disabledTagName,
+			// "tag":                             disabledTagName,
 		}
 		wantResource := &resource.Resource{
 			Type: "knative_revision",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #
We just found out stackdriver metrics for queue-proxy(request_count and request_latency) are broken.  Further investigation showed stackdriver backend rejected those metrics, because of unrecognized metric tag "tag".

We would like to roll this back temporarily, which will allow us time to fix the stackdriver backend to accept that tag.  Then we can add this back.

The estimated time is 3-4 weeks to fix stackdriver backend.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
