### PR TITLE
Properly pin to a commit of knative-sandbox/net-istio for Istio setup 

### DIFF
--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -19,11 +19,8 @@ function install_istio() {
     readonly ISTIO_VERSION="stable"
   fi
 
-  # Find out the commit of net-istio.yaml.
-  local NET_ISTIO_COMMIT=$(
-    grep 'serving.knative.dev/release:' third_party/net-istio.yaml \
-      | cut -f2 -d\: | cut -f2 -d- | sed "s/[^0-9a-f]//g" \
-      | head -n1)
+  # TODO: Figure out the commit of net-istio.yaml from net-istio.yaml
+  local NET_ISTIO_COMMIT=f64ed34d3776a444372483dddc15a330c6c1ac53
 
   # And checkout the setup script based on that commit.
   local NET_ISTIO_DIR=$(mktemp -d)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/9109

I will follow up with another change to pin to same commit version of `net-istio.yaml`. This also fix breakage of `-stable-mesh` CI grid.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
