### PR TITLE
Apply gosec checks to the codebase, except tests.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,7 +18,14 @@ run:
 
 linters:
   enable:
-    - unconvert
+    - gosec
     - prealloc
+    - unconvert
   disable:
     - errcheck
+
+issues:
+  exclude-rules:
+    - path: test # Excludes /test, *_test.go etc.
+      linters:
+        - gosec

--- a/pkg/activator/net/lb_policy.go
+++ b/pkg/activator/net/lb_policy.go
@@ -54,6 +54,7 @@ func randomChoice2Policy(_ context.Context, targets []*podTracker) (func(), *pod
 	// Two trackers - we know both contestants,
 	// otherwise pick 2 random unequal integers.
 	if l > 2 {
+		// nolint:gosec // We don't need cryptographic randomness here.
 		r1, r2 = rand.Intn(l), rand.Intn(l-1)
 		// shift second half of second rand.Intn down so we're picking
 		// from range of numbers other than r1.

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -250,7 +250,8 @@ func validateEnv(ctx context.Context, envVars []corev1.EnvVar) *apis.FieldError 
 
 func validateEnvFrom(envFromList []corev1.EnvFromSource) *apis.FieldError {
 	var errs *apis.FieldError
-	for i, envFrom := range envFromList {
+	for i := range envFromList {
+		envFrom := envFromList[i]
 		errs = errs.Also(apis.CheckDisallowedFields(envFrom, *EnvFromSourceMask(&envFrom)).ViaIndex(i))
 
 		cm := envFrom.ConfigMapRef
@@ -473,7 +474,8 @@ func validateVolumeMounts(mounts []corev1.VolumeMount, volumes sets.String) *api
 	// coverage, and the field restrictions.
 	seenName := make(sets.String, len(mounts))
 	seenMountPath := make(sets.String, len(mounts))
-	for i, vm := range mounts {
+	for i := range mounts {
+		vm := mounts[i]
 		errs = errs.Also(apis.CheckDisallowedFields(vm, *VolumeMountMask(&vm)).ViaIndex(i))
 		// This effectively checks that Name is non-empty because Volume name must be non-empty.
 		if !volumes.Has(vm.Name) {

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -62,6 +62,7 @@ func HTTPProbe(config HTTPProbeConfigOptions) error {
 		Transport: &http.Transport{
 			DisableKeepAlives: true,
 			TLSClientConfig: &tls.Config{
+				// nolint:gosec // We explicitly don't need to check certs here.
 				InsecureSkipVerify: true,
 			},
 		},

--- a/pkg/reconciler/revision/resolve.go
+++ b/pkg/reconciler/revision/resolve.go
@@ -78,7 +78,8 @@ func newResolverTransport(path string) (*http.Transport, error) {
 		ExpectContinueTimeout: 1 * time.Second,
 		// Use the cert pool with k8s cert bundle appended.
 		TLSClientConfig: &tls.Config{
-			RootCAs: pool,
+			MinVersion: tls.VersionTLS12,
+			RootCAs:    pool,
 		},
 	}, nil
 }

--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -165,8 +165,8 @@ func newBuilder(
 }
 
 func (cb *configBuilder) applySpecTraffic(traffic []v1.TrafficTarget) error {
-	for _, tt := range traffic {
-		if err := cb.addTrafficTarget(&tt); err != nil {
+	for i := range traffic {
+		if err := cb.addTrafficTarget(&traffic[i]); err != nil {
 			// Other non-traffic target errors shouldn't be ignored.
 			return err
 		}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

I found the findings somewhat interesting and worth enabling the check if only to force us to think through decisions (like the TLS version for example) and document why we've chosen to disable security features.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
For security reasons, registries that are shipping image metadata on TLS version 1.0 or 1.1 are no longer supported.
```

/assign @julz @vagababov @mattmoor 

/hold

Especially for the TLS Version bump on the image digest resolution. That needs some eyes for sure.
