### PR TITLE
Cleanup and quicken up statforwarder tests.

### DIFF
--- a/pkg/autoscaler/statforwarder/forwarder_test.go
+++ b/pkg/autoscaler/statforwarder/forwarder_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -38,9 +37,9 @@ import (
 	fakeserviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/hash"
+	"knative.dev/pkg/logging"
 	rtesting "knative.dev/pkg/reconciler/testing"
 	"knative.dev/pkg/system"
-	_ "knative.dev/pkg/system/testing"
 	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
 )
 
@@ -68,15 +67,14 @@ var (
 )
 
 func TestForwarderReconcile(t *testing.T) {
-	t.Parallel()
-	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
+	ctx, cancel, informers := rtesting.SetupFakeContextWithCancel(t)
+	logger := logging.FromContext(ctx)
 	kubeClient := fakekubeclient.Get(ctx)
 	endpoints := fakeendpointsinformer.Get(ctx)
 	service := fakeserviceinformer.Get(ctx)
 	lease := fakeleaseinformer.Get(ctx)
 
-	waitInformers, err := controller.RunInformers(
-		ctx.Done(), endpoints.Informer(), service.Informer(), lease.Informer())
+	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		t.Fatal("Failed to start informers:", err)
 	}
@@ -86,15 +84,15 @@ func TestForwarderReconcile(t *testing.T) {
 		waitInformers()
 	})
 
-	New(ctx, zap.NewNop().Sugar(), kubeClient, testIP1, testBs, noOp)
-	New(ctx, zap.NewNop().Sugar(), kubeClient, testIP2, testBs, noOp)
+	New(ctx, logger, kubeClient, testIP1, testBs, noOp)
+	New(ctx, logger, kubeClient, testIP2, testBs, noOp)
 
 	kubeClient.CoordinationV1().Leases(testNs).Create(testLease)
 	lease.Informer().GetIndexer().Add(testLease)
 
 	var lastErr error
 	// Wait for the resources to be created.
-	if err := wait.PollImmediate(100*time.Millisecond, 2*time.Second, func() (bool, error) {
+	if err := wait.PollImmediate(10*time.Millisecond, 2*time.Second, func() (bool, error) {
 		_, err := service.Lister().Services(testNs).Get(bucket1)
 		lastErr = err
 		return err == nil, nil
@@ -114,7 +112,7 @@ func TestForwarderReconcile(t *testing.T) {
 	}
 
 	// Check the endpoints got updated.
-	if err := wait.PollImmediate(100*time.Millisecond, 2*time.Second, func() (bool, error) {
+	if err := wait.PollImmediate(10*time.Millisecond, 2*time.Second, func() (bool, error) {
 		got, err := endpoints.Lister().Endpoints(testNs).Get(bucket1)
 		if err != nil {
 			lastErr = err
@@ -135,10 +133,11 @@ func TestForwarderReconcile(t *testing.T) {
 	l := testLease.DeepCopy()
 	l.Spec.HolderIdentity = &testIP2
 	kubeClient.CoordinationV1().Leases(testNs).Update(l)
+	lease.Informer().GetIndexer().Add(l)
 
 	// Check the endpoints got updated.
 	wantSubsets[0].Addresses[0].IP = testIP2
-	if err := wait.PollImmediate(100*time.Millisecond, 2*time.Second, func() (bool, error) {
+	if err := wait.PollImmediate(10*time.Millisecond, 2*time.Second, func() (bool, error) {
 		// Check the endpoints get updated.
 		got, err := endpoints.Lister().Endpoints(testNs).Get(bucket1)
 		if err != nil {
@@ -158,15 +157,12 @@ func TestForwarderReconcile(t *testing.T) {
 }
 
 func TestForwarderRetryOnSvcCreationFailure(t *testing.T) {
-	t.Parallel()
-	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
+	ctx, cancel, informers := rtesting.SetupFakeContextWithCancel(t)
+	logger := logging.FromContext(ctx)
 	kubeClient := fakekubeclient.Get(ctx)
-	endpoints := fakeendpointsinformer.Get(ctx)
-	service := fakeserviceinformer.Get(ctx)
 	lease := fakeleaseinformer.Get(ctx)
 
-	waitInformers, err := controller.RunInformers(
-		ctx.Done(), endpoints.Informer(), service.Informer(), lease.Informer())
+	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		t.Fatal("Failed to start informers:", err)
 	}
@@ -176,7 +172,7 @@ func TestForwarderRetryOnSvcCreationFailure(t *testing.T) {
 		waitInformers()
 	})
 
-	New(ctx, zap.NewNop().Sugar(), kubeClient, testIP1, testBs, noOp)
+	New(ctx, logger, kubeClient, testIP1, testBs, noOp)
 
 	svcCreation := 0
 	retried := make(chan struct{})
@@ -185,6 +181,7 @@ func TestForwarderRetryOnSvcCreationFailure(t *testing.T) {
 			svcCreation++
 			if svcCreation == 2 {
 				retried <- struct{}{}
+				return true, nil, nil
 			}
 			return true, nil, errors.New("Failed to create")
 		},
@@ -201,15 +198,12 @@ func TestForwarderRetryOnSvcCreationFailure(t *testing.T) {
 }
 
 func TestForwarderRetryOnEndpointsCreationFailure(t *testing.T) {
-	t.Parallel()
-	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
+	ctx, cancel, informers := rtesting.SetupFakeContextWithCancel(t)
+	logger := logging.FromContext(ctx)
 	kubeClient := fakekubeclient.Get(ctx)
-	endpoints := fakeendpointsinformer.Get(ctx)
-	service := fakeserviceinformer.Get(ctx)
 	lease := fakeleaseinformer.Get(ctx)
 
-	waitInformers, err := controller.RunInformers(
-		ctx.Done(), endpoints.Informer(), service.Informer(), lease.Informer())
+	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		t.Fatal("Failed to start informers:", err)
 	}
@@ -219,7 +213,7 @@ func TestForwarderRetryOnEndpointsCreationFailure(t *testing.T) {
 		waitInformers()
 	})
 
-	New(ctx, zap.NewNop().Sugar(), kubeClient, testIP1, testBs, noOp)
+	New(ctx, logger, kubeClient, testIP1, testBs, noOp)
 
 	endpointsCreation := 0
 	retried := make(chan struct{})
@@ -228,6 +222,7 @@ func TestForwarderRetryOnEndpointsCreationFailure(t *testing.T) {
 			endpointsCreation++
 			if endpointsCreation == 2 {
 				retried <- struct{}{}
+				return true, nil, nil
 			}
 			return true, nil, errors.New("Failed to create")
 		},
@@ -244,15 +239,13 @@ func TestForwarderRetryOnEndpointsCreationFailure(t *testing.T) {
 }
 
 func TestForwarderRetryOnEndpointsUpdateFailure(t *testing.T) {
-	t.Parallel()
-	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
+	ctx, cancel, informers := rtesting.SetupFakeContextWithCancel(t)
+	logger := logging.FromContext(ctx)
 	kubeClient := fakekubeclient.Get(ctx)
 	endpoints := fakeendpointsinformer.Get(ctx)
-	service := fakeserviceinformer.Get(ctx)
 	lease := fakeleaseinformer.Get(ctx)
 
-	waitInformers, err := controller.RunInformers(
-		ctx.Done(), endpoints.Informer(), service.Informer(), lease.Informer())
+	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		t.Fatal("Failed to start informers:", err)
 	}
@@ -262,7 +255,7 @@ func TestForwarderRetryOnEndpointsUpdateFailure(t *testing.T) {
 		waitInformers()
 	})
 
-	New(ctx, zap.NewNop().Sugar(), kubeClient, testIP1, testBs, noOp)
+	New(ctx, logger, kubeClient, testIP1, testBs, noOp)
 
 	endpointsUpdate := 0
 	retried := make(chan struct{})
@@ -271,6 +264,7 @@ func TestForwarderRetryOnEndpointsUpdateFailure(t *testing.T) {
 			endpointsUpdate++
 			if endpointsUpdate == 2 {
 				retried <- struct{}{}
+				return true, nil, nil
 			}
 			return true, nil, errors.New("Failed to update")
 		},
@@ -295,16 +289,12 @@ func TestForwarderRetryOnEndpointsUpdateFailure(t *testing.T) {
 }
 
 func TestForwarderSkipReconciling(t *testing.T) {
-	t.Parallel()
-	ns := system.Namespace()
-	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
+	ctx, cancel, informers := rtesting.SetupFakeContextWithCancel(t)
+	logger := logging.FromContext(ctx)
 	kubeClient := fakekubeclient.Get(ctx)
-	endpoints := fakeendpointsinformer.Get(ctx)
-	service := fakeserviceinformer.Get(ctx)
 	lease := fakeleaseinformer.Get(ctx)
 
-	waitInformers, err := controller.RunInformers(
-		ctx.Done(), endpoints.Informer(), service.Informer(), lease.Informer())
+	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		t.Fatal("Failed to start informers:", err)
 	}
@@ -314,7 +304,7 @@ func TestForwarderSkipReconciling(t *testing.T) {
 		waitInformers()
 	})
 
-	New(ctx, zap.NewNop().Sugar(), kubeClient, testIP1, testBs, noOp)
+	New(ctx, logger, kubeClient, testIP1, testBs, noOp)
 
 	svcCreated := make(chan struct{})
 	kubeClient.PrependReactor("create", "services",
@@ -338,7 +328,7 @@ func TestForwarderSkipReconciling(t *testing.T) {
 		holder      string
 	}{{
 		description: "not autoscaler bucket lease",
-		namespace:   ns,
+		namespace:   testNs,
 		name:        bucket2,
 		holder:      testIP1,
 	}, {
@@ -348,11 +338,11 @@ func TestForwarderSkipReconciling(t *testing.T) {
 		holder:      testIP1,
 	}, {
 		description: "without holder",
-		namespace:   ns,
+		namespace:   testNs,
 		name:        bucket1,
 	}, {
 		description: "not the holder",
-		namespace:   ns,
+		namespace:   testNs,
 		name:        bucket1,
 		holder:      testIP2,
 	}}
@@ -369,33 +359,30 @@ func TestForwarderSkipReconciling(t *testing.T) {
 					HolderIdentity: &tc.holder,
 				}
 			}
-			kubeClient.CoordinationV1().Leases(ns).Create(l)
+			kubeClient.CoordinationV1().Leases(testNs).Create(l)
 			lease.Informer().GetIndexer().Add(l)
 
 			select {
 			case <-svcCreated:
 				t.Error("Got Service created, want no actions")
-			case <-time.After(time.Second):
+			case <-time.After(50 * time.Millisecond):
 			}
 			select {
 			case <-endpointsCreated:
 				t.Error("Got Endpoints created, want no actions")
-			case <-time.After(time.Second):
+			case <-time.After(50 * time.Millisecond):
 			}
 		})
 	}
 }
 
 func TestProcess(t *testing.T) {
-	t.Parallel()
-	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
+	ctx, cancel, informers := rtesting.SetupFakeContextWithCancel(t)
+	logger := logging.FromContext(ctx)
 	kubeClient := fakekubeclient.Get(ctx)
-	endpoints := fakeendpointsinformer.Get(ctx)
-	service := fakeserviceinformer.Get(ctx)
 	lease := fakeleaseinformer.Get(ctx)
 
-	waitInformers, err := controller.RunInformers(
-		ctx.Done(), endpoints.Informer(), service.Informer(), lease.Informer())
+	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		t.Fatal("Failed to start informers:", err)
 	}
@@ -409,7 +396,7 @@ func TestProcess(t *testing.T) {
 	accept := func(sm asmetrics.StatMessage) {
 		acceptCount++
 	}
-	f := New(ctx, zap.NewNop().Sugar(), kubeClient, testIP1, hash.NewBucketSet(sets.NewString(bucket1, bucket2)), accept)
+	f := New(ctx, logger, kubeClient, testIP1, hash.NewBucketSet(sets.NewString(bucket1, bucket2)), accept)
 
 	stat1 := asmetrics.StatMessage{
 		Key: types.NamespacedName{
@@ -429,6 +416,7 @@ func TestProcess(t *testing.T) {
 
 	kubeClient.CoordinationV1().Leases(testNs).Create(testLease)
 	lease.Informer().GetIndexer().Add(testLease)
+
 	anotherLease := &coordinationv1.Lease{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      bucket2,
@@ -442,7 +430,7 @@ func TestProcess(t *testing.T) {
 	lease.Informer().GetIndexer().Add(anotherLease)
 
 	// Wait for the forwarder to become the leader for bucket1.
-	if err := wait.PollImmediate(100*time.Millisecond, 2*time.Second, func() (bool, error) {
+	if err := wait.PollImmediate(10*time.Millisecond, 2*time.Second, func() (bool, error) {
 		p1 := f.getProcessor(bucket1)
 		p2 := f.getProcessor(bucket2)
 		return p1 != nil && p2 != nil && p1.holder == testIP1 && p2.holder == testIP2 && p1.conn == nil && p2.conn != nil, nil


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This reduces the runtime of the tests from 8s parallel (17s sequential) to 1.5s.

- Tighten up retries.
- Short-circuit failed creations/updates to not have to wait for the entire retry timeout once the test's condition is verified.
- Dropped t.Parallel() (we don't use that in unit tests).
- Included a proper logger to aid in test debuggability.
- Use informers list from test helper to reduce boilerplate.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
