### PR TITLE
Fix intermittent 404 in TestServiceWithTrafficSplit

### DIFF
--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -108,6 +108,16 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconcil
 	logger := logging.FromContext(ctx)
 	logger.Debugf("Reconciling route: %#v", r.Spec)
 
+	// When a new generation is observed for the first time, we need to make sure that we
+	// do not report ourselves as being ready prematurely due to an error during
+	// reconciliation.  For instance, if we were to hit an error creating new placeholder
+	// service, we might report "Ready: True" with a bumped ObservedGeneration without
+	// having updated the kingress at all!
+	// We hit this in: https://github.com/knative-sandbox/net-contour/issues/238
+	if r.GetObjectMeta().GetGeneration() != r.Status.ObservedGeneration {
+		r.Status.MarkIngressNotConfigured()
+	}
+
 	// Configure traffic based on the RouteSpec.
 	traffic, err := c.configureTraffic(ctx, r)
 	if traffic == nil || err != nil {


### PR DESCRIPTION
While debugging the linked issue, I noticed that the test was mistakenly thinking that the Service was Ready before the kingress had even been reprogrammed (let alone probed!).  When I drilled into why I discovered that it is possible for the Route controller, when it hits an error creating a placeholder service to trigger a status update that inadvertently reports the Route as Ready before it has even updated the kingress resource.

The sequence of events here is:
1. `PreProcessReconcile` changes `Ready: Unknown` in preparation for an `ObservedGeneration` bump.
2. The early traffic assignment computation returns the condition to `Ready: True`.
3. Before we even reach the `kingress` update, the placeholder service update errors out.
4. `PostProcessReconcile` bumps the `ObservedGeneration`.
5. `UpdateStatus` records the status.

The net effect of this is that we have put the `Route` into an `IsReady()` state before we've even attempted to reconcile the `kingress`, prompting the tests to probe and get a 404.

The fix is to `MarkIngressNotConfigured` upon observing new generations, since this is the last thing we'll flip back on our path to `Ready: True`, but I wonder whether `PreProcessReconcile` should take a callback to let (require?) the reconciler itself to specify how to properly adjust the conditions.

Fixes: https://github.com/knative-sandbox/net-contour/issues/238

/assign @tcnghia @vagababov 
cc @dprotaso @whaught 

```release-note
Fixes a race where the Route controller would report readiness prematurely.
```
