### PR TITLE
Create unix domain socket file in temp directory

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -63,7 +63,7 @@ const (
 	// reportingPeriod is the interval of time between reporting stats by queue proxy.
 	reportingPeriod = 1 * time.Second
 
-	unixSocketPath = "queue.sock"
+	unixSocketPath = "/queue.sock"
 )
 
 var (
@@ -201,7 +201,7 @@ func main() {
 		// when we're actually in the same container.
 		transport := &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", unixSocketPath)
+				return net.Dial("unix", os.TempDir()+unixSocketPath)
 			},
 		}
 
@@ -297,7 +297,7 @@ func main() {
 	// Listen on a unix socket so that the exec probe can avoid having to go
 	// through the full tcp network stack.
 	go func() {
-		l, err := net.Listen("unix", unixSocketPath)
+		l, err := net.Listen("unix", os.TempDir()+unixSocketPath)
 		if err != nil {
 			errCh <- err
 			return


### PR DESCRIPTION
Currently queue-proxy creates unix domain socket file in the "current"
directory, where is /ko-app/ in upstream.

It works when root user runs queue-proxy or when the directory has
runtime user's permission. In other words, `/ko-app/` dir must have
runtime user's permission when nonroot users run queue-proxy.

It is a pain that the directory permission must be cared.

To solve the permission problem, this patch changes to create the
socket file under temp directory.

/lint

/cc @julz @mattmoor @vagababov 

**Release Note**

```release-note
NONE
```
