### PR TITLE
[WIP] Refactor TrafficSplit and BlueGreenRoute test to use thread pools

### DIFF
--- a/test/conformance.go
+++ b/test/conformance.go
@@ -55,7 +55,7 @@ const (
 
 	MultiContainerResponse = "Yay!! multi-container works"
 
-	ConcurrentRequests = 200
+	NumRequests = 200
 	// We expect to see 100% of requests succeed for traffic sent directly to revisions.
 	// This might be a bad assumption.
 	MinDirectPercentage = 1

--- a/test/conformance/api/v1alpha1/blue_green_test.go
+++ b/test/conformance/api/v1alpha1/blue_green_test.go
@@ -24,8 +24,6 @@ import (
 	"net/url"
 	"testing"
 
-	"golang.org/x/sync/errgroup"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"knative.dev/pkg/ptr"
@@ -150,21 +148,25 @@ func TestBlueGreenRoute(t *testing.T) {
 		t.Fatalf("Error probing %s: %v", greenURL, err)
 	}
 
+	// expectedTraffic holds traffic objectives for all domains.
+	expectedTraffic := []shared.TrafficObjectives{
+		{
+			URL:               tealURL,
+			MinSuccesses:      int(math.Floor(test.NumRequests * test.MinSplitPercentage)),
+			ExpectedResponses: []string{expectedBlue, expectedGreen}},
+		{
+			URL:               blueURL,
+			MinSuccesses:      int(math.Floor(test.NumRequests * test.MinDirectPercentage)),
+			ExpectedResponses: []string{expectedBlue}},
+		{
+			URL:               greenURL,
+			MinSuccesses:      int(math.Floor(test.NumRequests * test.MinDirectPercentage)),
+			ExpectedResponses: []string{expectedGreen},
+		},
+	}
+
 	// Send concurrentRequests to blueDomain, greenDomain, and tealDomain.
-	g, _ := errgroup.WithContext(context.Background())
-	g.Go(func() error {
-		min := int(math.Floor(test.ConcurrentRequests * test.MinSplitPercentage))
-		return shared.CheckDistribution(t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
-	})
-	g.Go(func() error {
-		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return shared.CheckDistribution(t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
-	})
-	g.Go(func() error {
-		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return shared.CheckDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
-	})
-	if err := g.Wait(); err != nil {
-		t.Fatal("Error sending requests:", err)
+	if err := shared.CheckDistribution(t, clients, expectedTraffic); err != nil {
+		t.Fatal("Error sending requests")
 	}
 }


### PR DESCRIPTION
This is to stabilize the tests which currently spin too many threads in the background (up to 800) which can result in various errors such as :
```
For domain current-service-with-traffic-split-ypdikawy-serving-tests.apps.ut-56-upstream-tests-debug-mgencur.openshift-aws.rhocf-dev.net: saw unexpected response "<html><body><h1>408 Request Time-out</h1>\nYour browser didn't send a complete request in time.\n</body>
```

This PR uses a thread pool similar to what is done in some tests in knative/networking.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
