### PR TITLE
Support more security context properties behind a feature flag

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "4891c4ff"
+    knative.dev/example-checksum: "dd011edb"
 data:
   _example: |
     ################################

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "66de029c"
+    knative.dev/example-checksum: "4891c4ff"
 data:
   _example: |
     ################################
@@ -61,6 +61,29 @@ data:
     #   However, clients may enable the behavior on an individual Service by
     #   attaching the following metadata annotation: "features.knative.dev/podspec-dryrun":"enabled".
     kubernetes.podspec-dryrun: "allowed"
+
+    # This feature allows end-users to set a subset of fields on the Pod's SecurityContext
+    # in addition to expanding the allowable fields within a Container's SecurityContext.
+    #
+    # When set to "enabled" or "allowed" it allows the following
+    # PodSecurityContext properties:
+    # - FSGroup
+    # - RunAsGroup
+    # - RunAsNonRoot
+    # - SupplementalGroups
+    # - RunAsUser
+    #
+    # When set to "enabled" or "allowed" it allows the following
+    # Container SecurityContext properties:
+    # - RunAsNonRoot
+    # - RunAsGroup
+    # - RunAsUser (already allowed without this flag)
+    #
+    # This feature flag should be used with caution as the PodSecurityContext
+    # properties may have a side-effect on non-user sidecar containers that come
+    # from Knative or your service mesh
+    #
+    kubernetes.podspec-securitycontext: "disabled"
 
     # Indicates whether new responsive garbage collection is enabled. This
     # feature labels revisions in real-time as they become referenced and

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -40,13 +40,14 @@ const (
 
 func defaultFeaturesConfig() *Features {
 	return &Features{
-		MultiContainer:       Enabled,
-		PodSpecAffinity:      Disabled,
-		PodSpecFieldRef:      Disabled,
-		PodSpecDryRun:        Allowed,
-		PodSpecNodeSelector:  Disabled,
-		PodSpecTolerations:   Disabled,
-		ResponsiveRevisionGC: Disabled,
+		MultiContainer:         Enabled,
+		PodSpecAffinity:        Disabled,
+		PodSpecFieldRef:        Disabled,
+		PodSpecDryRun:          Allowed,
+		PodSpecNodeSelector:    Disabled,
+		PodSpecSecurityContext: Disabled,
+		PodSpecTolerations:     Disabled,
+		ResponsiveRevisionGC:   Disabled,
 	}
 }
 
@@ -60,6 +61,7 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 		asFlag("kubernetes.podspec-fieldref", &nc.PodSpecFieldRef),
 		asFlag("kubernetes.podspec-dryrun", &nc.PodSpecDryRun),
 		asFlag("kubernetes.podspec-nodeselector", &nc.PodSpecNodeSelector),
+		asFlag("kubernetes.podspec-securitycontext", &nc.PodSpecSecurityContext),
 		asFlag("kubernetes.podspec-tolerations", &nc.PodSpecTolerations),
 		asFlag("responsive-revision-gc", &nc.ResponsiveRevisionGC)); err != nil {
 		return nil, err
@@ -74,13 +76,14 @@ func NewFeaturesConfigFromConfigMap(config *corev1.ConfigMap) (*Features, error)
 
 // Features specifies which features are allowed by the webhook.
 type Features struct {
-	MultiContainer       Flag
-	PodSpecAffinity      Flag
-	PodSpecFieldRef      Flag
-	PodSpecDryRun        Flag
-	PodSpecNodeSelector  Flag
-	PodSpecTolerations   Flag
-	ResponsiveRevisionGC Flag
+	MultiContainer         Flag
+	PodSpecAffinity        Flag
+	PodSpecFieldRef        Flag
+	PodSpecDryRun          Flag
+	PodSpecNodeSelector    Flag
+	PodSpecTolerations     Flag
+	PodSpecSecurityContext Flag
+	ResponsiveRevisionGC   Flag
 }
 
 // asFlag parses the value at key as a Flag into the target, if it exists.

--- a/pkg/apis/config/features_test.go
+++ b/pkg/apis/config/features_test.go
@@ -59,20 +59,22 @@ func TestFeaturesConfiguration(t *testing.T) {
 		name:    "features Enabled",
 		wantErr: false,
 		wantFeatures: defaultWith(&Features{
-			MultiContainer:       Enabled,
-			PodSpecAffinity:      Enabled,
-			PodSpecDryRun:        Enabled,
-			PodSpecNodeSelector:  Enabled,
-			PodSpecTolerations:   Enabled,
-			ResponsiveRevisionGC: Enabled,
+			MultiContainer:         Enabled,
+			PodSpecAffinity:        Enabled,
+			PodSpecDryRun:          Enabled,
+			PodSpecNodeSelector:    Enabled,
+			PodSpecSecurityContext: Enabled,
+			PodSpecTolerations:     Enabled,
+			ResponsiveRevisionGC:   Enabled,
 		}),
 		data: map[string]string{
-			"multi-container":                 "Enabled",
-			"kubernetes.podspec-affinity":     "Enabled",
-			"kubernetes.podspec-dryrun":       "Enabled",
-			"kubernetes.podspec-nodeselector": "Enabled",
-			"kubernetes.podspec-tolerations":  "Enabled",
-			"responsive-revision-gc":          "Enabled",
+			"multi-container":                    "Enabled",
+			"kubernetes.podspec-affinity":        "Enabled",
+			"kubernetes.podspec-dryrun":          "Enabled",
+			"kubernetes.podspec-nodeselector":    "Enabled",
+			"kubernetes.podspec-securitycontext": "Enabled",
+			"kubernetes.podspec-tolerations":     "Enabled",
+			"responsive-revision-gc":             "Enabled",
 		},
 	}, {
 		name:    "multi-container Allowed",
@@ -226,6 +228,24 @@ func TestFeaturesConfiguration(t *testing.T) {
 		}),
 		data: map[string]string{
 			"responsive-revision-gc": "Enabled",
+		},
+	}, {
+		name:    "security context Allowed",
+		wantErr: false,
+		wantFeatures: defaultWith(&Features{
+			PodSpecSecurityContext: Allowed,
+		}),
+		data: map[string]string{
+			"kubernetes.podspec-securitycontext": "Allowed",
+		},
+	}, {
+		name:    "security context disabled",
+		wantErr: false,
+		wantFeatures: defaultWith(&Features{
+			PodSpecSecurityContext: Disabled,
+		}),
+		data: map[string]string{
+			"kubernetes.podspec-securitycontext": "Disabled",
 		},
 	}}
 

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -164,6 +164,9 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	if cfg.Features.PodSpecTolerations != config.Disabled {
 		out.Tolerations = in.Tolerations
 	}
+	if cfg.Features.PodSpecSecurityContext != config.Disabled {
+		out.SecurityContext = in.SecurityContext
+	}
 
 	// Disallowed fields
 	// This list is unnecessary, but added here for clarity
@@ -178,7 +181,6 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.HostPID = false
 	out.HostIPC = false
 	out.ShareProcessNamespace = nil
-	out.SecurityContext = nil
 	out.Hostname = ""
 	out.Subdomain = ""
 	out.SchedulerName = ""
@@ -528,10 +530,39 @@ func ResourceRequirementsMask(in *corev1.ResourceRequirements) *corev1.ResourceR
 
 }
 
+// PodSecurityContext performs a _shallow_ copy of the Kubernetes PodSecurityContext object into a new
+// Kubernetes PodSecurityContext object bringing over only the fields allowed in the Knative API. This
+// does not validate the contents or bounds of the provided fields.
+func PodSecurityContextMask(ctx context.Context, in *corev1.PodSecurityContext) *corev1.PodSecurityContext {
+	if in == nil {
+		return nil
+	}
+
+	out := new(corev1.PodSecurityContext)
+
+	if config.FromContextOrDefaults(ctx).Features.PodSpecSecurityContext == config.Disabled {
+		return out
+	}
+
+	out.RunAsUser = in.RunAsUser
+	out.RunAsGroup = in.RunAsGroup
+	out.RunAsNonRoot = in.RunAsNonRoot
+	out.FSGroup = in.FSGroup
+
+	// Disallowed
+	// This list is unnecessary, but added here for clarity
+	out.SELinuxOptions = nil
+	out.WindowsOptions = nil
+	out.SupplementalGroups = nil
+	out.Sysctls = nil
+
+	return out
+}
+
 // SecurityContextMask performs a _shallow_ copy of the Kubernetes SecurityContext object to a new
 // Kubernetes SecurityContext object bringing over only the fields allowed in the Knative API. This
 // does not validate the contents or the bounds of the provided fields.
-func SecurityContextMask(in *corev1.SecurityContext) *corev1.SecurityContext {
+func SecurityContextMask(ctx context.Context, in *corev1.SecurityContext) *corev1.SecurityContext {
 	if in == nil {
 		return nil
 	}
@@ -541,13 +572,15 @@ func SecurityContextMask(in *corev1.SecurityContext) *corev1.SecurityContext {
 	// Allowed fields
 	out.RunAsUser = in.RunAsUser
 
+	if config.FromContextOrDefaults(ctx).Features.PodSpecSecurityContext != config.Disabled {
+		out.RunAsGroup = in.RunAsGroup
+		out.RunAsNonRoot = in.RunAsNonRoot
+	}
 	// Disallowed
 	// This list is unnecessary, but added here for clarity
 	out.Capabilities = nil
 	out.Privileged = nil
 	out.SELinuxOptions = nil
-	out.RunAsGroup = nil
-	out.RunAsNonRoot = nil
 	out.ReadOnlyRootFilesystem = nil
 	out.AllowPrivilegeEscalation = nil
 	out.ProcMount = nil

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -530,7 +530,7 @@ func ResourceRequirementsMask(in *corev1.ResourceRequirements) *corev1.ResourceR
 
 }
 
-// PodSecurityContext performs a _shallow_ copy of the Kubernetes PodSecurityContext object into a new
+// PodSecurityContextMask performs a _shallow_ copy of the Kubernetes PodSecurityContext object into a new
 // Kubernetes PodSecurityContext object bringing over only the fields allowed in the Knative API. This
 // does not validate the contents or bounds of the provided fields.
 func PodSecurityContextMask(ctx context.Context, in *corev1.PodSecurityContext) *corev1.PodSecurityContext {

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -548,12 +548,12 @@ func PodSecurityContextMask(ctx context.Context, in *corev1.PodSecurityContext) 
 	out.RunAsGroup = in.RunAsGroup
 	out.RunAsNonRoot = in.RunAsNonRoot
 	out.FSGroup = in.FSGroup
+	out.SupplementalGroups = in.SupplementalGroups
 
 	// Disallowed
 	// This list is unnecessary, but added here for clarity
 	out.SELinuxOptions = nil
 	out.WindowsOptions = nil
-	out.SupplementalGroups = nil
 	out.Sysctls = nil
 
 	return out

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -680,7 +680,7 @@ func TestPodSecurityContextMask_FeatureEnabled(t *testing.T) {
 	in := &corev1.PodSecurityContext{
 		SELinuxOptions:     &corev1.SELinuxOptions{},
 		WindowsOptions:     &corev1.WindowsSecurityContextOptions{},
-		SupplementalGroups: []int64{},
+		SupplementalGroups: []int64{1},
 		Sysctls:            []corev1.Sysctl{},
 		RunAsUser:          ptr.Int64(1),
 		RunAsGroup:         ptr.Int64(1),
@@ -689,10 +689,11 @@ func TestPodSecurityContextMask_FeatureEnabled(t *testing.T) {
 	}
 
 	want := &corev1.PodSecurityContext{
-		RunAsUser:    ptr.Int64(1),
-		RunAsGroup:   ptr.Int64(1),
-		RunAsNonRoot: ptr.Bool(true),
-		FSGroup:      ptr.Int64(1),
+		RunAsUser:          ptr.Int64(1),
+		RunAsGroup:         ptr.Int64(1),
+		RunAsNonRoot:       ptr.Bool(true),
+		FSGroup:            ptr.Int64(1),
+		SupplementalGroups: []int64{1},
 	}
 
 	ctx := config.ToContext(context.Background(),

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/config"
 )
 
 func TestVolumeMask(t *testing.T) {
@@ -643,6 +644,78 @@ func TestResourceRequirementsMask(t *testing.T) {
 	}
 }
 
+func TestPodSecurityContextMask(t *testing.T) {
+	in := &corev1.PodSecurityContext{
+		SELinuxOptions:     &corev1.SELinuxOptions{},
+		WindowsOptions:     &corev1.WindowsSecurityContextOptions{},
+		SupplementalGroups: []int64{},
+		Sysctls:            []corev1.Sysctl{},
+		RunAsUser:          ptr.Int64(1),
+		RunAsGroup:         ptr.Int64(1),
+		RunAsNonRoot:       ptr.Bool(true),
+		FSGroup:            ptr.Int64(1),
+	}
+
+	want := &corev1.PodSecurityContext{}
+	ctx := context.Background()
+
+	got := PodSecurityContextMask(ctx, in)
+
+	if &want == &got {
+		t.Error("Input and output share addresses. Want different addresses")
+	}
+
+	if diff, err := kmp.SafeDiff(want, got); err != nil {
+		t.Errorf("Got error comparing output, err = %v", err)
+	} else if diff != "" {
+		t.Errorf("PostSecurityContextMask (-want, +got): %s", diff)
+	}
+
+	if got = PodSecurityContextMask(ctx, nil); got != nil {
+		t.Errorf("PodSecurityContextMask(nil) = %v, want: nil", got)
+	}
+}
+
+func TestPodSecurityContextMask_FeatureEnabled(t *testing.T) {
+	in := &corev1.PodSecurityContext{
+		SELinuxOptions:     &corev1.SELinuxOptions{},
+		WindowsOptions:     &corev1.WindowsSecurityContextOptions{},
+		SupplementalGroups: []int64{},
+		Sysctls:            []corev1.Sysctl{},
+		RunAsUser:          ptr.Int64(1),
+		RunAsGroup:         ptr.Int64(1),
+		RunAsNonRoot:       ptr.Bool(true),
+		FSGroup:            ptr.Int64(1),
+	}
+
+	want := &corev1.PodSecurityContext{
+		RunAsUser:    ptr.Int64(1),
+		RunAsGroup:   ptr.Int64(1),
+		RunAsNonRoot: ptr.Bool(true),
+		FSGroup:      ptr.Int64(1),
+	}
+
+	ctx := config.ToContext(context.Background(),
+		&config.Config{
+			Features: &config.Features{
+				PodSpecSecurityContext: config.Enabled,
+			},
+		},
+	)
+
+	got := PodSecurityContextMask(ctx, in)
+
+	if &want == &got {
+		t.Error("Input and output share addresses. Want different addresses")
+	}
+
+	if diff, err := kmp.SafeDiff(want, got); err != nil {
+		t.Errorf("Got error comparing output, err = %v", err)
+	} else if diff != "" {
+		t.Errorf("PostSecurityContextMask (-want, +got): %s", diff)
+	}
+}
+
 func TestSecurityContextMask(t *testing.T) {
 	mtype := corev1.UnmaskedProcMount
 	want := &corev1.SecurityContext{
@@ -660,7 +733,7 @@ func TestSecurityContextMask(t *testing.T) {
 		ProcMount:                &mtype,
 	}
 
-	got := SecurityContextMask(in)
+	got := SecurityContextMask(context.Background(), in)
 
 	if &want == &got {
 		t.Error("Input and output share addresses. Want different addresses")
@@ -672,7 +745,47 @@ func TestSecurityContextMask(t *testing.T) {
 		t.Errorf("SecurityContextMask (-want, +got): %s", diff)
 	}
 
-	if got = SecurityContextMask(nil); got != nil {
+	if got = SecurityContextMask(context.Background(), nil); got != nil {
 		t.Errorf("SecurityContextMask(nil) = %v, want: nil", got)
+	}
+}
+
+func TestSecurityContextMask_FeatureEnabled(t *testing.T) {
+	mtype := corev1.UnmaskedProcMount
+	want := &corev1.SecurityContext{
+		RunAsGroup:   ptr.Int64(2),
+		RunAsNonRoot: ptr.Bool(true),
+		RunAsUser:    ptr.Int64(1),
+	}
+	in := &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.Bool(true),
+		Capabilities:             &corev1.Capabilities{},
+		Privileged:               ptr.Bool(true),
+		ProcMount:                &mtype,
+		ReadOnlyRootFilesystem:   ptr.Bool(true),
+		RunAsGroup:               ptr.Int64(2),
+		RunAsNonRoot:             ptr.Bool(true),
+		RunAsUser:                ptr.Int64(1),
+		SELinuxOptions:           &corev1.SELinuxOptions{},
+	}
+
+	ctx := config.ToContext(context.Background(),
+		&config.Config{
+			Features: &config.Features{
+				PodSpecSecurityContext: config.Enabled,
+			},
+		},
+	)
+
+	got := SecurityContextMask(ctx, in)
+
+	if &want == &got {
+		t.Error("Input and output share addresses. Want different addresses")
+	}
+
+	if diff, err := kmp.SafeDiff(want, got); err != nil {
+		t.Errorf("Got error comparing output, err = %v", err)
+	} else if diff != "" {
+		t.Errorf("SecurityContextMask (-want, +got): %s", diff)
 	}
 }

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -642,6 +642,10 @@ func ValidateNamespacedObjectReference(p *corev1.ObjectReference) *apis.FieldErr
 	return errs
 }
 
+// ValidatePodSecurityContext validates the PodSecurityContext struct. All fields are disallowed
+// unless the 'PodSpecSecurityContext' feature flag is enabled
+//
+// See the allowed properties in the `PodSecurityContextMask`
 func ValidatePodSecurityContext(ctx context.Context, sc *corev1.PodSecurityContext) *apis.FieldError {
 	if sc == nil {
 		return nil

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -669,6 +669,15 @@ func ValidatePodSecurityContext(ctx context.Context, sc *corev1.PodSecurityConte
 			errs = errs.Also(apis.ErrOutOfBoundsValue(gid, minGroupID, maxGroupID, "fsGroup"))
 		}
 	}
+
+	for i, gid := range sc.SupplementalGroups {
+		if gid < minGroupID || gid > maxGroupID {
+			err := apis.ErrOutOfBoundsValue(gid, minGroupID, maxGroupID, "").
+				ViaFieldIndex("supplementalGroups", i)
+			errs = errs.Also(err)
+		}
+	}
+
 	return errs
 }
 

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -1778,12 +1778,11 @@ func TestPodSpecSecurityContextValidation(t *testing.T) {
 	}, {
 		name: "disallowed fields",
 		sc: &corev1.PodSecurityContext{
-			SELinuxOptions:     &corev1.SELinuxOptions{},
-			WindowsOptions:     &corev1.WindowsSecurityContextOptions{},
-			SupplementalGroups: []int64{},
-			Sysctls:            []corev1.Sysctl{},
+			SELinuxOptions: &corev1.SELinuxOptions{},
+			WindowsOptions: &corev1.WindowsSecurityContextOptions{},
+			Sysctls:        []corev1.Sysctl{},
 		},
-		want: apis.ErrDisallowedFields("seLinuxOptions", "supplementalGroups", "sysctls", "windowsOptions"),
+		want: apis.ErrDisallowedFields("seLinuxOptions", "sysctls", "windowsOptions"),
 	}, {
 		name: "too large uid",
 		sc: &corev1.PodSecurityContext{
@@ -1820,6 +1819,18 @@ func TestPodSpecSecurityContextValidation(t *testing.T) {
 			FSGroup: ptr.Int64(-10),
 		},
 		want: apis.ErrOutOfBoundsValue(-10, 0, math.MaxInt32, "fsGroup"),
+	}, {
+		name: "too large supplementalGroups",
+		sc: &corev1.PodSecurityContext{
+			SupplementalGroups: []int64{int64(math.MaxInt32 + 1)},
+		},
+		want: apis.ErrOutOfBoundsValue(int64(math.MaxInt32+1), 0, math.MaxInt32, "supplementalGroups[0]"),
+	}, {
+		name: "negative supplementalGroups",
+		sc: &corev1.PodSecurityContext{
+			SupplementalGroups: []int64{-10},
+		},
+		want: apis.ErrOutOfBoundsValue(-10, 0, math.MaxInt32, "supplementalGroups[0]"),
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -69,6 +69,13 @@ func withPodSpecTolerationsEnabled() configOption {
 	}
 }
 
+func withPodSpecSecurityContextEnabled() configOption {
+	return func(cfg *config.Config) *config.Config {
+		cfg.Features.PodSpecSecurityContext = config.Enabled
+		return cfg
+	}
+}
+
 func TestPodSpecValidation(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -590,6 +597,16 @@ func TestPodSpecFeatureValidation(t *testing.T) {
 			Paths:   []string{"tolerations"},
 		},
 		cfgOpts: []configOption{withPodSpecTolerationsEnabled()},
+	}, {
+		name: "PodSpecSecurityContext",
+		featureSpec: corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{},
+		},
+		err: &apis.FieldError{
+			Message: "must not set the field(s)",
+			Paths:   []string{"securityContext"},
+		},
+		cfgOpts: []configOption{withPodSpecSecurityContextEnabled()},
 	}}
 
 	featureTests := []struct {
@@ -640,9 +657,10 @@ func TestPodSpecFeatureValidation(t *testing.T) {
 					ctx = config.ToContext(ctx, cfg)
 				}
 				if test.includeFeatureSpec {
-					obj.Affinity = featureData.featureSpec.Affinity
-					obj.NodeSelector = featureData.featureSpec.NodeSelector
-					obj.Tolerations = featureData.featureSpec.Tolerations
+					obj = featureData.featureSpec
+					obj.Containers = []corev1.Container{{
+						Image: "busybox",
+					}}
 				}
 				got := ValidatePodSpec(ctx, obj)
 				if diff := cmp.Diff(want.Error(), got.Error()); diff != "" {
@@ -774,6 +792,7 @@ func TestContainerValidation(t *testing.T) {
 		c       corev1.Container
 		want    *apis.FieldError
 		volumes sets.String
+		cfgOpts []configOption
 	}{{
 		name: "empty container",
 		c:    corev1.Container{},
@@ -1246,6 +1265,26 @@ func TestContainerValidation(t *testing.T) {
 		},
 		want: apis.ErrOutOfBoundsValue(-10, 0, math.MaxInt32, "securityContext.runAsUser"),
 	}, {
+		name:    "too large gid - feature enabled",
+		cfgOpts: []configOption{withPodSpecSecurityContextEnabled()},
+		c: corev1.Container{
+			Image: "foo",
+			SecurityContext: &corev1.SecurityContext{
+				RunAsGroup: ptr.Int64(math.MaxInt32 + 1),
+			},
+		},
+		want: apis.ErrOutOfBoundsValue(int64(math.MaxInt32+1), 0, math.MaxInt32, "securityContext.runAsGroup"),
+	}, {
+		name:    "negative gid - feature enabled",
+		cfgOpts: []configOption{withPodSpecSecurityContextEnabled()},
+		c: corev1.Container{
+			Image: "foo",
+			SecurityContext: &corev1.SecurityContext{
+				RunAsGroup: ptr.Int64(-10),
+			},
+		},
+		want: apis.ErrOutOfBoundsValue(-10, 0, math.MaxInt32, "securityContext.runAsGroup"),
+	}, {
 		name: "envFrom - None of",
 		c: corev1.Container{
 			Image:   "foo",
@@ -1385,7 +1424,16 @@ func TestContainerValidation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := ValidateContainer(context.Background(), test.c, test.volumes)
+			ctx := context.Background()
+			if test.cfgOpts != nil {
+				cfg := config.FromContextOrDefaults(ctx)
+				for _, opt := range test.cfgOpts {
+					cfg = opt(cfg)
+				}
+				ctx = config.ToContext(ctx, cfg)
+			}
+
+			got := ValidateContainer(ctx, test.c, test.volumes)
 			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
 				t.Errorf("ValidateContainer (-want, +got): \n%s", diff)
 			}
@@ -1714,6 +1762,78 @@ func TestObjectReferenceValidation(t *testing.T) {
 			got := ValidateNamespacedObjectReference(test.r)
 			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
 				t.Errorf("ValidateNamespacedObjectReference (-want, +got): \n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPodSpecSecurityContextValidation(t *testing.T) {
+	// Note the feature flag is always enabled on this test
+	tests := []struct {
+		name string
+		sc   *corev1.PodSecurityContext
+		want *apis.FieldError
+	}{{
+		name: "nil",
+	}, {
+		name: "disallowed fields",
+		sc: &corev1.PodSecurityContext{
+			SELinuxOptions:     &corev1.SELinuxOptions{},
+			WindowsOptions:     &corev1.WindowsSecurityContextOptions{},
+			SupplementalGroups: []int64{},
+			Sysctls:            []corev1.Sysctl{},
+		},
+		want: apis.ErrDisallowedFields("seLinuxOptions", "supplementalGroups", "sysctls", "windowsOptions"),
+	}, {
+		name: "too large uid",
+		sc: &corev1.PodSecurityContext{
+			RunAsUser: ptr.Int64(math.MaxInt32 + 1),
+		},
+		want: apis.ErrOutOfBoundsValue(int64(math.MaxInt32+1), 0, math.MaxInt32, "runAsUser"),
+	}, {
+		name: "negative uid",
+		sc: &corev1.PodSecurityContext{
+			RunAsUser: ptr.Int64(-10),
+		},
+		want: apis.ErrOutOfBoundsValue(-10, 0, math.MaxInt32, "runAsUser"),
+	}, {
+		name: "too large gid",
+		sc: &corev1.PodSecurityContext{
+			RunAsGroup: ptr.Int64(math.MaxInt32 + 1),
+		},
+		want: apis.ErrOutOfBoundsValue(int64(math.MaxInt32+1), 0, math.MaxInt32, "runAsGroup"),
+	}, {
+		name: "negative gid",
+		sc: &corev1.PodSecurityContext{
+			RunAsGroup: ptr.Int64(-10),
+		},
+		want: apis.ErrOutOfBoundsValue(-10, 0, math.MaxInt32, "runAsGroup"),
+	}, {
+		name: "too large fsGroup",
+		sc: &corev1.PodSecurityContext{
+			FSGroup: ptr.Int64(math.MaxInt32 + 1),
+		},
+		want: apis.ErrOutOfBoundsValue(int64(math.MaxInt32+1), 0, math.MaxInt32, "fsGroup"),
+	}, {
+		name: "negative fsGroup",
+		sc: &corev1.PodSecurityContext{
+			FSGroup: ptr.Int64(-10),
+		},
+		want: apis.ErrOutOfBoundsValue(-10, 0, math.MaxInt32, "fsGroup"),
+	}}
+
+	for _, test := range tests {
+		ctx := config.ToContext(context.Background(),
+			&config.Config{
+				Features: &config.Features{
+					PodSpecSecurityContext: config.Enabled,
+				},
+			})
+
+		t.Run(test.name, func(t *testing.T) {
+			got := ValidatePodSecurityContext(ctx, test.sc)
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("ValidatePodSecurityContext(-want, +got): \n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #7924

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* `kubernetes.podspec-securitycontext` feature flag now allows you to set `securityContext` options on the Pod & Container
*  The Pod's context allows for `runAsUser`, `runAsGroup`, `fsGroup`  `runAsNonRoot`, `supplementalGroups`
*  The Container's context allows for `runAsUser`, `runAsGroup`, `runAsNonRoot`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
- `kubernetes.podspec-securitycontext` feature flag now allows you to set `securityContext` options on the Pod & Container
-  The Pod's context allows for `runAsUser`, `runAsGroup`, `fsGroup`  `runAsNonRoot`, `supplementalGroups`
-  The Container's context allows for `runAsUser`, `runAsGroup`, `runAsNonRoot`
```

/assign @julz 