### PR TITLE
Make sure revision config wraps the api config

### DIFF
--- a/pkg/apis/config/store.go
+++ b/pkg/apis/config/store.go
@@ -101,9 +101,15 @@ func (s *Store) ToContext(ctx context.Context) context.Context {
 
 // Load creates a Config from the current config state of the Store.
 func (s *Store) Load() *Config {
-	return &Config{
-		Defaults:   s.UntypedLoad(DefaultsConfigName).(*Defaults).DeepCopy(),
-		Features:   s.UntypedLoad(FeaturesConfigName).(*Features).DeepCopy(),
-		Autoscaler: s.UntypedLoad(autoscalerconfig.ConfigName).(*autoscalerconfig.Config).DeepCopy(),
+	cfg := &Config{}
+	if def, ok := s.UntypedLoad(DefaultsConfigName).(*Defaults); ok {
+		cfg.Defaults = def.DeepCopy()
 	}
+	if feat, ok := s.UntypedLoad(FeaturesConfigName).(*Features); ok {
+		cfg.Features = feat.DeepCopy()
+	}
+	if as, ok := s.UntypedLoad(autoscalerconfig.ConfigName).(*autoscalerconfig.Config); ok {
+		cfg.Autoscaler = as.DeepCopy()
+	}
+	return cfg
 }

--- a/pkg/reconciler/revision/config/store.go
+++ b/pkg/reconciler/revision/config/store.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2018 The Knative Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/reconciler/revision/config/store.go
+++ b/pkg/reconciler/revision/config/store.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2018 The Knative Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,13 +16,12 @@ package config
 import (
 	"context"
 
-	"knative.dev/serving/pkg/apis/config"
-
 	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
 	pkgtracing "knative.dev/pkg/tracing/config"
+	"knative.dev/serving/pkg/apis/config"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
 )
@@ -57,6 +53,7 @@ func ToContext(ctx context.Context, c *Config) context.Context {
 // +k8s:deepcopy-gen=false
 type Store struct {
 	*configmap.UntypedStore
+	apiStore *config.Store
 }
 
 // NewStore creates a new store of Configs and optionally calls functions when ConfigMaps are updated for Revisions
@@ -76,24 +73,46 @@ func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value i
 			},
 			onAfterStore...,
 		),
+		apiStore: config.NewStore(logger),
 	}
 	return store
 }
 
+func (s *Store) WatchConfigs(cmw configmap.Watcher) {
+	s.UntypedStore.WatchConfigs(cmw)
+	s.apiStore.WatchConfigs(cmw)
+}
+
 // ToContext persists the config on the context.
 func (s *Store) ToContext(ctx context.Context) context.Context {
-	return ToContext(ctx, s.Load())
+	return s.apiStore.ToContext(ToContext(ctx, s.Load()))
 }
 
 // Load returns the config from the store.
 func (s *Store) Load() *Config {
-	return &Config{
-		Defaults:      s.UntypedLoad(config.DefaultsConfigName).(*config.Defaults).DeepCopy(),
-		Deployment:    s.UntypedLoad(deployment.ConfigName).(*deployment.Config).DeepCopy(),
-		Logging:       s.UntypedLoad((logging.ConfigMapName())).(*logging.Config).DeepCopy(),
-		Network:       s.UntypedLoad(network.ConfigName).(*network.Config).DeepCopy(),
-		Observability: s.UntypedLoad(metrics.ConfigMapName()).(*metrics.ObservabilityConfig).DeepCopy(),
-		Tracing:       s.UntypedLoad(pkgtracing.ConfigName).(*pkgtracing.Config).DeepCopy(),
-		Autoscaler:    s.UntypedLoad(autoscalerconfig.ConfigName).(*autoscalerconfig.Config).DeepCopy(),
+	cfg := &Config{}
+
+	if def, ok := s.UntypedLoad(config.DefaultsConfigName).(*config.Defaults); ok {
+		cfg.Defaults = def.DeepCopy()
 	}
+	if dep, ok := s.UntypedLoad(deployment.ConfigName).(*deployment.Config); ok {
+		cfg.Deployment = dep.DeepCopy()
+	}
+	if log, ok := s.UntypedLoad((logging.ConfigMapName())).(*logging.Config); ok {
+		cfg.Logging = log.DeepCopy()
+	}
+	if net, ok := s.UntypedLoad(network.ConfigName).(*network.Config); ok {
+		cfg.Network = net.DeepCopy()
+	}
+	if obs, ok := s.UntypedLoad(metrics.ConfigMapName()).(*metrics.ObservabilityConfig); ok {
+		cfg.Observability = obs.DeepCopy()
+	}
+	if tr, ok := s.UntypedLoad(pkgtracing.ConfigName).(*pkgtracing.Config); ok {
+		cfg.Tracing = tr.DeepCopy()
+	}
+	if as, ok := s.UntypedLoad(autoscalerconfig.ConfigName).(*autoscalerconfig.Config); ok {
+		cfg.Autoscaler = as.DeepCopy()
+	}
+
+	return cfg
 }

--- a/pkg/reconciler/revision/queueing_test.go
+++ b/pkg/reconciler/revision/queueing_test.go
@@ -173,6 +173,18 @@ func newTestController(t *testing.T, opts ...reconcilerOption) (
 			}}, {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.Namespace(),
+				Name:      config.FeaturesConfigName,
+			},
+			Data: map[string]string{},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      config.FeaturesConfigName,
+			},
+			Data: map[string]string{},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
 				Name:      logging.ConfigMapName(),
 			},
 			Data: map[string]string{

--- a/pkg/reconciler/revision/queueing_test.go
+++ b/pkg/reconciler/revision/queueing_test.go
@@ -179,12 +179,6 @@ func newTestController(t *testing.T, opts ...reconcilerOption) (
 		}, {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.Namespace(),
-				Name:      config.FeaturesConfigName,
-			},
-			Data: map[string]string{},
-		}, {
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.Namespace(),
 				Name:      logging.ConfigMapName(),
 			},
 			Data: map[string]string{

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -624,7 +624,11 @@ func TestReconcile(t *testing.T) {
 
 		return revisionreconciler.NewReconciler(ctx, logging.FromContext(ctx), servingclient.Get(ctx),
 			listers.GetRevisionLister(), controller.GetEventRecorder(ctx), r,
-			controller.Options{ConfigStore: &testConfigStore{config: ReconcilerTestConfig()}})
+			controller.Options{
+				ConfigStore: &testConfigStore{
+					config: ReconcilerTestConfig(),
+				},
+			})
 	}))
 }
 


### PR DESCRIPTION
This is required for proper defaulting in the reconciler.
this was under the radar because all the defaulting was done in the WebHook, but in general when the call to PreReconcile is made and as such resource.SetDefaults is called — that has a different view of the world — how I discovered it.
While this probably never the issue for defaults, due to the WH, it might be a problem with other CMs in the API Store, e.g. features.