### PR TITLE
Not run SetDefaults when updating revision

### DIFF
--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -31,6 +31,11 @@ import (
 
 // SetDefaults implements apis.Defaultable
 func (r *Revision) SetDefaults(ctx context.Context) {
+	// SetDefaults may update revision spec which is immutable.
+	// See: https://github.com/knative/serving/issues/8128 for details.
+	if apis.IsInUpdate(ctx) {
+		return
+	}
 	r.Spec.SetDefaults(apis.WithinSpec(ctx))
 }
 

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"knative.dev/pkg/apis"
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/config"
@@ -500,6 +501,30 @@ func TestRevisionDefaulting(t *testing.T) {
 					}},
 				},
 			},
+		},
+	}, {
+		name: "no SetDefaults if update revision",
+		in: &Revision{
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "user-container-1",
+					}},
+				},
+			},
+		},
+		want: &Revision{
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "user-container-1",
+					}},
+				},
+			},
+		},
+		wc: func(ctx context.Context) context.Context {
+			ctx = apis.WithinUpdate(ctx, "fake")
+			return ctx
 		},
 	}}
 


### PR DESCRIPTION

Fixes #8128

## Proposed Changes

* Not run SetDefaults if updating revision.
* Add SetDefaults unit test.

