### PR TITLE
Give Webhook time to have a leader elected and reconcile the TLS certificate.

### DIFF
--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -90,7 +90,7 @@ spec:
         - name: https-webhook
           containerPort: 8443
 
-        readinessProbe:
+        readinessProbe: &probe
           periodSeconds: 1
           httpGet:
             scheme: HTTPS
@@ -99,14 +99,9 @@ spec:
             - name: k-kubelet-probe
               value: "webhook"
         livenessProbe:
-          periodSeconds: 1
-          httpGet:
-            scheme: HTTPS
-            port: 8443
-            httpHeaders:
-            - name: k-kubelet-probe
-              value: "webhook"
+          <<: *probe
           failureThreshold: 6
+          initialDelaySeconds: 20
 
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
       # high value that we respect whatever value it has configured for the lame duck grace period.


### PR DESCRIPTION
In `mesh` mode, we see that the `webhook` is killed before being ready.
It fails readiness probe with `Request to probe app failed: Get "https://localhost:8443/": remote error: tls: internal error` on the proxy side and `http: TLS handshake error from 127.0.0.1:56432: server key missing` on the Webhook side suggesting the Secret is not ready yet.

See https://github.com/knative/eventing/pull/4168 and https://github.com/knative-sandbox/net-istio/issues/249#issuecomment-702527224.

I am doing what Eventing is doing.

Example of failing run: https://storage.googleapis.com/knative-prow/logs/ci-knative-serving-istio-stable-mesh/1311832861287911424/build-log.txt