### PR TITLE
Set visibility for ingress spec

### DIFF
--- a/pkg/reconciler/route/resources/ingress.go
+++ b/pkg/reconciler/route/resources/ingress.go
@@ -154,8 +154,9 @@ func MakeIngressSpec(
 	}
 
 	return netv1alpha1.IngressSpec{
-		Rules: rules,
-		TLS:   tls,
+		Rules:      rules,
+		TLS:        tls,
+		Visibility: netv1alpha1.IngressVisibilityExternalIP,
 	}, nil
 }
 

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -902,8 +902,9 @@ func TestMakeIngressWithTLS(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(r)},
 		},
 		Spec: netv1alpha1.IngressSpec{
-			Rules: []netv1alpha1.IngressRule{},
-			TLS:   tls,
+			Rules:      []netv1alpha1.IngressRule{},
+			TLS:        tls,
+			Visibility: netv1alpha1.IngressVisibilityExternalIP,
 		},
 	}
 	got, err := MakeIngress(testContext(), r, &traffic.Config{Targets: targets}, tls, ingressClass)

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -314,6 +314,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 				}},
 			},
 		}},
+		Visibility: v1alpha1.IngressVisibilityExternalIP,
 	}
 	if diff := cmp.Diff(expectedSpec, ci.Spec); diff != "" {
 		t.Errorf("Unexpected rule spec diff (-want +got): %s", diff)
@@ -465,6 +466,7 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 			},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 		}},
+		Visibility: v1alpha1.IngressVisibilityExternalIP,
 	}
 
 	if diff := cmp.Diff(expectedSpec, ci.Spec); diff != "" {
@@ -582,6 +584,7 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 			},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 		}},
+		Visibility: v1alpha1.IngressVisibilityExternalIP,
 	}
 	if diff := cmp.Diff(expectedSpec, ci.Spec); diff != "" {
 		t.Errorf("Unexpected rule spec diff (-want +got): %v", diff)
@@ -801,6 +804,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 			},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 		}},
+		Visibility: v1alpha1.IngressVisibilityExternalIP,
 	}
 
 	if diff := cmp.Diff(expectedSpec, ci.Spec); diff != "" {
@@ -1007,6 +1011,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 			},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 		}},
+		Visibility: v1alpha1.IngressVisibilityExternalIP,
 	}
 
 	if !cmp.Equal(expectedSpec, ci.Spec) {
@@ -1324,6 +1329,7 @@ func TestCreateRouteWithNamedTargetsAndTagBasedRouting(t *testing.T) {
 			},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 		}},
+		Visibility: v1alpha1.IngressVisibilityExternalIP,
 	}
 
 	if diff := cmp.Diff(expectedSpec, ci.Spec); diff != "" {


### PR DESCRIPTION
Fixes #6971

The knative controller often update ingress, because the desired ingress is different with the actual one. That will cause the ingress controller, such as gloo-ingress-controller, raise `the object has been modified` error. 
In my environment, the ksvc status often be `ingress not ready` after the ingress-controller tried and failed to update ingress after a few times.

## Proposed Changes

* Set visibility for ingress in `MakeIngressSpec`.
