### PR TITLE
Remove downstream usage of spoof.Interface

### DIFF
--- a/test/conformance/api/shared/util.go
+++ b/test/conformance/api/shared/util.go
@@ -71,7 +71,7 @@ func ValidateImageDigest(imageName string, imageDigest string) (bool, error) {
 }
 
 // sendRequests sends "num" requests to "url", returning a string for each spoof.Response.Body.
-func sendRequests(client spoof.Interface, url *url.URL, num int) ([]string, error) {
+func sendRequests(client *spoof.SpoofingClient, url *url.URL, num int) ([]string, error) {
 	responses := make([]string, num)
 
 	// Launch "num" requests, recording the responses we get in "responses".


### PR DESCRIPTION
This is a useless interface and it's used in one place only (eventing, client, networking and net-istio don't use it either, I presume so is elsewhere).
Everywhere else we just use the actual type

Once this merges we can remove the interface in pkg.

/assign mattmoor @julz 