### PR TITLE
/var/log volume mounts can now be toggled with a feature flag

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "6a69cdef"
+    knative.dev/example-checksum: "81b553d8"
 data:
   _example: |
     ################################
@@ -111,3 +111,8 @@ data:
     # 1. Enabled: enabling tag header based routing
     # 2. Disabled: disabling tag header based routing
     tag-header-based-routing: "disabled"
+
+    # This feature flags allows users to opt-out of the runtime /var/log mount
+    # requirement in the runtime contract
+    #
+    runtime.v1.var-log-volume: "enabled"

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -112,7 +112,6 @@ data:
     # 2. Disabled: disabling tag header based routing
     tag-header-based-routing: "disabled"
 
-    # This feature flags allows users to opt-out of the runtime /var/log mount
+    # This feature flag allows users to opt-out of the runtime /var/log mount
     # requirement in the runtime contract
-    #
     runtime.v1.var-log-volume: "enabled"

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "81b553d8"
+    knative.dev/example-checksum: "9914482a"
 data:
   _example: |
     ################################

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -50,6 +50,7 @@ func defaultFeaturesConfig() *Features {
 		PodSpecTolerations:      Disabled,
 		ResponsiveRevisionGC:    Allowed,
 		TagHeaderBasedRouting:   Disabled,
+		RuntimeV1VarLogVolume:   Enabled,
 	}
 }
 
@@ -67,6 +68,7 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 		asFlag("kubernetes.podspec-securitycontext", &nc.PodSpecSecurityContext),
 		asFlag("kubernetes.podspec-tolerations", &nc.PodSpecTolerations),
 		asFlag("responsive-revision-gc", &nc.ResponsiveRevisionGC),
+		asFlag("runtime.v1.var-log-volume", &nc.RuntimeV1VarLogVolume),
 		asFlag("tag-header-based-routing", &nc.TagHeaderBasedRouting)); err != nil {
 		return nil, err
 	}
@@ -90,6 +92,7 @@ type Features struct {
 	PodSpecTolerations      Flag
 	ResponsiveRevisionGC    Flag
 	TagHeaderBasedRouting   Flag
+	RuntimeV1VarLogVolume   Flag
 }
 
 // asFlag parses the value at key as a Flag into the target, if it exists.

--- a/pkg/apis/config/features_test.go
+++ b/pkg/apis/config/features_test.go
@@ -68,6 +68,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 			PodSpecTolerations:      Enabled,
 			ResponsiveRevisionGC:    Enabled,
 			TagHeaderBasedRouting:   Enabled,
+			RuntimeV1VarLogVolume:   Enabled,
 		}),
 		data: map[string]string{
 			"multi-container":                     "Enabled",
@@ -79,6 +80,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 			"kubernetes.podspec-tolerations":      "Enabled",
 			"responsive-revision-gc":              "Enabled",
 			"tag-header-based-routing":            "Enabled",
+			"runtime.v1.var-log-volume":           "Enabled",
 		},
 	}, {
 		name:    "multi-container Allowed",
@@ -295,6 +297,22 @@ func TestFeaturesConfiguration(t *testing.T) {
 		}),
 		data: map[string]string{
 			"tag-header-based-routing": "Enabled",
+		},
+	}, {
+		name: "runtime.v1.var-log-volume disabled",
+		wantFeatures: defaultWith(&Features{
+			RuntimeV1VarLogVolume: Disabled,
+		}),
+		data: map[string]string{
+			"runtime.v1.var-log-volume": "Disabled",
+		},
+	}, {
+		name: "runtime.v1.var-log-volume allowed",
+		wantFeatures: defaultWith(&Features{
+			RuntimeV1VarLogVolume: Allowed,
+		}),
+		data: map[string]string{
+			"runtime.v1.var-log-volume": "Allowed",
 		},
 	}}
 

--- a/pkg/reconciler/revision/config/store.go
+++ b/pkg/reconciler/revision/config/store.go
@@ -19,14 +19,14 @@ package config
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
 	pkgtracing "knative.dev/pkg/tracing/config"
 	"knative.dev/serving/pkg/apis/config"
-	asconfig "knative.dev/serving/pkg/autoscaler/config"
-	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
 	"knative.dev/serving/pkg/deployment"
 )
 
@@ -35,13 +35,12 @@ type cfgKey struct{}
 // +k8s:deepcopy-gen=false
 // Config contains the configmaps requires for revision reconciliation.
 type Config struct {
-	Defaults      *config.Defaults
+	*config.Config
 	Deployment    *deployment.Config
 	Logging       *logging.Config
 	Network       *network.Config
 	Observability *metrics.ObservabilityConfig
 	Tracing       *pkgtracing.Config
-	Autoscaler    *autoscalerconfig.Config
 }
 
 // FromContext loads the configuration from the context.
@@ -60,6 +59,14 @@ type Store struct {
 	apiStore *config.Store
 }
 
+var configs = sets.NewString(
+	deployment.ConfigName,
+	logging.ConfigMapName(),
+	metrics.ConfigMapName(),
+	network.ConfigName,
+	pkgtracing.ConfigName,
+)
+
 // NewStore creates a new store of Configs and optionally calls functions when ConfigMaps are updated for Revisions
 func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value interface{})) *Store {
 	store := &Store{
@@ -67,13 +74,11 @@ func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value i
 			"revision",
 			logger,
 			configmap.Constructors{
-				asconfig.ConfigName:       asconfig.NewConfigFromConfigMap,
-				config.DefaultsConfigName: config.NewDefaultsConfigFromConfigMap,
-				deployment.ConfigName:     deployment.NewConfigFromConfigMap,
-				logging.ConfigMapName():   logging.NewConfigFromConfigMap,
-				metrics.ConfigMapName():   metrics.NewObservabilityConfigFromConfigMap,
-				network.ConfigName:        network.NewConfigFromConfigMap,
-				pkgtracing.ConfigName:     pkgtracing.NewTracingConfigFromConfigMap,
+				deployment.ConfigName:   deployment.NewConfigFromConfigMap,
+				logging.ConfigMapName(): logging.NewConfigFromConfigMap,
+				metrics.ConfigMapName(): metrics.NewObservabilityConfigFromConfigMap,
+				network.ConfigName:      network.NewConfigFromConfigMap,
+				pkgtracing.ConfigName:   pkgtracing.NewTracingConfigFromConfigMap,
 			},
 			onAfterStore...,
 		),
@@ -87,6 +92,15 @@ func (s *Store) WatchConfigs(cmw configmap.Watcher) {
 	s.apiStore.WatchConfigs(cmw)
 }
 
+func (s *Store) OnConfigChanged(c *corev1.ConfigMap) {
+	if configs.Has(c.Name) {
+		s.UntypedStore.OnConfigChanged(c)
+		return
+	}
+
+	s.apiStore.OnConfigChanged(c)
+}
+
 // ToContext persists the config on the context.
 func (s *Store) ToContext(ctx context.Context) context.Context {
 	return s.apiStore.ToContext(ToContext(ctx, s.Load()))
@@ -94,11 +108,10 @@ func (s *Store) ToContext(ctx context.Context) context.Context {
 
 // Load returns the config from the store.
 func (s *Store) Load() *Config {
-	cfg := &Config{}
-
-	if def, ok := s.UntypedLoad(config.DefaultsConfigName).(*config.Defaults); ok {
-		cfg.Defaults = def.DeepCopy()
+	cfg := &Config{
+		Config: s.apiStore.Load(),
 	}
+
 	if dep, ok := s.UntypedLoad(deployment.ConfigName).(*deployment.Config); ok {
 		cfg.Deployment = dep.DeepCopy()
 	}
@@ -113,9 +126,6 @@ func (s *Store) Load() *Config {
 	}
 	if tr, ok := s.UntypedLoad(pkgtracing.ConfigName).(*pkgtracing.Config); ok {
 		cfg.Tracing = tr.DeepCopy()
-	}
-	if as, ok := s.UntypedLoad(asconfig.ConfigName).(*autoscalerconfig.Config); ok {
-		cfg.Autoscaler = as.DeepCopy()
 	}
 
 	return cfg

--- a/pkg/reconciler/revision/config/store.go
+++ b/pkg/reconciler/revision/config/store.go
@@ -92,6 +92,8 @@ func (s *Store) WatchConfigs(cmw configmap.Watcher) {
 	s.apiStore.WatchConfigs(cmw)
 }
 
+// OnConfigChanged will invoked the appropriate constructor
+// associated with a config
 func (s *Store) OnConfigChanged(c *corev1.ConfigMap) {
 	if configs.Has(c.Name) {
 		s.UntypedStore.OnConfigChanged(c)

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -39,6 +39,7 @@ func (c *Reconciler) createDeployment(ctx context.Context, rev *v1.Revision) (*a
 
 	deployment, err := resources.MakeDeployment(
 		rev,
+		cfgs.Features,
 		cfgs.Logging,
 		cfgs.Tracing,
 		cfgs.Network,
@@ -60,6 +61,7 @@ func (c *Reconciler) checkAndUpdateDeployment(ctx context.Context, rev *v1.Revis
 
 	deployment, err := resources.MakeDeployment(
 		rev,
+		cfgs.Features,
 		cfgs.Logging,
 		cfgs.Tracing,
 		cfgs.Network,

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -187,7 +187,6 @@ func makeServingContainer(servingContainer corev1.Container, rev *v1.Revision) c
 func BuildPodSpec(rev *v1.Revision, containers []corev1.Container) *corev1.PodSpec {
 	pod := rev.Spec.PodSpec.DeepCopy()
 	pod.Containers = containers
-	pod.Volumes = rev.Spec.Volumes
 	pod.TerminationGracePeriodSeconds = rev.Spec.TimeoutSeconds
 	return pod
 }

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -1,5 +1,4 @@
 /*
-
 Copyright 2018 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -1183,6 +1183,6 @@ func TestVarLogDisabled(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(want, got, quantityComparer); diff != "" {
-		t.Error("MakeDeployment (-want, +got) =", diff)
+		t.Error("makePodSpec (-want, +got) =", diff)
 	}
 }

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -41,6 +41,7 @@ import (
 	"knative.dev/pkg/system"
 	_ "knative.dev/pkg/system/testing"
 	tracingconfig "knative.dev/pkg/tracing/config"
+	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
@@ -72,6 +73,8 @@ var (
 		InitialScale:          1,
 		AllowZeroInitialScale: false,
 	}
+
+	features, _ = config.NewFeaturesConfigFromMap(nil)
 )
 
 const testProbeJSONTemplate = `{"tcpSocket":{"port":%d,"host":"127.0.0.1"}}`

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -746,7 +746,7 @@ func deploy(t *testing.T, namespace, name string, opts ...interface{}) *appsv1.D
 	// Do this here instead of in `rev` itself to ensure that we populate defaults
 	// before calling MakeDeployment within Reconcile.
 	rev.SetDefaults(context.Background())
-	deployment, err := resources.MakeDeployment(rev, cfg.Logging, cfg.Tracing, cfg.Network,
+	deployment, err := resources.MakeDeployment(rev, cfg.Features, cfg.Logging, cfg.Tracing, cfg.Network,
 		cfg.Observability, cfg.Deployment, cfg.Autoscaler)
 	if err != nil {
 		t.Fatal("failed to create deployment")
@@ -807,12 +807,15 @@ func ReconcilerTestConfig() *config.Config {
 		Observability: &metrics.ObservabilityConfig{
 			LoggingURLTemplate: "http://logger.io/${REVISION_UID}",
 		},
-		Logging:  &logging.Config{},
-		Tracing:  &tracingconfig.Config{},
-		Defaults: &defaultconfig.Defaults{},
-		Autoscaler: &autoscalerconfig.Config{
-			InitialScale:          1,
-			AllowZeroInitialScale: false,
+		Logging: &logging.Config{},
+		Tracing: &tracingconfig.Config{},
+		Config: &defaultconfig.Config{
+			Features: &defaultconfig.Features{},
+			Defaults: &defaultconfig.Defaults{},
+			Autoscaler: &autoscalerconfig.Config{
+				InitialScale:          1,
+				AllowZeroInitialScale: false,
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes https://github.com/knative/serving/issues/3809

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Provide a feature flag to disable an empty volume being mounted at /var/log

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
New feature flag 'runtime.v1.var-log-volume' allows operators to disable the /var/log volume mount
```
