### PR TITLE
Update ggcr, use remote.Head

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/google/go-cmp v0.5.1
-	github.com/google/go-containerregistry v0.1.3-0.20200910230023-d42b6a2ddfd1
+	github.com/google/go-containerregistry v0.1.3
 	github.com/google/gofuzz v1.1.0
 	github.com/google/mako v0.0.0-20190821191249-122f8dcef9e3
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -563,8 +563,8 @@ github.com/google/go-containerregistry v0.0.0-20200115214256-379933c9c22b/go.mod
 github.com/google/go-containerregistry v0.0.0-20200123184029-53ce695e4179/go.mod h1:Wtl/v6YdQxv397EREtzwgd9+Ud7Q5D8XMbi3Zazgkrs=
 github.com/google/go-containerregistry v0.0.0-20200331213917-3d03ed9b1ca2/go.mod h1:pD1UFYs7MCAx+ZLShBdttcaOSbyc8F9Na/9IZLNwJeA=
 github.com/google/go-containerregistry v0.1.1/go.mod h1:npTSyywOeILcgWqd+rvtzGWflIPPcBQhYoOONaY4ltM=
-github.com/google/go-containerregistry v0.1.3-0.20200910230023-d42b6a2ddfd1 h1:v9CWGV7SZQ0ckDcz7AyZosdTrZp+Vs50XRcoTbkv5dk=
-github.com/google/go-containerregistry v0.1.3-0.20200910230023-d42b6a2ddfd1/go.mod h1:5s8ngJYjVAwkC9MKbOtxmRphO/ZvIKZ5b2vsobilblI=
+github.com/google/go-containerregistry v0.1.3 h1:vD78UlG9hVJ8DZbUL8uuNco2G1o9eJTA87xR0Y2UX6c=
+github.com/google/go-containerregistry v0.1.3/go.mod h1:3Wg/Hjgn/ZDxrYYhtzZJWdThOd8zeI2zAmn4oVfm1Wg=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v27 v27.0.6 h1:oiOZuBmGHvrGM1X9uNUAUlLgp5r1UUO/M/KnbHnLRlQ=
@@ -1529,8 +1529,8 @@ golang.org/x/tools v0.0.0-20200725200936-102e7d357031/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6 h1:qKpj8TpV+LEhel7H/fR788J+KvhWZ3o3V6N2fU/iuLU=
 golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20200910222312-571a207697e7 h1:SJWJaZU+0cpPpc8YPrjwTiNrjlqgNl09cAFXuSijD2k=
-golang.org/x/tools v0.0.0-20200910222312-571a207697e7/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
+golang.org/x/tools v0.0.0-20200916195026-c9a70fc28ce3 h1:DywqrEscRX7O2phNjkT0L6lhHKGBoMLCNX+XcAe7t6s=
+golang.org/x/tools v0.0.0-20200916195026-c9a70fc28ce3/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/pkg/reconciler/revision/resolve.go
+++ b/pkg/reconciler/revision/resolve.go
@@ -108,7 +108,7 @@ func (r *digestResolver) Resolve(
 		return "", nil
 	}
 
-	desc, err := remote.Get(tag, remote.WithContext(ctx), remote.WithTransport(r.transport), remote.WithAuthFromKeychain(kc))
+	desc, err := remote.Head(tag, remote.WithContext(ctx), remote.WithTransport(r.transport), remote.WithAuthFromKeychain(kc))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/reconciler/revision/resolve_test.go
+++ b/pkg/reconciler/revision/resolve_test.go
@@ -55,14 +55,6 @@ func mustDigest(t *testing.T, img v1.Image) v1.Hash {
 	return h
 }
 
-func mustRawManifest(t *testing.T, img v1.Image) []byte {
-	m, err := img.RawManifest()
-	if err != nil {
-		t.Fatal("RawManifest() =", err)
-	}
-	return m
-}
-
 func fakeRegistry(t *testing.T, repo, username, password string, img v1.Image) *httptest.Server {
 	manifestPath := fmt.Sprintf("/v2/%s/manifests/latest", repo)
 	const basicAuth = "Basic "
@@ -81,10 +73,25 @@ func fakeRegistry(t *testing.T, repo, username, password string, img v1.Image) *
 			if want := base64.StdEncoding.EncodeToString([]byte(username + ":" + password)); !strings.HasSuffix(hdr, want) {
 				t.Errorf("Header.Get(Authorization) = %q, want suffix %q", hdr, want)
 			}
-			if r.Method != http.MethodGet {
-				t.Errorf("Method = %v, want %v", r.Method, http.MethodGet)
+			if r.Method != http.MethodHead {
+				t.Errorf("Method = %v, want %v", r.Method, http.MethodHead)
 			}
-			w.Write(mustRawManifest(t, img))
+			mt, err := img.MediaType()
+			if err != nil {
+				t.Errorf("MediaType() = %v", err)
+			}
+			sz, err := img.Size()
+			if err != nil {
+				t.Errorf("Size() = %v", err)
+			}
+			digest, err := img.Digest()
+			if err != nil {
+				t.Errorf("Digest() = %v", err)
+			}
+			w.Header().Set("Content-Type", string(mt))
+			w.Header().Set("Content-Length", fmt.Sprint(sz))
+			w.Header().Set("Docker-Content-Digest", digest.String())
+			w.WriteHeader(http.StatusOK)
 		default:
 			t.Error("Unexpected path:", r.URL.Path)
 		}

--- a/pkg/reconciler/revision/resolve_test.go
+++ b/pkg/reconciler/revision/resolve_test.go
@@ -78,20 +78,19 @@ func fakeRegistry(t *testing.T, repo, username, password string, img v1.Image) *
 			}
 			mt, err := img.MediaType()
 			if err != nil {
-				t.Errorf("MediaType() = %v", err)
+				t.Error("MediaType() =", err)
 			}
 			sz, err := img.Size()
 			if err != nil {
-				t.Errorf("Size() = %v", err)
+				t.Error("Size() =", err)
 			}
 			digest, err := img.Digest()
 			if err != nil {
-				t.Errorf("Digest() = %v", err)
+				t.Error("Digest() =", err)
 			}
 			w.Header().Set("Content-Type", string(mt))
 			w.Header().Set("Content-Length", fmt.Sprint(sz))
 			w.Header().Set("Docker-Content-Digest", digest.String())
-			w.WriteHeader(http.StatusOK)
 		default:
 			t.Error("Unexpected path:", r.URL.Path)
 		}

--- a/test/conformance/api/v1/errorcondition_test.go
+++ b/test/conformance/api/v1/errorcondition_test.go
@@ -21,10 +21,10 @@ package v1
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
-	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ptest "knative.dev/pkg/test"
@@ -68,7 +68,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	names.Config = serviceresourcenames.Configuration(svc)
 	names.Route = serviceresourcenames.Route(svc)
 
-	const manifestUnknown = string(transport.ManifestUnknownErrorCode)
+	manifestUnknown := fmt.Sprint(http.StatusNotFound)
 
 	// Wait for ServiceState becomes NotReady. It also waits for the creation of Configuration.
 	t.Log("When the imagepath is invalid, the Configuration should have error status.")

--- a/test/conformance/api/v1alpha1/errorcondition_test.go
+++ b/test/conformance/api/v1alpha1/errorcondition_test.go
@@ -21,10 +21,10 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
-	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ptest "knative.dev/pkg/test"
@@ -66,7 +66,8 @@ func TestContainerErrorMsg(t *testing.T) {
 	names.Config = serviceresourcenames.Configuration(svc)
 	names.Route = serviceresourcenames.Route(svc)
 
-	manifestUnknown := string(transport.ManifestUnknownErrorCode)
+	manifestUnknown := fmt.Sprint(http.StatusNotFound)
+
 	t.Log("When the imagepath is invalid, the Configuration should have error status.")
 
 	// Wait for ServiceState becomes NotReady. It also waits for the creation of Configuration.

--- a/test/conformance/api/v1beta1/errorcondition_test.go
+++ b/test/conformance/api/v1beta1/errorcondition_test.go
@@ -21,10 +21,10 @@ package v1beta1
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
-	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ptest "knative.dev/pkg/test"
@@ -68,7 +68,7 @@ func TestContainerErrorMsg(t *testing.T) {
 	names.Config = serviceresourcenames.Configuration(svc)
 	names.Route = serviceresourcenames.Route(svc)
 
-	manifestUnknown := string(transport.ManifestUnknownErrorCode)
+	manifestUnknown := fmt.Sprint(http.StatusNotFound)
 	t.Log("When the imagepath is invalid, the Configuration should have error status.")
 
 	// Wait for ServiceState becomes NotReady. It also waits for the creation of Configuration.

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/descriptor.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/descriptor.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/logs"
@@ -76,6 +77,8 @@ func (d *Descriptor) RawManifest() ([]byte, error) {
 // Get returns a remote.Descriptor for the given reference. The response from
 // the registry is left un-interpreted, for the most part. This is useful for
 // querying what kind of artifact a reference represents.
+//
+// See Head if you don't need the response body.
 func Get(ref name.Reference, options ...Option) (*Descriptor, error) {
 	acceptable := []types.MediaType{
 		// Just to look at them.
@@ -85,6 +88,30 @@ func Get(ref name.Reference, options ...Option) (*Descriptor, error) {
 	acceptable = append(acceptable, acceptableImageMediaTypes...)
 	acceptable = append(acceptable, acceptableIndexMediaTypes...)
 	return get(ref, acceptable, options...)
+}
+
+// Head returns a v1.Descriptor for the given reference by issuing a HEAD
+// request.
+func Head(ref name.Reference, options ...Option) (*v1.Descriptor, error) {
+	acceptable := []types.MediaType{
+		// Just to look at them.
+		types.DockerManifestSchema1,
+		types.DockerManifestSchema1Signed,
+	}
+	acceptable = append(acceptable, acceptableImageMediaTypes...)
+	acceptable = append(acceptable, acceptableIndexMediaTypes...)
+
+	o, err := makeOptions(ref.Context(), options...)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := makeFetcher(ref, o)
+	if err != nil {
+		return nil, err
+	}
+
+	return f.headManifest(ref, acceptable)
 }
 
 // Handle options and fetch the manifest with the acceptable MediaTypes in the
@@ -275,6 +302,55 @@ func (f *fetcher) fetchManifest(ref name.Reference, acceptable []types.MediaType
 	}
 
 	return manifest, &desc, nil
+}
+
+func (f *fetcher) headManifest(ref name.Reference, acceptable []types.MediaType) (*v1.Descriptor, error) {
+	u := f.url("manifests", ref.Identifier())
+	req, err := http.NewRequest(http.MethodHead, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	accept := []string{}
+	for _, mt := range acceptable {
+		accept = append(accept, string(mt))
+	}
+	req.Header.Set("Accept", strings.Join(accept, ","))
+
+	resp, err := f.Client.Do(req.WithContext(f.context))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := transport.CheckError(resp, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	mediaType := types.MediaType(resp.Header.Get("Content-Type"))
+
+	size, err := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	digest, err := v1.NewHash(resp.Header.Get("Docker-Content-Digest"))
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate the digest matches what we asked for, if pulling by digest.
+	if dgst, ok := ref.(name.Digest); ok {
+		if digest.String() != dgst.DigestStr() {
+			return nil, fmt.Errorf("manifest digest: %q does not match requested digest: %q for %q", digest, dgst.DigestStr(), f.Ref)
+		}
+	}
+
+	// Return all this info since we have to calculate it anyway.
+	return &v1.Descriptor{
+		Digest:    digest,
+		Size:      size,
+		MediaType: mediaType,
+	}, nil
 }
 
 func (f *fetcher) fetchBlob(h v1.Hash) (io.ReadCloser, error) {

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/write.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/write.go
@@ -261,8 +261,6 @@ func (w *writer) initiateUpload(from, mount string) (location string, mounted bo
 // On failure, this will return an error.  On success, this will return the location
 // header indicating how to commit the streamed blob.
 func (w *writer) streamBlob(blob io.ReadCloser, streamLocation string) (commitLocation string, err error) {
-	defer blob.Close()
-
 	req, err := http.NewRequest(http.MethodPatch, streamLocation, blob)
 	if err != nil {
 		return "", err

--- a/vendor/golang.org/x/tools/go/analysis/validate.go
+++ b/vendor/golang.org/x/tools/go/analysis/validate.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"unicode"
 )
 
@@ -58,12 +59,26 @@ func Validate(analyzers []*Analyzer) error {
 			}
 
 			// recursion
-			for i, req := range a.Requires {
+			for _, req := range a.Requires {
 				if err := visit(req); err != nil {
-					return fmt.Errorf("%s.Requires[%d]: %v", a.Name, i, err)
+					return err
 				}
 			}
 			color[a] = black
+		}
+
+		if color[a] == grey {
+			stack := []*Analyzer{a}
+			inCycle := map[string]bool{}
+			for len(stack) > 0 {
+				current := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				if color[current] == grey && !inCycle[current.Name] {
+					inCycle[current.Name] = true
+					stack = append(stack, current.Requires...)
+				}
+			}
+			return &CycleInRequiresGraphError{AnalyzerNames: inCycle}
 		}
 
 		return nil
@@ -94,4 +109,18 @@ func validIdent(name string) bool {
 		}
 	}
 	return name != ""
+}
+
+type CycleInRequiresGraphError struct {
+	AnalyzerNames map[string]bool
+}
+
+func (e *CycleInRequiresGraphError) Error() string {
+	var b strings.Builder
+	b.WriteString("cycle detected involving the following analyzers:")
+	for n := range e.AnalyzerNames {
+		b.WriteByte(' ')
+		b.WriteString(n)
+	}
+	return b.String()
 }

--- a/vendor/golang.org/x/tools/go/packages/golist.go
+++ b/vendor/golang.org/x/tools/go/packages/golist.go
@@ -246,6 +246,21 @@ extractQueries:
 			}
 		}
 	}
+	// Add root for any package that matches a pattern. This applies only to
+	// packages that are modified by overlays, since they are not added as
+	// roots automatically.
+	for _, pattern := range restPatterns {
+		match := matchPattern(pattern)
+		for _, pkgID := range modifiedPkgs {
+			pkg, ok := response.seenPackages[pkgID]
+			if !ok {
+				continue
+			}
+			if match(pkg.PkgPath) {
+				response.addRoot(pkg.ID)
+			}
+		}
+	}
 
 	sizeswg.Wait()
 	if sizeserr != nil {
@@ -753,7 +768,8 @@ func (state *golistState) getGoVersion() (string, error) {
 	return state.goVersion, state.goVersionError
 }
 
-// getPkgPath finds the package path of a directory if it's relative to a root directory.
+// getPkgPath finds the package path of a directory if it's relative to a root
+// directory.
 func (state *golistState) getPkgPath(dir string) (string, bool, error) {
 	absDir, err := filepath.Abs(dir)
 	if err != nil {

--- a/vendor/golang.org/x/tools/go/packages/golist_overlay.go
+++ b/vendor/golang.org/x/tools/go/packages/golist_overlay.go
@@ -8,9 +8,12 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+
+	"golang.org/x/tools/internal/gocommand"
 )
 
 // processGolistOverlay provides rudimentary support for adding
@@ -325,24 +328,25 @@ func (state *golistState) determineRootDirs() (map[string]string, error) {
 }
 
 func (state *golistState) determineRootDirsModules() (map[string]string, error) {
-	// This will only return the root directory for the main module.
-	// For now we only support overlays in main modules.
+	// List all of the modules--the first will be the directory for the main
+	// module. Any replaced modules will also need to be treated as roots.
 	// Editing files in the module cache isn't a great idea, so we don't
-	// plan to ever support that, but editing files in replaced modules
-	// is something we may want to support. To do that, we'll want to
-	// do a go list -m to determine the replaced module's module path and
-	// directory, and then a go list -m {{with .Replace}}{{.Dir}}{{end}} <replaced module's path>
-	// from the main module to determine if that module is actually a replacement.
-	// See bcmills's comment here: https://github.com/golang/go/issues/37629#issuecomment-594179751
-	// for more information.
-	out, err := state.invokeGo("list", "-m", "-json")
+	// plan to ever support that.
+	out, err := state.invokeGo("list", "-m", "-json", "all")
 	if err != nil {
-		return nil, err
+		// 'go list all' will fail if we're outside of a module and
+		// GO111MODULE=on. Try falling back without 'all'.
+		var innerErr error
+		out, innerErr = state.invokeGo("list", "-m", "-json")
+		if innerErr != nil {
+			return nil, err
+		}
 	}
-	m := map[string]string{}
-	type jsonMod struct{ Path, Dir string }
+	roots := map[string]string{}
+	modules := map[string]string{}
+	var i int
 	for dec := json.NewDecoder(out); dec.More(); {
-		mod := new(jsonMod)
+		mod := new(gocommand.ModuleJSON)
 		if err := dec.Decode(mod); err != nil {
 			return nil, err
 		}
@@ -352,10 +356,15 @@ func (state *golistState) determineRootDirsModules() (map[string]string, error) 
 			if err != nil {
 				return nil, err
 			}
-			m[absDir] = mod.Path
+			modules[absDir] = mod.Path
+			// The first result is the main module.
+			if i == 0 || mod.Replace != nil && mod.Replace.Path != "" {
+				roots[absDir] = mod.Path
+			}
 		}
+		i++
 	}
-	return m, nil
+	return roots, nil
 }
 
 func (state *golistState) determineRootDirsGOPATH() (map[string]string, error) {
@@ -480,4 +489,80 @@ func maybeFixPackageName(newName string, isTestFile bool, pkgsOfDir []*Package) 
 	for _, p := range pkgsOfDir {
 		p.Name = newName
 	}
+}
+
+// This function is copy-pasted from
+// https://github.com/golang/go/blob/9706f510a5e2754595d716bd64be8375997311fb/src/cmd/go/internal/search/search.go#L360.
+// It should be deleted when we remove support for overlays from go/packages.
+//
+// NOTE: This does not handle any ./... or ./ style queries, as this function
+// doesn't know the working directory.
+//
+// matchPattern(pattern)(name) reports whether
+// name matches pattern. Pattern is a limited glob
+// pattern in which '...' means 'any string' and there
+// is no other special syntax.
+// Unfortunately, there are two special cases. Quoting "go help packages":
+//
+// First, /... at the end of the pattern can match an empty string,
+// so that net/... matches both net and packages in its subdirectories, like net/http.
+// Second, any slash-separated pattern element containing a wildcard never
+// participates in a match of the "vendor" element in the path of a vendored
+// package, so that ./... does not match packages in subdirectories of
+// ./vendor or ./mycode/vendor, but ./vendor/... and ./mycode/vendor/... do.
+// Note, however, that a directory named vendor that itself contains code
+// is not a vendored package: cmd/vendor would be a command named vendor,
+// and the pattern cmd/... matches it.
+func matchPattern(pattern string) func(name string) bool {
+	// Convert pattern to regular expression.
+	// The strategy for the trailing /... is to nest it in an explicit ? expression.
+	// The strategy for the vendor exclusion is to change the unmatchable
+	// vendor strings to a disallowed code point (vendorChar) and to use
+	// "(anything but that codepoint)*" as the implementation of the ... wildcard.
+	// This is a bit complicated but the obvious alternative,
+	// namely a hand-written search like in most shell glob matchers,
+	// is too easy to make accidentally exponential.
+	// Using package regexp guarantees linear-time matching.
+
+	const vendorChar = "\x00"
+
+	if strings.Contains(pattern, vendorChar) {
+		return func(name string) bool { return false }
+	}
+
+	re := regexp.QuoteMeta(pattern)
+	re = replaceVendor(re, vendorChar)
+	switch {
+	case strings.HasSuffix(re, `/`+vendorChar+`/\.\.\.`):
+		re = strings.TrimSuffix(re, `/`+vendorChar+`/\.\.\.`) + `(/vendor|/` + vendorChar + `/\.\.\.)`
+	case re == vendorChar+`/\.\.\.`:
+		re = `(/vendor|/` + vendorChar + `/\.\.\.)`
+	case strings.HasSuffix(re, `/\.\.\.`):
+		re = strings.TrimSuffix(re, `/\.\.\.`) + `(/\.\.\.)?`
+	}
+	re = strings.ReplaceAll(re, `\.\.\.`, `[^`+vendorChar+`]*`)
+
+	reg := regexp.MustCompile(`^` + re + `$`)
+
+	return func(name string) bool {
+		if strings.Contains(name, vendorChar) {
+			return false
+		}
+		return reg.MatchString(replaceVendor(name, vendorChar))
+	}
+}
+
+// replaceVendor returns the result of replacing
+// non-trailing vendor path elements in x with repl.
+func replaceVendor(x, repl string) string {
+	if !strings.Contains(x, "vendor") {
+		return x
+	}
+	elem := strings.Split(x, "/")
+	for i := 0; i < len(elem)-1; i++ {
+		if elem[i] == "vendor" {
+			elem[i] = repl
+		}
+	}
+	return strings.Join(elem, "/")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -168,7 +168,7 @@ github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
-# github.com/google/go-containerregistry v0.1.3-0.20200910230023-d42b6a2ddfd1
+# github.com/google/go-containerregistry v0.1.3
 ## explicit
 github.com/google/go-containerregistry/pkg/authn
 github.com/google/go-containerregistry/pkg/authn/k8schain
@@ -410,7 +410,7 @@ golang.org/x/text/unicode/norm
 golang.org/x/text/width
 # golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 golang.org/x/time/rate
-# golang.org/x/tools v0.0.0-20200910222312-571a207697e7
+# golang.org/x/tools v0.0.0-20200916195026-c9a70fc28ce3
 golang.org/x/tools/cmd/goimports
 golang.org/x/tools/go/analysis
 golang.org/x/tools/go/analysis/passes/inspect


### PR DESCRIPTION
Some additional context: https://knative.slack.com/archives/CDJ8M6R34/p1600293665001500

This is to pull in https://github.com/google/go-containerregistry/pull/770 and enable the use of `remote.Head`, which bypasses the rate limiting that DockerHub is instituting.

```release-note
Uses HEAD rather than GET for resolving image digests, which avoids counting image digest resolution against dockerhub pull quotas.
```