### PR TITLE
Micronit: make the URL correct.

### DIFF
--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -78,7 +78,7 @@ func TestProbe(t *testing.T) {
 
 	defer server.Shutdown(0)
 	go server.listenAndServe()
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", server.listenAddr(), network.ProbePath), nil)
+	req, err := http.NewRequest(http.MethodGet, server.listenAddr()+network.ProbePath, nil)
 	if err != nil {
 		t.Fatal("Error creating request:", err)
 	}


### PR DESCRIPTION
- get rid of the sprintf
- make the URL actually right: right now it was '127.0.0.1//...' — double-slash not cool
- two for the price of 1!

/assign @markusthoemmes @julz 