### PR TITLE
Don't mark resources available false if ServiceName not populated

### DIFF
--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -194,8 +194,12 @@ func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *av1alpha1.PodAutoscalerS
 		// See #8922 for details. When we try to scale to 0, we force the Deployment's
 		// Progress status to become `true`, since successful scale down means
 		// progress has been achieved.
+		// There's the possibility of the revision reconciler reconciling PA before
+		// the ServiceName is populated, and therefore even though we will mark
+		// ScaleTargetInitialized down the road, we would have marked resources
+		// unavailable here, and have no way of recovering later.
 		// If the ResourcesAvailable is already false, don't override the message.
-		if !ps.IsScaleTargetInitialized() && resUnavailable {
+		if !ps.IsScaleTargetInitialized() && resUnavailable && ps.ServiceName != "" {
 			rs.MarkResourcesAvailableFalse(ReasonProgressDeadlineExceeded,
 				"Initial scale was never achieved")
 		}

--- a/pkg/apis/serving/v1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1/revision_lifecycle_test.go
@@ -611,6 +611,7 @@ func TestPropagateAutoscalerStatusNoProgress(t *testing.T) {
 
 	// PodAutoscaler is not ready and initial scale was never attained.
 	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
+		ServiceName: "testRevision",
 		Status: duckv1.Status{
 			Conditions: duckv1.Conditions{{
 				Type:   av1alpha1.PodAutoscalerConditionReady,

--- a/test/e2e/initial_scale_test.go
+++ b/test/e2e/initial_scale_test.go
@@ -36,7 +36,6 @@ import (
 // the revision level. This test runs after the cluster wide flag allow-zero-initial-scale
 // is set to true.
 func TestInitScaleZero(t *testing.T) {
-	t.Skip("Enable once #9245 is fixed")
 	t.Parallel()
 
 	clients := Setup(t)


### PR DESCRIPTION
Sometimes, we are marking resources available false too early, if we end up reconciling revision before `ScaleTargetInitialized` becomes true. And once we mark it false, we have no chance of marking resources available true again, because this condition https://github.com/knative/serving/blob/748381ed9cad78ccf34372dc496b41a2642f860c/pkg/apis/serving/v1/revision_lifecycle.go#L177 will always evaluate to false. Therefore, we don't mark resources available false if `ServiceName` is not populated yet.

Ran TestInitialScaleZero locally with count=20 passing.

/lint

Fixes #9245

/cc @julz @vagababov @markusthoemmes 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
