### PR TITLE
[Automated] Update net-certmanager nightly

### DIFF
--- a/third_party/cert-manager-0.12.0/net-certmanager.yaml
+++ b/third_party/cert-manager-0.12.0/net-certmanager.yaml
@@ -18,7 +18,7 @@ metadata:
   # These are the permissions needed by the `cert-manager` `Certificate` implementation.
   name: knative-serving-certmanager
   labels:
-    serving.knative.dev/release: "v20200921-3686f77"
+    serving.knative.dev/release: "v20200922-8d2edbb"
     serving.knative.dev/controller: "true"
     networking.knative.dev/certificate-provider: cert-manager
 rules:
@@ -49,7 +49,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.net-certmanager.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v20200921-3686f77"
+    serving.knative.dev/release: "v20200922-8d2edbb"
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -86,7 +86,7 @@ metadata:
   name: net-certmanager-webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200921-3686f77"
+    serving.knative.dev/release: "v20200922-8d2edbb"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -109,7 +109,7 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200921-3686f77"
+    serving.knative.dev/release: "v20200922-8d2edbb"
     networking.knative.dev/certificate-provider: cert-manager
 data:
   _example: |
@@ -156,7 +156,7 @@ metadata:
   name: networking-certmanager
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200921-3686f77"
+    serving.knative.dev/release: "v20200922-8d2edbb"
     networking.knative.dev/certificate-provider: cert-manager
 spec:
   selector:
@@ -168,14 +168,14 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: networking-certmanager
-        serving.knative.dev/release: "v20200921-3686f77"
+        serving.knative.dev/release: "v20200922-8d2edbb"
     spec:
       serviceAccountName: controller
       containers:
       - name: networking-certmanager
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/controller@sha256:905f61a5414be0c61d83870a124cec55c77189524053130bd5de9261f1631af4
+        image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/controller@sha256:6d44be920c89f20cb7bfc227202159ca2b4a262fecaee3eb9e13bdc51f0f6966
         resources:
           requests:
             cpu: 30m
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   labels:
     app: networking-certmanager
-    serving.knative.dev/release: "v20200921-3686f77"
+    serving.knative.dev/release: "v20200922-8d2edbb"
     networking.knative.dev/certificate-provider: cert-manager
   name: networking-certmanager
   namespace: knative-serving
@@ -245,7 +245,7 @@ metadata:
   name: net-certmanager-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20200921-3686f77"
+    serving.knative.dev/release: "v20200922-8d2edbb"
 spec:
   selector:
     matchLabels:
@@ -258,14 +258,14 @@ spec:
       labels:
         app: net-certmanager-webhook
         role: net-certmanager-webhook
-        serving.knative.dev/release: "v20200921-3686f77"
+        serving.knative.dev/release: "v20200922-8d2edbb"
     spec:
       serviceAccountName: controller
       containers:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/webhook@sha256:12c79020427bfc6ae02fc62fcd2b2625ebe750efde636641deefe96d20c14f50
+        image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/webhook@sha256:bf6a7e24f3ee0b0115b595627a3ebdd780a69555b52ddab12924c1422af284a3
         resources:
           requests:
             cpu: 20m
@@ -319,7 +319,7 @@ metadata:
   namespace: knative-serving
   labels:
     role: net-certmanager-webhook
-    serving.knative.dev/release: "v20200921-3686f77"
+    serving.knative.dev/release: "v20200922-8d2edbb"
 spec:
   ports:
   - # Define metrics and profiling for them to be accessible within service meshes.


### PR DESCRIPTION
Produced via:
```shell
for x in net-certmanager.yaml; do
  curl https://storage.googleapis.com/knative-nightly/net-certmanager/latest/$x > ${GITHUB_WORKSPACE}/./third_party/cert-manager-0.12.0/$x
done
```
/assign tcnghia nak3 ZhiminXiang