### PR TITLE
Drop unneeded error from RevisionContext

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -188,10 +188,7 @@ func uniScalerFactoryFunc(podLister corev1listers.PodLister,
 		serviceName := decider.Labels[serving.ServiceLabelKey] // This can be empty.
 
 		// Create a stats reporter which tags statistics by PA namespace, configuration name, and PA name.
-		ctx, err := smetrics.RevisionContext(decider.Namespace, serviceName, configName, revisionName)
-		if err != nil {
-			return nil, err
-		}
+		ctx := smetrics.RevisionContext(decider.Namespace, serviceName, configName, revisionName)
 
 		podAccessor := resources.NewPodAccessor(podLister, decider.Namespace, revisionName)
 		return scaling.New(ctx, decider.Namespace, decider.Name, metricClient,

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -183,10 +183,7 @@ func newServiceScraperWithClient(
 	svcName := metric.Labels[serving.ServiceLabelKey]
 	cfgName := metric.Labels[serving.ConfigurationLabelKey]
 
-	ctx, err := metrics.RevisionContext(metric.ObjectMeta.Namespace, svcName, cfgName, revName)
-	if err != nil {
-		return nil, err
-	}
+	ctx := metrics.RevisionContext(metric.ObjectMeta.Namespace, svcName, cfgName, revName)
 
 	return &serviceScraper{
 		directClient:    directClient,

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -629,10 +629,7 @@ func newTestAutoscalerWithScalingMetric(t *testing.T, targetValue, targetBurstCa
 	if startInPanic {
 		pc.readyCount = 2
 	}
-	ctx, err := smetrics.RevisionContext(testNamespace, "testSvc", "testConfig", testRevision)
-	if err != nil {
-		t.Fatal("Error creating context:", err)
-	}
+	ctx := smetrics.RevisionContext(testNamespace, "testSvc", "testConfig", testRevision)
 	return newAutoscaler(ctx, testNamespace, testRevision, metrics, pc, deciderSpec, nil), pc
 }
 

--- a/pkg/metrics/tags.go
+++ b/pkg/metrics/tags.go
@@ -56,7 +56,7 @@ func valueOrUnknown(v string) string {
 
 // RevisionContext generates a new base metric reporting context containing
 // the respective revision specific tags.
-func RevisionContext(ns, svc, cfg, rev string) (context.Context, error) {
+func RevisionContext(ns, svc, cfg, rev string) context.Context {
 	key := types.NamespacedName{Namespace: ns, Name: rev}
 	ctx, ok := contextCache.Get(key)
 	if !ok {
@@ -64,7 +64,7 @@ func RevisionContext(ns, svc, cfg, rev string) (context.Context, error) {
 		contextCache.Add(key, rctx)
 		ctx = rctx
 	}
-	return ctx.(context.Context), nil
+	return ctx.(context.Context)
 }
 
 type podCtx struct {

--- a/pkg/metrics/tags_test.go
+++ b/pkg/metrics/tags_test.go
@@ -89,7 +89,7 @@ func TestContexts(t *testing.T) {
 		},
 	}, {
 		name: "revision context",
-		ctx: mustCtx(t, func() (context.Context, error) {
+		ctx: purge(t, func() context.Context {
 			return RevisionContext("testns", "testsvc", "testcfg", "testrev")
 		}),
 		wantTags: map[string]string{},
@@ -104,7 +104,7 @@ func TestContexts(t *testing.T) {
 		},
 	}, {
 		name: "revision context (empty svc)",
-		ctx: mustCtx(t, func() (context.Context, error) {
+		ctx: purge(t, func() context.Context {
 			return RevisionContext("testns", "", "testcfg", "testrev")
 		}),
 		wantTags: map[string]string{},
@@ -262,5 +262,15 @@ func mustCtx(t *testing.T, f func() (context.Context, error)) context.Context {
 	if err != nil {
 		t.Fatal("Failed to create a new context:", err)
 	}
+	return ctx
+}
+
+func purge(t *testing.T, f func() context.Context) context.Context {
+	t.Helper()
+
+	// Force a way around the cache.
+	contextCache.Purge()
+
+	ctx := f()
 	return ctx
 }

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -205,10 +205,7 @@ func reportMetrics(pa *pav1alpha1.PodAutoscaler, pc podCounts) error {
 	serviceLabel := pa.Labels[serving.ServiceLabelKey] // This might be empty.
 	configLabel := pa.Labels[serving.ConfigurationLabelKey]
 
-	ctx, err := metrics.RevisionContext(pa.Namespace, serviceLabel, configLabel, pa.Name)
-	if err != nil {
-		return err
-	}
+	ctx := metrics.RevisionContext(pa.Namespace, serviceLabel, configLabel, pa.Name)
 
 	stats := []stats.Measurement{
 		actualPodCountM.M(int64(pc.ready)), notReadyPodCountM.M(int64(pc.notReady)),


### PR DESCRIPTION
`RevisionContext()` can't actually error, so remove it from the method signature so we can drop all the checks for the impossible error.

/assign @markusthoemmes @vagababov 