### PR TITLE
Import nightlies via github actions.

### DIFF
--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -1,0 +1,76 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Update Nightlies
+
+on:
+  schedule:
+  - cron:  '0 9 * * 1-5' # 2am Pacific on weekdays
+
+jobs:
+
+  update-nightlies:
+    name: update nightlies
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Keep running if one leg fails.
+      matrix:
+        nightly:
+        - net-certmanager
+        - net-contour
+        - net-istio
+        - net-kourier
+
+        # Map to nightly-specific parameters.
+        include:
+        - nightly: net-certmanager
+          directory: ./third_party/cert-manager-0.12.0
+          files: net-certmanager.yaml
+        - nightly: net-contour
+          directory: ./third_party/contour-latest
+          files: net-contour.yaml contour.yaml
+        - nightly: net-istio
+          directory: ./third_party/
+          files: net-istio
+        - nightly: net-kourier
+          directory: ./third_party/kourier-latest
+          files: kourier.yaml
+
+    steps:
+    - name: Check out code onto GOPATH
+      uses: actions/checkout@v2
+
+    - name: Go Format and Imports
+      shell: bash
+      run: |
+        for x in ${{ matrix.files }}; do
+          curl https://storage.googleapis.com/knative-nightly/${{ matrix.nightly }}/latest/$x > ${GITHUB_WORKSPACE}/${{ matrix.directory }}/$x
+        done
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: 'Update ${{ matrix.nightly }} nightly'
+        signoff: true
+        branch: update-nightly/${{ matrix.nightly }}
+        delete-branch: true
+        title: '[Automated] Update ${{ matrix.nightly }} nightly'
+        body: |
+          Produced via:
+          ```shell
+          for x in ${{ matrix.files }}; do
+            curl https://storage.googleapis.com/knative-nightly/${{ matrix.nightly }}/latest/$x > ${GITHUB_WORKSPACE}/${{ matrix.directory }}/$x
+          done
+          ```

--- a/.github/workflows/update-nightlies.yaml
+++ b/.github/workflows/update-nightlies.yaml
@@ -74,3 +74,4 @@ jobs:
             curl https://storage.googleapis.com/knative-nightly/${{ matrix.nightly }}/latest/$x > ${GITHUB_WORKSPACE}/${{ matrix.directory }}/$x
           done
           ```
+          /assign tcnghia nak3 ZhiminXiang mattmoor


### PR DESCRIPTION
This replaces the knobots equivalent jobs.

... assuming we can make the CLA bot happy with actions PRs.