### PR TITLE
Clean up autoscaling api types

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/doc.go
+++ b/pkg/apis/autoscaling/v1alpha1/doc.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +groupName=autoscaling.internal.knative.dev
+
+// Package v1alpha1 contains the Autoscaling v1alpha1 API types.
 package v1alpha1

--- a/pkg/apis/autoscaling/v1alpha1/pa_defaults.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_defaults.go
@@ -35,6 +35,7 @@ func defaultMetric(class string) string {
 	}
 }
 
+// SetDefaults sets the default values for the PodAutoscaler.
 func (r *PodAutoscaler) SetDefaults(ctx context.Context) {
 	r.Spec.SetDefaults(apis.WithinSpec(ctx))
 	config := config.FromContextOrDefaults(ctx)
@@ -51,4 +52,5 @@ func (r *PodAutoscaler) SetDefaults(ctx context.Context) {
 	}
 }
 
+// SetDefaults sets the default values for the PodAutoscalerSpec.
 func (rs *PodAutoscalerSpec) SetDefaults(ctx context.Context) {}

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -899,12 +899,12 @@ func TestTypicalFlow(t *testing.T) {
 	r.InitializeConditions()
 	apistest.CheckConditionOngoing(r, PodAutoscalerConditionActive, t)
 	apistest.CheckConditionOngoing(r, PodAutoscalerConditionReady, t)
-	apistest.CheckConditionOngoing(r, PodAutoscalerSKSReady, t)
+	apistest.CheckConditionOngoing(r, PodAutoscalerConditionSKSReady, t)
 	apistest.CheckConditionOngoing(r, PodAutoscalerConditionScaleTargetInitialized, t)
 
 	r.MarkActive()
 	r.MarkSKSReady()
-	apistest.CheckConditionSucceeded(r, PodAutoscalerSKSReady, t)
+	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionSKSReady, t)
 	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionActive, t)
 	apistest.CheckConditionOngoing(r, PodAutoscalerConditionReady, t)
 
@@ -912,7 +912,7 @@ func TestTypicalFlow(t *testing.T) {
 	r.MarkActive()
 	r.MarkScaleTargetInitialized()
 	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionScaleTargetInitialized, t)
-	apistest.CheckConditionSucceeded(r, PodAutoscalerSKSReady, t)
+	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionSKSReady, t)
 	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionActive, t)
 	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionReady, t)
 
@@ -922,13 +922,13 @@ func TestTypicalFlow(t *testing.T) {
 	r.MarkSKSReady()
 	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionScaleTargetInitialized, t)
 	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionActive, t)
-	apistest.CheckConditionSucceeded(r, PodAutoscalerSKSReady, t)
+	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionSKSReady, t)
 	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionReady, t)
 
 	r.MarkSKSNotReady("something something private")
 	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionScaleTargetInitialized, t)
 	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionActive, t)
-	apistest.CheckConditionOngoing(r, PodAutoscalerSKSReady, t)
+	apistest.CheckConditionOngoing(r, PodAutoscalerConditionSKSReady, t)
 	apistest.CheckConditionOngoing(r, PodAutoscalerConditionReady, t)
 
 	// Restore.
@@ -957,7 +957,7 @@ func TestTypicalFlow(t *testing.T) {
 		t.Error("Active was not set.")
 	}
 	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionActive, t)
-	apistest.CheckConditionSucceeded(r, PodAutoscalerSKSReady, t)
+	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionSKSReady, t)
 	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionReady, t)
 	apistest.CheckConditionSucceeded(r, PodAutoscalerConditionScaleTargetInitialized, t)
 }

--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -99,7 +99,7 @@ type PodAutoscalerSpec struct {
 	// is responsible for quickly right-sizing.
 	ScaleTargetRef corev1.ObjectReference `json:"scaleTargetRef"`
 
-	// Reachable specifies whether or not the `ScaleTargetRef` can be reached (ie. has a route).
+	// Reachability specifies whether or not the `ScaleTargetRef` can be reached (ie. has a route).
 	// Defaults to `ReachabilityUnknown`
 	// +optional
 	Reachability ReachabilityType `json:"reachability,omitempty"`
@@ -117,8 +117,8 @@ const (
 	PodAutoscalerConditionScaleTargetInitialized apis.ConditionType = "ScaleTargetInitialized"
 	// PodAutoscalerConditionActive is set when the PodAutoscaler's ScaleTargetRef is receiving traffic.
 	PodAutoscalerConditionActive apis.ConditionType = "Active"
-	// PodAutoscalerCondtionDependenciesReady is set when SKS is ready.
-	PodAutoscalerSKSReady = "SKSReady"
+	// PodAutoscalerConditionSKSReady is set when SKS is ready.
+	PodAutoscalerConditionSKSReady = "SKSReady"
 )
 
 // PodAutoscalerStatus communicates the observed state of the PodAutoscaler (from the controller).

--- a/pkg/apis/autoscaling/v1alpha1/register.go
+++ b/pkg/apis/autoscaling/v1alpha1/register.go
@@ -38,8 +38,10 @@ func Resource(resource string) schema.GroupResource {
 }
 
 var (
+	// SchemeBuilder registers the addKnownTypes function.
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
+	// AddToScheme applies all the stored functions to the scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
 )
 
 // Adds the list of known types to Scheme.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

- Make the lint gods happy
- Fix up some comment issues
- Rename `PodAutoscalerSKSReady` -> `PodAutoscalerConditionSKSReady` for consistency with all the other conditions

/assign @vagababov @yanweiguo 