### PR TITLE
Add -parallel 1 option for Istio e2e

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -46,6 +46,11 @@ failed=0
 # Run tests serially in the mesh and https scenarios
 parallelism=""
 use_https=""
+
+if [[ -n "${ISTIO_VERSION}" ]]; then
+  parallelism="-parallel 1"
+fi
+
 if (( MESH )); then
   parallelism="-parallel 1"
   # This is a workaround until Istio fixes https://github.com/istio/istio/issues/23485.


### PR DESCRIPTION
https://github.com/knative/serving/commit/0a29c97556466ebf1a99566b66732796d0c3f7a4 updated Istio version, but it is not stable.
This patch adds `parallel 1` option. If it does not help, the commit should be reverted.

**Release Note**

```release-note
NONE
```

/cc
