### PR TITLE
Do not require digest resolution for side-loaded images.

### DIFF
--- a/pkg/deployment/config_test.go
+++ b/pkg/deployment/config_test.go
@@ -30,9 +30,22 @@ import (
 	. "knative.dev/pkg/configmap/testing"
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
+	"knative.dev/serving/test/conformance/api/shared"
 )
 
 const defaultSidecarImage = "defaultImage"
+
+func TestMatchingExceptions(t *testing.T) {
+	cfg := defaultConfig()
+
+	if delta := cfg.RegistriesSkippingTagResolving.Difference(shared.DigestResolutionExceptions); delta.Len() > 0 {
+		t.Errorf("Got extra: %v", delta.List())
+	}
+
+	if delta := shared.DigestResolutionExceptions.Difference(cfg.RegistriesSkippingTagResolving); delta.Len() > 0 {
+		t.Errorf("Didn't get: %v", delta.List())
+	}
+}
 
 func TestControllerConfigurationFromFile(t *testing.T) {
 	cm, example := ConfigMapsFromTestFile(t, ConfigName, QueueSidecarImageKey)

--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"testing"
 
 	"golang.org/x/sync/errgroup"
 
@@ -119,16 +120,13 @@ func validateDataPlane(t pkgTest.TLegacy, clients *test.Clients, names test.Reso
 // Validates the state of Configuration, Revision, and Route objects for a runLatest Service.
 // The checks in this method should be able to be performed at any point in a
 // runLatest Service's lifecycle so long as the service is in a "Ready" state.
-func validateControlPlane(t pkgTest.T, clients *test.Clients, names test.ResourceNames, expectedGeneration string) error {
+func validateControlPlane(t *testing.T, clients *test.Clients, names test.ResourceNames, expectedGeneration string) error {
 	t.Log("Checking to ensure Revision is in desired state with", "generation", expectedGeneration)
 	err := v1test.CheckRevisionState(clients.ServingClient, names.Revision, func(r *v1.Revision) (bool, error) {
 		if ready, err := v1test.IsRevisionReady(r); !ready {
 			return false, fmt.Errorf("revision %s did not become ready to serve traffic: %w", names.Revision, err)
 		}
-		if r.Status.DeprecatedImageDigest == "" {
-			return false, fmt.Errorf("imageDigest not present for revision %s", names.Revision)
-		}
-		if validDigest, err := shared.ValidateImageDigest(names.Image, r.Status.DeprecatedImageDigest); !validDigest {
+		if validDigest, err := shared.ValidateImageDigest(t, names.Image, r.Status.DeprecatedImageDigest); !validDigest {
 			return false, fmt.Errorf("imageDigest %s is not valid for imageName %s: %w", r.Status.DeprecatedImageDigest, names.Image, err)
 		}
 		return true, nil

--- a/test/conformance/api/v1beta1/util.go
+++ b/test/conformance/api/v1beta1/util.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"testing"
 
 	"golang.org/x/sync/errgroup"
 
@@ -119,16 +120,13 @@ func validateDataPlane(t pkgTest.TLegacy, clients *test.Clients, names test.Reso
 // Validates the state of Configuration, Revision, and Route objects for a runLatest Service.
 // The checks in this method should be able to be performed at any point in a
 // runLatest Service's lifecycle so long as the service is in a "Ready" state.
-func validateControlPlane(t pkgTest.T, clients *test.Clients, names test.ResourceNames, expectedGeneration string) error {
+func validateControlPlane(t *testing.T, clients *test.Clients, names test.ResourceNames, expectedGeneration string) error {
 	t.Log("Checking to ensure Revision is in desired state with", "generation", expectedGeneration)
 	err := v1b1test.CheckRevisionState(clients.ServingBetaClient, names.Revision, func(r *v1beta1.Revision) (bool, error) {
 		if ready, err := v1b1test.IsRevisionReady(r); !ready {
 			return false, fmt.Errorf("revision %s did not become ready to serve traffic: %w", names.Revision, err)
 		}
-		if r.Status.DeprecatedImageDigest == "" {
-			return false, fmt.Errorf("imageDigest not present for revision %s", names.Revision)
-		}
-		if validDigest, err := shared.ValidateImageDigest(names.Image, r.Status.DeprecatedImageDigest); !validDigest {
+		if validDigest, err := shared.ValidateImageDigest(t, names.Image, r.Status.DeprecatedImageDigest); !validDigest {
 			return false, fmt.Errorf("imageDigest %s is not valid for imageName %s: %w", r.Status.DeprecatedImageDigest, names.Image, err)
 		}
 		return true, nil


### PR DESCRIPTION
For environments like KinD or minikube where test images may be side-loaded into the cluster's container daemon(s) do not require digest resolution.

/assign @dprotaso @markusthoemmes @vagababov @tcnghia 