### PR TITLE
Add an E2E test for disabling autotls with an annotation

### DIFF
--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -435,12 +435,14 @@ func autoTLSEnabled(ctx context.Context, r *v1.Route) bool {
 	logger := logging.FromContext(ctx)
 	annotationValue := r.Annotations[networking.DisableAutoTLSAnnotationKey]
 
-	disabledByAnnotation, err := strconv.ParseBool(annotationValue)
-	if err != nil {
-		// validation should've caught an invalid value here.
-		// if we have one anyways, assume not disabled and log a warning.
-		logger.Warnf("Invalid annotation value for %q. Value: %q",
-			networking.DisableAutoTLSAnnotationKey, annotationValue)
+	if annotationValue != "" {
+		disabledByAnnotation, err := strconv.ParseBool(annotationValue)
+		if err != nil {
+			// validation should've caught an invalid value here.
+			// if we have one anyways, assume not disabled and log a warning.
+			logger.Warnf("Invalid annotation value for %q. Value: %q",
+				networking.DisableAutoTLSAnnotationKey, annotationValue)
+		}
 	}
 
 	return !disabledByAnnotation

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -435,14 +435,12 @@ func autoTLSEnabled(ctx context.Context, r *v1.Route) bool {
 	logger := logging.FromContext(ctx)
 	annotationValue := r.Annotations[networking.DisableAutoTLSAnnotationKey]
 
-	if annotationValue != "" {
-		disabledByAnnotation, err := strconv.ParseBool(annotationValue)
-		if err != nil {
-			// validation should've caught an invalid value here.
-			// if we have one anyways, assume not disabled and log a warning.
-			logger.Warnf("Invalid annotation value for %q. Value: %q",
-				networking.DisableAutoTLSAnnotationKey, annotationValue)
-		}
+	disabledByAnnotation, err := strconv.ParseBool(annotationValue)
+	if annotationValue != "" && err != nil {
+		// validation should've caught an invalid value here.
+		// if we have one anyways, assume not disabled and log a warning.
+		logger.Warnf("Invalid annotation value for %q. Value: %q",
+			networking.DisableAutoTLSAnnotationKey, annotationValue)
 	}
 
 	return !disabledByAnnotation

--- a/test/e2e/autotls/README.md
+++ b/test/e2e/autotls/README.md
@@ -10,13 +10,13 @@ To run Auto TLS E2E test locally, run the following commands:
    1. `kubectl label namespace serving-tests networking.internal.knative.dev/disableWildcardCert=true`
    1. `kubectl delete kcert --all -n serving-tests`
    1. `kubectl apply -f test/config/autotls/certmanager/selfsigned/`
-   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestAutoTLS$`
+   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestTls$`
 1. test case 2: testing per namespace certificate provision with self-signed CA
    1. `kubectl delete kcert --all -n serving-tests`
    1. `kubectl apply -f test/config/autotls/certmanager/selfsigned/`
    1. Run `kubectl edit namespace serving-tests` and remove the label
       networking.internal.knative.dev/disableWildcardCert
-   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestAutoTLS$`
+   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestTls$`
 1. test case 3: testing per ksvc certificate provision with HTTP challenge
    1. `kubectl label namespace serving-tests networking.internal.knative.dev/disableWildcardCert=true`
    1. `kubectl delete kcert --all -n serving-tests`
@@ -25,4 +25,4 @@ To run Auto TLS E2E test locally, run the following commands:
    1. `kubectl patch cm config-domain -n knative-serving -p '{"data":{"<your-custom-domain>":""}}'`
    1. Add a DNS A record to map host `http01.serving-tests.<your-custom-domain>`
       to the Ingress IP.
-   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestAutoTLS$`
+   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestTls$`

--- a/test/e2e/autotls/README.md
+++ b/test/e2e/autotls/README.md
@@ -10,13 +10,13 @@ To run Auto TLS E2E test locally, run the following commands:
    1. `kubectl label namespace serving-tests networking.internal.knative.dev/disableWildcardCert=true`
    1. `kubectl delete kcert --all -n serving-tests`
    1. `kubectl apply -f test/config/autotls/certmanager/selfsigned/`
-   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestTls$`
+   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestTls`
 1. test case 2: testing per namespace certificate provision with self-signed CA
    1. `kubectl delete kcert --all -n serving-tests`
    1. `kubectl apply -f test/config/autotls/certmanager/selfsigned/`
    1. Run `kubectl edit namespace serving-tests` and remove the label
       networking.internal.knative.dev/disableWildcardCert
-   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestTls$`
+   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestTls`
 1. test case 3: testing per ksvc certificate provision with HTTP challenge
    1. `kubectl label namespace serving-tests networking.internal.knative.dev/disableWildcardCert=true`
    1. `kubectl delete kcert --all -n serving-tests`
@@ -25,4 +25,4 @@ To run Auto TLS E2E test locally, run the following commands:
    1. `kubectl patch cm config-domain -n knative-serving -p '{"data":{"<your-custom-domain>":""}}'`
    1. Add a DNS A record to map host `http01.serving-tests.<your-custom-domain>`
       to the Ingress IP.
-   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestTls$`
+   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestTls`

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -188,7 +188,7 @@ func routeTrafficHTTPS(route *servingv1.Route) (bool, error) {
 	return route.Status.IsReady(), nil
 }
 
-func routeUrlHTTP(route *servingv1.Route) (bool, error) {
+func routeURLHTTP(route *servingv1.Route) (bool, error) {
 	return route.Status.URL.URL().Scheme == "http", nil
 }
 

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -79,7 +79,7 @@ func TestTlsDisabledWithAnnotation(t *testing.T) {
 		t.Fatalf("Traffic for route: %s does not have TLS disabled: %v", names.Route, err)
 	}
 
-	if err = v1test.WaitForRouteState(clients.ServingClient, names.Route, routeUrlHTTP, "RouteURLIsHTTP"); err != nil {
+	if err = v1test.WaitForRouteState(clients.ServingClient, names.Route, routeURLHTTP, "RouteURLIsHTTP"); err != nil {
 		t.Fatalf("Traffic for route: %s is not HTTP: %v", names.Route, err)
 	}
 

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -193,12 +193,8 @@ func routeUrlHTTP(route *servingv1.Route) (bool, error) {
 }
 
 func routeTLSDisabled(route *servingv1.Route) (bool, error) {
-	for _, cond := range route.Status.Conditions {
-		if cond.Type == "CertificateProvisioned" {
-			return cond.Status == "True" && cond.Reason == "TLSNotEnabled", nil
-		}
-	}
-	return false, nil
+	var cond = route.Status.GetCondition("CertificateProvisioned")
+	return cond.Status == "True" && cond.Reason == "TLSNotEnabled", nil
 }
 
 func httpsReady(svc *servingv1.Service) (bool, error) {

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -249,7 +249,7 @@ func createHTTPClient(t *testing.T, clients *test.Clients, objects *v1test.Resou
 	if err != nil {
 		t.Fatalf("Failed to get Ingress %s: %v", routenames.Ingress(objects.Route), err)
 	}
-	dialer := CreateDialContext(t, ing, clients)
+	dialer := ingress.CreateDialContext(t, ing, clients)
 	return &http.Client{
 		Transport: &http.Transport{
 			DialContext:     dialer,

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -249,7 +249,7 @@ func createHTTPSClient(t *testing.T, clients *test.Clients, objects *v1test.Reso
 
 func createHTTPClient(t *testing.T, clients *test.Clients, objects *v1test.ResourceObjects) *http.Client {
 	t.Helper()
-	ing, err := clients.NetworkingClient.Ingresses.Get(routenames.Ingress(objects.Route), metav1.GetOptions{})
+	ing, err := clients.NetworkingClient.Ingresses.Get(context.Background(), routenames.Ingress(objects.Route), metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get Ingress %s: %v", routenames.Ingress(objects.Route), err)
 	}

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -249,7 +249,9 @@ func createHTTPClient(t *testing.T, clients *test.Clients, objects *v1test.Resou
 	if err != nil {
 		t.Fatalf("Failed to get Ingress %s: %v", routenames.Ingress(objects.Route), err)
 	}
-	dialer := ingress.CreateDialContext(t, ing, clients)
+	dialer := ingress.CreateDialContext(context.Background(), t, ing, &ntest.Clients{
+		KubeClient: clients.KubeClient,
+	})
 	return &http.Client{
 		Transport: &http.Transport{
 			DialContext:     dialer,


### PR DESCRIPTION
Fixes #9274

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add e2e test for AutoTLS disabling via annotation.
* Fix bug where we continuously log a warning if the annotation isn't set.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
