### PR TITLE
Do not send request to cluster local domain with ResolvableDomain 

### DIFF
--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -141,8 +141,8 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 	t.Log("httpproxy is ready.")
 
 	resolvableDomain := test.ServingFlags.ResolvableDomain
-	// When accessibleExternal is false, ResolvableDomain option is not available
-	// as helloworldURL is cluster local domain. The host cannot be resolved from outside cluster.
+	// When we're testing with resolvable domains, we fail trying
+	// to resolve the cluster local domain.
 	if !accessibleExternal {
 		resolvableDomain = false
 	}
@@ -151,11 +151,6 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 	// (or cannot) access the helloworld app externally.
 	response, err := sendRequest(t, clients, resolvableDomain, helloworldURL)
 	if err != nil {
-		if test.ServingFlags.ResolvableDomain {
-			// When we're testing with resolvable domains, we might fail earlier trying
-			// to resolve the shorter domain(s) off-cluster.
-			return
-		}
 		t.Fatal("Unexpected error when sending request to helloworld:", err)
 	}
 	expectedStatus := http.StatusNotFound

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -140,9 +140,16 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 	}
 	t.Log("httpproxy is ready.")
 
+	resolvableDomain := test.ServingFlags.ResolvableDomain
+	// When accessibleExternal is false, ResolvableDomain option is not available
+	// as helloworldURL is cluster local domain. The host cannot be resolved from outside cluster.
+	if !accessibleExternal {
+		resolvableDomain = false
+	}
+
 	// As a final check (since we know they are both up), check that if we can
 	// (or cannot) access the helloworld app externally.
-	response, err := sendRequest(t, clients, test.ServingFlags.ResolvableDomain, helloworldURL)
+	response, err := sendRequest(t, clients, resolvableDomain, helloworldURL)
 	if err != nil {
 		if test.ServingFlags.ResolvableDomain {
 			// When we're testing with resolvable domains, we might fail earlier trying

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -140,16 +140,15 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 	}
 	t.Log("httpproxy is ready.")
 
-	resolvableDomain := test.ServingFlags.ResolvableDomain
-	// When we're testing with resolvable domains, we fail trying
+	// When we're testing with resolvable domains, we fail earlier trying
 	// to resolve the cluster local domain.
-	if !accessibleExternal {
-		resolvableDomain = false
+	if !accessibleExternal && test.ServingFlags.ResolvableDomain {
+		return
 	}
 
 	// As a final check (since we know they are both up), check that if we can
 	// (or cannot) access the helloworld app externally.
-	response, err := sendRequest(t, clients, resolvableDomain, helloworldURL)
+	response, err := sendRequest(t, clients, test.ServingFlags.ResolvableDomain, helloworldURL)
 	if err != nil {
 		t.Fatal("Unexpected error when sending request to helloworld:", err)
 	}


### PR DESCRIPTION
`helloworldURL` is cluster local domain (`svc.cluster.locl`) when `accessibleExternal` is false.
In this case, the ResolvableDomain option is not available as the host name cannot be resolved from outside cluster.

Furthermore, the sending request keeps retrying for DNS resolution failure.

Here is the sample log when ResolvableDomain is enabled:

```
    spoof.go:119: Spoofing svc-to-svc-via-activ-dshkjqoi.serving-tests.svc.cluster.local -> svc-to-svc-via-activ-dshkjqoi.serving-tests.svc.cluster.local
    spoof.go:189: Retrying http://svc-to-svc-via-activ-dshkjqoi.serving-tests.svc.cluster.local: retrying for DNS error: Get "http://svc-to-svc-via-activ-dshkjqoi.serving-tests.svc.cluster.local": dial tcp: lookup svc-to-svc-via-activ-dshkjqoi.serving-tests.svc.cluster.local: no such host
  ... RETRY CONTINUE ...
```

So this patch changes to stop sending request with `ResolvableDomain` when `accessibleExternal` is false.

/lint

**Release Note**

```release-note
NONE
```

/cc @markusthoemmes 
