### PR TITLE
Remove manual lint comment from PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,9 +1,3 @@
-<!--
-Request Prow to automatically lint any go code in this PR:
-
-/lint
--->
-
 Fixes #
 
 <!-- Please include the 'why' behind your changes if no issue exists -->


### PR DESCRIPTION
When we create a PR, the template always says run `/lint` manually.
Now golint is always run by github action and we do not need to ask
contributors to run `/lint` every time.

/cc @markusthoemmes @julz 

