### PR TITLE
Enable golint through golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,6 +19,7 @@ run:
 linters:
   enable:
     - asciicheck
+    - golint
     - gosec
     - prealloc
     - stylecheck
@@ -34,8 +35,19 @@ issues:
         - gosec
         - unparam
 
+    # Ignore "context.Context should be the first parameter of a function" errors in tests.
+    # See: https://github.com/golang/lint/issues/422
+    - path: test
+      text: "context.Context should be the first"
+      linters:
+        - golint
+
     # Allow source and sink receivers in conversion code for clarity.
     - path: _conversion\.go
       text: "ST1016:"
       linters:
         - stylecheck
+    - path: _conversion\.go
+      text: "receiver name"
+      linters:
+        - golint

--- a/pkg/apis/serving/v1alpha1/revision_validation.go
+++ b/pkg/apis/serving/v1alpha1/revision_validation.go
@@ -70,17 +70,17 @@ func (rt *RevisionTemplateSpec) Validate(ctx context.Context) *apis.FieldError {
 
 // VerifyNameChange checks that if a user brought their own name previously that it
 // changes at the appropriate times.
-func (current *RevisionTemplateSpec) VerifyNameChange(ctx context.Context, og *RevisionTemplateSpec) *apis.FieldError {
-	if current.Name == "" {
+func (rt *RevisionTemplateSpec) VerifyNameChange(ctx context.Context, og *RevisionTemplateSpec) *apis.FieldError {
+	if rt.Name == "" {
 		// We only check that Name changes when the DeprecatedRevisionTemplate changes.
 		return nil
 	}
-	if current.Name != og.Name {
+	if rt.Name != og.Name {
 		// The name changed, so we're good.
 		return nil
 	}
 
-	if diff, err := kmp.ShortDiff(og, current); err != nil {
+	if diff, err := kmp.ShortDiff(og, rt); err != nil {
 		return &apis.FieldError{
 			Message: "Failed to diff DeprecatedRevisionTemplate",
 			Paths:   []string{apis.CurrentField},

--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -65,6 +65,7 @@ type autoscaler struct {
 }
 
 // New creates a new instance of default autoscaler implementation.
+// nolint:golint // The reporterContext should explicitly not got first.
 func New(
 	namespace, revision string,
 	metricClient metrics.MetricClient,
@@ -87,6 +88,7 @@ func New(
 		podCounter, deciderSpec, delayer, reporterCtx), nil
 }
 
+// nolint:golint // The reporterContext should explicitly not got first.
 func newAutoscaler(
 	namespace, revision string,
 	metricClient metrics.MetricClient,

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -347,7 +347,7 @@ func (r *errorResolver) Clear(types.NamespacedName) {
 
 func TestResolutionFailed(t *testing.T) {
 	// Unconditionally return this error during resolution.
-	innerError := errors.New("i am the expected error message, hear me ROAR!")
+	innerError := errors.New("i am the expected error message, hear me ROAR")
 	resolver := &errorResolver{cleared: false, err: innerError}
 	ctx, _, _, controller, _ := newTestController(t, nil /*additional CMs*/, func(r *Reconciler) {
 		r.resolver = resolver

--- a/test/clients.go
+++ b/test/clients.go
@@ -24,9 +24,11 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	// Allow E2E to run against a cluster using OpenID.
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
 	netclientset "knative.dev/networking/pkg/client/clientset/versioned"
 	networkingv1alpha1 "knative.dev/networking/pkg/client/clientset/versioned/typed/networking/v1alpha1"
@@ -35,6 +37,9 @@ import (
 	servingv1 "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1"
 	servingv1alpha1 "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1alpha1"
 	servingv1beta1 "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1beta1"
+
+	// Every E2E test requires this, so add it here.
+	_ "knative.dev/pkg/metrics/testing"
 )
 
 // Clients holds instances of interfaces for making requests to Knative Serving.

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -23,6 +23,8 @@ import (
 	"flag"
 
 	network "knative.dev/networking/pkg"
+
+	// Load the generic flags of knative.dev/pkg too.
 	_ "knative.dev/pkg/test"
 )
 

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -36,8 +36,6 @@ import (
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
 	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
-
-	_ "knative.dev/pkg/metrics/testing"
 )
 
 func validateCreatedServiceStatus(clients *test.Clients, names *test.ResourceNames) error {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

I thought `stylecheck` would cover these, but it didn't. I especially like that this forces us to comment on blank imports (I had to look all of the present imports up to find out why and if they are needed).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
