### PR TITLE
Various formatting tidy-ups in activator

### DIFF
--- a/pkg/activator/config/store.go
+++ b/pkg/activator/config/store.go
@@ -26,12 +26,12 @@ import (
 
 type cfgKey struct{}
 
-// Config is a configuration for the activator
+// Config is the configuration for the activator.
 type Config struct {
 	Tracing *tracingconfig.Config
 }
 
-// FromContext obtains a Config injected into the passed context
+// FromContext obtains a Config injected into the passed context.
 func FromContext(ctx context.Context) *Config {
 	return ctx.Value(cfgKey{}).(*Config)
 }
@@ -40,13 +40,13 @@ func toContext(ctx context.Context, c *Config) context.Context {
 	return context.WithValue(ctx, cfgKey{}, c)
 }
 
-// Store loads/unloads our untyped configuration
+// Store loads/unloads our untyped configuration.
 // +k8s:deepcopy-gen=false
 type Store struct {
 	*configmap.UntypedStore
 }
 
-// NewStore creates a configuration Store
+// NewStore creates a new configuration Store.
 func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value interface{})) *Store {
 	return &Store{
 		UntypedStore: configmap.NewUntypedStore(
@@ -60,12 +60,12 @@ func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value i
 	}
 }
 
-// ToContext stores the configuration Store in the passed context
+// ToContext stores the configuration Store in the passed context.
 func (s *Store) ToContext(ctx context.Context) context.Context {
 	return toContext(ctx, s.Load())
 }
 
-// Load creates a Config for this store
+// Load creates a Config for this store.
 func (s *Store) Load() *Config {
 	return &Config{
 		Tracing: s.UntypedLoad(tracingconfig.ConfigName).(*tracingconfig.Config).DeepCopy(),
@@ -77,13 +77,13 @@ type storeMiddleware struct {
 	next  http.Handler
 }
 
-// ServeHTTP injects Config in to the context of the http request r
+// ServeHTTP injects Config in to the context of the http request r.
 func (mw *storeMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := mw.store.ToContext(r.Context())
 	mw.next.ServeHTTP(w, r.WithContext(ctx))
 }
 
-// HTTPMiddleware is a middleware which stores the current config store in the request context
+// HTTPMiddleware is a middleware which stores the current config store in the request context.
 func (s *Store) HTTPMiddleware(next http.Handler) http.Handler {
 	return &storeMiddleware{
 		store: s,

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -91,7 +91,7 @@ func (a *activationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		return nil
 	}); err != nil {
-		// Set error on our capacity waiting span and end it
+		// Set error on our capacity waiting span and end it.
 		trySpan.Annotate([]trace.Attribute{trace.StringAttribute("activator.throttler.error", err.Error())}, "ThrottlerTry")
 		trySpan.End()
 
@@ -110,7 +110,7 @@ func (a *activationHandler) proxyRequest(logger *zap.SugaredLogger, w http.Respo
 	network.RewriteHostIn(r)
 	r.Header.Set(network.ProxyHeaderName, activator.Name)
 
-	// Setup the reverse proxy.
+	// Set up the reverse proxy.
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.BufferPool = a.bufferPool
 	proxy.Transport = a.transport

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -370,7 +370,7 @@ func BenchmarkHandler(b *testing.B) {
 }
 
 func randomString(n int) string {
-	var letter = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	letter := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
 	b := make([]rune, n)
 	for i := range b {

--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -28,7 +28,7 @@ import (
 	"knative.dev/serving/pkg/metrics"
 )
 
-// NewMetricHandler creates a handler collects and reports request metrics
+// NewMetricHandler creates a handler that collects and reports request metrics.
 func NewMetricHandler(podName string, next http.Handler) *MetricHandler {
 	return &MetricHandler{
 		nextHandler: next,
@@ -36,7 +36,7 @@ func NewMetricHandler(podName string, next http.Handler) *MetricHandler {
 	}
 }
 
-// MetricHandler sends metrics via reporter
+// MetricHandler is a handler that records request metrics.
 type MetricHandler struct {
 	podName     string
 	nextHandler http.Handler

--- a/pkg/activator/net/helpers.go
+++ b/pkg/activator/net/helpers.go
@@ -47,9 +47,9 @@ func healthyAddresses(endpoints *corev1.Endpoints, portName string) sets.String 
 
 // endpointsToDests takes an endpoints object and a port name and returns two sets of
 // ready and non-ready l4 dests in the endpoints object which have that port.
-func endpointsToDests(endpoints *corev1.Endpoints, portName string) (sets.String, sets.String) {
-	ready := sets.NewString()
-	notReady := sets.NewString()
+func endpointsToDests(endpoints *corev1.Endpoints, portName string) (ready, notReady sets.String) {
+	ready = sets.NewString()
+	notReady = sets.NewString()
 
 	for _, es := range endpoints.Subsets {
 		for _, port := range es.Ports {

--- a/pkg/activator/net/helpers_test.go
+++ b/pkg/activator/net/helpers_test.go
@@ -122,7 +122,6 @@ func TestEndpointsToDests(t *testing.T) {
 				t.Errorf("Got unexpected notReady dests (-want, +got): %s", cmp.Diff(want, got))
 			}
 		})
-
 	}
 }
 

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -164,7 +164,6 @@ func (rw *revisionWatcher) probe(ctx context.Context, dest string) (bool, error)
 		prober.WithHeader(network.UserAgentKey, network.ActivatorUserAgent),
 		prober.ExpectsBody(queue.Name),
 		prober.ExpectsStatusCodes([]int{http.StatusOK}))
-
 }
 
 func (rw *revisionWatcher) getDest() (string, error) {

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -480,7 +480,7 @@ func assertChClosed(t *testing.T, ch chan struct{}) {
 	}
 }
 
-func epSubset(port int32, portName string, ips []string, notReadyIps []string) *corev1.EndpointSubset {
+func epSubset(port int32, portName string, ips, notReadyIps []string) *corev1.EndpointSubset {
 	ss := &corev1.EndpointSubset{
 		Ports: []corev1.EndpointPort{{
 			Name: portName,
@@ -500,7 +500,7 @@ func ep(revL string, port int32, portName string, ips ...string) *corev1.Endpoin
 	return epNotReady(revL, port, portName, ips, nil)
 }
 
-func epNotReady(revL string, port int32, portName string, readyIps []string, notReadyIps []string) *corev1.Endpoints {
+func epNotReady(revL string, port int32, portName string, readyIps, notReadyIps []string) *corev1.Endpoints {
 	return &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: revL + "-ep",

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -147,7 +147,7 @@ type revisionThrottler struct {
 	clusterIPTracker *podTracker
 
 	// mux guards the "throttler state" which is the state we use during the
-	//request path. This is: trackers, clusterIPDest.
+	// request path. This is: trackers, clusterIPDest.
 	mux sync.RWMutex
 
 	logger *zap.SugaredLogger

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -1035,7 +1035,7 @@ func TestPickIndices(t *testing.T) {
 }
 
 func TestAssignSlice(t *testing.T) {
-	opt := cmp.Comparer(func(a *podTracker, b *podTracker) bool {
+	opt := cmp.Comparer(func(a, b *podTracker) bool {
 		return a.dest == b.dest
 	})
 	trackers := []*podTracker{{

--- a/pkg/activator/util/context.go
+++ b/pkg/activator/util/context.go
@@ -28,8 +28,10 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
-type revisionKey struct{}
-type revIDKey struct{}
+type (
+	revisionKey struct{}
+	revIDKey    struct{}
+)
 
 // WithRevision attaches the Revision object to the context.
 func WithRevision(ctx context.Context, rev *v1.Revision) context.Context {

--- a/pkg/activator/util/header.go
+++ b/pkg/activator/util/header.go
@@ -29,9 +29,9 @@ var headersToRemove = []string{
 }
 
 // SetupHeaderPruning will cause the http.ReverseProxy
-// to not forward activator headers
+// to not forward activator headers.
 func SetupHeaderPruning(p *httputil.ReverseProxy) {
-	// Director is never null - otherwise ServeHTTP panics
+	// Director is never nil - otherwise ServeHTTP panics.
 	orig := p.Director
 	p.Director = func(r *http.Request) {
 		orig(r)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Just some stray newlines, bit of weird spacing in a comment and a few duplicated types in arg lists. Also `null` -> `nil` and `Setup` -> `Set up` because I am a pedant.