### PR TITLE
Don't mark ScaleTargetInitialized if ServiceName not populated

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -243,10 +243,8 @@ func computeActiveCondition(ctx context.Context, pa *pav1alpha1.PodAutoscaler, p
 	// In this case we'll be in the NoTraffic/inactive state.
 	// TODO(taragu): remove after 0.19
 	alreadyScaledDownSuccessfully := minReady > 0 && pa.Status.GetCondition(pav1alpha1.PodAutoscalerConditionActive).Reason == noTrafficReason
-	if pc.ready >= minReady || alreadyScaledDownSuccessfully {
-		if pa.Status.ServiceName != "" {
-			pa.Status.MarkScaleTargetInitialized()
-		}
+	if (pc.ready >= minReady || alreadyScaledDownSuccessfully) && pa.Status.ServiceName != "" {
+		pa.Status.MarkScaleTargetInitialized()
 	}
 
 	switch {

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -244,7 +244,9 @@ func computeActiveCondition(ctx context.Context, pa *pav1alpha1.PodAutoscaler, p
 	// TODO(taragu): remove after 0.19
 	alreadyScaledDownSuccessfully := minReady > 0 && pa.Status.GetCondition(pav1alpha1.PodAutoscalerConditionActive).Reason == noTrafficReason
 	if pc.ready >= minReady || alreadyScaledDownSuccessfully {
-		pa.Status.MarkScaleTargetInitialized()
+		if pa.Status.ServiceName != "" {
+			pa.Status.MarkScaleTargetInitialized()
+		}
 	}
 
 	switch {

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1077,9 +1077,7 @@ func TestReconcile(t *testing.T) {
 			kpa(testNamespace, testRevision, withScales(0, -1), WithReachabilityReachable,
 				WithPAMetricsService(privateSvc), WithPASKSNotReady(noPrivateServiceName)),
 			// SKS won't be ready bc no ready endpoints, but private service name will be populated.
-			sks(testNamespace, testRevision, WithDeployRef(deployName), WithPrivateService, func(sks *nv1a1.ServerlessService) {
-				sks.Status.ServiceName = ""
-			}),
+			sks(testNamespace, testRevision, WithDeployRef(deployName), WithPrivateService),
 			metric(testNamespace, testRevision),
 			deploy(testNamespace, testRevision, func(d *appsv1.Deployment) {
 				d.Spec.Replicas = ptr.Int32(0)

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1048,9 +1048,7 @@ func TestReconcile(t *testing.T) {
 			kpa(testNamespace, testRevision, withScales(0, -1), WithReachabilityReachable,
 				WithPAMetricsService(privateSvc), WithPASKSNotReady(noPrivateServiceName)),
 			// SKS won't be ready bc no ready endpoints, but private service name will be populated.
-			sks(testNamespace, testRevision, WithDeployRef(deployName), WithPrivateService, func(sks *nv1a1.ServerlessService) {
-				sks.Status.ServiceName = testRevision
-			}),
+			sks(testNamespace, testRevision, WithDeployRef(deployName), WithPrivateService, WithPubService),
 			metric(testNamespace, testRevision),
 			deploy(testNamespace, testRevision, func(d *appsv1.Deployment) {
 				d.Spec.Replicas = ptr.Int32(0)
@@ -1061,10 +1059,7 @@ func TestReconcile(t *testing.T) {
 				WithNoTraffic(noTrafficReason, "The target is not receiving traffic."),
 				withScales(0, -1), WithReachabilityReachable,
 				WithPAMetricsService(privateSvc), WithObservedGeneration(1),
-				WithPASKSNotReady(""),
-				func(pa *asv1a1.PodAutoscaler) {
-					pa.Status.ServiceName = testRevision
-				},
+				WithPASKSNotReady(""), WithPAStatusService(testRevision),
 			),
 		}},
 	}, {


### PR DESCRIPTION
I was able to reproduce the problem in the issue, and there was a brief moment 
of RoutesReady=true in between `TrafficNotMigrated` and `IngressNotConfigured`:
```
$ kubectl get ksvc -ocustom-columns=:.status.conditions -w

(after updating ksvc to init scale 0)
[map[lastTransitionTime:2020-08-03T11:24:36Z message:The Configuration is still working to reflect the latest desired specification. reason:OutOfDate status:Unknown type:ConfigurationsReady] map[lastTransitionTime:2020-08-03T11:24:36Z message:The Configuration is still working to reflect the latest desired specification. reason:OutOfDate status:Unknown type:Ready] map[lastTransitionTime:2020-08-03T11:24:18Z status:True type:RoutesReady]]
[map[lastTransitionTime:2020-08-03T11:24:36Z status:Unknown type:ConfigurationsReady] map[lastTransitionTime:2020-08-03T11:24:36Z status:Unknown type:Ready] map[lastTransitionTime:2020-08-03T11:24:18Z status:True type:RoutesReady]]
[map[lastTransitionTime:2020-08-03T11:24:36Z status:Unknown type:ConfigurationsReady] map[lastTransitionTime:2020-08-03T11:24:36Z message:Ingress reconciliation failed reason:ReconcileIngressFailed status:False type:Ready] map[lastTransitionTime:2020-08-03T11:24:36Z message:Ingress reconciliation failed reason:ReconcileIngressFailed status:False type:RoutesReady]]
[map[lastTransitionTime:2020-08-03T11:24:36Z status:Unknown type:ConfigurationsReady] map[lastTransitionTime:2020-08-03T11:24:36Z status:Unknown type:Ready] map[lastTransitionTime:2020-08-03T11:24:36Z status:True type:RoutesReady]]
[map[lastTransitionTime:2020-08-03T11:24:36Z status:True type:ConfigurationsReady] map[lastTransitionTime:2020-08-03T11:24:36Z message:Traffic is not yet migrated to the latest revision. reason:TrafficNotMigrated status:Unknown type:Ready] map[lastTransitionTime:2020-08-03T11:24:36Z message:Traffic is not yet migrated to the latest revision. reason:TrafficNotMigrated status:Unknown type:RoutesReady]]
-----> [map[type:ConfigurationsReady lastTransitionTime:2020-08-03T11:24:36Z status:True] map[lastTransitionTime:2020-08-03T11:24:37Z status:True type:Ready] map[lastTransitionTime:2020-08-03T11:24:37Z status:True type:RoutesReady]]
[map[lastTransitionTime:2020-08-03T11:24:36Z status:True type:ConfigurationsReady] map[reason:IngressNotConfigured status:Unknown type:Ready lastTransitionTime:2020-08-03T11:24:37Z message:Ingress has not yet been reconciled.] map[type:RoutesReady lastTransitionTime:2020-08-03T11:24:37Z message:Ingress has not yet been reconciled. reason:IngressNotConfigured status:Unknown]]
[map[type:ConfigurationsReady lastTransitionTime:2020-08-03T11:24:36Z status:True] map[status:Unknown type:Ready lastTransitionTime:2020-08-03T11:24:37Z message:Waiting for load balancer to be ready reason:Uninitialized] map[type:RoutesReady lastTransitionTime:2020-08-03T11:24:37Z message:Waiting for load balancer to be ready reason:Uninitialized status:Unknown]]
[map[lastTransitionTime:2020-08-03T11:24:36Z status:True type:ConfigurationsReady] map[lastTransitionTime:2020-08-03T11:24:37Z status:True type:Ready] map[type:RoutesReady lastTransitionTime:2020-08-03T11:24:37Z status:True]]
```

When I looked at the logs, I saw this error produced by trying to update the ingress: 
```
failed to update Ingress: admission webhook "validation.webhook.serving.knative.dev" denied the request: validation failed: missing field(s): spec.rules[0].http.paths[0].splits[0].serviceName, spec.rules[1].http.paths[0].splits[0].serviceName
```
This error is thrown here https://github.com/knative/serving/blob/4c2ae6597b07c8ac05a9731e647d60164940a95e/pkg/reconciler/route/route.go#L144 , right before we mark ingress not configured, so in the case of init scale 0, we are not marking ingress not configured successfully when serviceName is empty, and therefore we have a brief moment of RoutesReady=True between RoutesReady unknown due to traffic not migrated, and ingress not configured. 

The serviceName field originates from SKS. We first propagate `sks.Status.ServiceName` to PA, then PA to revision, and we finally add it to `RevisionTarget` while configuring traffic, which will be used in building ingress.

The fix proposed in this PR is to not mark `ScaleTargetInitialized` if the SKS ServiceName is not populated, which happens when SKS is first created. So that we don't mark the revision and therefore ksvc ready early.

Fixes #8971

/cc @julz @vagababov @markusthoemmes 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
