### PR TITLE
Make the initial scale tests use configuration directly

### DIFF
--- a/test/e2e/initial_scale_test.go
+++ b/test/e2e/initial_scale_test.go
@@ -24,10 +24,10 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	v1testing "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 	v1test "knative.dev/serving/test/v1"
 )
@@ -40,14 +40,14 @@ func TestInitScaleZero(t *testing.T) {
 
 	clients := Setup(t)
 	names := test.ResourceNames{
-		Service: test.ObjectNameForTest(t),
-		Image:   "helloworld",
+		Config: test.ObjectNameForTest(t),
+		Image:  "helloworld",
 	}
 
 	test.EnsureTearDown(t, clients, &names)
 
-	t.Log("Creating a new Service with initial scale zero and verifying that no pods are created")
-	createAndVerifyInitialScaleService(t, clients, names, 0)
+	t.Log("Creating a new Configuration with initial scale zero and verifying that no pods are created")
+	createAndVerifyInitialScaleConfiguration(t, clients, names, 0)
 }
 
 // TestInitScalePositive tests setting of annotation initialScale to greater than 0 on
@@ -57,42 +57,44 @@ func TestInitScalePositive(t *testing.T) {
 
 	clients := Setup(t)
 	names := test.ResourceNames{
-		Service: test.ObjectNameForTest(t),
-		Image:   "helloworld",
+		Config: test.ObjectNameForTest(t),
+		Image:  "helloworld",
 	}
 	test.EnsureTearDown(t, clients, &names)
 
 	const initialScale = 3
-	t.Logf("Creating a new Service with initialScale %d and verifying that pods are created", initialScale)
-	createAndVerifyInitialScaleService(t, clients, names, initialScale)
+	t.Logf("Creating a new Configuration with initialScale %d and verifying that pods are created", initialScale)
+	createAndVerifyInitialScaleConfiguration(t, clients, names, initialScale)
 
-	t.Logf("Waiting for Service %q to scale back below initialScale", names.Service)
-	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, func(s *v1.Service) (b bool, e error) {
+	t.Logf("Waiting for Configuration %q to scale back below initialScale", names.Config)
+	if err := v1test.WaitForConfigurationState(clients.ServingClient, names.Config, func(s *v1.Configuration) (b bool, e error) {
 		pods := clients.KubeClient.Kube.CoreV1().Pods(test.ServingNamespace)
 		podList, err := pods.List(metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%s", serving.ConfigurationLabelKey, names.Service),
+			LabelSelector: fmt.Sprintf("%s=%s", serving.ConfigurationLabelKey, names.Config),
 			FieldSelector: "status.phase!=Terminating",
 		})
 
 		return len(podList.Items) < initialScale, err
-	}, "ServiceScaledBelowInitial"); err != nil {
-		t.Fatal("Service did not scale back below initialScale:", err)
+	}, "ConfigurationScaledBelowInitial"); err != nil {
+		t.Fatal("Configuration did not scale back below initialScale:", err)
 	}
 }
 
-func createAndVerifyInitialScaleService(t *testing.T, clients *test.Clients, names test.ResourceNames, wantPods int) {
-	t.Log("Creating a new Service.", "service", names.Service)
-	_, err := v1test.CreateService(t, clients, names,
-		v1testing.WithConfigAnnotations(map[string]string{
-			autoscaling.InitialScaleAnnotationKey: strconv.Itoa(wantPods),
-		}))
+func createAndVerifyInitialScaleConfiguration(t *testing.T, clients *test.Clients, names test.ResourceNames, wantPods int) {
+	t.Log("Creating a new Configuration.", "configuration", names.Config)
+	_, err := v1test.CreateConfiguration(t, clients, names, func(configuration *v1.Configuration) {
+		configuration.Spec.Template.Annotations = kmeta.UnionMaps(
+			configuration.Spec.Template.Annotations, map[string]string{
+				autoscaling.InitialScaleAnnotationKey: strconv.Itoa(wantPods),
+			})
+	})
 	if err != nil {
-		t.Fatal("Failed creating initial service:", err)
+		t.Fatal("Failed creating initial configuration:", err)
 	}
 
-	t.Logf("Waiting for Service %q to transition to Ready with %d number of pods.", names.Service, wantPods)
-	selector := fmt.Sprintf("%s=%s", serving.ConfigurationLabelKey, names.Service)
-	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, func(s *v1.Service) (b bool, e error) {
+	t.Logf("Waiting for Configuration %q to transition to Ready with %d number of pods.", names.Config, wantPods)
+	selector := fmt.Sprintf("%s=%s", serving.ConfigurationLabelKey, names.Config)
+	if err := v1test.WaitForConfigurationState(clients.ServingClient, names.Config, func(s *v1.Configuration) (b bool, e error) {
 		pods := clients.KubeClient.Kube.CoreV1().Pods(test.ServingNamespace)
 		podList, err := pods.List(metav1.ListOptions{
 			LabelSelector: selector,
@@ -111,7 +113,7 @@ func createAndVerifyInitialScaleService(t *testing.T, clients *test.Clients, nam
 			return false, fmt.Errorf("expected %d pods created, got %d", wantPods, gotPods)
 		}
 		return false, nil
-	}, "ServiceIsReadyWithWantPods"); err != nil {
-		t.Fatal("Service does not have the desired number of pods running:", err)
+	}, "ConfigurationIsReadyWithWantPods"); err != nil {
+		t.Fatal("Configuration does not have the desired number of pods running:", err)
 	}
 }


### PR DESCRIPTION
This is a property of Revision, so just create a Configuration that stamps our a Revision.