### PR TITLE
Satisfy the proper go naming

### DIFF
--- a/test/e2e/autotls/README.md
+++ b/test/e2e/autotls/README.md
@@ -10,13 +10,13 @@ To run Auto TLS E2E test locally, run the following commands:
    1. `kubectl label namespace serving-tests networking.internal.knative.dev/disableWildcardCert=true`
    1. `kubectl delete kcert --all -n serving-tests`
    1. `kubectl apply -f test/config/autotls/certmanager/selfsigned/`
-   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestTls`
+   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestTLS`
 1. test case 2: testing per namespace certificate provision with self-signed CA
    1. `kubectl delete kcert --all -n serving-tests`
    1. `kubectl apply -f test/config/autotls/certmanager/selfsigned/`
    1. Run `kubectl edit namespace serving-tests` and remove the label
       networking.internal.knative.dev/disableWildcardCert
-   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestTls`
+   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestTLS`
 1. test case 3: testing per ksvc certificate provision with HTTP challenge
    1. `kubectl label namespace serving-tests networking.internal.knative.dev/disableWildcardCert=true`
    1. `kubectl delete kcert --all -n serving-tests`
@@ -25,4 +25,4 @@ To run Auto TLS E2E test locally, run the following commands:
    1. `kubectl patch cm config-domain -n knative-serving -p '{"data":{"<your-custom-domain>":""}}'`
    1. Add a DNS A record to map host `http01.serving-tests.<your-custom-domain>`
       to the Ingress IP.
-   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestTls`
+   1. `go test -v -tags=e2e -count=1 -timeout=600s ./test/e2e/autotls/... -run ^TestTLS`

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -53,16 +53,14 @@ type config struct {
 
 var env config
 
-// Technically TLS is proper Go casing for acronyms, but it makes our test naming
-// hyphenate between every character, and we hit length problems.
-func TestTls(t *testing.T) {
+func TestTLS(t *testing.T) {
 	if err := envconfig.Process("", &env); err != nil {
 		t.Fatalf("Failed to process environment variable: %v.", err)
 	}
 	t.Run(env.AutoTLSTestName, testAutoTLS)
 }
 
-func TestTlsDisabledWithAnnotation(t *testing.T) {
+func TestTLSDisabledWithAnnotation(t *testing.T) {
 	clients := e2e.SetupWithNamespace(t, test.TLSNamespace)
 
 	names := test.ResourceNames{


### PR DESCRIPTION
Now that we have a helper that can deal with specific names
Name the tests correctly

/assign @ZhiminXiang @tcnghia 