### PR TITLE
Try to restrict a bit the limits and requests we have for AS tests

### DIFF
--- a/test/e2e/autoscale.go
+++ b/test/e2e/autoscale.go
@@ -203,10 +203,12 @@ func setup(t *testing.T, class, metric string, target int, targetUtilization flo
 				autoscaling.WindowAnnotationKey: "50s",
 			}), rtesting.WithResourceRequirements(corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("512Mi"),
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("128Mi"),
 				},
 				Requests: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("300Mi"),
+					corev1.ResourceCPU:    resource.MustParse("30m"),
+					corev1.ResourceMemory: resource.MustParse("20Mi"),
 				},
 			}),
 		}, fopts...)...)


### PR DESCRIPTION
512m seems a lot, for a delay binary

Let's see what's the limit for passing :)
/hold