### PR TITLE
Add startup probe checking DNS in the HTTP Proxy image.

### DIFF
--- a/test/test_images/httpproxy/service.yaml
+++ b/test/test_images/httpproxy/service.yaml
@@ -11,3 +11,11 @@ spec:
         env:
         - name: TARGET_HOST
           value: "helloworld-test-image.default.svc.cluster.local"
+        - name: PROBE_PORT
+          value: 9090
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+          failureThreshold: 120
+          periodSeconds: 10


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

In the Ksvc to Ksvc tests, we wait for the first service to be ready, then create the proxy service and then call the proxy service, but it is possible for the networking programming to not be complete and in this case the call fails and the test fails.
See https://github.com/knative/serving/pull/9471#issuecomment-697212990 for a real example where this happens (DNS returning `no such host` for a dozen seconds after the Service has been created).

Hopefully, this mitigates the problem by giving 2 minutes for the DNS to be setup properly.

/assign @mattmoor 