### PR TITLE
Exit AS pod if it fails to create bucket SVC/Endpoints

### DIFF
--- a/pkg/autoscaler/statforwarder/forwarder.go
+++ b/pkg/autoscaler/statforwarder/forwarder.go
@@ -159,15 +159,14 @@ func (f *Forwarder) leaseUpdated(obj interface{}) {
 		return
 	}
 
-	// TODO(yanweiguo): Better handling these errors instead of just logging.
 	if err := f.createService(ctx, ns, n); err != nil {
-		f.logger.Errorf("Failed to create Service for Lease %s/%s: %v", ns, n, err)
+		f.logger.Fatalf("Failed to create Service for Lease %s/%s: %v", ns, n, err)
 		return
 	}
 	f.logger.Infof("Created Service for Lease %s/%s", ns, n)
 
 	if err := f.createOrUpdateEndpoints(ctx, ns, n); err != nil {
-		f.logger.Errorf("Failed to create Endpoints for Lease %s/%s: %v", ns, n, err)
+		f.logger.Fatalf("Failed to create Endpoints for Lease %s/%s: %v", ns, n, err)
 		return
 	}
 	f.logger.Infof("Created Endpoints for Lease %s/%s", ns, n)


### PR DESCRIPTION
If the AS pod fails to create bucket SVC/Endpoints after retries, instead of just logging and staying in a bad state, crash it. So it will either in a crash loop to explicitly indicates something is wrong or succeeds to create after restarting pods.

/assign @vagababov 
