### PR TITLE
Explicitly use imagePullPolicy: IfNotPresent

### DIFF
--- a/test/v1/configuration.go
+++ b/test/v1/configuration.go
@@ -112,6 +112,13 @@ func ConfigurationSpec(imagePath string) *v1.ConfigurationSpec {
 				PodSpec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Image: imagePath,
+						// Kubernetes default pull policy is IfNotPresent unless
+						// the :latest tag (== no tag) is used, in which case it
+						// is Always.  To support e2e testing on KinD, we want to
+						// explicitly disable image pulls when present because we
+						// side-load the test images onto all nodes and never push
+						// them to a registry.
+						ImagePullPolicy: corev1.PullIfNotPresent,
 					}},
 				},
 			},

--- a/test/v1alpha1/configuration.go
+++ b/test/v1alpha1/configuration.go
@@ -133,6 +133,13 @@ func ConfigurationSpec(imagePath string) *v1alpha1.ConfigurationSpec {
 					PodSpec: corev1.PodSpec{
 						Containers: []corev1.Container{{
 							Image: imagePath,
+							// Kubernetes default pull policy is IfNotPresent unless
+							// the :latest tag (== no tag) is used, in which case it
+							// is Always.  To support e2e testing on KinD, we want to
+							// explicitly disable image pulls when present because we
+							// side-load the test images onto all nodes and never push
+							// them to a registry.
+							ImagePullPolicy: corev1.PullIfNotPresent,
 						}},
 					},
 				},
@@ -149,6 +156,13 @@ func LegacyConfigurationSpec(imagePath string) *v1alpha1.ConfigurationSpec {
 			Spec: v1alpha1.RevisionSpec{
 				DeprecatedContainer: &corev1.Container{
 					Image: imagePath,
+					// Kubernetes default pull policy is IfNotPresent unless
+					// the :latest tag (== no tag) is used, in which case it
+					// is Always.  To support e2e testing on KinD, we want to
+					// explicitly disable image pulls when present because we
+					// side-load the test images onto all nodes and never push
+					// them to a registry.
+					ImagePullPolicy: corev1.PullIfNotPresent,
 				},
 				RevisionSpec: v1.RevisionSpec{},
 			},

--- a/test/v1beta1/configuration.go
+++ b/test/v1beta1/configuration.go
@@ -116,6 +116,13 @@ func ConfigurationSpec(imagePath string) *v1.ConfigurationSpec {
 				PodSpec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Image: imagePath,
+						// Kubernetes default pull policy is IfNotPresent unless
+						// the :latest tag (== no tag) is used, in which case it
+						// is Always.  To support e2e testing on KinD, we want to
+						// explicitly disable image pulls when present because we
+						// side-load the test images onto all nodes and never push
+						// them to a registry.
+						ImagePullPolicy: corev1.PullIfNotPresent,
 					}},
 				},
 			},


### PR DESCRIPTION
/assign @dprotaso @markusthoemmes @vagababov @tcnghia 

This is to better support KinD when the test images have been side-loaded with `kind.local` (thanks @markusthoemmes 😍 )