### PR TITLE
Add network I/O panel

### DIFF
--- a/config/monitoring/metrics/prometheus/100-grafana-dash-knative.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana-dash-knative.yaml
@@ -1009,11 +1009,7 @@ data:
               "min": null,
               "show": false
             }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
+          ]
         },
         {
           "aliasColors": {},
@@ -1022,14 +1018,13 @@ data:
           "dashes": false,
           "datasource": "prometheus",
           "fill": 1,
-          "fillGradient": 0,
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
             "y": 0
           },
-          "id": 5,
+          "id": 3,
           "legend": {
             "avg": false,
             "current": false,
@@ -1043,9 +1038,6 @@ data:
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
-          "options": {
-            "dataLinks": []
-          },
           "percentage": false,
           "pointradius": 5,
           "points": false,
@@ -1056,7 +1048,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$revision.*\", container != \"POD\", container != \"\"}[1m])) by (container)",
+              "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$revision.*\", container != \"POD\", container != \"\"}) by (container)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{container}}",
@@ -1065,9 +1057,8 @@ data:
           ],
           "thresholds": [],
           "timeFrom": null,
-          "timeRegions": [],
           "timeShift": null,
-          "title": "Total CPU Usage",
+          "title": "Total Memory Usage",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -1083,7 +1074,7 @@ data:
           },
           "yaxes": [
             {
-              "format": "s",
+              "format": "decbytes",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -1098,11 +1089,7 @@ data:
               "min": null,
               "show": false
             }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
+          ]
         },
         {
           "aliasColors": {},
@@ -1119,7 +1106,7 @@ data:
             "x": 0,
             "y": 9
           },
-          "id": 3,
+          "id": 4,
           "legend": {
             "avg": false,
             "current": false,
@@ -1145,7 +1132,7 @@ data:
           "stack": false,
           "steppedLine": false,
           "targets": [
-            {
+           {
               "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$deployment.*\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 1,
@@ -1181,9 +1168,9 @@ data:
               "format": "decbytes",
               "label": null,
               "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
+                  "max": null,
+                  "min": null,
+                  "show": true
             },
             {
               "format": "short",
@@ -1195,8 +1182,8 @@ data:
             }
           ],
           "yaxis": {
-            "align": false,
-            "alignLevel": null
+                "align": false,
+                "alignLevel": null
           }
         },
         {
@@ -1214,7 +1201,7 @@ data:
             "x": 12,
             "y": 9
           },
-          "id": 4,
+          "id": 5,
           "legend": {
             "avg": false,
             "current": false,
@@ -1248,7 +1235,9 @@ data:
               "refId": "A"
             },
             {
-              "expr": "sum(rate(container_network_receive_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$deployment.*\"}[1m]))",
+              "expr": "sum(rate(container_network_transmit_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$deployment.*\"}[1m]))",
+              "format": "time_series",
+              "instant": false,
               "legendFormat": "{{transmit errors}}",
               "refId": "B"
             }
@@ -1273,11 +1262,11 @@ data:
           },
           "yaxes": [
             {
-              "format": "s",
-              "label": null,
+              "format": "none",
+              "label": "",
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -1371,10 +1360,10 @@ data:
             "multi": false,
             "name": "deployment",
             "query": "label_values(kube_deployment_labels{label_serving_knative_dev_configuration=~\"$configuration\", label_serving_knative_dev_revision=\"$revision\", namespace=\"$namespace\"}, deployment)",
-            "refresh": 0,
+            "refresh": 2,
             "regex": "",
             "skipUrlSync": false,
-            "sort": 0,
+            "sort": 2,
             "tagValuesQuery": "",
             "tags": [],
             "tagsQuery": "",

--- a/config/monitoring/metrics/prometheus/100-grafana-dash-knative.yaml
+++ b/config/monitoring/metrics/prometheus/100-grafana-dash-knative.yaml
@@ -1009,7 +1009,11 @@ data:
               "min": null,
               "show": false
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "aliasColors": {},
@@ -1018,11 +1022,102 @@ data:
           "dashes": false,
           "datasource": "prometheus",
           "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
             "y": 0
+          },
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$revision.*\", container != \"POD\", container != \"\"}[1m])) by (container)",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{container}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total CPU Usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "description": "Network I/O at the pod level",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 9
           },
           "id": 3,
           "legend": {
@@ -1038,6 +1133,9 @@ data:
           "linewidth": 1,
           "links": [],
           "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
           "percentage": false,
           "pointradius": 5,
           "points": false,
@@ -1048,17 +1146,23 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(container_memory_usage_bytes{namespace=\"$namespace\", pod=~\"$revision.*\", container != \"POD\", container != \"\"}) by (container)",
+              "expr": "sum(rate(container_network_receive_bytes_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$deployment.*\"}[1m]))",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "{{container}}",
+              "legendFormat": "{{received bytes}}",
               "refId": "A"
+            },
+            {
+              "expr": "sum(rate(container_network_transmit_bytes_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$deployment.*\"}[1m]))",
+              "legendFormat": "{{transmitted bytes}}",
+              "refId": "B"
             }
           ],
           "thresholds": [],
           "timeFrom": null,
+          "timeRegions": [],
           "timeShift": null,
-          "title": "Total Memory Usage",
+          "title": "Total Network I/O ",
           "tooltip": {
             "shared": true,
             "sort": 2,
@@ -1089,7 +1193,106 @@ data:
               "min": null,
               "show": false
             }
-          ]
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "prometheus",
+          "description": "Network I/O errors ",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 9
+          },
+          "id": 4,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(container_network_receive_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$deployment.*\"}[1m]))",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{receive errors}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(container_network_receive_errors_total{namespace=\"$namespace\", container=\"POD\", name=~\"k8s_POD_$deployment.*\"}[1m]))",
+              "legendFormat": "{{transmit errors}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Total Network Errors",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         }
       ],
       "refresh": "5s",
@@ -1152,6 +1355,26 @@ data:
             "refresh": 2,
             "regex": "",
             "sort": 2,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "datasource": "prometheus",
+            "definition": "label_values(kube_deployment_labels{label_serving_knative_dev_configuration=~\"$configuration\", label_serving_knative_dev_revision=\"$revision\", namespace=\"$namespace\"}, deployment)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "deployment",
+            "multi": false,
+            "name": "deployment",
+            "query": "label_values(kube_deployment_labels{label_serving_knative_dev_configuration=~\"$configuration\", label_serving_knative_dev_revision=\"$revision\", namespace=\"$namespace\"}, deployment)",
+            "refresh": 0,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
             "tagValuesQuery": "",
             "tags": [],
             "tagsQuery": "",


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds support for net i/o metrics visualization in ksvc resource grafana dashboard (this is at the pod level).
* Introduces a deployment variable to be used when filtering container metrics.
* Metrics per ksvc are as follows:
> container_network_receive_bytes_total{namespace="default"}
```

Element | Value
-- | --
container_network_receive_bytes_total{beta_kubernetes_io_arch="amd64",beta_kubernetes_io_os="linux",container="POD",id="/docker/3883be48d7c42516e7f4e459de99236a6bb58d1baca9b4fdcced48c16b4d2281/kubepods/burstable/pod00182cae-c5c9-411a-bd60-c8e9f9727fd7/fb8d8cf0f99b099597192b8ec4a9d0d33aec221ddbf882234db493d8cb6daaa1",image="k8s.gcr.io/pause:3.2",instance="minikube",interface="eth0",job="kubernetes-cadvisor",kubernetes_io_arch="amd64",kubernetes_io_hostname="minikube",kubernetes_io_os="linux",minikube_k8s_io_commit="0c5e9de4ca6f9c55147ae7f90af97eff5befef5f-dirty",minikube_k8s_io_name="minikube",minikube_k8s_io_updated_at="2020_09_29T16_26_06_0700",minikube_k8s_io_version="v1.13.0",name="k8s_POD_event-display-8flrt-deployment-7c8fbb99b4-dwqhs_default_00182cae-c5c9-411a-bd60-c8e9f9727fd7_0",namespace="default",pod="event-display-8flrt-deployment-7c8fbb99b4-dwqhs"} | 819882
container_network_receive_bytes_total{beta_kubernetes_io_arch="amd64",beta_kubernetes_io_os="linux",container="POD",id="/kubepods/burstable/pod00182cae-c5c9-411a-bd60-c8e9f9727fd7/fb8d8cf0f99b099597192b8ec4a9d0d33aec221ddbf882234db493d8cb6daaa1",image="k8s.gcr.io/pause:3.2",instance="minikube",interface="eth0",job="kubernetes-cadvisor",kubernetes_io_arch="amd64",kubernetes_io_hostname="minikube",kubernetes_io_os="linux",minikube_k8s_io_commit="0c5e9de4ca6f9c55147ae7f90af97eff5befef5f-dirty",minikube_k8s_io_name="minikube",minikube_k8s_io_updated_at="2020_09_29T16_26_06_0700",minikube_k8s_io_version="v1.13.0",name="k8s_POD_event-display-8flrt-deployment-7c8fbb99b4-dwqhs_default_00182cae-c5c9-411a-bd60-c8e9f9727fd7_0",namespace="default",pod="event-display-8flrt-deployment-7c8fbb99b4-dwqhs"} | 819553
```

It uses the sum over these metrics.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
Dashboard:

![image](https://user-images.githubusercontent.com/7945591/95207242-53898900-07f0-11eb-85c9-8c0a8dedb11a.png)


/cc @nak3 @markusthoemmes 