### PR TITLE
Start queue_main refactoring for testability

### DIFF
--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -34,7 +34,6 @@ import (
 	tracingconfig "knative.dev/pkg/tracing/config"
 	"knative.dev/pkg/tracing/propagation/tracecontextb3"
 	tracetesting "knative.dev/pkg/tracing/testing"
-	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/queue"
 	"knative.dev/serving/pkg/queue/health"
 
@@ -42,54 +41,6 @@ import (
 )
 
 const wantHost = "a-better-host.com"
-
-func TestHandlerReqEvent(t *testing.T) {
-	var httpHandler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get(activator.RevisionHeaderName) != "" {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-
-		if r.Header.Get(activator.RevisionHeaderNamespace) != "" {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-
-		if got, want := r.Host, wantHost; got != want {
-			t.Errorf("Host header = %q, want: %q", got, want)
-		}
-		if got, want := r.Header.Get(network.OriginalHostHeader), ""; got != want {
-			t.Errorf("%s header was preserved", network.OriginalHostHeader)
-		}
-
-		w.WriteHeader(http.StatusOK)
-	}
-
-	server := httptest.NewServer(httpHandler)
-	serverURL, _ := url.Parse(server.URL)
-
-	defer server.Close()
-	proxy := httputil.NewSingleHostReverseProxy(serverURL)
-
-	params := queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
-	breaker := queue.NewBreaker(params)
-	stats := network.NewRequestStats(time.Now())
-	h := proxyHandler(breaker, stats, true /*tracingEnabled*/, proxy)
-
-	writer := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
-
-	// Verify the Original host header processing.
-	req.Host = "nimporte.pas"
-	req.Header.Set(network.OriginalHostHeader, wantHost)
-
-	req.Header.Set(network.ProxyHeaderName, activator.Name)
-	h(writer, req)
-
-	if got := stats.Report(time.Now()).ProxiedRequestCount; got != 1 {
-		t.Errorf("ProxiedRequestCount = %v, want 1", got)
-	}
-}
 
 func TestProbeHandler(t *testing.T) {
 	logger := TestLogger(t)
@@ -257,7 +208,7 @@ func TestQueueTraceSpans(t *testing.T) {
 					Propagation: tracecontextb3.B3Egress,
 				}
 
-				h := proxyHandler(breaker, network.NewRequestStats(time.Now()), true /*tracingEnabled*/, proxy)
+				h := queue.ProxyHandler(breaker, network.NewRequestStats(time.Now()), true /*tracingEnabled*/, proxy)
 				h(writer, req)
 			} else {
 				h := knativeProbeHandler(logger, healthState, tc.prober, true /* isAggresive*/, true /*tracingEnabled*/, nil)
@@ -297,70 +248,5 @@ func TestQueueTraceSpans(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-func BenchmarkProxyHandler(b *testing.B) {
-	var baseHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	stats := network.NewRequestStats(time.Now())
-
-	promStatReporter, err := queue.NewPrometheusStatsReporter(
-		"ns", "testksvc", "testksvc",
-		"pod", reportingPeriod)
-	if err != nil {
-		b.Fatal("Failed to create stats reporter:", err)
-	}
-
-	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
-	req.Header.Set(network.OriginalHostHeader, wantHost)
-
-	tests := []struct {
-		label        string
-		breaker      *queue.Breaker
-		reportPeriod time.Duration
-	}{{
-		label:        "breaker-10-no-reports",
-		breaker:      queue.NewBreaker(queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}),
-		reportPeriod: time.Hour,
-	}, {
-		label:        "breaker-infinite-no-reports",
-		breaker:      nil,
-		reportPeriod: time.Hour,
-	}, {
-		label:        "breaker-10-many-reports",
-		breaker:      queue.NewBreaker(queue.BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}),
-		reportPeriod: time.Microsecond,
-	}, {
-		label:        "breaker-infinite-many-reports",
-		breaker:      nil,
-		reportPeriod: time.Microsecond,
-	}}
-
-	for _, tc := range tests {
-		reportTicker := time.NewTicker(tc.reportPeriod)
-
-		go func() {
-			for now := range reportTicker.C {
-				promStatReporter.Report(stats.Report(now))
-			}
-		}()
-
-		h := proxyHandler(tc.breaker, stats, true /*tracingEnabled*/, baseHandler)
-		b.Run(fmt.Sprintf("sequential-%s", tc.label), func(b *testing.B) {
-			resp := httptest.NewRecorder()
-			for j := 0; j < b.N; j++ {
-				h(resp, req)
-			}
-		})
-		b.Run(fmt.Sprintf("parallel-%s", tc.label), func(b *testing.B) {
-			b.RunParallel(func(pb *testing.PB) {
-				resp := httptest.NewRecorder()
-				for pb.Next() {
-					h(resp, req)
-				}
-			})
-		})
-
-		reportTicker.Stop()
 	}
 }

--- a/pkg/queue/handler.go
+++ b/pkg/queue/handler.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"go.opencensus.io/trace"
+	network "knative.dev/networking/pkg"
+	"knative.dev/serving/pkg/activator"
+)
+
+// Make handler a closure for testing.
+func ProxyHandler(breaker *Breaker, stats *network.RequestStats, tracingEnabled bool, next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if network.IsKubeletProbe(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if tracingEnabled {
+			proxyCtx, proxySpan := trace.StartSpan(r.Context(), "queue_proxy")
+			r = r.WithContext(proxyCtx)
+			defer proxySpan.End()
+		}
+
+		// Metrics for autoscaling.
+		in, out := network.ReqIn, network.ReqOut
+		if activator.Name == network.KnativeProxyHeader(r) {
+			in, out = network.ProxiedIn, network.ProxiedOut
+		}
+		stats.HandleEvent(network.ReqEvent{Time: time.Now(), Type: in})
+		defer func() {
+			stats.HandleEvent(network.ReqEvent{Time: time.Now(), Type: out})
+		}()
+		network.RewriteHostOut(r)
+
+		// Enforce queuing and concurrency limits.
+		if breaker != nil {
+			var waitSpan *trace.Span
+			if tracingEnabled {
+				_, waitSpan = trace.StartSpan(r.Context(), "queue_wait")
+			}
+			if err := breaker.Maybe(r.Context(), func() {
+				waitSpan.End()
+				next.ServeHTTP(w, r)
+			}); err != nil {
+				waitSpan.End()
+				switch err {
+				case context.DeadlineExceeded, ErrRequestQueueFull:
+					http.Error(w, err.Error(), http.StatusServiceUnavailable)
+				default:
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			}
+		} else {
+			next.ServeHTTP(w, r)
+		}
+	}
+}

--- a/pkg/queue/handler_test.go
+++ b/pkg/queue/handler_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"testing"
+	"time"
+
+	"go.uber.org/atomic"
+	network "knative.dev/networking/pkg"
+	"knative.dev/serving/pkg/activator"
+)
+
+const (
+	wantHost        = "a-better-host.com"
+	reportingPeriod = time.Second
+)
+
+func TestHandlerReqEvent(t *testing.T) {
+	var httpHandler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(activator.RevisionHeaderName) != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if r.Header.Get(activator.RevisionHeaderNamespace) != "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		if got, want := r.Host, wantHost; got != want {
+			t.Errorf("Host header = %q, want: %q", got, want)
+		}
+		if got, want := r.Header.Get(network.OriginalHostHeader), ""; got != want {
+			t.Errorf("%s header was preserved", network.OriginalHostHeader)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}
+
+	server := httptest.NewServer(httpHandler)
+	serverURL, _ := url.Parse(server.URL)
+
+	defer server.Close()
+	proxy := httputil.NewSingleHostReverseProxy(serverURL)
+
+	params := BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}
+	breaker := NewBreaker(params)
+	stats := network.NewRequestStats(time.Now())
+	h := ProxyHandler(breaker, stats, true /*tracingEnabled*/, proxy)
+
+	writer := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+
+	// Verify the Original host header processing.
+	req.Host = "nimporte.pas"
+	req.Header.Set(network.OriginalHostHeader, wantHost)
+
+	req.Header.Set(network.ProxyHeaderName, activator.Name)
+	h(writer, req)
+
+	if got := stats.Report(time.Now()).ProxiedRequestCount; got != 1 {
+		t.Errorf("ProxiedRequestCount = %v, want 1", got)
+	}
+}
+
+func TestIgnoreProbe(t *testing.T) {
+	// Verifies that probes don't queue.
+	resp := make(chan struct{})
+	c := atomic.NewInt32(0)
+	// Ensure we can receive 3 requests with CC=1.
+	go func() {
+		to := time.After(3 * time.Second)
+		tick := time.NewTicker(10 * time.Millisecond)
+		defer func() { tick.Stop() }()
+		for {
+			select {
+			case <-tick.C:
+				if c.Load() == 3 {
+					close(resp)
+					return
+				}
+			case <-to:
+				// No fatal'ing in goroutines.
+				t.Error("Timed out waiting to see 3 probes")
+				return
+			}
+		}
+	}()
+
+	var httpHandler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		c.Inc()
+		<-resp
+		if !network.IsKubeletProbe(r) {
+			t.Error("Request was not a probe")
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}
+
+	server := httptest.NewServer(httpHandler)
+	serverURL, _ := url.Parse(server.URL)
+
+	defer server.Close()
+	proxy := httputil.NewSingleHostReverseProxy(serverURL)
+
+	// Ensure no more than 1 request can be queued. So we'll send 3.
+	breaker := NewBreaker(BreakerParams{QueueDepth: 1, MaxConcurrency: 1, InitialCapacity: 1})
+	stats := network.NewRequestStats(time.Now())
+	h := ProxyHandler(breaker, stats, false /*tracingEnabled*/, proxy)
+
+	req := httptest.NewRequest(http.MethodPost, "http://prob.in", nil)
+	req.Header.Set(network.KubeletProbeHeaderName, "1") // Mark it a probe.
+	go h(httptest.NewRecorder(), req)
+	go h(httptest.NewRecorder(), req)
+
+	// Last one got synchronously.
+	w := httptest.NewRecorder()
+	h(w, req)
+
+	if got, want := w.Code, http.StatusOK; got != want {
+		t.Errorf("Status got = %d, want: %d", got, want)
+	}
+}
+
+func BenchmarkProxyHandler(b *testing.B) {
+	var baseHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	stats := network.NewRequestStats(time.Now())
+
+	promStatReporter, err := NewPrometheusStatsReporter(
+		"ns", "testksvc", "testksvc",
+		"pod", reportingPeriod)
+	if err != nil {
+		b.Fatal("Failed to create stats reporter:", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+	req.Header.Set(network.OriginalHostHeader, wantHost)
+
+	tests := []struct {
+		label        string
+		breaker      *Breaker
+		reportPeriod time.Duration
+	}{{
+		label:        "breaker-10-no-reports",
+		breaker:      NewBreaker(BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}),
+		reportPeriod: time.Hour,
+	}, {
+		label:        "breaker-infinite-no-reports",
+		breaker:      nil,
+		reportPeriod: time.Hour,
+	}, {
+		label:        "breaker-10-many-reports",
+		breaker:      NewBreaker(BreakerParams{QueueDepth: 10, MaxConcurrency: 10, InitialCapacity: 10}),
+		reportPeriod: time.Microsecond,
+	}, {
+		label:        "breaker-infinite-many-reports",
+		breaker:      nil,
+		reportPeriod: time.Microsecond,
+	}}
+
+	for _, tc := range tests {
+		reportTicker := time.NewTicker(tc.reportPeriod)
+
+		go func() {
+			for now := range reportTicker.C {
+				promStatReporter.Report(stats.Report(now))
+			}
+		}()
+
+		h := ProxyHandler(tc.breaker, stats, true /*tracingEnabled*/, baseHandler)
+		b.Run(fmt.Sprintf("sequential-%s", tc.label), func(b *testing.B) {
+			resp := httptest.NewRecorder()
+			for j := 0; j < b.N; j++ {
+				h(resp, req)
+			}
+		})
+		b.Run(fmt.Sprintf("parallel-%s", tc.label), func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				resp := httptest.NewRecorder()
+				for pb.Next() {
+					h(resp, req)
+				}
+			})
+		})
+
+		reportTicker.Stop()
+	}
+}


### PR DESCRIPTION
- Move proxy handler to its own file.
- Move benchmark and one test that seemed to be only proxy related.
- Add a new test to cover kubelet bypass

More to come!

/assign @markusthoemmes @julz mattmoor