### PR TITLE
Validate autoscaling annotations on Services and Configs.

### DIFF
--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -69,7 +69,8 @@ func validateKnativeAnnotations(annotations map[string]string) (errs *apis.Field
 func ValidateHasNoAutoscalingAnnotation(annotations map[string]string) (errs *apis.FieldError) {
 	for key := range annotations {
 		if strings.HasPrefix(key, autoscaling.GroupName) {
-			return apis.ErrInvalidKeyName(key, apis.CurrentField, `autoscaling annotations must be put under "spec.template.metadata.annotations" to work`)
+			errs = errs.Also(
+				apis.ErrInvalidKeyName(key, apis.CurrentField, `autoscaling annotations must be put under "spec.template.metadata.annotations" to work`))
 		}
 	}
 	return errs

--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -63,18 +63,16 @@ func validateKnativeAnnotations(annotations map[string]string) (errs *apis.Field
 	return
 }
 
-const noAutoscalingMsg = "annotations in group 'autoscaling.knative.dev' won't work here, they must be put under 'spec.template.metadata.annotations' instead"
-
 // ValidateHasNoAutoscalingAnnotation validates that the respective entity does not have
 // annotations from the autoscaling group. It's to be used to validate Service and
 // Configuration.
-func ValidateHasNoAutoscalingAnnotation(annotations map[string]string) *apis.FieldError {
+func ValidateHasNoAutoscalingAnnotation(annotations map[string]string) (errs *apis.FieldError) {
 	for key := range annotations {
 		if strings.HasPrefix(key, autoscaling.GroupName) {
-			return apis.ErrGeneric(noAutoscalingMsg, apis.CurrentField)
+			return apis.ErrInvalidKeyName(key, apis.CurrentField, `autoscaling annotations must be put under "spec.template.metadata.annotations" to work`)
 		}
 	}
-	return nil
+	return errs
 }
 
 // ValidateQueueSidecarAnnotation validates QueueSideCarResourcePercentageAnnotation

--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -63,6 +63,20 @@ func validateKnativeAnnotations(annotations map[string]string) (errs *apis.Field
 	return
 }
 
+const noAutoscalingMsg = "annotations in group 'autoscaling.knative.dev' won't work here, they must be put under 'spec.template.metadata.annotations' instead"
+
+// ValidateHasNoAutoscalingAnnotation validates that the respective entity does not have
+// annotations from the autoscaling group. It's to be used to validate Service and
+// Configuration.
+func ValidateHasNoAutoscalingAnnotation(annotations map[string]string) *apis.FieldError {
+	for key := range annotations {
+		if strings.HasPrefix(key, autoscaling.GroupName) {
+			return apis.ErrGeneric(noAutoscalingMsg, apis.CurrentField)
+		}
+	}
+	return nil
+}
+
 // ValidateQueueSidecarAnnotation validates QueueSideCarResourcePercentageAnnotation
 func ValidateQueueSidecarAnnotation(annotations map[string]string) *apis.FieldError {
 	if len(annotations) == 0 {

--- a/pkg/apis/serving/metadata_validation_test.go
+++ b/pkg/apis/serving/metadata_validation_test.go
@@ -212,6 +212,43 @@ func TestValidateObjectMetadata(t *testing.T) {
 	}
 }
 
+func TestValidateHasNoAutoscalingAnnotation(t *testing.T) {
+	cases := []struct {
+		name       string
+		annotation map[string]string
+		expectErr  *apis.FieldError
+	}{{
+		name:       "nil",
+		annotation: nil,
+	}, {
+		name:       "empty",
+		annotation: map[string]string{},
+	}, {
+		name:       "no offender",
+		annotation: map[string]string{"foo": "bar"},
+	}, {
+		name:       "only offender",
+		annotation: map[string]string{"autoscaling.knative.dev/foo": "bar"},
+		expectErr:  apis.ErrGeneric(noAutoscalingMsg),
+	}, {
+		name: "offender and non-offender",
+		annotation: map[string]string{
+			"autoscaling.knative.dev/foo": "bar",
+			"foo":                         "bar",
+		},
+		expectErr: apis.ErrGeneric(noAutoscalingMsg),
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateHasNoAutoscalingAnnotation(c.annotation)
+			if got, want := err.Error(), c.expectErr.Error(); got != want {
+				t.Errorf("\nGot:  %q\nwant: %q", got, want)
+			}
+		})
+	}
+}
+
 func TestValidateQueueSidecarAnnotation(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/pkg/apis/serving/metadata_validation_test.go
+++ b/pkg/apis/serving/metadata_validation_test.go
@@ -229,14 +229,14 @@ func TestValidateHasNoAutoscalingAnnotation(t *testing.T) {
 	}, {
 		name:       "only offender",
 		annotation: map[string]string{"autoscaling.knative.dev/foo": "bar"},
-		expectErr:  apis.ErrGeneric(noAutoscalingMsg),
+		expectErr:  apis.ErrInvalidKeyName("autoscaling.knative.dev/foo", apis.CurrentField, `autoscaling annotations must be put under "spec.template.metadata.annotations" to work`),
 	}, {
 		name: "offender and non-offender",
 		annotation: map[string]string{
 			"autoscaling.knative.dev/foo": "bar",
 			"foo":                         "bar",
 		},
-		expectErr: apis.ErrGeneric(noAutoscalingMsg),
+		expectErr: apis.ErrInvalidKeyName("autoscaling.knative.dev/foo", apis.CurrentField, `autoscaling annotations must be put under "spec.template.metadata.annotations" to work`),
 	}}
 
 	for _, c := range cases {

--- a/pkg/apis/serving/v1/configuration_validation.go
+++ b/pkg/apis/serving/v1/configuration_validation.go
@@ -32,8 +32,11 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 	// have changed (i.e. due to config-defaults changes), we elide the metadata and
 	// spec validation.
 	if !apis.IsInStatusUpdate(ctx) {
-		errs = errs.Also(serving.ValidateObjectMetadata(ctx, c.GetObjectMeta()).Also(
-			c.validateLabels().ViaField("labels")).ViaField("metadata"))
+		errs = errs.Also(serving.ValidateObjectMetadata(ctx, c.GetObjectMeta()))
+		errs = errs.Also(c.validateLabels().ViaField("labels"))
+		errs = errs.Also(serving.ValidateHasNoAutoscalingAnnotation(c.GetAnnotations()).ViaField("annotations"))
+		errs = errs.ViaField("metadata")
+
 		ctx = apis.WithinParent(ctx, c.ObjectMeta)
 		errs = errs.Also(c.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 	}

--- a/pkg/apis/serving/v1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1/configuration_validation_test.go
@@ -233,6 +233,28 @@ func TestConfigurationValidation(t *testing.T) {
 			},
 		},
 		want: nil,
+	}, {
+		name: "invalid autoscaling.knative.dev annotation",
+		c: &Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "autoscaling-annotation",
+				Annotations: map[string]string{
+					"autoscaling.knative.dev/foo": "bar",
+				},
+			},
+			Spec: ConfigurationSpec{
+				Template: RevisionTemplateSpec{
+					Spec: RevisionSpec{
+						PodSpec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Image: "hellworld",
+							}},
+						},
+					},
+				},
+			},
+		},
+		want: apis.ErrGeneric("annotations in group 'autoscaling.knative.dev' won't work here, they must be put under 'spec.template.metadata.annotations' instead", "metadata.annotations"),
 	}}
 
 	// TODO(dangerd): PodSpec validation failures.

--- a/pkg/apis/serving/v1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1/configuration_validation_test.go
@@ -254,7 +254,7 @@ func TestConfigurationValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrGeneric("annotations in group 'autoscaling.knative.dev' won't work here, they must be put under 'spec.template.metadata.annotations' instead", "metadata.annotations"),
+		want: apis.ErrInvalidKeyName("autoscaling.knative.dev/foo", "metadata.annotations", `autoscaling annotations must be put under "spec.template.metadata.annotations" to work`),
 	}}
 
 	// TODO(dangerd): PodSpec validation failures.

--- a/pkg/apis/serving/v1/service_validation.go
+++ b/pkg/apis/serving/v1/service_validation.go
@@ -32,8 +32,11 @@ func (s *Service) Validate(ctx context.Context) (errs *apis.FieldError) {
 	// have changed (i.e. due to config-defaults changes), we elide the metadata and
 	// spec validation.
 	if !apis.IsInStatusUpdate(ctx) {
-		errs = errs.Also(serving.ValidateObjectMetadata(ctx, s.GetObjectMeta()).Also(
-			s.validateLabels().ViaField("labels")).ViaField("metadata"))
+		errs = errs.Also(serving.ValidateObjectMetadata(ctx, s.GetObjectMeta()))
+		errs = errs.Also(s.validateLabels().ViaField("labels"))
+		errs = errs.Also(serving.ValidateHasNoAutoscalingAnnotation(s.GetAnnotations()).ViaField("annotations"))
+		errs = errs.ViaField("metadata")
+
 		ctx = apis.WithinParent(ctx, s.ObjectMeta)
 		errs = errs.Also(s.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 	}

--- a/pkg/apis/serving/v1/service_validation_test.go
+++ b/pkg/apis/serving/v1/service_validation_test.go
@@ -224,6 +224,36 @@ func TestServiceValidation(t *testing.T) {
 		want: apis.ErrOutOfBoundsValue(
 			-10, 0, config.DefaultMaxRevisionContainerConcurrency,
 			"spec.template.spec.containerConcurrency"),
+	}, {
+		name: "invalid autoscaling.knative.dev annotation",
+		r: &Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "autoscaling-annotation",
+				Annotations: map[string]string{
+					"autoscaling.knative.dev/foo": "bar",
+				},
+			},
+			Spec: ServiceSpec{
+				ConfigurationSpec: ConfigurationSpec{
+					Template: RevisionTemplateSpec{
+						Spec: RevisionSpec{
+							PodSpec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Image: "hellworld",
+								}},
+							},
+						},
+					},
+				},
+				RouteSpec: RouteSpec{
+					Traffic: []TrafficTarget{{
+						LatestRevision: ptr.Bool(true),
+						Percent:        ptr.Int64(100),
+					}},
+				},
+			},
+		},
+		want: apis.ErrGeneric("annotations in group 'autoscaling.knative.dev' won't work here, they must be put under 'spec.template.metadata.annotations' instead", "metadata.annotations"),
 	}}
 
 	// TODO(dangerd): PodSpec validation failures.

--- a/pkg/apis/serving/v1/service_validation_test.go
+++ b/pkg/apis/serving/v1/service_validation_test.go
@@ -253,7 +253,7 @@ func TestServiceValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrGeneric("annotations in group 'autoscaling.knative.dev' won't work here, they must be put under 'spec.template.metadata.annotations' instead", "metadata.annotations"),
+		want: apis.ErrInvalidKeyName("autoscaling.knative.dev/foo", "metadata.annotations", `autoscaling annotations must be put under "spec.template.metadata.annotations" to work`),
 	}}
 
 	// TODO(dangerd): PodSpec validation failures.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This validates that no autoscaling annotations are put onto top-level metadata in Services and Configurations. Further, it adds advice into the error message to guide users to put the annotations into the right spot.

Despite explicitly documenting this, we're still seeing users continuously struggling here. This is an attempt to frontload the error determination.

Happy to bin this if i'm completely off, haven't discussed this with anybody before cooking it up :sweat_smile: 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The absence of autoscaling annotations in both Service and Configuration's top-level metadata is now validated. This gives users an actionable error message but might potentially cause old (faulty) YAML to start to fail to be accepted now.
```

/assign @mattmoor @dprotaso 