### PR TITLE
Remove nil-checks that can't ever happen

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -208,7 +208,7 @@ func statsScraperFactoryFunc(podLister corev1listers.PodLister) asmetrics.StatsS
 		}
 
 		podAccessor := resources.NewPodAccessor(podLister, metric.Namespace, revisionName)
-		return asmetrics.NewStatsScraper(metric, podAccessor, logger)
+		return asmetrics.NewStatsScraper(metric, revisionName, podAccessor, logger), nil
 	}
 }
 

--- a/pkg/autoscaler/metrics/http_scrape_client.go
+++ b/pkg/autoscaler/metrics/http_scrape_client.go
@@ -40,14 +40,10 @@ var pool = sync.Pool{
 	},
 }
 
-func newHTTPScrapeClient(httpClient *http.Client) (*httpScrapeClient, error) {
-	if httpClient == nil {
-		return nil, errors.New("HTTP client must not be nil")
-	}
-
+func newHTTPScrapeClient(httpClient *http.Client) *httpScrapeClient {
 	return &httpScrapeClient{
 		httpClient: httpClient,
-	}, nil
+	}
 }
 
 func (c *httpScrapeClient) Scrape(ctx context.Context, url string) (Stat, error) {

--- a/pkg/autoscaler/metrics/http_scrape_client_test.go
+++ b/pkg/autoscaler/metrics/http_scrape_client_test.go
@@ -52,37 +52,9 @@ var (
 	}
 )
 
-func TestNewHTTPScrapeClientErrorCases(t *testing.T) {
-	testCases := []struct {
-		name        string
-		client      *http.Client
-		expectedErr string
-	}{{
-		name:        "Empty HTTP client",
-		expectedErr: "HTTP client must not be nil",
-	}}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			if _, err := newHTTPScrapeClient(test.client); err != nil {
-				got := err.Error()
-				want := test.expectedErr
-				if got != want {
-					t.Errorf("Got error message: %v. Want: %v", got, want)
-				}
-			} else {
-				t.Error("Expected error from newHTTPScrapeClient, got nil")
-			}
-		})
-	}
-}
-
 func TestHTTPScrapeClientScrapeHappyCaseWithOptionals(t *testing.T) {
 	hClient := newTestHTTPClient(makeProtoResponse(http.StatusOK, stat, network.ProtoAcceptContent), nil)
-	sClient, err := newHTTPScrapeClient(hClient)
-	if err != nil {
-		t.Fatalf("newHTTPScrapeClient = %v, want no error", err)
-	}
+	sClient := newHTTPScrapeClient(hClient)
 	got, err := sClient.Scrape(context.Background(), testURL)
 	if err != nil {
 		t.Fatalf("Scrape = %v, want no error", err)
@@ -119,11 +91,8 @@ func TestHTTPScrapeClientScrapeProtoErrorCases(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			hClient := newTestHTTPClient(makeProtoResponse(test.responseCode, test.stat, test.responseType), test.responseErr)
-			sClient, err := newHTTPScrapeClient(hClient)
-			if err != nil {
-				t.Fatalf("newHTTPScrapeClient=%v, want no error", err)
-			}
-			_, err = sClient.Scrape(context.Background(), testURL)
+			sClient := newHTTPScrapeClient(hClient)
+			_, err := sClient.Scrape(context.Background(), testURL)
 			if err == nil {
 				t.Fatal("Got no error")
 			}

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -155,35 +155,23 @@ type serviceScraper struct {
 
 // NewStatsScraper creates a new StatsScraper for the Revision which
 // the given Metric is responsible for.
-func NewStatsScraper(metric *av1alpha1.Metric, podAccessor resources.PodAccessor,
-	logger *zap.SugaredLogger) (StatsScraper, error) {
-	directClient, err := newHTTPScrapeClient(client)
-	if err != nil {
-		return nil, err
-	}
-	meshClient, err := newHTTPScrapeClient(noKeepaliveClient)
-	if err != nil {
-		return nil, err
-	}
-	return newServiceScraperWithClient(metric, podAccessor, directClient, meshClient, logger)
+func NewStatsScraper(metric *av1alpha1.Metric, revisionName string, podAccessor resources.PodAccessor,
+	logger *zap.SugaredLogger) StatsScraper {
+	directClient := newHTTPScrapeClient(client)
+	meshClient := newHTTPScrapeClient(noKeepaliveClient)
+	return newServiceScraperWithClient(metric, revisionName, podAccessor, directClient, meshClient, logger)
 }
 
 func newServiceScraperWithClient(
 	metric *av1alpha1.Metric,
+	revisionName string,
 	podAccessor resources.PodAccessor,
 	directClient, meshClient scrapeClient,
-	logger *zap.SugaredLogger) (*serviceScraper, error) {
-	if metric == nil {
-		return nil, errors.New("metric must not be nil")
-	}
-	revName := metric.Labels[serving.RevisionLabelKey]
-	if revName == "" {
-		return nil, errors.New("no Revision label found for Metric " + metric.Name)
-	}
+	logger *zap.SugaredLogger) *serviceScraper {
 	svcName := metric.Labels[serving.ServiceLabelKey]
 	cfgName := metric.Labels[serving.ConfigurationLabelKey]
 
-	ctx := metrics.RevisionContext(metric.ObjectMeta.Namespace, svcName, cfgName, revName)
+	ctx := metrics.RevisionContext(metric.ObjectMeta.Namespace, svcName, cfgName, revisionName)
 
 	return &serviceScraper{
 		directClient:    directClient,
@@ -193,7 +181,7 @@ func newServiceScraperWithClient(
 		podsAddressable: true,
 		statsCtx:        ctx,
 		logger:          logger,
-	}, nil
+	}
 }
 
 var portAndPath = strconv.Itoa(networking.AutoscalingQueueMetricsPort) + "/metrics"

--- a/pkg/autoscaler/metrics/stats_scraper_test.go
+++ b/pkg/autoscaler/metrics/stats_scraper_test.go
@@ -98,10 +98,7 @@ func TestNewServiceScraperWithClientHappyCase(t *testing.T) {
 	accessor := resources.NewPodAccessor(
 		fakepodsinformer.Get(ctx).Lister(),
 		testNamespace, testRevision)
-	sc, err := NewStatsScraper(metric, accessor, logtesting.TestLogger(t))
-	if err != nil {
-		t.Fatal("NewServiceScraper =", err)
-	}
+	sc := NewStatsScraper(metric, testRevision, accessor, logtesting.TestLogger(t))
 	if svcS, want := sc.(*serviceScraper), urlFromTarget(testRevision+"-zhudex", testNamespace); svcS.url != want {
 		t.Errorf("scraper.url = %s, want: %s", svcS.url, want)
 	}
@@ -131,53 +128,6 @@ func checkBaseStat(t *testing.T, got Stat) {
 	}
 }
 
-func TestNewServiceScraperWithClientErrorCases(t *testing.T) {
-	invalidMetric := testMetric()
-	invalidMetric.Labels = map[string]string{}
-	client := newTestScrapeClient(testStats, []error{nil})
-	ctx, cancel, _ := SetupFakeContextWithCancel(t)
-	t.Cleanup(cancel)
-	podAccessor := resources.NewPodAccessor(
-		fakepodsinformer.Get(ctx).Lister(),
-		testNamespace, testRevision)
-	logger := logtesting.TestLogger(t)
-
-	testCases := []struct {
-		name        string
-		metric      *av1alpha1.Metric
-		client      scrapeClient
-		counter     resources.EndpointsCounter
-		accessor    resources.PodAccessor
-		expectedErr string
-	}{{
-		name:        "Empty Decider",
-		client:      client,
-		accessor:    podAccessor,
-		expectedErr: "metric must not be nil",
-	}, {
-		name:        "Missing revision label in Decider",
-		metric:      invalidMetric,
-		client:      client,
-		accessor:    podAccessor,
-		expectedErr: "no Revision label found for Metric " + testRevision,
-	}}
-
-	for _, test := range testCases {
-		t.Run(test.name, func(t *testing.T) {
-			if _, err := newServiceScraperWithClient(test.metric,
-				test.accessor, test.client, test.client, logger); err != nil {
-				got := err.Error()
-				want := test.expectedErr
-				if got != want {
-					t.Errorf("Got error message: %v. Want: %v", got, want)
-				}
-			} else {
-				t.Error("Expected error from CreateNewServiceScraper, got nil")
-			}
-		})
-	}
-}
-
 func TestPodDirectScrapeSuccess(t *testing.T) {
 	ctx, cancel, informers := SetupFakeContextWithCancel(t)
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
@@ -191,10 +141,7 @@ func TestPodDirectScrapeSuccess(t *testing.T) {
 	})
 
 	client := newTestScrapeClient(testStats, []error{nil})
-	scraper, err := serviceScraperForTest(ctx, t, client, nil /* mesh not used */, true)
-	if err != nil {
-		t.Fatal("serviceScraperForTest:", err)
-	}
+	scraper := serviceScraperForTest(ctx, t, client, nil /* mesh not used */, true)
 
 	// No pods at all.
 	if stat, err := scraper.Scrape(defaultMetric.Spec.StableWindow); err != nil {
@@ -228,10 +175,7 @@ func TestPodDirectScrapeSomeFailButSuccess(t *testing.T) {
 	makePods(ctx, "pods-", 5, metav1.Now())
 
 	client := newTestScrapeClient(testStats, []error{nil, nil, errors.New("okay"), nil, nil})
-	scraper, err := serviceScraperForTest(ctx, t, client, nil /* mesh not used */, true)
-	if err != nil {
-		t.Fatal("serviceScraperForTest:", err)
-	}
+	scraper := serviceScraperForTest(ctx, t, client, nil /* mesh not used */, true)
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
@@ -270,10 +214,7 @@ func TestPodDirectScrapeNoneSucceed(t *testing.T) {
 	})
 	makePods(ctx, "pods-", 4, metav1.Now())
 
-	scraper, err := serviceScraperForTest(ctx, t, direct, mesh, true)
-	if err != nil {
-		t.Fatal("serviceScraperForTest:", err)
-	}
+	scraper := serviceScraperForTest(ctx, t, direct, mesh, true)
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
@@ -304,10 +245,7 @@ func TestPodDirectScrapePodsExhausted(t *testing.T) {
 	makePods(ctx, "pods-", 4, metav1.Now())
 
 	client := newTestScrapeClient(testStats, []error{nil, nil, errors.New("okay"), nil})
-	scraper, err := serviceScraperForTest(ctx, t, client, nil /* mesh not used */, true)
-	if err != nil {
-		t.Fatal("serviceScraperForTest:", err)
-	}
+	scraper := serviceScraperForTest(ctx, t, client, nil /* mesh not used */, true)
 	_, err = scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err == nil {
 		t.Fatal("Expected an error")
@@ -333,10 +271,7 @@ func TestScrapeReportStatWhenAllCallsSucceed(t *testing.T) {
 
 	// Scrape will set a timestamp bigger than this.
 	client := newTestScrapeClient(testStats, []error{nil})
-	scraper, err := serviceScraperForTest(ctx, t, client, client, false)
-	if err != nil {
-		t.Fatal("serviceScraperForTest:", err)
-	}
+	scraper := serviceScraperForTest(ctx, t, client, client, false)
 
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
@@ -371,10 +306,7 @@ func TestScrapeAllPodsYoungPods(t *testing.T) {
 	})
 	makePods(ctx, "pods-", numP, metav1.Now())
 
-	scraper, err := serviceScraperForTest(ctx, t, direct, mesh, false)
-	if err != nil {
-		t.Fatalf("serviceScraperForTest=%v, want no error", err)
-	}
+	scraper := serviceScraperForTest(ctx, t, direct, mesh, false)
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
@@ -407,10 +339,7 @@ func TestScrapeAllPodsOldPods(t *testing.T) {
 	makePods(ctx, "pods-", numP, metav1.Now())
 	direct := newTestScrapeClient(testStats, []error{errNoPodsScraped}) // fall back to service scrape
 	mesh := newTestScrapeClient(testStats, []error{nil})
-	scraper, err := serviceScraperForTest(ctx, t, direct, mesh, false)
-	if err != nil {
-		t.Fatalf("serviceScraperForTest=%v, want no error", err)
-	}
+	scraper := serviceScraperForTest(ctx, t, direct, mesh, false)
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
 		t.Fatal("Unexpected error from scraper.Scrape():", err)
@@ -446,10 +375,7 @@ func TestScrapeSomePodsOldPods(t *testing.T) {
 	// Scrape will set a timestamp bigger than this.
 	direct := newTestScrapeClient(testStats, []error{errNoPodsScraped}) // fall back to service scrape
 	mesh := newTestScrapeClient(testStats, []error{nil})
-	scraper, err := serviceScraperForTest(ctx, t, direct, mesh, false)
-	if err != nil {
-		t.Fatalf("serviceScraperForTest=%v, want no error", err)
-	}
+	scraper := serviceScraperForTest(ctx, t, direct, mesh, false)
 
 	got, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
@@ -479,10 +405,7 @@ func TestScrapeReportErrorCannotFindEnoughPods(t *testing.T) {
 	makePods(ctx, "pods-", 2, metav1.Now())
 
 	client := newTestScrapeClient(testStats[2:], []error{nil})
-	scraper, err := serviceScraperForTest(ctx, t, client, client, false)
-	if err != nil {
-		t.Fatalf("serviceScraperForTest=%v, want no error", err)
-	}
+	scraper := serviceScraperForTest(ctx, t, client, client, false)
 
 	_, err = scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err == nil {
@@ -508,10 +431,7 @@ func TestScrapeReportErrorIfAnyFails(t *testing.T) {
 	// 1 success and 10 failures so one scrape fails permanently through retries.
 	client := newTestScrapeClient(testStats, []error{nil, errTest, errTest,
 		errTest, errTest, errTest, errTest, errTest, errTest, errTest, errTest})
-	scraper, err := serviceScraperForTest(ctx, t, client, client, false)
-	if err != nil {
-		t.Fatalf("serviceScraperForTest=%v, want no error", err)
-	}
+	scraper := serviceScraperForTest(ctx, t, client, client, false)
 
 	_, err = scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if !errors.Is(err, errTest) {
@@ -523,10 +443,7 @@ func TestScrapeDoNotScrapeIfNoPodsFound(t *testing.T) {
 	ctx, cancel, _ := SetupFakeContextWithCancel(t)
 	t.Cleanup(cancel)
 	client := newTestScrapeClient(testStats, nil)
-	scraper, err := serviceScraperForTest(ctx, t, client, client, false)
-	if err != nil {
-		t.Fatalf("serviceScraperForTest=%v, want no error", err)
-	}
+	scraper := serviceScraperForTest(ctx, t, client, client, false)
 
 	stat, err := scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
@@ -560,10 +477,7 @@ func TestMixedPodShuffle(t *testing.T) {
 	t.Log("WantScrapes", wantScrapes)
 
 	client := newTestScrapeClient(testStats, []error{nil})
-	scraper, err := serviceScraperForTest(ctx, t, client, client, true)
-	if err != nil {
-		t.Fatalf("serviceScraperForTest=%v, want no error", err)
-	}
+	scraper := serviceScraperForTest(ctx, t, client, client, true)
 
 	_, err = scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
@@ -606,10 +520,7 @@ func TestOldPodShuffle(t *testing.T) {
 	t.Log("WantScrapes", wantScrapes)
 
 	client := newTestScrapeClient(testStats, []error{nil})
-	scraper, err := serviceScraperForTest(ctx, t, client, client, true)
-	if err != nil {
-		t.Fatalf("serviceScraperForTest=%v, want no error", err)
-	}
+	scraper := serviceScraperForTest(ctx, t, client, client, true)
 
 	_, err = scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
@@ -683,10 +594,7 @@ func TestOldPodsFallback(t *testing.T) {
 		}
 		return r
 	}())
-	scraper, err := serviceScraperForTest(ctx, t, client, client, true /*directPodScrapes*/)
-	if err != nil {
-		t.Fatalf("serviceScraperForTest=%v, want no error", err)
-	}
+	scraper := serviceScraperForTest(ctx, t, client, client, true /*directPodScrapes*/)
 
 	_, err = scraper.Scrape(defaultMetric.Spec.StableWindow)
 	if err != nil {
@@ -713,17 +621,15 @@ func TestOldPodsFallback(t *testing.T) {
 	}
 }
 
-func serviceScraperForTest(ctx context.Context, t *testing.T, directClient, meshClient scrapeClient, podsAddressable bool) (*serviceScraper, error) {
+func serviceScraperForTest(ctx context.Context, t *testing.T, directClient, meshClient scrapeClient, podsAddressable bool) *serviceScraper {
 	metric := testMetric()
 	accessor := resources.NewPodAccessor(
 		fakepodsinformer.Get(ctx).Lister(),
 		testNamespace, testRevision)
 	logger := logtesting.TestLogger(t)
-	ss, err := newServiceScraperWithClient(metric, accessor, directClient, meshClient, logger)
-	if ss != nil {
-		ss.podsAddressable = podsAddressable
-	}
-	return ss, err
+	ss := newServiceScraperWithClient(metric, testRevision, accessor, directClient, meshClient, logger)
+	ss.podsAddressable = podsAddressable
+	return ss
 }
 
 func testMetric() *av1alpha1.Metric {


### PR DESCRIPTION
`newHTTPScrapeClient` is private + only used within the package, and we never pass anything to it that could possibly be `nil`, so drop the nil checks and the resulting code to handle impossible error cases.

Also, in the case of the `metric == nil` check, the only place `NewStatsScraper` is called is https://github.com/knative/serving/blob/master/cmd/autoscaler/main.go#L214, but we do [`if metric.Spec.ScrapeTarget == "" {`](https://github.com/knative/serving/blob/master/cmd/autoscaler/main.go#L204) three lines up, so we would already have panicked if metric was ever nil. 

Finally, we already get the RevisionName from the Metric labels in the caller in main.go, so this check is unneeded too if we just pass that in to the constructor.

/assign @vagababov @markusthoemmes 