### PR TITLE
Teach Autoscaler about Scale Down Delay

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -78,10 +78,7 @@ func New(
 		return nil, errors.New("stats reporter must not be nil")
 	}
 
-	delayer := max.NewTimeWindow(tickInterval, tickInterval)
-	if deciderSpec.ScaleDownDelay > 0 {
-		delayer = max.NewTimeWindow(deciderSpec.ScaleDownDelay, tickInterval)
-	}
+	delayer := max.NewTimeWindow(deciderSpec.ScaleDownDelay, tickInterval)
 
 	return newAutoscaler(namespace, revision, metricClient,
 		podCounter, deciderSpec, delayer, reporterCtx), nil

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -31,7 +31,6 @@ import (
 	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/pkg/metrics/metricstest"
 
-	"knative.dev/serving/pkg/autoscaler/aggregation/max"
 	"knative.dev/serving/pkg/autoscaler/metrics"
 	smetrics "knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/resources"
@@ -657,7 +656,7 @@ func newTestAutoscalerWithScalingMetric(t *testing.T, targetValue, targetBurstCa
 	if err != nil {
 		t.Fatal("Error creating context:", err)
 	}
-	return newAutoscaler(testNamespace, testRevision, metrics, pc, deciderSpec, max.NewTimeWindow(tickInterval, tickInterval), ctx), pc
+	return newAutoscaler(testNamespace, testRevision, metrics, pc, deciderSpec, nil, ctx), pc
 }
 
 // approxEquateInt32 equates int32s with given path with ±-1 tolerance.
@@ -695,7 +694,7 @@ func TestStartInPanicMode(t *testing.T) {
 	pc := &fakePodCounter{}
 	for i := 0; i < 2; i++ {
 		pc.readyCount = i
-		a := newAutoscaler(testNamespace, testRevision, metrics, pc, deciderSpec, max.NewTimeWindow(tickInterval, tickInterval), context.Background())
+		a := newAutoscaler(testNamespace, testRevision, metrics, pc, deciderSpec, nil, context.Background())
 		if !a.panicTime.IsZero() {
 			t.Errorf("Create at scale %d had panic mode on", i)
 		}
@@ -706,7 +705,7 @@ func TestStartInPanicMode(t *testing.T) {
 
 	// Now start with 2 and make sure we're in panic mode.
 	pc.readyCount = 2
-	a := newAutoscaler(testNamespace, testRevision, metrics, pc, deciderSpec, max.NewTimeWindow(tickInterval, tickInterval), context.Background())
+	a := newAutoscaler(testNamespace, testRevision, metrics, pc, deciderSpec, nil, context.Background())
 	if a.panicTime.IsZero() {
 		t.Error("Create at scale 2 had panic mode off")
 	}
@@ -728,7 +727,7 @@ func TestNewFail(t *testing.T) {
 	}
 
 	pc := fakePodCounter{err: errors.New("starlight")}
-	a := newAutoscaler(testNamespace, testRevision, metrics, pc, deciderSpec, max.NewTimeWindow(tickInterval, tickInterval), context.Background())
+	a := newAutoscaler(testNamespace, testRevision, metrics, pc, deciderSpec, nil, context.Background())
 	if got, want := int(a.maxPanicPods), 0; got != want {
 		t.Errorf("maxPanicPods = %d, want: 0", got)
 	}

--- a/pkg/autoscaler/scaling/multiscaler.go
+++ b/pkg/autoscaler/scaling/multiscaler.go
@@ -68,6 +68,9 @@ type DeciderSpec struct {
 	PanicThreshold float64
 	// StableWindow is needed to determine when to exit panic mode.
 	StableWindow time.Duration
+	// ScaleDownDelay is the time that must pass at reduced concurrency before a
+	// scale-down decision is applied.
+	ScaleDownDelay time.Duration
 	// InitialScale is the calculated initial scale of the revision, taking both
 	// revision initial scale and cluster initial scale into account. Revision initial
 	// scale overrides cluster initial scale.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Part of #9092.

Add ScaleDownDelay to DeciderSpec and teach Autoscaler how to respect it. At this point this is still a no-op since we never actually set a non-zero ScaleDownDelay (next PR will change that).

Couple things worth commenting on:

- Although a 1-element scale-down window is _almost_ the same as no window at all, it's not quite the same (because if we run Scale twice in the same interval, which can happen on initial scale-up, we'll pick the largest of the two rather than the most recent), therefore use a `zeroDelay` when delay is zero. This also makes setting non-zero ScaleDownDelay effectively act as a feature flag for the whole feature, which is nice.

- ~~The max.TimedWindow package has a slightly different API from the `delayer` interface introduced here (Record/Current vs Delay). I think that's fine and good because the concept of delay is part of autoscaler, and doesn't make much sense in the more generic `aggregation/max` package, therefore Im wrapping here to avoid polluting the generic package with concepts from the specific one. This may be a terrible idea though; if anyone hates it happy to change it :) (this is all private anyway though).~~. Dropped the interfaces \o/.

/assign @markusthoemmes @vagababov 
