### PR TITLE
Revert "Set imagePullPolicy to always (#4486)"

### DIFF
--- a/test/conformance/runtime/util.go
+++ b/test/conformance/runtime/util.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	pkgTest "knative.dev/pkg/test"
-	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/types"
 
@@ -48,11 +47,6 @@ func fetchRuntimeInfo(
 	if err != nil {
 		return nil, nil, err
 	}
-
-	serviceOpts = append(serviceOpts, func(svc *v1.Service) {
-		// Always fetch the latest runtime image.
-		svc.Spec.Template.Spec.Containers[0].ImagePullPolicy = "Always"
-	})
 
 	objects, err := v1test.CreateServiceReady(t, clients, names,
 		serviceOpts...)


### PR DESCRIPTION
This reverts commit f5d39849337ec0fae7870ad1309183c0e20e6be9.


I (re)discovered this trying to run conformance testing on KinD.  The (poorly documented) history of this change (IIRC) was that we were hitting a bug / bad interaction between `ko`-built images and `containerd`(?) where images would run as different users depending on whether they were freshly pulled or not.  This was leading to a rash of flakes in our e2e tests, and this workaround was put in place to mitigate.  I believe both problems have long been fixed, so revert the workaround.

I think part of the reason for light details before was that I wasn't sure if you could bypass PSPs with this bug, and didn't want to advertise a CVE.  😬 

/assign @markusthoemmes @dprotaso @vagababov @tcnghia 