### PR TITLE
Replace obsolete Kubernetes installation guide with upstream's in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -41,12 +41,8 @@ If you're working on and changing `.proto` files:
 
 ### Create a cluster and a repo
 
-1. [Set up a kubernetes cluster](https://www.knative.dev/docs/install/)
-   - Follow an install guide up through "Creating a Kubernetes Cluster"
-   - You do _not_ need to install Istio or Knative using the instructions in the
-     guide. Simply create the cluster and come back here.
-   - If you _did_ install Istio/Knative following those instructions, that's
-     fine too, you'll just redeploy over them, below.
+1. [Set up a kubernetes cluster](https://kubernetes.io/docs/setup/)
+   - Follow the instructions in the Kubernetes doc.
 1. Set up a docker repository for pushing images. You can use any container
    image registry by adjusting the authentication methods and repository paths
    mentioned in the sections below.


### PR DESCRIPTION
The current link and instruction are obsolete. This patch updates the guide.

Fixes https://github.com/knative/serving/issues/8935

**Release Note**

```release-note
NONE
```
/cc @mattmoor 
