### PR TITLE
[master] Update net-certmanager nightly

### DIFF
--- a/third_party/cert-manager-0.12.0/net-certmanager.yaml
+++ b/third_party/cert-manager-0.12.0/net-certmanager.yaml
@@ -18,7 +18,7 @@ metadata:
   # These are the permissions needed by the `cert-manager` `Certificate` implementation.
   name: knative-serving-certmanager
   labels:
-    serving.knative.dev/release: "v20200903-f33fbfc"
+    serving.knative.dev/release: "v20200904-f33fbfc"
     serving.knative.dev/controller: "true"
     networking.knative.dev/certificate-provider: cert-manager
 rules:
@@ -49,7 +49,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.net-certmanager.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v20200903-f33fbfc"
+    serving.knative.dev/release: "v20200904-f33fbfc"
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -86,7 +86,7 @@ metadata:
   name: net-certmanager-webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200903-f33fbfc"
+    serving.knative.dev/release: "v20200904-f33fbfc"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -109,7 +109,7 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200903-f33fbfc"
+    serving.knative.dev/release: "v20200904-f33fbfc"
     networking.knative.dev/certificate-provider: cert-manager
 data:
   _example: |
@@ -156,7 +156,7 @@ metadata:
   name: networking-certmanager
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200903-f33fbfc"
+    serving.knative.dev/release: "v20200904-f33fbfc"
     networking.knative.dev/certificate-provider: cert-manager
 spec:
   selector:
@@ -168,7 +168,7 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: networking-certmanager
-        serving.knative.dev/release: "v20200903-f33fbfc"
+        serving.knative.dev/release: "v20200904-f33fbfc"
     spec:
       serviceAccountName: controller
       containers:
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   labels:
     app: networking-certmanager
-    serving.knative.dev/release: "v20200903-f33fbfc"
+    serving.knative.dev/release: "v20200904-f33fbfc"
     networking.knative.dev/certificate-provider: cert-manager
   name: networking-certmanager
   namespace: knative-serving
@@ -245,7 +245,7 @@ metadata:
   name: net-certmanager-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200903-f33fbfc"
+    serving.knative.dev/release: "v20200904-f33fbfc"
 spec:
   selector:
     matchLabels:
@@ -258,7 +258,7 @@ spec:
       labels:
         app: net-certmanager-webhook
         role: net-certmanager-webhook
-        serving.knative.dev/release: "v20200903-f33fbfc"
+        serving.knative.dev/release: "v20200904-f33fbfc"
     spec:
       serviceAccountName: controller
       containers:
@@ -319,7 +319,7 @@ metadata:
   namespace: knative-serving
   labels:
     role: net-certmanager-webhook
-    serving.knative.dev/release: "v20200903-f33fbfc"
+    serving.knative.dev/release: "v20200904-f33fbfc"
 spec:
   ports:
   - # Define metrics and profiling for them to be accessible within service meshes.


### PR DESCRIPTION
<!--[master] Update net-certmanager nightly-->
<!---->
Produced via:
  `curl https://storage.googleapis.com/knative-nightly/net-certmanager/latest/$x > /workspace/source/./third_party/cert-manager-0.12.0/$x`
/assign tcnghia ZhiminXiang
/cc tcnghia ZhiminXiang
