### PR TITLE
Cleanup route tests

### DIFF
--- a/pkg/reconciler/route/resources/labels/labels.go
+++ b/pkg/reconciler/route/resources/labels/labels.go
@@ -22,8 +22,8 @@ import (
 )
 
 // IsObjectLocalVisibility returns whether an ObjectMeta is of cluster-local visibility
-func IsObjectLocalVisibility(meta v1.ObjectMeta) bool {
-	return meta.Labels != nil && meta.Labels[serving.VisibilityLabelKey] != ""
+func IsObjectLocalVisibility(meta *v1.ObjectMeta) bool {
+	return meta.Labels[serving.VisibilityLabelKey] != ""
 }
 
 // SetVisibility sets the visibility on an ObjectMeta

--- a/pkg/reconciler/route/resources/labels/labels_test.go
+++ b/pkg/reconciler/route/resources/labels/labels_test.go
@@ -26,9 +26,9 @@ import (
 
 func TestIsObjectLocalVisibility(t *testing.T) {
 	tests := []struct {
-		name     string
-		meta     *v1.ObjectMeta
-		expected bool
+		name string
+		meta *v1.ObjectMeta
+		want bool
 	}{{
 		name: "nil",
 		meta: &v1.ObjectMeta{},
@@ -52,12 +52,12 @@ func TestIsObjectLocalVisibility(t *testing.T) {
 		meta: &v1.ObjectMeta{
 			Labels: map[string]string{serving.VisibilityLabelKey: "set"},
 		},
-		expected: true,
+		want: true,
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got, want := IsObjectLocalVisibility(test.meta), test.expected; got != want {
+			if got, want := IsObjectLocalVisibility(test.meta), test.want; got != want {
 				t.Errorf("IsObjectLocalVisibility = %v, want: %v", got, want)
 			}
 		})
@@ -66,22 +66,22 @@ func TestIsObjectLocalVisibility(t *testing.T) {
 
 func TestDeleteLabel(t *testing.T) {
 	tests := []struct {
-		name     string
-		meta     *v1.ObjectMeta
-		key      string
-		expected v1.ObjectMeta
+		name string
+		meta *v1.ObjectMeta
+		key  string
+		want v1.ObjectMeta
 	}{{
-		name:     "No labels in object meta",
-		meta:     &v1.ObjectMeta{},
-		key:      "key",
-		expected: v1.ObjectMeta{},
+		name: "No labels in object meta",
+		meta: &v1.ObjectMeta{},
+		key:  "key",
+		want: v1.ObjectMeta{},
 	}, {
 		name: "No matching key",
 		meta: &v1.ObjectMeta{
 			Labels: map[string]string{"some label": "some value"},
 		},
 		key: "unknown",
-		expected: v1.ObjectMeta{
+		want: v1.ObjectMeta{
 			Labels: map[string]string{"some label": "some value"},
 		},
 	}, {
@@ -90,7 +90,7 @@ func TestDeleteLabel(t *testing.T) {
 			Labels: map[string]string{"some label": "some value"},
 		},
 		key: "some label",
-		expected: v1.ObjectMeta{
+		want: v1.ObjectMeta{
 			Labels: map[string]string{},
 		},
 	}}
@@ -98,9 +98,9 @@ func TestDeleteLabel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			DeleteLabel(tt.meta, tt.key)
 
-			if !cmp.Equal(tt.expected, *tt.meta) {
+			if !cmp.Equal(tt.want, *tt.meta) {
 				t.Errorf("DeleteLabel (-want, +got) = %v",
-					cmp.Diff(tt.expected, *tt.meta))
+					cmp.Diff(tt.want, *tt.meta))
 			}
 		})
 	}
@@ -112,14 +112,13 @@ func TestSetLabel(t *testing.T) {
 		meta  *v1.ObjectMeta
 		key   string
 		value string
-
-		expected v1.ObjectMeta
+		want  v1.ObjectMeta
 	}{{
 		name:  "No labels in object meta",
 		meta:  &v1.ObjectMeta{},
 		key:   "key",
 		value: "value",
-		expected: v1.ObjectMeta{
+		want: v1.ObjectMeta{
 			Labels: map[string]string{"key": "value"},
 		},
 	}, {
@@ -129,7 +128,7 @@ func TestSetLabel(t *testing.T) {
 		},
 		key:   "key",
 		value: "value",
-		expected: v1.ObjectMeta{
+		want: v1.ObjectMeta{
 			Labels: map[string]string{"key": "value"},
 		},
 	}, {
@@ -139,7 +138,7 @@ func TestSetLabel(t *testing.T) {
 		},
 		key:   "key",
 		value: "new value",
-		expected: v1.ObjectMeta{
+		want: v1.ObjectMeta{
 			Labels: map[string]string{"key": "new value"},
 		},
 	}}
@@ -147,9 +146,9 @@ func TestSetLabel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			SetLabel(tt.meta, tt.key, tt.value)
 
-			if !cmp.Equal(tt.expected, *tt.meta) {
+			if !cmp.Equal(tt.want, *tt.meta) {
 				t.Errorf("DeleteLabel (-want, +got) = %v",
-					cmp.Diff(tt.expected, *tt.meta))
+					cmp.Diff(tt.want, *tt.meta))
 			}
 		})
 	}
@@ -160,17 +159,16 @@ func TestSetVisibility(t *testing.T) {
 		name           string
 		meta           *v1.ObjectMeta
 		isClusterLocal bool
-		expected       v1.ObjectMeta
+		want           v1.ObjectMeta
 	}{{
 		name:           "Set cluster local true",
 		meta:           &v1.ObjectMeta{},
 		isClusterLocal: true,
-		expected:       v1.ObjectMeta{Labels: map[string]string{serving.VisibilityLabelKey: serving.VisibilityClusterLocal}},
+		want:           v1.ObjectMeta{Labels: map[string]string{serving.VisibilityLabelKey: serving.VisibilityClusterLocal}},
 	}, {
-		name:           "Set cluster local false",
-		meta:           &v1.ObjectMeta{Labels: map[string]string{serving.VisibilityLabelKey: serving.VisibilityClusterLocal}},
-		isClusterLocal: false,
-		expected:       v1.ObjectMeta{Labels: map[string]string{}},
+		name: "Set cluster local false",
+		meta: &v1.ObjectMeta{Labels: map[string]string{serving.VisibilityLabelKey: serving.VisibilityClusterLocal}},
+		want: v1.ObjectMeta{Labels: map[string]string{}},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -116,7 +116,7 @@ func (t *Config) GetRevisionTrafficTargets(ctx context.Context, r *v1.Route) ([]
 
 			labels.SetVisibility(meta, t.Visibility[tt.Tag] == netv1alpha1.IngressVisibilityClusterLocal)
 
-			// http is currently the only supported scheme
+			// HTTP is currently the only supported scheme.
 			fullDomain, err := domains.DomainNameFromTemplate(ctx, *meta, hostname)
 			if err != nil {
 				return nil, err

--- a/pkg/reconciler/route/visibility/visibility.go
+++ b/pkg/reconciler/route/visibility/visibility.go
@@ -99,7 +99,7 @@ func (b *Resolver) GetVisibility(ctx context.Context, route *v1.Route) (map[stri
 		ttVisibility := netv1alpha1.IngressVisibilityExternalIP
 		// Is there a visibility setting on the placeholder Service?
 		if svc, ok := services[hostname]; ok {
-			if labels.IsObjectLocalVisibility(svc.ObjectMeta) {
+			if labels.IsObjectLocalVisibility(&svc.ObjectMeta) {
 				ttVisibility = netv1alpha1.IngressVisibilityClusterLocal
 			}
 		}


### PR DESCRIPTION
As I start to ramp up for the gradual rollout project, I am reading things and fixing things.
here's a batch

- no need to copy the whole meta obect just to query lables (perhaps
even passing labels is a better approach)
- collapse test indentations
- add tests and coverage for the missing function
- rename expected to want — shorter :)

/lint

/assign mattmoor @tcnghia 