### PR TITLE
Remove unnecessary 'WithContext' and align parallelism with networking.

### DIFF
--- a/test/conformance/api/shared/util.go
+++ b/test/conformance/api/shared/util.go
@@ -94,7 +94,7 @@ func sendRequests(client *spoof.SpoofingClient, url *url.URL, num int) ([]string
 	responses := make([]string, num)
 
 	// Launch "num" requests, recording the responses we get in "responses".
-	g, _ := pool.NewWithContext(context.Background(), 5, num)
+	g := pool.NewWithCapacity(8, num)
 	for i := 0; i < num; i++ {
 		// We don't index into "responses" inside the goroutine to avoid a race, see #1545.
 		result := &responses[i]


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This aligns things with https://github.com/knative/networking/blob/master/test/conformance/ingress/percentage.go#L100 and drops the unnecessary context which is then ignored anyway.

I dunno but a non power of 2 makes me uncomfortable here :joy: 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor 
