### PR TITLE
Remove unnecessary TODO in throttler.

### DIFF
--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -278,9 +278,7 @@ func (rt *revisionThrottler) updateCapacity(backendCount int) {
 		assigned := rt.podTrackers
 		if rt.containerConcurrency != 0 {
 			rt.resetTrackers()
-			// TODO(vagababov): pull assign slice into RT.
-			assigned = assignSlice(rt.podTrackers,
-				ai, ac, rt.containerConcurrency)
+			assigned = assignSlice(rt.podTrackers, ai, ac, rt.containerConcurrency)
 		}
 		rt.logger.Debugf("Trackers %d/%d:  %v", ai, ac, rt.assignedTrackers)
 		// The actual write out of the assigned trackers has to be under lock.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

I looked at fixing this TODO but leaving it as-is is actually better for encapsulation and testability imo so I just removed the comment.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 