### PR TITLE
Close existing WS connection when Lease change

### DIFF
--- a/pkg/autoscaler/statforwarder/forwarder.go
+++ b/pkg/autoscaler/statforwarder/forwarder.go
@@ -155,6 +155,10 @@ func (f *Forwarder) leaseUpdated(obj interface{}) {
 	}
 
 	holder := *l.Spec.HolderIdentity
+	p := f.getProcessor(n)
+	if p != nil && p.conn != nil {
+		p.conn.Shutdown()
+	}
 	f.setProcessor(n, f.createProcessor(n, holder))
 
 	if holder != f.selfIP {

--- a/pkg/autoscaler/statforwarder/forwarder.go
+++ b/pkg/autoscaler/statforwarder/forwarder.go
@@ -154,11 +154,13 @@ func (f *Forwarder) leaseUpdated(obj interface{}) {
 		return
 	}
 
-	holder := *l.Spec.HolderIdentity
+	// Close existing connection if there's one. The target address won't
+	// be the same as the IP has changed.
 	p := f.getProcessor(n)
 	if p != nil && p.conn != nil {
 		p.conn.Shutdown()
 	}
+	holder := *l.Spec.HolderIdentity
 	f.setProcessor(n, f.createProcessor(n, holder))
 
 	if holder != f.selfIP {

--- a/pkg/autoscaler/statforwarder/forwarder.go
+++ b/pkg/autoscaler/statforwarder/forwarder.go
@@ -24,7 +24,6 @@ import (
 
 	gorillawebsocket "github.com/gorilla/websocket"
 	"go.uber.org/zap"
-
 	coordinationv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -35,7 +34,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-
 	leaseinformer "knative.dev/pkg/client/injection/kube/informers/coordination/v1/lease"
 	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	"knative.dev/pkg/controller"
@@ -86,6 +84,9 @@ type Forwarder struct {
 	// processorsLock is the lock for processors.
 	processorsLock sync.RWMutex
 	processors     map[string]*bucketProcessor
+	// Used to capture asynchronous processes to be waited
+	// on when shutting the WebSocket connection down.
+	processingWg sync.WaitGroup
 }
 
 // New creates a new Forwarder.
@@ -156,10 +157,7 @@ func (f *Forwarder) leaseUpdated(obj interface{}) {
 
 	// Close existing connection if there's one. The target address won't
 	// be the same as the IP has changed.
-	p := f.getProcessor(n)
-	if p != nil && p.conn != nil {
-		p.conn.Shutdown()
-	}
+	f.shutdown(f.getProcessor(n))
 	holder := *l.Spec.HolderIdentity
 	f.setProcessor(n, f.createProcessor(n, holder))
 
@@ -348,11 +346,20 @@ func (f *Forwarder) Process(sm asmetrics.StatMessage) {
 	p.proc(sm)
 }
 
+func (f *Forwarder) shutdown(p *bucketProcessor) {
+	if p != nil && p.conn != nil {
+		f.processingWg.Add(1)
+		go func() {
+			defer f.processingWg.Done()
+			p.conn.Shutdown()
+		}()
+	}
+}
+
 // Cancel is the function to call when terminating a Forwarder.
 func (f *Forwarder) Cancel() {
 	for _, p := range f.processors {
-		if p.conn != nil {
-			p.conn.Shutdown()
-		}
+		f.shutdown(p)
 	}
+	f.processingWg.Wait()
 }

--- a/pkg/autoscaler/statforwarder/forwarder_test.go
+++ b/pkg/autoscaler/statforwarder/forwarder_test.go
@@ -79,13 +79,15 @@ func TestForwarderReconcile(t *testing.T) {
 		t.Fatal("Failed to start informers:", err)
 	}
 
+	f1 := New(ctx, logger, kubeClient, testIP1, testBs, noOp)
+	f2 := New(ctx, logger, kubeClient, testIP2, testBs, noOp)
+
 	defer func() {
+		f1.Cancel()
+		f2.Cancel()
 		cancel()
 		waitInformers()
 	}()
-
-	New(ctx, logger, kubeClient, testIP1, testBs, noOp)
-	New(ctx, logger, kubeClient, testIP2, testBs, noOp)
 
 	kubeClient.CoordinationV1().Leases(testNs).Create(testLease)
 	lease.Informer().GetIndexer().Add(testLease)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* The existing connection should be closed.
* Close the connections asynchronously and wait for the processing done. This should fix the flakiness in unit test.

/assign @vagababov @mattmoor 