### PR TITLE
Make sure to Clear after errors in digest resolution

### DIFF
--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -100,6 +100,9 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) (boo
 
 	statuses, err := c.resolver.Resolve(rev, opt, cfgs.Deployment.RegistriesSkippingTagResolving, digestResolutionTimeout)
 	if err != nil {
+		// Clear the resolver so we can retry the digest resolution rather than
+		// being stuck with this error.
+		c.resolver.Clear(types.NamespacedName{Namespace: rev.Namespace, Name: rev.Name})
 		rev.Status.MarkContainerHealthyFalse(v1.ReasonContainerMissing, err.Error())
 		return true, err
 	}

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -333,20 +333,24 @@ func (r *notResolvedYetResolver) Resolve(_ *v1.Revision, _ k8schain.Options, _ s
 func (r *notResolvedYetResolver) Clear(types.NamespacedName) {}
 
 type errorResolver struct {
-	err error
+	err     error
+	cleared bool
 }
 
 func (r *errorResolver) Resolve(_ *v1.Revision, _ k8schain.Options, _ sets.String, _ time.Duration) ([]v1.ContainerStatus, error) {
 	return nil, r.err
 }
 
-func (r *errorResolver) Clear(types.NamespacedName) {}
+func (r *errorResolver) Clear(types.NamespacedName) {
+	r.cleared = true
+}
 
 func TestResolutionFailed(t *testing.T) {
 	// Unconditionally return this error during resolution.
 	innerError := errors.New("i am the expected error message, hear me ROAR!")
+	resolver := &errorResolver{cleared: false, err: innerError}
 	ctx, _, _, controller, _ := newTestController(t, nil /*additional CMs*/, func(r *Reconciler) {
-		r.resolver = &errorResolver{innerError}
+		r.resolver = resolver
 	})
 
 	rev := testRevision(testPodSpec())
@@ -371,6 +375,10 @@ func TestResolutionFailed(t *testing.T) {
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Errorf("Unexpected revision conditions diff (-want +got):\n%s", diff)
 		}
+	}
+
+	if !resolver.cleared {
+		t.Fatal("Expected resolver.Clear() to have been called")
 	}
 }
 


### PR DESCRIPTION
Otherwise we can't retry digest resolution errors. Also there's a memory leak if we don't do this.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

/assign @markusthoemmes @mattmoor 