### PR TITLE
Increase the cluster size for auto-tls and upgrade test legs

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -160,7 +160,9 @@ function delete_dns_record() {
 # Script entry point.
 
 # Skip installing istio as an add-on
-initialize "$@" --skip-istio-addon
+# Temporarily increasing the cluster size for serving tests to rule out
+# resource/eviction as causes of flakiness.
+initialize "$@" --skip-istio-addon --min-nodes=4 --max-nodes=4
 
 header "Enabling high-availability"
 

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -69,7 +69,10 @@ function knative_setup() {
 
 # Script entry point.
 
-initialize "$@" --skip-istio-addon
+# Skip installing istio as an add-on.
+# Temporarily increasing the cluster size for serving tests to rule out
+# resource/eviction as causes of flakiness.
+initialize "$@" --skip-istio-addon --min-nodes=4 --max-nodes=4
 
 # We haven't configured these deployments for high-availability,
 # so disable the chaos duck.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
* The cluster size became smaller due to one recent breaking change in test-infra, which might be the reason for the test flakiness. The PR increases the cluster size auto-tls and upgrade test legs to be the same as the general e2e test leg.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
