### PR TITLE
Update autoscaler CM example block for max-scale-limit

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -20,7 +20,11 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
+<<<<<<< HEAD
     knative.dev/example-checksum: "b48f6747"
+=======
+    knative.dev/example-checksum: "65ad2138"
+>>>>>>> 71b0f2319... Update autoscaler CM example block for max-scale-limit
 data:
   _example: |
     ################################
@@ -194,3 +198,9 @@ data:
     # more requests come in within the scale down delay period.
     # The default, 0s, imposes no delay at all.
     scale-down-delay: "0s"
+
+    # max-scale-limit ensures that both cluster-wide flag max-scale and per-revision
+    # annotation "autoscaling.knative.dev/maxScale" for new revision will not exceed
+    # this number. If max-scale-limit is greater than 0, it disables both explicitly
+    # setting "autoscaling.knative.dev/maxScale" annotation to 0 and leaving it unset.
+    max-scale-limit: "0"

--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "fa417a48"
+    knative.dev/example-checksum: "12baeac1"
 data:
   _example: |
     ################################

--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -20,11 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-<<<<<<< HEAD
-    knative.dev/example-checksum: "b48f6747"
-=======
-    knative.dev/example-checksum: "65ad2138"
->>>>>>> 71b0f2319... Update autoscaler CM example block for max-scale-limit
+    knative.dev/example-checksum: "fa417a48"
 data:
   _example: |
     ################################
@@ -199,8 +195,8 @@ data:
     # The default, 0s, imposes no delay at all.
     scale-down-delay: "0s"
 
-    # max-scale-limit ensures that both cluster-wide flag max-scale and per-revision
-    # annotation "autoscaling.knative.dev/maxScale" for new revision will not exceed
-    # this number. If max-scale-limit is greater than 0, it disables both explicitly
-    # setting "autoscaling.knative.dev/maxScale" annotation to 0 and leaving it unset.
+    # max-scale-limit sets the maximum permitted value for the max scale of a revision.
+    # When this is set to a positive value, a revision with a maxScale above that value
+    # (including a maxScale of "0" = unlimited) is disallowed.
+    # A value of zero (the default) allows any limit, including unlimited.
     max-scale-limit: "0"


### PR DESCRIPTION
Part of knative/serving#8628
/hold for #9496

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
Update autoscaler CM example block for max-scale-limit

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adding cluster-wide flag max-scale-limit. This ensures that both cluster-wide flag max-scale and per-revision annotation "autoscaling.knative.dev/maxScale" for new revision will not exceed this number.
```
/assign @markusthoemmes @vagababov @julz