### PR TITLE
No need to cover with unit tests the test helpers for the e2e tests

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -16,5 +16,6 @@ ignore:
   - "**/*.pb.go" # Ignore proto-generated files.
   - "hack"
   - "pkg/client"
+  - "test"
   - "third_party"
   - "vendor"


### PR DESCRIPTION
If they are _there_ — it's good. But we should not fail for lack of UTs for a test util (e.g. WaitForState, etc).

/assign mattmoor @tcnghia 