### PR TITLE
Move scale's cancel to defer.

### DIFF
--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -112,13 +112,13 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 
 			eg.Go(func() error {
 				ctx, cancel := context.WithTimeout(context.Background(), duration)
-				t.Cleanup(cancel)
 
 				// This go routine runs until the ksvc is ready, at which point we should note that
 				// our part is done.
 				defer func() {
 					wg.Done()
 					t.Logf("Reporting done!")
+					cancel()
 				}()
 
 				// Start the clock for various waypoints towards Service readiness.


### PR DESCRIPTION
I think the way things are set up today could lead to context being prematurely cancelled.  We register `t.Cleanup(cancel)` in a go routine, which might execute after the `t.Run()` has returned.

The go routine must complete before the `t.Cleanup` above it can finish executing, but the behavior of `t.Cleanup` after the `t.Run` has completed is strange and probably something we should avoid.

/assign @vagababov @markusthoemmes 