### PR TITLE
Use http.Transport.Clone in preference to copy-pasting defaults

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -200,10 +200,9 @@ func main() {
 	if *readinessProbeTimeout >= 0 {
 		// Use a unix socket rather than TCP to avoid going via entire TCP stack
 		// when we're actually in the same container.
-		transport := &http.Transport{
-			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", unixSocketPath)
-			},
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
+			return net.Dial("unix", unixSocketPath)
 		}
 
 		os.Exit(standaloneProbeMain(*readinessProbeTimeout, transport))

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -55,12 +55,16 @@ func TCPProbe(config TCPProbeConfigOptions) error {
 	return nil
 }
 
+var transport = func() *http.Transport {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.DisableKeepAlives = true
+	// nolint:gosec // We explicitly don't need to check certs here.
+	t.TLSClientConfig.InsecureSkipVerify = true
+	return t
+}()
+
 // HTTPProbe checks that HTTP connection can be established to the address.
 func HTTPProbe(config HTTPProbeConfigOptions) error {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	// nolint:gosec // We explicitly don't need to check certs here.
-	transport.TLSClientConfig.InsecureSkipVerify = true
-	transport.DisableKeepAlives = true
 	httpClient := &http.Client{
 		Transport: transport,
 		Timeout:   config.Timeout,

--- a/pkg/reconciler/revision/resolve.go
+++ b/pkg/reconciler/revision/resolve.go
@@ -23,9 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
-	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -61,27 +59,13 @@ func newResolverTransport(path string) (*http.Transport, error) {
 		return nil, errors.New("failed to append k8s cert bundle to cert pool")
 	}
 
-	// Copied from https://github.com/golang/go/blob/release-branch.go1.12/src/net/http/transport.go#L42-L53
-	// We want to use the DefaultTransport but change its TLSClientConfig. There
-	// isn't a clean way to do this yet: https://github.com/golang/go/issues/26013
-	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
-		}).DialContext,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: 10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		// Use the cert pool with k8s cert bundle appended.
-		TLSClientConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			RootCAs:    pool,
-		},
-	}, nil
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    pool,
+	}
+
+	return transport, nil
 }
 
 // Resolve resolves the image references that use tags to digests.


### PR DESCRIPTION
Since go 1.13 `http.Transport` has a `Clone()` method (see https://github.com/golang/go/issues/26013) which means we can inherit and override the `http.DefaultTransport` defaults rather than re-stating them when we want to override a couple fields. In a couple cases here we were actually creating an empty Transport and not inheriting the defaults at all, even though I think we likely wanted to. Even in cases where we _do_ want to override most of the defaults, starting from Clone() of DefaultTransport is clearer about what's going on (and means we inherit changes to non-overridden defaults properly).

/assign @markusthoemmes @vagababov 