### PR TITLE
Ensure progress deadline is snapped to a whole second

### DIFF
--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -107,6 +107,10 @@ func NewConfigFromMap(configMap map[string]string) (*Config, error) {
 		return nil, fmt.Errorf("progressDeadline cannot be a non-positive duration, was %v", nc.ProgressDeadline)
 	}
 
+	if nc.ProgressDeadline.Truncate(time.Second) != nc.ProgressDeadline {
+		return nil, fmt.Errorf("ProgressDeadline must be rounded to a whole second, was: %v", nc.ProgressDeadline)
+	}
+
 	if nc.DigestResolutionTimeout <= 0 {
 		return nil, fmt.Errorf("digestResolutionTimeout cannot be a non-positive duration, was %v", nc.DigestResolutionTimeout)
 	}

--- a/pkg/deployment/config_test.go
+++ b/pkg/deployment/config_test.go
@@ -27,10 +27,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	. "knative.dev/pkg/configmap/testing"
 	"knative.dev/pkg/system"
-	_ "knative.dev/pkg/system/testing"
 	"knative.dev/serving/test/conformance/api/shared"
+
+	. "knative.dev/pkg/configmap/testing"
+	_ "knative.dev/pkg/system/testing"
 )
 
 const defaultSidecarImage = "defaultImage"
@@ -185,6 +186,13 @@ func TestControllerConfiguration(t *testing.T) {
 		data: map[string]string{
 			QueueSidecarImageKey: defaultSidecarImage,
 			ProgressDeadlineKey:  "0ms",
+		},
+	}, {
+		name:    "controller configuration invalid progress deadline IV",
+		wantErr: true,
+		data: map[string]string{
+			QueueSidecarImageKey: defaultSidecarImage,
+			ProgressDeadlineKey:  "1982ms",
 		},
 	}}
 


### PR DESCRIPTION
K8s accepts only whole seconds as input, so we should not accept values that will be truncated and not represent
the actual value passed to the deployment.

/assign @dprotaso mattmoor