### PR TITLE
validateDomains should check (not wait) for the expected text.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,8 +32,8 @@ require (
 	k8s.io/code-generator v0.18.6
 	k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29
 	knative.dev/caching v0.0.0-20200831164016-8993b9e0e6f6
-	knative.dev/networking v0.0.0-20200831163108-0195c961813b
-	knative.dev/pkg v0.0.0-20200831232415-383dd08a323b
+	knative.dev/networking v0.0.0-20200901153316-80398434dcd4
+	knative.dev/pkg v0.0.0-20200901172015-edd1b5e0bebf
 	knative.dev/test-infra v0.0.0-20200831235415-fac473dda98b
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1801,8 +1801,8 @@ knative.dev/caching v0.0.0-20200831164016-8993b9e0e6f6 h1:tS93pEA8jCt8onqnXE3LoE
 knative.dev/caching v0.0.0-20200831164016-8993b9e0e6f6/go.mod h1:5V2/0AagUm0RX4CsCDOY9FwLRnnF2c5IaaA+kqXbqAc=
 knative.dev/eventing-contrib v0.6.1-0.20190723221543-5ce18048c08b/go.mod h1:SnXZgSGgMSMLNFTwTnpaOH7hXDzTFtw0J8OmHflNx3g=
 knative.dev/eventing-contrib v0.11.2/go.mod h1:SnXZgSGgMSMLNFTwTnpaOH7hXDzTFtw0J8OmHflNx3g=
-knative.dev/networking v0.0.0-20200831163108-0195c961813b h1:RDQ+NOiTmSNOukmq57Y5CGAq6NJgamCXVf9FJsltJbc=
-knative.dev/networking v0.0.0-20200831163108-0195c961813b/go.mod h1:9ZMxo5uevxp5T+e7djbo+jH4KXK6Lja9rPS0u86+GHw=
+knative.dev/networking v0.0.0-20200901153316-80398434dcd4 h1:hdZOOdXg94MiBVZWJdgjO/JKoiC8kIdoMI9ChHv/sQc=
+knative.dev/networking v0.0.0-20200901153316-80398434dcd4/go.mod h1:9ZMxo5uevxp5T+e7djbo+jH4KXK6Lja9rPS0u86+GHw=
 knative.dev/pkg v0.0.0-20191101194912-56c2594e4f11/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
 knative.dev/pkg v0.0.0-20191111150521-6d806b998379/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
 knative.dev/pkg v0.0.0-20200207155214-fef852970f43/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
@@ -1813,8 +1813,8 @@ knative.dev/pkg v0.0.0-20200528142800-1c6815d7e4c9/go.mod h1:QgNZTxnwpB/oSpNcfnL
 knative.dev/pkg v0.0.0-20200711004937-22502028e31a/go.mod h1:AqAJV6rYi8IGikDjJ/9ZQd9qKdkXVlesVnVjwx62YB8=
 knative.dev/pkg v0.0.0-20200831094608-e9da10bc8a18 h1:BJTbbN0/J0BY76tzHE6/oko4lw6GEeahMrZUfigySyc=
 knative.dev/pkg v0.0.0-20200831094608-e9da10bc8a18/go.mod h1:vOVUMtkIWK+hq1+KwlLYBSYVjz5SNIP1vMj3/5SNGZw=
-knative.dev/pkg v0.0.0-20200831232415-383dd08a323b h1:EQv7fCQggjWO/kPc9OMOn4tHHhB12UfEpHkY+kSPasU=
-knative.dev/pkg v0.0.0-20200831232415-383dd08a323b/go.mod h1:q+4+Cm768P6vsAvsD9J+cZ1hoy4aHyHSfRTvaFyPd3g=
+knative.dev/pkg v0.0.0-20200901172015-edd1b5e0bebf h1:4sLAMPCGqJVocPMIGNwrh1NYsTbmefvWudnOKl5UZLo=
+knative.dev/pkg v0.0.0-20200901172015-edd1b5e0bebf/go.mod h1:q+4+Cm768P6vsAvsD9J+cZ1hoy4aHyHSfRTvaFyPd3g=
 knative.dev/test-infra v0.0.0-20200407185800-1b88cb3b45a5/go.mod h1:xcdUkMJrLlBswIZqL5zCuBFOC22WIPMQoVX1L35i0vQ=
 knative.dev/test-infra v0.0.0-20200505052144-5ea2f705bb55/go.mod h1:WqF1Azka+FxPZ20keR2zCNtiQA1MP9ZB4BH4HuI+SIU=
 knative.dev/test-infra v0.0.0-20200513011557-d03429a76034/go.mod h1:aMif0KXL4g19YCYwsy4Ocjjz5xgPlseYV+B95Oo4JGE=

--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -33,7 +33,7 @@ import (
 	v1test "knative.dev/serving/test/v1"
 )
 
-func waitForExpectedResponse(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, expectedResponse string) error {
+func checkForExpectedResponses(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, expectedResponses ...string) error {
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
 	if err != nil {
 		return err
@@ -42,7 +42,7 @@ func waitForExpectedResponse(t pkgTest.TLegacy, clients *test.Clients, url *url.
 	if err != nil {
 		return err
 	}
-	_, err = client.Poll(req, v1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedResponse))))
+	_, err = client.Poll(req, v1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesAllBodies(expectedResponses...))))
 	return err
 }
 
@@ -59,19 +59,15 @@ func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.U
 	// We don't have a good way to check if the route is updated so we will wait until a subdomain has
 	// started returning at least one expected result to key that we should validate percentage splits.
 	// In order for tests to succeed reliably, we need to make sure that all domains succeed.
-	for _, resp := range baseExpected {
-		// Check for each of the responses we expect from the base domain.
-		resp := resp
-		g.Go(func() error {
-			t.Log("Waiting for route to update", baseDomain)
-			return waitForExpectedResponse(t, clients, baseDomain, resp)
-		})
-	}
+	g.Go(func() error {
+		t.Log("Checking updated route", baseDomain)
+		return checkForExpectedResponses(t, clients, baseDomain, baseExpected...)
+	})
 	for i, s := range subdomains {
 		i, s := i, s
 		g.Go(func() error {
-			t.Log("Waiting for route to update", s)
-			return waitForExpectedResponse(t, clients, s, targetsExpected[i])
+			t.Log("Checking updated route tags", s)
+			return checkForExpectedResponses(t, clients, s, targetsExpected[i])
 		})
 	}
 	if err := g.Wait(); err != nil {

--- a/test/conformance/api/v1beta1/util.go
+++ b/test/conformance/api/v1beta1/util.go
@@ -33,7 +33,7 @@ import (
 	v1b1test "knative.dev/serving/test/v1beta1"
 )
 
-func waitForExpectedResponse(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, expectedResponse string) error {
+func checkForExpectedResponses(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, expectedResponses ...string) error {
 	client, err := pkgTest.NewSpoofingClient(clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(t.Logf, clients, test.ServingFlags.Https))
 	if err != nil {
 		return err
@@ -42,7 +42,7 @@ func waitForExpectedResponse(t pkgTest.TLegacy, clients *test.Clients, url *url.
 	if err != nil {
 		return err
 	}
-	_, err = client.Poll(req, v1b1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedResponse))))
+	_, err = client.Poll(req, v1b1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesAllBodies(expectedResponses...))))
 	return err
 }
 
@@ -59,19 +59,15 @@ func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.U
 	// We don't have a good way to check if the route is updated so we will wait until a subdomain has
 	// started returning at least one expected result to key that we should validate percentage splits.
 	// In order for tests to succeed reliably, we need to make sure that all domains succeed.
-	for _, resp := range baseExpected {
-		// Check for each of the responses we expect from the base domain.
-		resp := resp
-		g.Go(func() error {
-			t.Log("Waiting for route to update", baseDomain)
-			return waitForExpectedResponse(t, clients, baseDomain, resp)
-		})
-	}
+	g.Go(func() error {
+		t.Log("Checking updated route", baseDomain)
+		return checkForExpectedResponses(t, clients, baseDomain, baseExpected...)
+	})
 	for i, s := range subdomains {
 		i, s := i, s
 		g.Go(func() error {
-			t.Log("Waiting for route to update", s)
-			return waitForExpectedResponse(t, clients, s, targetsExpected[i])
+			t.Log("Checking updated route tags", s)
+			return checkForExpectedResponses(t, clients, s, targetsExpected[i])
 		})
 	}
 	if err := g.Wait(); err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1061,7 +1061,7 @@ knative.dev/caching/pkg/client/injection/informers/caching/v1alpha1/image/fake
 knative.dev/caching/pkg/client/injection/informers/factory
 knative.dev/caching/pkg/client/injection/informers/factory/fake
 knative.dev/caching/pkg/client/listers/caching/v1alpha1
-# knative.dev/networking v0.0.0-20200831163108-0195c961813b
+# knative.dev/networking v0.0.0-20200901153316-80398434dcd4
 ## explicit
 knative.dev/networking/pkg
 knative.dev/networking/pkg/apis/networking
@@ -1088,7 +1088,7 @@ knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/server
 knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice
 knative.dev/networking/pkg/client/listers/networking/v1alpha1
 knative.dev/networking/pkg/ingress
-# knative.dev/pkg v0.0.0-20200831232415-383dd08a323b
+# knative.dev/pkg v0.0.0-20200901172015-edd1b5e0bebf
 ## explicit
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate


### PR DESCRIPTION
We call validateDomains after the Route's `status.traffic` has reached a particular shape and the route has reported "Ready".  At this point we should be able to check (vs. wait) for the expected text.  So drop the "Eventually" prefix, and rename the helper method.

