### PR TITLE
Close the WS connection if the Server is not the owner of a bucket

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -147,8 +147,8 @@ func main() {
 	}
 
 	// Set up a statserver.
-	// TODO(yanweiguo): Populate the ownership from statfowarder.Forwarder.
-	statsServer := statserver.New(statsServerAddr, statsCh, logger, nil /* Ownership*/)
+	// TODO(yanweiguo): Populate the isBktOwner from statfowarder.Forwarder.
+	statsServer := statserver.New(statsServerAddr, statsCh, logger, nil /* isBktOwner*/)
 
 	// Start watching the configs.
 	if err := cmw.Start(ctx.Done()); err != nil {

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -147,7 +147,8 @@ func main() {
 	}
 
 	// Set up a statserver.
-	statsServer := statserver.New(statsServerAddr, statsCh, logger)
+	// TODO(yanweiguo): Populate the ownership from statfowarder.Forwarder.
+	statsServer := statserver.New(statsServerAddr, statsCh, logger, nil /* Ownership*/)
 
 	// Start watching the configs.
 	if err := cmw.Start(ctx.Done()); err != nil {

--- a/pkg/autoscaler/bucket/bucket.go
+++ b/pkg/autoscaler/bucket/bucket.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bucket
+
+import (
+	"strings"
+)
+
+const prefix = "autoscaler-bucket"
+
+// Ownership provides the ownership between an Autoscaler bucket and an Autoscaler pod.
+type Ownership interface {
+	// IsOwner returns true if the pod where this function is called is the owner
+	// of the given bucket.
+	IsOwner(bktName string) bool
+}
+
+// IsBucketHost returns true if the given host is a host of a K8S Service
+// of a bucket.
+func IsBucketHost(host string) bool {
+	// Currently checking prefix is ok as only requests sent via bucket service
+	// have host with the prefix. Maybe use regexp for improvement.
+	return strings.HasPrefix(host, prefix)
+}

--- a/pkg/autoscaler/bucket/bucket.go
+++ b/pkg/autoscaler/bucket/bucket.go
@@ -22,13 +22,6 @@ import (
 
 const prefix = "autoscaler-bucket"
 
-// Ownership provides the ownership between an Autoscaler bucket and an Autoscaler pod.
-type Ownership interface {
-	// IsOwner returns true if the pod where this function is called is the owner
-	// of the given bucket.
-	IsOwner(bktName string) bool
-}
-
 // IsBucketHost returns true if the given host is a host of a K8S Service
 // of a bucket.
 func IsBucketHost(host string) bool {

--- a/pkg/autoscaler/bucket/bucket_test.go
+++ b/pkg/autoscaler/bucket/bucket_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bucket
+
+import "testing"
+
+func TestIsBucketHost(t *testing.T) {
+	if got, want := IsBucketHost("autoscaler-bucket-00-of-03"), true; got != want {
+		t.Errorf("IsBucketHost = %v, want = %v", got, want)
+	}
+
+	if got, want := IsBucketHost("autoscaler"), false; got != want {
+		t.Errorf("IsBucketHost = %v, want = %v", got, want)
+	}
+
+	if got, want := IsBucketHost("autoscaler-bucket-non-exits"), true; got != want {
+		t.Errorf("IsBucketHost = %v, want = %v", got, want)
+	}
+}

--- a/pkg/autoscaler/bucket/doc.go
+++ b/pkg/autoscaler/bucket/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package bucket provides help functions for Autoscaler buckets. The
+// Package bucket provides helper functions for Autoscaler buckets. The
 // buckets are used in Leader Election to support multiple Autoscaler pods.
 package bucket

--- a/pkg/autoscaler/bucket/doc.go
+++ b/pkg/autoscaler/bucket/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package bucket provides help functions for Autoscaler buckets. The
+// buckets are used in Leader Election to support multiple Autoscaler pods.
+package bucket

--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -137,6 +137,7 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 
 	if s.ownership != nil && isBucketHost(r.Host) {
 		bkt := strings.Split(r.Host, ".")[0]
+		// It won't affect connections via Autoscaler service (used by Activator) or IP address.
 		if !s.ownership.IsOwner(bkt) {
 			s.logger.Warn("Close the connection because not the owner of the bucket ", bkt)
 			err := conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(closeCodeTryAgain, "NotOwner"))

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -420,10 +420,10 @@ func (t *testListener) Accept() (net.Conn, error) {
 	return t.Listener.Accept()
 }
 
-func alwaysTrue(bkt string) bool {
+func alwaysTrue(_ string) bool {
 	return true
 }
 
-func alwaysFalse(bkt string) bool {
+func alwaysFalse(_ string) bool {
 	return false
 }

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -218,6 +218,7 @@ func TestServerOwnerForBucketHost(t *testing.T) {
 	assertReceivedProto(t, both, statSink, statsCh)
 	closeSink(t, statSink)
 }
+
 func TestServerNotOwnerForBucketHost(t *testing.T) {
 	// Override the function to mock a bucket host.
 	isBucketHost = alwaysTrue
@@ -228,19 +229,9 @@ func TestServerNotOwnerForBucketHost(t *testing.T) {
 
 	go server.listenAndServe()
 
-	statSink := dialOK(t, server.listenAddr())
-	defer closeSink(t, statSink)
-
-	received := make(chan struct{})
-	go func() {
-		assertReceivedProto(t, both, statSink, statsCh)
-		close(received)
-	}()
-
-	select {
-	case <-received:
-		t.Error("Should not receive stat as the server should keep closing the connection.")
-	case <-time.After(time.Second):
+	_, err := dial(server.listenAddr())
+	if err == nil {
+		t.Error("Want error from Dial but got none")
 	}
 }
 

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -206,9 +206,6 @@ func TestServerWithOwnershipStatsReceived(t *testing.T) {
 func TestServerWithOwnershipConnectionClosed(t *testing.T) {
 	// Override the function to mock a bucket host.
 	isBucketHost = func(host string) bool { return true }
-	defer func() {
-		isBucketHost = bucket.IsBucketHost
-	}()
 
 	statsCh := make(chan metrics.StatMessage)
 	server := newTestServerWithOwnership(statsCh, &testOwnership{})

--- a/test/upgrade/service_postupgrade_test.go
+++ b/test/upgrade/service_postupgrade_test.go
@@ -54,6 +54,25 @@ func TestServicePostUpgrade(t *testing.T) {
 	updateService(serviceName, t)
 }
 
+/*
+TODO(6984): uncomment those.
+func configHasGeneration(clients *test.Clients, serviceName string, generation int) (bool, error) {
+	configObj, err := clients.ServingClient.Configs.Get(serviceName, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	return configObj.Generation == int64(generation), nil
+}
+
+func routeHasGeneration(clients *test.Clients, serviceName string, generation int) (bool, error) {
+	routeObj, err := clients.ServingClient.Routes.Get(serviceName, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	return routeObj.Generation == int64(generation), nil
+}
+*/
+
 func TestServicePostUpgradeFromScaleToZero(t *testing.T) {
 	t.Parallel()
 	updateService(scaleToZeroServiceName, t)
@@ -77,22 +96,6 @@ func TestBYORevisionPostUpgrade(t *testing.T) {
 	}); err != nil {
 		t.Fatal("Failed to update Service:", err)
 	}
-}
-
-func configHasGeneration(clients *test.Clients, serviceName string, generation int) (bool, error) {
-	configObj, err := clients.ServingClient.Configs.Get(serviceName, metav1.GetOptions{})
-	if err != nil {
-		return false, err
-	}
-	return configObj.Generation == int64(generation), nil
-}
-
-func routeHasGeneration(clients *test.Clients, serviceName string, generation int) (bool, error) {
-	routeObj, err := clients.ServingClient.Routes.Get(serviceName, metav1.GetOptions{})
-	if err != nil {
-		return false, err
-	}
-	return routeObj.Generation == int64(generation), nil
 }
 
 func updateService(serviceName string, t *testing.T) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

For #9235 and #2930.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Introduce a new package pkg/autoscaler/bucket to provide functions/interfaces for autoscaler buckets.
* Introduce an interface `Ownership` to check whether a pod is the owner a bucket.
* Add `Ownership` as a new parameter to StatServer. StatServer will close the connection if all the following conditions satisfy:

    1. The given `Ownership` is not nil
    2. The request is sent via bucket service.
    3. The pod is not the owner of the bucket.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
