### PR TITLE
Skip request logs e2e test if the configmap settings do not match

### DIFF
--- a/test/e2e/logging_test.go
+++ b/test/e2e/logging_test.go
@@ -92,15 +92,19 @@ func TestRequestLogs(t *testing.T) {
 	}
 
 	// Only check probe request logs if the feature is enabled in config-observability.
-	if cm.Data["logging.enable-probe-request-log"] == "true" {
-		// Health check requests are sent to / with a specific userAgent value periodically.
-		if err := waitForLog(t, clients, pod.Namespace, pod.Name, "queue-proxy", func(log logLine) bool {
-			return log.HTTPRequest.RequestURL == "/" &&
-				log.HTTPRequest.UserAgent == network.QueueProxyUserAgent
-		}); err != nil {
-			t.Fatalf("Got error waiting for health check log: %v", err)
-		}
+	if cm.Data["logging.enable-probe-request-log"] != "true" {
+		t.Log("Skipping verifing probe request logs because they are not enabled")
+		return
 	}
+
+	// Health check requests are sent to / with a specific userAgent value periodically.
+	if err := waitForLog(t, clients, pod.Namespace, pod.Name, "queue-proxy", func(log logLine) bool {
+		return log.HTTPRequest.RequestURL == "/" &&
+			log.HTTPRequest.UserAgent == network.QueueProxyUserAgent
+	}); err != nil {
+		t.Fatalf("Got error waiting for health check log: %v", err)
+	}
+
 }
 
 func theOnlyPod(clients *test.Clients, ns, rev string) (corev1.Pod, error) {

--- a/test/e2e/logging_test.go
+++ b/test/e2e/logging_test.go
@@ -104,7 +104,6 @@ func TestRequestLogs(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Got error waiting for health check log: %v", err)
 	}
-
 }
 
 func theOnlyPod(clients *test.Clients, ns, rev string) (corev1.Pod, error) {

--- a/test/e2e/logging_test.go
+++ b/test/e2e/logging_test.go
@@ -22,6 +22,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -52,7 +53,7 @@ func TestRequestLogs(t *testing.T) {
 	}
 
 	if got, want := cm.Data["logging.request-log-template"], template; got != want {
-		t.Skipf("Skipping verifing request logs because the template doesn't match: %s", cmp.Diff(want, got))
+		t.Skipf("Skipping verifing request logs because the template doesn't match:\n%s", cmp.Diff(want, got))
 	}
 
 	names := test.ResourceNames{
@@ -100,7 +101,7 @@ func TestRequestLogs(t *testing.T) {
 	}
 
 	// Only check probe request logs if the feature is enabled in config-observability.
-	if cm.Data["logging.enable-probe-request-log"] == "true" {
+	if strings.EqualFold(cm.Data["logging.enable-probe-request-log"], "true") {
 		// Health check requests are sent to / with a specific userAgent value periodically.
 		if err := waitForLog(t, clients, pod.Namespace, pod.Name, "queue-proxy", func(log logLine) bool {
 			return log.HTTPRequest.RequestURL == "/" &&

--- a/test/e2e/logging_test.go
+++ b/test/e2e/logging_test.go
@@ -52,7 +52,7 @@ func TestRequestLogs(t *testing.T) {
 	}
 
 	if got, want := cm.Data["logging.request-log-template"], template; got != want {
-		t.Skip("Skipping verifing request logs because the template doesn't match: %s", cmp.Diff(want, got))
+		t.Skipf("Skipping verifing request logs because the template doesn't match: %s", cmp.Diff(want, got))
 	}
 
 	names := test.ResourceNames{

--- a/test/e2e/logging_test.go
+++ b/test/e2e/logging_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -39,9 +40,20 @@ import (
 	v1test "knative.dev/serving/test/v1"
 )
 
+const template = `{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}`
+
 func TestRequestLogs(t *testing.T) {
 	t.Parallel()
 	clients := Setup(t)
+
+	cm, err := clients.KubeClient.GetConfigMap(system.Namespace()).Get("config-observability", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Fail to get ConfigMap config-observability: %v", err)
+	}
+
+	if got, want := cm.Data["logging.request-log-template"], template; got != want {
+		t.Skip("Skipping verifing request logs because the template doesn't match: %s", cmp.Diff(want, got))
+	}
 
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),
@@ -78,6 +90,7 @@ func TestRequestLogs(t *testing.T) {
 		t.Fatalf("Fail to fetch the pod: %v", err)
 	}
 
+	// TODO: add logging.enable-request-log check once it doesn't depends on the template.
 	// A request was sent to / in WaitForEndpointState.
 	if err := waitForLog(t, clients, pod.Namespace, pod.Name, "queue-proxy", func(log logLine) bool {
 		return log.HTTPRequest.RequestURL == "/" &&
@@ -86,23 +99,17 @@ func TestRequestLogs(t *testing.T) {
 		t.Fatalf("Got error waiting for normal request logs: %v", err)
 	}
 
-	cm, err := clients.KubeClient.GetConfigMap(system.Namespace()).Get("config-observability", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Fail to get ConfigMap config-observability: %v", err)
-	}
-
 	// Only check probe request logs if the feature is enabled in config-observability.
-	if cm.Data["logging.enable-probe-request-log"] != "true" {
+	if cm.Data["logging.enable-probe-request-log"] == "true" {
+		// Health check requests are sent to / with a specific userAgent value periodically.
+		if err := waitForLog(t, clients, pod.Namespace, pod.Name, "queue-proxy", func(log logLine) bool {
+			return log.HTTPRequest.RequestURL == "/" &&
+				log.HTTPRequest.UserAgent == network.QueueProxyUserAgent
+		}); err != nil {
+			t.Fatalf("Got error waiting for health check log: %v", err)
+		}
+	} else {
 		t.Log("Skipping verifing probe request logs because they are not enabled")
-		return
-	}
-
-	// Health check requests are sent to / with a specific userAgent value periodically.
-	if err := waitForLog(t, clients, pod.Namespace, pod.Name, "queue-proxy", func(log logLine) bool {
-		return log.HTTPRequest.RequestURL == "/" &&
-			log.HTTPRequest.UserAgent == network.QueueProxyUserAgent
-	}); err != nil {
-		t.Fatalf("Got error waiting for health check log: %v", err)
 	}
 }
 


### PR DESCRIPTION
The request logs e2e test requires the correct setting of config-observability config map, which is setting in https://github.com/knative/serving/blob/master/test/config/config-observability.yaml. For some downstream testing environments, the desired config map setting can't be applied. So skip the test if the requirement doesn't meet.
 
## Proposed Changes

* If the log template doesn't match, skip the whole test.
* If probe request log is not enabled, do not verify it.


