### PR TITLE
Clean up warning message for obsolete includeOutboundIPRanges config

### DIFF
--- a/vendor/knative.dev/networking/pkg/network.go
+++ b/vendor/knative.dev/networking/pkg/network.go
@@ -18,7 +18,6 @@ package pkg
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -31,7 +30,6 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	corev1 "k8s.io/api/core/v1"
 	cm "knative.dev/pkg/configmap"
-	"knative.dev/pkg/logging"
 )
 
 const (
@@ -262,12 +260,6 @@ func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
 // NewConfigFromMap creates a Config from the supplied data.
 func NewConfigFromMap(data map[string]string) (*Config, error) {
 	nc := defaultConfig()
-	if _, ok := data[IstioOutboundIPRangesKey]; ok {
-		// TODO(0.15): Until the next version is released, the validation check is
-		// enabled to notify users who configure this value.
-		logger := logging.FromContext(context.Background()).Named("config-network")
-		logger.Warnf("%q is deprecated as outbound network access is enabled by default now. Remove it from config-network", IstioOutboundIPRangesKey)
-	}
 
 	if err := cm.Parse(data,
 		cm.AsString(DeprecatedDefaultIngressClassKey, &nc.DefaultIngressClass),


### PR DESCRIPTION
This patch cleans up warning message for obsolete `includeOutboundIPRanges`.
The next release 0.18 will be 9 months since it was obsoleted so we can
remove it.

Fixes https://github.com/knative/serving/issues/6543
PR for knative/networking https://github.com/knative/networking/pull/108

/lint

**Release Note**

```release-note
NONE
```
