### PR TITLE
Move shared utilities to the version independent shared package

### DIFF
--- a/test/conformance/api/shared/doc.go
+++ b/test/conformance/api/shared/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Pakcage shared containes the functions and type that can be used across various versions of conformance tests, e.g. checkers, requests senders, etc.
+
+package shared

--- a/test/conformance/api/shared/doc.go
+++ b/test/conformance/api/shared/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Pakcage shared containes the functions and type that can be used across various versions of conformance tests, e.g. checkers, requests senders, etc.
+// Package shared contains functions and types that can be used across various versions of conformance tests, e.g. checkers, requests senders, etc.
 
 package shared

--- a/test/conformance/api/shared/util.go
+++ b/test/conformance/api/shared/util.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"golang.org/x/sync/errgroup"
+	appsv1 "k8s.io/api/apps/v1"
+
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/spoof"
+	"knative.dev/serving/test"
+)
+
+const scaleToZeroGracePeriod = 30 * time.Second
+
+// WaitForScaleToZero will wait for the specified deployment to scale to 0 replicas.
+// Will wait up to 6 times the scaleToZeroGracePeriod (30 seconds) before failing.
+func WaitForScaleToZero(t pkgTest.TLegacy, deploymentName string, clients *test.Clients) error {
+	t.Helper()
+	t.Logf("Waiting for %q to scale to zero", deploymentName)
+
+	return pkgTest.WaitForDeploymentState(
+		clients.KubeClient,
+		deploymentName,
+		func(d *appsv1.Deployment) (bool, error) {
+			return d.Status.ReadyReplicas == 0, nil
+		},
+		"DeploymentIsScaledDown",
+		test.ServingNamespace,
+		scaleToZeroGracePeriod*6,
+	)
+}
+
+// ValidateImageDigest validates the image digest.
+func ValidateImageDigest(imageName string, imageDigest string) (bool, error) {
+	ref, err := name.ParseReference(pkgTest.ImagePath(imageName))
+	if err != nil {
+		return false, err
+	}
+
+	digest, err := name.NewDigest(imageDigest)
+	if err != nil {
+		return false, err
+	}
+
+	return ref.Context().String() == digest.Context().String(), nil
+}
+
+// sendRequests sends "num" requests to "url", returning a string for each spoof.Response.Body.
+func sendRequests(client spoof.Interface, url *url.URL, num int) ([]string, error) {
+	responses := make([]string, num)
+
+	// Launch "num" requests, recording the responses we get in "responses".
+	g, _ := errgroup.WithContext(context.Background())
+	for i := 0; i < num; i++ {
+		// We don't index into "responses" inside the goroutine to avoid a race, see #1545.
+		result := &responses[i]
+		g.Go(func() error {
+			req, err := http.NewRequest(http.MethodGet, url.String(), nil)
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				return err
+			}
+
+			*result = string(resp.Body)
+			return nil
+		})
+	}
+	return responses, g.Wait()
+}
+
+func substrInList(key string, targets []string) string {
+	for _, t := range targets {
+		if strings.Contains(key, t) {
+			return t
+		}
+	}
+	return ""
+}
+
+// checkResponses verifies that each "expectedResponse" is present in "actualResponses" at least "min" times.
+func checkResponses(t pkgTest.TLegacy, num, min int, domain string, expectedResponses, actualResponses []string) error {
+	// counts maps the expected response body to the number of matching requests we saw.
+	counts := make(map[string]int, len(expectedResponses))
+	// badCounts maps the unexpected response body to the number of matching requests we saw.
+	badCounts := make(map[string]int)
+
+	// counts := eval(
+	//   SELECT body, count(*) AS total
+	//   FROM $actualResponses
+	//   WHERE body IN $expectedResponses
+	//   GROUP BY body
+	// )
+	for _, ar := range actualResponses {
+		if er := substrInList(ar, expectedResponses); er != "" {
+			counts[er]++
+		} else {
+			badCounts[ar]++
+		}
+	}
+
+	// Verify that the total expected responses match the number of requests made.
+	for badResponse, count := range badCounts {
+		t.Logf("Saw unexpected response %q %d times.", badResponse, count)
+	}
+
+	// Verify that we saw each entry in "expectedResponses" at least "min" times.
+	// check(SELECT body FROM $counts WHERE total < $min)
+	totalMatches := 0
+	errMsg := []string{}
+	for _, er := range expectedResponses {
+		count := counts[er]
+		if count < min {
+			errMsg = append(errMsg,
+				fmt.Sprintf("domain %s failed: want at least %d, got %d for response %q",
+					domain, min, count, er))
+		}
+
+		t.Logf("For domain %s: wanted at least %d, got %d requests.", domain, min, count)
+		totalMatches += count
+	}
+	if totalMatches < num {
+		errMsg = append(errMsg,
+			fmt.Sprintf("domain %s: saw expected responses %d times, wanted %d", domain, totalMatches, num))
+	}
+	if len(errMsg) == 0 {
+		// If we made it here, the implementation conforms. Congratulations!
+		return nil
+	}
+	return errors.New(strings.Join(errMsg, ","))
+}
+
+// CheckDistribution sends "num" requests to "domain", then validates that
+// we see each body in "expectedResponses" at least "min" times.
+func CheckDistribution(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, num, min int, expectedResponses []string) error {
+	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
+	if err != nil {
+		return err
+	}
+
+	t.Logf("Performing %d concurrent requests to %s", num, url)
+	actualResponses, err := sendRequests(client, url, num)
+	if err != nil {
+		return err
+	}
+
+	return checkResponses(t, num, min, url.Hostname(), expectedResponses, actualResponses)
+}

--- a/test/conformance/api/v1/blue_green_test.go
+++ b/test/conformance/api/v1/blue_green_test.go
@@ -33,6 +33,7 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
+	"knative.dev/serving/test/conformance/api/shared"
 	v1test "knative.dev/serving/test/v1"
 )
 
@@ -148,15 +149,15 @@ func TestBlueGreenRoute(t *testing.T) {
 	g, _ := errgroup.WithContext(context.Background())
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinSplitPercentage))
-		return checkDistribution(t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
+		return shared.CheckDistribution(t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return checkDistribution(t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
+		return shared.CheckDistribution(t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return checkDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
+		return shared.CheckDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
 	})
 	if err := g.Wait(); err != nil {
 		t.Fatal("Error sending requests:", err)

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -28,6 +28,7 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	resourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
 	"knative.dev/serving/test"
+	"knative.dev/serving/test/conformance/api/shared"
 	v1test "knative.dev/serving/test/v1"
 
 	. "knative.dev/serving/pkg/testing/v1"
@@ -116,7 +117,7 @@ func TestRevisionTimeout(t *testing.T) {
 
 			if tc.shouldScaleTo0 {
 				t.Log("Waiting to scale down to 0")
-				if err := WaitForScaleToZero(t, resourcenames.Deployment(resources.Revision), clients); err != nil {
+				if err := shared.WaitForScaleToZero(t, resourcenames.Deployment(resources.Revision), clients); err != nil {
 					t.Fatal("Could not scale to zero:", err)
 				}
 			} else {

--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -18,28 +18,20 @@ package v1
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"net/http"
 	"net/url"
-	"strings"
-	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
-
-	"github.com/google/go-containerregistry/pkg/name"
 	"golang.org/x/sync/errgroup"
 
 	pkgTest "knative.dev/pkg/test"
-	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/test"
+	"knative.dev/serving/test/conformance/api/shared"
 	v1test "knative.dev/serving/test/v1"
 )
-
-const scaleToZeroGracePeriod = 30 * time.Second
 
 func waitForExpectedResponse(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, expectedResponse string) error {
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
@@ -92,125 +84,19 @@ func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.U
 			minBasePercentage = test.MinDirectPercentage
 		}
 		min := int(math.Floor(test.ConcurrentRequests * minBasePercentage))
-		return checkDistribution(t, clients, baseDomain, test.ConcurrentRequests, min, baseExpected)
+		return shared.CheckDistribution(t, clients, baseDomain, test.ConcurrentRequests, min, baseExpected)
 	})
 	for i, subdomain := range subdomains {
 		i, subdomain := i, subdomain
 		g.Go(func() error {
 			min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-			return checkDistribution(t, clients, subdomain, test.ConcurrentRequests, min, []string{targetsExpected[i]})
+			return shared.CheckDistribution(t, clients, subdomain, test.ConcurrentRequests, min, []string{targetsExpected[i]})
 		})
 	}
 	if err := g.Wait(); err != nil {
 		return fmt.Errorf("error checking routing distribution: %w", err)
 	}
 	return nil
-}
-
-// checkDistribution sends "num" requests to "domain", then validates that
-// we see each body in "expectedResponses" at least "min" times.
-func checkDistribution(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, num, min int, expectedResponses []string) error {
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
-	if err != nil {
-		return err
-	}
-
-	t.Logf("Performing %d concurrent requests to %s", num, url)
-	actualResponses, err := sendRequests(client, url, num)
-	if err != nil {
-		return err
-	}
-
-	return checkResponses(t, num, min, url.Hostname(), expectedResponses, actualResponses)
-}
-
-func substrInList(key string, targets []string) string {
-	for _, t := range targets {
-		if strings.Contains(key, t) {
-			return t
-		}
-	}
-	return ""
-}
-
-// checkResponses verifies that each "expectedResponse" is present in "actualResponses" at least "min" times.
-func checkResponses(t pkgTest.TLegacy, num, min int, domain string, expectedResponses, actualResponses []string) error {
-	// counts maps the expected response body to the number of matching requests we saw.
-	counts := make(map[string]int, len(expectedResponses))
-	// badCounts maps the unexpected response body to the number of matching requests we saw.
-	badCounts := make(map[string]int)
-
-	// counts := eval(
-	//   SELECT body, count(*) AS total
-	//   FROM $actualResponses
-	//   WHERE body IN $expectedResponses
-	//   GROUP BY body
-	// )
-	for _, ar := range actualResponses {
-		if er := substrInList(ar, expectedResponses); er != "" {
-			counts[er]++
-		} else {
-			badCounts[ar]++
-		}
-	}
-
-	// Verify that the total expected responses match the number of requests made.
-	for badResponse, count := range badCounts {
-		t.Logf("Saw unexpected response %q %d times.", badResponse, count)
-	}
-
-	// Verify that we saw each entry in "expectedResponses" at least "min" times.
-	// check(SELECT body FROM $counts WHERE total < $min)
-	totalMatches := 0
-	errMsg := []string{}
-	for _, er := range expectedResponses {
-		count := counts[er]
-		if count < min {
-			errMsg = append(errMsg,
-				fmt.Sprintf("domain %s failed: want at least %d, got %d for response %q",
-					domain, min, count, er))
-		}
-
-		t.Logf("For domain %s: wanted at least %d, got %d requests for response %q",
-			domain, min, count, er)
-		totalMatches += count
-	}
-	if totalMatches < num {
-		errMsg = append(errMsg,
-			fmt.Sprintf("domain %s: saw expected responses %d times, wanted %d", domain, totalMatches, num))
-	}
-	if len(errMsg) == 0 {
-		// If we made it here, the implementation conforms. Congratulations!
-		return nil
-	}
-	return errors.New(strings.Join(errMsg, ","))
-}
-
-// sendRequests sends "num" requests to "url", returning a string for each spoof.Response.Body.
-func sendRequests(client spoof.Interface, url *url.URL, num int) ([]string, error) {
-	responses := make([]string, num)
-
-	// Launch "num" requests, recording the responses we get in "responses".
-	g, _ := errgroup.WithContext(context.Background())
-	for i := 0; i < num; i++ {
-		// We don't index into "responses" inside the goroutine to avoid a race, see #1545.
-		result := &responses[i]
-		g.Go(func() error {
-			req, err := http.NewRequest(http.MethodGet, url.String(), nil)
-			if err != nil {
-				return err
-			}
-
-			resp, err := client.Do(req)
-			if err != nil {
-				return err
-			}
-
-			*result = string(resp.Body)
-			return nil
-		})
-	}
-	return responses, g.Wait()
 }
 
 // Validates service health and vended content match for a runLatest Service.
@@ -245,7 +131,7 @@ func validateControlPlane(t pkgTest.T, clients *test.Clients, names test.Resourc
 		if r.Status.DeprecatedImageDigest == "" {
 			return false, fmt.Errorf("imageDigest not present for revision %s", names.Revision)
 		}
-		if validDigest, err := validateImageDigest(names.Image, r.Status.DeprecatedImageDigest); !validDigest {
+		if validDigest, err := shared.ValidateImageDigest(names.Image, r.Status.DeprecatedImageDigest); !validDigest {
 			return false, fmt.Errorf("imageDigest %s is not valid for imageName %s: %w", r.Status.DeprecatedImageDigest, names.Image, err)
 		}
 		return true, nil
@@ -345,36 +231,4 @@ func validateReleaseServiceShape(objs *v1test.ResourceObjects) error {
 		return fmt.Errorf("Status.Traffic[0].RevisionsName = %s, want: %s", got, want)
 	}
 	return nil
-}
-
-func validateImageDigest(imageName string, imageDigest string) (bool, error) {
-	ref, err := name.ParseReference(pkgTest.ImagePath(imageName))
-	if err != nil {
-		return false, err
-	}
-
-	digest, err := name.NewDigest(imageDigest)
-	if err != nil {
-		return false, err
-	}
-
-	return ref.Context().String() == digest.Context().String(), nil
-}
-
-// WaitForScaleToZero will wait for the specified deployment to scale to 0 replicas.
-// Will wait up to 6 times the scaleToZeroGracePeriod (30 seconds) before failing.
-func WaitForScaleToZero(t pkgTest.TLegacy, deploymentName string, clients *test.Clients) error {
-	t.Helper()
-	t.Logf("Waiting for %q to scale to zero", deploymentName)
-
-	return pkgTest.WaitForDeploymentState(
-		clients.KubeClient,
-		deploymentName,
-		func(d *appsv1.Deployment) (bool, error) {
-			return d.Status.ReadyReplicas == 0, nil
-		},
-		"DeploymentIsScaledDown",
-		test.ServingNamespace,
-		scaleToZeroGracePeriod*6,
-	)
 }

--- a/test/conformance/api/v1alpha1/blue_green_test.go
+++ b/test/conformance/api/v1alpha1/blue_green_test.go
@@ -33,6 +33,7 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/test"
+	"knative.dev/serving/test/conformance/api/shared"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
 
@@ -152,15 +153,15 @@ func TestBlueGreenRoute(t *testing.T) {
 	g, _ := errgroup.WithContext(context.Background())
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinSplitPercentage))
-		return checkDistribution(t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
+		return shared.CheckDistribution(t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return checkDistribution(t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
+		return shared.CheckDistribution(t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return checkDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
+		return shared.CheckDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
 	})
 	if err := g.Wait(); err != nil {
 		t.Fatal("Error sending requests:", err)

--- a/test/conformance/api/v1alpha1/revision_timeout_test.go
+++ b/test/conformance/api/v1alpha1/revision_timeout_test.go
@@ -28,6 +28,7 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	resourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
 	"knative.dev/serving/test"
+	"knative.dev/serving/test/conformance/api/shared"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 
 	. "knative.dev/serving/pkg/testing/v1alpha1"
@@ -115,7 +116,7 @@ func TestRevisionTimeout(t *testing.T) {
 
 			if tc.shouldScaleTo0 {
 				t.Log("Waiting to scale down to 0")
-				if err := waitForScaleToZero(t, resourcenames.Deployment(resources.Revision), clients); err != nil {
+				if err := shared.WaitForScaleToZero(t, resourcenames.Deployment(resources.Revision), clients); err != nil {
 					t.Fatal("Could not scale to zero:", err)
 				}
 			} else {

--- a/test/conformance/api/v1alpha1/util.go
+++ b/test/conformance/api/v1alpha1/util.go
@@ -18,28 +18,20 @@ package v1alpha1
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"net/http"
 	"net/url"
-	"strings"
-	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
-
-	"github.com/google/go-containerregistry/pkg/name"
 	"golang.org/x/sync/errgroup"
 
 	pkgTest "knative.dev/pkg/test"
-	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/test"
+	"knative.dev/serving/test/conformance/api/shared"
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
-
-const scaleToZeroGracePeriod = 30 * time.Second
 
 func waitForExpectedResponse(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, expectedResponse string) error {
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
@@ -92,124 +84,19 @@ func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.U
 			minBasePercentage = test.MinDirectPercentage
 		}
 		min := int(math.Floor(test.ConcurrentRequests * minBasePercentage))
-		return checkDistribution(t, clients, baseDomain, test.ConcurrentRequests, min, baseExpected)
+		return shared.CheckDistribution(t, clients, baseDomain, test.ConcurrentRequests, min, baseExpected)
 	})
 	for i, subdomain := range subdomains {
 		i, subdomain := i, subdomain
 		g.Go(func() error {
 			min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-			return checkDistribution(t, clients, subdomain, test.ConcurrentRequests, min, []string{targetsExpected[i]})
+			return shared.CheckDistribution(t, clients, subdomain, test.ConcurrentRequests, min, []string{targetsExpected[i]})
 		})
 	}
 	if err := g.Wait(); err != nil {
 		return fmt.Errorf("error checking routing distribution: %w", err)
 	}
 	return nil
-}
-
-// checkDistribution sends "num" requests to "domain", then validates that
-// we see each body in "expectedResponses" at least "min" times.
-func checkDistribution(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, num, min int, expectedResponses []string) error {
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
-	if err != nil {
-		return err
-	}
-
-	t.Logf("Performing %d concurrent requests to %s", num, url)
-	actualResponses, err := sendRequests(client, url, num)
-	if err != nil {
-		return err
-	}
-
-	return checkResponses(t, num, min, url.Hostname(), expectedResponses, actualResponses)
-}
-
-func substrInList(key string, targets []string) string {
-	for _, t := range targets {
-		if strings.Contains(key, t) {
-			return t
-		}
-	}
-	return ""
-}
-
-// checkResponses verifies that each "expectedResponse" is present in "actualResponses" at least "min" times.
-func checkResponses(t pkgTest.TLegacy, num, min int, domain string, expectedResponses, actualResponses []string) error {
-	// counts maps the expected response body to the number of matching requests we saw.
-	counts := make(map[string]int, len(expectedResponses))
-	// badCounts maps the unexpected response body to the number of matching requests we saw.
-	badCounts := make(map[string]int)
-
-	// counts := eval(
-	//   SELECT body, count(*) AS total
-	//   FROM $actualResponses
-	//   WHERE body IN $expectedResponses
-	//   GROUP BY body
-	// )
-	for _, ar := range actualResponses {
-		if er := substrInList(ar, expectedResponses); er != "" {
-			counts[er]++
-		} else {
-			badCounts[ar]++
-		}
-	}
-
-	// Verify that the total expected responses match the number of requests made.
-	for badResponse, count := range badCounts {
-		t.Logf("Saw unexpected response %q %d times.", badResponse, count)
-	}
-
-	// Verify that we saw each entry in "expectedResponses" at least "min" times.
-	// check(SELECT body FROM $counts WHERE total < $min)
-	totalMatches := 0
-	errMsg := []string{}
-	for _, er := range expectedResponses {
-		count := counts[er]
-		if count < min {
-			errMsg = append(errMsg,
-				fmt.Sprintf("domain %s failed: want at least %d, got %d for response %q",
-					domain, min, count, er))
-		}
-
-		t.Logf("For domain %s: wanted at least %d, got %d requests.", domain, min, count)
-		totalMatches += count
-	}
-	if totalMatches < num {
-		errMsg = append(errMsg,
-			fmt.Sprintf("domain %s: saw expected responses %d times, wanted %d", domain, totalMatches, num))
-	}
-	if len(errMsg) == 0 {
-		// If we made it here, the implementation conforms. Congratulations!
-		return nil
-	}
-	return errors.New(strings.Join(errMsg, ","))
-}
-
-// sendRequests sends "num" requests to "url", returning a string for each spoof.Response.Body.
-func sendRequests(client spoof.Interface, url *url.URL, num int) ([]string, error) {
-	responses := make([]string, num)
-
-	// Launch "num" requests, recording the responses we get in "responses".
-	g, _ := errgroup.WithContext(context.Background())
-	for i := 0; i < num; i++ {
-		// We don't index into "responses" inside the goroutine to avoid a race, see #1545.
-		result := &responses[i]
-		g.Go(func() error {
-			req, err := http.NewRequest(http.MethodGet, url.String(), nil)
-			if err != nil {
-				return err
-			}
-
-			resp, err := client.Do(req)
-			if err != nil {
-				return err
-			}
-
-			*result = string(resp.Body)
-			return nil
-		})
-	}
-	return responses, g.Wait()
 }
 
 // Validates service health and vended content match for a runLatest Service.
@@ -244,7 +131,7 @@ func validateRunLatestControlPlane(t pkgTest.T, clients *test.Clients, names tes
 		if r.Status.DeprecatedImageDigest == "" {
 			return false, fmt.Errorf("imageDigest not present for revision %s", names.Revision)
 		}
-		if validDigest, err := validateImageDigest(names.Image, r.Status.DeprecatedImageDigest); !validDigest {
+		if validDigest, err := shared.ValidateImageDigest(names.Image, r.Status.DeprecatedImageDigest); !validDigest {
 			return false, fmt.Errorf("imageDigest %s is not valid for imageName %s: %w", r.Status.DeprecatedImageDigest, names.Image, err)
 		}
 		return true, nil
@@ -344,36 +231,4 @@ func validateReleaseServiceShape(objs *v1a1test.ResourceObjects) error {
 		return fmt.Errorf("Status.Traffic[0].RevisionsName = %s, want: %s", got, want)
 	}
 	return nil
-}
-
-func validateImageDigest(imageName string, imageDigest string) (bool, error) {
-	ref, err := name.ParseReference(pkgTest.ImagePath(imageName))
-	if err != nil {
-		return false, err
-	}
-
-	digest, err := name.NewDigest(imageDigest)
-	if err != nil {
-		return false, err
-	}
-
-	return ref.Context().String() == digest.Context().String(), nil
-}
-
-// waitForScaleToZero will wait for the specified deployment to scale to 0 replicas.
-// Will wait up to 6 times the scaleToZeroGracePeriod (30 seconds) before failing.
-func waitForScaleToZero(t pkgTest.TLegacy, deploymentName string, clients *test.Clients) error {
-	t.Helper()
-	t.Logf("Waiting for %q to scale to zero", deploymentName)
-
-	return pkgTest.WaitForDeploymentState(
-		clients.KubeClient,
-		deploymentName,
-		func(d *appsv1.Deployment) (bool, error) {
-			return d.Status.ReadyReplicas == 0, nil
-		},
-		"DeploymentIsScaledDown",
-		test.ServingNamespace,
-		scaleToZeroGracePeriod*6,
-	)
 }

--- a/test/conformance/api/v1beta1/blue_green_test.go
+++ b/test/conformance/api/v1beta1/blue_green_test.go
@@ -33,6 +33,7 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	rtesting "knative.dev/serving/pkg/testing/v1beta1"
 	"knative.dev/serving/test"
+	"knative.dev/serving/test/conformance/api/shared"
 	v1b1test "knative.dev/serving/test/v1beta1"
 )
 
@@ -148,15 +149,15 @@ func TestBlueGreenRoute(t *testing.T) {
 	g, _ := errgroup.WithContext(context.Background())
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinSplitPercentage))
-		return checkDistribution(t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
+		return shared.CheckDistribution(t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return checkDistribution(t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
+		return shared.CheckDistribution(t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return checkDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
+		return shared.CheckDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
 	})
 	if err := g.Wait(); err != nil {
 		t.Fatal("Error sending requests:", err)

--- a/test/conformance/api/v1beta1/revision_timeout_test.go
+++ b/test/conformance/api/v1beta1/revision_timeout_test.go
@@ -28,6 +28,7 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	resourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
 	"knative.dev/serving/test"
+	"knative.dev/serving/test/conformance/api/shared"
 	v1b1test "knative.dev/serving/test/v1beta1"
 
 	. "knative.dev/serving/pkg/testing/v1beta1"
@@ -115,7 +116,7 @@ func TestRevisionTimeout(t *testing.T) {
 
 			if tc.shouldScaleTo0 {
 				t.Log("Waiting to scale down to 0")
-				if err := waitForScaleToZero(t, resourcenames.Deployment(resources.Revision), clients); err != nil {
+				if err := shared.WaitForScaleToZero(t, resourcenames.Deployment(resources.Revision), clients); err != nil {
 					t.Fatal("Could not scale to zero:", err)
 				}
 			} else {

--- a/test/conformance/api/v1beta1/util.go
+++ b/test/conformance/api/v1beta1/util.go
@@ -18,28 +18,20 @@ package v1beta1
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"net/http"
 	"net/url"
-	"strings"
-	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
-
-	"github.com/google/go-containerregistry/pkg/name"
 	"golang.org/x/sync/errgroup"
 
 	pkgTest "knative.dev/pkg/test"
-	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 	"knative.dev/serving/test"
+	"knative.dev/serving/test/conformance/api/shared"
 	v1b1test "knative.dev/serving/test/v1beta1"
 )
-
-const scaleToZeroGracePeriod = 30 * time.Second
 
 func waitForExpectedResponse(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, expectedResponse string) error {
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
@@ -92,124 +84,19 @@ func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.U
 			minBasePercentage = test.MinDirectPercentage
 		}
 		min := int(math.Floor(test.ConcurrentRequests * minBasePercentage))
-		return checkDistribution(t, clients, baseDomain, test.ConcurrentRequests, min, baseExpected)
+		return shared.CheckDistribution(t, clients, baseDomain, test.ConcurrentRequests, min, baseExpected)
 	})
 	for i, subdomain := range subdomains {
 		i, subdomain := i, subdomain
 		g.Go(func() error {
 			min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-			return checkDistribution(t, clients, subdomain, test.ConcurrentRequests, min, []string{targetsExpected[i]})
+			return shared.CheckDistribution(t, clients, subdomain, test.ConcurrentRequests, min, []string{targetsExpected[i]})
 		})
 	}
 	if err := g.Wait(); err != nil {
 		return fmt.Errorf("error checking routing distribution: %w", err)
 	}
 	return nil
-}
-
-// checkDistribution sends "num" requests to "domain", then validates that
-// we see each body in "expectedResponses" at least "min" times.
-func checkDistribution(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, num, min int, expectedResponses []string) error {
-	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
-	if err != nil {
-		return err
-	}
-
-	t.Logf("Performing %d concurrent requests to %s", num, url)
-	actualResponses, err := sendRequests(client, url, num)
-	if err != nil {
-		return err
-	}
-
-	return checkResponses(t, num, min, url.Hostname(), expectedResponses, actualResponses)
-}
-
-func substrInList(key string, targets []string) string {
-	for _, t := range targets {
-		if strings.Contains(key, t) {
-			return t
-		}
-	}
-	return ""
-}
-
-// checkResponses verifies that each "expectedResponse" is present in "actualResponses" at least "min" times.
-func checkResponses(t pkgTest.TLegacy, num, min int, domain string, expectedResponses, actualResponses []string) error {
-	// counts maps the expected response body to the number of matching requests we saw.
-	counts := make(map[string]int, len(expectedResponses))
-	// badCounts maps the unexpected response body to the number of matching requests we saw.
-	badCounts := make(map[string]int)
-
-	// counts := eval(
-	//   SELECT body, count(*) AS total
-	//   FROM $actualResponses
-	//   WHERE body IN $expectedResponses
-	//   GROUP BY body
-	// )
-	for _, ar := range actualResponses {
-		if er := substrInList(ar, expectedResponses); er != "" {
-			counts[er]++
-		} else {
-			badCounts[ar]++
-		}
-	}
-
-	// Verify that the total expected responses match the number of requests made.
-	for badResponse, count := range badCounts {
-		t.Logf("Saw unexpected response %q %d times.", badResponse, count)
-	}
-
-	// Verify that we saw each entry in "expectedResponses" at least "min" times.
-	// check(SELECT body FROM $counts WHERE total < $min)
-	totalMatches := 0
-	errMsg := []string{}
-	for _, er := range expectedResponses {
-		count := counts[er]
-		if count < min {
-			errMsg = append(errMsg,
-				fmt.Sprintf("domain %s failed: want at least %d, got %d for response %q",
-					domain, min, count, er))
-		}
-
-		t.Logf("For domain %s: wanted at least %d, got %d requests.", domain, min, count)
-		totalMatches += count
-	}
-	if totalMatches < num {
-		errMsg = append(errMsg,
-			fmt.Sprintf("domain %s: saw expected responses %d times, wanted %d", domain, totalMatches, num))
-	}
-	if len(errMsg) == 0 {
-		// If we made it here, the implementation conforms. Congratulations!
-		return nil
-	}
-	return errors.New(strings.Join(errMsg, ","))
-}
-
-// sendRequests sends "num" requests to "url", returning a string for each spoof.Response.Body.
-func sendRequests(client spoof.Interface, url *url.URL, num int) ([]string, error) {
-	responses := make([]string, num)
-
-	// Launch "num" requests, recording the responses we get in "responses".
-	g, _ := errgroup.WithContext(context.Background())
-	for i := 0; i < num; i++ {
-		// We don't index into "responses" inside the goroutine to avoid a race, see #1545.
-		result := &responses[i]
-		g.Go(func() error {
-			req, err := http.NewRequest(http.MethodGet, url.String(), nil)
-			if err != nil {
-				return err
-			}
-
-			resp, err := client.Do(req)
-			if err != nil {
-				return err
-			}
-
-			*result = string(resp.Body)
-			return nil
-		})
-	}
-	return responses, g.Wait()
 }
 
 // Validates service health and vended content match for a runLatest Service.
@@ -244,7 +131,7 @@ func validateControlPlane(t pkgTest.T, clients *test.Clients, names test.Resourc
 		if r.Status.DeprecatedImageDigest == "" {
 			return false, fmt.Errorf("imageDigest not present for revision %s", names.Revision)
 		}
-		if validDigest, err := validateImageDigest(names.Image, r.Status.DeprecatedImageDigest); !validDigest {
+		if validDigest, err := shared.ValidateImageDigest(names.Image, r.Status.DeprecatedImageDigest); !validDigest {
 			return false, fmt.Errorf("imageDigest %s is not valid for imageName %s: %w", r.Status.DeprecatedImageDigest, names.Image, err)
 		}
 		return true, nil
@@ -344,36 +231,4 @@ func validateReleaseServiceShape(objs *v1b1test.ResourceObjects) error {
 		return fmt.Errorf("Status.Traffic[0].RevisionsName = %s, want: %s", got, want)
 	}
 	return nil
-}
-
-func validateImageDigest(imageName string, imageDigest string) (bool, error) {
-	ref, err := name.ParseReference(pkgTest.ImagePath(imageName))
-	if err != nil {
-		return false, err
-	}
-
-	digest, err := name.NewDigest(imageDigest)
-	if err != nil {
-		return false, err
-	}
-
-	return ref.Context().String() == digest.Context().String(), nil
-}
-
-// waitForScaleToZero will wait for the specified deployment to scale to 0 replicas.
-// Will wait up to 6 times the scaleToZeroGracePeriod (30 seconds) before failing.
-func waitForScaleToZero(t pkgTest.TLegacy, deploymentName string, clients *test.Clients) error {
-	t.Helper()
-	t.Logf("Waiting for %q to scale to zero", deploymentName)
-
-	return pkgTest.WaitForDeploymentState(
-		clients.KubeClient,
-		deploymentName,
-		func(d *appsv1.Deployment) (bool, error) {
-			return d.Status.ReadyReplicas == 0, nil
-		},
-		"DeploymentIsScaledDown",
-		test.ServingNamespace,
-		scaleToZeroGracePeriod*6,
-	)
 }

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -25,7 +25,7 @@ import (
 	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
 	v1opts "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
-	v1conf "knative.dev/serving/test/conformance/api/v1"
+	"knative.dev/serving/test/conformance/api/shared"
 	v1test "knative.dev/serving/test/v1"
 )
 
@@ -82,7 +82,7 @@ func TestProbeRuntime(t *testing.T) {
 				t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 			}
 			// Check if scaling down works even if access from liveness probe exists.
-			if err := v1conf.WaitForScaleToZero(t, revisionresourcenames.Deployment(resources.Revision), clients); err != nil {
+			if err := shared.WaitForScaleToZero(t, revisionresourcenames.Deployment(resources.Revision), clients); err != nil {
 				t.Fatal("Could not scale to zero:", err)
 			}
 		})


### PR DESCRIPTION
Our versioned tests have a lot of versionless utilities, which can be moved in one shared place
and save us some maintenance burden, some investigation burden, etc.

/assign mattmoor @dprotaso 