### PR TITLE
Replace knative-serving namespace in Kourier manifest before running e2e

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -233,6 +233,7 @@ function install_gloo() {
 
 function install_kourier() {
   local INSTALL_KOURIER_YAML="./third_party/kourier-latest/kourier.yaml"
+  sed -i "s/${KNATIVE_DEFAULT_NAMESPACE}/${SYSTEM_NAMESPACE}/g" ${INSTALL_KOURIER_YAML}
   echo "Kourier YAML: ${INSTALL_KOURIER_YAML}"
   echo ">> Bringing up Kourier"
 


### PR DESCRIPTION
Currently serving e2e test runs system pods in random namespace
instead of `knative-serving`.

Hencee Kourier tries to deploy resources on `knative-serving` but it
fails.

This patch fixes the knative-serving namespace in the yaml.

/lint

**Release Note**

```release-note
NONE
```

/cc @jmprusi @davidor 
