### PR TITLE
Use Unix socket rather than TCP for local probes

### DIFF
--- a/cmd/queue/execprobe.go
+++ b/cmd/queue/execprobe.go
@@ -65,7 +65,7 @@ const (
 // until the HTTP endpoint responds with success. This allows us to get an
 // initial readiness result much faster than the effective upstream Kubernetes
 // minimum of 1 second.
-func standaloneProbeMain(timeout time.Duration) (exitCode int) {
+func standaloneProbeMain(timeout time.Duration, transport http.RoundTripper) (exitCode int) {
 	queueServingPort, err := strconv.ParseUint(os.Getenv(queuePortEnvVar), 10, 16 /*ports are 16 bit*/)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "parse queue port:", err)
@@ -80,7 +80,7 @@ func standaloneProbeMain(timeout time.Duration) (exitCode int) {
 		timeout = readiness.PollTimeout
 	}
 
-	if err := probeQueueHealthPath(timeout, int(queueServingPort)); err != nil {
+	if err := probeQueueHealthPath(timeout, int(queueServingPort), transport); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
@@ -88,8 +88,12 @@ func standaloneProbeMain(timeout time.Duration) (exitCode int) {
 	return 0
 }
 
-func probeQueueHealthPath(timeout time.Duration, queueServingPort int) error {
+func probeQueueHealthPath(timeout time.Duration, queueServingPort int, transport http.RoundTripper) error {
 	url := healthURLPrefix + strconv.Itoa(queueServingPort)
+
+	if transport == nil {
+		transport = &http.Transport{}
+	}
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -101,8 +105,10 @@ func probeQueueHealthPath(timeout time.Duration, queueServingPort int) error {
 	req.Header.Add(network.UserAgentKey, network.QueueProxyUserAgent)
 
 	httpClient := &http.Client{
-		Timeout: timeout,
+		Timeout:   timeout,
+		Transport: transport,
 	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/cmd/queue/execprobe_test.go
+++ b/cmd/queue/execprobe_test.go
@@ -35,14 +35,14 @@ func TestProbeQueueInvalidPort(t *testing.T) {
 	t.Cleanup(func() { os.Unsetenv(queuePortEnvVar) })
 	for _, port := range []string{"-1", "0", "66000"} {
 		os.Setenv(queuePortEnvVar, port)
-		if rv := standaloneProbeMain(1); rv != 1 {
+		if rv := standaloneProbeMain(1, nil); rv != 1 {
 			t.Error("Unexpected return code", rv)
 		}
 	}
 }
 
 func TestProbeQueueConnectionFailure(t *testing.T) {
-	if err := probeQueueHealthPath(1, 12345); err == nil {
+	if err := probeQueueHealthPath(1, 12345, nil); err == nil {
 		t.Error("Expected error, got nil")
 	}
 }
@@ -54,7 +54,7 @@ func TestProbeQueueNotReady(t *testing.T) {
 		w.WriteHeader(http.StatusBadRequest)
 	})
 
-	err := probeQueueHealthPath(time.Second, port)
+	err := probeQueueHealthPath(time.Second, port, nil)
 
 	if err == nil || err.Error() != "probe returned not ready" {
 		t.Error("Unexpected not ready error:", err)
@@ -72,7 +72,7 @@ func TestProbeShuttingDown(t *testing.T) {
 		w.WriteHeader(http.StatusGone)
 	})
 
-	err := probeQueueHealthPath(time.Second, port)
+	err := probeQueueHealthPath(time.Second, port, nil)
 
 	if err == nil || err.Error() != "failed to probe: failing probe deliberately for shutdown" {
 		t.Error("Unexpected error:", err)
@@ -89,7 +89,7 @@ func TestProbeQueueShuttingDownFailsFast(t *testing.T) {
 	})
 
 	start := time.Now()
-	if err := probeQueueHealthPath(1, port); err == nil {
+	if err := probeQueueHealthPath(1, port, nil); err == nil {
 		t.Error("probeQueueHealthPath did not fail")
 	}
 
@@ -109,7 +109,7 @@ func TestProbeQueueReady(t *testing.T) {
 	t.Cleanup(func() { os.Unsetenv(queuePortEnvVar) })
 	os.Setenv(queuePortEnvVar, strconv.Itoa(port))
 
-	if rv := standaloneProbeMain(0 /*use default*/); rv != 0 {
+	if rv := standaloneProbeMain(0 /*use default*/, nil); rv != 0 {
 		t.Error("Unexpected return value from standaloneProbeMain:", rv)
 	}
 
@@ -130,7 +130,7 @@ func TestProbeQueueTimeout(t *testing.T) {
 	os.Setenv(queuePortEnvVar, strconv.Itoa(port))
 
 	const timeout = time.Second
-	if rv := standaloneProbeMain(timeout); rv == 0 {
+	if rv := standaloneProbeMain(timeout, nil); rv == 0 {
 		t.Error("Unexpected return value from standaloneProbeMain:", rv)
 	}
 
@@ -149,7 +149,7 @@ func TestProbeQueueDelayedReady(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	if err := probeQueueHealthPath(readiness.PollTimeout, port); err != nil {
+	if err := probeQueueHealthPath(readiness.PollTimeout, port, nil); err != nil {
 		t.Errorf("probeQueueHealthPath(%d) = %s", port, err)
 	}
 }

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -275,7 +275,7 @@ func main() {
 	}
 
 	errCh := make(chan error, len(servers)+1)
-	listeners := make(map[string]net.Listener)
+	listeners := make(map[string]net.Listener, len(servers))
 	for name, server := range servers {
 		l, err := net.Listen("tcp", server.Addr)
 		if err != nil {
@@ -294,7 +294,7 @@ func main() {
 		}(name, server)
 	}
 
-	// listen on a unix socket so that the exec probe can avoid having to go
+	// Listen on a unix socket so that the exec probe can avoid having to go
 	// through the full tcp network stack.
 	go func() {
 		l, err := net.Listen("unix", unixSocketPath)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -62,6 +62,8 @@ const (
 
 	// reportingPeriod is the interval of time between reporting stats by queue proxy.
 	reportingPeriod = 1 * time.Second
+
+	unixSocketPath = "queue.sock"
 )
 
 var (
@@ -195,7 +197,15 @@ func main() {
 
 	// If this is set, we run as a standalone binary to probe the queue-proxy.
 	if *readinessProbeTimeout >= 0 {
-		os.Exit(standaloneProbeMain(*readinessProbeTimeout))
+		// Use a unix socket rather than TCP to avoid going via entire TCP stack
+		// when we're actually in the same container.
+		transport := &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", unixSocketPath)
+			},
+		}
+
+		os.Exit(standaloneProbeMain(*readinessProbeTimeout, transport))
 	}
 
 	// Parse the environment.
@@ -264,7 +274,7 @@ func main() {
 		servers["profile"] = profiling.NewServer(profiling.NewHandler(logger, true))
 	}
 
-	errCh := make(chan error, len(servers))
+	errCh := make(chan error, len(servers)+1)
 	for name, server := range servers {
 		go func(name string, s *http.Server) {
 			// Don't forward ErrServerClosed as that indicates we're already shutting down.
@@ -273,6 +283,19 @@ func main() {
 			}
 		}(name, server)
 	}
+
+	// listen on a unix socket so that the exec probe can avoid having to go
+	// through the full tcp network stack.
+	go func() {
+		l, err := net.Listen("unix", unixSocketPath)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if err := http.Serve(l, server.Handler); err != nil {
+			errCh <- err
+		}
+	}()
 
 	// Blocks until we actually receive a TERM signal or one of the servers
 	// exit unexpectedly. We fold both signals together because we only want


### PR DESCRIPTION
The QP makes many connections in a 25ms loop on startup (and then throughout the life of the container). Using a unix socket avoids these having to go through the whole network stack.

Benchmarking [simple request via unix socket vs. tcp](https://gist.github.com/julz/78d67c841f10f2fd713ef398cf187157):

~~~~
BenchmarkUnixVsTcpProbe/tcp-serial-16              20767             57306 ns/op            3643 B/op         46 allocs/op
BenchmarkUnixVsTcpProbe/tcp-parallel-16            30310             57608 ns/op            7299 B/op         62 allocs/op
BenchmarkUnixVsTcpProbe/unix-serial-16             29560             41051 ns/op            3639 B/op         46 allocs/op
BenchmarkUnixVsTcpProbe/unix-parallel-16           47365             23413 ns/op            7826 B/op         61 allocs/op
~~~~

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This seems like enough of an improvement to be worth the small amount of extra complexity: wdyt @vagababov @mattmoor ?
