### PR TITLE
Add missing t.Helper()

### DIFF
--- a/test/e2e/autotls/util.go
+++ b/test/e2e/autotls/util.go
@@ -35,6 +35,7 @@ type requestOption func(*http.Request)
 type responseExpectation func(response *http.Response) error
 
 func runtimeRequest(t *testing.T, client *http.Client, url string, opts ...requestOption) *types.RuntimeInfo {
+	t.Helper()
 	return runtimeRequestWithExpectations(t, client, url,
 		[]responseExpectation{statusCodeExpectation(sets.NewInt(http.StatusOK))},
 		false,


### PR DESCRIPTION
I noticed lousy error numbering in the logs for: https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-contour-latest/1310560995248181248