### PR TITLE
Remove prometheus stat parsing from the autoscaler.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a
 	github.com/prometheus/client_golang v1.6.0
 	github.com/prometheus/client_model v0.2.0
-	github.com/prometheus/common v0.9.1
 	github.com/tsenart/vegeta v12.7.1-0.20190725001342-b5f4fca92137+incompatible
 	go.opencensus.io v0.22.4
 	go.uber.org/atomic v1.6.0

--- a/pkg/autoscaler/metrics/http_scrape_client_test.go
+++ b/pkg/autoscaler/metrics/http_scrape_client_test.go
@@ -40,28 +40,6 @@ const (
 
 var (
 	testURL = "http://test-revision-zhudex.test-namespace:9090/metrics"
-	// TODO: Use Prometheus lib to generate the following text instead of using text format directly.
-	testAverageConcurrencyContext = fmt.Sprintf(`# HELP queue_average_concurrent_requests Number of requests currently being handled by this pod
-# TYPE queue_average_concurrent_requests gauge
-queue_average_concurrent_requests{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} %f
-`, queueAverageConcurrentRequests)
-	testQPSContext = fmt.Sprintf(`# HELP queue_requests_per_second Number of requests received since last Stat
-# TYPE queue_requests_per_second gauge
-queue_requests_per_second{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} %d
-`, queueRequestsPerSecond)
-	testAverageProxiedConcurrenyContext = fmt.Sprintf(`# HELP queue_average_proxied_concurrent_requests Number of proxied requests currently being handled by this pod
-# TYPE queue_average_proxied_concurrent_requests gauge
-queue_average_proxied_concurrent_requests{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} %f
-`, queueAverageProxiedConcurrentRequests)
-	testProxiedQPSContext = fmt.Sprintf(`# HELP queue_proxied_operations_per_second Number of proxied requests received since last Stat
-# TYPE queue_proxied_operations_per_second gauge
-queue_proxied_operations_per_second{destination_namespace="test-namespace",destination_revision="test-revision",destination_pod="test-revision-1234"} %d
-`, queueProxiedOperationsPerSecond)
-	testUptimeContext = fmt.Sprintf(`# HELP process_uptime The number of seconds that the process has been up
-# TYPE process_uptime gauge
-process_uptime{destination_configuration="s1",destination_namespace="default",destination_pod="s1-tdgpn-deployment-86f6459cf8-mc9mw",destination_revision="s1-tdgpn"} %f
-`, processUptime)
-	testFullContext = testAverageConcurrencyContext + testQPSContext + testAverageProxiedConcurrenyContext + testProxiedQPSContext + testUptimeContext
 
 	stat = Stat{
 		PodName:                          podName,
@@ -99,82 +77,17 @@ func TestNewHTTPScrapeClientErrorCases(t *testing.T) {
 }
 
 func TestHTTPScrapeClientScrapeHappyCaseWithOptionals(t *testing.T) {
-	for _, hClient := range []*http.Client{
-		newTestHTTPClient(makeResponse(http.StatusOK, testFullContext), nil),
-		newTestHTTPClient(makeProtoResponse(http.StatusOK, stat, network.ProtoAcceptContent), nil),
-	} {
-		sClient, err := newHTTPScrapeClient(hClient)
-		if err != nil {
-			t.Fatalf("newHTTPScrapeClient = %v, want no error", err)
-		}
-		got, err := sClient.Scrape(testURL)
-		if err != nil {
-			t.Fatalf("Scrape = %v, want no error", err)
-		}
-		if !cmp.Equal(got, stat) {
-			t.Errorf("Scraped stat mismatch; diff(-want,+got):\n%s", cmp.Diff(stat, got))
-		}
+	hClient := newTestHTTPClient(makeProtoResponse(http.StatusOK, stat, network.ProtoAcceptContent), nil)
+	sClient, err := newHTTPScrapeClient(hClient)
+	if err != nil {
+		t.Fatalf("newHTTPScrapeClient = %v, want no error", err)
 	}
-}
-
-func TestHTTPScrapeClientScrapeErrorCases(t *testing.T) {
-	testCases := []struct {
-		name            string
-		responseCode    int
-		responseErr     error
-		responseContext string
-		expectedErr     string
-	}{{
-		name:         "Non 200 return code",
-		responseCode: http.StatusForbidden,
-		expectedErr:  fmt.Sprintf(`GET request for URL %q returned HTTP status 403`, testURL),
-	}, {
-		name:         "Error got when sending request",
-		responseCode: http.StatusOK,
-		responseErr:  errors.New("upstream closed"),
-		expectedErr:  "upstream closed",
-	}, {
-		name:            "Bad response context format",
-		responseCode:    http.StatusOK,
-		responseContext: "bad context",
-		expectedErr:     "reading text format failed: text format parsing error in line 1: unexpected end of input stream",
-	}, {
-		name:            "Missing average concurrency",
-		responseCode:    http.StatusOK,
-		responseContext: testQPSContext + testAverageProxiedConcurrenyContext + testProxiedQPSContext,
-		expectedErr:     "could not find value for queue_average_concurrent_requests in response",
-	}, {
-		name:            "Missing QPS",
-		responseCode:    http.StatusOK,
-		responseContext: testAverageConcurrencyContext + testAverageProxiedConcurrenyContext + testProxiedQPSContext,
-		expectedErr:     "could not find value for queue_requests_per_second in response",
-	}, {
-		name:            "Missing average proxied concurrency",
-		responseCode:    http.StatusOK,
-		responseContext: testAverageConcurrencyContext + testQPSContext + testProxiedQPSContext,
-		expectedErr:     "could not find value for queue_average_proxied_concurrent_requests in response",
-	}, {
-		name:            "Missing proxied QPS",
-		responseCode:    http.StatusOK,
-		responseContext: testAverageConcurrencyContext + testQPSContext + testAverageProxiedConcurrenyContext,
-		expectedErr:     "could not find value for queue_proxied_operations_per_second in response",
-	}}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			hClient := newTestHTTPClient(makeResponse(test.responseCode, test.responseContext), test.responseErr)
-			sClient, err := newHTTPScrapeClient(hClient)
-			if err != nil {
-				t.Errorf("newHTTPScrapeClient=%v, want no error", err)
-			}
-			if _, err := sClient.Scrape(testURL); err != nil {
-				if !strings.Contains(err.Error(), test.expectedErr) {
-					t.Errorf("Got error message: %q, want to contain: %q", err.Error(), test.expectedErr)
-				}
-			} else {
-				t.Error("Expected error from newServiceScraperWithClient, got nil")
-			}
-		})
+	got, err := sClient.Scrape(testURL)
+	if err != nil {
+		t.Fatalf("Scrape = %v, want no error", err)
+	}
+	if !cmp.Equal(got, stat) {
+		t.Errorf("Scraped stat mismatch; diff(-want,+got):\n%s", cmp.Diff(stat, got))
 	}
 }
 
@@ -182,6 +95,7 @@ func TestHTTPScrapeClientScrapeProtoErrorCases(t *testing.T) {
 	testCases := []struct {
 		name         string
 		responseCode int
+		responseType string
 		responseErr  error
 		stat         Stat
 		expectedErr  string
@@ -194,11 +108,16 @@ func TestHTTPScrapeClientScrapeProtoErrorCases(t *testing.T) {
 		responseCode: http.StatusOK,
 		responseErr:  errors.New("upstream closed"),
 		expectedErr:  "upstream closed",
+	}, {
+		name:         "Wrong Content-Type",
+		responseCode: http.StatusOK,
+		responseType: "text/html",
+		expectedErr:  errUnsupportedMetricType.Error(),
 	}}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			hClient := newTestHTTPClient(makeProtoResponse(test.responseCode, test.stat, network.ProtoAcceptContent), test.responseErr)
+			hClient := newTestHTTPClient(makeProtoResponse(test.responseCode, test.stat, test.responseType), test.responseErr)
 			sClient, err := newHTTPScrapeClient(hClient)
 			if err != nil {
 				t.Fatalf("newHTTPScrapeClient=%v, want no error", err)
@@ -211,13 +130,6 @@ func TestHTTPScrapeClientScrapeProtoErrorCases(t *testing.T) {
 				t.Errorf("Error = %q, want to contain: %q", err.Error(), test.expectedErr)
 			}
 		})
-	}
-}
-
-func makeResponse(statusCode int, context string) *http.Response {
-	return &http.Response{
-		StatusCode: statusCode,
-		Body:       ioutil.NopCloser(bytes.NewBufferString(context)),
 	}
 }
 
@@ -262,21 +174,19 @@ func BenchmarkUnmarshallingProtoData(b *testing.B) {
 	benchmarks := []struct {
 		name    string
 		podName string
-	}{
-		{
-			name:    "BenchmarkStatWithEmptyPodName",
-			podName: "",
-		}, {
-			name:    "BenchmarkStatWithSmallPodName",
-			podName: "a-lzrjc-deployment-85d4b7d859-gspjs",
-		}, {
-			name:    "BenchmarkStatWithMediumPodName",
-			podName: "a-lzrjc-deployment-85d4b7d859-gspjs" + strings.Repeat("p", 50),
-		}, {
-			name:    "BenchmarkStatWithLargePodName",
-			podName: strings.Repeat("p", 253),
-		},
-	}
+	}{{
+		name:    "BenchmarkStatWithEmptyPodName",
+		podName: "",
+	}, {
+		name:    "BenchmarkStatWithSmallPodName",
+		podName: "a-lzrjc-deployment-85d4b7d859-gspjs",
+	}, {
+		name:    "BenchmarkStatWithMediumPodName",
+		podName: "a-lzrjc-deployment-85d4b7d859-gspjs" + strings.Repeat("p", 50),
+	}, {
+		name:    "BenchmarkStatWithLargePodName",
+		podName: strings.Repeat("p", 253),
+	}}
 	for _, bm := range benchmarks {
 		stat.PodName = bm.podName
 		bodyBytes, err := stat.Marshal()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -279,7 +279,6 @@ github.com/prometheus/client_golang/prometheus/promhttp
 ## explicit
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.9.1
-## explicit
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/common/log


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

We shipped a version that contains protobuf based metric reporting now so we can safely remove the ability to parse prometheus based metrics in the autoscaler.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @skonto @vagababov @julz 
