### PR TITLE
Change window type to int32 to match desiredPodCount

### DIFF
--- a/pkg/autoscaler/aggregation/max/timewindow.go
+++ b/pkg/autoscaler/aggregation/max/timewindow.go
@@ -35,13 +35,13 @@ func NewTimeWindow(duration, granularity time.Duration) *TimeWindow {
 }
 
 // Record records a value in the bucket derived from the given time.
-func (t *TimeWindow) Record(now time.Time, value float64) {
+func (t *TimeWindow) Record(now time.Time, value int32) {
 	index := int(now.Unix()) / int(t.granularity.Seconds())
 	t.window.Record(index, value)
 }
 
 // Current returns the current maximum value observed in the previous
 // window duration.
-func (t *TimeWindow) Current() float64 {
+func (t *TimeWindow) Current() int32 {
 	return t.window.Current()
 }

--- a/pkg/autoscaler/aggregation/max/timewindow_test.go
+++ b/pkg/autoscaler/aggregation/max/timewindow_test.go
@@ -27,14 +27,14 @@ import (
 func TestTimedWindowMax(t *testing.T) {
 	type entry struct {
 		time  time.Time
-		value float64
+		value int32
 	}
 
 	now := time.Now()
 
 	tests := []struct {
 		name   string
-		expect float64
+		expect int32
 		values []entry
 	}{{
 		name: "single value",
@@ -84,7 +84,7 @@ func TestTimedWindowMax(t *testing.T) {
 			}
 
 			if got, want := m.Current(), tt.expect; got != want {
-				t.Errorf("Current() = %f, expected %f", got, want)
+				t.Errorf("Current() = %d, expected %d", got, want)
 			}
 		})
 	}
@@ -106,7 +106,7 @@ func BenchmarkLargeTimeWindowRecord(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		now = now.Add(1 * time.Second)
-		w.Record(now, rand.Float64())
+		w.Record(now, rand.Int31())
 	}
 }
 
@@ -116,7 +116,7 @@ func BenchmarkLargeTimeWindowAscendingRecord(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		now = now.Add(1 * time.Second)
-		w.Record(now, float64(i))
+		w.Record(now, int32(i))
 	}
 }
 
@@ -128,7 +128,7 @@ func BenchmarkLargeTimeWindowDescendingRecord(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				now = now.Add(1 * time.Second)
-				w.Record(now, float64(math.MaxInt32-i))
+				w.Record(now, int32(math.MaxInt32-i))
 			}
 		})
 	}

--- a/pkg/autoscaler/aggregation/max/window.go
+++ b/pkg/autoscaler/aggregation/max/window.go
@@ -23,7 +23,7 @@ import (
 )
 
 type entry struct {
-	value float64
+	value int32
 	index int
 }
 
@@ -42,7 +42,7 @@ func newWindow(size int) *window {
 }
 
 // Record records a value for a monotonically increasing index.
-func (m *window) Record(index int, v float64) {
+func (m *window) Record(index int, v int32) {
 	// Step One: Remove any elements where v > element.
 	// An element that's lower than the new element can never influence the
 	// maximum again, because the new element is both larger _and_ more
@@ -97,7 +97,7 @@ func (m *window) Record(index int, v float64) {
 }
 
 // Current returns the current maximum value observed.
-func (m *window) Current() float64 {
+func (m *window) Current() int32 {
 	return m.maxima[m.first].value
 }
 

--- a/pkg/autoscaler/aggregation/max/window_test.go
+++ b/pkg/autoscaler/aggregation/max/window_test.go
@@ -24,32 +24,32 @@ import (
 func TestWindowMax(t *testing.T) {
 	tests := []struct {
 		name      string
-		values    []float64
+		values    []int32
 		indexFunc func(int) int
-		expect    []float64
+		expect    []int32
 	}{{
 		name:   "single value",
-		values: []float64{1},
-		expect: []float64{1},
+		values: []int32{1},
+		expect: []int32{1},
 	}, {
 		name:   "ascending values",
-		values: []float64{1, 2},
-		expect: []float64{1, 2},
+		values: []int32{1, 2},
+		expect: []int32{1, 2},
 	}, {
 		name:   "descending values",
-		values: []float64{2, 1},
-		expect: []float64{2, 2},
+		values: []int32{2, 1},
+		expect: []int32{2, 2},
 	}, {
 		name:   "up, down, up",
-		values: []float64{1, 2, 1},
-		expect: []float64{1, 2, 2},
+		values: []int32{1, 2, 1},
+		expect: []int32{1, 2, 2},
 	}, {
 		name:   "windowing out",
-		values: []float64{5, 6, 5, 5, 5, 5, 5},
-		expect: []float64{5, 6, 6, 6, 6, 6, 5},
+		values: []int32{5, 6, 5, 5, 5, 5, 5},
+		expect: []int32{5, 6, 6, 6, 6, 6, 5},
 	}, {
 		name:   "windowing out with gaps",
-		values: []float64{6, 5, 2, 1},
+		values: []int32{6, 5, 2, 1},
 		indexFunc: func(i int) int {
 			if i >= 3 {
 				return i + 3
@@ -57,49 +57,49 @@ func TestWindowMax(t *testing.T) {
 
 			return i
 		},
-		expect: []float64{6, 6, 6, 2},
+		expect: []int32{6, 6, 6, 2},
 	}, {
 		name:   "windowing out 2",
-		values: []float64{5, 6, 5, 7, 5, 5, 1},
-		expect: []float64{5, 6, 6, 7, 7, 7, 7},
+		values: []int32{5, 6, 5, 7, 5, 5, 1},
+		expect: []int32{5, 6, 6, 7, 7, 7, 7},
 	}, {
 		name:   "windowing out 3",
-		values: []float64{5, 8, 5, 7, 5, 5},
-		expect: []float64{5, 8, 8, 8, 8, 8},
+		values: []int32{5, 8, 5, 7, 5, 5},
+		expect: []int32{5, 8, 8, 8, 8, 8},
 	}, {
 		name:   "windowing out 4",
-		values: []float64{5, 8, 5, 7, 5, 5, 1},
-		expect: []float64{5, 8, 8, 8, 8, 8, 7},
+		values: []int32{5, 8, 5, 7, 5, 5, 1},
+		expect: []int32{5, 8, 8, 8, 8, 8, 7},
 	}, {
 		name:   "windowing out 5",
-		values: []float64{5, 8, 5, 7, 5, 5, 1, 4, 4, 4},
-		expect: []float64{5, 8, 8, 8, 8, 8, 7, 7, 5, 5},
+		values: []int32{5, 8, 5, 7, 5, 5, 1, 4, 4, 4},
+		expect: []int32{5, 8, 8, 8, 8, 8, 7, 7, 5, 5},
 	}, {
 		name:   "windowing out 6",
-		values: []float64{5, 8, 5, 7, 5, 5, 1, 4, 4, 4, 4},
-		expect: []float64{5, 8, 8, 8, 8, 8, 7, 7, 5, 5, 4},
+		values: []int32{5, 8, 5, 7, 5, 5, 1, 4, 4, 4, 4},
+		expect: []int32{5, 8, 8, 8, 8, 8, 7, 7, 5, 5, 4},
 	}, {
 		name:   "windowing out 7",
-		values: []float64{5, 8, 5, 7, 5, 5, 1, 4, 4, 4, 4, 9},
-		expect: []float64{5, 8, 8, 8, 8, 8, 7, 7, 5, 5, 4, 9},
+		values: []int32{5, 8, 5, 7, 5, 5, 1, 4, 4, 4, 4, 9},
+		expect: []int32{5, 8, 8, 8, 8, 8, 7, 7, 5, 5, 4, 9},
 	}, {
 		name:   "windowing out 8",
-		values: []float64{5, 8, 5, 7, 5, 5, 1, 4, 4, 4, 4, 9, 3, 4, 2, 1, 0},
-		expect: []float64{5, 8, 8, 8, 8, 8, 7, 7, 5, 5, 4, 9, 9, 9, 9, 9, 4},
+		values: []int32{5, 8, 5, 7, 5, 5, 1, 4, 4, 4, 4, 9, 3, 4, 2, 1, 0},
+		expect: []int32{5, 8, 8, 8, 8, 8, 7, 7, 5, 5, 4, 9, 9, 9, 9, 9, 4},
 	}, {
 		name:   "multiple with same index, ascending",
-		values: []float64{1, 2, 3, 4, 5, 6, 7},
+		values: []int32{1, 2, 3, 4, 5, 6, 7},
 		indexFunc: func(int) int {
 			return 1
 		},
-		expect: []float64{1, 2, 3, 4, 5, 6, 7},
+		expect: []int32{1, 2, 3, 4, 5, 6, 7},
 	}, {
 		name:   "multiple with same index, descending",
-		values: []float64{7, 6, 5, 4, 3, 2, 1},
+		values: []int32{7, 6, 5, 4, 3, 2, 1},
 		indexFunc: func(int) int {
 			return 1
 		},
-		expect: []float64{7, 7, 7, 7, 7, 7, 7},
+		expect: []int32{7, 7, 7, 7, 7, 7, 7},
 	}}
 
 	for _, tt := range tests {
@@ -111,14 +111,14 @@ func TestWindowMax(t *testing.T) {
 				indexFunc = tt.indexFunc
 			}
 
-			current := make([]float64, 0, len(tt.expect))
+			current := make([]int32, 0, len(tt.expect))
 			for i, v := range tt.values {
 				max.Record(indexFunc(i), v)
 				current = append(current, max.Current())
 			}
 
 			if got, want := current, tt.expect; !reflect.DeepEqual(got, want) {
-				t.Errorf("Current() = %f, expected %f", got, want)
+				t.Errorf("Current() = %d, expected %d", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Float64s are more generic, but actually we're going be using the window on desiredPodCount which is an int32, so swap to that.

/assign @markusthoemmes 