### PR TITLE
Float the CodeCov summary near the GitHub PR status box

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -11,6 +11,10 @@ coverage:
       # only failing because of overall project coverage threshold.
       # See https://docs.codecov.io/docs/commit-status#disabling-a-status.
       default: false
+comment:
+  # CodeCov will delete the old comment and create a new one, so the
+  # coverage information always hovers near the GitHub PR status box.
+  behavior: new
 ignore:
   - "**/zz_generated*.go" # Ignore generated files.
   - "**/*.pb.go" # Ignore proto-generated files.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Float the CodeCov summary near the GitHub PR status box so the coverage information isn't buried like this https://github.com/knative/serving/pull/9471 
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
