### PR TITLE
Add ScaleDownDelay to autoscaler config

### DIFF
--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -82,8 +82,23 @@ type Config struct {
 	PanicWindowPercentage    float64
 	PanicThresholdPercentage float64
 
-	ScaleToZeroGracePeriod        time.Duration
+	// ScaleToZeroGracePeriod is the time we will wait for networking to
+	// propagate before scaling down. We may wait less than this if it is safe to
+	// do so, for example if the Activator has already been in the path for
+	// longer than the window.
+	ScaleToZeroGracePeriod time.Duration
+
+	// ScaleToZeroPodRetentionPeriod is the minimum amount of time we will wait
+	// before scaling down the last pod.
 	ScaleToZeroPodRetentionPeriod time.Duration
+
+	// ScaleDownDelay is the amount of time that must pass at reduced concurrency
+	// before a scale-down decision is applied. This can be useful for keeping
+	// scaled-up revisions "warm" for a certain period before scaling down. This
+	// applies to all scale-down decisions, not just the very last pod.
+	// It is independent of ScaleToZeroPodRetentionPeriod, which can be used to
+	// add an additional delay to the very last pod, if required.
+	ScaleDownDelay time.Duration
 
 	PodAutoscalerClass string
 }
@@ -105,6 +120,7 @@ func defaultConfig() *Config {
 		StableWindow:                  60 * time.Second,
 		ScaleToZeroGracePeriod:        30 * time.Second,
 		ScaleToZeroPodRetentionPeriod: 0 * time.Second,
+		ScaleDownDelay:                0 * time.Second,
 		PodAutoscalerClass:            autoscaling.KPA,
 		AllowZeroInitialScale:         false,
 		InitialScale:                  1,
@@ -136,6 +152,7 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		cm.AsInt32("max-scale", &lc.MaxScale),
 
 		cm.AsDuration("stable-window", &lc.StableWindow),
+		cm.AsDuration("scale-down-delay", &lc.ScaleDownDelay),
 		cm.AsDuration("scale-to-zero-grace-period", &lc.ScaleToZeroGracePeriod),
 		cm.AsDuration("scale-to-zero-pod-retention-period", &lc.ScaleToZeroPodRetentionPeriod),
 	); err != nil {
@@ -155,7 +172,11 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 
 func validate(lc *Config) (*Config, error) {
 	if lc.ScaleToZeroGracePeriod < autoscaling.WindowMin {
-		return nil, fmt.Errorf("scale-to-zero-grace-period must be at least %v, got %v", autoscaling.WindowMin, lc.ScaleToZeroGracePeriod)
+		return nil, fmt.Errorf("scale-to-zero-grace-period must be at least %v, was: %v", autoscaling.WindowMin, lc.ScaleToZeroGracePeriod)
+	}
+
+	if lc.ScaleDownDelay < 0 {
+		return nil, fmt.Errorf("scale-down-delay cannot be negative, was: %v", lc.ScaleDownDelay)
 	}
 
 	if lc.ScaleToZeroPodRetentionPeriod < 0 {
@@ -163,7 +184,7 @@ func validate(lc *Config) (*Config, error) {
 	}
 
 	if lc.TargetBurstCapacity < 0 && lc.TargetBurstCapacity != -1 {
-		return nil, fmt.Errorf("target-burst-capacity must be either non-negative or -1 (for unlimited), got %f", lc.TargetBurstCapacity)
+		return nil, fmt.Errorf("target-burst-capacity must be either non-negative or -1 (for unlimited), was: %f", lc.TargetBurstCapacity)
 	}
 
 	if lc.ContainerConcurrencyTargetFraction <= 0 || lc.ContainerConcurrencyTargetFraction > 1 {
@@ -175,7 +196,7 @@ func validate(lc *Config) (*Config, error) {
 	}
 
 	if lc.RPSTargetDefault < autoscaling.TargetMin {
-		return nil, fmt.Errorf("requests-per-second-target-default must be at least %v, got %v", autoscaling.TargetMin, lc.RPSTargetDefault)
+		return nil, fmt.Errorf("requests-per-second-target-default must be at least %v, was: %v", autoscaling.TargetMin, lc.RPSTargetDefault)
 	}
 
 	if lc.ActivatorCapacity < 1 {

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -55,6 +55,7 @@ func TestNewConfig(t *testing.T) {
 			"container-concurrency-target-default":    "10.5",
 			"requests-per-second-target-default":      "10.11",
 			"target-burst-capacity":                   "12345",
+			"scale-down-delay":                        "15m",
 			"stable-window":                           "5m",
 			"tick-interval":                           "2s",
 			"panic-window-percentage":                 "10",
@@ -71,6 +72,7 @@ func TestNewConfig(t *testing.T) {
 			c.RPSTargetDefault = 10.11
 			c.MaxScaleDownRate = 3
 			c.MaxScaleUpRate = 1.01
+			c.ScaleDownDelay = 15 * time.Minute
 			c.StableWindow = 5 * time.Minute
 			c.ActivatorCapacity = 905
 			c.PodAutoscalerClass = "some.class"
@@ -152,6 +154,12 @@ func TestNewConfig(t *testing.T) {
 		name: "malformed float",
 		input: map[string]string{
 			"max-scale-up-rate": "not a float",
+		},
+		wantErr: true,
+	}, {
+		name: "invalid scale-down-delay",
+		input: map[string]string{
+			"scale-down-delay": "-1m23s",
 		},
 		wantErr: true,
 	}, {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Part of #9092.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

- Add ScaleDownDelay to autoscaler config.
- Also added some extra comments to the related fields for clarity.

**Release Note:**

Will add release note when adding the config map examples (since that'll be the last step).

/assign @markusthoemmes @vagababov 