### PR TITLE
Fix the feature-flag config location for Routes

### DIFF
--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -125,7 +125,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconcil
 		return err
 	}
 
-	if cfgmap.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC != cfgmap.Enabled {
+	if config.FromContextOrDefaults(ctx).Features.ResponsiveRevisionGC != cfgmap.Enabled {
 		// In all cases we will add annotations to the referred targets.  This is so that when they become
 		// routable we can know (through a listener) and attempt traffic configuration again.
 		if err := c.reconcileTargetRevisions(ctx, traffic, r); err != nil {

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -1889,8 +1889,7 @@ func TestReconcile_ResponsiveGC(t *testing.T) {
 				WithConfigLabel("serving.knative.dev/route", "stale-lastpinned"),
 			),
 			rev("default", "config", 1, MarkRevisionReady,
-				WithRevName("config-00001"),
-				WithLastPinned(fakeCurTime.Add(-10*time.Minute))),
+				WithRevName("config-00001")),
 			simpleReadyIngress(
 				Route("default", "stale-lastpinned", WithConfigTarget("config"), WithURL),
 				&traffic.Config{

--- a/test/v1/configuration.go
+++ b/test/v1/configuration.go
@@ -85,7 +85,7 @@ func WaitForConfigLatestRevision(clients *test.Clients, names test.ResourceNames
 			if ensurePinned {
 				// Without this it might happen that the latest created revision is later overridden by a newer one
 				// that is pinned and the following check for LatestReadyRevisionName would fail.
-				return CheckRevisionState(clients.ServingClient, revisionName, IsRevisionPinned) == nil, nil
+				return CheckRevisionState(clients.ServingClient, revisionName, IsRevisionRoutingActive) == nil, nil
 			}
 			return true, nil
 		}

--- a/test/v1/revision.go
+++ b/test/v1/revision.go
@@ -77,8 +77,15 @@ func IsRevisionReady(r *v1.Revision) (bool, error) {
 	return r.IsReady(), nil
 }
 
-// IsRevisionPinned will check if the revision is pinned to a route.
-func IsRevisionPinned(r *v1.Revision) (bool, error) {
+// IsRevisionRoutingActive will check if the revision is actively routing to a route.
+func IsRevisionRoutingActive(r *v1.Revision) (bool, error) {
+	routingState := r.Labels[serving.RoutingStateLabelKey]
+	if v1.RoutingState(routingState) == v1.RoutingStateActive {
+		return true, nil
+	}
+
+	// TODO(whaught): remove this fallback as we remove the lastPinned annotation
+	// Fallback to lastPinned - this is needed for downgrade tests where the annotation still exists.
 	_, pinned := r.Annotations[serving.RevisionLastPinnedAnnotationKey]
 	return pinned, nil
 }

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -207,10 +207,9 @@ func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 	if err := WaitForServiceState(clients.ServingClient, names.Service, func(s *v1.Service) (bool, error) {
 		if s.Status.LatestCreatedRevisionName != names.Revision {
 			revisionName = s.Status.LatestCreatedRevisionName
-			// We also check that the revision is pinned, meaning it's not a stale revision.
 			// Without this it might happen that the latest created revision is later overridden by a newer one
 			// and the following check for LatestReadyRevisionName would fail.
-			if revErr := CheckRevisionState(clients.ServingClient, revisionName, IsRevisionPinned); revErr != nil {
+			if revErr := CheckRevisionState(clients.ServingClient, revisionName, IsRevisionRoutingActive); revErr != nil {
 				return false, nil
 			}
 			return true, nil

--- a/test/v1alpha1/configuration.go
+++ b/test/v1alpha1/configuration.go
@@ -105,7 +105,7 @@ func WaitForConfigLatestRevision(clients *test.Clients, names test.ResourceNames
 			if ensurePinned {
 				// Without this it might happen that the latest created revision is later overridden by a newer one
 				// that is pinned and the following check for LatestReadyRevisionName would fail.
-				return CheckRevisionState(clients.ServingAlphaClient, revisionName, IsRevisionPinned) == nil, nil
+				return CheckRevisionState(clients.ServingAlphaClient, revisionName, IsRevisionRoutingActive) == nil, nil
 			}
 			return true, nil
 		}

--- a/test/v1alpha1/revision.go
+++ b/test/v1alpha1/revision.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/serving/pkg/apis/serving"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"knative.dev/serving/test"
 )
@@ -75,10 +76,10 @@ func IsRevisionReady(r *v1alpha1.Revision) (bool, error) {
 	return r.Generation == r.Status.ObservedGeneration && r.Status.IsReady(), nil
 }
 
-// IsRevisionPinned will check if the revision is pinned to a route.
-func IsRevisionPinned(r *v1alpha1.Revision) (bool, error) {
-	_, pinned := r.Annotations[serving.RevisionLastPinnedAnnotationKey]
-	return pinned, nil
+// IsRevisionRoutingActive will check if the revision is actively routing to a route.
+func IsRevisionRoutingActive(r *v1alpha1.Revision) (bool, error) {
+	routingState := r.Labels[serving.RoutingStateLabelKey]
+	return v1.RoutingState(routingState) == v1.RoutingStateActive, nil
 }
 
 // IsRevisionAtExpectedGeneration returns a function that will check if the annotations

--- a/test/v1alpha1/service.go
+++ b/test/v1alpha1/service.go
@@ -269,10 +269,9 @@ func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 	if err := WaitForServiceState(clients.ServingAlphaClient, names.Service, func(s *v1alpha1.Service) (bool, error) {
 		if s.Status.LatestCreatedRevisionName != names.Revision {
 			revisionName = s.Status.LatestCreatedRevisionName
-			// We also check that the revision is pinned, meaning it's not a stale revision.
 			// Without this it might happen that the latest created revision is later overridden by a newer one
 			// and the following check for LatestReadyRevisionName would fail.
-			if revErr := CheckRevisionState(clients.ServingAlphaClient, revisionName, IsRevisionPinned); revErr != nil {
+			if revErr := CheckRevisionState(clients.ServingAlphaClient, revisionName, IsRevisionRoutingActive); revErr != nil {
 				return false, nil
 			}
 			return true, nil

--- a/test/v1beta1/configuration.go
+++ b/test/v1beta1/configuration.go
@@ -89,7 +89,7 @@ func WaitForConfigLatestRevision(clients *test.Clients, names test.ResourceNames
 			if ensurePinned {
 				// Without this it might happen that the latest created revision is later overridden by a newer one
 				// that is pinned and the following check for LatestReadyRevisionName would fail.
-				return CheckRevisionState(clients.ServingBetaClient, revisionName, IsRevisionPinned) == nil, nil
+				return CheckRevisionState(clients.ServingBetaClient, revisionName, IsRevisionRoutingActive) == nil, nil
 			}
 			return true, nil
 		}

--- a/test/v1beta1/revision.go
+++ b/test/v1beta1/revision.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/test/logging"
 	"knative.dev/serving/pkg/apis/serving"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1beta1"
 	"knative.dev/serving/test"
 )
@@ -75,10 +76,10 @@ func IsRevisionReady(r *v1beta1.Revision) (bool, error) {
 	return r.IsReady(), nil
 }
 
-// IsRevisionPinned will check if the revision is pinned to a route.
-func IsRevisionPinned(r *v1beta1.Revision) (bool, error) {
-	_, pinned := r.Annotations[serving.RevisionLastPinnedAnnotationKey]
-	return pinned, nil
+// IsRevisionRoutingActive will check if the revision is actively routing to a route.
+func IsRevisionRoutingActive(r *v1beta1.Revision) (bool, error) {
+	routingState := r.Labels[serving.RoutingStateLabelKey]
+	return v1.RoutingState(routingState) == v1.RoutingStateActive, nil
 }
 
 // IsRevisionAtExpectedGeneration returns a function that will check if the annotations

--- a/test/v1beta1/service.go
+++ b/test/v1beta1/service.go
@@ -184,10 +184,9 @@ func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 	if err := WaitForServiceState(clients.ServingBetaClient, names.Service, func(s *v1beta1.Service) (bool, error) {
 		if s.Status.LatestCreatedRevisionName != names.Revision {
 			revisionName = s.Status.LatestCreatedRevisionName
-			// We also check that the revision is pinned, meaning it's not a stale revision.
 			// Without this it might happen that the latest created revision is later overridden by a newer one
 			// and the following check for LatestReadyRevisionName would fail.
-			if revErr := CheckRevisionState(clients.ServingBetaClient, revisionName, IsRevisionPinned); revErr != nil {
+			if revErr := CheckRevisionState(clients.ServingBetaClient, revisionName, IsRevisionRoutingActive); revErr != nil {
 				return false, nil
 			}
 			return true, nil


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* The routes reconciler is trying to get an api/config instead of routes/config store from context.
* Update the related tests to not expect the LastPinned annotation and check the routingState label instead.