### PR TITLE
Give the test more time to complete.

### DIFF
--- a/pkg/reconciler/serverlessservice/global_resync_test.go
+++ b/pkg/reconciler/serverlessservice/global_resync_test.go
@@ -125,7 +125,7 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 
 	// Actively wait for the endpoints to change their value.
 	eps := fakeendpointsinformer.Get(ctx).Lister()
-	if err := wait.PollImmediate(10*time.Millisecond, 3*time.Second, func() (bool, error) {
+	if err := wait.PollImmediate(25*time.Millisecond, 5*time.Second, func() (bool, error) {
 		ep, err := eps.Endpoints(ns1).Get(sks1)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
A flake was discovered with following error:

```
    global_resync_test.go:138: Failed to see Public Endpoints propagation: endpoints test-sks-1 not found
    logger.go:130: 2020-09-15T18:04:28.032ZINFOserverlessservice-controllerserverlessservice/controller.go:85Doing a global resync due to activator endpoint changes{knative.dev/controller: serverlessservice-controller}
    logger.go:130: 2020-09-15T18:04:28.032ZINFOserverlessservice-controller.knative.dev-serving-pkg-reconciler-serverlessservice.reconcilercontroller/controller.go:458Shutting down workers{knative.dev/controller: serverlessservice-controller}
```
In this run: https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_serving/9406/pull-knative-serving-unit-tests/1305929141358432257

Which basically means it took us longer than the test expects.

/assign @julz mattmoor