### PR TITLE
Remove the redundant things in the tests

### DIFF
--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -31,6 +31,7 @@ import (
 
 	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/metrics"
 	_ "knative.dev/pkg/metrics/testing"
 	"knative.dev/pkg/ptr"
@@ -484,7 +485,6 @@ func TestMakePodSpec(t *testing.T) {
 				}},
 				ReadinessProbe: withTCPReadinessProbe(v1.DefaultUserPort),
 			}}),
-			withContainerConcurrency(1),
 			WithContainerStatuses([]v1.ContainerStatuses{{
 				ImageDigest: "busybox@sha256:deadbeef",
 			}}),
@@ -499,7 +499,6 @@ func TestMakePodSpec(t *testing.T) {
 					withEnvVar("PORT", "8888"),
 				),
 				queueContainer(
-					withEnvVar("CONTAINER_CONCURRENCY", "1"),
 					withEnvVar("USER_PORT", "8888"),
 					withEnvVar("SERVING_READINESS_PROBE", `{"tcpSocket":{"port":8888,"host":"127.0.0.1"}}`),
 				)}),
@@ -518,7 +517,6 @@ func TestMakePodSpec(t *testing.T) {
 				}},
 				ReadinessProbe: withTCPReadinessProbe(v1.DefaultUserPort),
 			}}),
-			withContainerConcurrency(1),
 			WithContainerStatuses([]v1.ContainerStatuses{{
 				ImageDigest: "busybox@sha256:deadbeef",
 			}}),
@@ -547,7 +545,6 @@ func TestMakePodSpec(t *testing.T) {
 					}),
 				),
 				queueContainer(
-					withEnvVar("CONTAINER_CONCURRENCY", "1"),
 					withEnvVar("USER_PORT", "8888"),
 					withEnvVar("SERVING_READINESS_PROBE", `{"tcpSocket":{"port":8888,"host":"127.0.0.1"}}`),
 				),
@@ -582,14 +579,14 @@ func TestMakePodSpec(t *testing.T) {
 				),
 			}),
 	}, {
-		name: "concurrency=1 no owner digest resolved",
+		name: "concurrency=121 no owner digest resolved",
 		rev: revision("bar", "foo",
 			withContainers([]corev1.Container{{
 				Name:           servingContainerName,
 				Image:          "busybox",
 				ReadinessProbe: withTCPReadinessProbe(v1.DefaultUserPort),
 			}}),
-			withContainerConcurrency(1),
+			withContainerConcurrency(121),
 			WithContainerStatuses([]v1.ContainerStatuses{{
 				ImageDigest: "busybox@sha256:deadbeef",
 			}}),
@@ -600,7 +597,7 @@ func TestMakePodSpec(t *testing.T) {
 					container.Image = "busybox@sha256:deadbeef"
 				}),
 				queueContainer(
-					withEnvVar("CONTAINER_CONCURRENCY", "1"),
+					withEnvVar("CONTAINER_CONCURRENCY", "121"),
 				),
 			}),
 	}, {
@@ -611,7 +608,7 @@ func TestMakePodSpec(t *testing.T) {
 				Image:          "busybox",
 				ReadinessProbe: withTCPReadinessProbe(v1.DefaultUserPort),
 			}}),
-			withContainerConcurrency(1),
+			withContainerConcurrency(42),
 			withOwnerReference("parent-config"),
 			WithContainerStatuses([]v1.ContainerStatuses{{
 				ImageDigest: "busybox@sha256:deadbeef",
@@ -624,7 +621,7 @@ func TestMakePodSpec(t *testing.T) {
 				}),
 				queueContainer(
 					withEnvVar("SERVING_CONFIGURATION", "parent-config"),
-					withEnvVar("CONTAINER_CONCURRENCY", "1"),
+					withEnvVar("CONTAINER_CONCURRENCY", "42"),
 				),
 			}),
 	}, {
@@ -645,7 +642,6 @@ func TestMakePodSpec(t *testing.T) {
 					container.Image = "busybox@sha256:deadbeef"
 				}),
 				queueContainer(
-					withEnvVar("CONTAINER_CONCURRENCY", "0"),
 					withEnvVar("SERVING_READINESS_PROBE", `{"httpGet":{"path":"/","port":8080,"host":"127.0.0.1","scheme":"HTTP","httpHeaders":[{"name":"K-Kubelet-Probe","value":"queue"}]}}`),
 				),
 			}),
@@ -667,7 +663,6 @@ func TestMakePodSpec(t *testing.T) {
 					container.Image = "busybox@sha256:deadbeef"
 				}),
 				queueContainer(
-					withEnvVar("CONTAINER_CONCURRENCY", "0"),
 					withEnvVar("SERVING_READINESS_PROBE", `{"tcpSocket":{"port":8080,"host":"127.0.0.1"}}`),
 				),
 			}),
@@ -691,12 +686,11 @@ func TestMakePodSpec(t *testing.T) {
 						container.ReadinessProbe = withExecReadinessProbe([]string{"echo", "hello"})
 					}),
 				queueContainer(
-					withEnvVar("CONTAINER_CONCURRENCY", "0"),
 					withEnvVar("SERVING_READINESS_PROBE", `{"tcpSocket":{"port":8080,"host":"127.0.0.1"}}`),
 				),
 			}),
 	}, {
-		name: "with http liveness probe",
+		name: "with HTTP liveness probe",
 		rev: revision("bar", "foo",
 			withContainers([]corev1.Container{{
 				Name:           servingContainerName,
@@ -731,9 +725,7 @@ func TestMakePodSpec(t *testing.T) {
 						},
 					}),
 				),
-				queueContainer(
-					withEnvVar("CONTAINER_CONCURRENCY", "0"),
-				),
+				queueContainer(),
 			}),
 	}, {
 		name: "with tcp liveness probe",
@@ -763,9 +755,7 @@ func TestMakePodSpec(t *testing.T) {
 						},
 					}),
 				),
-				queueContainer(
-					withEnvVar("CONTAINER_CONCURRENCY", "0"),
-				),
+				queueContainer(),
 			}),
 	}, {
 		name: "complex pod spec",
@@ -775,7 +765,6 @@ func TestMakePodSpec(t *testing.T) {
 				Image:          "busybox",
 				ReadinessProbe: withTCPReadinessProbe(v1.DefaultUserPort),
 			}}),
-			withContainerConcurrency(1),
 			WithContainerStatuses([]v1.ContainerStatuses{{
 				ImageDigest: "busybox@sha256:deadbeef",
 			}}),
@@ -798,7 +787,6 @@ func TestMakePodSpec(t *testing.T) {
 					withEnvVar("K_SERVICE", "svc"),
 				),
 				queueContainer(
-					withEnvVar("CONTAINER_CONCURRENCY", "1"),
 					withEnvVar("SERVING_SERVICE", "svc"),
 				)}),
 	}, {
@@ -818,7 +806,6 @@ func TestMakePodSpec(t *testing.T) {
 				Name:  "sidecar-container-2",
 				Image: "alpine",
 			}}),
-			withContainerConcurrency(1),
 			WithContainerStatuses([]v1.ContainerStatuses{{
 				ImageDigest: "busybox@sha256:deadbeef",
 			}, {
@@ -864,7 +851,6 @@ func TestMakePodSpec(t *testing.T) {
 					withEnvVar("K_SERVICE", "svc"),
 				),
 				queueContainer(
-					withEnvVar("CONTAINER_CONCURRENCY", "1"),
 					withEnvVar("SERVING_SERVICE", "svc"),
 				),
 			}),
@@ -882,7 +868,6 @@ func TestMakePodSpec(t *testing.T) {
 				Name:  sidecarContainerName,
 				Image: "ubuntu",
 			}}),
-			withContainerConcurrency(1),
 			WithContainerStatuses([]v1.ContainerStatuses{{
 				ImageDigest: "busybox@sha256:deadbeef",
 			}, {
@@ -918,7 +903,6 @@ func TestMakePodSpec(t *testing.T) {
 					withEnvVar("K_SERVICE", "svc"),
 				),
 				queueContainer(
-					withEnvVar("CONTAINER_CONCURRENCY", "1"),
 					withEnvVar("SERVING_SERVICE", "svc"),
 					withEnvVar("USER_PORT", "8888"),
 					withEnvVar("SERVING_READINESS_PROBE", `{"tcpSocket":{"port":8888,"host":"127.0.0.1"}}`),
@@ -958,9 +942,6 @@ func TestMakePodSpec(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			quantityComparer := cmp.Comparer(func(x, y resource.Quantity) bool {
-				return x.Cmp(y) == 0
-			})
 			got, err := makePodSpec(test.rev, &logConfig, &traceConfig, &test.oc, &deploymentConfig)
 			if err != nil {
 				t.Fatal("makePodSpec returned error:", err)
@@ -971,6 +952,10 @@ func TestMakePodSpec(t *testing.T) {
 		})
 	}
 }
+
+var quantityComparer = cmp.Comparer(func(x, y resource.Quantity) bool {
+	return x.Cmp(y) == 0
+})
 
 func TestMissingProbeError(t *testing.T) {
 	if _, err := MakeDeployment(revision("bar", "foo"), &logConfig, &traceConfig,
@@ -1039,8 +1024,10 @@ func TestMakeDeployment(t *testing.T) {
 				}
 			}),
 		want: appsv1deployment(func(deploy *appsv1.Deployment) {
-			deploy.Annotations[sidecarIstioInjectAnnotation] = "false"
-			deploy.Spec.Template.Annotations[sidecarIstioInjectAnnotation] = "false"
+			deploy.Annotations = kmeta.UnionMaps(deploy.Annotations,
+				map[string]string{sidecarIstioInjectAnnotation: "false"})
+			deploy.Spec.Template.Annotations = kmeta.UnionMaps(deploy.Spec.Template.Annotations,
+				map[string]string{sidecarIstioInjectAnnotation: "false"})
 		}),
 	}, {
 		name: "with ProgressDeadline override",
@@ -1119,9 +1106,9 @@ func TestMakeDeployment(t *testing.T) {
 			got, err := MakeDeployment(test.rev, &logConfig, &traceConfig,
 				&network.Config{}, &obsConfig, &test.dc, ac)
 			if err != nil {
-				t.Fatal("got unexpected error:", err)
+				t.Fatal("Got unexpected error:", err)
 			}
-			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(resource.Quantity{})); diff != "" {
+			if diff := cmp.Diff(test.want, got, quantityComparer); diff != "" {
 				t.Error("MakeDeployment (-want, +got) =", diff)
 			}
 		})

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -85,7 +85,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		dc   deployment.Config
 		want corev1.Container
 	}{{
-		name: "no owner no autoscaler single",
+		name: "autoscaler single",
 		rev: revision("bar", "foo",
 			withContainers(containers),
 			withContainerConcurrency(1)),
@@ -104,8 +104,7 @@ func TestMakeQueueContainer(t *testing.T) {
 					ContainerPort: 1955,
 					Name:          string(networking.ProtocolH2C),
 				}},
-			}}),
-			withContainerConcurrency(1)),
+			}})),
 		dc: deployment.Config{
 			QueueSidecarImage: "alpine",
 		},
@@ -113,16 +112,14 @@ func TestMakeQueueContainer(t *testing.T) {
 			c.Image = "alpine"
 			c.Ports = append(queueNonServingPorts, queueHTTP2Port)
 			c.Env = env(map[string]string{
-				"USER_PORT":             "1955",
-				"QUEUE_SERVING_PORT":    "8013",
-				"CONTAINER_CONCURRENCY": "1",
+				"USER_PORT":          "1955",
+				"QUEUE_SERVING_PORT": "8013",
 			})
 		}),
 	}, {
 		name: "service name in labels",
 		rev: revision("bar", "foo",
 			withContainers(containers),
-			withContainerConcurrency(1),
 			func(revision *v1.Revision) {
 				revision.Labels = map[string]string{
 					serving.ServiceLabelKey: "svc",
@@ -158,8 +155,7 @@ func TestMakeQueueContainer(t *testing.T) {
 	}, {
 		name: "logging configuration as env var",
 		rev: revision("this", "log",
-			withContainers(containers),
-			withContainerConcurrency(1)),
+			withContainers(containers)),
 		lc: logging.Config{
 			LoggingConfig: "The logging configuration goes here",
 			LoggingLevel: map[string]zapcore.Level{
@@ -187,8 +183,7 @@ func TestMakeQueueContainer(t *testing.T) {
 	}, {
 		name: "request log configuration as env var",
 		rev: revision("bar", "foo",
-			withContainers(containers),
-			withContainerConcurrency(1)),
+			withContainers(containers)),
 		oc: metrics.ObservabilityConfig{
 			RequestLogTemplate:    "test template",
 			EnableProbeRequestLog: true,
@@ -202,8 +197,7 @@ func TestMakeQueueContainer(t *testing.T) {
 	}, {
 		name: "disabled request log configuration as env var",
 		rev: revision("bar", "foo",
-			withContainers(containers),
-			withContainerConcurrency(1)),
+			withContainers(containers)),
 		oc: metrics.ObservabilityConfig{
 			RequestLogTemplate:    "test template",
 			EnableProbeRequestLog: false,
@@ -219,8 +213,7 @@ func TestMakeQueueContainer(t *testing.T) {
 	}, {
 		name: "request metrics backend as env var",
 		rev: revision("bar", "foo",
-			withContainers(containers),
-			withContainerConcurrency(1)),
+			withContainers(containers)),
 		oc: metrics.ObservabilityConfig{
 			RequestMetricsBackend: "prometheus",
 		},
@@ -232,8 +225,7 @@ func TestMakeQueueContainer(t *testing.T) {
 	}, {
 		name: "enable profiling",
 		rev: revision("bar", "foo",
-			withContainers(containers),
-			withContainerConcurrency(1)),
+			withContainers(containers)),
 		oc: metrics.ObservabilityConfig{EnableProfiling: true},
 		want: queueContainer(func(c *corev1.Container) {
 			c.Env = env(map[string]string{
@@ -244,8 +236,7 @@ func TestMakeQueueContainer(t *testing.T) {
 	}, {
 		name: "custom TimeoutSeconds",
 		rev: revision("bar", "foo",
-			withContainers(containers),
-			withContainerConcurrency(1)),
+			withContainers(containers)),
 		want: queueContainer(func(c *corev1.Container) {
 			c.Env = env(map[string]string{
 				"REVISION_TIMEOUT_SECONDS": "45",
@@ -254,8 +245,7 @@ func TestMakeQueueContainer(t *testing.T) {
 	}, {
 		name: "default resource config",
 		rev: revision("bar", "foo",
-			withContainers(containers),
-			withContainerConcurrency(1)),
+			withContainers(containers)),
 		dc: deployment.Config{
 			QueueSidecarCPURequest: &deployment.QueueSidecarCPURequestDefault,
 		},
@@ -269,8 +259,7 @@ func TestMakeQueueContainer(t *testing.T) {
 	}, {
 		name: "overridden resources",
 		rev: revision("bar", "foo",
-			withContainers(containers),
-			withContainerConcurrency(1)),
+			withContainers(containers)),
 		dc: deployment.Config{
 			QueueSidecarCPURequest:              resourcePtr(resource.MustParse("123m")),
 			QueueSidecarEphemeralStorageRequest: resourcePtr(resource.MustParse("456M")),
@@ -309,8 +298,8 @@ func TestMakeQueueContainer(t *testing.T) {
 			})
 			sortEnv(got.Env)
 			sortEnv(test.want.Env)
-			if diff := cmp.Diff(test.want, *got, cmp.AllowUnexported(resource.Quantity{})); diff != "" {
-				t.Error("makeQueueContainer (-want, +got) =", diff)
+			if got, want := *got, test.want; !cmp.Equal(got, want, quantityComparer) {
+				t.Errorf("makeQueueContainer (-want, +got) =\n%s", cmp.Diff(want, got, quantityComparer))
 			}
 		})
 	}
@@ -325,7 +314,6 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 	}{{
 		name: "resources percentage in annotations",
 		rev: revision("bar", "foo",
-			withContainerConcurrency(1),
 			func(revision *v1.Revision) {
 				revision.Annotations = map[string]string{
 					serving.QueueSideCarResourcePercentageAnnotation: "20",
@@ -351,7 +339,6 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 	}, {
 		name: "resources percentage in annotations smaller than min allowed",
 		rev: revision("bar", "foo",
-			withContainerConcurrency(1),
 			func(revision *v1.Revision) {
 				revision.Annotations = map[string]string{
 					serving.QueueSideCarResourcePercentageAnnotation: "0.2",
@@ -377,7 +364,6 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 	}, {
 		name: "invalid resources percentage in annotations uses defaults",
 		rev: revision("bar", "foo",
-			withContainerConcurrency(1),
 			func(revision *v1.Revision) {
 				revision.Annotations = map[string]string{
 					serving.QueueSideCarResourcePercentageAnnotation: "foo",
@@ -405,7 +391,6 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 	}, {
 		name: "resources percentage in annotations bigger than than math.MaxInt64",
 		rev: revision("bar", "foo",
-			withContainerConcurrency(1),
 			func(revision *v1.Revision) {
 				revision.Annotations = map[string]string{
 					serving.QueueSideCarResourcePercentageAnnotation: "100",
@@ -444,8 +429,8 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 			})
 			sortEnv(got.Env)
 			sortEnv(test.want.Env)
-			if diff := cmp.Diff(test.want, *got, cmp.AllowUnexported(resource.Quantity{})); diff != "" {
-				t.Error("makeQueueContainer (-want, +got) =", diff)
+			if got, want := *got, test.want; !cmp.Equal(got, want, quantityComparer) {
+				t.Errorf("makeQueueContainer (-want, +got) =\n%s", cmp.Diff(want, got, quantityComparer))
 			}
 		})
 	}
@@ -453,7 +438,6 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 
 func TestProbeGenerationHTTPDefaults(t *testing.T) {
 	rev := revision("bar", "foo",
-		withContainerConcurrency(1),
 		func(revision *v1.Revision) {
 			revision.Spec.PodSpec.Containers = []corev1.Container{{
 				Name: servingContainerName,
@@ -511,8 +495,8 @@ func TestProbeGenerationHTTPDefaults(t *testing.T) {
 		t.Fatal("makeQueueContainer returned error")
 	}
 	sortEnv(got.Env)
-	if diff := cmp.Diff(want, *got, cmp.AllowUnexported(resource.Quantity{})); diff != "" {
-		t.Error("makeQueueContainer(-want, +got) =", diff)
+	if got, want := *got, want; !cmp.Equal(got, want, quantityComparer) {
+		t.Errorf("makeQueueContainer(-want, +got) =\n%s", cmp.Diff(want, got, quantityComparer))
 	}
 }
 
@@ -521,7 +505,6 @@ func TestProbeGenerationHTTP(t *testing.T) {
 	const probePath = "/health"
 
 	rev := revision("bar", "foo",
-		withContainerConcurrency(1),
 		func(revision *v1.Revision) {
 			revision.Spec.PodSpec.Containers = []corev1.Container{{
 				Name: servingContainerName,
@@ -583,8 +566,8 @@ func TestProbeGenerationHTTP(t *testing.T) {
 		t.Fatal("makeQueueContainer returned error")
 	}
 	sortEnv(got.Env)
-	if diff := cmp.Diff(want, *got, cmp.AllowUnexported(resource.Quantity{})); diff != "" {
-		t.Error("makeQueueContainer(-want, +got) =", diff)
+	if got, want := *got, want; !cmp.Equal(got, want, quantityComparer) {
+		t.Errorf("makeQueueContainer(-want, +got) =\n%s", cmp.Diff(want, got, quantityComparer))
 	}
 }
 
@@ -608,8 +591,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 			SuccessThreshold: 3,
 		},
 		rev: v1.RevisionSpec{
-			ContainerConcurrency: ptr.Int64(1),
-			TimeoutSeconds:       ptr.Int64(45),
+			TimeoutSeconds: ptr.Int64(45),
 			PodSpec: corev1.PodSpec{
 				Containers: []corev1.Container{{
 					Name: servingContainerName,
@@ -641,8 +623,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 	}, {
 		name: "tcp defaults",
 		rev: v1.RevisionSpec{
-			ContainerConcurrency: ptr.Int64(1),
-			TimeoutSeconds:       ptr.Int64(45),
+			TimeoutSeconds: ptr.Int64(45),
 			PodSpec: corev1.PodSpec{
 				Containers: []corev1.Container{{
 					Name: servingContainerName,
@@ -693,8 +674,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 			InitialDelaySeconds: 3,
 		},
 		rev: v1.RevisionSpec{
-			ContainerConcurrency: ptr.Int64(1),
-			TimeoutSeconds:       ptr.Int64(45),
+			TimeoutSeconds: ptr.Int64(45),
 			PodSpec: corev1.PodSpec{
 				Containers: []corev1.Container{{
 					Name: servingContainerName,
@@ -751,36 +731,36 @@ func TestTCPProbeGeneration(t *testing.T) {
 			}
 			sortEnv(got.Env)
 			sortEnv(test.want.Env)
-			if diff := cmp.Diff(test.want, *got, cmp.AllowUnexported(resource.Quantity{})); diff != "" {
-				t.Error("makeQueueContainer (-want, +got) =", diff)
+			if got, want := *got, test.want; !cmp.Equal(want, got, quantityComparer) {
+				t.Errorf("makeQueueContainer (-want, +got) =\n%s", cmp.Diff(want, got, quantityComparer))
 			}
 		})
 	}
 }
 
 var defaultEnv = map[string]string{
-	"SERVING_NAMESPACE":                     "foo",
-	"SERVING_SERVICE":                       "",
-	"SERVING_CONFIGURATION":                 "",
-	"SERVING_REVISION":                      "bar",
-	"CONTAINER_CONCURRENCY":                 "1",
-	"REVISION_TIMEOUT_SECONDS":              "45",
-	"SERVING_LOGGING_CONFIG":                "",
-	"SERVING_LOGGING_LEVEL":                 "",
-	"TRACING_CONFIG_BACKEND":                "",
-	"TRACING_CONFIG_ZIPKIN_ENDPOINT":        "",
-	"TRACING_CONFIG_STACKDRIVER_PROJECT_ID": "",
-	"TRACING_CONFIG_SAMPLE_RATE":            "0",
-	"TRACING_CONFIG_DEBUG":                  "false",
-	"SERVING_REQUEST_LOG_TEMPLATE":          "",
-	"SERVING_ENABLE_REQUEST_LOG":            "false",
-	"SERVING_REQUEST_METRICS_BACKEND":       "",
-	"USER_PORT":                             strconv.Itoa(v1.DefaultUserPort),
-	"SYSTEM_NAMESPACE":                      system.Namespace(),
+	"CONTAINER_CONCURRENCY":                 "0",
+	"ENABLE_PROFILING":                      "false",
 	"METRICS_DOMAIN":                        metrics.Domain(),
 	"QUEUE_SERVING_PORT":                    "8012",
-	"ENABLE_PROFILING":                      "false",
+	"REVISION_TIMEOUT_SECONDS":              "45",
+	"SERVING_CONFIGURATION":                 "",
 	"SERVING_ENABLE_PROBE_REQUEST_LOG":      "false",
+	"SERVING_ENABLE_REQUEST_LOG":            "false",
+	"SERVING_LOGGING_CONFIG":                "",
+	"SERVING_LOGGING_LEVEL":                 "",
+	"SERVING_NAMESPACE":                     "foo",
+	"SERVING_REQUEST_LOG_TEMPLATE":          "",
+	"SERVING_REQUEST_METRICS_BACKEND":       "",
+	"SERVING_REVISION":                      "bar",
+	"SERVING_SERVICE":                       "",
+	"SYSTEM_NAMESPACE":                      system.Namespace(),
+	"TRACING_CONFIG_BACKEND":                "",
+	"TRACING_CONFIG_DEBUG":                  "false",
+	"TRACING_CONFIG_SAMPLE_RATE":            "0",
+	"TRACING_CONFIG_STACKDRIVER_PROJECT_ID": "",
+	"TRACING_CONFIG_ZIPKIN_ENDPOINT":        "",
+	"USER_PORT":                             strconv.Itoa(v1.DefaultUserPort),
 }
 
 func probeJSON(container *corev1.Container) string {


### PR DESCRIPTION
and other cleanups.
No reason to specify CC=1 on every test, and other things which are redundant are gone

/assign mattmoor @markusthoemmes @whaught 