### PR TITLE
Wait for route terminal conditions to clear annotations

### DIFF
--- a/pkg/reconciler/labeler/labelerv1_test.go
+++ b/pkg/reconciler/labeler/labelerv1_test.go
@@ -224,9 +224,9 @@ func TestV1Reconcile(t *testing.T) {
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchRemoveLabel("default", rev("default", "old-config").Name,
 				"serving.knative.dev/route"),
+			patchRemoveLabel("default", "old-config", "serving.knative.dev/route"),
 			patchAddLabel("default", rev("default", "new-config").Name,
 				"serving.knative.dev/route", "config-change"),
-			patchRemoveLabel("default", "old-config", "serving.knative.dev/route"),
 			patchAddLabel("default", "new-config", "serving.knative.dev/route", "config-change"),
 		},
 		Key: "default/config-change",

--- a/pkg/reconciler/labeler/labelerv2_test.go
+++ b/pkg/reconciler/labeler/labelerv2_test.go
@@ -235,9 +235,9 @@ func TestV2Reconcile(t *testing.T) {
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchRemoveRouteAndServingStateLabel("default", rev("default", "old-config").Name, now.Time),
+			patchRemoveRouteAnn("default", "old-config"),
 			patchAddRouteAndServingStateLabel(
 				"default", rev("default", "new-config").Name, "config-change", now.Time),
-			patchRemoveRouteAnn("default", "old-config"),
 			patchAddRouteAnn("default", "new-config", "config-change"),
 		},
 		Key: "default/config-change",
@@ -391,7 +391,8 @@ func revTraffic(name string, latest bool) v1.TrafficTarget {
 
 func routeWithTraffic(namespace, name string, spec, status v1.TrafficTarget, opts ...RouteOption) *v1.Route {
 	return Route(namespace, name,
-		append([]RouteOption{WithSpecTraffic(spec), WithStatusTraffic(status), WithInitRouteConditions}, opts...)...)
+		append([]RouteOption{WithSpecTraffic(spec), WithStatusTraffic(status), WithInitRouteConditions,
+			MarkTrafficAssigned, MarkCertificateReady, MarkIngressReady, WithRouteObservedGeneration}, opts...)...)
 }
 
 func simpleRunLatest(namespace, name, config string, opts ...RouteOption) *v1.Route {

--- a/pkg/reconciler/labeler/v1/labels.go
+++ b/pkg/reconciler/labeler/v1/labels.go
@@ -83,16 +83,17 @@ func SyncLabels(ctx context.Context, r *v1.Route, cacc *Configuration, racc *Rev
 		}
 	}
 
-	// Use a revision accessor to manipulate the revisions.
-	if err := deleteLabelForNotListed(ctx, r.Namespace, r.Name, racc, revisions); err != nil {
-		return err
-	}
-	if err := setLabelForListed(ctx, r, racc, revisions); err != nil {
-		return err
+	// Clear old labels only after the route is fully resolved
+	if r.IsReady() || r.IsFailed() {
+		if err := deleteLabelForNotListed(ctx, r.Namespace, r.Name, racc, revisions); err != nil {
+			return err
+		}
+		if err := deleteLabelForNotListed(ctx, r.Namespace, r.Name, cacc, configs); err != nil {
+			return err
+		}
 	}
 
-	// Use a config access to manipulate the configs.
-	if err := deleteLabelForNotListed(ctx, r.Namespace, r.Name, cacc, configs); err != nil {
+	if err := setLabelForListed(ctx, r, racc, revisions); err != nil {
 		return err
 	}
 	return setLabelForListed(ctx, r, cacc, configs)

--- a/pkg/reconciler/labeler/v2/metasync.go
+++ b/pkg/reconciler/labeler/v2/metasync.go
@@ -82,6 +82,7 @@ func SyncRoutingMeta(ctx context.Context, r *v1.Route, cacc *Configuration, racc
 		}
 	}
 
+	// Clear old meta only after the route is fully resolved
 	if r.IsReady() || r.IsFailed() {
 		if err := clearMetaForNotListed(ctx, r, racc, revisions); err != nil {
 			return err

--- a/pkg/reconciler/labeler/v2/metasync.go
+++ b/pkg/reconciler/labeler/v2/metasync.go
@@ -82,16 +82,16 @@ func SyncRoutingMeta(ctx context.Context, r *v1.Route, cacc *Configuration, racc
 		}
 	}
 
-	// Use a revision accessor to manipulate the revisions.
-	if err := clearMetaForNotListed(ctx, r, racc, revisions); err != nil {
-		return err
-	}
-	if err := setMetaForListed(ctx, r, racc, revisions); err != nil {
-		return err
+	if r.IsReady() || r.IsFailed() {
+		if err := clearMetaForNotListed(ctx, r, racc, revisions); err != nil {
+			return err
+		}
+		if err := clearMetaForNotListed(ctx, r, cacc, configs); err != nil {
+			return err
+		}
 	}
 
-	// Use a config access to manipulate the configs.
-	if err := clearMetaForNotListed(ctx, r, cacc, configs); err != nil {
+	if err := setMetaForListed(ctx, r, racc, revisions); err != nil {
 		return err
 	}
 	return setMetaForListed(ctx, r, cacc, configs)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Issue https://github.com/knative/serving/issues/9582

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Have the labeler wait for Route to be ready or failed before removing annotations.

### Explained
#### The Route Reconciler
Routes are reconciled in phases
1)  Assign traffic targets
**_Look at the Route.Spec traffic, convert Configuration targets to their latest revision
Check that all referenced revisions are Ready
Update Route.Status traffic with the resolved targets_**

2) Create k8s Service & Ingress
    2a) Create a placeholder k8s service
    2b) Create an Ingress object referring to the k8s service
    2c) Update placeholder k8s service with the Ingress reference
**_These steps allow networking to route traffic to the newly assigned routes (potentially with a domain and certificate)_**

3) Keep looping until everything is ready

#### The Race Condition
After Step 1, all revisions are ready and are now marked in status. However they may not yet be accessible until step 2 finishes. For a brief time, the Route.Status has lost all references to the old revisions (even if those are still being routed to) until Ingress is ready. 

One solution to this problem might look like this: https://github.com/knative/serving/pull/9603
Where we add in the new traffic targets at step 1. and then wait for Ingress to become ready in step 2. Only after Ingress is pointing at the new traffic do we remove the old traffic targets. This way references are never lost (even if ingress fails).

#### The Labeler & GC
The labeler looks at Route Spec and Status traffic targets and marks all referenced targets as "active". This both allows the autoscaler to know which revisions to scale up and tells the Garbage Collector not to take action on them. In the above situation, the labeler will remove "active" from old revisions before Ingress has finished. The Garbage Collector may even delete these old revisions. If Ingress never becomes ready, the old revisions are deleted and lost from status, and the new revisions aren't truly serving.

#### This Mitigation
This fix simply tells the Labeler not to remove the "active" tag until the Route is full reconciled (either Ready=True or Ready=False). While we are in the Unknown state, this race condition may be in effect. This causes the Garbage Collector to wait until Ingress is ready and traffic is routing to the new revisions before collecting the old once.

This is only a partial fix, however, if Ingress fails to become ready we may still end up in a state where the status.traffic is inaccurate and references have been lost (and possibly serving revisions become eligible for GC).