### PR TITLE
Allow configuring activator max idle connections

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -79,7 +79,8 @@ var (
 
 	// This is here to allow configuring higher values of keep-alive for larger environments.
 	// TODO: run loadtests using this flag to determine optimal default values.
-	maxIdleProxyConns = flag.Int("maxidleconns", 1000, "The number of idle keep-alive connections maintained by the proxy transport.")
+	maxIdleProxyConns        = flag.Int("maxidleconns", 1000, "The number of idle keep-alive connections maintained by the proxy transport.")
+	maxIdleProxyConnsPerHost = flag.Int("maxidleconnsperhost", 100, "The number of idle keep-alive connections maintained per-host by the proxy transport.")
 )
 
 func statReporter(statSink *websocket.ManagedConnection, statChan <-chan []asmetrics.StatMessage,
@@ -199,7 +200,7 @@ func main() {
 	concurrencyReporter := activatorhandler.NewConcurrencyReporter(ctx, env.PodName, statCh)
 	go concurrencyReporter.Run(ctx.Done())
 
-	proxyTransport := pkgnet.NewAutoTransport(*maxIdleProxyConns, 100 /*maxidleperhost*/)
+	proxyTransport := pkgnet.NewAutoTransport(*maxIdleProxyConns, *maxIdleProxyConnsPerHost)
 
 	// Create activation handler chain
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -52,14 +52,11 @@ type activationHandler struct {
 }
 
 // New constructs a new http.Handler that deals with revision activation.
-func New(ctx context.Context, t Throttler) http.Handler {
-	// TODO: run loadtests to determine the optimal values here.
-	defaultTransport := pkgnet.NewAutoTransport(1000, /*maxidleconnes*/
-		100 /*maxidleperhos*/)
+func New(ctx context.Context, t Throttler, transport http.RoundTripper) http.Handler {
 	return &activationHandler{
-		transport: defaultTransport,
+		transport: transport,
 		tracingTransport: &ochttp.Transport{
-			Base:        defaultTransport,
+			Base:        transport,
 			Propagation: tracecontextb3.B3Egress,
 		},
 		throttler:  t,


### PR DESCRIPTION
Inject the transport into activatorHandler and allow configuring maxIdleConns using a flag. As a bonus, this means the tests for activatorHandler no longer need to do casts and set the private transport field \o/.

Using a flag rather than a configmap here because maxIdleConns can't be easily changed dynamically, so we really need the value on startup.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

/assign @markusthoemmes @vagababov 