### PR TITLE
Drop unused params in autoscaler

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -102,7 +102,7 @@ type config struct {
 	TracingConfigStackdriverProjectID string                    `split_words:"true"` // optional
 }
 
-func knativeProbeHandler(logger *zap.SugaredLogger, healthState *health.State, prober func() bool, isAggressive bool, tracingEnabled bool, next http.Handler) http.HandlerFunc {
+func knativeProbeHandler(healthState *health.State, prober func() bool, isAggressive bool, tracingEnabled bool, next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ph := network.KnativeProbeHeader(r)
 
@@ -336,7 +336,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	}
 	composedHandler = tracing.HTTPSpanMiddleware(composedHandler)
 
-	composedHandler = knativeProbeHandler(logger, healthState, rp.ProbeContainer, rp.IsAggressive(), tracingEnabled, composedHandler)
+	composedHandler = knativeProbeHandler(healthState, rp.ProbeContainer, rp.IsAggressive(), tracingEnabled, composedHandler)
 	composedHandler = network.NewProbeHandler(composedHandler)
 	// We might want sometimes capture the probes/healthchecks in the request
 	// logs. Hence we need to have RequestLogHandler to be the first one.

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -36,15 +36,11 @@ import (
 	tracetesting "knative.dev/pkg/tracing/testing"
 	"knative.dev/serving/pkg/queue"
 	"knative.dev/serving/pkg/queue/health"
-
-	. "knative.dev/pkg/logging/testing"
 )
 
 const wantHost = "a-better-host.com"
 
 func TestProbeHandler(t *testing.T) {
-	logger := TestLogger(t)
-
 	testcases := []struct {
 		name          string
 		prober        func() bool
@@ -83,7 +79,7 @@ func TestProbeHandler(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
 			req.Header.Set(network.ProbeHeaderName, tc.requestHeader)
 
-			h := knativeProbeHandler(logger, healthState, tc.prober, true /* isAggresive*/, true /*tracingEnabled*/, nil)
+			h := knativeProbeHandler(healthState, tc.prober, true /* isAggresive*/, true /*tracingEnabled*/, nil)
 			h(writer, req)
 
 			if got, want := writer.Code, tc.wantCode; got != want {
@@ -98,7 +94,6 @@ func TestProbeHandler(t *testing.T) {
 }
 
 func TestQueueTraceSpans(t *testing.T) {
-	logger := TestLogger(t)
 	testcases := []struct {
 		name          string
 		prober        func() bool
@@ -211,7 +206,7 @@ func TestQueueTraceSpans(t *testing.T) {
 				h := queue.ProxyHandler(breaker, network.NewRequestStats(time.Now()), true /*tracingEnabled*/, proxy)
 				h(writer, req)
 			} else {
-				h := knativeProbeHandler(logger, healthState, tc.prober, true /* isAggresive*/, true /*tracingEnabled*/, nil)
+				h := knativeProbeHandler(healthState, tc.prober, true /* isAggresive*/, true /*tracingEnabled*/, nil)
 				req.Header.Set(network.ProbeHeaderName, tc.requestHeader)
 				h(writer, req)
 			}

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -323,7 +323,7 @@ func (rt *revisionThrottler) updateCapacity(backendCount int) {
 }
 
 func (rt *revisionThrottler) updateThrottlerState(
-	throttler *Throttler, backendCount int,
+	backendCount int,
 	trackers []*podTracker, clusterIPDest *podTracker) {
 	rt.logger.Infof("Updating Revision Throttler with: clusterIP = %v, trackers = %d, backends = %d",
 		clusterIPDest, len(trackers), backendCount)
@@ -408,7 +408,7 @@ func assignSlice(trackers []*podTracker, selfIndex, numActivators, cc int) []*po
 
 // This function will never be called in parallel but `try` can be called in parallel to this so we need
 // to lock on updating concurrency / trackers
-func (rt *revisionThrottler) handleUpdate(throttler *Throttler, update revisionDestsUpdate) {
+func (rt *revisionThrottler) handleUpdate(update revisionDestsUpdate) {
 	rt.logger.Debugw("Handling update",
 		zap.String("ClusterIP", update.ClusterIPDest), zap.Object("dests", logging.StringSet(update.Dests)))
 
@@ -442,11 +442,11 @@ func (rt *revisionThrottler) handleUpdate(throttler *Throttler, update revisionD
 			trackers = append(trackers, tracker)
 		}
 
-		rt.updateThrottlerState(throttler, len(update.Dests), trackers, nil /*clusterIP*/)
+		rt.updateThrottlerState(len(update.Dests), trackers, nil /*clusterIP*/)
 		return
 	}
 
-	rt.updateThrottlerState(throttler, len(update.Dests), nil /*trackers*/, newPodTracker(update.ClusterIPDest, nil))
+	rt.updateThrottlerState(len(update.Dests), nil /*trackers*/, newPodTracker(update.ClusterIPDest, nil))
 }
 
 // Throttler load balances requests to revisions based on capacity. When `Run` is called it listens for
@@ -595,7 +595,7 @@ func (t *Throttler) handleUpdate(update revisionDestsUpdate) {
 				zap.Object(logkey.Key, logging.NamespacedName(update.Rev)))
 		}
 	} else {
-		rt.handleUpdate(t, update)
+		rt.handleUpdate(update)
 	}
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Given we now have a linter checking this as of https://github.com/knative/serving/pull/9513, might as well tidy up existing unused params in autoscaler.

/assign @markusthoemmes @vagababov 