### PR TITLE
Benchmark PodRevisionContext and bump cache a bit

### DIFF
--- a/pkg/metrics/tags.go
+++ b/pkg/metrics/tags.go
@@ -35,12 +35,16 @@ var (
 	contextCache *lru.Cache
 )
 
-const lruCacheSize = 1024
+// This is a fairly arbitrary number but we want it to be higher than the
+// number of active revisions a single activator might be handling, to avoid
+// churning the cache, without being so much higher that it causes an
+// (effective) memory leak.
+// The contents of the cache are quite small, so we can err on the high side.
+const lruCacheSize = 4096
 
 func init() {
 	// The only possible error is when cache size is not positive.
-	lc, _ := lru.New(lruCacheSize)
-	contextCache = lc
+	contextCache, _ = lru.New(lruCacheSize)
 }
 
 func valueOrUnknown(v string) string {

--- a/pkg/metrics/tags_test.go
+++ b/pkg/metrics/tags_test.go
@@ -228,12 +228,15 @@ func TestContexts(t *testing.T) {
 }
 
 func BenchmarkPodRevisionContext(b *testing.B) {
+	// pre-warm the cache cases.
+	PodRevisionContext("pod", "container", "ns", "svc", "cfg", "name")
+
 	for _, cache := range []bool{true, false} {
 		b.Run(fmt.Sprintf("sequential-cache-%v", cache), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				rev := "name"
 				if !cache {
-					rev = rev + strconv.Itoa(i)
+					rev += strconv.Itoa(i)
 				}
 
 				PodRevisionContext("pod", "container", "ns", "svc", "cfg", rev)
@@ -246,7 +249,7 @@ func BenchmarkPodRevisionContext(b *testing.B) {
 				for pb.Next() {
 					rev := "name"
 					if !cache {
-						rev = rev + strconv.FormatInt(n.Inc(), 10)
+						rev += strconv.FormatInt(n.Inc(), 10)
 					}
 
 					PodRevisionContext("pod", "container", "ns", "svc", "cfg", rev)

--- a/pkg/metrics/tags_test.go
+++ b/pkg/metrics/tags_test.go
@@ -228,30 +228,24 @@ func TestContexts(t *testing.T) {
 }
 
 func BenchmarkPodRevisionContext(b *testing.B) {
-	// pre-warm the cache cases.
-	PodRevisionContext("pod", "container", "ns", "svc", "cfg", "name")
-
-	for _, cache := range []bool{true, false} {
-		b.Run(fmt.Sprintf("sequential-cache-%v", cache), func(b *testing.B) {
+	// test with 1 (always hits cache), 4095 (always hits cache, but at capacity),
+	// and 409600  (often misses cache)
+	for _, revisions := range []int{1, 4095, 409600} {
+		b.Run(fmt.Sprintf("sequential-%d-revisions", revisions), func(b *testing.B) {
+			contextCache.Purge()
 			for i := 0; i < b.N; i++ {
-				rev := "name"
-				if !cache {
-					rev += strconv.Itoa(i)
-				}
-
+				rev := "name" + strconv.Itoa(i%revisions)
 				PodRevisionContext("pod", "container", "ns", "svc", "cfg", rev)
 			}
 		})
 
-		b.Run(fmt.Sprintf("parallel-cache-%v", cache), func(b *testing.B) {
+		b.Run(fmt.Sprintf("parallel-%d-revisions", revisions), func(b *testing.B) {
+			contextCache.Purge()
+
 			var n atomic.Int64
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					rev := "name"
-					if !cache {
-						rev += strconv.FormatInt(n.Inc(), 10)
-					}
-
+					rev := "name" + strconv.Itoa(int(n.Inc())%revisions)
 					PodRevisionContext("pod", "container", "ns", "svc", "cfg", rev)
 				}
 			})


### PR DESCRIPTION
Add a benchmark to check the caching is worthwhile (it is), and bump the cache
size a little to handle larger numbers of revisions (the cache entries are small so 
we can err on the higher side).

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


~~~~
BenchmarkPodRevisionContext/sequential-1-revisions-16            5047066               292 ns/op              69 B/op          2 allocs/op
BenchmarkPodRevisionContext/parallel-1-revisions-16              3450831               337 ns/op              69 B/op          2 allocs/op
BenchmarkPodRevisionContext/sequential-4095-revisions-16         4155703               276 ns/op              80 B/op          2 allocs/op
BenchmarkPodRevisionContext/parallel-4095-revisions-16           2755446               431 ns/op              80 B/op          2 allocs/op
BenchmarkPodRevisionContext/sequential-409600-revisions-16       1000000              1242 ns/op             673 B/op         11 allocs/op
BenchmarkPodRevisionContext/parallel-409600-revisions-16          715194              1629 ns/op             673 B/op         11 allocs/op
~~~~

/assign @markusthoemmes @vagababov 
