### PR TITLE
Remove the field which is not set by the test clients

### DIFF
--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -1750,7 +1750,6 @@ func TestReconcile(t *testing.T) {
 				Namespace: "default",
 				Verb:      "delete",
 				Resource: schema.GroupVersionResource{
-					Group:    "core",
 					Version:  "v1",
 					Resource: "services",
 				},
@@ -1789,7 +1788,6 @@ func TestReconcile(t *testing.T) {
 				Namespace: "default",
 				Verb:      "delete",
 				Resource: schema.GroupVersionResource{
-					Group:    "core",
 					Version:  "v1",
 					Resource: "services",
 				},


### PR DESCRIPTION
This blocks from having unordered deletes.

The test client does not set group for some reason and delete action does not have it... :/

/assign @tcnghia 