### PR TITLE
Route test cleanups

### DIFF
--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/clock"
+
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -66,7 +66,7 @@ func TestReconcile(t *testing.T) {
 		Name: "nop deletion reconcile",
 		// Test that with a DeletionTimestamp we do nothing.
 		Objects: []runtime.Object{
-			rev("foo", "delete-pending", WithRevisionDeletionTimestamp),
+			Revision("foo", "delete-pending", WithRevisionDeletionTimestamp),
 		},
 		Key: "foo/delete-pending",
 	}, {
@@ -75,7 +75,7 @@ func TestReconcile(t *testing.T) {
 		// We feed in a well formed Revision where none of its sub-resources exist,
 		// and we expect it to create them and initialize the Revision's status.
 		Objects: []runtime.Object{
-			rev("foo", "first-reconcile"),
+			Revision("foo", "first-reconcile"),
 		},
 		WantCreates: []runtime.Object{
 			// The first reconciliation of a Revision creates the following resources.
@@ -84,10 +84,10 @@ func TestReconcile(t *testing.T) {
 			image("foo", "first-reconcile"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "first-reconcile",
+			Object: Revision("foo", "first-reconcile",
 				// The first reconciliation Populates the following status properties.
-				WithLogURL, AllUnknownConditions, MarkDeploying("Deploying"),
-				withDefaultContainerStatuses(), withObservedGeneration(1)),
+				WithLogURL, allUnknownConditions, MarkDeploying("Deploying"),
+				withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 		}},
 		Key: "foo/first-reconcile",
 	}, {
@@ -99,7 +99,7 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("update", "revisions"),
 		},
 		Objects: []runtime.Object{
-			rev("foo", "update-status-failure"),
+			Revision("foo", "update-status-failure"),
 			pa("foo", "update-status-failure"),
 		},
 		WantCreates: []runtime.Object{
@@ -108,10 +108,10 @@ func TestReconcile(t *testing.T) {
 			image("foo", "update-status-failure"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "update-status-failure",
+			Object: Revision("foo", "update-status-failure",
 				// Despite failure, the following status properties are set.
-				WithLogURL, AllUnknownConditions, MarkDeploying("Deploying"),
-				withDefaultContainerStatuses(), withObservedGeneration(1)),
+				WithLogURL, allUnknownConditions, MarkDeploying("Deploying"),
+				withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "UpdateFailed", "Failed to update status for %q: %v",
@@ -127,7 +127,7 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("create", "podautoscalers"),
 		},
 		Objects: []runtime.Object{
-			rev("foo", "create-pa-failure"),
+			Revision("foo", "create-pa-failure"),
 		},
 		WantCreates: []runtime.Object{
 			// We still see the following creates before the failure is induced.
@@ -136,10 +136,10 @@ func TestReconcile(t *testing.T) {
 			image("foo", "create-pa-failure"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "create-pa-failure",
+			Object: Revision("foo", "create-pa-failure",
 				// Despite failure, the following status properties are set.
 				WithLogURL, WithInitRevConditions,
-				MarkDeploying("Deploying"), withDefaultContainerStatuses(), withObservedGeneration(1)),
+				MarkDeploying("Deploying"), withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError", `failed to create PA "create-pa-failure": inducing failure for create podautoscalers`),
@@ -154,7 +154,7 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("create", "deployments"),
 		},
 		Objects: []runtime.Object{
-			rev("foo", "create-user-deploy-failure"),
+			Revision("foo", "create-user-deploy-failure"),
 			pa("foo", "create-user-deploy-failure"),
 		},
 		WantCreates: []runtime.Object{
@@ -162,10 +162,10 @@ func TestReconcile(t *testing.T) {
 			deploy(t, "foo", "create-user-deploy-failure"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "create-user-deploy-failure",
+			Object: Revision("foo", "create-user-deploy-failure",
 				// Despite failure, the following status properties are set.
 				WithLogURL, WithInitRevConditions,
-				MarkDeploying("Deploying"), withDefaultContainerStatuses(), withObservedGeneration(1)),
+				MarkDeploying("Deploying"), withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError",
@@ -179,8 +179,8 @@ func TestReconcile(t *testing.T) {
 		// state (immediately post-creation), and verify that no changes
 		// are necessary.
 		Objects: []runtime.Object{
-			rev("foo", "stable-reconcile", WithLogURL, AllUnknownConditions,
-				withDefaultContainerStatuses(), withObservedGeneration(1)),
+			Revision("foo", "stable-reconcile", WithLogURL, allUnknownConditions,
+				withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 			pa("foo", "stable-reconcile", WithReachabilityUnknown),
 
 			deploy(t, "foo", "stable-reconcile"),
@@ -193,8 +193,8 @@ func TestReconcile(t *testing.T) {
 		// Test that we update a deployment with new containers when they disagree
 		// with our desired spec.
 		Objects: []runtime.Object{
-			rev("foo", "fix-containers",
-				WithLogURL, AllUnknownConditions, withDefaultContainerStatuses(), withObservedGeneration(1)),
+			Revision("foo", "fix-containers",
+				WithLogURL, allUnknownConditions, withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 			pa("foo", "fix-containers", WithReachabilityUnknown),
 			changeContainers(deploy(t, "foo", "fix-containers")),
 			image("foo", "fix-containers"),
@@ -211,9 +211,9 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("update", "deployments"),
 		},
 		Objects: []runtime.Object{
-			rev("foo", "failure-update-deploy",
-				withK8sServiceName("whateves"), WithLogURL, AllUnknownConditions,
-				withDefaultContainerStatuses(), withObservedGeneration(1)),
+			Revision("foo", "failure-update-deploy",
+				WithK8sServiceName("whateves"), WithLogURL, allUnknownConditions,
+				withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 			pa("foo", "failure-update-deploy"),
 			changeContainers(deploy(t, "foo", "failure-update-deploy")),
 			image("foo", "failure-update-deploy"),
@@ -232,10 +232,10 @@ func TestReconcile(t *testing.T) {
 		// We feed in a Revision and the resources it controls in a steady
 		// state (port-Reserve), and verify that no changes are necessary.
 		Objects: []runtime.Object{
-			rev("foo", "stable-deactivation",
+			Revision("foo", "stable-deactivation",
 				WithLogURL, MarkRevisionReady,
 				MarkInactive("NoTraffic", "This thing is inactive."),
-				withDefaultContainerStatuses(), withObservedGeneration(1)),
+				withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 			pa("foo", "stable-deactivation",
 				WithNoTraffic("NoTraffic", "This thing is inactive."), WithReachabilityUnreachable,
 				WithScaleTargetInitialized),
@@ -246,19 +246,19 @@ func TestReconcile(t *testing.T) {
 	}, {
 		Name: "pa is ready",
 		Objects: []runtime.Object{
-			rev("foo", "pa-ready",
-				withK8sServiceName("old-stuff"), WithLogURL, AllUnknownConditions),
+			Revision("foo", "pa-ready",
+				WithK8sServiceName("old-stuff"), WithLogURL, allUnknownConditions),
 			pa("foo", "pa-ready", WithPASKSReady, WithTraffic,
 				WithScaleTargetInitialized, WithPAStatusService("new-stuff"), WithReachabilityUnknown),
 			deploy(t, "foo", "pa-ready"),
 			image("foo", "pa-ready"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "pa-ready", withK8sServiceName("new-stuff"),
+			Object: Revision("foo", "pa-ready", WithK8sServiceName("new-stuff"),
 				WithLogURL,
 				// When the endpoint and pa are ready, then we will see the
 				// Revision become ready.
-				MarkRevisionReady, withDefaultContainerStatuses(), withObservedGeneration(1)),
+				MarkRevisionReady, withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "RevisionReady", "Revision becomes ready upon all resources being ready"),
@@ -268,9 +268,9 @@ func TestReconcile(t *testing.T) {
 		Name: "pa not ready",
 		// Test propagating the pa not ready status to the Revision.
 		Objects: []runtime.Object{
-			rev("foo", "pa-not-ready",
-				withK8sServiceName("somebody-told-me"), WithLogURL,
-				MarkRevisionReady, withObservedGeneration(1)),
+			Revision("foo", "pa-not-ready",
+				WithK8sServiceName("somebody-told-me"), WithLogURL,
+				MarkRevisionReady, WithRevisionObservedGeneration(1)),
 			pa("foo", "pa-not-ready",
 				WithPAStatusService("its-not-confidential"),
 				WithBufferedTraffic,
@@ -279,13 +279,13 @@ func TestReconcile(t *testing.T) {
 			image("foo", "pa-not-ready"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "pa-not-ready",
+			Object: Revision("foo", "pa-not-ready",
 				WithLogURL, MarkRevisionReady, withDefaultContainerStatuses(),
-				withK8sServiceName("its-not-confidential"),
+				WithK8sServiceName("its-not-confidential"),
 				// When we reconcile a ready state and our pa is in an activating
 				// state, we should see the following mutation.
 				MarkActivating("Queued", "Requests to the target are being buffered as resources are provisioned."),
-				withObservedGeneration(1),
+				WithRevisionObservedGeneration(1),
 			),
 		}},
 		Key: "foo/pa-not-ready",
@@ -293,9 +293,9 @@ func TestReconcile(t *testing.T) {
 		Name: "pa inactive",
 		// Test propagating the inactivity signal from the pa to the Revision.
 		Objects: []runtime.Object{
-			rev("foo", "pa-inactive",
-				withK8sServiceName("something-in-the-way"), WithLogURL,
-				MarkRevisionReady, withObservedGeneration(1)),
+			Revision("foo", "pa-inactive",
+				WithK8sServiceName("something-in-the-way"), WithLogURL,
+				MarkRevisionReady, WithRevisionObservedGeneration(1)),
 			pa("foo", "pa-inactive",
 				WithNoTraffic("NoTraffic", "This thing is inactive."),
 				WithScaleTargetInitialized,
@@ -304,31 +304,31 @@ func TestReconcile(t *testing.T) {
 			image("foo", "pa-inactive"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "pa-inactive",
+			Object: Revision("foo", "pa-inactive",
 				WithLogURL, MarkRevisionReady, withDefaultContainerStatuses(),
 				// When we reconcile an "all ready" revision when the PA
 				// is inactive, we should see the following change.
-				MarkInactive("NoTraffic", "This thing is inactive."), withObservedGeneration(1)),
+				MarkInactive("NoTraffic", "This thing is inactive."), WithRevisionObservedGeneration(1)),
 		}},
 		Key: "foo/pa-inactive",
 	}, {
 		Name: "pa inactive II",
 		// Test propagating the inactivity signal from the pa to the Revision.
 		Objects: []runtime.Object{
-			rev("foo", "pa-inactive",
-				withK8sServiceName("something-in-the-way"), WithLogURL,
-				withObservedGeneration(1)),
+			Revision("foo", "pa-inactive",
+				WithK8sServiceName("something-in-the-way"), WithLogURL,
+				WithRevisionObservedGeneration(1)),
 			pa("foo", "pa-inactive",
 				WithNoTraffic("NoTraffic", "This thing is inactive.")),
 			readyDeploy(deploy(t, "foo", "pa-inactive")),
 			image("foo", "pa-inactive"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "pa-inactive",
+			Object: Revision("foo", "pa-inactive",
 				WithLogURL, withDefaultContainerStatuses(), MarkDeploying(""),
 				// When we reconcile an "all ready" revision when the PA
 				// is inactive, we should see the following change.
-				MarkInactive("NoTraffic", "This thing is inactive."), withObservedGeneration(1),
+				MarkInactive("NoTraffic", "This thing is inactive."), WithRevisionObservedGeneration(1),
 				MarkResourcesUnavailable(v1.ReasonProgressDeadlineExceeded,
 					"Initial scale was never achieved")),
 		}},
@@ -338,9 +338,9 @@ func TestReconcile(t *testing.T) {
 		// Test propagating the inactivity signal from the pa to the Revision.
 		// But propagate the service name.
 		Objects: []runtime.Object{
-			rev("foo", "pa-inactive",
-				withK8sServiceName("here-comes-the-sun"), WithLogURL,
-				MarkRevisionReady, withObservedGeneration(1)),
+			Revision("foo", "pa-inactive",
+				WithK8sServiceName("here-comes-the-sun"), WithLogURL,
+				MarkRevisionReady, WithRevisionObservedGeneration(1)),
 			pa("foo", "pa-inactive",
 				WithNoTraffic("NoTraffic", "This thing is inactive."),
 				WithPAStatusService("pa-inactive-svc"),
@@ -350,13 +350,13 @@ func TestReconcile(t *testing.T) {
 			image("foo", "pa-inactive"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "pa-inactive",
+			Object: Revision("foo", "pa-inactive",
 				WithLogURL, MarkRevisionReady,
-				withK8sServiceName("pa-inactive-svc"),
+				WithK8sServiceName("pa-inactive-svc"),
 				// When we reconcile an "all ready" revision when the PA
 				// is inactive, we should see the following change.
 				MarkInactive("NoTraffic", "This thing is inactive."),
-				withDefaultContainerStatuses(), withObservedGeneration(1)),
+				withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 		}},
 		Key: "foo/pa-inactive",
 	}, {
@@ -365,40 +365,37 @@ func TestReconcile(t *testing.T) {
 		// we bring it back to the required shape.
 		// Protocol type is the only thing that can be changed on PA
 		Objects: []runtime.Object{
-			rev("foo", "fix-mutated-pa",
-				withK8sServiceName("ill-follow-the-sun"), WithLogURL, MarkRevisionReady,
+			Revision("foo", "fix-mutated-pa",
+				WithK8sServiceName("ill-follow-the-sun"), WithLogURL, MarkRevisionReady,
 				WithRevisionLabel(serving.RouteLabelKey, "foo")),
 			pa("foo", "fix-mutated-pa", WithProtocolType(networking.ProtocolH2C),
-				WithTraffic, WithPASKSReady, WithScaleTargetInitialized,
+				WithTraffic, WithPASKSReady, WithScaleTargetInitialized, WithReachabilityReachable,
 				WithPAStatusService("fix-mutated-pa")),
 			deploy(t, "foo", "fix-mutated-pa"),
 			image("foo", "fix-mutated-pa"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "fix-mutated-pa",
-				WithLogURL, AllUnknownConditions,
+			Object: Revision("foo", "fix-mutated-pa",
+				WithLogURL, allUnknownConditions,
 				// When our reconciliation has to change the service
 				// we should see the following mutations to status.
-				withK8sServiceName("fix-mutated-pa"),
+				WithK8sServiceName("fix-mutated-pa"),
 				WithRevisionLabel(serving.RouteLabelKey, "foo"), WithLogURL, MarkRevisionReady,
-				withDefaultContainerStatuses(), withObservedGeneration(1)),
+				withDefaultContainerStatuses()),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: pa("foo", "fix-mutated-pa", WithPASKSReady,
 				WithTraffic, WithScaleTargetInitialized,
 				WithPAStatusService("fix-mutated-pa"), WithReachabilityReachable),
 		}},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "RevisionReady", "Revision becomes ready upon all resources being ready"),
-		},
 		Key: "foo/fix-mutated-pa",
 	}, {
 		Name: "mutated pa gets error during the fix",
 		// Same as above, but will fail during the update.
 		Objects: []runtime.Object{
-			rev("foo", "fix-mutated-pa-fail",
-				withK8sServiceName("some-old-stuff"),
-				WithLogURL, AllUnknownConditions, withDefaultContainerStatuses(), withObservedGeneration(1)),
+			Revision("foo", "fix-mutated-pa-fail",
+				WithK8sServiceName("some-old-stuff"),
+				WithLogURL, allUnknownConditions, withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 			pa("foo", "fix-mutated-pa-fail", WithProtocolType(networking.ProtocolH2C), WithReachabilityUnknown),
 			deploy(t, "foo", "fix-mutated-pa-fail"),
 			image("foo", "fix-mutated-pa-fail"),
@@ -422,19 +419,19 @@ func TestReconcile(t *testing.T) {
 		// condition.  It then verifies that Reconcile propagates this into the
 		// status of the Revision.
 		Objects: []runtime.Object{
-			rev("foo", "deploy-timeout",
-				withK8sServiceName("the-taxman"), WithLogURL, MarkActive),
+			Revision("foo", "deploy-timeout",
+				WithK8sServiceName("the-taxman"), WithLogURL, MarkActive),
 			pa("foo", "deploy-timeout"), // pa can't be ready since deployment times out.
 			timeoutDeploy(deploy(t, "foo", "deploy-timeout"), "I timed out!"),
 			image("foo", "deploy-timeout"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "deploy-timeout",
-				WithLogURL, AllUnknownConditions,
+			Object: Revision("foo", "deploy-timeout",
+				WithLogURL, allUnknownConditions,
 				// When the revision is reconciled after a Deployment has
 				// timed out, we should see it marked with the PDE state.
 				MarkProgressDeadlineExceeded("I timed out!"), withDefaultContainerStatuses(),
-				withObservedGeneration(1)),
+				WithRevisionObservedGeneration(1)),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: pa("foo", "deploy-timeout", WithReachabilityUnreachable),
@@ -447,19 +444,19 @@ func TestReconcile(t *testing.T) {
 		// but changes the user deployment to have a FailedCreate condition.
 		// It then verifies that Reconcile propagates this into the status of the Revision.
 		Objects: []runtime.Object{
-			rev("foo", "deploy-replica-failure",
-				withK8sServiceName("the-taxman"), WithLogURL, MarkActive),
+			Revision("foo", "deploy-replica-failure",
+				WithK8sServiceName("the-taxman"), WithLogURL, MarkActive),
 			pa("foo", "deploy-replica-failure"),
 			replicaFailureDeploy(deploy(t, "foo", "deploy-replica-failure"), "I replica failed!"),
 			image("foo", "deploy-replica-failure"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "deploy-replica-failure",
-				WithLogURL, AllUnknownConditions,
+			Object: Revision("foo", "deploy-replica-failure",
+				WithLogURL, allUnknownConditions,
 				// When the revision is reconciled after a Deployment has
 				// timed out, we should see it marked with the FailedCreate state.
 				MarkResourcesUnavailable("FailedCreate", "I replica failed!"),
-				withDefaultContainerStatuses(), withObservedGeneration(1)),
+				withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: pa("foo", "deploy-replica-failure", WithReachabilityUnreachable),
@@ -469,17 +466,17 @@ func TestReconcile(t *testing.T) {
 		Name: "surface ImagePullBackoff",
 		// Test the propagation of ImagePullBackoff from user container.
 		Objects: []runtime.Object{
-			rev("foo", "pull-backoff",
-				withK8sServiceName("the-taxman"), WithLogURL, MarkActivating("Deploying", "")),
+			Revision("foo", "pull-backoff",
+				WithK8sServiceName("the-taxman"), WithLogURL, MarkActivating("Deploying", "")),
 			pa("foo", "pull-backoff"), // pa can't be ready since deployment times out.
 			pod(t, "foo", "pull-backoff", WithWaitingContainer("pull-backoff", "ImagePullBackoff", "can't pull it")),
 			timeoutDeploy(deploy(t, "foo", "pull-backoff"), "Timed out!"),
 			image("foo", "pull-backoff"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "pull-backoff",
-				WithLogURL, AllUnknownConditions,
-				MarkResourcesUnavailable("ImagePullBackoff", "can't pull it"), withDefaultContainerStatuses(), withObservedGeneration(1)),
+			Object: Revision("foo", "pull-backoff",
+				WithLogURL, allUnknownConditions,
+				MarkResourcesUnavailable("ImagePullBackoff", "can't pull it"), withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: pa("foo", "pull-backoff", WithReachabilityUnreachable),
@@ -492,17 +489,17 @@ func TestReconcile(t *testing.T) {
 		// but changes the user deployment to have a failing pod. It then verifies
 		// that Reconcile propagates this into the status of the Revision.
 		Objects: []runtime.Object{
-			rev("foo", "pod-error",
-				withK8sServiceName("a-pod-error"), WithLogURL, AllUnknownConditions, MarkActive),
+			Revision("foo", "pod-error",
+				WithK8sServiceName("a-pod-error"), WithLogURL, allUnknownConditions, MarkActive),
 			pa("foo", "pod-error"), // PA can't be ready, since no traffic.
 			pod(t, "foo", "pod-error", WithFailingContainer("pod-error", 5, "I failed man!")),
 			deploy(t, "foo", "pod-error"),
 			image("foo", "pod-error"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "pod-error",
-				WithLogURL, AllUnknownConditions, MarkContainerExiting(5,
-					v1.RevisionContainerExitingMessage("I failed man!")), withDefaultContainerStatuses(), withObservedGeneration(1)),
+			Object: Revision("foo", "pod-error",
+				WithLogURL, allUnknownConditions, MarkContainerExiting(5,
+					v1.RevisionContainerExitingMessage("I failed man!")), withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: pa("foo", "pod-error", WithReachabilityUnreachable),
@@ -514,17 +511,17 @@ func TestReconcile(t *testing.T) {
 		// This initializes the world to unschedule pod. It then verifies
 		// that Reconcile propagates this into the status of the Revision.
 		Objects: []runtime.Object{
-			rev("foo", "pod-schedule-error",
-				withK8sServiceName("a-pod-schedule-error"), WithLogURL, AllUnknownConditions, MarkActive),
+			Revision("foo", "pod-schedule-error",
+				WithK8sServiceName("a-pod-schedule-error"), WithLogURL, allUnknownConditions, MarkActive),
 			pa("foo", "pod-schedule-error"), // PA can't be ready, since no traffic.
 			pod(t, "foo", "pod-schedule-error", WithUnschedulableContainer("Insufficient energy", "Unschedulable")),
 			deploy(t, "foo", "pod-schedule-error"),
 			image("foo", "pod-schedule-error"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "pod-schedule-error",
-				WithLogURL, AllUnknownConditions, MarkResourcesUnavailable("Insufficient energy",
-					"Unschedulable"), withDefaultContainerStatuses(), withObservedGeneration(1)),
+			Object: Revision("foo", "pod-schedule-error",
+				WithLogURL, allUnknownConditions, MarkResourcesUnavailable("Insufficient energy",
+					"Unschedulable"), withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: pa("foo", "pod-schedule-error", WithReachabilityUnreachable),
@@ -538,17 +535,17 @@ func TestReconcile(t *testing.T) {
 		// Revision.  It then creates an Endpoints resource with active subsets.
 		// This signal should make our Reconcile mark the Revision as Ready.
 		Objects: []runtime.Object{
-			rev("foo", "steady-ready", withK8sServiceName("very-steady"), WithLogURL),
+			Revision("foo", "steady-ready", WithK8sServiceName("very-steady"), WithLogURL),
 			pa("foo", "steady-ready", WithPASKSReady, WithTraffic,
 				WithScaleTargetInitialized, WithPAStatusService("steadier-even")),
 			deploy(t, "foo", "steady-ready"),
 			image("foo", "steady-ready"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "steady-ready", withK8sServiceName("steadier-even"), WithLogURL,
+			Object: Revision("foo", "steady-ready", WithK8sServiceName("steadier-even"), WithLogURL,
 				// All resources are ready to go, we should see the revision being
 				// marked ready
-				MarkRevisionReady, withDefaultContainerStatuses(), withObservedGeneration(1)),
+				MarkRevisionReady, withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "RevisionReady", "Revision becomes ready upon all resources being ready"),
@@ -558,17 +555,17 @@ func TestReconcile(t *testing.T) {
 		Name:    "lost pa owner ref",
 		WantErr: true,
 		Objects: []runtime.Object{
-			rev("foo", "missing-owners", withK8sServiceName("lesser-revision"), WithLogURL,
+			Revision("foo", "missing-owners", WithK8sServiceName("lesser-revision"), WithLogURL,
 				MarkRevisionReady),
 			pa("foo", "missing-owners", WithTraffic, WithPodAutoscalerOwnersRemoved),
 			deploy(t, "foo", "missing-owners"),
 			image("foo", "missing-owners"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "missing-owners", withK8sServiceName("lesser-revision"), WithLogURL,
+			Object: Revision("foo", "missing-owners", WithK8sServiceName("lesser-revision"), WithLogURL,
 				MarkRevisionReady,
 				// When we're missing the OwnerRef for PodAutoscaler we see this update.
-				MarkResourceNotOwned("PodAutoscaler", "missing-owners"), withDefaultContainerStatuses(), withObservedGeneration(1)),
+				MarkResourceNotOwned("PodAutoscaler", "missing-owners"), withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError", `revision: "missing-owners" does not own PodAutoscaler: "missing-owners"`),
@@ -578,17 +575,17 @@ func TestReconcile(t *testing.T) {
 		Name:    "lost deployment owner ref",
 		WantErr: true,
 		Objects: []runtime.Object{
-			rev("foo", "missing-owners", withK8sServiceName("youre-gonna-lose"), WithLogURL,
+			Revision("foo", "missing-owners", WithK8sServiceName("youre-gonna-lose"), WithLogURL,
 				MarkRevisionReady),
 			pa("foo", "missing-owners", WithTraffic),
 			noOwner(deploy(t, "foo", "missing-owners")),
 			image("foo", "missing-owners"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "missing-owners", withK8sServiceName("youre-gonna-lose"), WithLogURL,
+			Object: Revision("foo", "missing-owners", WithK8sServiceName("youre-gonna-lose"), WithLogURL,
 				MarkRevisionReady,
 				// When we're missing the OwnerRef for Deployment we see this update.
-				MarkResourceNotOwned("Deployment", "missing-owners-deployment"), withDefaultContainerStatuses(), withObservedGeneration(1)),
+				MarkResourceNotOwned("Deployment", "missing-owners-deployment"), withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError", `revision: "missing-owners" does not own Deployment: "missing-owners-deployment"`),
@@ -598,7 +595,7 @@ func TestReconcile(t *testing.T) {
 		Name: "image pull secrets",
 		// This test case tests that the image pull secrets from revision propagate to deployment and image
 		Objects: []runtime.Object{
-			rev("foo", "image-pull-secrets", WithImagePullSecrets("foo-secret")),
+			Revision("foo", "image-pull-secrets", WithImagePullSecrets("foo-secret")),
 		},
 		WantCreates: []runtime.Object{
 			pa("foo", "image-pull-secrets"),
@@ -606,9 +603,9 @@ func TestReconcile(t *testing.T) {
 			imagePullSecrets(image("foo", "image-pull-secrets"), "foo-secret"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: rev("foo", "image-pull-secrets",
+			Object: Revision("foo", "image-pull-secrets",
 				WithImagePullSecrets("foo-secret"),
-				WithLogURL, AllUnknownConditions, MarkDeploying("Deploying"), withDefaultContainerStatuses(), withObservedGeneration(1)),
+				WithLogURL, allUnknownConditions, MarkDeploying("Deploying"), withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
 		}},
 		Key: "foo/image-pull-secrets",
 	}}
@@ -671,11 +668,11 @@ func deployImagePullSecrets(deploy *appsv1.Deployment, secretName string) *appsv
 	return deploy
 }
 
-func imagePullSecrets(image *caching.Image, secretName string) *caching.Image {
-	image.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{
+func imagePullSecrets(Revision *caching.Image, secretName string) *caching.Image {
+	Revision.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{
 		Name: secretName,
 	}}
-	return image
+	return Revision
 }
 
 func changeContainers(deploy *appsv1.Deployment) *appsv1.Deployment {
@@ -684,43 +681,6 @@ func changeContainers(deploy *appsv1.Deployment) *appsv1.Deployment {
 		podSpec.Containers[i].Image = "asdf"
 	}
 	return deploy
-}
-
-func rev(namespace, name string, ro ...RevisionOption) *v1.Revision {
-	r := &v1.Revision{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Namespace:  namespace,
-			UID:        "test-uid",
-			Generation: 1,
-		},
-		Spec: v1.RevisionSpec{
-			PodSpec: corev1.PodSpec{
-				Containers: []corev1.Container{{
-					Name:  name,
-					Image: "busybox",
-				}},
-			},
-		},
-	}
-	r.SetDefaults(context.Background())
-
-	for _, opt := range ro {
-		opt(r)
-	}
-	return r
-}
-
-func withK8sServiceName(sn string) RevisionOption {
-	return func(r *v1.Revision) {
-		r.Status.ServiceName = sn
-	}
-}
-
-func withObservedGeneration(gen int64) RevisionOption {
-	return func(r *v1.Revision) {
-		r.Status.ObservedGeneration = gen
-	}
 }
 
 func withDefaultContainerStatuses() RevisionOption {
@@ -733,7 +693,7 @@ func withDefaultContainerStatuses() RevisionOption {
 }
 
 // TODO(mattmoor): Come up with a better name for this.
-func AllUnknownConditions(r *v1.Revision) {
+func allUnknownConditions(r *v1.Revision) {
 	WithInitRevConditions(r)
 	MarkDeploying("")(r)
 	MarkActivating("Deploying", "")(r)
@@ -751,7 +711,7 @@ func deploy(t *testing.T, namespace, name string, opts ...interface{}) *appsv1.D
 		}
 	}
 
-	rev := rev(namespace, name)
+	rev := Revision(namespace, name)
 
 	for _, opt := range opts {
 		if revOpt, ok := opt.(RevisionOption); ok {
@@ -776,11 +736,11 @@ func image(namespace, name string, co ...configOption) *caching.Image {
 		opt(config)
 	}
 
-	return resources.MakeImageCache(rev(namespace, name), name, "")
+	return resources.MakeImageCache(Revision(namespace, name), name, "")
 }
 
 func pa(namespace, name string, ko ...PodAutoscalerOption) *asv1a1.PodAutoscaler {
-	rev := rev(namespace, name)
+	rev := Revision(namespace, name)
 	k := resources.MakePA(rev)
 
 	for _, opt := range ko {

--- a/pkg/reconciler/route/queueing_test.go
+++ b/pkg/reconciler/route/queueing_test.go
@@ -21,9 +21,11 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	network "knative.dev/networking/pkg"
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	fakenetworkingclient "knative.dev/networking/pkg/client/injection/client/fake"
@@ -46,9 +48,9 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 	ctx, cancel, informers := SetupFakeContextWithCancel(t)
 
 	// A standalone revision
-	rev := getTestRevision("test-rev")
+	rev := Revision(testNamespace, "test-rev", MarkRevisionReady, WithK8sServiceName("test-rev"))
 	// A route targeting the revision
-	route := getTestRouteWithTrafficTargets(WithSpecTraffic(
+	route := Route(testNamespace, "test-route", WithSpecTraffic(
 		v1.TrafficTarget{
 			RevisionName: "test-rev",
 			Percent:      ptr.Int64(100),

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -47,8 +47,6 @@ import (
 
 	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
-	"knative.dev/pkg/apis"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/ptr"
@@ -71,81 +69,20 @@ const (
 	prodDomainSuffix    = "prod-domain.com"
 )
 
-func getTestRouteWithTrafficTargets(trafficTarget RouteOption) *v1.Route {
-	return Route(testNamespace, "test-route",
-		WithRouteLabel(map[string]string{"route": "test-route"}), trafficTarget)
-}
-
-func getTestRevision(name string) *v1.Revision {
-	return getTestRevisionWithCondition(name, apis.Condition{
-		Type:   v1.RevisionConditionReady,
-		Status: corev1.ConditionTrue,
-		Reason: "ServiceReady",
-	})
-}
-
-func getTestRevisionWithCondition(name string, cond apis.Condition) *v1.Revision {
-	return &v1.Revision{
-		ObjectMeta: metav1.ObjectMeta{
-			SelfLink:  fmt.Sprint("/apis/serving/v1/namespaces/test/revisions/", name),
-			Name:      name,
-			Namespace: testNamespace,
-		},
-		Spec: v1.RevisionSpec{
-			PodSpec: corev1.PodSpec{
-				Containers: []corev1.Container{{
-					Image: "test-image",
-				}},
-			},
-		},
-		Status: v1.RevisionStatus{
-			ServiceName: name,
-			Status: duckv1.Status{
-				Conditions: duckv1.Conditions{cond},
-			},
-		},
-	}
-}
-
-func getTestConfiguration() *v1.Configuration {
+func testConfiguration() *v1.Configuration {
 	return &v1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
-			SelfLink:  "/apis/serving/v1/namespaces/test/revisiontemplates/test-config",
 			Name:      "test-config",
 			Namespace: testNamespace,
 		},
-		Spec: v1.ConfigurationSpec{
-			Template: v1.RevisionTemplateSpec{
-				Spec: v1.RevisionSpec{
-					PodSpec: corev1.PodSpec{
-						Containers: []corev1.Container{{
-							Image: "test-image",
-						}},
-					},
-				},
-			},
-		},
+		Spec: v1.ConfigurationSpec{},
 	}
 }
 
-func getTestRevisionForConfig(config *v1.Configuration) *v1.Revision {
-	rev := &v1.Revision{
-		ObjectMeta: metav1.ObjectMeta{
-			SelfLink:  "/apis/serving/v1/namespaces/test/revisions/p-deadbeef",
-			Name:      "p-deadbeef",
-			Namespace: testNamespace,
-			Labels: map[string]string{
-				serving.ConfigurationLabelKey: config.Name,
-			},
-		},
-		Spec: *config.Spec.GetTemplate().Spec.DeepCopy(),
-		Status: v1.RevisionStatus{
-			ServiceName: "p-deadbeef",
-		},
-	}
-	rev.Status.MarkResourcesAvailableTrue()
-	rev.Status.MarkContainerHealthyTrue()
-	return rev
+func revisionForConfig(config *v1.Configuration) *v1.Revision {
+	return Revision(testNamespace, "p-deadbeef", func(r *v1.Revision) {
+		r.Spec = *config.Spec.GetTemplate().Spec.DeepCopy()
+	}, MarkRevisionReady, WithK8sServiceName("p-deadbeef"))
 }
 
 func newTestSetup(t *testing.T, opts ...reconcilerOption) (
@@ -204,7 +141,7 @@ func getRouteIngressFromClient(ctx context.Context, t *testing.T, route *v1.Rout
 	}
 
 	if len(ingresses.Items) != 1 {
-		t.Errorf("Ingress.Get(%v), expect 1 instance, but got %d", opts, len(ingresses.Items))
+		t.Fatalf("Ingress.Get(%v), expect 1 instance, but got %d", opts, len(ingresses.Items))
 	}
 
 	return &ingresses.Items[0]
@@ -235,19 +172,19 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 
 	fakeRecorder := controller.GetEventRecorder(ctx).(*record.FakeRecorder)
 
-	// An inactive revision
-	rev := getTestRevision("test-rev")
-	rev.Status.MarkActiveFalse("NoTraffic", "no message")
+	// An inactive revision.
+	rev := Revision(testNamespace, "test-rev", MarkRevisionReady,
+		MarkInactive("NoTraffic", "no message"))
 
 	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Create(rev)
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
 
 	// A route targeting the revision
-	route := getTestRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+	route := Route(testNamespace, "test-route", WithSpecTraffic(v1.TrafficTarget{
 		RevisionName:      "test-rev",
 		ConfigurationName: "test-config",
 		Percent:           ptr.Int64(100),
-	}))
+	}), WithRouteLabel(map[string]string{"route": "test-route"}))
 	fakeservingclient.Get(ctx).ServingV1().Routes(testNamespace).Create(route)
 	// Since Reconcile looks in the lister, we need to add it to the informer
 	fakerouteinformer.Get(ctx).Informer().GetIndexer().Add(route)
@@ -263,7 +200,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 		"route":                        "test-route",
 	}
 	if diff := cmp.Diff(expectedLabels, ci.Labels); diff != "" {
-		t.Errorf("Unexpected label diff (-want +got): %v", diff)
+		t.Errorf("Unexpected label diff (-want +got):\n%s", diff)
 	}
 
 	domain := strings.Join([]string{route.Name, route.Namespace, defaultDomainSuffix}, ".")
@@ -362,15 +299,15 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 		cf()
 		wicb()
 	}()
-	// A standalone revision
-	rev := getTestRevision("test-rev")
+	// A standalone revision.
+	rev := Revision(testNamespace, "test-rev", MarkRevisionReady)
 	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Create(rev)
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
 
 	// A configuration and associated revision. Normally the revision would be
 	// created by the configuration reconciler.
-	config := getTestConfiguration()
-	cfgrev := getTestRevisionForConfig(config)
+	config := testConfiguration()
+	cfgrev := revisionForConfig(config)
 	config.Status.SetLatestCreatedRevisionName(cfgrev.Name)
 	config.Status.SetLatestReadyRevisionName(cfgrev.Name)
 	fakeservingclient.Get(ctx).ServingV1().Configurations(testNamespace).Create(config)
@@ -380,7 +317,7 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(cfgrev)
 
 	// A route targeting both the config and standalone revision.
-	route := getTestRouteWithTrafficTargets(WithSpecTraffic(
+	route := Route(testNamespace, "test-route", WithSpecTraffic(
 		v1.TrafficTarget{
 			ConfigurationName: config.Name,
 			Percent:           ptr.Int64(90),
@@ -477,16 +414,16 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 	ctx, _, ctl, _, cf := newTestSetup(t)
 	defer cf()
 	// A standalone inactive revision
-	rev := getTestRevision("test-rev")
-	rev.Status.MarkActiveFalse("NoTraffic", "no message")
+	rev := Revision(testNamespace, "test-rev", MarkRevisionReady,
+		MarkInactive("NoTraffic", "no message"))
 
 	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Create(rev)
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
 
 	// A configuration and associated revision. Normally the revision would be
 	// created by the configuration reconciler.
-	config := getTestConfiguration()
-	cfgrev := getTestRevisionForConfig(config)
+	config := testConfiguration()
+	cfgrev := revisionForConfig(config)
 	config.Status.SetLatestCreatedRevisionName(cfgrev.Name)
 	config.Status.SetLatestReadyRevisionName(cfgrev.Name)
 	fakeservingclient.Get(ctx).ServingV1().Configurations(testNamespace).Create(config)
@@ -496,7 +433,7 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(cfgrev)
 
 	// A route targeting both the config and standalone revision
-	route := getTestRouteWithTrafficTargets(WithSpecTraffic(
+	route := Route(testNamespace, "test-route", WithSpecTraffic(
 		v1.TrafficTarget{
 			ConfigurationName: config.Name,
 			Percent:           ptr.Int64(90),
@@ -593,14 +530,14 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 	defer cf()
 
 	// A standalone revision
-	rev := getTestRevision("test-rev")
+	rev := Revision(testNamespace, "test-rev", MarkRevisionReady, WithK8sServiceName("test-rev"))
 	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Create(rev)
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
 
 	// A configuration and associated revision. Normally the revision would be
 	// created by the configuration reconciler.
-	config := getTestConfiguration()
-	cfgrev := getTestRevisionForConfig(config)
+	config := testConfiguration()
+	cfgrev := revisionForConfig(config)
 	config.Status.SetLatestCreatedRevisionName(cfgrev.Name)
 	config.Status.SetLatestReadyRevisionName(cfgrev.Name)
 	fakeservingclient.Get(ctx).ServingV1().Configurations(testNamespace).Create(config)
@@ -610,7 +547,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(cfgrev)
 
 	// A route with duplicate targets. These will be deduped.
-	route := getTestRouteWithTrafficTargets(WithSpecTraffic(
+	route := Route(testNamespace, "test-route", WithSpecTraffic(
 		v1.TrafficTarget{
 			ConfigurationName: "test-config",
 			Percent:           ptr.Int64(30),
@@ -813,14 +750,14 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 	ctx, _, ctl, _, cf := newTestSetup(t)
 	defer cf()
 	// A standalone revision
-	rev := getTestRevision("test-rev")
+	rev := Revision(testNamespace, "test-rev", MarkRevisionReady, WithK8sServiceName("test-rev"))
 	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Create(rev)
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
 
 	// A configuration and associated revision. Normally the revision would be
 	// created by the configuration reconciler.
-	config := getTestConfiguration()
-	cfgrev := getTestRevisionForConfig(config)
+	config := testConfiguration()
+	cfgrev := revisionForConfig(config)
 	config.Status.SetLatestCreatedRevisionName(cfgrev.Name)
 	config.Status.SetLatestReadyRevisionName(cfgrev.Name)
 	fakeservingclient.Get(ctx).ServingV1().Configurations(testNamespace).Create(config)
@@ -831,7 +768,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 
 	// A route targeting both the config and standalone revision with named
 	// targets
-	route := getTestRouteWithTrafficTargets(WithSpecTraffic(
+	route := Route(testNamespace, "test-route", WithSpecTraffic(
 		v1.TrafficTarget{
 			Tag:          "foo",
 			RevisionName: "test-rev",
@@ -1028,14 +965,14 @@ func TestCreateRouteWithNamedTargetsAndTagBasedRouting(t *testing.T) {
 		},
 	})
 	// A standalone revision
-	rev := getTestRevision("test-rev")
+	rev := Revision(testNamespace, "test-rev", MarkRevisionReady, WithK8sServiceName("test-rev"))
 	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Create(rev)
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
 
 	// A configuration and associated revision. Normally the revision would be
 	// created by the configuration reconciler.
-	config := getTestConfiguration()
-	cfgrev := getTestRevisionForConfig(config)
+	config := testConfiguration()
+	cfgrev := revisionForConfig(config)
 	config.Status.SetLatestCreatedRevisionName(cfgrev.Name)
 	config.Status.SetLatestReadyRevisionName(cfgrev.Name)
 	fakeservingclient.Get(ctx).ServingV1().Configurations(testNamespace).Create(config)
@@ -1046,7 +983,7 @@ func TestCreateRouteWithNamedTargetsAndTagBasedRouting(t *testing.T) {
 
 	// A route targeting both the config and standalone revision with named
 	// targets
-	route := getTestRouteWithTrafficTargets(WithSpecTraffic(
+	route := Route(testNamespace, "test-route", WithSpecTraffic(
 		v1.TrafficTarget{
 			Tag:          "foo",
 			RevisionName: "test-rev",
@@ -1390,7 +1327,7 @@ func TestUpdateDomainConfigMap(t *testing.T) {
 				cf()
 				waitInformers()
 			}()
-			route := getTestRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{}))
+			route := Route(testNamespace, "test-route", WithRouteLabel(map[string]string{"route": "test-route"}))
 			route.Name = uuid.New().String()
 			route.Labels = map[string]string{"app": "prod"}
 			routeClient := fakeservingclient.Get(ctx).ServingV1().Routes(route.Namespace)
@@ -1535,9 +1472,8 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 			grp.Go(func() error { return ctrl.Run(1, ctx.Done()) })
 
 			// Create a route.
-			route := getTestRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{}))
-			route.Labels = map[string]string{"app": "prod"}
-			route.Generation = 1
+			route := Route(testNamespace, "test-route",
+				WithRouteLabel(map[string]string{"app": "prod"}), WithRouteGeneration(1))
 
 			created, err := servingClient.ServingV1().Routes(route.Namespace).Create(route)
 			if err != nil {
@@ -1566,7 +1502,7 @@ func TestGlobalResyncOnUpdateDomainConfigMap(t *testing.T) {
 					return false, err
 				}
 
-				return r.Status.URL.Host == expectedDomain, nil
+				return r.Status.URL != nil && r.Status.URL.Host == expectedDomain, nil
 			}); err != nil {
 				t.Fatal("Failed to see route update propagation:", err)
 			}

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -179,7 +179,7 @@ func testRouteWithTrafficTargets(trafficTarget RouteOption) *v1.Route {
 		WithRouteLabel(map[string]string{"route": "test-route"}), trafficTarget)
 }
 
-func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
+func TestBuildTrafficConfigurationNoNameRevision(t *testing.T) {
 	tts := v1.TrafficTarget{
 		RevisionName: goodNewRev.Name,
 		Percent:      ptr.Int64(100),
@@ -218,7 +218,7 @@ func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
 }
 
 // The vanilla use case of 100% directing to latest revision of an inactive configuration.
-func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
+func TestBuildTrafficConfigurationVanillaScaledToZero(t *testing.T) {
 	tts := v1.TrafficTarget{
 		ConfigurationName: inactiveConfig.Name,
 		Percent:           ptr.Int64(100),
@@ -261,7 +261,7 @@ func TestBuildTrafficConfiguration_VanillaScaledToZero(t *testing.T) {
 }
 
 // Transitioning from one good config to another by splitting traffic.
-func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
+func TestBuildTrafficConfigurationTwoConfigs(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
 			DefaultTarget: {{
@@ -326,7 +326,7 @@ func TestBuildTrafficConfiguration_TwoConfigs(t *testing.T) {
 }
 
 // Splitting traffic between a fixed revision and the latest revision (canary).
-func TestBuildTrafficConfiguration_Canary(t *testing.T) {
+func TestBuildTrafficConfigurationCanary(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
 			DefaultTarget: {{
@@ -390,7 +390,7 @@ func TestBuildTrafficConfiguration_Canary(t *testing.T) {
 }
 
 // Splitting traffic between latest revision and a fixed revision which is also latest.
-func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
+func TestBuildTrafficConfigurationConsolidated(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
 			DefaultTarget: {{
@@ -507,7 +507,7 @@ func TestBuildTrafficConfiguration_Consolidated(t *testing.T) {
 }
 
 // Splitting traffic between a two fixed revisions.
-func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
+func TestBuildTrafficConfigurationTwoFixedRevisions(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
 			DefaultTarget: {{
@@ -571,7 +571,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisions(t *testing.T) {
 }
 
 // Splitting traffic between a two fixed revisions of two configurations.
-func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *testing.T) {
+func TestBuildTrafficConfigurationTwoFixedRevisionsFromTwoConfigurations(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
 			DefaultTarget: {{
@@ -781,7 +781,7 @@ func TestBuildTrafficConfigurationMissingConfig(t *testing.T) {
 	}
 }
 
-func TestBuildTrafficConfiguration_NotRoutableRevision(t *testing.T) {
+func TestBuildTrafficConfigurationNotRoutableRevision(t *testing.T) {
 	expected := &Config{
 		Targets:        map[string]RevisionTargets{},
 		Configurations: map[string]*v1.Configuration{},
@@ -798,7 +798,7 @@ func TestBuildTrafficConfiguration_NotRoutableRevision(t *testing.T) {
 	}
 }
 
-func TestBuildTrafficConfiguration_NotRoutableConfiguration(t *testing.T) {
+func TestBuildTrafficConfigurationNotRoutableConfiguration(t *testing.T) {
 	expected := &Config{
 		Targets:        map[string]RevisionTargets{},
 		Configurations: map[string]*v1.Configuration{unreadyConfig.Name: unreadyConfig},
@@ -815,7 +815,7 @@ func TestBuildTrafficConfiguration_NotRoutableConfiguration(t *testing.T) {
 	}
 }
 
-func TestBuildTrafficConfiguration_EmptyConfiguration(t *testing.T) {
+func TestBuildTrafficConfigurationEmptyConfiguration(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{},
 		Configurations: map[string]*v1.Configuration{
@@ -835,7 +835,7 @@ func TestBuildTrafficConfiguration_EmptyConfiguration(t *testing.T) {
 	}
 }
 
-func TestBuildTrafficConfiguration_EmptyAndFailedConfigurations(t *testing.T) {
+func TestBuildTrafficConfigurationEmptyAndFailedConfigurations(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{},
 		Configurations: map[string]*v1.Configuration{
@@ -858,7 +858,7 @@ func TestBuildTrafficConfiguration_EmptyAndFailedConfigurations(t *testing.T) {
 	}
 }
 
-func TestBuildTrafficConfiguration_FailedAndEmptyConfigurations(t *testing.T) {
+func TestBuildTrafficConfigurationFailedAndEmptyConfigurations(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{},
 		Configurations: map[string]*v1.Configuration{
@@ -881,7 +881,7 @@ func TestBuildTrafficConfiguration_FailedAndEmptyConfigurations(t *testing.T) {
 	}
 }
 
-func TestBuildTrafficConfiguration_MissingRevision(t *testing.T) {
+func TestBuildTrafficConfigurationMissingRevision(t *testing.T) {
 	expected := &Config{
 		Targets:        map[string]RevisionTargets{},
 		Configurations: map[string]*v1.Configuration{goodConfig.Name: goodConfig},
@@ -924,7 +924,7 @@ func (l revFakeErrorLister) Revisions(namespace string) listers.RevisionNamespac
 	return l
 }
 
-func TestBuildTrafficConfiguration_FailedGetRevision(t *testing.T) {
+func TestBuildTrafficConfigurationFailedGetRevision(t *testing.T) {
 	_, err := BuildTrafficConfiguration(configLister, revErrorLister, testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
 		RevisionName: goodNewRev.Name,
 		Percent:      ptr.Int64(50)})))
@@ -966,10 +966,10 @@ func TestRoundTripping(t *testing.T) {
 	} else {
 		targets, err := tc.GetRevisionTrafficTargets(getContext(), route)
 		if err != nil {
-			t.Errorf("Unexpected error %v", err)
+			t.Error("Unexpected error:", err)
 		}
-		if want, got := expected, targets; !cmp.Equal(want, got) {
-			t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got))
+		if got, want := targets, expected; !cmp.Equal(want, got) {
+			t.Errorf("Unexpected traffic diff (-want +got):\n%s", cmp.Diff(want, got))
 		}
 	}
 }

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -175,7 +175,8 @@ func TestBuildTrafficConfigurationVanilla(t *testing.T) {
 }
 
 func testRouteWithTrafficTargets(trafficTarget RouteOption) *v1.Route {
-	return Route(testNamespace, "test-route", WithRouteLabel(map[string]string{"route": "test-route"}), trafficTarget)
+	return Route(testNamespace, "test-route",
+		WithRouteLabel(map[string]string{"route": "test-route"}), trafficTarget)
 }
 
 func TestBuildTrafficConfiguration_NoNameRevision(t *testing.T) {
@@ -635,7 +636,7 @@ func TestBuildTrafficConfiguration_TwoFixedRevisionsFromTwoConfigurations(t *tes
 }
 
 // One fixed, two named targets for newer stuffs.
-func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
+func TestBuildTrafficConfigurationPreliminary(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
 			DefaultTarget: {{
@@ -727,23 +728,24 @@ func TestBuildTrafficConfiguration_Preliminary(t *testing.T) {
 			niceNewRev.Name: niceNewRev,
 		},
 	}
-	if tc, err := BuildTrafficConfiguration(configLister, revLister, testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
-		RevisionName: goodOldRev.Name,
-		Percent:      ptr.Int64(100),
-	}, v1.TrafficTarget{
-		Tag:          "beta",
-		RevisionName: goodNewRev.Name,
-	}, v1.TrafficTarget{
-		Tag:               "alpha",
-		ConfigurationName: niceConfig.Name,
-	}))); err != nil {
-		t.Errorf("Unexpected error %v", err)
-	} else if want, got := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
-		t.Errorf("Unexpected traffic diff (-want +got): %v", cmp.Diff(want, got, cmpOpts...))
+	if tc, err := BuildTrafficConfiguration(configLister, revLister,
+		testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+			RevisionName: goodOldRev.Name,
+			Percent:      ptr.Int64(100),
+		}, v1.TrafficTarget{
+			Tag:          "beta",
+			RevisionName: goodNewRev.Name,
+		}, v1.TrafficTarget{
+			Tag:               "alpha",
+			ConfigurationName: niceConfig.Name,
+		}))); err != nil {
+		t.Error("Unexpected error:", err)
+	} else if got, want := tc, expected; !cmp.Equal(want, got, cmpOpts...) {
+		t.Errorf("Unexpected traffic diff (-want +got):\n%s", cmp.Diff(want, got, cmpOpts...))
 	}
 }
 
-func TestBuildTrafficConfiguration_MissingConfig(t *testing.T) {
+func TestBuildTrafficConfigurationMissingConfig(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{},
 		Configurations: map[string]*v1.Configuration{

--- a/pkg/testing/v1/revision.go
+++ b/pkg/testing/v1/revision.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -143,6 +144,13 @@ func MarkActive(r *v1.Revision) {
 	r.Status.MarkActiveTrue()
 }
 
+// WithK8sServiceName applies sn to the revision status field.
+func WithK8sServiceName(sn string) RevisionOption {
+	return func(r *v1.Revision) {
+		r.Status.ServiceName = sn
+	}
+}
+
 // MarkInactive calls .Status.MarkInactive on the Revision.
 func MarkInactive(reason, message string) RevisionOption {
 	return func(r *v1.Revision) {
@@ -201,6 +209,7 @@ func MarkRevisionReady(r *v1.Revision) {
 	MarkActive(r)
 	r.Status.MarkResourcesAvailableTrue()
 	r.Status.MarkContainerHealthyTrue()
+	r.Status.ObservedGeneration = r.Generation
 }
 
 // WithRevisionLabel attaches a particular label to the revision.
@@ -222,4 +231,39 @@ func WithContainerStatuses(containerStatus []v1.ContainerStatuses) RevisionOptio
 	return func(r *v1.Revision) {
 		r.Status.ContainerStatuses = containerStatus
 	}
+}
+
+// WithRevisionObservedGeneration sets the observed generation on the
+// revision status.
+func WithRevisionObservedGeneration(gen int64) RevisionOption {
+	return func(r *v1.Revision) {
+		r.Status.ObservedGeneration = gen
+	}
+}
+
+// Revision creates a revision object with given ns/name and options.
+func Revision(namespace, name string, ro ...RevisionOption) *v1.Revision {
+	r := &v1.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			SelfLink:   "/apis/serving/v1/namespaces/test/revisions/" + name,
+			Name:       name,
+			Namespace:  namespace,
+			UID:        "test-uid",
+			Generation: 1,
+		},
+		Spec: v1.RevisionSpec{
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  name,
+					Image: "busybox",
+				}},
+			},
+		},
+	}
+	r.SetDefaults(context.Background())
+
+	for _, opt := range ro {
+		opt(r)
+	}
+	return r
 }

--- a/pkg/testing/v1/route.go
+++ b/pkg/testing/v1/route.go
@@ -285,9 +285,9 @@ func Route(namespace, name string, ro ...RouteOption) *v1.Route {
 			Name:      name,
 		},
 	}
+	r.SetDefaults(context.Background())
 	for _, opt := range ro {
 		opt(r)
 	}
-	r.SetDefaults(context.Background())
 	return r
 }

--- a/pkg/testing/v1/route.go
+++ b/pkg/testing/v1/route.go
@@ -285,9 +285,9 @@ func Route(namespace, name string, ro ...RouteOption) *v1.Route {
 			Name:      name,
 		},
 	}
-	r.SetDefaults(context.Background())
 	for _, opt := range ro {
 		opt(r)
 	}
+	r.SetDefaults(context.Background())
 	return r
 }


### PR DESCRIPTION
Properly clean the route test and its helpers. It might have more things to cleanup, but right now I don't see the forest behind the trees.

Traffic test needs more cleanups I think, but that's for another time. 

/assign @whaught @tcnghia 
/hold 
For #8997 to merge.