### PR TITLE
Actually use the errgroups in tests to exit early and abort operations on error

### DIFF
--- a/test/conformance/api/shared/doc.go
+++ b/test/conformance/api/shared/doc.go
@@ -15,5 +15,4 @@ limitations under the License.
 */
 
 // Package shared contains functions and types that can be used across various versions of conformance tests, e.g. checkers, requests senders, etc.
-
 package shared

--- a/test/conformance/api/v1/blue_green_test.go
+++ b/test/conformance/api/v1/blue_green_test.go
@@ -142,18 +142,18 @@ func TestBlueGreenRoute(t *testing.T) {
 	}
 
 	// Send concurrentRequests to blueDomain, greenDomain, and tealDomain.
-	g, _ := errgroup.WithContext(context.Background())
+	g, egCtx := errgroup.WithContext(context.Background())
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinSplitPercentage))
-		return shared.CheckDistribution(t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
+		return shared.CheckDistribution(egCtx, t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return shared.CheckDistribution(t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
+		return shared.CheckDistribution(egCtx, t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return shared.CheckDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
+		return shared.CheckDistribution(egCtx, t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
 	})
 	if err := g.Wait(); err != nil {
 		t.Fatal("Error sending requests:", err)

--- a/test/conformance/api/v1/single_threaded_test.go
+++ b/test/conformance/api/v1/single_threaded_test.go
@@ -74,13 +74,13 @@ func TestSingleConcurrency(t *testing.T) {
 	concurrency := 5
 	duration := 20 * time.Second
 	t.Logf("Maintaining %d concurrent requests for %v.", concurrency, duration)
-	group, _ := errgroup.WithContext(context.Background())
+	group, egCtx := errgroup.WithContext(context.Background())
 	for i := 0; i < concurrency; i++ {
 		threadIdx := i
 		group.Go(func() error {
 			requestIdx := 0
 			done := time.After(duration)
-			req, err := http.NewRequest(http.MethodGet, url.String(), nil)
+			req, err := http.NewRequestWithContext(egCtx, http.MethodGet, url.String(), nil)
 			if err != nil {
 				return fmt.Errorf("error creating http request: %w", err)
 			}

--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -75,6 +75,7 @@ func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.U
 		return fmt.Errorf("error with initial domain probing: %w", err)
 	}
 
+	g, egCtx = errgroup.WithContext(context.Background())
 	g.Go(func() error {
 		minBasePercentage := test.MinSplitPercentage
 		if len(baseExpected) == 1 {

--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -34,12 +34,12 @@ import (
 	v1test "knative.dev/serving/test/v1"
 )
 
-func checkForExpectedResponses(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, expectedResponses ...string) error {
-	client, err := pkgTest.NewSpoofingClient(context.Background(), clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
+func checkForExpectedResponses(ctx context.Context, t pkgTest.TLegacy, clients *test.Clients, url *url.URL, expectedResponses ...string) error {
+	client, err := pkgTest.NewSpoofingClient(ctx, clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(ctx, t.Logf, clients, test.ServingFlags.HTTPS))
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -56,19 +56,19 @@ func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.U
 		subdomains[i] = subdomain
 	}
 
-	g, _ := errgroup.WithContext(context.Background())
+	g, egCtx := errgroup.WithContext(context.Background())
 	// We don't have a good way to check if the route is updated so we will wait until a subdomain has
 	// started returning at least one expected result to key that we should validate percentage splits.
 	// In order for tests to succeed reliably, we need to make sure that all domains succeed.
 	g.Go(func() error {
 		t.Log("Checking updated route", baseDomain)
-		return checkForExpectedResponses(t, clients, baseDomain, baseExpected...)
+		return checkForExpectedResponses(egCtx, t, clients, baseDomain, baseExpected...)
 	})
 	for i, s := range subdomains {
 		i, s := i, s
 		g.Go(func() error {
 			t.Log("Checking updated route tags", s)
-			return checkForExpectedResponses(t, clients, s, targetsExpected[i])
+			return checkForExpectedResponses(egCtx, t, clients, s, targetsExpected[i])
 		})
 	}
 	if err := g.Wait(); err != nil {
@@ -81,13 +81,13 @@ func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.U
 			minBasePercentage = test.MinDirectPercentage
 		}
 		min := int(math.Floor(test.ConcurrentRequests * minBasePercentage))
-		return shared.CheckDistribution(t, clients, baseDomain, test.ConcurrentRequests, min, baseExpected)
+		return shared.CheckDistribution(egCtx, t, clients, baseDomain, test.ConcurrentRequests, min, baseExpected)
 	})
 	for i, subdomain := range subdomains {
 		i, subdomain := i, subdomain
 		g.Go(func() error {
 			min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-			return shared.CheckDistribution(t, clients, subdomain, test.ConcurrentRequests, min, []string{targetsExpected[i]})
+			return shared.CheckDistribution(egCtx, t, clients, subdomain, test.ConcurrentRequests, min, []string{targetsExpected[i]})
 		})
 	}
 	if err := g.Wait(); err != nil {

--- a/test/conformance/api/v1alpha1/blue_green_test.go
+++ b/test/conformance/api/v1alpha1/blue_green_test.go
@@ -146,18 +146,18 @@ func TestBlueGreenRoute(t *testing.T) {
 	}
 
 	// Send concurrentRequests to blueDomain, greenDomain, and tealDomain.
-	g, _ := errgroup.WithContext(context.Background())
+	g, egCtx := errgroup.WithContext(context.Background())
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinSplitPercentage))
-		return shared.CheckDistribution(t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
+		return shared.CheckDistribution(egCtx, t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return shared.CheckDistribution(t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
+		return shared.CheckDistribution(egCtx, t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return shared.CheckDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
+		return shared.CheckDistribution(egCtx, t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
 	})
 	if err := g.Wait(); err != nil {
 		t.Fatal("Error sending requests:", err)

--- a/test/conformance/api/v1alpha1/single_threaded_test.go
+++ b/test/conformance/api/v1alpha1/single_threaded_test.go
@@ -75,13 +75,13 @@ func TestSingleConcurrency(t *testing.T) {
 	concurrency := 5
 	duration := 20 * time.Second
 	t.Logf("Maintaining %d concurrent requests for %v.", concurrency, duration)
-	group, _ := errgroup.WithContext(context.Background())
+	group, egCtx := errgroup.WithContext(context.Background())
 	for i := 0; i < concurrency; i++ {
 		threadIdx := i
 		group.Go(func() error {
 			requestIdx := 0
 			done := time.After(duration)
-			req, err := http.NewRequest(http.MethodGet, url.String(), nil)
+			req, err := http.NewRequestWithContext(egCtx, http.MethodGet, url.String(), nil)
 			if err != nil {
 				return fmt.Errorf("error creating http request: %w", err)
 			}

--- a/test/conformance/api/v1alpha1/util.go
+++ b/test/conformance/api/v1alpha1/util.go
@@ -75,6 +75,7 @@ func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.U
 		return fmt.Errorf("error with initial domain probing: %w", err)
 	}
 
+	g, egCtx = errgroup.WithContext(context.Background())
 	g.Go(func() error {
 		minBasePercentage := test.MinSplitPercentage
 		if len(baseExpected) == 1 {

--- a/test/conformance/api/v1alpha1/util.go
+++ b/test/conformance/api/v1alpha1/util.go
@@ -34,12 +34,12 @@ import (
 	v1a1test "knative.dev/serving/test/v1alpha1"
 )
 
-func checkForExpectedResponses(t pkgTest.TLegacy, clients *test.Clients, url *url.URL, expectedResponses ...string) error {
-	client, err := pkgTest.NewSpoofingClient(context.Background(), clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
+func checkForExpectedResponses(ctx context.Context, t pkgTest.TLegacy, clients *test.Clients, url *url.URL, expectedResponses ...string) error {
+	client, err := pkgTest.NewSpoofingClient(ctx, clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(ctx, t.Logf, clients, test.ServingFlags.HTTPS))
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest(http.MethodGet, url.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -56,19 +56,19 @@ func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.U
 		subdomains[i] = subdomain
 	}
 
-	g, _ := errgroup.WithContext(context.Background())
+	g, egCtx := errgroup.WithContext(context.Background())
 	// We don't have a good way to check if the route is updated so we will wait until a subdomain has
 	// started returning at least one expected result to key that we should validate percentage splits.
 	// In order for tests to succeed reliably, we need to make sure that all domains succeed.
 	g.Go(func() error {
 		t.Log("Checking updated route", baseDomain)
-		return checkForExpectedResponses(t, clients, baseDomain, baseExpected...)
+		return checkForExpectedResponses(egCtx, t, clients, baseDomain, baseExpected...)
 	})
 	for i, s := range subdomains {
 		i, s := i, s
 		g.Go(func() error {
 			t.Log("Checking updated route tags", s)
-			return checkForExpectedResponses(t, clients, s, targetsExpected[i])
+			return checkForExpectedResponses(egCtx, t, clients, s, targetsExpected[i])
 		})
 	}
 	if err := g.Wait(); err != nil {
@@ -81,13 +81,13 @@ func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.U
 			minBasePercentage = test.MinDirectPercentage
 		}
 		min := int(math.Floor(test.ConcurrentRequests * minBasePercentage))
-		return shared.CheckDistribution(t, clients, baseDomain, test.ConcurrentRequests, min, baseExpected)
+		return shared.CheckDistribution(egCtx, t, clients, baseDomain, test.ConcurrentRequests, min, baseExpected)
 	})
 	for i, subdomain := range subdomains {
 		i, subdomain := i, subdomain
 		g.Go(func() error {
 			min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-			return shared.CheckDistribution(t, clients, subdomain, test.ConcurrentRequests, min, []string{targetsExpected[i]})
+			return shared.CheckDistribution(egCtx, t, clients, subdomain, test.ConcurrentRequests, min, []string{targetsExpected[i]})
 		})
 	}
 	if err := g.Wait(); err != nil {

--- a/test/conformance/api/v1beta1/blue_green_test.go
+++ b/test/conformance/api/v1beta1/blue_green_test.go
@@ -142,18 +142,18 @@ func TestBlueGreenRoute(t *testing.T) {
 	}
 
 	// Send concurrentRequests to blueDomain, greenDomain, and tealDomain.
-	g, _ := errgroup.WithContext(context.Background())
+	g, egCtx := errgroup.WithContext(context.Background())
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinSplitPercentage))
-		return shared.CheckDistribution(t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
+		return shared.CheckDistribution(egCtx, t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return shared.CheckDistribution(t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
+		return shared.CheckDistribution(egCtx, t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return shared.CheckDistribution(t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
+		return shared.CheckDistribution(egCtx, t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
 	})
 	if err := g.Wait(); err != nil {
 		t.Fatal("Error sending requests:", err)

--- a/test/conformance/api/v1beta1/single_threaded_test.go
+++ b/test/conformance/api/v1beta1/single_threaded_test.go
@@ -74,13 +74,13 @@ func TestSingleConcurrency(t *testing.T) {
 	concurrency := 5
 	duration := 20 * time.Second
 	t.Logf("Maintaining %d concurrent requests for %v.", concurrency, duration)
-	group, _ := errgroup.WithContext(context.Background())
+	group, egCtx := errgroup.WithContext(context.Background())
 	for i := 0; i < concurrency; i++ {
 		threadIdx := i
 		group.Go(func() error {
 			requestIdx := 0
 			done := time.After(duration)
-			req, err := http.NewRequest(http.MethodGet, url.String(), nil)
+			req, err := http.NewRequestWithContext(egCtx, http.MethodGet, url.String(), nil)
 			if err != nil {
 				return fmt.Errorf("error creating http request: %w", err)
 			}

--- a/test/conformance/api/v1beta1/util.go
+++ b/test/conformance/api/v1beta1/util.go
@@ -75,6 +75,7 @@ func validateDomains(t pkgTest.TLegacy, clients *test.Clients, baseDomain *url.U
 		return fmt.Errorf("error with initial domain probing: %w", err)
 	}
 
+	g, egCtx = errgroup.WithContext(context.Background())
 	g.Go(func() error {
 		minBasePercentage := test.MinSplitPercentage
 		if len(baseExpected) == 1 {

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -297,11 +297,6 @@ func TestDestroyPodWithRequests(t *testing.T) {
 		i := i
 		t.Logf("Starting request %d at %v", i, time.Now())
 		eg.Go(func() error {
-			// The request will sleep for more than 12 seconds.
-			// NOTE: 12s + 6s must be less than drainSleepDuration and TERMINATION_DRAIN_DURATION_SECONDS.
-			q := u.Query()
-			q.Set("sleep", "12001")
-			u.RawQuery = q.Encode()
 			req, err := http.NewRequestWithContext(egCtx, http.MethodGet, u.String(), nil)
 			if err != nil {
 				return fmt.Errorf("failed to create HTTP request: %w", err)

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -107,17 +107,17 @@ func TestDestroyPodInflight(t *testing.T) {
 		t.Fatal("Error creating spoofing client:", err)
 	}
 
+	g, egCtx := errgroup.WithContext(context.Background())
+
 	// The timeout app sleeps for the time passed via the timeout query parameter in milliseconds
 	u, _ := url.Parse(routeURL.String())
 	q := u.Query()
 	q.Set("timeout", fmt.Sprintf("%d", timeoutRequestDuration.Milliseconds()))
 	u.RawQuery = q.Encode()
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	req, err := http.NewRequestWithContext(egCtx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		t.Fatal("Error creating http request:", err)
 	}
-
-	g, _ := errgroup.WithContext(context.Background())
 
 	g.Go(func() error {
 		t.Log("Sending in a long running request")
@@ -142,7 +142,7 @@ func TestDestroyPodInflight(t *testing.T) {
 		time.Sleep(timeoutRequestDuration / 2)
 
 		t.Log("Destroying the configuration (also destroys the pods)")
-		return clients.ServingClient.Configs.Delete(context.Background(), names.Config, metav1.DeleteOptions{})
+		return clients.ServingClient.Configs.Delete(egCtx, names.Config, metav1.DeleteOptions{})
 	})
 
 	if err := g.Wait(); err != nil {
@@ -278,27 +278,29 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	}
 	t.Logf("Saw %d pods. Pods: %s", len(pods.Items), spew.Sdump(pods))
 
-	// The request will sleep for more than 12 seconds.
-	// NOTE: 12s + 6s must be less than drainSleepDuration and TERMINATION_DRAIN_DURATION_SECONDS.
 	u, _ := url.Parse(routeURL.String())
-	q := u.Query()
-	q.Set("sleep", "12001")
-	u.RawQuery = q.Encode()
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
-	if err != nil {
-		t.Fatal("Error creating HTTP request:", err)
-	}
 	httpClient, err := pkgTest.NewSpoofingClient(context.Background(), clients.KubeClient, t.Logf, u.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
 	if err != nil {
 		t.Fatal("Error creating spoofing client:", err)
 	}
 
+	eg, egCtx := errgroup.WithContext(context.Background())
+
 	// Start several requests staggered with 1s delay.
-	var eg errgroup.Group
 	for i := 1; i < 7; i++ {
 		i := i
 		t.Logf("Starting request %d at %v", i, time.Now())
 		eg.Go(func() error {
+			// The request will sleep for more than 12 seconds.
+			// NOTE: 12s + 6s must be less than drainSleepDuration and TERMINATION_DRAIN_DURATION_SECONDS.
+			q := u.Query()
+			q.Set("sleep", "12001")
+			u.RawQuery = q.Encode()
+			req, err := http.NewRequestWithContext(egCtx, http.MethodGet, u.String(), nil)
+			if err != nil {
+				return fmt.Errorf("failed to create HTTP request: %w", err)
+			}
+
 			res, err := httpClient.Do(req)
 			t.Logf("Request %d done at %v", i, time.Now())
 			if err != nil {

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -278,7 +278,13 @@ func TestDestroyPodWithRequests(t *testing.T) {
 	}
 	t.Logf("Saw %d pods. Pods: %s", len(pods.Items), spew.Sdump(pods))
 
+	// The request will sleep for more than 12 seconds.
+	// NOTE: 12s + 6s must be less than drainSleepDuration and TERMINATION_DRAIN_DURATION_SECONDS.
 	u, _ := url.Parse(routeURL.String())
+	q := u.Query()
+	q.Set("sleep", "12001")
+	u.RawQuery = q.Encode()
+
 	httpClient, err := pkgTest.NewSpoofingClient(context.Background(), clients.KubeClient, t.Logf, u.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
 	if err != nil {
 		t.Fatal("Error creating spoofing client:", err)

--- a/test/prober.go
+++ b/test/prober.go
@@ -180,7 +180,7 @@ func (m *manager) Stop() error {
 
 	m.logf("Stopping all probers")
 
-	errgrp := &errgroup.Group{}
+	errgrp := errgroup.Group{}
 	for _, prober := range m.probes {
 		errgrp.Go(prober.Stop)
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

A bit of plumbing work to actually use the errgroups in our tests where possible to short circuit ongoing requests in case an error happens anyway.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
