### PR TITLE
Actually test changing custom TimeoutSeconds

### DIFF
--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -236,10 +236,14 @@ func TestMakeQueueContainer(t *testing.T) {
 	}, {
 		name: "custom TimeoutSeconds",
 		rev: revision("bar", "foo",
-			withContainers(containers)),
+			withContainers(containers),
+			func(revision *v1.Revision) {
+				revision.Spec.TimeoutSeconds = ptr.Int64(99)
+			},
+		),
 		want: queueContainer(func(c *corev1.Container) {
 			c.Env = env(map[string]string{
-				"REVISION_TIMEOUT_SECONDS": "45",
+				"REVISION_TIMEOUT_SECONDS": "99",
 			})
 		}),
 	}, {


### PR DESCRIPTION
At some point this test became a bit of a no-op. This tests actually changing the default TimeoutSeconds from the default one in the other tests so it's a bit clearer what's actually being tested.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

/assign @vagababov 

