### PR TITLE
Remove allocations from randomChoice2 policy

### DIFF
--- a/pkg/activator/net/lb_policy.go
+++ b/pkg/activator/net/lb_policy.go
@@ -45,10 +45,9 @@ func randomChoice2Policy(_ context.Context, targets []*podTracker) (func(), *pod
 	l := len(targets)
 	// One tracker = no choice.
 	if l == 1 {
-		targets[0].addWeight(1)
-		return func() {
-			targets[0].addWeight(-1)
-		}, targets[0]
+		pick := targets[0]
+		cb := pick.increaseWeight()
+		return cb, pick
 	}
 	r1, r2 := 0, 1
 	// Two trackers - we know both contestants,
@@ -70,10 +69,8 @@ func randomChoice2Policy(_ context.Context, targets []*podTracker) (func(), *pod
 	if pick.getWeight() > alt.getWeight() {
 		pick = alt
 	}
-	pick.addWeight(1)
-	return func() {
-		pick.addWeight(-1)
-	}, pick
+	cb := pick.increaseWeight()
+	return cb, pick
 }
 
 // firstAvailableLBPolicy is a load balancer policy, that picks the first target

--- a/pkg/activator/net/lb_policy.go
+++ b/pkg/activator/net/lb_policy.go
@@ -46,8 +46,8 @@ func randomChoice2Policy(_ context.Context, targets []*podTracker) (func(), *pod
 	// One tracker = no choice.
 	if l == 1 {
 		pick := targets[0]
-		cb := pick.increaseWeight()
-		return cb, pick
+		pick.increaseWeight()
+		return pick.decreaseWeight, pick
 	}
 	r1, r2 := 0, 1
 	// Two trackers - we know both contestants,
@@ -69,8 +69,8 @@ func randomChoice2Policy(_ context.Context, targets []*podTracker) (func(), *pod
 	if pick.getWeight() > alt.getWeight() {
 		pick = alt
 	}
-	cb := pick.increaseWeight()
-	return cb, pick
+	pick.increaseWeight()
+	return pick.decreaseWeight, pick
 }
 
 // firstAvailableLBPolicy is a load balancer policy, that picks the first target

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -82,9 +82,8 @@ type podTracker struct {
 	decreaseWeight func()
 }
 
-func (p *podTracker) increaseWeight() func() {
+func (p *podTracker) increaseWeight() {
 	p.weight.Add(1)
-	return p.decreaseWeight
 }
 
 func (p *podTracker) getWeight() int32 {

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -197,7 +197,7 @@ func TestThrottlerUpdateCapacity(t *testing.T) {
 func makeTrackers(num, cc int) []*podTracker {
 	x := make([]*podTracker, num)
 	for i := 0; i < num; i++ {
-		x[i] = &podTracker{dest: strconv.Itoa(i)}
+		x[i] = newPodTracker(strconv.Itoa(i), nil)
 		if cc > 0 {
 			x[i].b = queue.NewBreaker(queue.BreakerParams{
 				QueueDepth:      1,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This is run as part of **each** request that has CC=0. Might as well make that as quick and cheap as we can.

```
benchmark                                                               old ns/op     new ns/op     delta
BenchmarkPolicy/random-power-of-2-choice-1-trackers-sequential-16       50.4          10.1          -79.96%
BenchmarkPolicy/random-power-of-2-choice-1-trackers-parallel-16         35.9          24.2          -32.59%
BenchmarkPolicy/random-power-of-2-choice-2-trackers-sequential-16       34.8          9.84          -71.72%
BenchmarkPolicy/random-power-of-2-choice-2-trackers-parallel-16         38.8          40.4          +4.12%
BenchmarkPolicy/random-power-of-2-choice-3-trackers-sequential-16       63.1          34.9          -44.69%
BenchmarkPolicy/random-power-of-2-choice-3-trackers-parallel-16         487           410           -15.81%
BenchmarkPolicy/random-power-of-2-choice-10-trackers-sequential-16      70.2          40.4          -42.45%
BenchmarkPolicy/random-power-of-2-choice-10-trackers-parallel-16        537           447           -16.76%
BenchmarkPolicy/random-power-of-2-choice-100-trackers-sequential-16     69.1          39.2          -43.27%
BenchmarkPolicy/random-power-of-2-choice-100-trackers-parallel-16       550           492           -10.55%

benchmark                                                               old allocs     new allocs     delta
BenchmarkPolicy/random-power-of-2-choice-1-trackers-sequential-16       1              0              -100.00%
BenchmarkPolicy/random-power-of-2-choice-1-trackers-parallel-16         1              0              -100.00%
BenchmarkPolicy/random-power-of-2-choice-2-trackers-sequential-16       1              0              -100.00%
BenchmarkPolicy/random-power-of-2-choice-2-trackers-parallel-16         1              0              -100.00%
BenchmarkPolicy/random-power-of-2-choice-3-trackers-sequential-16       1              0              -100.00%
BenchmarkPolicy/random-power-of-2-choice-3-trackers-parallel-16         1              0              -100.00%
BenchmarkPolicy/random-power-of-2-choice-10-trackers-sequential-16      1              0              -100.00%
BenchmarkPolicy/random-power-of-2-choice-10-trackers-parallel-16        1              0              -100.00%
BenchmarkPolicy/random-power-of-2-choice-100-trackers-sequential-16     1              0              -100.00%
BenchmarkPolicy/random-power-of-2-choice-100-trackers-parallel-16       1              0              -100.00%

benchmark                                                               old bytes     new bytes     delta
BenchmarkPolicy/random-power-of-2-choice-1-trackers-sequential-16       32            0             -100.00%
BenchmarkPolicy/random-power-of-2-choice-1-trackers-parallel-16         32            0             -100.00%
BenchmarkPolicy/random-power-of-2-choice-2-trackers-sequential-16       16            0             -100.00%
BenchmarkPolicy/random-power-of-2-choice-2-trackers-parallel-16         16            0             -100.00%
BenchmarkPolicy/random-power-of-2-choice-3-trackers-sequential-16       16            0             -100.00%
BenchmarkPolicy/random-power-of-2-choice-3-trackers-parallel-16         16            0             -100.00%
BenchmarkPolicy/random-power-of-2-choice-10-trackers-sequential-16      16            0             -100.00%
BenchmarkPolicy/random-power-of-2-choice-10-trackers-parallel-16        16            0             -100.00%
BenchmarkPolicy/random-power-of-2-choice-100-trackers-sequential-16     16            0             -100.00%
BenchmarkPolicy/random-power-of-2-choice-100-trackers-parallel-16       16            0             -100.00%
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
