### PR TITLE
Fix race in breaker timeout test

### DIFF
--- a/pkg/queue/handler_test.go
+++ b/pkg/queue/handler_test.go
@@ -60,7 +60,8 @@ func TestHandlerBreakerQueueFull(t *testing.T) {
 		}()
 	}
 
-	// The first we see should've failed.
+	// One of the three requests fails and it should be the first we see since the others
+	// are still held by the resp channel.
 	failure := <-resps
 	if got, want := failure.Code, http.StatusServiceUnavailable; got != want {
 		t.Errorf("Code = %d, want: %d", got, want)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #9611

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

### TestHandlerBreakerTimeout

The test did not properly wait for the request to actually reach the handler before sending the second request, making for an ever so slight chance that the requests would race each other to the handler. This can no longer happen.

Also:
- Reduced the need for concurrency in the test, which simplifies the flow a lot.
- Usage of httptest helpers to avoid unnecessary error handling.

### TestHandlerBreakerQueueFull

This was a little trickier as we can't verify the request's order seeing as only one of three will actually reach the handler. So now we just throw 3 requests at it and verify that only one of them fails as expected.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @julz 
