### PR TITLE
Fix performance testing (again)

### DIFF
--- a/test/performance/benchmarks/dataplane-probe/continuous/main.go
+++ b/test/performance/benchmarks/dataplane-probe/continuous/main.go
@@ -27,8 +27,11 @@ import (
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/test/mako"
+
 	"knative.dev/serving/test/performance"
 	"knative.dev/serving/test/performance/metrics"
+
+	_ "knative.dev/pkg/system/testing"
 )
 
 var (

--- a/test/performance/benchmarks/rollout-probe/continuous/sla.go
+++ b/test/performance/benchmarks/rollout-probe/continuous/sla.go
@@ -64,7 +64,7 @@ var (
 		estat     string
 		analyzers []*tpb.ThresholdAnalyzerInput
 	}{
-		"queue": {
+		"queue-proxy": {
 			target: vegeta.Target{
 				Method: http.MethodGet,
 				URL:    "http://queue-proxy.default.svc.cluster.local?sleep=100",
@@ -73,7 +73,7 @@ var (
 			estat:     "qe",
 			analyzers: []*tpb.ThresholdAnalyzerInput{newQueue95PercentileLatency("q")},
 		},
-		"queue-with-cc": {
+		"queue-proxy-with-cc": {
 			target: vegeta.Target{
 				Method: http.MethodGet,
 				URL:    "http://queue-proxy-with-cc.default.svc.cluster.local?sleep=100",

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -42,6 +42,9 @@ function update_knative() {
   # and services from istio before reintalling it, to get them freshly recreated
   kubectl delete deployments --all -n istio-system
   kubectl delete services --all -n istio-system
+
+  # Create the ${SYSTEM_NAMESPACE} is it does not exist.
+  kubectl get ns "${SYSTEM_NAMESPACE}" || kubectl create namespace "${SYSTEM_NAMESPACE}"
   install_istio "./third_party/net-istio.yaml" || abort "Failed to install Istio"
 
   # Overprovision the Istio gateways and pilot.
@@ -102,6 +105,9 @@ function update_benchmark() {
   echo ">> Deleting all Knative serving services"
   kubectl delete ksvc --all
 
+  echo ">> Upload the test images"
+  # Upload helloworld test image as it's used by the scale-from-zero benchmark.
+  ko resolve -RBf test/test_images/helloworld > /dev/null
   echo ">> Applying all the yamls for benchmark $1"
   ko apply -f ${BENCHMARK_ROOT_PATH}/$1/continuous || abort "failed to apply benchmarks yaml $1"
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

There are more issues than I thought:

* Create `SYSTEM_NAMESPACE` before installing Istio, since `networking-istio` needs to be installed in this namespace
* `dataplane-probe` benchmark:  import `_ "knative.dev/pkg/system/testing"` according to the error message in the Pod log
* `rollout-probe` benchmark: fix the ksvc name in the code to correctly correlate with the names used in the yaml config files
* `scale-from-zero` benchmark: upload the `helloworld` image as it's used by this benchmark

I have verified that these benchmarks have been fixed, and I'm really hoping we will be able to have cycles in the next quarter to make this infra less brittle...

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vagababov 
