### PR TITLE
Add initial PDB for activator.

### DIFF
--- a/config/core/deployments/activator-hpa.yaml
+++ b/config/core/deployments/activator-hpa.yaml
@@ -32,3 +32,20 @@ spec:
         name: cpu
         # Percentage of the requested CPU
         targetAverageUtilization: 100
+
+
+# Activator PDB. Currently we permit unavailability of 20% of tasks at the same time.
+# Given the subsetting and that the activators are partially stateful systems, we want
+# a slow rollout of the new versions and slow migration during node upgrades.
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: activator-pdb
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  maxUnavailable: 20%
+  selector:
+    matchLabels:
+      app: activator

--- a/config/core/deployments/activator-hpa.yaml
+++ b/config/core/deployments/activator-hpa.yaml
@@ -34,6 +34,8 @@ spec:
         targetAverageUtilization: 100
 
 
+---
+
 # Activator PDB. Currently we permit unavailability of 20% of tasks at the same time.
 # Given the subsetting and that the activators are partially stateful systems, we want
 # a slow rollout of the new versions and slow migration during node upgrades.


### PR DESCRIPTION
I went with conservative not more than 20% of tasks out at the same time.
Activators restart on my cluster pretty fast and the state is mostly in
relation to the requests in progress through _this_ activator,
so this should not make the rollout much longer, or disrupt it by a lot
even in the face of subseting.

Obviously once the PDB is in we can tweak it in either direction (as far
as not more than 1 unavailable at a time).

For #9138

/assign @julz mattmoor