### PR TITLE
Use const value for the value of KubeletProbeHeaderName

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -25,6 +25,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -35,8 +36,6 @@ import (
 	"go.uber.org/zap"
 
 	"k8s.io/apimachinery/pkg/types"
-
-	"path/filepath"
 
 	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking"

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -83,7 +83,7 @@ func rewriteUserProbe(p *corev1.Probe, userPort int) {
 		// between probes and real requests.
 		p.HTTPGet.HTTPHeaders = append(p.HTTPGet.HTTPHeaders, corev1.HTTPHeader{
 			Name:  network.KubeletProbeHeaderName,
-			Value: "queue",
+			Value: queue.Name,
 		})
 	case p.TCPSocket != nil:
 		p.TCPSocket.Port = intstr.FromInt(userPort)

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -42,6 +42,7 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	asconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
+	"knative.dev/serving/pkg/queue"
 
 	. "knative.dev/serving/pkg/testing/v1"
 )
@@ -749,7 +750,7 @@ func TestMakePodSpec(t *testing.T) {
 							Port: intstr.FromInt(networking.BackendHTTPPort),
 							HTTPHeaders: []corev1.HTTPHeader{{
 								Name:  network.KubeletProbeHeaderName,
-								Value: "queue",
+								Value: queue.Name,
 							}},
 						},
 					}),

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -45,6 +45,7 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	asconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
+	"knative.dev/serving/pkg/queue"
 )
 
 var (
@@ -480,7 +481,7 @@ func TestProbeGenerationHTTPDefaults(t *testing.T) {
 				Scheme: corev1.URISchemeHTTP,
 				HTTPHeaders: []corev1.HTTPHeader{{
 					Name:  network.KubeletProbeHeaderName,
-					Value: "queue",
+					Value: queue.Name,
 				}},
 			},
 		},
@@ -551,7 +552,7 @@ func TestProbeGenerationHTTP(t *testing.T) {
 				Scheme: corev1.URISchemeHTTPS,
 				HTTPHeaders: []corev1.HTTPHeader{{
 					Name:  network.KubeletProbeHeaderName,
-					Value: "queue",
+					Value: queue.Name,
 				}},
 			},
 		},


### PR DESCRIPTION
/lint

This patch makes a tiny change which to use const for the value of
`KubeletProbeHeaderName`

Currently a few code use the const value like [this](https://github.com/knative/serving/blob/478bac341ace7155ae88999d38d8513412d4edb0/pkg/reconciler/revision/resources/queue.go#L372-L375)
but not all codes.

**Release Note**

```release-note
NONE
```

