### PR TITLE
Add configurable timeout for digest resolution

### DIFF
--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "d57841a3"
+    knative.dev/example-checksum: "52900e59"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -46,7 +46,7 @@ data:
 
     # digestResolutionTimeout is the maximum time allowed for an image's
     # digests to be resolved.
-    digestResolutionTimeout: "2s"
+    digestResolutionTimeout: "10s"
 
     # ProgressDeadline is the duration we wait for the deployment to
     # be ready before considering it failed.

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "b4ce3a17"
+    knative.dev/example-checksum: "d57841a3"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -43,6 +43,10 @@ data:
 
     # List of repositories for which tag to digest resolving should be skipped
     registriesSkippingTagResolving: "kind.local,ko.local,dev.local"
+
+    # digestResolutionTimeout is the maximum time allowed for an image's
+    # digests to be resolved.
+    digestResolutionTimeout: "2s"
 
     # ProgressDeadline is the duration we wait for the deployment to
     # be ready before considering it failed.

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -46,7 +46,7 @@ const (
 	digestResolutionTimeoutKey = "digestResolutionTimeout"
 
 	// digestResolutionTimeoutDefault is the default digest resolution timeout.
-	digestResolutionTimeoutDefault = 2 * time.Second
+	digestResolutionTimeoutDefault = 10 * time.Second
 
 	// registriesSkippingTagResolvingKey is the config map key for the set of registries
 	// (e.g. ko.local) where tags should not be resolved to digests.

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -32,7 +32,7 @@ const (
 	// ConfigName is the name of config map for the deployment.
 	ConfigName = "config-deployment"
 
-	// QueueSidecarImageKey is the config map key for queue sidecar image
+	// QueueSidecarImageKey is the config map key for queue sidecar image.
 	QueueSidecarImageKey = "queueSidecarImage"
 
 	// ProgressDeadlineDefault is the default value for the config's
@@ -41,6 +41,12 @@ const (
 
 	// ProgressDeadlineKey is the key to configure deployment progress deadline.
 	ProgressDeadlineKey = "progressDeadline"
+
+	// digestResolutionTimeoutKey is the key to configure the digest resolution timeout.
+	digestResolutionTimeoutKey = "digestResolutionTimeout"
+
+	// digestResolutionTimeoutDefault is the default digest resolution timeout.
+	digestResolutionTimeoutDefault = 2 * time.Second
 
 	// registriesSkippingTagResolvingKey is the config map key for the set of registries
 	// (e.g. ko.local) where tags should not be resolved to digests.
@@ -67,18 +73,20 @@ var (
 func defaultConfig() *Config {
 	return &Config{
 		ProgressDeadline:               ProgressDeadlineDefault,
+		DigestResolutionTimeout:        digestResolutionTimeoutDefault,
 		RegistriesSkippingTagResolving: sets.NewString("kind.local", "ko.local", "dev.local"),
 		QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 	}
 }
 
-// NewConfigFromMap creates a DeploymentConfig from the supplied Map
+// NewConfigFromMap creates a DeploymentConfig from the supplied Map.
 func NewConfigFromMap(configMap map[string]string) (*Config, error) {
 	nc := defaultConfig()
 
 	if err := cm.Parse(configMap,
 		cm.AsString(QueueSidecarImageKey, &nc.QueueSidecarImage),
 		cm.AsDuration(ProgressDeadlineKey, &nc.ProgressDeadline),
+		cm.AsDuration(digestResolutionTimeoutKey, &nc.DigestResolutionTimeout),
 		cm.AsStringSet(registriesSkippingTagResolvingKey, &nc.RegistriesSkippingTagResolving),
 
 		cm.AsQuantity(queueSidecarCPURequestKey, &nc.QueueSidecarCPURequest),
@@ -99,10 +107,14 @@ func NewConfigFromMap(configMap map[string]string) (*Config, error) {
 		return nil, fmt.Errorf("progressDeadline cannot be a non-positive duration, was %v", nc.ProgressDeadline)
 	}
 
+	if nc.DigestResolutionTimeout <= 0 {
+		return nil, fmt.Errorf("digestResolutionTimeout cannot be a non-positive duration, was %v", nc.DigestResolutionTimeout)
+	}
+
 	return nc, nil
 }
 
-// NewConfigFromConfigMap creates a DeploymentConfig from the supplied configMap
+// NewConfigFromConfigMap creates a DeploymentConfig from the supplied configMap.
 func NewConfigFromConfigMap(config *corev1.ConfigMap) (*Config, error) {
 	return NewConfigFromMap(config.Data)
 }
@@ -110,33 +122,36 @@ func NewConfigFromConfigMap(config *corev1.ConfigMap) (*Config, error) {
 // Config includes the configurations for the controller.
 type Config struct {
 	// QueueSidecarImage is the name of the image used for the queue sidecar
-	// injected into the revision pod
+	// injected into the revision pod.
 	QueueSidecarImage string
 
-	// Repositories for which tag to digest resolving should be skipped
+	// Repositories for which tag to digest resolving should be skipped.
 	RegistriesSkippingTagResolving sets.String
+
+	// DigestResolutionTimeout is the maximum time allowed for image digest resolution.
+	DigestResolutionTimeout time.Duration
 
 	// ProgressDeadline is the time in seconds we wait for the deployment to
 	// be ready before considering it failed.
 	ProgressDeadline time.Duration
 
-	// QueueSidecarCPURequest is the CPU Request to set for the queue proxy sidecar container
+	// QueueSidecarCPURequest is the CPU Request to set for the queue proxy sidecar container.
 	QueueSidecarCPURequest *resource.Quantity
 
-	// QueueSidecarCPULimit is the CPU Limit to set for the queue proxy sidecar container
+	// QueueSidecarCPULimit is the CPU Limit to set for the queue proxy sidecar container.
 	QueueSidecarCPULimit *resource.Quantity
 
-	// QueueSidecarMemoryRequest is the Memory Request to set for the queue proxy sidecar container
+	// QueueSidecarMemoryRequest is the Memory Request to set for the queue proxy sidecar container.
 	QueueSidecarMemoryRequest *resource.Quantity
 
-	// QueueSidecarMemoryLimit is the Memory Limit to set for the queue proxy sidecar container
+	// QueueSidecarMemoryLimit is the Memory Limit to set for the queue proxy sidecar container.
 	QueueSidecarMemoryLimit *resource.Quantity
 
 	// QueueSidecarEphemeralStorageRequest is the Ephemeral Storage Request to
-	// set for the queue proxy sidecar container
+	// set for the queue proxy sidecar container.
 	QueueSidecarEphemeralStorageRequest *resource.Quantity
 
 	// QueueSidecarEphemeralStorageLimit is the Ephemeral Storage Limit to set
-	// for the queue proxy sidecar container
+	// for the queue proxy sidecar container.
 	QueueSidecarEphemeralStorageLimit *resource.Quantity
 }

--- a/pkg/deployment/config_test.go
+++ b/pkg/deployment/config_test.go
@@ -83,6 +83,7 @@ func TestControllerConfiguration(t *testing.T) {
 		name: "controller configuration with bad registries",
 		wantConfig: &Config{
 			RegistriesSkippingTagResolving: sets.NewString("ko.local", ""),
+			DigestResolutionTimeout:        digestResolutionTimeoutDefault,
 			QueueSidecarImage:              defaultSidecarImage,
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			ProgressDeadline:               ProgressDeadlineDefault,
@@ -95,6 +96,7 @@ func TestControllerConfiguration(t *testing.T) {
 		name: "controller configuration good progress deadline",
 		wantConfig: &Config{
 			RegistriesSkippingTagResolving: sets.NewString("kind.local", "ko.local", "dev.local"),
+			DigestResolutionTimeout:        digestResolutionTimeoutDefault,
 			QueueSidecarImage:              defaultSidecarImage,
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			ProgressDeadline:               444 * time.Second,
@@ -104,9 +106,23 @@ func TestControllerConfiguration(t *testing.T) {
 			ProgressDeadlineKey:  "444s",
 		},
 	}, {
+		name: "controller configuration good digest resolution timeout",
+		wantConfig: &Config{
+			RegistriesSkippingTagResolving: sets.NewString("kind.local", "ko.local", "dev.local"),
+			DigestResolutionTimeout:        60 * time.Second,
+			QueueSidecarImage:              defaultSidecarImage,
+			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
+			ProgressDeadline:               ProgressDeadlineDefault,
+		},
+		data: map[string]string{
+			QueueSidecarImageKey:       defaultSidecarImage,
+			digestResolutionTimeoutKey: "60s",
+		},
+	}, {
 		name: "controller configuration with registries",
 		wantConfig: &Config{
 			RegistriesSkippingTagResolving: sets.NewString("ko.local", "ko.dev"),
+			DigestResolutionTimeout:        digestResolutionTimeoutDefault,
 			QueueSidecarImage:              defaultSidecarImage,
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			ProgressDeadline:               ProgressDeadlineDefault,
@@ -119,6 +135,7 @@ func TestControllerConfiguration(t *testing.T) {
 		name: "controller configuration with custom queue sidecar resource request/limits",
 		wantConfig: &Config{
 			RegistriesSkippingTagResolving:      sets.NewString("kind.local", "ko.local", "dev.local"),
+			DigestResolutionTimeout:             digestResolutionTimeoutDefault,
 			QueueSidecarImage:                   defaultSidecarImage,
 			ProgressDeadline:                    ProgressDeadlineDefault,
 			QueueSidecarCPURequest:              resourcePtr(resource.MustParse("123m")),
@@ -141,6 +158,13 @@ func TestControllerConfiguration(t *testing.T) {
 		name:    "controller with no side car image",
 		wantErr: true,
 		data:    map[string]string{},
+	}, {
+		name:    "controller configuration invalid digest resolution timeout",
+		wantErr: true,
+		data: map[string]string{
+			QueueSidecarImageKey:       defaultSidecarImage,
+			digestResolutionTimeoutKey: "-1s",
+		},
 	}, {
 		name:    "controller configuration invalid progress deadline",
 		wantErr: true,

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -41,8 +41,6 @@ import (
 	"knative.dev/serving/pkg/reconciler/revision/config"
 )
 
-const digestResolutionTimeout = 60 * time.Second
-
 type resolver interface {
 	Resolve(*v1.Revision, k8schain.Options, sets.String, time.Duration) ([]v1.ContainerStatus, error)
 	Clear(types.NamespacedName)
@@ -98,7 +96,7 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) (boo
 		ImagePullSecrets:   imagePullSecrets,
 	}
 
-	statuses, err := c.resolver.Resolve(rev, opt, cfgs.Deployment.RegistriesSkippingTagResolving, digestResolutionTimeout)
+	statuses, err := c.resolver.Resolve(rev, opt, cfgs.Deployment.RegistriesSkippingTagResolving, cfgs.Deployment.DigestResolutionTimeout)
 	if err != nil {
 		// Clear the resolver so we can retry the digest resolution rather than
 		// being stuck with this error.


### PR DESCRIPTION
adds the ability to configure the digest resolution timeout in deployment.yaml and, now that it's configurable, uses the opportunity to make the timeout much more aggressive (60s->10s).

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #9296.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
- Lowers the default digest resolution timeout to 10 seconds.
- Allows changing the digest resolution timeout.
```

/assign @markusthoemmes @mattmoor 