### PR TITLE
Use prober transport for probes in revision backend manager.

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -383,12 +383,13 @@ type revisionBackendsManager struct {
 }
 
 // NewRevisionBackendsManager returns a new RevisionBackendsManager with default
-// probe time out.
+// probe time out. The passed transport backs the probing done by the backend manager.
 func newRevisionBackendsManager(ctx context.Context, tr http.RoundTripper) *revisionBackendsManager {
 	return newRevisionBackendsManagerWithProbeFrequency(ctx, tr, defaultProbeFrequency)
 }
 
 // newRevisionBackendsManagerWithProbeFrequency creates a fully spec'd RevisionBackendsManager.
+// The passed transport backs the probing done by the backend manager.
 func newRevisionBackendsManagerWithProbeFrequency(ctx context.Context, tr http.RoundTripper,
 	probeFreq time.Duration) *revisionBackendsManager {
 	rbm := &revisionBackendsManager{

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -490,7 +490,7 @@ func NewThrottler(ctx context.Context, ipAddr string) *Throttler {
 
 // Run starts the throttler and blocks until the context is done.
 func (t *Throttler) Run(ctx context.Context) {
-	rbm := newRevisionBackendsManager(ctx, network.AutoTransport)
+	rbm := newRevisionBackendsManager(ctx, network.NewProberTransport())
 	// Update channel is closed when ctx is done.
 	t.run(rbm.updates())
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Noticed while debugging #9422 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

I'm not quite sure why we'd want to have keep-alive and a ton of connections around in this case, given that these are health probes. I might be missing something though.

/assign @julz @vagababov 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
