### PR TITLE
Use random to generate keys for the benchmark

### DIFF
--- a/pkg/metrics/tags_test.go
+++ b/pkg/metrics/tags_test.go
@@ -19,11 +19,11 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"strconv"
 	"strings"
 	"testing"
 
-	"go.uber.org/atomic"
 	pkgmetrics "knative.dev/pkg/metrics"
 	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/pkg/metrics/metricstest"
@@ -234,7 +234,7 @@ func BenchmarkPodRevisionContext(b *testing.B) {
 		b.Run(fmt.Sprintf("sequential-%d-revisions", revisions), func(b *testing.B) {
 			contextCache.Purge()
 			for i := 0; i < b.N; i++ {
-				rev := "name" + strconv.Itoa(i%revisions)
+				rev := "name" + strconv.Itoa(rand.Intn(revisions))
 				PodRevisionContext("pod", "container", "ns", "svc", "cfg", rev)
 			}
 		})
@@ -242,10 +242,9 @@ func BenchmarkPodRevisionContext(b *testing.B) {
 		b.Run(fmt.Sprintf("parallel-%d-revisions", revisions), func(b *testing.B) {
 			contextCache.Purge()
 
-			var n atomic.Int64
 			b.RunParallel(func(pb *testing.PB) {
 				for pb.Next() {
-					rev := "name" + strconv.Itoa(int(n.Inc())%revisions)
+					rev := "name" + strconv.Itoa(rand.Intn(revisions))
 					PodRevisionContext("pod", "container", "ns", "svc", "cfg", rev)
 				}
 			})


### PR DESCRIPTION
In real life the keys would probably come with different periods, than just sequentially

This also prepares us better should we try _other_ LRU cache implementations for a more realistic comparison.