### PR TITLE
Enable unparam linter to catch unused parameters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,7 @@ linters:
     - prealloc
     - stylecheck
     - unconvert
+    - unparam
   disable:
     - errcheck
 
@@ -31,6 +32,7 @@ issues:
     - path: test # Excludes /test, *_test.go etc.
       linters:
         - gosec
+        - unparam
 
     # Allow source and sink receivers in conversion code for clarity.
     - path: _conversion\.go

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -102,7 +102,7 @@ type config struct {
 	TracingConfigStackdriverProjectID string                    `split_words:"true"` // optional
 }
 
-func knativeProbeHandler(logger *zap.SugaredLogger, healthState *health.State, prober func() bool, isAggressive bool, tracingEnabled bool, next http.Handler) http.HandlerFunc {
+func knativeProbeHandler(healthState *health.State, prober func() bool, isAggressive bool, tracingEnabled bool, next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ph := network.KnativeProbeHeader(r)
 
@@ -336,7 +336,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	}
 	composedHandler = tracing.HTTPSpanMiddleware(composedHandler)
 
-	composedHandler = knativeProbeHandler(logger, healthState, rp.ProbeContainer, rp.IsAggressive(), tracingEnabled, composedHandler)
+	composedHandler = knativeProbeHandler(healthState, rp.ProbeContainer, rp.IsAggressive(), tracingEnabled, composedHandler)
 	composedHandler = network.NewProbeHandler(composedHandler)
 	// We might want sometimes capture the probes/healthchecks in the request
 	// logs. Hence we need to have RequestLogHandler to be the first one.

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -36,15 +36,9 @@ import (
 	tracetesting "knative.dev/pkg/tracing/testing"
 	"knative.dev/serving/pkg/queue"
 	"knative.dev/serving/pkg/queue/health"
-
-	. "knative.dev/pkg/logging/testing"
 )
 
-const wantHost = "a-better-host.com"
-
 func TestProbeHandler(t *testing.T) {
-	logger := TestLogger(t)
-
 	testcases := []struct {
 		name          string
 		prober        func() bool
@@ -83,7 +77,7 @@ func TestProbeHandler(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
 			req.Header.Set(network.ProbeHeaderName, tc.requestHeader)
 
-			h := knativeProbeHandler(logger, healthState, tc.prober, true /* isAggresive*/, true /*tracingEnabled*/, nil)
+			h := knativeProbeHandler(healthState, tc.prober, true /* isAggresive*/, true /*tracingEnabled*/, nil)
 			h(writer, req)
 
 			if got, want := writer.Code, tc.wantCode; got != want {
@@ -98,7 +92,6 @@ func TestProbeHandler(t *testing.T) {
 }
 
 func TestQueueTraceSpans(t *testing.T) {
-	logger := TestLogger(t)
 	testcases := []struct {
 		name          string
 		prober        func() bool
@@ -211,7 +204,7 @@ func TestQueueTraceSpans(t *testing.T) {
 				h := queue.ProxyHandler(breaker, network.NewRequestStats(time.Now()), true /*tracingEnabled*/, proxy)
 				h(writer, req)
 			} else {
-				h := knativeProbeHandler(logger, healthState, tc.prober, true /* isAggresive*/, true /*tracingEnabled*/, nil)
+				h := knativeProbeHandler(healthState, tc.prober, true /* isAggresive*/, true /*tracingEnabled*/, nil)
 				req.Header.Set(network.ProbeHeaderName, tc.requestHeader)
 				h(writer, req)
 			}

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -322,9 +322,7 @@ func (rt *revisionThrottler) updateCapacity(backendCount int) {
 	rt.breaker.UpdateConcurrency(capacity)
 }
 
-func (rt *revisionThrottler) updateThrottlerState(
-	throttler *Throttler, backendCount int,
-	trackers []*podTracker, clusterIPDest *podTracker) {
+func (rt *revisionThrottler) updateThrottlerState(backendCount int, trackers []*podTracker, clusterIPDest *podTracker) {
 	rt.logger.Infof("Updating Revision Throttler with: clusterIP = %v, trackers = %d, backends = %d",
 		clusterIPDest, len(trackers), backendCount)
 
@@ -408,7 +406,7 @@ func assignSlice(trackers []*podTracker, selfIndex, numActivators, cc int) []*po
 
 // This function will never be called in parallel but `try` can be called in parallel to this so we need
 // to lock on updating concurrency / trackers
-func (rt *revisionThrottler) handleUpdate(throttler *Throttler, update revisionDestsUpdate) {
+func (rt *revisionThrottler) handleUpdate(update revisionDestsUpdate) {
 	rt.logger.Debugw("Handling update",
 		zap.String("ClusterIP", update.ClusterIPDest), zap.Object("dests", logging.StringSet(update.Dests)))
 
@@ -442,11 +440,11 @@ func (rt *revisionThrottler) handleUpdate(throttler *Throttler, update revisionD
 			trackers = append(trackers, tracker)
 		}
 
-		rt.updateThrottlerState(throttler, len(update.Dests), trackers, nil /*clusterIP*/)
+		rt.updateThrottlerState(len(update.Dests), trackers, nil /*clusterIP*/)
 		return
 	}
 
-	rt.updateThrottlerState(throttler, len(update.Dests), nil /*trackers*/, newPodTracker(update.ClusterIPDest, nil))
+	rt.updateThrottlerState(len(update.Dests), nil /*trackers*/, newPodTracker(update.ClusterIPDest, nil))
 }
 
 // Throttler load balances requests to revisions based on capacity. When `Run` is called it listens for
@@ -595,7 +593,7 @@ func (t *Throttler) handleUpdate(update revisionDestsUpdate) {
 				zap.Object(logkey.Key, logging.NamespacedName(update.Rev)))
 		}
 	} else {
-		rt.handleUpdate(t, update)
+		rt.handleUpdate(update)
 	}
 }
 

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -27,7 +27,7 @@ import (
 	"knative.dev/serving/pkg/apis/serving"
 )
 
-func (r *Revision) checkImmutableFields(ctx context.Context, original *Revision) *apis.FieldError {
+func (r *Revision) checkImmutableFields(original *Revision) *apis.FieldError {
 	if diff, err := kmp.ShortDiff(original.Spec, r.Spec); err != nil {
 		return &apis.FieldError{
 			Message: "Failed to diff Revision",
@@ -49,7 +49,7 @@ func (r *Revision) Validate(ctx context.Context) *apis.FieldError {
 	errs := serving.ValidateObjectMetadata(ctx, r.GetObjectMeta()).ViaField("metadata")
 	if apis.IsInUpdate(ctx) {
 		old := apis.GetBaseline(ctx).(*Revision)
-		errs = errs.Also(r.checkImmutableFields(ctx, old))
+		errs = errs.Also(r.checkImmutableFields(old))
 	} else {
 		errs = errs.Also(r.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 	}

--- a/pkg/autoscaler/statforwarder/forwarder.go
+++ b/pkg/autoscaler/statforwarder/forwarder.go
@@ -349,19 +349,19 @@ func (f *Forwarder) process() {
 			p := f.getProcessor(bkt)
 			if p == nil {
 				l.Warn("Can't find the owner for Revision.")
-				f.maybeRetry(l, s, rev)
+				f.maybeRetry(l, s)
 				continue
 			}
 
 			if err := p.process(s.sm); err != nil {
 				l.Errorw("Error while processing stat", zap.Error(err))
-				f.maybeRetry(l, s, rev)
+				f.maybeRetry(l, s)
 			}
 		}
 	}
 }
 
-func (f *Forwarder) maybeRetry(logger *zap.SugaredLogger, s stat, rev string) {
+func (f *Forwarder) maybeRetry(logger *zap.SugaredLogger, s stat) {
 	if s.retry > maxProcessingRetry {
 		logger.Warn("Exceeding max retries. Dropping the stat.")
 	}

--- a/pkg/reconciler/labeler/v2/accessors.go
+++ b/pkg/reconciler/labeler/v2/accessors.go
@@ -40,7 +40,7 @@ import (
 type Accessor interface {
 	list(ctx context.Context, ns, routeName string, state v1.RoutingState) ([]kmeta.Accessor, error)
 	patch(ctx context.Context, ns, name string, pt types.PatchType, p []byte) error
-	makeMetadataPatch(ctx context.Context, route *v1.Route, name string, remove bool) (map[string]interface{}, error)
+	makeMetadataPatch(route *v1.Route, name string, remove bool) (map[string]interface{}, error)
 }
 
 // Revision is an implementation of Accessor for Revisions.
@@ -73,15 +73,14 @@ func NewRevisionAccessor(
 
 // makeMetadataPatch makes a metadata map to be patched or nil if no changes are needed.
 func makeMetadataPatch(
-	ctx context.Context,
 	acc kmeta.Accessor, routeName string, addRoutingState, remove bool, clock clock.Clock) (map[string]interface{}, error) {
 	labels := map[string]interface{}{}
 	annotations := map[string]interface{}{}
 
-	updateRouteAnnotation(ctx, acc, routeName, annotations, remove)
+	updateRouteAnnotation(acc, routeName, annotations, remove)
 
 	if addRoutingState {
-		markRoutingState(ctx, acc, clock, labels, annotations)
+		markRoutingState(acc, clock, labels, annotations)
 	}
 
 	meta := map[string]interface{}{}
@@ -98,9 +97,7 @@ func makeMetadataPatch(
 }
 
 // markRoutingState updates the RoutingStateLabel and bumps the modified time annotation.
-func markRoutingState(
-	ctx context.Context,
-	acc kmeta.Accessor, clock clock.Clock, diffLabels, diffAnn map[string]interface{}) {
+func markRoutingState(acc kmeta.Accessor, clock clock.Clock, diffLabels, diffAnn map[string]interface{}) {
 
 	hasRoute := acc.GetAnnotations()[serving.RoutesAnnotationKey] != ""
 	if val, has := diffAnn[serving.RoutesAnnotationKey]; has {
@@ -121,7 +118,7 @@ func markRoutingState(
 // updateRouteAnnotation appends the route annotation to the list of labels if needed
 // or removes the annotation if routeName is nil.
 // Returns true if the entire annotation is newly added or removed, which signifies a state change.
-func updateRouteAnnotation(ctx context.Context, acc kmeta.Accessor, routeName string, diffAnn map[string]interface{}, remove bool) {
+func updateRouteAnnotation(acc kmeta.Accessor, routeName string, diffAnn map[string]interface{}, remove bool) {
 	valSet := GetListAnnValue(acc.GetAnnotations(), serving.RoutesAnnotationKey)
 	has := valSet.Has(routeName)
 	switch {
@@ -168,12 +165,12 @@ func (r *Revision) patch(ctx context.Context, ns, name string, pt types.PatchTyp
 	return err
 }
 
-func (r *Revision) makeMetadataPatch(ctx context.Context, route *v1.Route, name string, remove bool) (map[string]interface{}, error) {
+func (r *Revision) makeMetadataPatch(route *v1.Route, name string, remove bool) (map[string]interface{}, error) {
 	rev, err := r.lister.Revisions(route.Namespace).Get(name)
 	if err != nil {
 		return nil, err
 	}
-	return makeMetadataPatch(ctx, rev, route.Name, true /*addRoutingState*/, remove, r.clock)
+	return makeMetadataPatch(rev, route.Name, true /*addRoutingState*/, remove, r.clock)
 }
 
 // Configuration is an implementation of Accessor for Configurations.
@@ -236,10 +233,10 @@ func (c *Configuration) patch(ctx context.Context, ns, name string, pt types.Pat
 	return err
 }
 
-func (c *Configuration) makeMetadataPatch(ctx context.Context, r *v1.Route, name string, remove bool) (map[string]interface{}, error) {
+func (c *Configuration) makeMetadataPatch(r *v1.Route, name string, remove bool) (map[string]interface{}, error) {
 	config, err := c.lister.Configurations(r.Namespace).Get(name)
 	if err != nil {
 		return nil, err
 	}
-	return makeMetadataPatch(ctx, config, r.Name, false /*addRoutingState*/, remove, c.clock)
+	return makeMetadataPatch(config, r.Name, false /*addRoutingState*/, remove, c.clock)
 }

--- a/pkg/reconciler/labeler/v2/metasync.go
+++ b/pkg/reconciler/labeler/v2/metasync.go
@@ -148,7 +148,7 @@ func clearMetaForNotListed(ctx context.Context, r *v1.Route, acc Accessor, names
 // A nil route name will cause the route to be de-referenced, and a non-nil route will cause
 // that route name to be attached to the element.
 func setRoutingMeta(ctx context.Context, acc Accessor, r *v1.Route, name string, remove bool) error {
-	if mergePatch, err := acc.makeMetadataPatch(ctx, r, name, remove); err != nil {
+	if mergePatch, err := acc.makeMetadataPatch(r, name, remove); err != nil {
 		return err
 	} else if mergePatch != nil {
 		patch, err := json.Marshal(mergePatch)

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -247,7 +247,7 @@ func TestReconcileCertificatesInsert(t *testing.T) {
 
 	r := Route("test-ns", "test-route")
 	certificate := newCerts([]string{"*.default.example.com"}, r)
-	if _, err := reconciler.reconcileCertificate(ctx, r, certificate); err != nil {
+	if err := reconciler.reconcileCertificate(ctx, r, certificate); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	created := getCertificateFromClient(ctx, t, certificate)
@@ -265,7 +265,7 @@ func TestReconcileCertificateUpdate(t *testing.T) {
 
 	r := Route("test-ns", "test-route")
 	certificate := newCerts([]string{"old.example.com"}, r)
-	if _, err := reconciler.reconcileCertificate(ctx, r, certificate); err != nil {
+	if err := reconciler.reconcileCertificate(ctx, r, certificate); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
@@ -273,7 +273,7 @@ func TestReconcileCertificateUpdate(t *testing.T) {
 	fakecertinformer.Get(ctx).Informer().GetIndexer().Add(storedCert)
 
 	newCertificate := newCerts([]string{"new.example.com"}, r)
-	if _, err := reconciler.reconcileCertificate(ctx, r, newCertificate); err != nil {
+	if err := reconciler.reconcileCertificate(ctx, r, newCertificate); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -59,7 +59,7 @@ var _ ksvcreconciler.Interface = (*Reconciler)(nil)
 func (c *Reconciler) ReconcileKind(ctx context.Context, service *v1.Service) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 
-	config, err := c.config(ctx, logger, service)
+	config, err := c.config(ctx, service)
 	if err != nil {
 		return err
 	}
@@ -90,7 +90,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, service *v1.Service) pkg
 		return nil
 	}
 
-	route, err := c.route(ctx, logger, service)
+	route, err := c.route(ctx, service)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, service *v1.Service) pkg
 	return nil
 }
 
-func (c *Reconciler) config(ctx context.Context, logger *zap.SugaredLogger, service *v1.Service) (*v1.Configuration, error) {
+func (c *Reconciler) config(ctx context.Context, service *v1.Service) (*v1.Configuration, error) {
 	recorder := controller.GetEventRecorder(ctx)
 	configName := resourcenames.Configuration(service)
 	config, err := c.configurationLister.Configurations(service.Namespace).Get(configName)
@@ -133,7 +133,7 @@ func (c *Reconciler) config(ctx context.Context, logger *zap.SugaredLogger, serv
 	return config, nil
 }
 
-func (c *Reconciler) route(ctx context.Context, logger *zap.SugaredLogger, service *v1.Service) (*v1.Route, error) {
+func (c *Reconciler) route(ctx context.Context, service *v1.Service) (*v1.Route, error) {
 	recorder := controller.GetEventRecorder(ctx)
 	routeName := resourcenames.Route(service)
 	route, err := c.routeLister.Routes(service.Namespace).Get(routeName)

--- a/pkg/webhook/podspec_dryrun.go
+++ b/pkg/webhook/podspec_dryrun.go
@@ -33,7 +33,7 @@ import (
 	"knative.dev/serving/pkg/reconciler/revision/resources"
 )
 
-func decodeTemplate(ctx context.Context, val interface{}) (*v1.RevisionTemplateSpec, error) {
+func decodeTemplate(val interface{}) (*v1.RevisionTemplateSpec, error) {
 	templ := &v1.RevisionTemplateSpec{}
 	asData, ok := val.(map[string]interface{})
 	if !ok {

--- a/pkg/webhook/validate_unstructured.go
+++ b/pkg/webhook/validate_unstructured.go
@@ -93,7 +93,7 @@ func validateRevisionTemplate(ctx context.Context, uns *unstructured.Unstructure
 		return nil
 	}
 
-	templ, err := decodeTemplate(ctx, val)
+	templ, err := decodeTemplate(val)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

I find this check super helpful in that it calls out unused parameters, unused return values etc. It caught a bug or two in the past where we accidentally used a shadowed default value instead of the actual parameter.

A pass through the tests will follow.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor @vagababov 
