### PR TITLE
Add Autoscaling approvers/reviewers to queue OWNERS

### DIFF
--- a/cmd/queue/OWNERS
+++ b/cmd/queue/OWNERS
@@ -1,10 +1,13 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
+- autoscaling-approvers
 - networking-approvers
 
 reviewers:
+- autoscaling-reviewers
 - networking-reviewers
 
 labels:
+- area/autoscale
 - area/networking

--- a/pkg/queue/OWNERS
+++ b/pkg/queue/OWNERS
@@ -1,10 +1,13 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
+- autoscaling-approvers
 - networking-approvers
 
 reviewers:
+- autoscaling-reviewers
 - networking-reviewers
 
 labels:
+- area/autoscale
 - area/networking


### PR DESCRIPTION
In practice Queue is quite actively maintained by autoscaling group these days, and is an integral part of the autoscaling system.

This [matches the ownership](https://github.com/knative/serving/blob/master/pkg/activator/OWNERS) of Activator, which was [updated for similar reasons](https://github.com/knative/serving/pull/5965).

/assign @markusthoemmes