### PR TITLE
Bump max idle for digest resolution transport

### DIFF
--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -46,6 +46,11 @@ import (
 
 const controllerAgentName = "revision-controller"
 
+// digestResolutionWorkers is the number of image digest resolutions that can
+// take place in parallel. MaxIdleConns and MaxIdleConnsPerHost for the digest
+// resolution's Transport will also be set to this value.
+const digestResolutionWorkers = 100
+
 // NewController initializes the controller and is called by the generated code
 // Registers eventhandlers to enqueue events
 func NewController(
@@ -62,13 +67,6 @@ func newControllerWithOptions(
 	cmw configmap.Watcher,
 	opts ...reconcilerOption,
 ) *controller.Impl {
-	transport := http.DefaultTransport
-	if rt, err := newResolverTransport(k8sCertPath); err != nil {
-		logging.FromContext(ctx).Errorf("Failed to create resolver transport: %v", err)
-	} else {
-		transport = rt
-	}
-
 	ctx = servingreconciler.AnnotateLoggerWithName(ctx, controllerAgentName)
 	logger := logging.FromContext(ctx)
 	revisionInformer := revisioninformer.Get(ctx)
@@ -105,9 +103,15 @@ func newControllerWithOptions(
 		return controller.Options{ConfigStore: configStore}
 	})
 
-	resolver := newBackgroundResolver(logger, &digestResolver{client: kubeclient.Get(ctx), transport: transport}, impl.EnqueueKey)
-	resolver.Start(ctx.Done(), 100)
+	transport := http.DefaultTransport
+	if rt, err := newResolverTransport(k8sCertPath, digestResolutionWorkers, digestResolutionWorkers); err != nil {
+		logging.FromContext(ctx).Errorf("Failed to create resolver transport: %v", err)
+	} else {
+		transport = rt
+	}
 
+	resolver := newBackgroundResolver(logger, &digestResolver{client: kubeclient.Get(ctx), transport: transport}, impl.EnqueueKey)
+	resolver.Start(ctx.Done(), digestResolutionWorkers)
 	c.resolver = resolver
 
 	// Set up an event handler for when the resource types of interest change

--- a/pkg/reconciler/revision/resolve.go
+++ b/pkg/reconciler/revision/resolve.go
@@ -47,7 +47,7 @@ const (
 // at path to the system cert pool.
 //
 // Use this with k8sCertPath to trust the same certs as the cluster.
-func newResolverTransport(path string) (*http.Transport, error) {
+func newResolverTransport(path string, maxIdleConns, maxIdleConnsPerHost int) (*http.Transport, error) {
 	pool, err := x509.SystemCertPool()
 	if err != nil {
 		pool = x509.NewCertPool()
@@ -60,6 +60,8 @@ func newResolverTransport(path string) (*http.Transport, error) {
 	}
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = maxIdleConns
+	transport.MaxIdleConnsPerHost = maxIdleConnsPerHost
 	transport.TLSClientConfig = &tls.Config{
 		MinVersion: tls.VersionTLS12,
 		RootCAs:    pool,

--- a/pkg/reconciler/revision/resolve_test.go
+++ b/pkg/reconciler/revision/resolve_test.go
@@ -529,7 +529,7 @@ yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
 			}
 
 			// The actual test.
-			if tr, err := newResolverTransport(path); err != nil && !tc.wantErr {
+			if tr, err := newResolverTransport(path, 100, 100); err != nil && !tc.wantErr {
 				t.Error("Got unexpected err:", err)
 			} else if tc.wantErr && err == nil {
 				t.Error("Didn't get an error when we wanted it")


### PR DESCRIPTION
Now that we do multiple image digest resolves in the background, we want the max size of the keep-alive connection pool to be ~as big as the number of workers.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

/assign @markusthoemmes @mattmoor

