### PR TITLE
Specify port on the placeholder service.

### DIFF
--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"knative.dev/networking/pkg/apis/networking"
@@ -71,6 +72,11 @@ func MakeK8sPlaceholderService(ctx context.Context, route *v1.Route, targetName 
 		Type:            corev1.ServiceTypeExternalName,
 		ExternalName:    fullName,
 		SessionAffinity: corev1.ServiceAffinityNone,
+		Ports: []corev1.ServicePort{{
+			Name:       networking.ServicePortNameH2C,
+			Port:       int32(80),
+			TargetPort: intstr.FromInt(80),
+		}},
 	}
 
 	return service, nil
@@ -151,11 +157,21 @@ func makeServiceSpec(ingress *netv1alpha1.Ingress, isPrivate bool, clusterIP str
 			Type:            corev1.ServiceTypeExternalName,
 			ExternalName:    balancer.DomainInternal,
 			SessionAffinity: corev1.ServiceAffinityNone,
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameH2C,
+				Port:       int32(80),
+				TargetPort: intstr.FromInt(80),
+			}},
 		}, nil
 	case len(balancer.Domain) != 0:
 		return &corev1.ServiceSpec{
 			Type:         corev1.ServiceTypeExternalName,
 			ExternalName: balancer.Domain,
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameH2C,
+				Port:       int32(80),
+				TargetPort: intstr.FromInt(80),
+			}},
 		}, nil
 	case balancer.MeshOnly:
 		// The Ingress is loadbalanced through a Service mesh.

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -26,9 +26,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	network "knative.dev/networking/pkg"
+	"knative.dev/networking/pkg/apis/networking"
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving"
@@ -139,6 +141,11 @@ func TestNewMakeK8SService(t *testing.T) {
 		expectedSpec: corev1.ServiceSpec{
 			Type:         corev1.ServiceTypeExternalName,
 			ExternalName: "domain.com",
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameH2C,
+				Port:       int32(80),
+				TargetPort: intstr.FromInt(80),
+			}},
 		},
 	}, {
 		name:  "ingress-with-domaininternal",
@@ -161,6 +168,11 @@ func TestNewMakeK8SService(t *testing.T) {
 			Type:            corev1.ServiceTypeExternalName,
 			ExternalName:    "private-istio-ingressgateway.istio-system.svc.cluster.local",
 			SessionAffinity: corev1.ServiceAffinityNone,
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameH2C,
+				Port:       int32(80),
+				TargetPort: intstr.FromInt(80),
+			}},
 		},
 	}, {
 		name:  "ingress-with-only-mesh",
@@ -262,6 +274,11 @@ func TestMakeK8sPlaceholderService(t *testing.T) {
 			Type:            corev1.ServiceTypeExternalName,
 			ExternalName:    "foo-test-route.test-ns.example.com",
 			SessionAffinity: corev1.ServiceAffinityNone,
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameH2C,
+				Port:       int32(80),
+				TargetPort: intstr.FromInt(80),
+			}},
 		},
 		expectedLabels: map[string]string{
 			serving.RouteLabelKey: "test-route",
@@ -275,6 +292,11 @@ func TestMakeK8sPlaceholderService(t *testing.T) {
 			Type:            corev1.ServiceTypeExternalName,
 			ExternalName:    "foo-test-route.test-ns.example.com",
 			SessionAffinity: corev1.ServiceAffinityNone,
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameH2C,
+				Port:       int32(80),
+				TargetPort: intstr.FromInt(80),
+			}},
 		},
 		expectedLabels: map[string]string{
 			serving.RouteLabelKey: "test-route",
@@ -291,6 +313,11 @@ func TestMakeK8sPlaceholderService(t *testing.T) {
 			Type:            corev1.ServiceTypeExternalName,
 			ExternalName:    "foo-test-route.test-ns.svc.cluster.local",
 			SessionAffinity: corev1.ServiceAffinityNone,
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameH2C,
+				Port:       int32(80),
+				TargetPort: intstr.FromInt(80),
+			}},
 		},
 		expectedLabels: map[string]string{
 			serving.RouteLabelKey: "test-route",

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -507,7 +507,8 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-			simpleK8sService(Route("default", "steady-state", WithConfigTarget("config"))),
+			simpleK8sService(Route("default", "steady-state", WithConfigTarget("config")),
+				WithExternalName("private-istio-ingressgateway.istio-system.svc.cluster.local")),
 		},
 		Key: "default/steady-state",
 	}, {

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"knative.dev/networking/pkg/apis/networking"
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
@@ -264,6 +265,11 @@ func WithClusterIP(ip string) K8sServiceOption {
 func WithExternalName(name string) K8sServiceOption {
 	return func(svc *corev1.Service) {
 		svc.Spec.ExternalName = name
+		svc.Spec.Ports = []corev1.ServicePort{{
+			Name:       networking.ServicePortNameH2C,
+			Port:       int32(80),
+			TargetPort: intstr.FromInt(80),
+		}}
 	}
 }
 


### PR DESCRIPTION
While somewhat superfluous in general, this indicates what port(s) the placeholder service expects to route traffic on.  This is just `80` because cluster-locally we don't to auto-TLS.

This also serves the role of specifying the application protocol according to our port naming convention, to enable composition.  We use http/2 because all conformant gateways must support it, and it can be downgraded to http/1, but nothe the other way around.

/hold

/assign @tcnghia 

Nghia, perhaps you could elaborate more on the conversation we had re: port name?