### PR TITLE
Rephrase in terms on availability.

### DIFF
--- a/config/core/deployments/activator-hpa.yaml
+++ b/config/core/deployments/activator-hpa.yaml
@@ -47,7 +47,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
 spec:
-  maxUnavailable: 20%
+  minAvailable: 80%
   selector:
     matchLabels:
       app: activator


### PR DESCRIPTION
Right now with 20% unavailability due to rounding up, with a single pod the
k8s pdb controller will permit eviction of that single task. Which is not what we want.
Instead we want 80% availability, which in case of 1 task yields:

```
status:
    currentHealthy: 1
    desiredHealthy: 1
    disruptionsAllowed: 0
    expectedPods: 1
    observedGeneration: 4
```

and in case of 8:
```
  status:
    currentHealthy: 8
    desiredHealthy: 7
    disruptionsAllowed: 1
    expectedPods: 8
    observedGeneration: 4
```

For #9138 
/assign @julz @dprotaso mattmoor