### PR TITLE
Remove unnecessary usages of the 'log' package

### DIFF
--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -917,7 +917,6 @@ func (l revFakeErrorLister) Get(name string) (*v1.Revision, error) {
 
 func (l revFakeErrorLister) List(selector labels.Selector) ([]*v1.Revision, error) {
 	panic("not implemented")
-	return nil, nil
 }
 
 func (l revFakeErrorLister) Revisions(namespace string) listers.RevisionNamespaceLister {

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -19,7 +19,6 @@ package traffic
 import (
 	"context"
 	"errors"
-	"log"
 	"os"
 	"testing"
 	"time"
@@ -917,7 +916,7 @@ func (l revFakeErrorLister) Get(name string) (*v1.Revision, error) {
 }
 
 func (l revFakeErrorLister) List(selector labels.Selector) ([]*v1.Revision, error) {
-	log.Panic("not implemented")
+	panic("not implemented")
 	return nil, nil
 }
 

--- a/pkg/reconciler/route/visibility/visibility_test.go
+++ b/pkg/reconciler/route/visibility/visibility_test.go
@@ -19,7 +19,6 @@ package visibility
 import (
 	"context"
 	"errors"
-	"log"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -458,6 +457,6 @@ func (l *fakeServiceLister) Services(namespace string) listers.ServiceNamespaceL
 }
 
 func (l *fakeServiceLister) Get(name string) (*corev1.Service, error) {
-	log.Panic("not implemented")
+	panic("not implemented")
 	return nil, nil
 }

--- a/pkg/reconciler/route/visibility/visibility_test.go
+++ b/pkg/reconciler/route/visibility/visibility_test.go
@@ -458,5 +458,4 @@ func (l *fakeServiceLister) Services(namespace string) listers.ServiceNamespaceL
 
 func (l *fakeServiceLister) Get(name string) (*corev1.Service, error) {
 	panic("not implemented")
-	return nil, nil
 }

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -20,7 +20,6 @@ package ha
 
 import (
 	"context"
-	"log"
 	"testing"
 	"time"
 
@@ -97,7 +96,7 @@ func testActivatorHA(t *testing.T, gracePeriod *int64, slo float64) {
 	}
 
 	t.Log("Starting prober")
-	prober := test.NewProberManager(log.Printf, clients, minProbes)
+	prober := test.NewProberManager(t.Logf, clients, minProbes)
 	prober.Spawn(resources.Service.Status.URL.URL())
 	defer assertSLO(t, prober, slo)
 

--- a/test/upgrade/probe_test.go
+++ b/test/upgrade/probe_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"flag"
 	"io/ioutil"
-	"log"
 	"os"
 	"syscall"
 	"testing"
@@ -64,9 +63,7 @@ func TestProbe(t *testing.T) {
 	// This polls until we get a 200 with the right body.
 	assertServiceResourcesUpdated(t, clients, names, url, test.PizzaPlanetText1)
 
-	// Use log.Printf instead of t.Logf because we want to see failures
-	// inline with other logs instead of buffered until the end.
-	prober := test.RunRouteProber(log.Printf, clients, url, test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
+	prober := test.RunRouteProber(t.Logf, clients, url, test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
 	defer test.CheckSLO(*successFraction, t.Name(), prober)
 
 	// e2e-upgrade-test.sh will close this pipe to signal the upgrade is


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

We should only be using this package if really necessary. Either zap or testing based loggers should be used in almost all cases.

Since Go 1.14 t.Logf streams logs as they happen too, so replace those occurrences.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz 
