### PR TITLE
Move responsive-gc feature to allowed

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "7f1b7e2d"
+    knative.dev/example-checksum: "6a69cdef"
 data:
   _example: |
     ################################
@@ -105,10 +105,7 @@ data:
     # feature labels revisions in real-time as they become referenced and
     # dereferenced by Routes. This allows us to reap revisions shortly after
     # they are no longer active.
-    #
-    # ALPHA WARNING: This feature is not yet stable or complete. Enabling it
-    # should be used for testing purposes only.
-    responsive-revision-gc: "disabled"
+    responsive-revision-gc: "allowed"
 
     # Controls whether tag header based routing feature are enabled or not.
     # 1. Enabled: enabling tag header based routing

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -48,7 +48,7 @@ func defaultFeaturesConfig() *Features {
 		PodSpecRuntimeClassName: Disabled,
 		PodSpecSecurityContext:  Disabled,
 		PodSpecTolerations:      Disabled,
-		ResponsiveRevisionGC:    Disabled,
+		ResponsiveRevisionGC:    Allowed,
 		TagHeaderBasedRouting:   Disabled,
 	}
 }

--- a/pkg/reconciler/configuration/resources/revision_test.go
+++ b/pkg/reconciler/configuration/resources/revision_test.go
@@ -323,9 +323,7 @@ func TestMakeRevisions(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
-			if test.responsiveGC {
-				ctx = enableResponsiveGC(ctx)
-			}
+			ctx = enableResponsiveGC(ctx, test.responsiveGC)
 
 			got := MakeRevision(ctx, test.configuration, clock)
 			if diff := cmp.Diff(test.want, got); diff != "" {
@@ -335,11 +333,16 @@ func TestMakeRevisions(t *testing.T) {
 	}
 }
 
-func enableResponsiveGC(ctx context.Context) context.Context {
+func enableResponsiveGC(ctx context.Context, enabled bool) context.Context {
+	flag := cfgmap.Disabled
+	if enabled {
+		flag = cfgmap.Enabled
+	}
+
 	defaultDefaults, _ := cfgmap.NewDefaultsConfigFromMap(map[string]string{})
 	c := &config.Config{
 		Features: &cfgmap.Features{
-			ResponsiveRevisionGC: cfgmap.Enabled,
+			ResponsiveRevisionGC: flag,
 		},
 		Defaults: defaultDefaults,
 	}

--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -32,7 +32,7 @@ import (
 
 // MakeConfiguration creates a Configuration from a Service object.
 func MakeConfiguration(service *v1.Service) (*v1.Configuration, error) {
-	return MakeConfigurationFromExisting(service, &v1.Configuration{}, cfgmap.Disabled)
+	return MakeConfigurationFromExisting(service, &v1.Configuration{}, cfgmap.Allowed)
 }
 
 // MakeConfigurationFromExisting creates a Configuration from a Service object given an existing Configuration.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/8208

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Move the responsive garbage collection to Allowed. In this state the new collector will run, but the lastPinned annotation continues to be updated for backwards-compat's sake in case it needs to be turned off.
    * In another release we will move it to Enabled where lastPinned is dropped.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Responsive revision garbage collection is on (allowed) by default.
```
