### PR TITLE
Migrate networking constants that are only used in Serving

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	network "knative.dev/networking/pkg"
-	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection/sharedmain"
@@ -60,6 +59,7 @@ import (
 	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
 	pkghttp "knative.dev/serving/pkg/http"
 	"knative.dev/serving/pkg/logging"
+	"knative.dev/serving/pkg/networking"
 )
 
 const (

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	network "knative.dev/networking/pkg"
-	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/injection/sharedmain"
 	pkglogging "knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
@@ -52,6 +51,7 @@ import (
 	pkghttp "knative.dev/serving/pkg/http"
 	"knative.dev/serving/pkg/http/handler"
 	"knative.dev/serving/pkg/logging"
+	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/queue"
 	"knative.dev/serving/pkg/queue/health"
 	"knative.dev/serving/pkg/queue/readiness"

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	network "knative.dev/networking/pkg"
-	commonnet "knative.dev/networking/pkg/apis/networking"
+	pkgnet "knative.dev/networking/pkg/apis/networking"
 	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/controller"
@@ -94,7 +94,7 @@ type revisionWatcher struct {
 	stopCh   <-chan struct{}
 	cancel   context.CancelFunc
 	rev      types.NamespacedName
-	protocol commonnet.ProtocolType
+	protocol pkgnet.ProtocolType
 	updateCh chan<- revisionDestsUpdate
 	done     chan struct{}
 
@@ -113,7 +113,7 @@ type revisionWatcher struct {
 	podsAddressable bool
 }
 
-func newRevisionWatcher(ctx context.Context, rev types.NamespacedName, protocol commonnet.ProtocolType,
+func newRevisionWatcher(ctx context.Context, rev types.NamespacedName, protocol pkgnet.ProtocolType,
 	updateCh chan<- revisionDestsUpdate, destsCh chan dests,
 	transport http.RoundTripper, serviceLister corev1listers.ServiceLister,
 	logger *zap.SugaredLogger) *revisionWatcher {
@@ -440,7 +440,7 @@ func (rbm *revisionBackendsManager) updates() <-chan revisionDestsUpdate {
 	return rbm.updateCh
 }
 
-func (rbm *revisionBackendsManager) getRevisionProtocol(revID types.NamespacedName) (commonnet.ProtocolType, error) {
+func (rbm *revisionBackendsManager) getRevisionProtocol(revID types.NamespacedName) (pkgnet.ProtocolType, error) {
 	revision, err := rbm.revisionLister.Revisions(revID.Namespace).Get(revID.Name)
 	if err != nil {
 		return "", err
@@ -489,7 +489,7 @@ func (rbm *revisionBackendsManager) endpointsUpdated(newObj interface{}) {
 		logger.Errorw("Failed to get revision watcher", zap.Error(err))
 		return
 	}
-	ready, notReady := endpointsToDests(endpoints, commonnet.ServicePortName(rw.protocol))
+	ready, notReady := endpointsToDests(endpoints, pkgnet.ServicePortName(rw.protocol))
 	logger.Debugf("Updating Endpoints: ready backends: %d, not-ready backends: %d", len(ready), len(notReady))
 	select {
 	case <-rbm.ctx.Done():

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	network "knative.dev/networking/pkg"
-	"knative.dev/networking/pkg/apis/networking"
+	commonnet "knative.dev/networking/pkg/apis/networking"
 	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/controller"
@@ -50,6 +50,7 @@ import (
 	"knative.dev/serving/pkg/apis/serving"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
+	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/queue"
 )
 
@@ -93,7 +94,7 @@ type revisionWatcher struct {
 	stopCh   <-chan struct{}
 	cancel   context.CancelFunc
 	rev      types.NamespacedName
-	protocol networking.ProtocolType
+	protocol commonnet.ProtocolType
 	updateCh chan<- revisionDestsUpdate
 	done     chan struct{}
 
@@ -112,7 +113,7 @@ type revisionWatcher struct {
 	podsAddressable bool
 }
 
-func newRevisionWatcher(ctx context.Context, rev types.NamespacedName, protocol networking.ProtocolType,
+func newRevisionWatcher(ctx context.Context, rev types.NamespacedName, protocol commonnet.ProtocolType,
 	updateCh chan<- revisionDestsUpdate, destsCh chan dests,
 	transport http.RoundTripper, serviceLister corev1listers.ServiceLister,
 	logger *zap.SugaredLogger) *revisionWatcher {
@@ -439,7 +440,7 @@ func (rbm *revisionBackendsManager) updates() <-chan revisionDestsUpdate {
 	return rbm.updateCh
 }
 
-func (rbm *revisionBackendsManager) getRevisionProtocol(revID types.NamespacedName) (networking.ProtocolType, error) {
+func (rbm *revisionBackendsManager) getRevisionProtocol(revID types.NamespacedName) (commonnet.ProtocolType, error) {
 	revision, err := rbm.revisionLister.Revisions(revID.Namespace).Get(revID.Name)
 	if err != nil {
 		return "", err
@@ -488,7 +489,7 @@ func (rbm *revisionBackendsManager) endpointsUpdated(newObj interface{}) {
 		logger.Errorw("Failed to get revision watcher", zap.Error(err))
 		return
 	}
-	ready, notReady := endpointsToDests(endpoints, networking.ServicePortName(rw.protocol))
+	ready, notReady := endpointsToDests(endpoints, commonnet.ServicePortName(rw.protocol))
 	logger.Debugf("Updating Endpoints: ready backends: %d, not-ready backends: %d", len(ready), len(notReady))
 	select {
 	case <-rbm.ctx.Done():

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	commonnet "knative.dev/networking/pkg/apis/networking"
+	pkgnet "knative.dev/networking/pkg/apis/networking"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	fakeendpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
 	fakeserviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
@@ -58,11 +58,11 @@ const (
 )
 
 // revisionCC1 - creates a revision with concurrency == 1.
-func revisionCC1(revID types.NamespacedName, protocol commonnet.ProtocolType) *v1.Revision {
+func revisionCC1(revID types.NamespacedName, protocol pkgnet.ProtocolType) *v1.Revision {
 	return revision(revID, protocol, 1)
 }
 
-func revision(revID types.NamespacedName, protocol commonnet.ProtocolType, cc int64) *v1.Revision {
+func revision(revID types.NamespacedName, protocol pkgnet.ProtocolType, cc int64) *v1.Revision {
 	return &v1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: revID.Namespace,
@@ -119,7 +119,7 @@ func TestRevisionWatcher(t *testing.T) {
 	for _, tc := range []struct {
 		name                  string
 		dests                 dests
-		protocol              commonnet.ProtocolType
+		protocol              pkgnet.ProtocolType
 		clusterPort           corev1.ServicePort
 		clusterIP             string
 		expectUpdates         []revisionDestsUpdate
@@ -159,7 +159,7 @@ func TestRevisionWatcher(t *testing.T) {
 	}, {
 		name:     "single http2 podIP",
 		dests:    dests{ready: sets.NewString("128.0.0.1:1234")},
-		protocol: commonnet.ProtocolH2C,
+		protocol: pkgnet.ProtocolH2C,
 		clusterPort: corev1.ServicePort{
 			Name: "http2",
 			Port: 1234,
@@ -178,7 +178,7 @@ func TestRevisionWatcher(t *testing.T) {
 	}, {
 		name:     "single http2 clusterIP",
 		dests:    dests{ready: sets.NewString("128.0.0.1:1234"), notReady: sets.NewString("128.0.0.2:1234")},
-		protocol: commonnet.ProtocolH2C,
+		protocol: pkgnet.ProtocolH2C,
 		clusterPort: corev1.ServicePort{
 			Name: "http2",
 			Port: 1234,
@@ -392,7 +392,7 @@ func TestRevisionWatcher(t *testing.T) {
 
 			// Default for protocol is http1
 			if tc.protocol == "" {
-				tc.protocol = commonnet.ProtocolHTTP1
+				tc.protocol = pkgnet.ProtocolHTTP1
 			}
 
 			fake := fakekubeclient.Get(ctx)
@@ -529,7 +529,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		name:         "add slow healthy",
 		endpointsArr: []*corev1.Endpoints{ep(testRevision, 1234, "http", "128.0.0.1")},
 		revisions: []*v1.Revision{
-			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, pkgnet.ProtocolHTTP1),
 		},
 		services: []*corev1.Service{
 			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, "129.0.0.1",
@@ -557,7 +557,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		name:         "add slow ready http2",
 		endpointsArr: []*corev1.Endpoints{ep(testRevision, 1234, "http2", "128.0.0.1")},
 		revisions: []*v1.Revision{
-			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolH2C),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, pkgnet.ProtocolH2C),
 		},
 		services: []*corev1.Service{
 			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, "129.0.0.1",
@@ -588,8 +588,8 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 			ep("test-revision2", 1235, "http", "128.1.0.2"),
 		},
 		revisions: []*v1.Revision{
-			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: "test-revision1"}, commonnet.ProtocolHTTP1),
-			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: "test-revision2"}, commonnet.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: "test-revision1"}, pkgnet.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: "test-revision2"}, pkgnet.ProtocolHTTP1),
 		},
 		services: []*corev1.Service{
 			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: "test-revision1"}, "129.0.0.1",
@@ -614,7 +614,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		name:         "no pod addressability",
 		endpointsArr: []*corev1.Endpoints{ep(testRevision, 1234, "http", "128.0.0.1")},
 		revisions: []*v1.Revision{
-			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, pkgnet.ProtocolHTTP1),
 		},
 		services: []*corev1.Service{
 			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, "129.0.0.1",
@@ -640,7 +640,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		name:         "unhealthy",
 		endpointsArr: []*corev1.Endpoints{ep(testRevision, 1234, "http", "128.0.0.1")},
 		revisions: []*v1.Revision{
-			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, pkgnet.ProtocolHTTP1),
 		},
 		services: []*corev1.Service{
 			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, "129.0.0.1",
@@ -660,7 +660,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		name:         "unready pod successfully probed",
 		endpointsArr: []*corev1.Endpoints{epNotReady(testRevision, 1234, "http", nil, []string{"128.0.0.1"})},
 		revisions: []*v1.Revision{
-			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, pkgnet.ProtocolHTTP1),
 		},
 		services: []*corev1.Service{
 			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, "129.0.0.1",
@@ -1163,7 +1163,7 @@ func TestRevisionDeleted(t *testing.T) {
 		t.Fatal("Failed to start informers:", err)
 	}
 
-	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1)
+	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, pkgnet.ProtocolHTTP1)
 	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Create(ctx, rev, metav1.CreateOptions{})
 	ri := fakerevisioninformer.Get(ctx)
 	ri.Informer().GetIndexer().Add(rev)
@@ -1205,7 +1205,7 @@ func TestServiceDoesNotExist(t *testing.T) {
 		t.Fatal("Failed to start informers:", err)
 	}
 
-	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1)
+	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, pkgnet.ProtocolHTTP1)
 	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Create(ctx, rev, metav1.CreateOptions{})
 	ri := fakerevisioninformer.Get(ctx)
 	ri.Informer().GetIndexer().Add(rev)
@@ -1255,7 +1255,7 @@ func TestServiceMoreThanOne(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to start informers:", err)
 	}
-	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1)
+	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, pkgnet.ProtocolHTTP1)
 	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Create(ctx, rev, metav1.CreateOptions{})
 	ri := fakerevisioninformer.Get(ctx)
 	ri.Informer().GetIndexer().Add(rev)

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"knative.dev/networking/pkg/apis/networking"
+	commonnet "knative.dev/networking/pkg/apis/networking"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	fakeendpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
 	fakeserviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
@@ -43,6 +43,7 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
+	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/queue"
 
 	. "knative.dev/pkg/logging/testing"
@@ -57,11 +58,11 @@ const (
 )
 
 // revisionCC1 - creates a revision with concurrency == 1.
-func revisionCC1(revID types.NamespacedName, protocol networking.ProtocolType) *v1.Revision {
+func revisionCC1(revID types.NamespacedName, protocol commonnet.ProtocolType) *v1.Revision {
 	return revision(revID, protocol, 1)
 }
 
-func revision(revID types.NamespacedName, protocol networking.ProtocolType, cc int64) *v1.Revision {
+func revision(revID types.NamespacedName, protocol commonnet.ProtocolType, cc int64) *v1.Revision {
 	return &v1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: revID.Namespace,
@@ -118,7 +119,7 @@ func TestRevisionWatcher(t *testing.T) {
 	for _, tc := range []struct {
 		name                  string
 		dests                 dests
-		protocol              networking.ProtocolType
+		protocol              commonnet.ProtocolType
 		clusterPort           corev1.ServicePort
 		clusterIP             string
 		expectUpdates         []revisionDestsUpdate
@@ -158,7 +159,7 @@ func TestRevisionWatcher(t *testing.T) {
 	}, {
 		name:     "single http2 podIP",
 		dests:    dests{ready: sets.NewString("128.0.0.1:1234")},
-		protocol: networking.ProtocolH2C,
+		protocol: commonnet.ProtocolH2C,
 		clusterPort: corev1.ServicePort{
 			Name: "http2",
 			Port: 1234,
@@ -177,7 +178,7 @@ func TestRevisionWatcher(t *testing.T) {
 	}, {
 		name:     "single http2 clusterIP",
 		dests:    dests{ready: sets.NewString("128.0.0.1:1234"), notReady: sets.NewString("128.0.0.2:1234")},
-		protocol: networking.ProtocolH2C,
+		protocol: commonnet.ProtocolH2C,
 		clusterPort: corev1.ServicePort{
 			Name: "http2",
 			Port: 1234,
@@ -391,7 +392,7 @@ func TestRevisionWatcher(t *testing.T) {
 
 			// Default for protocol is http1
 			if tc.protocol == "" {
-				tc.protocol = networking.ProtocolHTTP1
+				tc.protocol = commonnet.ProtocolHTTP1
 			}
 
 			fake := fakekubeclient.Get(ctx)
@@ -528,7 +529,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		name:         "add slow healthy",
 		endpointsArr: []*corev1.Endpoints{ep(testRevision, 1234, "http", "128.0.0.1")},
 		revisions: []*v1.Revision{
-			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
 		},
 		services: []*corev1.Service{
 			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, "129.0.0.1",
@@ -556,7 +557,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		name:         "add slow ready http2",
 		endpointsArr: []*corev1.Endpoints{ep(testRevision, 1234, "http2", "128.0.0.1")},
 		revisions: []*v1.Revision{
-			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolH2C),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolH2C),
 		},
 		services: []*corev1.Service{
 			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, "129.0.0.1",
@@ -587,8 +588,8 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 			ep("test-revision2", 1235, "http", "128.1.0.2"),
 		},
 		revisions: []*v1.Revision{
-			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: "test-revision1"}, networking.ProtocolHTTP1),
-			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: "test-revision2"}, networking.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: "test-revision1"}, commonnet.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: "test-revision2"}, commonnet.ProtocolHTTP1),
 		},
 		services: []*corev1.Service{
 			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: "test-revision1"}, "129.0.0.1",
@@ -613,7 +614,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		name:         "no pod addressability",
 		endpointsArr: []*corev1.Endpoints{ep(testRevision, 1234, "http", "128.0.0.1")},
 		revisions: []*v1.Revision{
-			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
 		},
 		services: []*corev1.Service{
 			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, "129.0.0.1",
@@ -639,7 +640,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		name:         "unhealthy",
 		endpointsArr: []*corev1.Endpoints{ep(testRevision, 1234, "http", "128.0.0.1")},
 		revisions: []*v1.Revision{
-			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
 		},
 		services: []*corev1.Service{
 			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, "129.0.0.1",
@@ -659,7 +660,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		name:         "unready pod successfully probed",
 		endpointsArr: []*corev1.Endpoints{epNotReady(testRevision, 1234, "http", nil, []string{"128.0.0.1"})},
 		revisions: []*v1.Revision{
-			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
+			revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
 		},
 		services: []*corev1.Service{
 			privateSKSService(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, "129.0.0.1",
@@ -1162,7 +1163,7 @@ func TestRevisionDeleted(t *testing.T) {
 		t.Fatal("Failed to start informers:", err)
 	}
 
-	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1)
+	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1)
 	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Create(ctx, rev, metav1.CreateOptions{})
 	ri := fakerevisioninformer.Get(ctx)
 	ri.Informer().GetIndexer().Add(rev)
@@ -1204,7 +1205,7 @@ func TestServiceDoesNotExist(t *testing.T) {
 		t.Fatal("Failed to start informers:", err)
 	}
 
-	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1)
+	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1)
 	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Create(ctx, rev, metav1.CreateOptions{})
 	ri := fakerevisioninformer.Get(ctx)
 	ri.Informer().GetIndexer().Add(rev)
@@ -1254,7 +1255,7 @@ func TestServiceMoreThanOne(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to start informers:", err)
 	}
-	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1)
+	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1)
 	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespace).Create(ctx, rev, metav1.CreateOptions{})
 	ri := fakerevisioninformer.Get(ctx)
 	ri.Informer().GetIndexer().Add(rev)

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -32,7 +32,7 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
-	commonnet "knative.dev/networking/pkg/apis/networking"
+	pkgnet "knative.dev/networking/pkg/apis/networking"
 	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/controller"
@@ -548,7 +548,7 @@ func (t *Throttler) getOrCreateRevisionThrottler(revID types.NamespacedName) (*r
 		revThrottler = newRevisionThrottler(
 			revID,
 			int(rev.Spec.GetContainerConcurrency()),
-			commonnet.ServicePortName(rev.GetProtocol()),
+			pkgnet.ServicePortName(rev.GetProtocol()),
 			queue.BreakerParams{QueueDepth: breakerQueueDepth, MaxConcurrency: revisionMaxConcurrency},
 			t.logger,
 		)

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -32,7 +32,7 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
-	"knative.dev/networking/pkg/apis/networking"
+	commonnet "knative.dev/networking/pkg/apis/networking"
 	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/controller"
@@ -45,6 +45,7 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
+	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/queue"
 )
 
@@ -547,7 +548,7 @@ func (t *Throttler) getOrCreateRevisionThrottler(revID types.NamespacedName) (*r
 		revThrottler = newRevisionThrottler(
 			revID,
 			int(rev.Spec.GetContainerConcurrency()),
-			networking.ServicePortName(rev.GetProtocol()),
+			commonnet.ServicePortName(rev.GetProtocol()),
 			queue.BreakerParams{QueueDepth: breakerQueueDepth, MaxConcurrency: revisionMaxConcurrency},
 			t.logger,
 		)

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	commonnet "knative.dev/networking/pkg/apis/networking"
+	pkgnet "knative.dev/networking/pkg/apis/networking"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	fakeendpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
 	"knative.dev/pkg/controller"
@@ -225,7 +225,7 @@ func TestThrottlerErrorNoRevision(t *testing.T) {
 
 	// Add the revision we're testing.
 	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
-	revision := revisionCC1(revID, commonnet.ProtocolHTTP1)
+	revision := revisionCC1(revID, pkgnet.ProtocolHTTP1)
 	servfake.ServingV1().Revisions(revision.Namespace).Create(ctx, revision, metav1.CreateOptions{})
 	revisions.Informer().GetIndexer().Add(revision)
 
@@ -276,7 +276,7 @@ func TestThrottlerErrorOneTimesOut(t *testing.T) {
 
 	// Add the revision we're testing.
 	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
-	revision := revisionCC1(revID, commonnet.ProtocolHTTP1)
+	revision := revisionCC1(revID, pkgnet.ProtocolHTTP1)
 	servfake.ServingV1().Revisions(revision.Namespace).Create(ctx, revision, metav1.CreateOptions{})
 	revisions.Informer().GetIndexer().Add(revision)
 
@@ -328,7 +328,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 		wantDests   sets.String
 	}{{
 		name:     "single healthy podIP",
-		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
+		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, pkgnet.ProtocolHTTP1),
 		initUpdates: []revisionDestsUpdate{{
 			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.1:1234"),
@@ -340,7 +340,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 		wantDests: sets.NewString("128.0.0.1:1234"),
 	}, {
 		name:     "single healthy podIP, infinite cc",
-		revision: revision(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1, 0),
+		revision: revision(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, pkgnet.ProtocolHTTP1, 0),
 		// Double updates exercise additional paths.
 		initUpdates: []revisionDestsUpdate{{
 			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
@@ -353,7 +353,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 		wantDests: sets.NewString("128.0.0.1:1234"),
 	}, {
 		name:     "single healthy clusterIP",
-		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
+		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, pkgnet.ProtocolHTTP1),
 		initUpdates: []revisionDestsUpdate{{
 			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234"),
@@ -366,7 +366,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 		wantDests: sets.NewString("129.0.0.1:1234"),
 	}, {
 		name:     "spread podIP load",
-		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
+		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, pkgnet.ProtocolHTTP1),
 		initUpdates: []revisionDestsUpdate{{
 			// Double update here exercises some additional paths.
 			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
@@ -379,7 +379,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 		wantDests: sets.NewString("128.0.0.2:1234", "128.0.0.1:1234"),
 	}, {
 		name:     "clumping test",
-		revision: revision(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1, 3),
+		revision: revision(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, pkgnet.ProtocolHTTP1, 3),
 		initUpdates: []revisionDestsUpdate{{
 			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234", "128.0.0.2:4236", "128.0.0.2:1233", "128.0.0.2:1230"),
@@ -389,7 +389,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 	}, {
 		name: "roundrobin test",
 		revision: revision(types.NamespacedName{Namespace: testNamespace, Name: testRevision},
-			commonnet.ProtocolHTTP1, 5 /*cc >3*/),
+			pkgnet.ProtocolHTTP1, 5 /*cc >3*/),
 		initUpdates: []revisionDestsUpdate{{
 			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234", "211.212.213.214"),
@@ -399,7 +399,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 		wantDests: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234", "211.212.213.214"),
 	}, {
 		name:     "multiple ClusterIP requests",
-		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
+		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, pkgnet.ProtocolHTTP1),
 		initUpdates: []revisionDestsUpdate{{
 			Rev:           types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			ClusterIPDest: "129.0.0.1:1234",
@@ -540,7 +540,7 @@ func TestPodAssignmentFinite(t *testing.T) {
 	defer cancel()
 
 	throttler := newTestThrottler(ctx)
-	rt := newRevisionThrottler(revName, 42 /*cc*/, commonnet.ServicePortNameHTTP1, testBreakerParams, logger)
+	rt := newRevisionThrottler(revName, 42 /*cc*/, pkgnet.ServicePortNameHTTP1, testBreakerParams, logger)
 	rt.numActivators.Store(4)
 	rt.activatorIndex.Store(0)
 	throttler.revisionThrottlers[revName] = rt
@@ -594,7 +594,7 @@ func TestPodAssignmentInfinite(t *testing.T) {
 	defer cancel()
 
 	throttler := newTestThrottler(ctx)
-	rt := newRevisionThrottler(revName, 0 /*cc*/, commonnet.ServicePortNameHTTP1, testBreakerParams, logger)
+	rt := newRevisionThrottler(revName, 0 /*cc*/, pkgnet.ServicePortNameHTTP1, testBreakerParams, logger)
 	throttler.revisionThrottlers[revName] = rt
 
 	update := revisionDestsUpdate{
@@ -646,7 +646,7 @@ func TestActivatorsIndexUpdate(t *testing.T) {
 	}
 
 	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
-	rev := revisionCC1(revID, commonnet.ProtocolH2C)
+	rev := revisionCC1(revID, pkgnet.ProtocolH2C)
 	// Add the revision we're testing.
 	servfake.ServingV1().Revisions(rev.Namespace).Create(ctx, rev, metav1.CreateOptions{})
 	revisions.Informer().GetIndexer().Add(rev)
@@ -741,7 +741,7 @@ func TestMultipleActivators(t *testing.T) {
 		t.Fatal("Failed to start informers:", err)
 	}
 
-	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1)
+	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, pkgnet.ProtocolHTTP1)
 	// Add the revision we're testing.
 	servfake.ServingV1().Revisions(rev.Namespace).Create(ctx, rev, metav1.CreateOptions{})
 	revisions.Informer().GetIndexer().Add(rev)
@@ -825,7 +825,7 @@ func TestMultipleActivators(t *testing.T) {
 func TestInfiniteBreakerCreation(t *testing.T) {
 	// This test verifies that we use infiniteBreaker when CC==0.
 	tttl := newRevisionThrottler(types.NamespacedName{Namespace: "a", Name: "b"}, 0, /*cc*/
-		commonnet.ServicePortNameHTTP1, queue.BreakerParams{}, TestLogger(t))
+		pkgnet.ServicePortNameHTTP1, queue.BreakerParams{}, TestLogger(t))
 	if _, ok := tttl.breaker.(*infiniteBreaker); !ok {
 		t.Errorf("The type of revisionBreaker = %T, want %T", tttl, (*infiniteBreaker)(nil))
 	}

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"knative.dev/networking/pkg/apis/networking"
+	commonnet "knative.dev/networking/pkg/apis/networking"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
 	fakeendpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
 	"knative.dev/pkg/controller"
@@ -47,6 +47,7 @@ import (
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
+	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/queue"
 )
 
@@ -224,7 +225,7 @@ func TestThrottlerErrorNoRevision(t *testing.T) {
 
 	// Add the revision we're testing.
 	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
-	revision := revisionCC1(revID, networking.ProtocolHTTP1)
+	revision := revisionCC1(revID, commonnet.ProtocolHTTP1)
 	servfake.ServingV1().Revisions(revision.Namespace).Create(ctx, revision, metav1.CreateOptions{})
 	revisions.Informer().GetIndexer().Add(revision)
 
@@ -275,7 +276,7 @@ func TestThrottlerErrorOneTimesOut(t *testing.T) {
 
 	// Add the revision we're testing.
 	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
-	revision := revisionCC1(revID, networking.ProtocolHTTP1)
+	revision := revisionCC1(revID, commonnet.ProtocolHTTP1)
 	servfake.ServingV1().Revisions(revision.Namespace).Create(ctx, revision, metav1.CreateOptions{})
 	revisions.Informer().GetIndexer().Add(revision)
 
@@ -327,7 +328,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 		wantDests   sets.String
 	}{{
 		name:     "single healthy podIP",
-		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
+		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
 		initUpdates: []revisionDestsUpdate{{
 			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.1:1234"),
@@ -339,7 +340,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 		wantDests: sets.NewString("128.0.0.1:1234"),
 	}, {
 		name:     "single healthy podIP, infinite cc",
-		revision: revision(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1, 0),
+		revision: revision(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1, 0),
 		// Double updates exercise additional paths.
 		initUpdates: []revisionDestsUpdate{{
 			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
@@ -352,7 +353,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 		wantDests: sets.NewString("128.0.0.1:1234"),
 	}, {
 		name:     "single healthy clusterIP",
-		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
+		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
 		initUpdates: []revisionDestsUpdate{{
 			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234"),
@@ -365,7 +366,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 		wantDests: sets.NewString("129.0.0.1:1234"),
 	}, {
 		name:     "spread podIP load",
-		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
+		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
 		initUpdates: []revisionDestsUpdate{{
 			// Double update here exercises some additional paths.
 			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
@@ -378,7 +379,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 		wantDests: sets.NewString("128.0.0.2:1234", "128.0.0.1:1234"),
 	}, {
 		name:     "clumping test",
-		revision: revision(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1, 3),
+		revision: revision(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1, 3),
 		initUpdates: []revisionDestsUpdate{{
 			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234", "128.0.0.2:4236", "128.0.0.2:1233", "128.0.0.2:1230"),
@@ -388,7 +389,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 	}, {
 		name: "roundrobin test",
 		revision: revision(types.NamespacedName{Namespace: testNamespace, Name: testRevision},
-			networking.ProtocolHTTP1, 5 /*cc >3*/),
+			commonnet.ProtocolHTTP1, 5 /*cc >3*/),
 		initUpdates: []revisionDestsUpdate{{
 			Rev:   types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			Dests: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234", "211.212.213.214"),
@@ -398,7 +399,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 		wantDests: sets.NewString("128.0.0.1:1234", "128.0.0.2:1234", "211.212.213.214"),
 	}, {
 		name:     "multiple ClusterIP requests",
-		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1),
+		revision: revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1),
 		initUpdates: []revisionDestsUpdate{{
 			Rev:           types.NamespacedName{Namespace: testNamespace, Name: testRevision},
 			ClusterIPDest: "129.0.0.1:1234",
@@ -539,7 +540,7 @@ func TestPodAssignmentFinite(t *testing.T) {
 	defer cancel()
 
 	throttler := newTestThrottler(ctx)
-	rt := newRevisionThrottler(revName, 42 /*cc*/, networking.ServicePortNameHTTP1, testBreakerParams, logger)
+	rt := newRevisionThrottler(revName, 42 /*cc*/, commonnet.ServicePortNameHTTP1, testBreakerParams, logger)
 	rt.numActivators.Store(4)
 	rt.activatorIndex.Store(0)
 	throttler.revisionThrottlers[revName] = rt
@@ -593,7 +594,7 @@ func TestPodAssignmentInfinite(t *testing.T) {
 	defer cancel()
 
 	throttler := newTestThrottler(ctx)
-	rt := newRevisionThrottler(revName, 0 /*cc*/, networking.ServicePortNameHTTP1, testBreakerParams, logger)
+	rt := newRevisionThrottler(revName, 0 /*cc*/, commonnet.ServicePortNameHTTP1, testBreakerParams, logger)
 	throttler.revisionThrottlers[revName] = rt
 
 	update := revisionDestsUpdate{
@@ -645,7 +646,7 @@ func TestActivatorsIndexUpdate(t *testing.T) {
 	}
 
 	revID := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
-	rev := revisionCC1(revID, networking.ProtocolH2C)
+	rev := revisionCC1(revID, commonnet.ProtocolH2C)
 	// Add the revision we're testing.
 	servfake.ServingV1().Revisions(rev.Namespace).Create(ctx, rev, metav1.CreateOptions{})
 	revisions.Informer().GetIndexer().Add(rev)
@@ -740,7 +741,7 @@ func TestMultipleActivators(t *testing.T) {
 		t.Fatal("Failed to start informers:", err)
 	}
 
-	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, networking.ProtocolHTTP1)
+	rev := revisionCC1(types.NamespacedName{Namespace: testNamespace, Name: testRevision}, commonnet.ProtocolHTTP1)
 	// Add the revision we're testing.
 	servfake.ServingV1().Revisions(rev.Namespace).Create(ctx, rev, metav1.CreateOptions{})
 	revisions.Informer().GetIndexer().Add(rev)
@@ -824,7 +825,7 @@ func TestMultipleActivators(t *testing.T) {
 func TestInfiniteBreakerCreation(t *testing.T) {
 	// This test verifies that we use infiniteBreaker when CC==0.
 	tttl := newRevisionThrottler(types.NamespacedName{Namespace: "a", Name: "b"}, 0, /*cc*/
-		networking.ServicePortNameHTTP1, queue.BreakerParams{}, TestLogger(t))
+		commonnet.ServicePortNameHTTP1, queue.BreakerParams{}, TestLogger(t))
 	if _, ok := tttl.breaker.(*infiniteBreaker); !ok {
 		t.Errorf("The type of revisionBreaker = %T, want %T", tttl, (*infiniteBreaker)(nil))
 	}

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -28,10 +28,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/profiling"
 	"knative.dev/serving/pkg/apis/config"
+	"knative.dev/serving/pkg/networking"
 )
 
 const (

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -32,11 +32,11 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
-	"knative.dev/networking/pkg/apis/networking"
 	pkgmetrics "knative.dev/pkg/metrics"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/metrics"
+	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/resources"
 )
 

--- a/pkg/networking/constants.go
+++ b/pkg/networking/constants.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networking
+
+import "knative.dev/networking/pkg/apis/networking"
+
+// The ports we setup on our services.
+const (
+	// BackendHTTPPort is the backend, i.e. `targetPort` that we setup for HTTP services.
+	BackendHTTPPort = 8012
+
+	// BackendHTTP2Port is the backend, i.e. `targetPort` that we setup for HTTP services.
+	BackendHTTP2Port = 8013
+
+	// QueueAdminPort specifies the port number for
+	// health check and lifecycle hooks for queue-proxy.
+	QueueAdminPort = 8022
+
+	// AutoscalingQueueMetricsPort specifies the port number for metrics emitted
+	// by queue-proxy for autoscaler.
+	AutoscalingQueueMetricsPort = 9090
+
+	// UserQueueMetricsPort specifies the port number for metrics emitted
+	// by queue-proxy for end user.
+	UserQueueMetricsPort = 9091
+
+	// ActivatorServiceName is the name of the activator Kubernetes service.
+	ActivatorServiceName = "activator-service"
+
+	// SKSLabelKey is the label key that SKS Controller attaches to the
+	// underlying resources it controls.
+	SKSLabelKey = networking.GroupName + "/serverlessservice"
+
+	// ServiceTypeKey is the label key attached to a service specifying the type of service.
+	// e.g. Public, Private.
+	ServiceTypeKey = networking.GroupName + "/serviceType"
+)
+
+// ServiceType is the enumeration type for the Kubernetes services
+// that we have in our system, classified by usage purpose.
+type ServiceType string
+
+const (
+	// ServiceTypePrivate is the label value for internal only services
+	// for user applications.
+	ServiceTypePrivate ServiceType = "Private"
+	// ServiceTypePublic is the label value for externally reachable
+	// services for user applications.
+	ServiceTypePublic ServiceType = "Public"
+)

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 
 	network "knative.dev/networking/pkg"
-	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
@@ -31,6 +30,7 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
 	"knative.dev/serving/pkg/deployment"
+	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/queue"
 	"knative.dev/serving/pkg/reconciler/revision/resources/names"
 

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	network "knative.dev/networking/pkg"
-	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/metrics"
 	_ "knative.dev/pkg/metrics/testing"
@@ -42,6 +41,7 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
 	"knative.dev/serving/pkg/deployment"
+	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/queue"
 
 	. "knative.dev/serving/pkg/testing/v1"

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	network "knative.dev/networking/pkg"
-	commonnet "knative.dev/networking/pkg/apis/networking"
+	pkgnet "knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/profiling"
@@ -246,7 +246,7 @@ func makeQueueContainer(rev *v1.Revision, loggingConfig *logging.Config, tracing
 	// We need to configure only one serving port for the Queue proxy, since
 	// we know the protocol that is being used by this application.
 	servingPort := queueHTTPPort
-	if rev.GetProtocol() == commonnet.ProtocolH2C {
+	if rev.GetProtocol() == pkgnet.ProtocolH2C {
 		servingPort = queueHTTP2Port
 	}
 	ports = append(ports, servingPort)

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	network "knative.dev/networking/pkg"
-	"knative.dev/networking/pkg/apis/networking"
+	commonnet "knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/profiling"
@@ -37,6 +37,7 @@ import (
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/deployment"
+	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/queue"
 	"knative.dev/serving/pkg/queue/readiness"
 )
@@ -245,7 +246,7 @@ func makeQueueContainer(rev *v1.Revision, loggingConfig *logging.Config, tracing
 	// We need to configure only one serving port for the Queue proxy, since
 	// we know the protocol that is being used by this application.
 	servingPort := queueHTTPPort
-	if rev.GetProtocol() == networking.ProtocolH2C {
+	if rev.GetProtocol() == commonnet.ProtocolH2C {
 		servingPort = queueHTTP2Port
 	}
 	ports = append(ports, servingPort)

--- a/pkg/reconciler/serverlessservice/controller.go
+++ b/pkg/reconciler/serverlessservice/controller.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/client-go/tools/cache"
 
-	"knative.dev/networking/pkg/apis/networking"
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	sksinformer "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/serverlessservice"
 	sksreconciler "knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice"
@@ -34,6 +33,7 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/client/injection/ducks/autoscaling/v1alpha1/podscalable"
+	"knative.dev/serving/pkg/networking"
 	servingreconciler "knative.dev/serving/pkg/reconciler"
 )
 

--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -17,10 +17,11 @@ limitations under the License.
 package resources
 
 import (
-	"knative.dev/networking/pkg/apis/networking"
+	commonnet "knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/networking"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,7 @@ import (
 
 // targetPort chooses the target (pod) port for the public and private service.
 func targetPort(sks *v1alpha1.ServerlessService) intstr.IntOrString {
-	if sks.Spec.ProtocolType == networking.ProtocolH2C {
+	if sks.Spec.ProtocolType == commonnet.ProtocolH2C {
 		return intstr.FromInt(networking.BackendHTTP2Port)
 	}
 	return intstr.FromInt(networking.BackendHTTPPort)
@@ -52,9 +53,9 @@ func MakePublicService(sks *v1alpha1.ServerlessService) *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{
-				Name:       networking.ServicePortName(sks.Spec.ProtocolType),
+				Name:       commonnet.ServicePortName(sks.Spec.ProtocolType),
 				Protocol:   corev1.ProtocolTCP,
-				Port:       int32(networking.ServicePort(sks.Spec.ProtocolType)),
+				Port:       int32(commonnet.ServicePort(sks.Spec.ProtocolType)),
 				TargetPort: targetPort(sks),
 			}},
 		},
@@ -126,9 +127,9 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{
-				Name:     networking.ServicePortName(sks.Spec.ProtocolType),
+				Name:     commonnet.ServicePortName(sks.Spec.ProtocolType),
 				Protocol: corev1.ProtocolTCP,
-				Port:     networking.ServiceHTTPPort,
+				Port:     commonnet.ServiceHTTPPort,
 				// This one is matching the public one, since this is the
 				// port queue-proxy listens on.
 				TargetPort: targetPort(sks),

--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -17,7 +17,7 @@ limitations under the License.
 package resources
 
 import (
-	commonnet "knative.dev/networking/pkg/apis/networking"
+	pkgnet "knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -30,7 +30,7 @@ import (
 
 // targetPort chooses the target (pod) port for the public and private service.
 func targetPort(sks *v1alpha1.ServerlessService) intstr.IntOrString {
-	if sks.Spec.ProtocolType == commonnet.ProtocolH2C {
+	if sks.Spec.ProtocolType == pkgnet.ProtocolH2C {
 		return intstr.FromInt(networking.BackendHTTP2Port)
 	}
 	return intstr.FromInt(networking.BackendHTTPPort)
@@ -53,9 +53,9 @@ func MakePublicService(sks *v1alpha1.ServerlessService) *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{
-				Name:       commonnet.ServicePortName(sks.Spec.ProtocolType),
+				Name:       pkgnet.ServicePortName(sks.Spec.ProtocolType),
 				Protocol:   corev1.ProtocolTCP,
-				Port:       int32(commonnet.ServicePort(sks.Spec.ProtocolType)),
+				Port:       int32(pkgnet.ServicePort(sks.Spec.ProtocolType)),
 				TargetPort: targetPort(sks),
 			}},
 		},
@@ -127,9 +127,9 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{
-				Name:     commonnet.ServicePortName(sks.Spec.ProtocolType),
+				Name:     pkgnet.ServicePortName(sks.Spec.ProtocolType),
 				Protocol: corev1.ProtocolTCP,
-				Port:     commonnet.ServiceHTTPPort,
+				Port:     pkgnet.ServiceHTTPPort,
 				// This one is matching the public one, since this is the
 				// port queue-proxy listens on.
 				TargetPort: targetPort(sks),

--- a/pkg/reconciler/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/serverlessservice/resources/services_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	commonnet "knative.dev/networking/pkg/apis/networking"
+	pkgnet "knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/ptr"
@@ -48,7 +48,7 @@ func sks(mod func(*v1alpha1.ServerlessService)) *v1alpha1.ServerlessService {
 			Annotations: map[string]string{},
 		},
 		Spec: v1alpha1.ServerlessServiceSpec{
-			ProtocolType: commonnet.ProtocolHTTP1,
+			ProtocolType: pkgnet.ProtocolHTTP1,
 			Mode:         v1alpha1.SKSOperationModeServe,
 		},
 	}
@@ -108,9 +108,9 @@ func svc(t networking.ServiceType, mods ...func(*corev1.Service)) *corev1.Servic
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{
-				Name:       commonnet.ServicePortNameHTTP1,
+				Name:       pkgnet.ServicePortNameHTTP1,
 				Protocol:   corev1.ProtocolTCP,
-				Port:       commonnet.ServiceHTTPPort,
+				Port:       pkgnet.ServiceHTTPPort,
 				TargetPort: intstr.FromInt(networking.BackendHTTPPort),
 			}},
 		},
@@ -168,13 +168,13 @@ func TestMakePublicService(t *testing.T) {
 			// Introduce some variability.
 			s.UID = "1988"
 			s.Annotations["cherub"] = "rock"
-			s.Spec.ProtocolType = commonnet.ProtocolH2C
+			s.Spec.ProtocolType = pkgnet.ProtocolH2C
 		}),
 		want: svc(networking.ServiceTypePublic, func(s *corev1.Service) {
 			s.Spec.Ports = []corev1.ServicePort{{
-				Name:       commonnet.ServicePortNameH2C,
+				Name:       pkgnet.ServicePortNameH2C,
 				Protocol:   corev1.ProtocolTCP,
-				Port:       commonnet.ServiceHTTP2Port,
+				Port:       pkgnet.ServiceHTTP2Port,
 				TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
 			}}
 			s.Annotations = map[string]string{"cherub": "rock"}
@@ -183,28 +183,28 @@ func TestMakePublicService(t *testing.T) {
 	}, {
 		name: "HTTP2 -  serve - no backends",
 		sks: sks(func(s *v1alpha1.ServerlessService) {
-			s.Spec.ProtocolType = commonnet.ProtocolH2C
+			s.Spec.ProtocolType = pkgnet.ProtocolH2C
 		}),
 		want: svc(networking.ServiceTypePublic, func(s *corev1.Service) {
 			s.Spec.Ports = []corev1.ServicePort{{
-				Name:       commonnet.ServicePortNameH2C,
+				Name:       pkgnet.ServicePortNameH2C,
 				Protocol:   corev1.ProtocolTCP,
-				Port:       commonnet.ServiceHTTP2Port,
+				Port:       pkgnet.ServiceHTTP2Port,
 				TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
 			}}
 		}),
 	}, {
 		name: "HTTP2 - proxy",
 		sks: sks(func(s *v1alpha1.ServerlessService) {
-			s.Spec.ProtocolType = commonnet.ProtocolH2C
+			s.Spec.ProtocolType = pkgnet.ProtocolH2C
 			s.Spec.Mode = v1alpha1.SKSOperationModeProxy
 			s.Labels["infinite"] = "sadness"
 		}),
 		want: svc(networking.ServiceTypePublic, func(s *corev1.Service) {
 			s.Spec.Ports = []corev1.ServicePort{{
-				Name:       commonnet.ServicePortNameH2C,
+				Name:       pkgnet.ServicePortNameH2C,
 				Protocol:   corev1.ProtocolTCP,
-				Port:       commonnet.ServiceHTTP2Port,
+				Port:       pkgnet.ServiceHTTP2Port,
 				TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
 			}}
 			s.Labels["infinite"] = "sadness"
@@ -389,7 +389,7 @@ func TestMakePrivateService(t *testing.T) {
 		name: "HTTP2 and long",
 		sks: sks(func(s *v1alpha1.ServerlessService) {
 			s.Name = "dream-tonight-cherub-rock-mayonaise-hummer-disarm-rocket-soma-quiet"
-			s.Spec.ProtocolType = commonnet.ProtocolH2C
+			s.Spec.ProtocolType = pkgnet.ProtocolH2C
 			s.Annotations["cherub"] = "rock"
 			s.Labels["ava"] = "adore"
 			s.UID = "1988"
@@ -409,9 +409,9 @@ func TestMakePrivateService(t *testing.T) {
 		}, privateSvcMod, func(s *corev1.Service) {
 			// And now patch port to be http2.
 			s.Spec.Ports[0] = corev1.ServicePort{
-				Name:       commonnet.ServicePortNameH2C,
+				Name:       pkgnet.ServicePortNameH2C,
 				Protocol:   corev1.ProtocolTCP,
-				Port:       commonnet.ServiceHTTPPort,
+				Port:       pkgnet.ServiceHTTPPort,
 				TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
 			}
 		}),

--- a/pkg/reconciler/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/serverlessservice/resources/services_test.go
@@ -25,12 +25,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"knative.dev/networking/pkg/apis/networking"
+	commonnet "knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/networking"
 )
 
 func sks(mod func(*v1alpha1.ServerlessService)) *v1alpha1.ServerlessService {
@@ -47,7 +48,7 @@ func sks(mod func(*v1alpha1.ServerlessService)) *v1alpha1.ServerlessService {
 			Annotations: map[string]string{},
 		},
 		Spec: v1alpha1.ServerlessServiceSpec{
-			ProtocolType: networking.ProtocolHTTP1,
+			ProtocolType: commonnet.ProtocolHTTP1,
 			Mode:         v1alpha1.SKSOperationModeServe,
 		},
 	}
@@ -107,9 +108,9 @@ func svc(t networking.ServiceType, mods ...func(*corev1.Service)) *corev1.Servic
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{
-				Name:       networking.ServicePortNameHTTP1,
+				Name:       commonnet.ServicePortNameHTTP1,
 				Protocol:   corev1.ProtocolTCP,
-				Port:       networking.ServiceHTTPPort,
+				Port:       commonnet.ServiceHTTPPort,
 				TargetPort: intstr.FromInt(networking.BackendHTTPPort),
 			}},
 		},
@@ -167,13 +168,13 @@ func TestMakePublicService(t *testing.T) {
 			// Introduce some variability.
 			s.UID = "1988"
 			s.Annotations["cherub"] = "rock"
-			s.Spec.ProtocolType = networking.ProtocolH2C
+			s.Spec.ProtocolType = commonnet.ProtocolH2C
 		}),
 		want: svc(networking.ServiceTypePublic, func(s *corev1.Service) {
 			s.Spec.Ports = []corev1.ServicePort{{
-				Name:       networking.ServicePortNameH2C,
+				Name:       commonnet.ServicePortNameH2C,
 				Protocol:   corev1.ProtocolTCP,
-				Port:       networking.ServiceHTTP2Port,
+				Port:       commonnet.ServiceHTTP2Port,
 				TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
 			}}
 			s.Annotations = map[string]string{"cherub": "rock"}
@@ -182,28 +183,28 @@ func TestMakePublicService(t *testing.T) {
 	}, {
 		name: "HTTP2 -  serve - no backends",
 		sks: sks(func(s *v1alpha1.ServerlessService) {
-			s.Spec.ProtocolType = networking.ProtocolH2C
+			s.Spec.ProtocolType = commonnet.ProtocolH2C
 		}),
 		want: svc(networking.ServiceTypePublic, func(s *corev1.Service) {
 			s.Spec.Ports = []corev1.ServicePort{{
-				Name:       networking.ServicePortNameH2C,
+				Name:       commonnet.ServicePortNameH2C,
 				Protocol:   corev1.ProtocolTCP,
-				Port:       networking.ServiceHTTP2Port,
+				Port:       commonnet.ServiceHTTP2Port,
 				TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
 			}}
 		}),
 	}, {
 		name: "HTTP2 - proxy",
 		sks: sks(func(s *v1alpha1.ServerlessService) {
-			s.Spec.ProtocolType = networking.ProtocolH2C
+			s.Spec.ProtocolType = commonnet.ProtocolH2C
 			s.Spec.Mode = v1alpha1.SKSOperationModeProxy
 			s.Labels["infinite"] = "sadness"
 		}),
 		want: svc(networking.ServiceTypePublic, func(s *corev1.Service) {
 			s.Spec.Ports = []corev1.ServicePort{{
-				Name:       networking.ServicePortNameH2C,
+				Name:       commonnet.ServicePortNameH2C,
 				Protocol:   corev1.ProtocolTCP,
-				Port:       networking.ServiceHTTP2Port,
+				Port:       commonnet.ServiceHTTP2Port,
 				TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
 			}}
 			s.Labels["infinite"] = "sadness"
@@ -388,7 +389,7 @@ func TestMakePrivateService(t *testing.T) {
 		name: "HTTP2 and long",
 		sks: sks(func(s *v1alpha1.ServerlessService) {
 			s.Name = "dream-tonight-cherub-rock-mayonaise-hummer-disarm-rocket-soma-quiet"
-			s.Spec.ProtocolType = networking.ProtocolH2C
+			s.Spec.ProtocolType = commonnet.ProtocolH2C
 			s.Annotations["cherub"] = "rock"
 			s.Labels["ava"] = "adore"
 			s.UID = "1988"
@@ -408,9 +409,9 @@ func TestMakePrivateService(t *testing.T) {
 		}, privateSvcMod, func(s *corev1.Service) {
 			// And now patch port to be http2.
 			s.Spec.Ports[0] = corev1.ServicePort{
-				Name:       networking.ServicePortNameH2C,
+				Name:       commonnet.ServicePortNameH2C,
 				Protocol:   corev1.ProtocolTCP,
-				Port:       networking.ServiceHTTPPort,
+				Port:       commonnet.ServiceHTTPPort,
 				TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
 			}
 		}),

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -34,7 +34,6 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	sksreconciler "knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice"
 
-	"knative.dev/networking/pkg/apis/networking"
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/hash"
@@ -42,6 +41,7 @@ import (
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
+	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/reconciler/serverlessservice/resources"
 	presources "knative.dev/serving/pkg/resources"
 )

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientgotesting "k8s.io/client-go/testing"
 
-	commonnet "knative.dev/networking/pkg/apis/networking"
+	pkgnet "knative.dev/networking/pkg/apis/networking"
 	nv1a1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	sksreconciler "knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice"
 	"knative.dev/pkg/configmap"
@@ -732,7 +732,7 @@ func markNoEndpoints(sks *nv1a1.ServerlessService) {
 }
 
 func withHTTP2Protocol(sks *nv1a1.ServerlessService) {
-	sks.Spec.ProtocolType = commonnet.ProtocolH2C
+	sks.Spec.ProtocolType = pkgnet.ProtocolH2C
 }
 
 type deploymentOption func(*appsv1.Deployment)
@@ -765,7 +765,7 @@ func withHTTP2Priv(svc *corev1.Service) {
 }
 
 func withHTTP2(svc *corev1.Service) {
-	svc.Spec.Ports[0].Port = commonnet.ServiceHTTP2Port
+	svc.Spec.Ports[0].Port = pkgnet.ServiceHTTP2Port
 	svc.Spec.Ports[0].Name = "http2"
 	svc.Spec.Ports[0].TargetPort = intstr.FromInt(networking.BackendHTTP2Port)
 }

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	clientgotesting "k8s.io/client-go/testing"
 
-	"knative.dev/networking/pkg/apis/networking"
+	commonnet "knative.dev/networking/pkg/apis/networking"
 	nv1a1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	sksreconciler "knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/serverlessservice"
 	"knative.dev/pkg/configmap"
@@ -49,6 +49,7 @@ import (
 	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/system"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/reconciler/serverlessservice/resources"
 	presources "knative.dev/serving/pkg/resources"
 
@@ -731,7 +732,7 @@ func markNoEndpoints(sks *nv1a1.ServerlessService) {
 }
 
 func withHTTP2Protocol(sks *nv1a1.ServerlessService) {
-	sks.Spec.ProtocolType = networking.ProtocolH2C
+	sks.Spec.ProtocolType = commonnet.ProtocolH2C
 }
 
 type deploymentOption func(*appsv1.Deployment)
@@ -764,7 +765,7 @@ func withHTTP2Priv(svc *corev1.Service) {
 }
 
 func withHTTP2(svc *corev1.Service) {
-	svc.Spec.Ports[0].Port = networking.ServiceHTTP2Port
+	svc.Spec.Ports[0].Port = commonnet.ServiceHTTP2Port
 	svc.Spec.Ports[0].Name = "http2"
 	svc.Spec.Ports[0].TargetPort = intstr.FromInt(networking.BackendHTTP2Port)
 }

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -33,7 +33,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
@@ -43,6 +42,7 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	asconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
+	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/test"
 	v1test "knative.dev/serving/test/v1"
 )


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As per title, this migrates constants from networking back into serving that are only used here anyway to allow them to be changed locally too.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @tcnghia 
