### PR TITLE
Document existence of update-checksums script

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -269,7 +269,8 @@ of:
   - API type definitions in [pkg/apis/serving/v1/](./pkg/apis/serving/v1/.).
   - Type definitions annotated with `// +k8s:deepcopy-gen=true`.
   - The `_example` value of config maps (to keep the
-    `knative.dev/example-checksum` label in sync).
+    `knative.dev/example-checksum` annotations in sync). These can also be
+    individually updated using `./hack/update-checksums.sh`.
   - `.proto` files. Run `./hack/update-codegen.sh` with the
     `--generate-protobufs` flag to enable protocol buffer generation.
 

--- a/hack/README.md
+++ b/hack/README.md
@@ -8,6 +8,8 @@ Knative Serving.
 - `generate-yamls.sh` Builds all the YAMLs that Knative Serving publishes.
 - `release.sh` Creates a new release of Knative Serving.
 - `update-codegen.sh` Updates auto-generated client libraries.
+- `update-checksums.sh` Updates the `knative.dev/example-checksum` annotations
+  in config maps.
 - `update-deps.sh` Updates Go dependencies.
 - `verify-codegen.sh` Verifies that auto-generated client libraries are
   up-to-date.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

If a useful little script exists in the hack directory with no-one around to hear it, does it make a sound?

also `s/label/annotation/`.

/assign @markusthoemmes 