### PR TITLE
Document scale-down-delay in config map example

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "7b6520ae"
+    knative.dev/example-checksum: "b48f6747"
 data:
   _example: |
     ################################
@@ -187,3 +187,10 @@ data:
     # unless overridden by the "autoscaling.knative.dev/maxScale" annotation.
     # If set to 0, the revision has no maximum scale.
     max-scale: "0"
+
+    # scale-down-delay is the amount of time that must pass at reduced
+    # concurrency before a scale down decision is applied. This can be useful,
+    # for example, to maintain replica count and avoid a cold start penalty if
+    # more requests come in within the scale down delay period.
+    # The default, 0s, imposes no delay at all.
+    scale-down-delay: "0s"


### PR DESCRIPTION
subj.

Fixes https://github.com/knative/serving/issues/9092.

/hold for #9568

**Release Note**

```release-note
Adds a Scale Down Delay feature, allowing maintaining replica count for a configurable period after request count drops to avoid cold start penalty.
```

/assign @markusthoemmes @vagababov 