### PR TITLE
Add window max package for scale down delay

### DIFF
--- a/pkg/autoscaler/aggregation/max/doc.go
+++ b/pkg/autoscaler/aggregation/max/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package max contains functions for calculating the maximum value observed over a sliding window.
+package max

--- a/pkg/autoscaler/aggregation/max/timewindow.go
+++ b/pkg/autoscaler/aggregation/max/timewindow.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package max
+
+import (
+	"math"
+	"time"
+)
+
+// TimeWindow is a descending minima window whose indexes are calculated based
+// on time.Time values.
+type TimeWindow struct {
+	window      *Window
+	granularity time.Duration
+}
+
+// NewTimeWindow creates a new TimeWindow.
+func NewTimeWindow(duration, granularity time.Duration) *TimeWindow {
+	buckets := int(math.Ceil(float64(duration) / float64(granularity)))
+	return &TimeWindow{window: NewWindow(buckets), granularity: granularity}
+}
+
+// Record records a value in the bucket derived from the given time.
+func (t *TimeWindow) Record(now time.Time, value float64) {
+	index := int(now.Unix()) / int(t.granularity.Seconds())
+	t.window.Record(index, value)
+}
+
+// Current returns the current maximum value observed in the previous
+// window duration.
+func (t *TimeWindow) Current() float64 {
+	return t.window.Current()
+}

--- a/pkg/autoscaler/aggregation/max/timewindow.go
+++ b/pkg/autoscaler/aggregation/max/timewindow.go
@@ -24,14 +24,14 @@ import (
 // TimeWindow is a descending minima window whose indexes are calculated based
 // on time.Time values.
 type TimeWindow struct {
-	window      *Window
+	window      *window
 	granularity time.Duration
 }
 
 // NewTimeWindow creates a new TimeWindow.
 func NewTimeWindow(duration, granularity time.Duration) *TimeWindow {
 	buckets := int(math.Ceil(float64(duration) / float64(granularity)))
-	return &TimeWindow{window: NewWindow(buckets), granularity: granularity}
+	return &TimeWindow{window: newWindow(buckets), granularity: granularity}
 }
 
 // Record records a value in the bucket derived from the given time.

--- a/pkg/autoscaler/aggregation/max/timewindow_test.go
+++ b/pkg/autoscaler/aggregation/max/timewindow_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package max_test
+package max
 
 import (
 	"fmt"
@@ -22,8 +22,6 @@ import (
 	"math/rand"
 	"testing"
 	"time"
-
-	"knative.dev/serving/pkg/autoscaler/aggregation/max"
 )
 
 func TestTimedWindowMax(t *testing.T) {
@@ -79,7 +77,7 @@ func TestTimedWindowMax(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := max.NewTimeWindow(5*time.Second, 1*time.Second)
+			m := NewTimeWindow(5*time.Second, 1*time.Second)
 
 			for _, v := range tt.values {
 				m.Record(v.time, v.value)
@@ -93,17 +91,17 @@ func TestTimedWindowMax(t *testing.T) {
 }
 
 func BenchmarkLargeTimeWindowCreate(b *testing.B) {
-	for _, duration := range []time.Duration{5, 15, 30, 45} {
-		b.Run(fmt.Sprintf("duration-%d-minutes", duration), func(b *testing.B) {
+	for _, duration := range []time.Duration{5 * time.Minute, 15 * time.Minute, 30 * time.Minute, 45 * time.Minute} {
+		b.Run(fmt.Sprintf("duration-%v", duration), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_ = max.NewTimeWindow(duration*time.Minute, 1*time.Second)
+				_ = NewTimeWindow(duration, 1*time.Second)
 			}
 		})
 	}
 }
 
 func BenchmarkLargeTimeWindowRecord(b *testing.B) {
-	w := max.NewTimeWindow(45*time.Minute, 1*time.Second)
+	w := NewTimeWindow(45*time.Minute, 1*time.Second)
 	now := time.Now()
 
 	b.ResetTimer()
@@ -114,7 +112,7 @@ func BenchmarkLargeTimeWindowRecord(b *testing.B) {
 }
 
 func BenchmarkLargeTimeWindowAscendingRecord(b *testing.B) {
-	w := max.NewTimeWindow(45*time.Minute, 1*time.Second)
+	w := NewTimeWindow(45*time.Minute, 1*time.Second)
 	now := time.Now()
 
 	b.ResetTimer()
@@ -127,7 +125,7 @@ func BenchmarkLargeTimeWindowAscendingRecord(b *testing.B) {
 func BenchmarkLargeTimeWindowDescendingRecord(b *testing.B) {
 	for _, duration := range []time.Duration{5, 15, 30, 45} {
 		b.Run(fmt.Sprintf("duration-%d-minutes", duration), func(b *testing.B) {
-			w := max.NewTimeWindow(duration*time.Minute, 1*time.Second)
+			w := NewTimeWindow(duration*time.Minute, 1*time.Second)
 			now := time.Now()
 
 			b.ResetTimer()

--- a/pkg/autoscaler/aggregation/max/timewindow_test.go
+++ b/pkg/autoscaler/aggregation/max/timewindow_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package max_test
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+
+	"knative.dev/serving/pkg/autoscaler/aggregation/max"
+)
+
+func TestTimedWindowMax(t *testing.T) {
+	type entry struct {
+		time  time.Time
+		value float64
+	}
+
+	now := time.Now()
+
+	tests := []struct {
+		name   string
+		expect float64
+		values []entry
+	}{{
+		name: "single value",
+		values: []entry{{
+			time:  now,
+			value: 5,
+		}},
+		expect: 5,
+	}, {
+		name: "two values in same second",
+		values: []entry{{
+			time:  now,
+			value: 6,
+		}, {
+			time:  now.Add(500 * time.Millisecond),
+			value: 5,
+		}},
+		expect: 6,
+	}, {
+		name: "two values",
+		values: []entry{{
+			time:  now,
+			value: 5,
+		}, {
+			time:  now.Add(1 * time.Second),
+			value: 8,
+		}},
+		expect: 8,
+	}, {
+		name: "time gap",
+		values: []entry{{
+			time:  now,
+			value: 5,
+		}, {
+			time:  now.Add(6 * time.Second),
+			value: 4,
+		}},
+		expect: 4,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := max.NewTimeWindow(5*time.Second, 1*time.Second)
+
+			for _, v := range tt.values {
+				m.Record(v.time, v.value)
+			}
+
+			if got, want := m.Current(), tt.expect; got != want {
+				t.Errorf("Current() = %f, expected %f", got, want)
+			}
+		})
+	}
+}
+
+func BenchmarkLargeTimeWindowCreate(b *testing.B) {
+	for _, duration := range []time.Duration{5, 15, 30, 45} {
+		b.Run(fmt.Sprintf("duration-%d-minutes", duration), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = max.NewTimeWindow(duration*time.Minute, 1*time.Second)
+			}
+		})
+	}
+}
+
+func BenchmarkLargeTimeWindowRecord(b *testing.B) {
+	w := max.NewTimeWindow(45*time.Minute, 1*time.Second)
+	now := time.Now()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		now = now.Add(1 * time.Second)
+		w.Record(now, rand.Float64())
+	}
+}
+
+func BenchmarkLargeTimeWindowAscendingRecord(b *testing.B) {
+	w := max.NewTimeWindow(45*time.Minute, 1*time.Second)
+	now := time.Now()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		now = now.Add(1 * time.Second)
+		w.Record(now, float64(i))
+	}
+}
+
+func BenchmarkLargeTimeWindowDescendingRecord(b *testing.B) {
+	for _, duration := range []time.Duration{5, 15, 30, 45} {
+		b.Run(fmt.Sprintf("duration-%d-minutes", duration), func(b *testing.B) {
+			w := max.NewTimeWindow(duration*time.Minute, 1*time.Second)
+			now := time.Now()
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				now = now.Add(1 * time.Second)
+				w.Record(now, float64(math.MaxInt32-i))
+			}
+		})
+	}
+}

--- a/pkg/autoscaler/aggregation/max/timewindow_test.go
+++ b/pkg/autoscaler/aggregation/max/timewindow_test.go
@@ -104,7 +104,6 @@ func BenchmarkLargeTimeWindowRecord(b *testing.B) {
 	w := NewTimeWindow(45*time.Minute, 1*time.Second)
 	now := time.Now()
 
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		now = now.Add(1 * time.Second)
 		w.Record(now, rand.Float64())
@@ -115,7 +114,6 @@ func BenchmarkLargeTimeWindowAscendingRecord(b *testing.B) {
 	w := NewTimeWindow(45*time.Minute, 1*time.Second)
 	now := time.Now()
 
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		now = now.Add(1 * time.Second)
 		w.Record(now, float64(i))
@@ -128,7 +126,6 @@ func BenchmarkLargeTimeWindowDescendingRecord(b *testing.B) {
 			w := NewTimeWindow(duration*time.Minute, 1*time.Second)
 			now := time.Now()
 
-			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				now = now.Add(1 * time.Second)
 				w.Record(now, float64(math.MaxInt32-i))

--- a/pkg/autoscaler/aggregation/max/window.go
+++ b/pkg/autoscaler/aggregation/max/window.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package max
+
+type entry struct {
+	value float64
+	index int
+}
+
+// Window is a circular buffer which keeps track of the maximum value observed in a particular time.
+// Based on the "ascending minima algorithm" (http://web.archive.org/web/20120805114719/http://home.tiac.net/~cri/2001/slidingmin.html).
+type Window struct {
+	maxima        []entry
+	first, length int
+}
+
+// NewWindow creates an descending minima window buffer of size size.
+func NewWindow(size int) *Window {
+	return &Window{
+		maxima: make([]entry, size),
+	}
+}
+
+// Record records a value for a monotonically increasing index.
+func (m *Window) Record(index int, v float64) {
+	// Step One: Remove any elements where v > element.
+	// An element that's lower than the new element can never influence the
+	// maximum again, because the new element is both larger _and_ more
+	// recent than it.
+	originalLength := m.length
+	for i := 0; i < originalLength; i++ {
+		// Search backwards because that way we can delete by just decrementing length.
+		// The elements are guaranteed to be in descending order as described in Step Three.
+		if v >= m.maxima[m.index(m.first+originalLength-i-1)].value {
+			m.length--
+		} else {
+			// The elements are sorted, no point continuing.
+			break
+		}
+	}
+
+	// Step Two: Remove out of date elements from front of array.
+	// We only ever add at end of list, so the indexes are in ascending order,
+	// therefore the oldest are always first.
+	for m.length > 0 && index-m.maxima[m.first].index >= len(m.maxima) {
+		m.length--
+		m.first++
+
+		// circle around the buffer if neccessary.
+		if m.first == len(m.maxima) {
+			m.first = 0
+		}
+	}
+
+	// Step 2b: To be defensive against multiple values being recorded against
+	// the same index, if the last index is the same as this one, we'll pick the largest.
+	if m.length > 0 {
+		if last := m.maxima[m.index(m.first+m.length-1)]; last.index == index {
+			if last.value > v {
+				v = last.value
+			}
+
+			// Remove last element because we'll add it back in Step Three.
+			m.length--
+		}
+	}
+
+	// Step Three: Add the new value to the end (which maintains sorted order
+	// since we removed any lesser values above, so value we're appending is
+	// always smallest value in list).
+	m.maxima[m.index(m.first+m.length)] = entry{index: index, value: v}
+	m.length++
+
+	// We removed any items from the list in Step Two that were added more than
+	// len(maxima) ago, so length can never be larger than len(maxima).
+	if m.length > len(m.maxima) {
+		panic("length exceeded buffer size. this is impossible, you win a prize.")
+	}
+}
+
+// Current returns the current maximum value observed.
+func (m *Window) Current() float64 {
+	return m.maxima[m.first].value
+}
+
+func (m *Window) index(i int) int {
+	return i % len(m.maxima)
+}

--- a/pkg/autoscaler/aggregation/max/window.go
+++ b/pkg/autoscaler/aggregation/max/window.go
@@ -27,22 +27,22 @@ type entry struct {
 	index int
 }
 
-// Window is a circular buffer which keeps track of the maximum value observed in a particular time.
+// window is a circular buffer which keeps track of the maximum value observed in a particular time.
 // Based on the "ascending minima algorithm" (http://web.archive.org/web/20120805114719/http://home.tiac.net/~cri/2001/slidingmin.html).
-type Window struct {
+type window struct {
 	maxima        []entry
 	first, length int
 }
 
-// NewWindow creates an descending minima window buffer of size size.
-func NewWindow(size int) *Window {
-	return &Window{
+// newWindow creates an descending minima window buffer of size size.
+func newWindow(size int) *window {
+	return &window{
 		maxima: make([]entry, size),
 	}
 }
 
 // Record records a value for a monotonically increasing index.
-func (m *Window) Record(index int, v float64) {
+func (m *window) Record(index int, v float64) {
 	// Step One: Remove any elements where v > element.
 	// An element that's lower than the new element can never influence the
 	// maximum again, because the new element is both larger _and_ more
@@ -98,10 +98,10 @@ func (m *Window) Record(index int, v float64) {
 }
 
 // Current returns the current maximum value observed.
-func (m *Window) Current() float64 {
+func (m *window) Current() float64 {
 	return m.maxima[m.first].value
 }
 
-func (m *Window) index(i int) int {
+func (m *window) index(i int) int {
 	return i % len(m.maxima)
 }

--- a/pkg/autoscaler/aggregation/max/window.go
+++ b/pkg/autoscaler/aggregation/max/window.go
@@ -65,7 +65,7 @@ func (m *Window) Record(index int, v float64) {
 		m.length--
 		m.first++
 
-		// Circle around the buffer if neccessary.
+		// Circle around the buffer if necessary.
 		if m.first == len(m.maxima) {
 			m.first = 0
 		}

--- a/pkg/autoscaler/aggregation/max/window.go
+++ b/pkg/autoscaler/aggregation/max/window.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package max
 
+import (
+	"fmt"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
 type entry struct {
 	value float64
 	index int
@@ -41,11 +47,10 @@ func (m *Window) Record(index int, v float64) {
 	// An element that's lower than the new element can never influence the
 	// maximum again, because the new element is both larger _and_ more
 	// recent than it.
-	originalLength := m.length
-	for i := 0; i < originalLength; i++ {
+	for l := m.length - 1; l >= 0; l-- {
 		// Search backwards because that way we can delete by just decrementing length.
 		// The elements are guaranteed to be in descending order as described in Step Three.
-		if v >= m.maxima[m.index(m.first+originalLength-i-1)].value {
+		if v >= m.maxima[m.index(m.first+l)].value {
 			m.length--
 		} else {
 			// The elements are sorted, no point continuing.
@@ -60,7 +65,7 @@ func (m *Window) Record(index int, v float64) {
 		m.length--
 		m.first++
 
-		// circle around the buffer if neccessary.
+		// Circle around the buffer if neccessary.
 		if m.first == len(m.maxima) {
 			m.first = 0
 		}
@@ -88,7 +93,7 @@ func (m *Window) Record(index int, v float64) {
 	// We removed any items from the list in Step Two that were added more than
 	// len(maxima) ago, so length can never be larger than len(maxima).
 	if m.length > len(m.maxima) {
-		panic("length exceeded buffer size. this is impossible, you win a prize.")
+		panic(fmt.Sprintf("length %d exceeded buffer size %d. This should be impossible. Current state: %v", m.length, len(m.maxima), spew.Sdump(m)))
 	}
 }
 

--- a/pkg/autoscaler/aggregation/max/window_test.go
+++ b/pkg/autoscaler/aggregation/max/window_test.go
@@ -104,7 +104,7 @@ func TestWindowMax(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			max := NewWindow(5)
+			max := newWindow(5)
 
 			indexFunc := func(i int) int { return i }
 			if tt.indexFunc != nil {

--- a/pkg/autoscaler/aggregation/max/window_test.go
+++ b/pkg/autoscaler/aggregation/max/window_test.go
@@ -14,13 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package max_test
+package max
 
 import (
 	"reflect"
 	"testing"
-
-	"knative.dev/serving/pkg/autoscaler/aggregation/max"
 )
 
 func TestWindowMax(t *testing.T) {
@@ -106,7 +104,7 @@ func TestWindowMax(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			max := max.NewWindow(5)
+			max := NewWindow(5)
 
 			indexFunc := func(i int) int { return i }
 			if tt.indexFunc != nil {

--- a/pkg/autoscaler/aggregation/max/window_test.go
+++ b/pkg/autoscaler/aggregation/max/window_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package max_test
+
+import (
+	"reflect"
+	"testing"
+
+	"knative.dev/serving/pkg/autoscaler/aggregation/max"
+)
+
+func TestWindowMax(t *testing.T) {
+	tests := []struct {
+		name      string
+		values    []float64
+		indexFunc func(int) int
+		expect    []float64
+	}{{
+		name:   "single value",
+		values: []float64{1},
+		expect: []float64{1},
+	}, {
+		name:   "ascending values",
+		values: []float64{1, 2},
+		expect: []float64{1, 2},
+	}, {
+		name:   "descending values",
+		values: []float64{2, 1},
+		expect: []float64{2, 2},
+	}, {
+		name:   "up, down, up",
+		values: []float64{1, 2, 1},
+		expect: []float64{1, 2, 2},
+	}, {
+		name:   "windowing out",
+		values: []float64{5, 6, 5, 5, 5, 5, 5},
+		expect: []float64{5, 6, 6, 6, 6, 6, 5},
+	}, {
+		name:   "windowing out with gaps",
+		values: []float64{6, 5, 2, 1},
+		indexFunc: func(i int) int {
+			if i >= 3 {
+				return i + 3
+			}
+
+			return i
+		},
+		expect: []float64{6, 6, 6, 2},
+	}, {
+		name:   "windowing out 2",
+		values: []float64{5, 6, 5, 7, 5, 5, 1},
+		expect: []float64{5, 6, 6, 7, 7, 7, 7},
+	}, {
+		name:   "windowing out 3",
+		values: []float64{5, 8, 5, 7, 5, 5},
+		expect: []float64{5, 8, 8, 8, 8, 8},
+	}, {
+		name:   "windowing out 4",
+		values: []float64{5, 8, 5, 7, 5, 5, 1},
+		expect: []float64{5, 8, 8, 8, 8, 8, 7},
+	}, {
+		name:   "windowing out 5",
+		values: []float64{5, 8, 5, 7, 5, 5, 1, 4, 4, 4},
+		expect: []float64{5, 8, 8, 8, 8, 8, 7, 7, 5, 5},
+	}, {
+		name:   "windowing out 6",
+		values: []float64{5, 8, 5, 7, 5, 5, 1, 4, 4, 4, 4},
+		expect: []float64{5, 8, 8, 8, 8, 8, 7, 7, 5, 5, 4},
+	}, {
+		name:   "windowing out 7",
+		values: []float64{5, 8, 5, 7, 5, 5, 1, 4, 4, 4, 4, 9},
+		expect: []float64{5, 8, 8, 8, 8, 8, 7, 7, 5, 5, 4, 9},
+	}, {
+		name:   "windowing out 8",
+		values: []float64{5, 8, 5, 7, 5, 5, 1, 4, 4, 4, 4, 9, 3, 4, 2, 1, 0},
+		expect: []float64{5, 8, 8, 8, 8, 8, 7, 7, 5, 5, 4, 9, 9, 9, 9, 9, 4},
+	}, {
+		name:   "multiple with same index, ascending",
+		values: []float64{1, 2, 3, 4, 5, 6, 7},
+		indexFunc: func(int) int {
+			return 1
+		},
+		expect: []float64{1, 2, 3, 4, 5, 6, 7},
+	}, {
+		name:   "multiple with same index, descending",
+		values: []float64{7, 6, 5, 4, 3, 2, 1},
+		indexFunc: func(int) int {
+			return 1
+		},
+		expect: []float64{7, 7, 7, 7, 7, 7, 7},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			max := max.NewWindow(5)
+
+			indexFunc := func(i int) int { return i }
+			if tt.indexFunc != nil {
+				indexFunc = tt.indexFunc
+			}
+
+			current := make([]float64, 0, len(tt.expect))
+			for i, v := range tt.values {
+				max.Record(indexFunc(i), v)
+				current = append(current, max.Current())
+			}
+
+			if got, want := current, tt.expect; !reflect.DeepEqual(got, want) {
+				t.Errorf("Current() = %f, expected %f", got, want)
+			}
+		})
+	}
+}

--- a/pkg/queue/readiness/probe_test.go
+++ b/pkg/queue/readiness/probe_test.go
@@ -102,8 +102,7 @@ func TestExecHandler(t *testing.T) {
 		Handler: corev1.Handler{
 			Exec: &corev1.ExecAction{
 				Command: []string{"echo", "hello"},
-			},
-		},
+			}},
 	})
 
 	if pb.ProbeContainer() {
@@ -529,7 +528,6 @@ func TestKnUnimplementedProbe(t *testing.T) {
 		t.Error("Got probe success. Wanted failure.")
 	}
 }
-
 func TestKnTCPProbeFailure(t *testing.T) {
 	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,

--- a/pkg/queue/readiness/probe_test.go
+++ b/pkg/queue/readiness/probe_test.go
@@ -102,7 +102,8 @@ func TestExecHandler(t *testing.T) {
 		Handler: corev1.Handler{
 			Exec: &corev1.ExecAction{
 				Command: []string{"echo", "hello"},
-			}},
+			},
+		},
 	})
 
 	if pb.ProbeContainer() {
@@ -528,6 +529,7 @@ func TestKnUnimplementedProbe(t *testing.T) {
 		t.Error("Got probe success. Wanted failure.")
 	}
 }
+
 func TestKnTCPProbeFailure(t *testing.T) {
 	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Part of https://github.com/knative/serving/issues/9092.

Introduce sliding window maxima package for use in [`scale-down-delay` feature](https://docs.google.com/document/d/1ECm1Ervw6DxV6__i71NfUsRjO7l6-RYlhYPhcDqPx3A).

First pass, but I think it's approximately reasonable, so PTAL. Arguably we should lose the panic, but it _seems_ like potentially a legit panic case; maybe logging is better than throwing our toys out of the pram, though?

/assign @markusthoemmes @vagababov 