### PR TITLE
Add script to only update checksums

### DIFF
--- a/hack/update-checksums.sh
+++ b/hack/update-checksums.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export GO111MODULE=on
+
+if [ -z "${GOPATH:-}" ]; then
+  export GOPATH=$(go env GOPATH)
+fi
+
+source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/library.sh
+
+go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/config/core/configmaps/*.yaml

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -30,26 +30,17 @@ source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/library.sh
 
 boilerplate="${REPO_ROOT_DIR}/hack/boilerplate/boilerplate.go.txt"
 
-# Parse flags.
+# Parse flags to determine if we should generate protobufs.
 generate_protobufs=0
-checksums_only=0
 while [[ $# -ne 0 ]]; do
   parameter=$1
   case ${parameter} in
     --generate-protobufs) generate_protobufs=1 ;;
-    --checksums-only) checksums_only=1 ;;
     *) abort "unknown option ${parameter}" ;;
   esac
   shift
 done
 readonly generate_protobufs
-
-echo "Generating checksums for configmap _example keys"
-go run "${REPO_ROOT_DIR}/vendor/knative.dev/pkg/configmap/hash-gen" "${REPO_ROOT_DIR}"/config/core/configmaps/*.yaml
-
-if (( checksums_only )); then
-  exit 0
-fi
 
 if (( generate_protobufs )); then
   echo "Generating protocol buffer code"
@@ -65,6 +56,9 @@ if (( generate_protobufs )); then
     echo -e "$(cat "${boilerplate}")\n\n$(cat "${generated}")" > "${generated}"
   done
 fi
+
+echo "Generating checksums for configmap _example keys"
+${REPO_ROOT_DIR}/hack/update-checksums.sh
 
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 $(dirname $0)/../vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 KNATIVE_CODEGEN_PKG=${KNATIVE_CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 $(dirname $0)/../vendor/knative.dev/pkg 2>/dev/null || echo ../pkg)}


### PR DESCRIPTION
Quite often I find that I've already run `update-codegen.sh` (or haven't touched anything else) but then I fiddle with a config map example and have to run the whole thing again just to update the checksums, which takes ages and warms the planet a few fractions of a degree for nothing. This PR helps save the planet.