### PR TITLE
Increase the timeout to ensure the test passes on prow

### DIFF
--- a/pkg/queue/handler_test.go
+++ b/pkg/queue/handler_test.go
@@ -53,7 +53,7 @@ func TestHandlerBreakerQueueFull(t *testing.T) {
 
 	h := ProxyHandler(breaker, stats, false /*tracingEnabled*/, blockHandler)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
 	t.Cleanup(cancel)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:8081/time", nil)
 	if err != nil {


### PR DESCRIPTION
An example here: https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_serving/9565/pull-knative-serving-unit-tests/1309541527130738690
Obviously it took more than 500s to schedule 2 go routines on prow :/

/assign @julz 