### PR TITLE
Avoid using Cleanup in reconciler test to fix races

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1259,13 +1259,13 @@ func TestGlobalResyncOnUpdateAutoscalerConfigMap(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to start informers:", err)
 	}
-	t.Cleanup(func() {
+	defer func() {
 		cancel()
 		if err := grp.Wait(); err != nil {
 			t.Errorf("Wait() = %v", err)
 		}
 		waitInformers()
-	})
+	}()
 
 	if err := watcher.Start(ctx.Done()); err != nil {
 		t.Fatal("failed to start configmap watcher:", err)
@@ -1330,11 +1330,11 @@ func TestReconcileDeciderCreatesAndDeletes(t *testing.T) {
 
 	var eg errgroup.Group
 	eg.Go(func() error { return ctl.Run(1, ctx.Done()) })
-	t.Cleanup(func() {
+	defer func() {
 		cancel()
 		wf()
 		eg.Wait()
-	})
+	}()
 
 	rev := newTestRevision(testNamespace, testRevision)
 	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Create(rev)
@@ -1469,10 +1469,10 @@ func TestControllerCreateError(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error starting up informers:", err)
 	}
-	t.Cleanup(func() {
+	defer func() {
 		cancel()
 		waitInformers()
-	})
+	}()
 
 	want := apierrors.NewBadRequest("asdf")
 
@@ -1510,10 +1510,10 @@ func TestControllerUpdateError(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error starting up informers:", err)
 	}
-	t.Cleanup(func() {
+	defer func() {
 		cancel()
 		waitInformers()
-	})
+	}()
 
 	want := apierrors.NewBadRequest("asdf")
 
@@ -1551,10 +1551,10 @@ func TestControllerGetError(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error starting up informers:", err)
 	}
-	t.Cleanup(func() {
+	defer func() {
 		cancel()
 		waitInformers()
-	})
+	}()
 
 	want := apierrors.NewBadRequest("asdf")
 
@@ -1591,10 +1591,10 @@ func TestScaleFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error starting up informers:", err)
 	}
-	t.Cleanup(func() {
+	defer func() {
 		cancel()
 		waitInformers()
-	})
+	}()
 
 	ctl := NewController(ctx, newConfigWatcher(), newTestDeciders())
 

--- a/pkg/reconciler/metric/metric_test.go
+++ b/pkg/reconciler/metric/metric_test.go
@@ -199,11 +199,11 @@ func TestReconcileWithCollector(t *testing.T) {
 
 	barrier := make(chan struct{})
 	var eg errgroup.Group
-	t.Cleanup(func() {
+	defer func() {
 		cancel()
 		wf()
 		eg.Wait()
-	})
+	}()
 
 	eg.Go(func() error {
 		close(barrier)

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -460,13 +460,13 @@ func TestGlobalResyncOnDefaultCMChange(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to start informers:", err)
 	}
-	t.Cleanup(func() {
+	defer func() {
 		cancel()
 		if err := grp.Wait(); err != nil {
 			t.Error("Wait() = ", err)
 		}
 		waitInformers()
-	})
+	}()
 
 	if err := watcher.Start(ctx.Done()); err != nil {
 		t.Fatal("Failed to start watcher:", err)
@@ -547,13 +547,13 @@ func TestGlobalResyncOnConfigMapUpdateRevision(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to start informers:", err)
 	}
-	t.Cleanup(func() {
+	defer func() {
 		cancel()
 		if err := grp.Wait(); err != nil {
 			t.Error("Wait() = ", err)
 		}
 		waitInformers()
-	})
+	}()
 
 	if err := watcher.Start(ctx.Done()); err != nil {
 		t.Fatal("Failed to start watcher:", err)
@@ -625,13 +625,13 @@ func TestGlobalResyncOnConfigMapUpdateDeployment(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to start informers:", err)
 	}
-	t.Cleanup(func() {
+	defer func() {
 		cancel()
 		if err := grp.Wait(); err != nil {
 			t.Error("Wait() = ", err)
 		}
 		waitInformers()
-	})
+	}()
 
 	if err := watcher.Start(ctx.Done()); err != nil {
 		t.Fatal("Failed to start configuration manager:", err)


### PR DESCRIPTION
Unfortunately, t.Cleanup seems to cause data races with zaptest logging since we end up writing logs "after" the test has finished (see https://github.com/uber-go/zap/issues/687#issuecomment-473382859). Reverting to defer in reconciler tests fixes it.

Races show up quite a lot in go 1.15, and in the new GitHub action tests, e.g. https://github.com/knative/serving/runs/1060445647. Similar issue in eventing here: https://github.com/knative/eventing/issues/3978.

I can quite consistently reproduce races locally with 1.15 without this change, afterwards ran -count 10 multiple times without problems.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

/assign @markusthoemmes @vagababov 