### PR TITLE
Add missing reset to TestNewRequestMetricsHandlerFailure

### DIFF
--- a/pkg/queue/request_metric_test.go
+++ b/pkg/queue/request_metric_test.go
@@ -32,7 +32,7 @@ import (
 const targetURI = "http://example.com"
 
 func TestNewRequestMetricsHandlerFailure(t *testing.T) {
-	defer reset()
+	t.Cleanup(reset)
 	if _, err := NewRequestMetricsHandler(nil /*next*/, "a", "b", "c", "d", "shøüld fail"); err == nil {
 		t.Error("Should get error when tag value is not ascii")
 	}

--- a/pkg/queue/request_metric_test.go
+++ b/pkg/queue/request_metric_test.go
@@ -32,6 +32,7 @@ import (
 const targetURI = "http://example.com"
 
 func TestNewRequestMetricsHandlerFailure(t *testing.T) {
+	defer reset()
 	if _, err := NewRequestMetricsHandler(nil /*next*/, "a", "b", "c", "d", "shøüld fail"); err == nil {
 		t.Error("Should get error when tag value is not ascii")
 	}


### PR DESCRIPTION
This currently does not cause a test failure because opencensus will recognize that the same view is being registered. This will no longer work, however, if views are deep copied before being registered.