### PR TITLE
Add short domains to ingress.spec.rules.hosts for cluster local visibility

### DIFF
--- a/pkg/reconciler/route/resources/ingress.go
+++ b/pkg/reconciler/route/resources/ingress.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"context"
 	"sort"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +30,7 @@ import (
 	"knative.dev/networking/pkg/apis/networking"
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
+	networkpkg "knative.dev/pkg/network"
 	"knative.dev/serving/pkg/activator"
 	defaults "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
@@ -112,11 +114,11 @@ func MakeIngressSpec(
 			visibilities = append(visibilities, netv1alpha1.IngressVisibilityExternalIP)
 		}
 		for _, visibility := range visibilities {
-			domain, err := routeDomain(ctx, name, r, visibility)
+			domains, err := routeDomain(ctx, name, r, visibility)
 			if err != nil {
 				return netv1alpha1.IngressSpec{}, err
 			}
-			rule := makeIngressRule(ctx, []string{domain}, r.Namespace, visibility, targets[name])
+			rule := makeIngressRule(ctx, domains, r.Namespace, visibility, targets[name])
 			if networkConfig.TagHeaderBasedRouting {
 				if rule.HTTP.Paths[0].AppendHeaders == nil {
 					rule.HTTP.Paths[0].AppendHeaders = make(map[string]string)
@@ -147,7 +149,7 @@ func MakeIngressSpec(
 			// If this is a public rule, we need to configure ACME challenge paths.
 			if visibility == netv1alpha1.IngressVisibilityExternalIP {
 				rule.HTTP.Paths = append(
-					makeACMEIngressPaths(challengeHosts, []string{domain}), rule.HTTP.Paths...)
+					makeACMEIngressPaths(challengeHosts, domains), rule.HTTP.Paths...)
 			}
 			rules = append(rules, rule)
 		}
@@ -169,17 +171,31 @@ func getChallengeHosts(challenges []netv1alpha1.HTTP01Challenge) map[string]netv
 	return c
 }
 
-func routeDomain(ctx context.Context, targetName string, r *servingv1.Route, visibility netv1alpha1.IngressVisibility) (string, error) {
+func routeDomain(ctx context.Context, targetName string, r *servingv1.Route, visibility netv1alpha1.IngressVisibility) ([]string, error) {
 	hostname, err := domains.HostnameFromTemplate(ctx, r.Name, targetName)
 	if err != nil {
-		return "", err
+		return []string{}, err
 	}
 
 	meta := r.ObjectMeta.DeepCopy()
 	isClusterLocal := visibility == netv1alpha1.IngressVisibilityClusterLocal
 	labels.SetVisibility(meta, isClusterLocal)
 
-	return domains.DomainNameFromTemplate(ctx, *meta, hostname)
+	domain, err := domains.DomainNameFromTemplate(ctx, *meta, hostname)
+	if err != nil {
+		return []string{}, err
+	}
+	domains := []string{domain}
+	if isClusterLocal {
+		// cluster local domains to support short domains.
+		// e.g. hello.default.svc.cluster.local supports hello.default.svc and hello.default.
+		localDomainSuffix := "svc." + networkpkg.GetClusterDomainName()
+		if strings.HasSuffix(domain, localDomainSuffix) {
+			domains = append(domains, strings.TrimSuffix(domain, "."+networkpkg.GetClusterDomainName())) // hello.default.svc
+			domains = append(domains, strings.TrimSuffix(domain, "."+localDomainSuffix))                 // hello.default
+		}
+	}
+	return domains, err
 }
 
 func makeACMEIngressPaths(challenges map[string]netv1alpha1.HTTP01Challenge, domains []string) []netv1alpha1.HTTPIngressPath {

--- a/pkg/reconciler/route/resources/ingress.go
+++ b/pkg/reconciler/route/resources/ingress.go
@@ -189,10 +189,10 @@ func routeDomain(ctx context.Context, targetName string, r *servingv1.Route, vis
 	if isClusterLocal {
 		// cluster local domains to support short domains.
 		// e.g. hello.default.svc.cluster.local supports hello.default.svc and hello.default.
-		localDomainSuffix := "svc." + networkpkg.GetClusterDomainName()
+		localDomainSuffix := ".svc." + networkpkg.GetClusterDomainName()
 		if strings.HasSuffix(domain, localDomainSuffix) {
 			domains = append(domains, strings.TrimSuffix(domain, "."+networkpkg.GetClusterDomainName())) // hello.default.svc
-			domains = append(domains, strings.TrimSuffix(domain, "."+localDomainSuffix))                 // hello.default
+			domains = append(domains, strings.TrimSuffix(domain, localDomainSuffix))                     // hello.default
 		}
 	}
 	return domains, err

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -131,6 +131,8 @@ func TestMakeIngressSpec_CorrectRules(t *testing.T) {
 	expected := []netv1alpha1.IngressRule{{
 		Hosts: []string{
 			"test-route." + ns + ".svc.cluster.local",
+			"test-route." + ns + ".svc",
+			"test-route." + ns,
 		},
 		HTTP: &netv1alpha1.HTTPIngressRuleValue{
 			Paths: []netv1alpha1.HTTPIngressPath{{
@@ -175,6 +177,8 @@ func TestMakeIngressSpec_CorrectRules(t *testing.T) {
 	}, {
 		Hosts: []string{
 			"v1-test-route." + ns + ".svc.cluster.local",
+			"v1-test-route." + ns + ".svc",
+			"v1-test-route." + ns,
 		},
 		HTTP: &netv1alpha1.HTTPIngressRuleValue{
 			Paths: []netv1alpha1.HTTPIngressPath{{
@@ -339,6 +343,8 @@ func TestMakeIngressSpec_CorrectRulesWithTagBasedRouting(t *testing.T) {
 	expected := []netv1alpha1.IngressRule{{
 		Hosts: []string{
 			"test-route." + ns + ".svc.cluster.local",
+			"test-route." + ns + ".svc",
+			"test-route." + ns,
 		},
 		HTTP: &netv1alpha1.HTTPIngressRuleValue{
 			Paths: []netv1alpha1.HTTPIngressPath{{
@@ -427,6 +433,8 @@ func TestMakeIngressSpec_CorrectRulesWithTagBasedRouting(t *testing.T) {
 	}, {
 		Hosts: []string{
 			"v1-test-route." + ns + ".svc.cluster.local",
+			"v1-test-route." + ns + ".svc",
+			"v1-test-route." + ns,
 		},
 		HTTP: &netv1alpha1.HTTPIngressRuleValue{
 			Paths: []netv1alpha1.HTTPIngressPath{{
@@ -981,6 +989,8 @@ func TestMakeIngressACMEChallenges(t *testing.T) {
 	expected := []netv1alpha1.IngressRule{{
 		Hosts: []string{
 			"test-route.test-ns.svc.cluster.local",
+			"test-route.test-ns.svc",
+			"test-route.test-ns",
 		},
 		Visibility: netv1alpha1.IngressVisibilityClusterLocal,
 		HTTP: &netv1alpha1.HTTPIngressRuleValue{

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -254,8 +254,8 @@ func TestMakeIngressSpec_CorrectRuleVisibility(t *testing.T) {
 			}},
 		},
 		expectedVisibility: map[netv1alpha1.IngressVisibility][]string{
-			netv1alpha1.IngressVisibilityClusterLocal: []string{"myroute.default", "myroute.default.svc", "myroute.default.svc.cluster.local"},
-			netv1alpha1.IngressVisibilityExternalIP:   []string{"myroute.default.example.com"},
+			netv1alpha1.IngressVisibilityClusterLocal: {"myroute.default", "myroute.default.svc", "myroute.default.svc.cluster.local"},
+			netv1alpha1.IngressVisibilityExternalIP:   {"myroute.default.example.com"},
 		},
 	}, {
 		name:  "private route",
@@ -275,7 +275,7 @@ func TestMakeIngressSpec_CorrectRuleVisibility(t *testing.T) {
 			traffic.DefaultTarget: netv1alpha1.IngressVisibilityClusterLocal,
 		},
 		expectedVisibility: map[netv1alpha1.IngressVisibility][]string{
-			netv1alpha1.IngressVisibilityClusterLocal: []string{"myroute.default", "myroute.default.svc", "myroute.default.svc.cluster.local"},
+			netv1alpha1.IngressVisibilityClusterLocal: {"myroute.default", "myroute.default.svc", "myroute.default.svc.cluster.local"},
 		},
 	}, {
 		name:  "unspecified route",
@@ -292,8 +292,8 @@ func TestMakeIngressSpec_CorrectRuleVisibility(t *testing.T) {
 			}},
 		},
 		expectedVisibility: map[netv1alpha1.IngressVisibility][]string{
-			netv1alpha1.IngressVisibilityClusterLocal: []string{"myroute.default", "myroute.default.svc", "myroute.default.svc.cluster.local"},
-			netv1alpha1.IngressVisibilityExternalIP:   []string{"myroute.default.example.com"},
+			netv1alpha1.IngressVisibilityClusterLocal: {"myroute.default", "myroute.default.svc", "myroute.default.svc.cluster.local"},
+			netv1alpha1.IngressVisibilityExternalIP:   {"myroute.default.example.com"},
 		},
 	}}
 	for _, c := range cases {

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -209,6 +209,8 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 		Rules: []v1alpha1.IngressRule{{
 			Hosts: []string{
 				"test-route.test.svc.cluster.local",
+				"test-route.test.svc",
+				"test-route.test",
 			},
 			Visibility: v1alpha1.IngressVisibilityClusterLocal,
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
@@ -338,6 +340,8 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 		Rules: []v1alpha1.IngressRule{{
 			Hosts: []string{
 				"test-route.test.svc.cluster.local",
+				"test-route.test.svc",
+				"test-route.test",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -455,6 +459,8 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 		Rules: []v1alpha1.IngressRule{{
 			Hosts: []string{
 				"test-route.test.svc.cluster.local",
+				"test-route.test.svc",
+				"test-route.test",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -586,6 +592,8 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 		Rules: []v1alpha1.IngressRule{{
 			Hosts: []string{
 				"test-route.test.svc.cluster.local",
+				"test-route.test.svc",
+				"test-route.test",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -652,6 +660,8 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 		}, {
 			Hosts: []string{
 				"test-revision-1-test-route.test.svc.cluster.local",
+				"test-revision-1-test-route.test.svc",
+				"test-revision-1-test-route.test",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -696,6 +706,8 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 		}, {
 			Hosts: []string{
 				"test-revision-2-test-route.test.svc.cluster.local",
+				"test-revision-2-test-route.test.svc",
+				"test-revision-2-test-route.test",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -792,6 +804,8 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 		Rules: []v1alpha1.IngressRule{{
 			Hosts: []string{
 				"test-route.test.svc.cluster.local",
+				"test-route.test.svc",
+				"test-route.test",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -858,6 +872,8 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 		}, {
 			Hosts: []string{
 				"bar-test-route.test.svc.cluster.local",
+				"bar-test-route.test.svc",
+				"bar-test-route.test",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -902,6 +918,8 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 		}, {
 			Hosts: []string{
 				"foo-test-route.test.svc.cluster.local",
+				"foo-test-route.test.svc",
+				"foo-test-route.test",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -1007,6 +1025,8 @@ func TestCreateRouteWithNamedTargetsAndTagBasedRouting(t *testing.T) {
 		Rules: []v1alpha1.IngressRule{{
 			Hosts: []string{
 				"test-route.test.svc.cluster.local",
+				"test-route.test.svc",
+				"test-route.test",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -1163,6 +1183,8 @@ func TestCreateRouteWithNamedTargetsAndTagBasedRouting(t *testing.T) {
 		}, {
 			Hosts: []string{
 				"bar-test-route.test.svc.cluster.local",
+				"bar-test-route.test.svc",
+				"bar-test-route.test",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -1213,6 +1235,8 @@ func TestCreateRouteWithNamedTargetsAndTagBasedRouting(t *testing.T) {
 		}, {
 			Hosts: []string{
 				"foo-test-route.test.svc.cluster.local",
+				"foo-test-route.test.svc",
+				"foo-test-route.test",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -208,9 +208,9 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 		TLS: []v1alpha1.IngressTLS{},
 		Rules: []v1alpha1.IngressRule{{
 			Hosts: []string{
-				"test-route.test.svc.cluster.local",
-				"test-route.test.svc",
 				"test-route.test",
+				"test-route.test.svc",
+				"test-route.test.svc.cluster.local",
 			},
 			Visibility: v1alpha1.IngressVisibilityClusterLocal,
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
@@ -339,9 +339,9 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 		TLS: []v1alpha1.IngressTLS{},
 		Rules: []v1alpha1.IngressRule{{
 			Hosts: []string{
-				"test-route.test.svc.cluster.local",
-				"test-route.test.svc",
 				"test-route.test",
+				"test-route.test.svc",
+				"test-route.test.svc.cluster.local",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -458,9 +458,9 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 		TLS: []v1alpha1.IngressTLS{},
 		Rules: []v1alpha1.IngressRule{{
 			Hosts: []string{
-				"test-route.test.svc.cluster.local",
-				"test-route.test.svc",
 				"test-route.test",
+				"test-route.test.svc",
+				"test-route.test.svc.cluster.local",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -591,9 +591,9 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 		TLS: []v1alpha1.IngressTLS{},
 		Rules: []v1alpha1.IngressRule{{
 			Hosts: []string{
-				"test-route.test.svc.cluster.local",
-				"test-route.test.svc",
 				"test-route.test",
+				"test-route.test.svc",
+				"test-route.test.svc.cluster.local",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -659,9 +659,9 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 		}, {
 			Hosts: []string{
-				"test-revision-1-test-route.test.svc.cluster.local",
-				"test-revision-1-test-route.test.svc",
 				"test-revision-1-test-route.test",
+				"test-revision-1-test-route.test.svc",
+				"test-revision-1-test-route.test.svc.cluster.local",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -705,9 +705,9 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 		}, {
 			Hosts: []string{
-				"test-revision-2-test-route.test.svc.cluster.local",
-				"test-revision-2-test-route.test.svc",
 				"test-revision-2-test-route.test",
+				"test-revision-2-test-route.test.svc",
+				"test-revision-2-test-route.test.svc.cluster.local",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -803,9 +803,9 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 		TLS: []v1alpha1.IngressTLS{},
 		Rules: []v1alpha1.IngressRule{{
 			Hosts: []string{
-				"test-route.test.svc.cluster.local",
-				"test-route.test.svc",
 				"test-route.test",
+				"test-route.test.svc",
+				"test-route.test.svc.cluster.local",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -871,9 +871,9 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 		}, {
 			Hosts: []string{
-				"bar-test-route.test.svc.cluster.local",
-				"bar-test-route.test.svc",
 				"bar-test-route.test",
+				"bar-test-route.test.svc",
+				"bar-test-route.test.svc.cluster.local",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -917,9 +917,9 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 		}, {
 			Hosts: []string{
-				"foo-test-route.test.svc.cluster.local",
-				"foo-test-route.test.svc",
 				"foo-test-route.test",
+				"foo-test-route.test.svc",
+				"foo-test-route.test.svc.cluster.local",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -1024,9 +1024,9 @@ func TestCreateRouteWithNamedTargetsAndTagBasedRouting(t *testing.T) {
 		TLS: []v1alpha1.IngressTLS{},
 		Rules: []v1alpha1.IngressRule{{
 			Hosts: []string{
-				"test-route.test.svc.cluster.local",
-				"test-route.test.svc",
 				"test-route.test",
+				"test-route.test.svc",
+				"test-route.test.svc.cluster.local",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -1182,9 +1182,9 @@ func TestCreateRouteWithNamedTargetsAndTagBasedRouting(t *testing.T) {
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 		}, {
 			Hosts: []string{
-				"bar-test-route.test.svc.cluster.local",
-				"bar-test-route.test.svc",
 				"bar-test-route.test",
+				"bar-test-route.test.svc",
+				"bar-test-route.test.svc.cluster.local",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{
@@ -1234,9 +1234,9 @@ func TestCreateRouteWithNamedTargetsAndTagBasedRouting(t *testing.T) {
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
 		}, {
 			Hosts: []string{
-				"foo-test-route.test.svc.cluster.local",
-				"foo-test-route.test.svc",
 				"foo-test-route.test",
+				"foo-test-route.test.svc",
+				"foo-test-route.test.svc.cluster.local",
 			},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
 				Paths: []v1alpha1.HTTPIngressPath{{

--- a/vendor/knative.dev/networking/pkg/ingress/doc.go
+++ b/vendor/knative.dev/networking/pkg/ingress/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ingress holds utilities related to the implementation of ingress
+// controllers.
+package ingress

--- a/vendor/knative.dev/networking/pkg/ingress/ingress.go
+++ b/vendor/knative.dev/networking/pkg/ingress/ingress.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2019 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	net "knative.dev/networking/pkg"
+	"knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/pkg/network"
+)
+
+// ComputeHash computes a hash of the Ingress Spec, Namespace and Name
+func ComputeHash(ing *v1alpha1.Ingress) ([sha256.Size]byte, error) {
+	bytes, err := json.Marshal(ing.Spec)
+	if err != nil {
+		return [sha256.Size]byte{}, fmt.Errorf("failed to serialize Ingress: %w", err)
+	}
+	bytes = append(bytes, []byte(ing.GetNamespace())...)
+	bytes = append(bytes, []byte(ing.GetName())...)
+	return sha256.Sum256(bytes), nil
+}
+
+// InsertProbe adds a AppendHeader rule so that any request going through a Gateway is tagged with
+// the version of the Ingress currently deployed on the Gateway.
+// TODO: move this to github.com/knative/networking — currently it is used by downstream
+// consumers, see: https://github.com/knative/serving/issues/7482.
+func InsertProbe(ing *v1alpha1.Ingress) (string, error) {
+	bytes, err := ComputeHash(ing)
+	if err != nil {
+		return "", fmt.Errorf("failed to compute the hash of the Ingress: %w", err)
+	}
+	hash := fmt.Sprintf("%x", bytes)
+
+	for _, rule := range ing.Spec.Rules {
+		if rule.HTTP == nil {
+			return "", fmt.Errorf("rule is missing HTTP block: %+v", rule)
+		}
+		for i := range rule.HTTP.Paths {
+			if rule.HTTP.Paths[i].AppendHeaders == nil {
+				rule.HTTP.Paths[i].AppendHeaders = make(map[string]string, 1)
+			}
+			rule.HTTP.Paths[i].AppendHeaders[net.HashHeaderName] = hash
+		}
+	}
+
+	return hash, nil
+}
+
+// HostsPerVisibility takes an Ingress and a map from visibility levels to a set of string keys,
+// it then returns a map from that key space to the hosts under that visibility.
+func HostsPerVisibility(ing *v1alpha1.Ingress, visibilityToKey map[v1alpha1.IngressVisibility]sets.String) map[string]sets.String {
+	output := make(map[string]sets.String, 2) // We currently have public and internal.
+	for _, rule := range ing.Spec.Rules {
+		for host := range ExpandedHosts(sets.NewString(rule.Hosts...)) {
+			for key := range visibilityToKey[rule.Visibility] {
+				if _, ok := output[key]; !ok {
+					output[key] = make(sets.String, len(rule.Hosts))
+				}
+				output[key].Insert(host)
+			}
+		}
+	}
+	return output
+}
+
+// ExpandedHosts sets up hosts for the short-names for cluster DNS names.
+func ExpandedHosts(hosts sets.String) sets.String {
+	allowedSuffixes := []string{
+		"",
+		"." + network.GetClusterDomainName(),
+		".svc." + network.GetClusterDomainName(),
+	}
+	// Optimistically pre-alloc.
+	expanded := make(sets.String, len(hosts)*len(allowedSuffixes))
+	for _, h := range hosts.List() {
+		for _, suffix := range allowedSuffixes {
+			if strings.HasSuffix(h, suffix) {
+				expanded.Insert(strings.TrimSuffix(h, suffix))
+			}
+		}
+	}
+	return expanded
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1102,6 +1102,7 @@ knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/server
 knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice
 knative.dev/networking/pkg/client/istio/listers/networking/v1alpha3
 knative.dev/networking/pkg/client/listers/networking/v1alpha1
+knative.dev/networking/pkg/ingress
 # knative.dev/pkg v0.0.0-20200812224206-44c860147a87
 ## explicit
 knative.dev/pkg/apiextensions/storageversion


### PR DESCRIPTION
**Proposed Changes**

This patch expands host names to short names in
ingress.rules.hosts. For example,
`hello-example.default.svc.cluster.local` will have
`hello-example.default.svc` and `hello-example.default`.

* Ingress after this patch:
```
  spec:
    rules:
    - hosts:
      - hello-example.default.svc.cluster.local
      - hello-example.default.svc
      - hello-example.default
      http:
        paths:
        - splits:
          - appendHeaders:
              Knative-Serving-Namespace: default
              Knative-Serving-Revision: hello-example-fsjyh-1
            percent: 100
            serviceName: hello-example-fsjyh-1
            serviceNamespace: default
            servicePort: 80
          timeout: 48h0m0s
      visibility: ClusterLocal
```

Currently each KIngress has to expand the host names by themselves, but
Knative Ingress should have the host names in the rules to make it easy.
Actually I got the exact same question [here](https://github.com/Kong/kubernetes-ingress-controller/pull/804#issuecomment-675775423).

**Release Note**

```release-note
Ingress objects have short names in the spec.rules.hosts for ClusterLocal visibility.
```

/lint
