### PR TITLE
Resolve image digests in the background

### DIFF
--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -34,6 +34,10 @@ const (
 	// as false if the a container image for the revision is missing.
 	ReasonContainerMissing = "ContainerMissing"
 
+	// ReasonResolvingDigests defines the reason for marking container healthiness status
+	// as unknown if the digests for the container images are being resolved.
+	ReasonResolvingDigests = "ResolvingDigests"
+
 	// ReasonDeploying defines the reason for marking revision availability status as
 	// unknown if the revision is still deploying.
 	ReasonDeploying = "Deploying"

--- a/pkg/reconciler/revision/background.go
+++ b/pkg/reconciler/revision/background.go
@@ -51,14 +51,16 @@ type backgroundResolver struct {
 // resolveResult is the overall result for a particular revision. We create a
 // workItem for each container we need to resolve for the overall result.
 type resolveResult struct {
+	// these fields are immutable afer creation, so can be accessed without a lock.
+	opt                k8schain.Options
+	registriesToSkip   sets.String
+	completionCallback func()
+
+	// these fields can be written concurrently, so should only be accessed while
+	// holding the backgroundResolver mutex.
 	statuses  []v1.ContainerStatus
 	err       error
 	remaining int
-
-	opt              k8schain.Options
-	registriesToSkip sets.String
-
-	completionCallback func()
 }
 
 // workItem is a single task submitted to the queue, to resolve a single image

--- a/pkg/reconciler/revision/background.go
+++ b/pkg/reconciler/revision/background.go
@@ -166,8 +166,10 @@ func (r *backgroundResolver) Resolve(rev *v1.Revision, opt k8schain.Options, reg
 // This is expected to be called with the mutex locked.
 func (r *backgroundResolver) addWorkItems(rev *v1.Revision, name types.NamespacedName, opt k8schain.Options, registriesToSkip sets.String, timeout time.Duration) {
 	r.results[name] = &resolveResult{
-		statuses:  make([]v1.ContainerStatus, len(rev.Spec.Containers)),
-		remaining: len(rev.Spec.Containers),
+		opt:              opt,
+		registriesToSkip: registriesToSkip,
+		statuses:         make([]v1.ContainerStatus, len(rev.Spec.Containers)),
+		remaining:        len(rev.Spec.Containers),
 		completionCallback: func() {
 			r.enqueue(name)
 		},

--- a/pkg/reconciler/revision/background.go
+++ b/pkg/reconciler/revision/background.go
@@ -107,7 +107,7 @@ func (r *backgroundResolver) Start(stop <-chan struct{}, maxInFlight int) (done 
 
 				rrItem, ok := item.(*workItem)
 				if !ok {
-					r.logger.Fatalf("Unexpected work item type: want: %T, got: %T\n", &workItem{}, item)
+					r.logger.Fatalf("Unexpected work item type: want: %T, got: %T", &workItem{}, item)
 				}
 
 				r.processWorkItem(rrItem)
@@ -212,12 +212,14 @@ func (r *backgroundResolver) processWorkItem(item *workItem) {
 	if err != nil {
 		item.result.statuses = nil
 		item.result.err = containerMissingError{image: item.image, cause: err}
-	} else {
-		item.result.remaining--
-		item.result.statuses[item.index] = v1.ContainerStatus{
-			Name:        item.name,
-			ImageDigest: result,
-		}
+		item.result.completionCallback()
+		return
+	}
+
+	item.result.remaining--
+	item.result.statuses[item.index] = v1.ContainerStatus{
+		Name:        item.name,
+		ImageDigest: result,
 	}
 
 	if item.result.ready() {

--- a/pkg/reconciler/revision/background.go
+++ b/pkg/reconciler/revision/background.go
@@ -1,0 +1,260 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn/k8schain"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/workqueue"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+)
+
+// imageResolver is an interface used mostly to mock digestResolver for tests.
+type imageResolver interface {
+	Resolve(ctx context.Context, image string, opt k8schain.Options, registriesToSkip sets.String) (string, error)
+}
+
+// backgroundResolver performs background downloads of image digests.
+type backgroundResolver struct {
+	logger *zap.SugaredLogger
+
+	resolver imageResolver
+	enqueue  func(types.NamespacedName)
+
+	queue workqueue.Interface
+
+	mu      sync.Mutex
+	results map[types.NamespacedName]*resolveResult
+}
+
+// resolveResult is the overall result for a particular revision. We create a
+// workItem for each container we need to resolve for the overall result.
+type resolveResult struct {
+	statuses  []v1.ContainerStatus
+	err       error
+	remaining int
+
+	opt              k8schain.Options
+	registriesToSkip sets.String
+
+	completionCallback func()
+}
+
+// workItem is a single task submitted to the queue, to resolve a single image
+// for a resolveResult.
+type workItem struct {
+	result  *resolveResult
+	timeout time.Duration
+
+	name  string
+	image string
+	index int
+}
+
+func newBackgroundResolver(logger *zap.SugaredLogger, resolver imageResolver, enqueue func(types.NamespacedName)) *backgroundResolver {
+	r := &backgroundResolver{
+		logger: logger,
+
+		resolver: resolver,
+		enqueue:  enqueue,
+
+		results: make(map[types.NamespacedName]*resolveResult),
+		queue:   workqueue.NewNamed("digests"),
+	}
+
+	return r
+}
+
+// Start starts the worker threads and runs maxInFlight workers until the stop
+// channel is closed. It returns a done channel which will be closed when all
+// workers have exited.
+func (r *backgroundResolver) Start(stop <-chan struct{}, maxInFlight int) (done chan struct{}) {
+	var wg sync.WaitGroup
+
+	// Run the worker threads.
+	wg.Add(maxInFlight)
+	for i := 0; i < maxInFlight; i++ {
+		go func() {
+			defer wg.Done()
+			for {
+				item, shutdown := r.queue.Get()
+				if shutdown {
+					return
+				}
+
+				rrItem, ok := item.(*workItem)
+				if !ok {
+					r.logger.Fatalf("Unexpected work item type: want: %s, got: %s\n",
+						reflect.TypeOf(&workItem{}).Name(), reflect.TypeOf(item).Name())
+				}
+
+				r.processWorkItem(rrItem)
+			}
+		}()
+	}
+
+	// Shut down the queue once the stop channel is closed, this will cause all
+	// the workers to exit.
+	go func() {
+		<-stop
+		r.queue.ShutDown()
+	}()
+
+	// Return a done channel which is closed once all workers exit.
+	done = make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	return done
+}
+
+// Resolve is intended to be called from a reconciler to resolve a revision. If
+// the resolver already has the digest in cache it is returned immediately, if
+// it does not and no resolution is already in flight a resolution is triggered
+// in the background.
+// If this method returns nil, nil this implies a resolve was triggered or is
+// already in progress, so the reconciler should exit and wait for the revision
+// to be re-enqueued when the result is ready.
+func (r *backgroundResolver) Resolve(rev *v1.Revision, opt k8schain.Options, registriesToSkip sets.String, timeout time.Duration) ([]v1.ContainerStatus, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	name := types.NamespacedName{
+		Name:      rev.Name,
+		Namespace: rev.Namespace,
+	}
+
+	result, inFlight := r.results[name]
+	if !inFlight {
+		r.addWorkItems(rev, opt, registriesToSkip, timeout)
+		return nil, nil
+	}
+
+	if !result.ready() {
+		return nil, nil
+	}
+
+	return r.results[name].statuses, r.results[name].err
+}
+
+// addWorkItems adds a digest resolve item to the queue for each container in the revision.
+// This is expected to be called with the mutex locked.
+func (r *backgroundResolver) addWorkItems(rev *v1.Revision, opt k8schain.Options, registriesToSkip sets.String, timeout time.Duration) {
+	name := types.NamespacedName{
+		Name:      rev.Name,
+		Namespace: rev.Namespace,
+	}
+
+	r.results[name] = &resolveResult{
+		statuses:  make([]v1.ContainerStatus, len(rev.Spec.Containers)),
+		remaining: len(rev.Spec.Containers),
+		completionCallback: func() {
+			r.enqueue(name)
+		},
+	}
+
+	for i := range rev.Spec.Containers {
+		image := rev.Spec.Containers[i].Image
+
+		r.queue.Add(&workItem{
+			result:  r.results[name],
+			timeout: timeout,
+			name:    rev.Spec.Containers[i].Name,
+			image:   image,
+			index:   i,
+		})
+	}
+}
+
+// processWorkItem runs a single image digest resolution and stores the result
+// in the resolveResult. If this completes the work for the revision, the
+// completionCallback is called.
+func (r *backgroundResolver) processWorkItem(item *workItem) {
+	ctx, cancel := context.WithTimeout(context.Background(), item.timeout)
+	defer cancel()
+
+	result, err := r.resolver.Resolve(ctx, item.image, item.result.opt, item.result.registriesToSkip)
+
+	// lock after the resolve because we don't want to block parallel resolves,
+	// just storing the result.
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// If we're already ready we don't want to callback twice.
+	// This can happen if an image resolve completes but we've already reported
+	// an error from another image in the result.
+	if item.result.ready() {
+		return
+	}
+
+	if err != nil {
+		item.result.statuses = nil
+		item.result.err = ContainerMissingError{image: item.image, cause: err}
+	} else {
+		item.result.remaining--
+		item.result.statuses[item.index] = v1.ContainerStatus{
+			Name:        item.name,
+			ImageDigest: result,
+		}
+	}
+
+	if item.result.ready() {
+		item.result.completionCallback()
+	}
+}
+
+// Clear removes any cached results for the revision. This should be called
+// when the revision is deleted or once the revision's ContainerStatus has been
+// set.
+func (r *backgroundResolver) Clear(name types.NamespacedName) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// delete the map entry, the result can still be accessed via the pointer in
+	// the workItem so processWorkItem doesn't care about this, but once the
+	// workItem is done the result will be GC-ed.
+	delete(r.results, name)
+}
+
+func (r *resolveResult) ready() bool {
+	return r.remaining == 0 || r.err != nil
+}
+
+// ContainerMissingError converts an error in to the expected format for the
+// RevisionContainerMissing condition.
+type ContainerMissingError struct {
+	image string
+	cause error
+}
+
+func (e ContainerMissingError) Error() string {
+	return v1.RevisionContainerMissingMessage(e.image, fmt.Sprintf("failed to resolve image to digest: %v", e.cause))
+}
+
+func (e ContainerMissingError) Unwrap() error {
+	return e.cause
+}

--- a/pkg/reconciler/revision/background.go
+++ b/pkg/reconciler/revision/background.go
@@ -19,7 +19,6 @@ package revision
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
@@ -106,8 +105,7 @@ func (r *backgroundResolver) Start(stop <-chan struct{}, maxInFlight int) (done 
 
 				rrItem, ok := item.(*workItem)
 				if !ok {
-					r.logger.Fatalf("Unexpected work item type: want: %s, got: %s\n",
-						reflect.TypeOf(&workItem{}).Name(), reflect.TypeOf(item).Name())
+					r.logger.Fatalf("Unexpected work item type: want: %T, got: %T\n", &workItem{}, item)
 				}
 
 				r.processWorkItem(rrItem)

--- a/pkg/reconciler/revision/background.go
+++ b/pkg/reconciler/revision/background.go
@@ -209,7 +209,7 @@ func (r *backgroundResolver) processWorkItem(item *workItem) {
 
 	if err != nil {
 		item.result.statuses = nil
-		item.result.err = ContainerMissingError{image: item.image, cause: err}
+		item.result.err = containerMissingError{image: item.image, cause: err}
 	} else {
 		item.result.remaining--
 		item.result.statuses[item.index] = v1.ContainerStatus{
@@ -240,17 +240,17 @@ func (r *resolveResult) ready() bool {
 	return r.remaining == 0 || r.err != nil
 }
 
-// ContainerMissingError converts an error in to the expected format for the
+// containerMissingError converts an error in to the expected format for the
 // RevisionContainerMissing condition.
-type ContainerMissingError struct {
+type containerMissingError struct {
 	image string
 	cause error
 }
 
-func (e ContainerMissingError) Error() string {
+func (e containerMissingError) Error() string {
 	return v1.RevisionContainerMissingMessage(e.image, fmt.Sprintf("failed to resolve image to digest: %v", e.cause))
 }
 
-func (e ContainerMissingError) Unwrap() error {
+func (e containerMissingError) Unwrap() error {
 	return e.cause
 }

--- a/pkg/reconciler/revision/background_test.go
+++ b/pkg/reconciler/revision/background_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	logtesting "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/ptr"
+
+	"github.com/google/go-containerregistry/pkg/authn/k8schain"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+)
+
+var (
+	fakeError    = errors.New("digest error")
+	fakeRevision = &v1.Revision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rev",
+			Namespace: "ns",
+		},
+		Spec: v1.RevisionSpec{
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "first",
+					Image: "first-image",
+				}, {
+					Name:  "second",
+					Image: "second-image",
+				}},
+			},
+		},
+	}
+)
+
+func TestResolveInBackground(t *testing.T) {
+	tests := []struct {
+		name         string
+		resolver     resolveFunc
+		timeout      *time.Duration
+		wantStatuses []v1.ContainerStatus
+		wantError    error
+	}{{
+		name: "success",
+		resolver: func(_ context.Context, img string, _ k8schain.Options, _ sets.String) (string, error) {
+			return img + "-digest", nil
+		},
+		wantStatuses: []v1.ContainerStatus{{
+			Name:        "first",
+			ImageDigest: "first-image-digest",
+		}, {
+			Name:        "second",
+			ImageDigest: "second-image-digest",
+		}},
+	}, {
+		name: "one slow resolve",
+		resolver: func(_ context.Context, img string, _ k8schain.Options, _ sets.String) (string, error) {
+			if img == "first-image" {
+				// make the first resolve arrive after the second.
+				time.Sleep(200 * time.Millisecond)
+			}
+			return img + "-digest", nil
+		},
+		wantStatuses: []v1.ContainerStatus{{
+			Name:        "first",
+			ImageDigest: "first-image-digest",
+		}, {
+			Name:        "second",
+			ImageDigest: "second-image-digest",
+		}},
+	}, {
+		name: "resolver entirely fails",
+		resolver: func(_ context.Context, img string, _ k8schain.Options, _ sets.String) (string, error) {
+			return img + "-digest", fakeError
+		},
+		wantError: fakeError,
+	}, {
+		name: "resolver fails one image",
+		resolver: func(_ context.Context, img string, _ k8schain.Options, _ sets.String) (string, error) {
+			if img == "second-image" {
+				return "", fakeError
+			}
+
+			return img + "-digest", nil
+		},
+		wantError: fakeError,
+	}, {
+		name:    "timeout",
+		timeout: ptr.Duration(10 * time.Millisecond),
+		resolver: func(ctx context.Context, img string, _ k8schain.Options, _ sets.String) (string, error) {
+			if img == "second-image" {
+				time.Sleep(500 * time.Millisecond)
+			}
+
+			return img + "-digest", ctx.Err()
+		},
+		wantError: context.DeadlineExceeded,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timeout := 5 * time.Second
+			if tt.timeout != nil {
+				timeout = *tt.timeout
+			}
+
+			ready := make(chan types.NamespacedName)
+			cb := func(rev types.NamespacedName) {
+				ready <- rev
+				close(ready)
+			}
+
+			logger := logtesting.TestLogger(t)
+			subject := newBackgroundResolver(logger, tt.resolver, cb)
+
+			stop := make(chan struct{})
+			done := subject.Start(stop, 10)
+
+			defer func() {
+				close(stop)
+				<-done
+			}()
+
+			for i := 0; i < 2; i++ {
+				t.Run(fmt.Sprintf("iteration %d", i), func(t *testing.T) {
+					statuses, err := subject.Resolve(fakeRevision, k8schain.Options{}, nil, timeout)
+					if err != nil || statuses != nil {
+						// Initial result should be nil, nil since we have nothing in cache.
+						t.Errorf("Resolve() = %v, %v, wanted nil, nil", statuses, err)
+					}
+
+					select {
+					case <-ready:
+						// got the result.
+					case <-time.After(2 * time.Second):
+						// This shouldn't happen in these tests. The callback is always
+						// eventually called.
+						t.Fatalf("Resolver did not report ready")
+					}
+
+					statuses, err = subject.Resolve(fakeRevision, k8schain.Options{}, nil, timeout)
+					if got, want := err, tt.wantError; !errors.Is(got, want) {
+						t.Errorf("Resolve() = _, %q, wanted %q", got, want)
+					}
+					if got, want := statuses, tt.wantStatuses; !reflect.DeepEqual(got, want) {
+						t.Errorf("Resolve() = %v, wanted %v", got, want)
+					}
+
+					// Clear, then we'll loop and make sure that we look everything up from scratch.
+					subject.Clear(types.NamespacedName{Namespace: fakeRevision.Namespace, Name: fakeRevision.Name})
+					ready = make(chan types.NamespacedName)
+				})
+			}
+		})
+	}
+}
+
+type resolveFunc func(context.Context, string, k8schain.Options, sets.String) (string, error)
+
+func (r resolveFunc) Resolve(c context.Context, s string, o k8schain.Options, t sets.String) (string, error) {
+	return r(c, s, o, t)
+}

--- a/pkg/reconciler/revision/background_test.go
+++ b/pkg/reconciler/revision/background_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 var (
-	fakeError    = errors.New("digest error")
+	errDigest    = errors.New("digest error")
 	fakeRevision = &v1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "rev",
@@ -106,19 +106,19 @@ func TestResolveInBackground(t *testing.T) {
 	}, {
 		name: "resolver entirely fails",
 		resolver: func(_ context.Context, img string, _ k8schain.Options, _ sets.String) (string, error) {
-			return img + "-digest", fakeError
+			return img + "-digest", errDigest
 		},
-		wantError: fakeError,
+		wantError: errDigest,
 	}, {
 		name: "resolver fails one image",
 		resolver: func(_ context.Context, img string, _ k8schain.Options, _ sets.String) (string, error) {
 			if img == "second-image" {
-				return "", fakeError
+				return "", errDigest
 			}
 
 			return img + "-digest", nil
 		},
-		wantError: fakeError,
+		wantError: errDigest,
 	}, {
 		name:    "timeout",
 		timeout: ptr.Duration(10 * time.Millisecond),

--- a/pkg/reconciler/revision/background_test.go
+++ b/pkg/reconciler/revision/background_test.go
@@ -92,7 +92,7 @@ func TestResolveInBackground(t *testing.T) {
 		resolver: func(_ context.Context, img string, _ k8schain.Options, _ sets.String) (string, error) {
 			if img == "first-image" {
 				// make the first resolve arrive after the second.
-				time.Sleep(200 * time.Millisecond)
+				time.Sleep(50 * time.Millisecond)
 			}
 			return img + "-digest", nil
 		},

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -105,6 +105,14 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) (boo
 	}
 	if len(statuses) > 0 {
 		rev.Status.ContainerStatuses = statuses
+
+		// For backwards-compatibility we need to continue to set the DeprecatedImageDigest field.
+		for i := range rev.Spec.Containers {
+			if len(rev.Spec.Containers) == 1 || len(rev.Spec.Containers[i].Ports) != 0 {
+				rev.Status.DeprecatedImageDigest = statuses[i].ImageDigest
+			}
+		}
+
 		return true, nil
 	}
 

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -18,15 +18,13 @@ package revision
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"strings"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
-	"golang.org/x/sync/errgroup"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
@@ -46,7 +44,8 @@ import (
 const digestResolutionTimeout = 60 * time.Second
 
 type resolver interface {
-	Resolve(context.Context, string, k8schain.Options, sets.String) (string, error)
+	Resolve(*v1.Revision, k8schain.Options, sets.String, time.Duration) ([]v1.ContainerStatus, error)
+	Clear(types.NamespacedName)
 }
 
 // Reconciler implements controller.Reconciler for Revision resources.
@@ -66,7 +65,7 @@ type Reconciler struct {
 // Check that our Reconciler implements revisionreconciler.Interface
 var _ revisionreconciler.Interface = (*Reconciler)(nil)
 
-func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) error {
+func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) (bool, error) {
 	if rev.Status.ContainerStatuses == nil {
 		rev.Status.ContainerStatuses = make([]v1.ContainerStatus, 0, len(rev.Spec.Containers))
 	}
@@ -84,7 +83,8 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) erro
 
 	// The image digest has already been resolved.
 	if len(rev.Status.ContainerStatuses) == len(rev.Spec.Containers) {
-		return nil
+		c.resolver.Clear(types.NamespacedName{Namespace: rev.Namespace, Name: rev.Name})
+		return true, nil
 	}
 
 	imagePullSecrets := make([]string, 0, len(rev.Spec.ImagePullSecrets))
@@ -98,47 +98,38 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) erro
 		ImagePullSecrets:   imagePullSecrets,
 	}
 
-	var digestGrp errgroup.Group
-	containerStatuses := make([]v1.ContainerStatus, len(rev.Spec.Containers))
-	for i, container := range rev.Spec.Containers {
-		container := container // Standard Go concurrency pattern.
-		i := i
-		digestGrp.Go(func() error {
-			ctx, cancel := context.WithTimeout(ctx, digestResolutionTimeout)
-			defer cancel()
-
-			digest, err := c.resolver.Resolve(ctx, container.Image,
-				opt, cfgs.Deployment.RegistriesSkippingTagResolving)
-			if err != nil {
-				return errors.New(v1.RevisionContainerMissingMessage(container.Image, fmt.Sprintf("failed to resolve image to digest: %v", err)))
-			}
-
-			if len(rev.Spec.Containers) == 1 || len(container.Ports) != 0 {
-				rev.Status.DeprecatedImageDigest = digest
-			}
-
-			containerStatuses[i] = v1.ContainerStatus{
-				Name:        container.Name,
-				ImageDigest: digest,
-			}
-			return nil
-		})
-	}
-	if err := digestGrp.Wait(); err != nil {
+	statuses, err := c.resolver.Resolve(rev, opt, cfgs.Deployment.RegistriesSkippingTagResolving, digestResolutionTimeout)
+	if err != nil {
 		rev.Status.MarkContainerHealthyFalse(v1.ReasonContainerMissing, err.Error())
-		return err
+		return true, err
 	}
-	rev.Status.ContainerStatuses = containerStatuses
-	return nil
+	if len(statuses) > 0 {
+		rev.Status.ContainerStatuses = statuses
+		return true, nil
+	}
+
+	// No digest yet, wait for re-enqueue when resolution is done.
+	return false, nil
 }
 
 func (c *Reconciler) ReconcileKind(ctx context.Context, rev *v1.Revision) pkgreconciler.Event {
 	readyBeforeReconcile := rev.IsReady()
 	c.updateRevisionLoggingURL(ctx, rev)
 
+	reconciled, err := c.reconcileDigest(ctx, rev)
+	if err != nil {
+		return err
+	}
+	if !reconciled {
+		// Digest not resolved yet, wait for background resolution to re-enqueue the revision.
+		rev.Status.MarkContainerHealthyUnknown("ResolvingDigests", "")
+		return nil
+	}
+
 	for _, phase := range []func(context.Context, *v1.Revision) error{
-		c.reconcileDigest, c.reconcileDeployment,
-		c.reconcileImageCache, c.reconcilePA,
+		c.reconcileDeployment,
+		c.reconcileImageCache,
+		c.reconcilePA,
 	} {
 		if err := phase(ctx, rev); err != nil {
 			return err

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -130,7 +130,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, rev *v1.Revision) pkgrec
 	}
 	if !reconciled {
 		// Digest not resolved yet, wait for background resolution to re-enqueue the revision.
-		rev.Status.MarkContainerHealthyUnknown("ResolvingDigests", "")
+		rev.Status.MarkResourcesAvailableUnknown(v1.ReasonResolvingDigests, "")
 		return nil
 	}
 

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -229,9 +229,13 @@ func addResourcesToInformers(t *testing.T, ctx context.Context, rev *v1.Revision
 
 type nopResolver struct{}
 
-func (r *nopResolver) Resolve(context.Context, string, k8schain.Options, sets.String) (string, error) {
-	return "", nil
+func (r *nopResolver) Resolve(rev *v1.Revision, _ k8schain.Options, _ sets.String, _ time.Duration) ([]v1.ContainerStatus, error) {
+	return []v1.ContainerStatus{{
+		Name: rev.Spec.Containers[0].Name,
+	}}, nil
 }
+
+func (r *nopResolver) Clear(types.NamespacedName) {}
 
 func testPodSpec() corev1.PodSpec {
 	return corev1.PodSpec{
@@ -320,13 +324,23 @@ func testDefaultsCM() *corev1.ConfigMap {
 	}
 }
 
+type notResolvedYetResolver struct{}
+
+func (r *notResolvedYetResolver) Resolve(_ *v1.Revision, _ k8schain.Options, _ sets.String, _ time.Duration) ([]v1.ContainerStatus, error) {
+	return nil, nil
+}
+
+func (r *notResolvedYetResolver) Clear(types.NamespacedName) {}
+
 type errorResolver struct {
 	err error
 }
 
-func (r *errorResolver) Resolve(_ context.Context, _ string, _ k8schain.Options, _ sets.String) (string, error) {
-	return "", r.err
+func (r *errorResolver) Resolve(_ *v1.Revision, _ k8schain.Options, _ sets.String, _ time.Duration) ([]v1.ContainerStatus, error) {
+	return nil, r.err
 }
+
+func (r *errorResolver) Clear(types.NamespacedName) {}
 
 func TestResolutionFailed(t *testing.T) {
 	// Unconditionally return this error during resolution.
@@ -336,7 +350,6 @@ func TestResolutionFailed(t *testing.T) {
 	})
 
 	rev := testRevision(testPodSpec())
-
 	createRevision(t, ctx, controller, rev)
 
 	rev, err := fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Get(ctx, rev.Name, metav1.GetOptions{})
@@ -348,11 +361,10 @@ func TestResolutionFailed(t *testing.T) {
 	for _, ct := range []apis.ConditionType{"ContainerHealthy", "Ready"} {
 		got := rev.Status.GetCondition(ct)
 		want := &apis.Condition{
-			Type:   ct,
-			Status: corev1.ConditionFalse,
-			Reason: "ContainerMissing",
-			Message: v1.RevisionContainerMissingMessage(
-				rev.Spec.GetContainer().Image, "failed to resolve image to digest: "+innerError.Error()),
+			Type:               ct,
+			Status:             corev1.ConditionFalse,
+			Reason:             "ContainerMissing",
+			Message:            innerError.Error(),
 			LastTransitionTime: got.LastTransitionTime,
 			Severity:           apis.ConditionSeverityError,
 		}
@@ -403,48 +415,40 @@ func TestUpdateRevWithWithUpdatedLoggingURL(t *testing.T) {
 	}
 }
 
-func TestRevWithImageDigests(t *testing.T) {
-	ctx, _, _, controller, _ := newTestController(t, nil /*additional CMs*/)
-	rev := testRevision(corev1.PodSpec{
-		Containers: []corev1.Container{{
-			Name:  "first",
-			Image: "gcr.io/repo/image",
-			Ports: []corev1.ContainerPort{{
-				ContainerPort: 8888,
-			}},
-		}, {
-			Name:  "second",
-			Image: "docker.io/repo/image",
-		}, {
-			Name:  "third",
-			Image: "docker.io/anotherrepo/image",
-		}},
+func TestStatusUnknownWhenDigestsNotResolvedYet(t *testing.T) {
+	ctx, _, _, controller, _ := newTestController(t, nil /*additional CMs*/, func(r *Reconciler) {
+		r.resolver = &notResolvedYetResolver{}
 	})
-	createRevision(t, ctx, controller, rev)
-	revClient := fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace)
-	rev, err := revClient.Get(ctx, rev.Name, metav1.GetOptions{})
+
+	rev := testRevision(testPodSpec())
+
+	fakeservingclient.Get(ctx).ServingV1().Revisions(rev.Namespace).Create(ctx, rev, metav1.CreateOptions{})
+	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
+	if err := controller.Reconciler.Reconcile(context.Background(), KeyOrDie(rev)); err != nil {
+		t.Fatal("Reconcile failed:", err)
+	}
+
+	rev, err := fakeservingclient.Get(ctx).ServingV1().Revisions(rev.Namespace).Get(ctx, rev.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal("Couldn't get revision:", err)
 	}
-	if len(rev.Status.ContainerStatuses) < 2 {
-		t.Error("Revision status does not have imageDigests")
-	}
 
-	rev.Status.DeprecatedImageDigest = "gcr.io/repo/image"
-	updateRevision(t, ctx, controller, rev)
-	if len(rev.Spec.Containers) != len(rev.Status.ContainerStatuses) {
-		t.Fatal("Image digests do not match the provided containers")
-	}
-	for i, c := range rev.Spec.Containers {
-		if c.Name != rev.Status.ContainerStatuses[i].Name {
-			t.Error("Container statuses do not match the order of containers in spec")
+	// Status should be Unknown until the resolution.
+	for _, ct := range []apis.ConditionType{"ContainerHealthy", "Ready"} {
+		got := rev.Status.GetCondition(ct)
+		want := &apis.Condition{
+			Type:               ct,
+			Status:             corev1.ConditionUnknown,
+			Reason:             "ResolvingDigests",
+			Message:            "",
+			LastTransitionTime: got.LastTransitionTime,
+			Severity:           apis.ConditionSeverityError,
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("Unexpected revision conditions diff for condition %q (-want +got):\n%s", ct, diff)
 		}
 	}
-	rev.Status.ContainerStatuses = []v1.ContainerStatus{}
-	updateRevision(t, ctx, controller, rev)
-	if len(rev.Status.ContainerStatuses) != 0 {
-		t.Error("Failed to update revision")
-	}
+
 }
 
 func TestGlobalResyncOnDefaultCMChange(t *testing.T) {

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -433,8 +433,8 @@ func TestStatusUnknownWhenDigestsNotResolvedYet(t *testing.T) {
 		t.Fatal("Couldn't get revision:", err)
 	}
 
-	// Status should be Unknown until the resolution.
-	for _, ct := range []apis.ConditionType{"ContainerHealthy", "Ready"} {
+	// Status should be Unknown until the digest resolution completes.
+	for _, ct := range []apis.ConditionType{"ResourcesAvailable", "Ready"} {
 		got := rev.Status.GetCondition(ct)
 		want := &apis.Condition{
 			Type:               ct,

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -448,7 +448,6 @@ func TestStatusUnknownWhenDigestsNotResolvedYet(t *testing.T) {
 			t.Errorf("Unexpected revision conditions diff for condition %q (-want +got):\n%s", ct, diff)
 		}
 	}
-
 }
 
 func TestGlobalResyncOnDefaultCMChange(t *testing.T) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Related to https://github.com/knative/serving/issues/9296.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Uses a background work pool, modelled on networking's prober, to resolve digests in the background, avoiding blocking up reconciler threads. Cache is cleared either when revision is deleted, or once we see a revision that already has ContainerStatuses set.

~~**Note: few loose ends here still, but I think it's possibly(?) at least roughly there. Letting prow tell me what I broke 🍿.**~~. Prow says it works!

~~**Note 2: this is currently based on top of https://github.com/knative/serving/pull/9329, so we shouldn't merge this until ~~we figure out if that change is OK~~ that merges.. Also this makes the diff look scarier than it is 😱. Advise looking at second commit.**~~ Rebased.

/hold

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Resolves image digests in a background work pool to avoid blocking reconciler when digest resolution takes a long time.
```

