### PR TITLE
Have codecov ignore *.pb.go

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,5 +1,6 @@
 ignore:
   - "**/zz_generated*.go" # Ignore generated files.
+  - "**/*.pb.go" # Ignore proto-generated files.
   - "hack"
   - "pkg/client"
   - "third_party"


### PR DESCRIPTION
Noticed that this file is a big chunk of the poor coverage in the sunburst chart.