### PR TITLE
Pin `net-istio` commit to be used in E2E scripts

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -191,7 +191,8 @@ function install_istio() {
   fi
 
   local NET_ISTIO_DIR=$(mktemp -d)
-  git clone --quiet --depth 1 --branch master https://github.com/knative-sandbox/net-istio.git ${NET_ISTIO_DIR}
+  git clone --quiet --branch master https://github.com/knative-sandbox/net-istio.git ${NET_ISTIO_DIR}
+  git --git-dir "${NET_ISTIO_DIR}/.git" checkout 7398a24a5fa9b06154ce5ef6b551fce856591b08
 
   if (( MESH )); then
     ISTIO_PROFILE="istio-ci-mesh.yaml"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Pin the `net-istio` version used in the tests scripts to a specific commit https://github.com/knative-sandbox/net-istio/commit/7398a24a5fa9b06154ce5ef6b551fce856591b08. 

/assign @mattmoor @tcnghia 
