### PR TITLE
Change the way worker timeout is handled.

### DIFF
--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -61,8 +61,6 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 		minProbes = 20
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), duration)
-
 	// wg tracks the number of ksvcs that we are still waiting to see become ready.
 	wg := sync.WaitGroup{}
 
@@ -73,7 +71,6 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 	t.Cleanup(func() {
 		// Wait for the ksvcs to all become ready (or fail)
 		wg.Wait()
-		cancel()
 
 		// Wait for all of the service creations to complete (possibly in failure),
 		// and signal the done channel.
@@ -114,6 +111,9 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 			})
 
 			eg.Go(func() error {
+				ctx, cancel := context.WithTimeout(context.Background(), duration)
+				t.Cleanup(cancel)
+
 				// This go routine runs until the ksvc is ready, at which point we should note that
 				// our part is done.
 				defer func() {

--- a/test/scale/scale_test.go
+++ b/test/scale/scale_test.go
@@ -41,8 +41,9 @@ func (nl *nopLatencies) Add(metric string, start time.Time) {
 const (
 	// Limit for scale in -short mode
 	shortModeMaxScale = 10
+
 	// Timeout for each worker task
-	workerTimeout = 5 * time.Minute
+	workerTimeout = 3 * time.Minute
 )
 
 // While redundant, we run two versions of this by default:


### PR DESCRIPTION
/hold

The way the "worker" timeout is handled today is effectively a global deadline for ALL ksvcs, which feels inconsistent with the comment above the value.  As things stand today, we have 5 minutes from when the test starts to create all N services, and we only create 50 at a time, so with scale-200, 4 waves have 5 minutes to complete (1m15s is a *very* reasonable MTTR under stress).  The current sense of this parameter doesn't really provide much value over the `-timeout` flag to `go test` IMO.

This changes the way this duration is evaluated to start the timer when the ksvc is created, and *lowers* the bound itself such that each ksvc has 3 minutes to become ready after it is created.  The `-timeout` will still act as a global bound, but this will give each ksvc a more reasonable bound.  I suspect we can pull this value down over time, but I'm starting somewhat conservatively.