### PR TITLE
Add log message when Serve mode happens

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -120,11 +120,11 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 	//			already scaled to 0).
 	// 2. The excess burst capacity is negative.
 	if want == 0 || decider.Status.ExcessBurstCapacity < 0 || want == scaleUnknown && pa.Status.IsInactive() {
-		logger.Infof("SKS should be in proxy mode: want = %d, ebc = %d, #act's = %d PA Inactive? = %v",
-			want, decider.Status.ExcessBurstCapacity, decider.Status.NumActivators,
-			pa.Status.IsInactive())
 		mode = nv1alpha1.SKSOperationModeProxy
 	}
+	logger.Infof("SKS should be in %s mode: want = %d, ebc = %d, #act's = %d PA Inactive? = %v",
+		mode, want, decider.Status.ExcessBurstCapacity, decider.Status.NumActivators,
+		pa.Status.IsInactive())
 
 	// If we have not successfully reconciled Decider yet, NumActivators will be 0 and
 	// we'll use all activators to back this revision.


### PR DESCRIPTION
Currently only proxy mode prints the following logs, but serve mode does not.

```
SKS should be in proxy mode: want = 1, ebc = -100, #act's = 3 PA Inactive? = false
```

It is difficult to debug "when" and "why" serve mode happens. Hence this patch adds the same
log message when serve mode was assigned.

/lint

**Release Note**

```release-note
NONE
```
