### PR TITLE
Set up HorizontalPodAutoscaler for Webhook

### DIFF
--- a/config/core/deployments/webhook-hpa.yaml
+++ b/config/core/deployments/webhook-hpa.yaml
@@ -1,0 +1,51 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: webhook
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  minReplicas: 1
+  maxReplicas: 5
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: webhook
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        # Percentage of the requested CPU
+        targetAverageUtilization: 100
+
+
+---
+
+# Webhook PDB.
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: webhook-pdb
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  maxUnavailable: 20%
+  selector:
+    matchLabels:
+      app: webhook

--- a/config/core/deployments/webhook-hpa.yaml
+++ b/config/core/deployments/webhook-hpa.yaml
@@ -45,7 +45,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 spec:
-  maxUnavailable: 20%
+  minAvailable: 80%
   selector:
     matchLabels:
       app: webhook


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #9129 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Set up HorizontalPodAutoscaler for Webhook:
- Scale Webhook based on CPU
- Add initial PodDisruptionBudget

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```
NONE
```
