### PR TITLE
Reimplement semaphore using packaged integer.

### DIFF
--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -199,7 +199,7 @@ type semaphore struct {
 	queue chan struct{}
 }
 
-// tryAcquire receives the token from the semaphore if there's one otherwise returns false.
+// tryAcquire receives a token from the semaphore if there is one otherwise returns false.
 func (s *semaphore) tryAcquire() bool {
 	for {
 		old := s.state.Load()

--- a/pkg/queue/breaker.go
+++ b/pkg/queue/breaker.go
@@ -185,10 +185,10 @@ func newSemaphore(maxCapacity, initialCapacity int) *semaphore {
 }
 
 // semaphore is an implementation of a semaphore based on packed integers and a channel.
-// state is an int64 that has two int32s packed into it: capacity and inFlight. The
+// state is an uint64 that has two uint32s packed into it: capacity and inFlight. The
 // former specifies how many request are allowed at any given time into the semaphore
 // while the latter refers to the currently in-flight requests.
-// Packing them both into one int64 allows us to optimize access semantics using atomic
+// Packing them both into one uint64 allows us to optimize access semantics using atomic
 // operations, which can't be guaranteed on 2 individual values.
 // The channel is merely used as a vehicle to be able to "wake up" individual goroutines
 // if capacity becomes free. It's not consistently used in accordance to actual capacity

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -94,7 +94,7 @@ func TestBreakerOverloadMixed(t *testing.T) {
 	// Bring breaker to capacity.
 	reqs.request()
 	// This happens in go-routine, so spin.
-	for len(b.sem.queue) > 0 {
+	for _, in := unpack(b.sem.state.Load()); in != 1; _, in = unpack(b.sem.state.Load()) {
 		time.Sleep(time.Millisecond * 2)
 	}
 	_, rr := b.Reserve(context.Background())
@@ -263,7 +263,7 @@ func TestSemaphoreAcquireHasCapacity(t *testing.T) {
 
 	sem := newSemaphore(1, 0)
 	tryAcquire(sem, gotChan)
-	sem.release() // Allows 1 acquire
+	sem.updateCapacity(1) // Allows 1 acquire
 
 	for i := 0; i < want; i++ {
 		select {
@@ -293,30 +293,6 @@ func TestSemaphoreRelease(t *testing.T) {
 	}
 }
 
-func TestSemaphoreReleasesSeveralReducers(t *testing.T) {
-	const wantAfterFirstrelease = 1
-	const wantAfterSecondrelease = 0
-	sem := newSemaphore(2, 2)
-	sem.acquire(context.Background())
-	sem.acquire(context.Background())
-	sem.updateCapacity(0)
-	sem.release()
-	if got := sem.Capacity(); got != wantAfterSecondrelease {
-		t.Errorf("Capacity = %d, want: %d", got, wantAfterSecondrelease)
-	}
-	if sem.reducers != wantAfterFirstrelease {
-		t.Errorf("sem.reducers = %d, want: %d", sem.reducers, wantAfterFirstrelease)
-	}
-
-	sem.release()
-	if got := sem.Capacity(); got != wantAfterSecondrelease {
-		t.Errorf("Capacity = %d, want: %d", got, wantAfterSecondrelease)
-	}
-	if sem.reducers != wantAfterSecondrelease {
-		t.Errorf("sem.reducers = %d, want: %d", sem.reducers, wantAfterSecondrelease)
-	}
-}
-
 func TestSemaphoreUpdateCapacity(t *testing.T) {
 	const initialCapacity = 1
 	sem := newSemaphore(3, initialCapacity)
@@ -327,40 +303,6 @@ func TestSemaphoreUpdateCapacity(t *testing.T) {
 	sem.updateCapacity(initialCapacity + 2)
 	if got, want := sem.Capacity(), 3; got != want {
 		t.Errorf("Capacity = %d, want: %d", got, want)
-	}
-}
-
-// Test the case when we add more capacity then the number of waiting reducers
-func TestSemaphoreUpdateCapacityLessThenReducers(t *testing.T) {
-	const initialCapacity = 2
-	sem := newSemaphore(2, initialCapacity)
-	sem.acquire(context.Background())
-	sem.acquire(context.Background())
-	sem.updateCapacity(initialCapacity - 2)
-	if got, want := sem.reducers, 2; got != want {
-		t.Errorf("sem.reducers = %d, want: %d", got, want)
-	}
-	sem.release()
-	sem.release()
-	sem.release()
-	if got, want := sem.reducers, 0; got != want {
-		t.Errorf("sem.reducers = %d, want: %d", got, want)
-	}
-}
-
-func TestSemaphoreUpdateCapacityConsumingReducers(t *testing.T) {
-	const initialCapacity = 2
-	sem := newSemaphore(2, initialCapacity)
-	sem.acquire(context.Background())
-	sem.acquire(context.Background())
-	sem.updateCapacity(initialCapacity - 2)
-	if got, want := sem.reducers, 2; got != want {
-		t.Errorf("sem.reducers = %d, want: %d", got, want)
-	}
-
-	sem.updateCapacity(initialCapacity)
-	if got, want := sem.reducers, 0; got != want {
-		t.Errorf("sem.reducers = %d, want: %d", got, want)
 	}
 }
 
@@ -375,14 +317,6 @@ func TestSemaphoreUpdateCapacityOutOfBound(t *testing.T) {
 	sem := newSemaphore(1, 1)
 	sem.acquire(context.Background())
 	if err := sem.updateCapacity(-1); err != ErrUpdateCapacity {
-		t.Errorf("updateCapacity = %v, want: %v", err, ErrUpdateCapacity)
-	}
-}
-
-func TestSemaphoreUpdateCapacityBrokenState(t *testing.T) {
-	sem := newSemaphore(1, 0)
-	sem.release() // This Release is not paired with an acquire
-	if err := sem.updateCapacity(1); err != ErrUpdateCapacity {
 		t.Errorf("updateCapacity = %v, want: %v", err, ErrUpdateCapacity)
 	}
 }

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -328,6 +328,17 @@ func TestSemaphoreUpdateCapacityDoNothing(t *testing.T) {
 	}
 }
 
+func TestPackUnpack(t *testing.T) {
+	wantL := uint64(256)
+	wantR := uint64(513)
+
+	gotL, gotR := unpack(pack(wantL, wantR))
+
+	if gotL != wantL || gotR != wantR {
+		t.Fatalf("Got %d, %d want %d, %d", gotL, gotR, wantL, wantR)
+	}
+}
+
 func tryAcquire(sem *semaphore, gotChan chan struct{}) {
 	go func() {
 		// blocking until someone puts the token into the semaphore


### PR DESCRIPTION
**Note:** This needs **thorough** review. It's the 1000th iteration of this and I'm still not 100% certain it's correct :joy: 

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This is an implementation of a semaphore based on packed integers and a channel.

state is an int64 that has two int32s packed into it: capacity and inFlight. The former specifies how many request are allowed at any given time into the semaphore while the latter refers to the currently in-flight requests. Packing them both into one int64 allows us to optimize access semantics using atomic operations, which can't be guaranteed on 2 individual values.

The channel is merely used as a vehicle to be able to "wake up" individual goroutines if capacity becomes free. It's not consistently used in accordance to actual capacity but is rather a communication vehicle to ensure waiting routines are properly worken up.

### Benchmarks

```
benchmark                                 old ns/op     new ns/op     delta
BenchmarkBreakerReserve/sequential-16     60.2          23.3          -61.30%
BenchmarkBreakerReserve/parallel-16       243           80.6          -66.83%

benchmark                                    old ns/op     new ns/op     delta
BenchmarkBreakerMaybe/1-sequential-16        92.1          27.5          -70.14%
BenchmarkBreakerMaybe/1-parallel-16          310           224           -27.74%
BenchmarkBreakerMaybe/10-sequential-16       92.1          28.0          -69.60%
BenchmarkBreakerMaybe/10-parallel-16         843           83.1          -90.14%
BenchmarkBreakerMaybe/100-sequential-16      91.6          28.0          -69.43%
BenchmarkBreakerMaybe/100-parallel-16        183           74.0          -59.56%
BenchmarkBreakerMaybe/1000-sequential-16     90.3          27.9          -69.10%
BenchmarkBreakerMaybe/1000-parallel-16       220           74.1          -66.32%
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @julz 
