### PR TITLE
update the Service schema with v1 schema

### DIFF
--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -32,11 +32,30 @@ spec:
     schema:
       openAPIV3Schema:
         type: object
-        # this is a work around so we don't need to flush out the
-        # schema for each version at this time
-        #
-        # see issue: https://github.com/knative/serving/issues/912
         x-kubernetes-preserve-unknown-fields: true
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              template:
+                x-kubernetes-preserve-unknown-fields: true
+                description: |
+                  A template for the current desired application state.
+                  Changes to `template` will cause a new Revision to be created as
+                  defined in the lifecycle section. The contents of the Service's
+                  RevisionTemplateSpec is used to create a corresponding Configuration.
+              traffic:
+                x-kubernetes-preserve-unknown-fields: true
+                description: |
+                  Traffic specifies how to distribute traffic over a
+                  collection of Revisions belonging to the Service. If traffic is
+                  empty or not provided, defaults to 100% traffic to the latest
+                  `Ready` Revision. The contents of the Service's TrafficTarget is
+                  used to create a corresponding Route.
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
     additionalPrinterColumns:
     - name: URL
       type: string

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -39,6 +39,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
             properties:
               template:
+                type: object
                 x-kubernetes-preserve-unknown-fields: true
                 description: |
                   A template for the current desired application state.
@@ -47,12 +48,16 @@ spec:
                   RevisionTemplateSpec is used to create a corresponding Configuration.
               traffic:
                 x-kubernetes-preserve-unknown-fields: true
+                type: array
                 description: |
                   Traffic specifies how to distribute traffic over a
                   collection of Revisions belonging to the Service. If traffic is
                   empty or not provided, defaults to 100% traffic to the latest
                   `Ready` Revision. The contents of the Service's TrafficTarget is
                   used to create a corresponding Route.
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
Releated to #912 

## Proposed Changes

* This is the most basic level of the schema. The intention is create a foundation on which future updates to the schema will build. 

* This a bespoke schema. I used the docs and the API to make as complete a schema for only `v1` as I could. Please note this was manually written, I did not generate it. 
* Currently the schema has nothing in it. Until the we can auto-generate it, this at least provides something. 
* Discussions on #912 suggest that we will soon drop support for alpha and beta so we would only need v1 anyway.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Updated the Service schema to include a high level basic schema.
```