### PR TITLE
[DO NOT REVIEW] Route status traffic include all targets until Ingress resolved

### DIFF
--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -169,8 +169,6 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconcil
 		return err
 	}
 
-	logger.Info("All referred targets are routable, marking AllTrafficAssigned with traffic information.")
-	// Domain should already be present
 	if r.Status.Traffic, err = traffic.GetRevisionTrafficTargets(ctx, r); err != nil {
 		return err
 	}
@@ -351,12 +349,17 @@ func (c *Reconciler) configureTraffic(ctx context.Context, r *v1.Route) (*traffi
 		return nil, err
 	}
 
+	logger.Info("All referred targets are routable, marking AllTrafficAssigned with traffic information.")
+
 	mergeTraffic(r, tts)
 	r.Status.MarkTrafficAssigned()
 
 	return t, nil
 }
 
+// mergeTraffic appends all new traffic targets, leaving any old or orphaned targets
+// with a zero percent traffic. These will be removed once ingress is directed to
+// all new targets.
 func mergeTraffic(r *v1.Route, newTraffic []v1.TrafficTarget) {
 	all := make(map[string]v1.TrafficTarget, len(r.Status.Traffic))
 	for _, tt := range r.Status.Traffic {

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -438,7 +438,7 @@ func TestReconcile(t *testing.T) {
 			InduceFailure("create", "ingresses"),
 		},
 		WantCreates: []runtime.Object{
-			//This is the Create we see for the ingress, but we induce a failure.
+			// This is the Create we see for the ingress, but we induce a failure.
 			simpleIngress(
 				Route("default", "ingress-create-failure", WithConfigTarget("config"),
 					WithURL),
@@ -465,16 +465,9 @@ func TestReconcile(t *testing.T) {
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: Route("default", "ingress-create-failure", WithConfigTarget("config"),
-				WithRouteFinalizer, WithRouteGeneration(1),
-				MarkIngressNotConfigured, WithRouteObservedGeneration,
+				WithRouteFinalizer, WithRouteGeneration(1), WithRouteObservedGeneration,
 				// Populated by reconciliation when we fail to create the ingress.
-				WithURL, WithAddress, WithRouteConditionsAutoTLSDisabled,
-				MarkTrafficAssigned, WithStatusTraffic(
-					v1.TrafficTarget{
-						RevisionName:   "config-00001",
-						Percent:        ptr.Int64(100),
-						LatestRevision: ptr.Bool(true),
-					})),
+				WithURL, WithAddress, WithRouteConditionsAutoTLSDisabled, MarkIngressNotConfigured),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "ingress-create-failure"),
@@ -544,9 +537,8 @@ func TestReconcile(t *testing.T) {
 				WithURL, WithAddress, WithRouteConditionsAutoTLSDisabled, WithRouteGeneration(1),
 				MarkTrafficAssigned, MarkIngressReady, WithRouteObservedGeneration, WithRouteFinalizer, WithStatusTraffic(
 					v1.TrafficTarget{
-						RevisionName:   "config-00001",
-						Percent:        ptr.Int64(100),
-						LatestRevision: ptr.Bool(true),
+						RevisionName: "config-00001",
+						Percent:      ptr.Int64(100),
 					}),
 				// The owner is not us, so we are unhappy.
 				MarkServiceNotOwned),
@@ -913,16 +905,6 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			),
-		}},
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: Route("default", "update-ci-failure", WithConfigTarget("config"),
-				WithURL, WithAddress, WithRouteConditionsAutoTLSDisabled, WithRouteGeneration(1),
-				MarkTrafficAssigned, MarkIngressReady, WithRouteObservedGeneration, WithRouteFinalizer, WithStatusTraffic(
-					v1.TrafficTarget{
-						RevisionName:   "config-00002",
-						Percent:        ptr.Int64(100),
-						LatestRevision: ptr.Bool(true),
-					})),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "InternalError", "failed to update Ingress: inducing failure for update ingresses"),
@@ -2307,13 +2289,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 			Object: Route("default", "becomes-ready", WithConfigTarget("config"),
 				WithRouteUID("12-34"),
 				WithRouteGeneration(1), MarkIngressNotConfigured, WithRouteObservedGeneration,
-				WithAddress, WithInitRouteConditions, WithURL,
-				MarkTrafficAssigned, WithStatusTraffic(
-					v1.TrafficTarget{
-						RevisionName:   "config-00001",
-						Percent:        ptr.Int64(100),
-						LatestRevision: ptr.Bool(true),
-					}), MarkCertificateNotOwned),
+				WithAddress, WithInitRouteConditions, WithURL, MarkCertificateNotOwned),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "becomes-ready"),

--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -127,7 +127,7 @@ function setup_selfsigned_per_namespace_auto_tls() {
 
   # SERVING_NSCERT_YAML is set in build_knative_from_source function
   # when building knative.
-  echo "Intall namespace cert controller: ${SERVING_NSCERT_YAML}"
+  echo "Install namespace cert controller: ${SERVING_NSCERT_YAML}"
   if [[ -z "${SERVING_NSCERT_YAML}" ]]; then
     echo "Error: variable SERVING_NSCERT_YAML is not set."
     exit 1


### PR DESCRIPTION
Issue #9582

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* After traffic targets are ready, add them into status. Then remove the old targets only after Ingress is read.

#### Alternative
* https://github.com/knative/serving/pull/9642 Only update the traffic status _after_ Ingress is ready. This might leave status accurate if Ingress fails.

### Explained
#### The Route Reconciler
Routes are reconciled in phases
1)  Assign traffic targets
**_Look at the Route.Spec traffic, convert Configuration targets to their latest revision
Check that all referenced revisions are Ready
Update Route.Status traffic with the resolved targets_**

2) Create k8s Service & Ingress
    2a) Create a placeholder k8s service
    2b) Create an Ingress object referring to the k8s service
    2c) Update placeholder k8s service with the Ingress reference
**_These steps allow networking to route traffic to the newly assigned routes (potentially with a domain and certificate)_**

3) Keep looping until everything is ready

#### The Race Condition
After Step 1, all revisions are ready and are now marked in status. However they may not yet be accessible until step 2 finishes. For a brief time, the Route.Status has lost all references to the old revisions (even if those are still being routed to) until Ingress is ready.

#### The Labeler & GC
The labeler looks at Route Spec and Status traffic targets and marks all referenced targets as "active". This both allows the autoscaler to know which revisions to scale up and tells the Garbage Collector not to take action on them. In the above situation, the labeler will remove "active" from old revisions before Ingress has finished. The Garbage Collector may even delete these old revisions. If Ingress never becomes ready, the old revisions are deleted and lost from status, and the new revisions aren't truly serving.

#### This Fix
After AllTrafficAssigned in Step 1, this adds in the new traffic targets, but leaves in any old ones (with percentage 0) in status. This means that no references are lost. Only when Ingress succeeds, do we drop the old ones.

The beginning and end state of the Route are the same, but while Ingress is reconciling we are keeping around the old targets so that Route more accurately shows where traffic might be. One thing to consider might be what to do if Ingress fails (should status go back to the old traffic?), but with this we won't lose references in the labeler/autoscaler/gc.