### PR TITLE
Remove JSON tag of DeprecatedGeneration in v1alpha1.Route.

### DIFF
--- a/pkg/apis/serving/v1alpha1/route_types.go
+++ b/pkg/apis/serving/v1alpha1/route_types.go
@@ -89,7 +89,7 @@ type RouteSpec struct {
 	// Tracking issue: https://github.com/knative/serving/issues/643
 	//
 	// +optional
-	DeprecatedGeneration int64 `json:"generation,omitempty"`
+	DeprecatedGeneration int64
 
 	// Traffic specifies how to distribute traffic over a collection of Knative Serving Revisions and Configurations.
 	// +optional


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #9216 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

`go vet` barks at this and we're fairly sure this is safe to drop as v1alpha1 isn't used as a storage version anymore anyway and newer API versions do not have this field at all anymore. Nothing in our code keys off of it either, so this is the least invasive change to make go vet happy without breaking the golang struct.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor 
