### PR TITLE
Refactor StatForwarder

### DIFF
--- a/pkg/autoscaler/statforwarder/forwarder.go
+++ b/pkg/autoscaler/statforwarder/forwarder.go
@@ -295,7 +295,7 @@ func (f *Forwarder) createProcessor(bkt, holder string) *bucketProcessor {
 	f.processingWg.Add(1)
 	return &bucketProcessor{
 		bkt:    bkt,
-		logger: f.logger,
+		logger: f.logger.With(zap.String("buckjet", bkt)),
 		holder: holder,
 		conn:   websocket.NewDurableSendingConnection(dns, f.logger),
 	}

--- a/pkg/autoscaler/statforwarder/forwarder.go
+++ b/pkg/autoscaler/statforwarder/forwarder.go
@@ -295,7 +295,7 @@ func (f *Forwarder) createProcessor(bkt, holder string) *bucketProcessor {
 	f.processingWg.Add(1)
 	return &bucketProcessor{
 		bkt:    bkt,
-		logger: f.logger.With(zap.String("buckjet", bkt)),
+		logger: f.logger.With(zap.String("bucket", bkt)),
 		holder: holder,
 		conn:   websocket.NewDurableSendingConnection(dns, f.logger),
 	}

--- a/pkg/autoscaler/statforwarder/forwarder.go
+++ b/pkg/autoscaler/statforwarder/forwarder.go
@@ -282,7 +282,7 @@ func (f *Forwarder) createProcessor(bkt, holder string) *bucketProcessor {
 	if holder == f.selfIP {
 		return &bucketProcessor{
 			bkt:    bkt,
-			logger: f.logger.With(zap.String("buckjet", bkt)),
+			logger: f.logger.With(zap.String("bucket", bkt)),
 			holder: holder,
 			accept: f.accept,
 		}

--- a/pkg/autoscaler/statforwarder/forwarder.go
+++ b/pkg/autoscaler/statforwarder/forwarder.go
@@ -282,7 +282,7 @@ func (f *Forwarder) createProcessor(bkt, holder string) *bucketProcessor {
 	if holder == f.selfIP {
 		return &bucketProcessor{
 			bkt:    bkt,
-			logger: f.logger,
+			logger: f.logger.With(zap.String("buckjet", bkt)),
 			holder: holder,
 			accept: f.accept,
 		}

--- a/pkg/autoscaler/statforwarder/forwarder_test.go
+++ b/pkg/autoscaler/statforwarder/forwarder_test.go
@@ -442,9 +442,14 @@ func TestProcess(t *testing.T) {
 	// Stat1 should be accepted and stat2 should be forwarded.
 	f.Process(stat1)
 	f.Process(stat2)
-	f.Process(stat2)
 
 	if got, want := acceptCount, 1; got != want {
+		t.Errorf("acceptCount = %d, want = %d", got, want)
+	}
+
+	// One more accept.
+	f.Process(stat1)
+	if got, want := acceptCount, 2; got != want {
 		t.Errorf("acceptCount = %d, want = %d", got, want)
 	}
 

--- a/pkg/autoscaler/statforwarder/forwarder_test.go
+++ b/pkg/autoscaler/statforwarder/forwarder_test.go
@@ -62,6 +62,18 @@ var (
 			HolderIdentity: &testIP1,
 		},
 	}
+	stat1 = asmetrics.StatMessage{
+		Key: types.NamespacedName{
+			Namespace: testNs,
+			Name:      "succulent", // Mapped to bucket1
+		},
+	}
+	stat2 = asmetrics.StatMessage{
+		Key: types.NamespacedName{
+			Namespace: testNs,
+			Name:      "plant", // Mapped to bucket2
+		},
+	}
 	// A statProcessor doing nothing.
 	noOp = func(sm asmetrics.StatMessage) {}
 )
@@ -400,19 +412,6 @@ func TestProcess(t *testing.T) {
 	}
 	f := New(ctx, logger, kubeClient, testIP1, hash.NewBucketSet(sets.NewString(bucket1, bucket2)), accept)
 
-	stat1 := asmetrics.StatMessage{
-		Key: types.NamespacedName{
-			Namespace: testNs,
-			Name:      "succulent", // Mapped to bucket1
-		},
-	}
-	stat2 := asmetrics.StatMessage{
-		Key: types.NamespacedName{
-			Namespace: testNs,
-			Name:      "plant", // Mapped to bucket2
-		},
-	}
-
 	// A Forward without any leadership information should process without error.
 	f.Process(stat1)
 
@@ -440,21 +439,13 @@ func TestProcess(t *testing.T) {
 		t.Fatalf("Timeout waiting f.processors got updated")
 	}
 
-	forwardCount := 0
-	// Override the proc so we do not actually send via WebSocket.
-	f.processors[bucket2].proc = func(sm asmetrics.StatMessage) {
-		forwardCount++
-	}
-
+	// Stat1 should be accepted and stat2 should be forwarded.
 	f.Process(stat1)
 	f.Process(stat2)
 	f.Process(stat2)
 
 	if got, want := acceptCount, 1; got != want {
 		t.Errorf("acceptCount = %d, want = %d", got, want)
-	}
-	if got, want := forwardCount, 2; got != want {
-		t.Errorf("forwardCount = %d, want = %d", got, want)
 	}
 
 	// Make sure Cancel can be called without crash.

--- a/pkg/autoscaler/statforwarder/processor.go
+++ b/pkg/autoscaler/statforwarder/processor.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statforwarder
+
+import (
+	gorillawebsocket "github.com/gorilla/websocket"
+	"go.uber.org/zap"
+	"knative.dev/pkg/websocket"
+	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
+)
+
+// bucketProcessor includes the information about how to process
+// the StatMessage owned by a bucket.
+type bucketProcessor struct {
+	logger *zap.SugaredLogger
+	// The name of the bucket
+	bkt string
+	// holder is the HolderIdentity for a bucket from the Lease.
+	holder string
+	// conn is the WebSocket connection to the holder pod.
+	conn *websocket.ManagedConnection
+	// `accept` is the function to process a StatMessage which doesn't need
+	// to be forwarded.
+	accept statProcessor
+}
+
+func (p *bucketProcessor) process(sm asmetrics.StatMessage) {
+	l := p.logger.With(zap.String("revision", sm.Key.String()))
+	if p.accept != nil {
+		l.Debug("Accept stat as owner of bucket ", p.bkt)
+		p.accept(sm)
+		return
+	}
+
+	l.Debugf("Forward stat of bucket %s to the holder %s", p.bkt, p.holder)
+	wsms := asmetrics.ToWireStatMessages([]asmetrics.StatMessage{sm})
+	b, err := wsms.Marshal()
+	if err != nil {
+		l.Errorw("Error while marshaling stats", zap.Error(err))
+		return
+	}
+
+	if err := p.conn.SendRaw(gorillawebsocket.BinaryMessage, b); err != nil {
+		l.Errorw("Error while sending stats", zap.Error(err))
+	}
+}

--- a/pkg/autoscaler/statforwarder/processor.go
+++ b/pkg/autoscaler/statforwarder/processor.go
@@ -19,6 +19,7 @@ package statforwarder
 import (
 	gorillawebsocket "github.com/gorilla/websocket"
 	"go.uber.org/zap"
+
 	"knative.dev/pkg/websocket"
 	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
 )

--- a/pkg/autoscaler/statforwarder/processor_test.go
+++ b/pkg/autoscaler/statforwarder/processor_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statforwarder
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	gorillawebsocket "github.com/gorilla/websocket"
+	"k8s.io/apimachinery/pkg/util/wait"
+	. "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/websocket"
+)
+
+func TestProcessorForwarding(t *testing.T) {
+	received := make(chan struct{})
+	var httpHandler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		var upgrader gorillawebsocket.Upgrader
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("error upgrading websocket: %v", err)
+		}
+
+		defer conn.Close()
+		for {
+			_, _, err := conn.ReadMessage()
+			if err != nil {
+				t.Fatalf("error reading message: %v", err)
+			}
+			received <- struct{}{}
+		}
+	}
+
+	s := httptest.NewServer(httpHandler)
+	defer s.Close()
+
+	logger := TestLogger(t)
+	conn := websocket.NewDurableSendingConnection("ws"+strings.TrimPrefix(s.URL, "http"), logger)
+	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+		return conn.HasEstablished(), nil
+	}); err != nil {
+		t.Fatalf("Timeout waiting f.processors got updated")
+	}
+
+	p := bucketProcessor{
+		logger: logger,
+		bkt:    bucket1,
+		conn:   conn,
+	}
+
+	p.process(stat1)
+
+	select {
+	case <-received:
+	case <-time.After(time.Second):
+		t.Error("Timeout waiting for SVC retry")
+	}
+}

--- a/pkg/autoscaler/statforwarder/processor_test.go
+++ b/pkg/autoscaler/statforwarder/processor_test.go
@@ -25,6 +25,7 @@ import (
 
 	gorillawebsocket "github.com/gorilla/websocket"
 	"k8s.io/apimachinery/pkg/util/wait"
+
 	. "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/websocket"
 )
@@ -57,7 +58,7 @@ func TestProcessorForwarding(t *testing.T) {
 	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
 		return conn.IsEstablished(), nil
 	}); err != nil {
-		t.Fatalf("Timeout waiting f.processors got updated")
+		t.Fatal("Timeout waiting f.processors got updated")
 	}
 
 	p := bucketProcessor{

--- a/vendor/knative.dev/pkg/websocket/connection.go
+++ b/vendor/knative.dev/pkg/websocket/connection.go
@@ -327,3 +327,11 @@ func (c *ManagedConnection) Shutdown() error {
 	c.processingWg.Wait()
 	return err
 }
+
+// Shutdown closes the websocket connection.
+func (c *ManagedConnection) HasEstablished() bool {
+	c.connectionLock.RLock()
+	defer c.connectionLock.RUnlock()
+
+	return c.connection != nil
+}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

For #2930. We need more complicated logic for forwarding stat path if there's mesh. Refactor the code to make it easier to add the logic to send stat via Service URL and write unit tests.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Move `bucketProcessor` to its own file.
* Move the process stat func from a field of a struct to a function of a struct.
* Add unit test for the process func.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
