### PR TITLE
bump knative.dev/caching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	k8s.io/code-generator v0.18.8
 	k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29
-	knative.dev/caching v0.0.0-20200921175450-fe7e4b865bbb
+	knative.dev/caching v0.0.0-20200922160940-9eace6743861
 	knative.dev/networking v0.0.0-20200921221136-1530efa59285
 	knative.dev/pkg v0.0.0-20200921223636-6a12c7596267
 	knative.dev/test-infra v0.0.0-20200921012245-37f1a12adbd3

--- a/go.sum
+++ b/go.sum
@@ -1829,8 +1829,8 @@ k8s.io/utils v0.0.0-20200603063816-c1c6865ac451 h1:v8ud2Up6QK1lNOKFgiIVrZdMg7Mpm
 k8s.io/utils v0.0.0-20200603063816-c1c6865ac451/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 knative.dev/caching v0.0.0-20190719140829-2032732871ff/go.mod h1:dHXFU6CGlLlbzaWc32g80cR92iuBSpsslDNBWI8C7eg=
 knative.dev/caching v0.0.0-20200116200605-67bca2c83dfa/go.mod h1:dHXFU6CGlLlbzaWc32g80cR92iuBSpsslDNBWI8C7eg=
-knative.dev/caching v0.0.0-20200921175450-fe7e4b865bbb h1:/iHhuJrZnTmfGCvg5LDZNh3o3OwYE7z0l9XgzsjI8oI=
-knative.dev/caching v0.0.0-20200921175450-fe7e4b865bbb/go.mod h1:Tp9HLVRVqz0mdSGXVMtIb4fH+YWMSmRUUPC6dKj+3tI=
+knative.dev/caching v0.0.0-20200922160940-9eace6743861 h1:0pgFj6PLbTctw0AMRRq2Jqv6P+HhS5bfxlKOm0uayeo=
+knative.dev/caching v0.0.0-20200922160940-9eace6743861/go.mod h1:Tp9HLVRVqz0mdSGXVMtIb4fH+YWMSmRUUPC6dKj+3tI=
 knative.dev/eventing-contrib v0.6.1-0.20190723221543-5ce18048c08b/go.mod h1:SnXZgSGgMSMLNFTwTnpaOH7hXDzTFtw0J8OmHflNx3g=
 knative.dev/eventing-contrib v0.11.2/go.mod h1:SnXZgSGgMSMLNFTwTnpaOH7hXDzTFtw0J8OmHflNx3g=
 knative.dev/networking v0.0.0-20200921221136-1530efa59285 h1:RLq26BFg3YIyKUVtZor71mz3lJdo0ID1A+ytdZJq6Sc=

--- a/vendor/knative.dev/caching/config/image.yaml
+++ b/vendor/knative.dev/caching/config/image.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: images.caching.internal.knative.dev
@@ -20,7 +20,6 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: caching.internal.knative.dev
-  version: v1alpha1
   names:
     kind: Image
     plural: images
@@ -31,5 +30,17 @@ spec:
     shortNames:
     - img
   scope: Namespaced
-  subresources:
-    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1015,7 +1015,7 @@ k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# knative.dev/caching v0.0.0-20200921175450-fe7e4b865bbb
+# knative.dev/caching v0.0.0-20200922160940-9eace6743861
 ## explicit
 knative.dev/caching/config
 knative.dev/caching/pkg/apis/caching


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/9494

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Bump knative.dev/caching which uses CRD v1 API

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
