### PR TITLE
Refactor the gRPC e2e test

### DIFF
--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -362,6 +362,7 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 	f(&testContext{
 		t:         t,
 		clients:   clients,
+		names:     names,
 		resources: resources,
 	}, host, url.Hostname())
 }


### PR DESCRIPTION
- use testContext throughout, significantly reducing the parameter lists
- other nits

/assign @julz mattmoor