### PR TITLE
[WIP - debug only] dump istio ingress-gateway profile during test

### DIFF
--- a/test/dumper.sh
+++ b/test/dumper.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mkdir -p ${ARTIFACTS}/dump
+
+while true; do
+  kubectl exec $(kubectl -n istio-system get pods -lapp=istio-ingressgateway -oname) -n istio-system -- curl -s localhost:15000/config_dump > ${ARTIFACTS}/dump/config-$(date  "+%FT%T.%N")
+  kubectl exec $(kubectl -n istio-system get pods -lapp=istio-ingressgateway -oname) -n istio-system -- curl -s localhost:15000/clusters > ${ARTIFACTS}/dump/clusters-$(date  "+%FT%T.%N")
+  echo "dump done"
+done

--- a/test/dumper.sh
+++ b/test/dumper.sh
@@ -16,7 +16,11 @@
 mkdir -p ${ARTIFACTS}/dump
 
 while true; do
-  kubectl exec $(kubectl -n istio-system get pods -lapp=istio-ingressgateway -oname) -n istio-system -- curl -s localhost:15000/config_dump > ${ARTIFACTS}/dump/config-$(date  "+%FT%T.%N")
-  kubectl exec $(kubectl -n istio-system get pods -lapp=istio-ingressgateway -oname) -n istio-system -- curl -s localhost:15000/clusters > ${ARTIFACTS}/dump/clusters-$(date  "+%FT%T.%N")
-  echo "dump done"
+  date  "+%FT%T.%N" >> ${ARTIFACTS}/dump/config
+  kubectl exec $(kubectl -n istio-system get pods -lapp=istio-ingressgateway -oname) -n istio-system -- curl -s localhost:15000/config_dump >> ${ARTIFACTS}/dump/config
+  #kubectl exec $(kubectl -n istio-system get pods -lapp=istio-ingressgateway -oname) -n istio-system -- curl -s localhost:15000/config_dump > ${ARTIFACTS}/dump/config-$(date  "+%FT%T.%N")
+  date  "+%FT%T.%N" >> ${ARTIFACTS}/dump/clusters
+  kubectl exec $(kubectl -n istio-system get pods -lapp=istio-ingressgateway -oname) -n istio-system -- curl -s localhost:15000/clusters >> ${ARTIFACTS}/dump/clusters
+  #kubectl exec $(kubectl -n istio-system get pods -lapp=istio-ingressgateway -oname) -n istio-system -- curl -s localhost:15000/clusters > ${ARTIFACTS}/dump/clusters-$(date  "+%FT%T.%N")
+#  echo "dump done"
 done

--- a/test/dumper.sh
+++ b/test/dumper.sh
@@ -18,9 +18,6 @@ mkdir -p ${ARTIFACTS}/dump
 while true; do
   date  "+%FT%T.%N" >> ${ARTIFACTS}/dump/config
   kubectl exec $(kubectl -n istio-system get pods -lapp=istio-ingressgateway -oname) -n istio-system -- curl -s localhost:15000/config_dump >> ${ARTIFACTS}/dump/config
-  #kubectl exec $(kubectl -n istio-system get pods -lapp=istio-ingressgateway -oname) -n istio-system -- curl -s localhost:15000/config_dump > ${ARTIFACTS}/dump/config-$(date  "+%FT%T.%N")
   date  "+%FT%T.%N" >> ${ARTIFACTS}/dump/clusters
   kubectl exec $(kubectl -n istio-system get pods -lapp=istio-ingressgateway -oname) -n istio-system -- curl -s localhost:15000/clusters >> ${ARTIFACTS}/dump/clusters
-  #kubectl exec $(kubectl -n istio-system get pods -lapp=istio-ingressgateway -oname) -n istio-system -- curl -s localhost:15000/clusters > ${ARTIFACTS}/dump/clusters-$(date  "+%FT%T.%N")
-#  echo "dump done"
 done

--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -19,29 +19,32 @@ function install_istio() {
     readonly ISTIO_VERSION="stable"
   fi
 
-  # TODO: Figure out the commit of net-istio.yaml from net-istio.yaml
-  local NET_ISTIO_COMMIT=f64ed34d3776a444372483dddc15a330c6c1ac53
+#  # TODO: Figure out the commit of net-istio.yaml from net-istio.yaml
+#  local NET_ISTIO_COMMIT=f64ed34d3776a444372483dddc15a330c6c1ac53
+#
+#  # And checkout the setup script based on that commit.
+#  local NET_ISTIO_DIR=$(mktemp -d)
+#  (
+#    cd $NET_ISTIO_DIR \
+#      && git init \
+#      && git remote add origin https://github.com/knative-sandbox/net-istio.git \
+#      && git fetch --depth 1 origin $NET_ISTIO_COMMIT \
+#      && git checkout FETCH_HEAD
+#  )
+#
+#  if (( MESH )); then
+#    ISTIO_PROFILE="istio-ci-mesh.yaml"
+#  else
+#    ISTIO_PROFILE="istio-ci-no-mesh.yaml"
+#  fi
 
-  # And checkout the setup script based on that commit.
-  local NET_ISTIO_DIR=$(mktemp -d)
-  (
-    cd $NET_ISTIO_DIR \
-      && git init \
-      && git remote add origin https://github.com/knative-sandbox/net-istio.git \
-      && git fetch --depth 1 origin $NET_ISTIO_COMMIT \
-      && git checkout FETCH_HEAD
-  )
+#  echo ">> Installing Istio"
+#  echo "Istio version: ${ISTIO_VERSION}"
+#  echo "Istio profile: ${ISTIO_PROFILE}"
+#  ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/install-istio.sh ${ISTIO_PROFILE}
 
-  if (( MESH )); then
-    ISTIO_PROFILE="istio-ci-mesh.yaml"
-  else
-    ISTIO_PROFILE="istio-ci-no-mesh.yaml"
-  fi
-
-  echo ">> Installing Istio"
-  echo "Istio version: ${ISTIO_VERSION}"
-  echo "Istio profile: ${ISTIO_PROFILE}"
-  ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/install-istio.sh ${ISTIO_PROFILE}
+  ISTIO_PROFILE="istio-ci-no-mesh.yaml"
+  ./third_party/istio-stable/install-istio.sh ${ISTIO_PROFILE}
 
   if [[ -n "$1" ]]; then
     echo ">> Installing net-istio"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -91,8 +91,10 @@ sleep 30
 
 # Run conformance and e2e tests.
 
+./test/dumper.sh &
+
 go_test_e2e -timeout=30m \
- ./test/conformance/api/... \
+ ./test/conformance/api/... ./test/conformance/runtime/... \
   ${parallelism} \
   "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -93,6 +93,8 @@ sleep 30
 
 #./test/dumper.sh &
 
+kubectl -n ${SYSTEM_NAMESPACE} patch configmap/config-autoscaler --type=merge --patch='{"data":{"enable-scale-to-zero":"false"}}' || fail_test
+
 go_test_e2e -timeout=30m \
  ./test/conformance/api/... ./test/conformance/runtime/... \
  ./test/e2e \

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -91,10 +91,11 @@ sleep 30
 
 # Run conformance and e2e tests.
 
-./test/dumper.sh &
+#./test/dumper.sh &
 
 go_test_e2e -timeout=30m \
  ./test/conformance/api/... ./test/conformance/runtime/... \
+ ./test/e2e \
   ${parallelism} \
   "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -92,10 +92,16 @@ sleep 30
 # Run conformance and e2e tests.
 
 go_test_e2e -timeout=30m \
- ./test/conformance/api/... ./test/conformance/runtime/... \
- ./test/e2e \
+ ./test/conformance/api/... \
   ${parallelism} \
   "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
+
+# We just want to collect log from TestService's error.
+
+# Dump cluster state in case of failure
+(( failed )) && dump_cluster_state
+(( failed )) && fail_test
+success
 
 if (( HTTPS )); then
   kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -32,6 +32,4 @@ source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/presubmit-tests.sh
 
 # We use the default build, unit and integration test runners.
 
-test/dumper.sh &
-
 main "$@"

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -32,4 +32,6 @@ source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/presubmit-tests.sh
 
 # We use the default build, unit and integration test runners.
 
+test/dumper.sh &
+
 main "$@"

--- a/third_party/istio-stable/install-istio.sh
+++ b/third_party/istio-stable/install-istio.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Download and unpack Istio
+ISTIO_VERSION=1.6.8
+ISTIO_TARBALL=istio-${ISTIO_VERSION}-linux-amd64.tar.gz
+DOWNLOAD_URL=https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/${ISTIO_TARBALL}
+
+wget --no-check-certificate $DOWNLOAD_URL
+if [ $? != 0 ]; then
+  echo "Failed to download Istio package"
+  exit 1
+fi
+tar xzf ${ISTIO_TARBALL}
+
+# Install Istio
+./istio-${ISTIO_VERSION}/bin/istioctl install -f "$(dirname $0)/$1"
+
+# Clean up
+rm -rf istio-${ISTIO_VERSION}
+rm ${ISTIO_TARBALL}
+
+## Add in the `istio-system` namespace to reduce number of commands.
+#patch istio-crds.yaml namespace.yaml.patch
+#patch istio-ci-mesh.yaml namespace.yaml.patch
+#patch istio-ci-no-mesh.yaml namespace.yaml.patch
+#patch istio-minimal.yaml namespace.yaml.patch
+#
+## Increase termination drain duration seconds.
+#patch -l istio-ci-mesh.yaml drain-seconds.yaml.patch
+

--- a/third_party/istio-stable/istio-ci-no-mesh.yaml
+++ b/third_party/istio-stable/istio-ci-no-mesh.yaml
@@ -1,0 +1,75 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    global:
+      proxy:
+        autoInject: disabled
+      useMCP: false
+      # The third-party-jwt is not enabled on all k8s.
+      # See: https://istio.io/docs/ops/best-practices/security/#configure-third-party-service-account-tokens
+      jwtPolicy: first-party-jwt
+    pilot:
+      autoscaleMin: 3
+      autoscaleMax: 10
+      cpu:
+        targetAverageUtilization: 60
+    gateways:
+      istio-ingressgateway:
+        autoscaleMin: 1
+        autoscaleMax: 1
+
+  addonComponents:
+    pilot:
+      enabled: true
+    prometheus:
+      enabled: false
+
+  components:
+    ingressGateways:
+      - name: istio-ingressgateway
+        enabled: true
+        k8s:
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2048Mi
+            requests:
+              cpu: 1000m
+              memory: 1024Mi
+      - name: cluster-local-gateway
+        enabled: true
+        label:
+          istio: cluster-local-gateway
+          app: cluster-local-gateway
+        k8s:
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2048Mi
+            requests:
+              cpu: 1000m
+              memory: 1024Mi
+          service:
+            type: ClusterIP
+            ports:
+            - port: 15020
+              name: status-port
+            - port: 80
+              name: http2
+            - port: 443
+              name: https

--- a/third_party/istio-stable/istio-ci-no-mesh.yaml
+++ b/third_party/istio-stable/istio-ci-no-mesh.yaml
@@ -30,8 +30,8 @@ spec:
         targetAverageUtilization: 60
     gateways:
       istio-ingressgateway:
-        autoscaleMin: 1
-        autoscaleMax: 1
+        autoscaleMin: 15
+        autoscaleMax: 15
 
   addonComponents:
     pilot:
@@ -46,8 +46,8 @@ spec:
         k8s:
           resources:
             limits:
-              cpu: 10000m
-              memory: 20480Mi
+              cpu: 3000m
+              memory: 2048Mi
             requests:
               cpu: 1000m
               memory: 1024Mi

--- a/third_party/istio-stable/istio-ci-no-mesh.yaml
+++ b/third_party/istio-stable/istio-ci-no-mesh.yaml
@@ -46,8 +46,8 @@ spec:
         k8s:
           resources:
             limits:
-              cpu: 3000m
-              memory: 2048Mi
+              cpu: 10000m
+              memory: 20480Mi
             requests:
               cpu: 1000m
               memory: 1024Mi


### PR DESCRIPTION
This patch adds dump script.

The current issue summary:

- Istio 1.5 or later gets 503 error from ingress gateway's envoy pod during e2e test.
- It does not happen when `-parallel 1` option. 
- It also does not happen when installing Istio 1.5 by helm instead of istioctl. But helm installation is obsolete by Istio upstream.
- The issue happens after passing through `test/conformance/api/{v1,v1beta1,v1alpha1}/TestService*`. It seems break something  networking routing during the tests.

/cc
