### PR TITLE
Improve ProxyHandler benchmark

### DIFF
--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -329,11 +329,11 @@ func BenchmarkProxyHandler(b *testing.B) {
 	}, {
 		label:        "breaker-10-many-reports",
 		breaker:      queue.NewBreaker(queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}),
-		reportPeriod: 1 * time.Microsecond,
+		reportPeriod: time.Microsecond,
 	}, {
 		label:        "breaker-infinite-many-reports",
 		breaker:      nil,
-		reportPeriod: 1 * time.Microsecond,
+		reportPeriod: time.Microsecond,
 	}}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

The reporting period is 1s. Go runs benchmarks by default as many times as it can within 1s. This means _most_ of the time `Report()` never actually runs during the benchmark, and when it does run it's a random artifact of test timings, not the actual speed of the code-under-test.

This runs the tests with Report either 1 hour (so not involved at all) or 1ms (so actually relevant). The updated benchmarks are:

~~~~
BenchmarkProxyHandler/sequential-breaker-10-no-reports-16         	  903356	      1115 ns/op	     768 B/op	       8 allocs/op
BenchmarkProxyHandler/parallel-breaker-10-no-reports-16           	  935715	      1301 ns/op	     768 B/op	       8 allocs/op
BenchmarkProxyHandler/sequential-breaker-infinite-no-reports-16   	 1636414	       724 ns/op	     576 B/op	       5 allocs/op
BenchmarkProxyHandler/parallel-breaker-infinite-no-reports-16     	 1863506	       667 ns/op	     576 B/op	       5 allocs/op

BenchmarkProxyHandler/sequential-breaker-10-many-reports-16       	  832585	      1243 ns/op	     768 B/op	       8 allocs/op
BenchmarkProxyHandler/parallel-breaker-10-many-reports-16         	  912895	      1446 ns/op	     768 B/op	       8 allocs/op
BenchmarkProxyHandler/sequential-breaker-infinite-many-reports-16 	 1000000	      1006 ns/op	     576 B/op	       5 allocs/op
BenchmarkProxyHandler/parallel-breaker-infinite-many-reports-16   	 1561693	       784 ns/op	     576 B/op	       5 allocs/op
~~~~

/assign @vagababov 
