### PR TITLE
Creates new e2e to validate http2 behavior and help developing http2/gRPC autodetection

### DIFF
--- a/test/conformance.go
+++ b/test/conformance.go
@@ -52,6 +52,7 @@ const (
 	PizzaPlanetText1 = "What a spaceport!"
 	PizzaPlanetText2 = "Re-energize yourself with a slice of pepperoni!"
 	HelloWorldText   = "Hello World! How about some tasty noodles?"
+	HelloHTTP2Text   = "Hello, New World! How about donuts and coffee?"
 
 	MultiContainerResponse = "Yay!! multi-container works"
 

--- a/test/e2e/http2_test.go
+++ b/test/e2e/http2_test.go
@@ -1,0 +1,107 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	pkgTest "knative.dev/pkg/test"
+	rtesting "knative.dev/serving/pkg/testing/v1"
+	"knative.dev/serving/test"
+	v1test "knative.dev/serving/test/v1"
+)
+
+// TestHelloHttp2WithPortNameH2C validates that an http/2-only service can be
+// reached if the portName is "h2c".
+func TestHelloHttp2WithPortNameH2C(t *testing.T) {
+	t.Parallel()
+
+	clients := Setup(t)
+
+	// hellohttp2 returns client errors (4xx) if contacted via http1.1,
+	// and behaves like helloworld if called with http/2.
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "hellohttp2",
+	}
+
+	test.EnsureTearDown(t, clients, &names)
+
+	t.Log("Creating a new Service")
+
+	resources, err := v1test.CreateServiceReady(t, clients, &names, rtesting.WithNamedPort("h2c"))
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	url := resources.Route.Status.URL.URL()
+	if _, err := pkgTest.WaitForEndpointState(
+		context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		url,
+		v1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsStatusOK, pkgTest.MatchesBody(test.HelloHTTP2Text))),
+		"HelloHttp2ServesTextOnH2C",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("The endpoint %s for Route %s didn't serve the expected text %q: %v", url, names.Route, test.HelloHTTP2Text, err)
+	}
+}
+
+// TestHelloHttp2WithEmptyPortName validates that an http/2-only service
+// is unreachable if the port name is not specified.
+// TODO(knative/serving#4283): Once the feature is implemented, this test
+// should succeed.
+func TestHelloHttp2WithEmptyPortName(t *testing.T) {
+	t.Parallel()
+
+	clients := Setup(t)
+
+	// hellohttp2 returns client errors (4xx) if contacted via http1.1,
+	// and behaves like helloworld if called with http/2.
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "hellohttp2",
+	}
+
+	test.EnsureTearDown(t, clients, &names)
+
+	t.Log("Creating a new Service")
+
+	resources, err := v1test.CreateServiceReady(t, clients, &names, rtesting.WithNamedPort(""))
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	url := resources.Route.Status.URL.URL()
+	if _, err := pkgTest.WaitForEndpointState(
+		context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		url,
+		pkgTest.IsOneOfStatusCodes(426),
+		"HelloHttp2ServesTextWithEmptyPort",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("The endpoint %s for Route %s didn't serve the expected status code 426: %v", url, names.Route, err)
+	}
+}

--- a/test/test_images/hellohttp2/README.md
+++ b/test/test_images/hellohttp2/README.md
@@ -1,0 +1,19 @@
+# Hellohttp2 test image
+
+This directory contains the test image used in the auto gRPC/http2 tests.
+
+The image contains a simple Go webserver, `helloworld.go`, that will, by
+default, listen on port `8080` and expose a service at `/`.
+
+When called using http2, the server emits a "hello world" message.
+
+## Trying out
+
+To run the image as a Service outisde of the test suite:
+
+`ko apply -f service.yaml`
+
+## Building
+
+For details about building and adding new images, see the
+[section about test images](/test/README.md#test-images).

--- a/test/test_images/hellohttp2/hellohttp2.go
+++ b/test/test_images/hellohttp2/hellohttp2.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	networkingpkg "knative.dev/networking/pkg"
+	"knative.dev/pkg/network"
+)
+
+func httpWrapper() http.Handler {
+	return networkingpkg.NewProbeHandler(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.ProtoMajor == 2 {
+				log.Print("hellohttp2 received an http2 request.")
+				fmt.Fprintln(w, "Hello, New World! How about donuts and coffee?")
+			} else {
+				log.Print("hellohttp2 received an HTTP 1.1 request.")
+				w.WriteHeader(http.StatusUpgradeRequired)
+			}
+		}),
+	)
+}
+
+func main() {
+	flag.Parse()
+	log.Print("hellohttp2 app started.")
+
+	s := network.NewServer(":"+os.Getenv("PORT"), httpWrapper())
+	log.Fatal(s.ListenAndServe())
+}

--- a/test/test_images/hellohttp2/service.yaml
+++ b/test/test_images/hellohttp2/service.yaml
@@ -11,6 +11,3 @@ spec:
         ports:
         - name: h2c
           containerPort: 8080
-
-  
-          

--- a/test/test_images/hellohttp2/service.yaml
+++ b/test/test_images/hellohttp2/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: hellohttp2-test-image
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - image: ko://knative.dev/serving/test/test_images/hellohttp2
+        ports:
+        - name: h2c
+          containerPort: 8080
+
+  
+          


### PR DESCRIPTION
Issue #4283 

## Proposed Changes

* Two new E2E tests:
    * TestHelloHttp2WithPortNameH2C validates that an http2-only ksvc is reachable if we use port name "h2c"
    * TestHelloHttp2WithEmptyPortName for now asserts that an http2-only ksvc fails if we use an empty port.
* Adds a new test image "hellohttp2" that returns a text message if called using http/2, but returns 426 error code (upgrade required) if called via http/1.1.
     * This was being merged as https://github.com/knative/serving/pull/9676

**Release Note**

```release-note
NONE
```
