### PR TITLE
Refactor the scale test to use t.Run subtests

### DIFF
--- a/test/clients.go
+++ b/test/clients.go
@@ -209,9 +209,11 @@ func (clients *ServingClients) Delete(routes, configs, services []string) []erro
 		}
 		items []string
 	}{
+		// Delete services first, since we otherwise might delete a route/configuration
+		// out from under the ksvc
+		{clients.Services, services},
 		{clients.Routes, routes},
 		{clients.Configs, configs},
-		{clients.Services, services},
 	}
 
 	propPolicy := v1.DeletePropagationForeground

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -119,7 +119,10 @@ kubectl patch cm "config-gc" -n ${SYSTEM_NAMESPACE} -p ${GC_CONFIG}
 toggle_feature responsive-revision-gc Disabled
 
 # Run scale tests.
-go_test_e2e -timeout=10m ${parallelism} ./test/scale || failed=1
+# Note that we use a very high -parallel because each ksvc is run as its own
+# sub-test.  If this is not larger than the maximum scale tested then the test
+# simply cannot pass.
+go_test_e2e -timeout=10m -parallel=200 ./test/scale || failed=1
 
 # Istio E2E tests mutate the cluster and must be ran separately
 if [[ -n "${ISTIO_VERSION}" ]]; then


### PR DESCRIPTION
With this, the failure logs will be constrained to just the failing ksvc.
This also bumps the SLO to 100%, since things should have improved dramatically
since this was last adjusted.

/hold

cc @tcnghia @vagababov @markusthoemmes 