### PR TITLE
Creates hellohttp2 test image mounted with an h2c port

### DIFF
--- a/test/test_images/hellohttp2/README.md
+++ b/test/test_images/hellohttp2/README.md
@@ -1,0 +1,19 @@
+# Hellohttp2 test image
+
+This directory contains the test image used in the auto gRPC/http2 tests.
+
+The image contains a simple Go webserver, `helloworld.go`, that will, by
+default, listen on port `8080` and expose a service at `/`.
+
+When called using http2, the server emits a "hello world" message.
+
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
+## Building
+
+For details about building and adding new images, see the
+[section about test images](/test/README.md#test-images).

--- a/test/test_images/hellohttp2/hellohttp2.go
+++ b/test/test_images/hellohttp2/hellohttp2.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	networkingpkg "knative.dev/networking/pkg"
+	"knative.dev/pkg/network"
+)
+
+func httpWrapper() http.Handler {
+	return networkingpkg.NewProbeHandler(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.ProtoMajor == 2 {
+				log.Print("hellohttp2 received an http2 request.")
+				fmt.Fprintln(w, "Hello, New World! How about donuts and coffee?")
+			} else {
+				log.Print("hellohttp2 received an HTTP 1.1 request.")
+				w.WriteHeader(http.StatusUpgradeRequired)
+			}
+		}),
+	)
+}
+
+func main() {
+	flag.Parse()
+	log.Print("hellohttp2 app started.")
+
+	s := network.NewServer(":"+os.Getenv("PORT"), httpWrapper())
+	log.Fatal(s.ListenAndServe())
+}

--- a/test/test_images/hellohttp2/service.yaml
+++ b/test/test_images/hellohttp2/service.yaml
@@ -11,6 +11,3 @@ spec:
         ports:
         - name: h2c
           containerPort: 8080
-
-  
-          

--- a/test/test_images/hellohttp2/service.yaml
+++ b/test/test_images/hellohttp2/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: hellohttp2-test-image
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - image: ko://knative.dev/serving/test/test_images/hellohttp2
+        ports:
+        - name: h2c
+          containerPort: 8080
+
+  
+          


### PR DESCRIPTION
## Proposed Changes

* Creates new test image that returns a text message in http/2, but returns a 426 HTTP error if it's http/1.1.
* This will enable E2E tests to help with #4283 development.
* For now, service.yaml uses `portName="h2c"`, since otherwise the service would always be unreachable.

**Release Note**
```release-note
NONE
```
