### PR TITLE
Make the liveness check failureThreshold higher than the readiness check.

### DIFF
--- a/config/core/deployments/activator.yaml
+++ b/config/core/deployments/activator.yaml
@@ -87,14 +87,21 @@ spec:
         - name: h2c
           containerPort: 8013
 
-        readinessProbe: &probe
+        readinessProbe:
           httpGet:
             port: 8012
             httpHeaders:
             - name: k-kubelet-probe
               value: "activator"
           failureThreshold: 12
-        livenessProbe: *probe
+        livenessProbe:
+          httpGet:
+            port: 8012
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "activator"
+          failureThreshold: 12
+          initialDelaySeconds: 15
 
       # The activator (often) sits on the dataplane, and may proxy long (e.g.
       # streaming, websockets) requests.  We give a long grace period for the

--- a/config/core/deployments/autoscaler.yaml
+++ b/config/core/deployments/autoscaler.yaml
@@ -82,13 +82,19 @@ spec:
         - name: websocket
           containerPort: 8080
 
-        readinessProbe: &probe
+        readinessProbe:
           httpGet:
             port: 8080
             httpHeaders:
             - name: k-kubelet-probe
               value: "autoscaler"
-        livenessProbe: *probe
+        livenessProbe:
+          httpGet:
+            port: 8080
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "autoscaler"
+          failureThreshold: 6
 
 ---
 apiVersion: v1

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -86,7 +86,7 @@ spec:
         - name: https-webhook
           containerPort: 8443
 
-        readinessProbe: &probe
+        readinessProbe:
           periodSeconds: 1
           httpGet:
             scheme: HTTPS
@@ -94,7 +94,15 @@ spec:
             httpHeaders:
             - name: k-kubelet-probe
               value: "webhook"
-        livenessProbe: *probe
+        livenessProbe:
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "webhook"
+          failureThreshold: 6
 
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
       # high value that we respect whatever value it has configured for the lame duck grace period.

--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -38,10 +38,13 @@ spec:
         ports:
         - name: http
           containerPort: 8080
-        readinessProbe: &probe
+        readinessProbe:
           httpGet:
             port: 8080
-        livenessProbe: *probe
+        livenessProbe:
+          httpGet:
+            port: 8080
+          failureThreshold: 6
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #9077 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
Make the liveness check failureThreshold higher than the readiness check:
* If the 2 checks were using the default failureThreshold value (3 times), double the one for liveness.
* For Activator, since we already waited for 12 times, only add 15 initialDelaySeconds here for liveness.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```
NONE
```
@taragu Hi Tara, I followed the guideline and created such a PR, hope this meets the requirements. Please let me know if there is anything I can improve and if the changes look good. Thanks!

/assign @taragu 