### PR TITLE
Move unused constants into commented section.

### DIFF
--- a/pkg/queue/request_metric.go
+++ b/pkg/queue/request_metric.go
@@ -61,12 +61,6 @@ var (
 		stats.UnitDimensionless)
 )
 
-const (
-	defaultTagName   = "DEFAULT"
-	undefinedTagName = "UNDEFINED"
-	disabledTagName  = "DISABLED"
-)
-
 type requestMetricsHandler struct {
 	next     http.Handler
 	statsCtx context.Context
@@ -211,8 +205,15 @@ func (h *appRequestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	h.next.ServeHTTP(rr, r)
 }
 
+/*
+const (
+	defaultTagName   = "DEFAULT"
+	undefinedTagName = "UNDEFINED"
+	disabledTagName  = "DISABLED"
+)
+
 // GetRouteTagNameFromRequest extracts the value of the tag header from http.Request
-/*func GetRouteTagNameFromRequest(r *http.Request) string {
+func GetRouteTagNameFromRequest(r *http.Request) string {
 	name := r.Header.Get(network.TagHeaderName)
 	isDefaultRoute := r.Header.Get(network.DefaultRouteHeaderName)
 

--- a/pkg/queue/request_metric.go
+++ b/pkg/queue/request_metric.go
@@ -206,6 +206,9 @@ func (h *appRequestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 }
 
 /*
+TODO: add the routeTag back after stackdriver adds support for it.
+https://github.com/knative/serving/issues/8970
+
 const (
 	defaultTagName   = "DEFAULT"
 	undefinedTagName = "UNDEFINED"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Arguably, these constants should be close to their **only** usage anyway. They are also unused now.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @evankanderson 
