### PR TITLE
Wire up Scale Down Delay config and annotation

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -50,9 +50,14 @@ func ValidateAnnotations(allowInitScaleZero bool, anns map[string]string) *apis.
 	if len(anns) == 0 {
 		return nil
 	}
-	return validateClass(anns).Also(validateMinMaxScale(anns)).Also(validateFloats(anns)).
-		Also(validateWindow(anns).Also(validateLastPodRetention(anns)).
-			Also(validateMetric(anns).Also(validateInitialScale(allowInitScaleZero, anns))))
+	return validateClass(anns).
+		Also(validateMinMaxScale(anns)).
+		Also(validateFloats(anns)).
+		Also(validateWindow(anns)).
+		Also(validateLastPodRetention(anns)).
+		Also(validateScaleDownDelay(anns)).
+		Also(validateMetric(anns)).
+		Also(validateInitialScale(allowInitScaleZero, anns))
 }
 
 func validateClass(annotations map[string]string) *apis.FieldError {
@@ -100,6 +105,22 @@ func validateFloats(annotations map[string]string) *apis.FieldError {
 	if v, ok := annotations[TargetBurstCapacityKey]; ok {
 		if fv, err := strconv.ParseFloat(v, 64); err != nil || fv < 0 && fv != -1 {
 			errs = errs.Also(apis.ErrInvalidValue(v, TargetBurstCapacityKey))
+		}
+	}
+	return errs
+}
+
+func validateScaleDownDelay(annotations map[string]string) *apis.FieldError {
+	var errs *apis.FieldError
+	if w, ok := annotations[ScaleDownDelayAnnotationKey]; ok {
+		if d, err := time.ParseDuration(w); err != nil {
+			errs = apis.ErrInvalidValue(w, ScaleDownDelayAnnotationKey)
+		} else if d < 0 || d > WindowMax {
+			// Since we disallow windows longer than WindowMax, so we should limit this
+			// as well.
+			errs = apis.ErrOutOfBoundsValue(w, 0*time.Second, WindowMax, ScaleDownDelayAnnotationKey)
+		} else if d.Round(time.Second) != d {
+			errs = apis.ErrGeneric("must be specified with at most second precision", ScaleDownDelayAnnotationKey)
 		}
 	}
 	return errs

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -214,6 +214,28 @@ func TestValidateAnnotations(t *testing.T) {
 		annotations: map[string]string{ScaleToZeroPodRetentionPeriodKey: "twenty-two-minutes-and-five-seconds"},
 		expectErr:   "invalid value: twenty-two-minutes-and-five-seconds: " + ScaleToZeroPodRetentionPeriodKey,
 	}, {
+		name:        "valid 0 scale down delay",
+		annotations: map[string]string{ScaleDownDelayAnnotationKey: "0"},
+	}, {
+		name:        "valid positive scale down delay",
+		annotations: map[string]string{ScaleDownDelayAnnotationKey: "21m31s"},
+	}, {
+		name:        "invalid positive scale down delay",
+		annotations: map[string]string{ScaleDownDelayAnnotationKey: "311m"},
+		expectErr:   "expected 0s <= 311m <= 1h0m0s: " + ScaleDownDelayAnnotationKey,
+	}, {
+		name:        "invalid positive scale down delay - too precise",
+		annotations: map[string]string{ScaleDownDelayAnnotationKey: "42.5s"},
+		expectErr:   "must be specified with at most second precision: " + ScaleDownDelayAnnotationKey,
+	}, {
+		name:        "invalid negative scale down delay",
+		annotations: map[string]string{ScaleDownDelayAnnotationKey: "-42s"},
+		expectErr:   "expected 0s <= -42s <= 1h0m0s: " + ScaleDownDelayAnnotationKey,
+	}, {
+		name:        "invalid scale down delay",
+		annotations: map[string]string{ScaleDownDelayAnnotationKey: "twenty-two-minutes-and-five-seconds"},
+		expectErr:   "invalid value: twenty-two-minutes-and-five-seconds: " + ScaleDownDelayAnnotationKey,
+	}, {
 		name: "all together now fail",
 		annotations: map[string]string{
 			PanicThresholdPercentageAnnotationKey: "fifty",

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -51,6 +51,9 @@ const (
 	// allow-zero-initial-scale of config-autoscaler is true.
 	InitialScaleAnnotationKey = GroupName + "/initialScale"
 
+	// ScaleDownDelayAnnotationKey is the annotation to specify a scale down delay.
+	ScaleDownDelayAnnotationKey = GroupName + "/scaleDownDelay"
+
 	// MetricAnnotationKey is the annotation to specify what metric the PodAutoscaler
 	// should be scaled on. For example,
 	//   autoscaling.knative.dev/metric: cpu

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -138,6 +138,12 @@ func (pa *PodAutoscaler) Window() (time.Duration, bool) {
 	return pa.annotationDuration(autoscaling.WindowAnnotationKey)
 }
 
+// ScaleDownDelay returns the scale down delay annotation, or false if not present.
+func (pa *PodAutoscaler) ScaleDownDelay() (time.Duration, bool) {
+	// The value is validated in the webhook.
+	return pa.annotationDuration(autoscaling.ScaleDownDelayAnnotationKey)
+}
+
 // PanicWindowPercentage returns the panic window annotation value, or false if not present.
 func (pa *PodAutoscaler) PanicWindowPercentage() (percentage float64, ok bool) {
 	// The value is validated in the webhook.

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -721,6 +721,53 @@ func TestMetric(t *testing.T) {
 	}
 }
 
+func TestScaleDownDelayAnnotation(t *testing.T) {
+	cases := []struct {
+		name      string
+		pa        *PodAutoscaler
+		wantDelay time.Duration
+		wantOK    bool
+	}{{
+		name:      "not present",
+		pa:        pa(map[string]string{}),
+		wantDelay: 0,
+		wantOK:    false,
+	}, {
+		name: "present",
+		pa: pa(map[string]string{
+			autoscaling.ScaleDownDelayAnnotationKey: "120s",
+		}),
+		wantDelay: 120 * time.Second,
+		wantOK:    true,
+	}, {
+		name: "complex",
+		pa: pa(map[string]string{
+			autoscaling.ScaleDownDelayAnnotationKey: "2m33s",
+		}),
+		wantDelay: 153 * time.Second,
+		wantOK:    true,
+	}, {
+		name: "invalid",
+		pa: pa(map[string]string{
+			autoscaling.ScaleDownDelayAnnotationKey: "365d",
+		}),
+		wantDelay: 0,
+		wantOK:    false,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotDelay, gotOK := tc.pa.ScaleDownDelay()
+			if gotDelay != tc.wantDelay {
+				t.Errorf("ScaleDownDelay = %v, want: %v", gotDelay, tc.wantDelay)
+			}
+			if gotOK != tc.wantOK {
+				t.Errorf("OK = %v, want: %v", gotOK, tc.wantOK)
+			}
+		})
+	}
+}
+
 func TestWindowAnnotation(t *testing.T) {
 	cases := []struct {
 		name       string

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -60,6 +60,12 @@ func MakeDecider(ctx context.Context, pa *asv1a1.PodAutoscaler, config *autoscal
 	if x, ok := pa.TargetBC(); ok {
 		tbc = x
 	}
+
+	scaleDownDelay := config.ScaleDownDelay
+	if sdd, ok := pa.ScaleDownDelay(); ok {
+		scaleDownDelay = sdd
+	}
+
 	return &scaling.Decider{
 		ObjectMeta: *pa.ObjectMeta.DeepCopy(),
 		Spec: scaling.DeciderSpec{
@@ -72,6 +78,7 @@ func MakeDecider(ctx context.Context, pa *asv1a1.PodAutoscaler, config *autoscal
 			ActivatorCapacity:   config.ActivatorCapacity,
 			PanicThreshold:      panicThreshold,
 			StableWindow:        resources.StableWindow(pa, config),
+			ScaleDownDelay:      scaleDownDelay,
 			InitialScale:        GetInitialScale(config, pa),
 			Reachable:           pa.Spec.Reachability != asv1a1.ReachabilityUnreachable,
 		},


### PR DESCRIPTION
Part of #9092.

After this all that remains (I think) is adding the config map example (which is where I'll add the Release Note). 

Docs PR: https://github.com/knative/docs/pull/2857.

~~/hold this will need rebasing once the first two commits land in https://github.com/knative/serving/pull/9565.~~ 

/hold for release on Tuesday

/assign @markusthoemmes @vagababov ~~(until https://github.com/knative/serving/pull/9565 lands you probably want to skip to third commit for the new stuff).~~