### PR TITLE
Add 'kind.local' to registries skipping tag resolution.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,7 +50,8 @@ If you're working on and changing `.proto` files:
    - [Docker Hub quickstart](https://docs.docker.com/docker-hub/)
    - If developing locally with Docker or Minikube, you can set
      `KO_DOCKER_REPO=ko.local` (preferred) or use the `-L` flag to `ko` to build
-     and push locally (in this case, authentication is not needed).
+     and push locally (in this case, authentication is not needed). If
+     developing with kind you can set `KO_DOCKER_REPO=kind.local`.
 
 **Note**: You'll need to be authenticated with your `KO_DOCKER_REPO` before
 pushing images. Run `gcloud auth configure-docker` if you are using Google
@@ -191,8 +192,8 @@ This step includes building Knative Serving, creating and pushing developer
 images and deploying them to your Kubernetes cluster. If you're developing
 locally (for example, using
 [Docker-on-Mac](https://knative.dev/docs/install/knative-with-docker-for-mac/)),
-set `KO_DOCKER_REPO=ko.local` to avoid needing to push your images to an
-off-machine registry.
+set `KO_DOCKER_REPO=ko.local` (or `KO_DOCKER_REPO=kind.local` respectively to
+avoid needing to push your images to an off-machine registry.
 
 Run:
 

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "a409bec7"
+    knative.dev/example-checksum: "b4ce3a17"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -42,7 +42,7 @@ data:
     # to actually change the configuration.
 
     # List of repositories for which tag to digest resolving should be skipped
-    registriesSkippingTagResolving: "ko.local,dev.local"
+    registriesSkippingTagResolving: "kind.local,ko.local,dev.local"
 
     # ProgressDeadline is the duration we wait for the deployment to
     # be ready before considering it failed.

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -67,7 +67,7 @@ var (
 func defaultConfig() *Config {
 	return &Config{
 		ProgressDeadline:               ProgressDeadlineDefault,
-		RegistriesSkippingTagResolving: sets.NewString("ko.local", "dev.local"),
+		RegistriesSkippingTagResolving: sets.NewString("kind.local", "ko.local", "dev.local"),
 		QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 	}
 }

--- a/pkg/deployment/config_test.go
+++ b/pkg/deployment/config_test.go
@@ -81,7 +81,7 @@ func TestControllerConfiguration(t *testing.T) {
 	}, {
 		name: "controller configuration good progress deadline",
 		wantConfig: &Config{
-			RegistriesSkippingTagResolving: sets.NewString("ko.local", "dev.local"),
+			RegistriesSkippingTagResolving: sets.NewString("kind.local", "ko.local", "dev.local"),
 			QueueSidecarImage:              defaultSidecarImage,
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			ProgressDeadline:               444 * time.Second,
@@ -105,7 +105,7 @@ func TestControllerConfiguration(t *testing.T) {
 	}, {
 		name: "controller configuration with custom queue sidecar resource request/limits",
 		wantConfig: &Config{
-			RegistriesSkippingTagResolving:      sets.NewString("ko.local", "dev.local"),
+			RegistriesSkippingTagResolving:      sets.NewString("kind.local", "ko.local", "dev.local"),
 			QueueSidecarImage:                   defaultSidecarImage,
 			ProgressDeadline:                    ProgressDeadlineDefault,
 			QueueSidecarCPURequest:              resourcePtr(resource.MustParse("123m")),


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

https://github.com/google/ko/pull/180 introduced the ability to sideload images into `kind` directly when using `kind.local` as a registry. This adds that registry to Knative's config by default to provide a nice OOTB experience with kind.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor 
