### PR TITLE
Set the default in the deploy.go and propagate config to build pod spec

### DIFF
--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -32,10 +32,8 @@ import (
 	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/metrics"
-	_ "knative.dev/pkg/metrics/testing"
 	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/system"
-	_ "knative.dev/pkg/system/testing"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -44,6 +42,8 @@ import (
 	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/queue"
 
+	_ "knative.dev/pkg/metrics/testing"
+	_ "knative.dev/pkg/system/testing"
 	. "knative.dev/serving/pkg/testing/v1"
 )
 

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -36,17 +36,19 @@ import (
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
-	_ "knative.dev/pkg/metrics/testing"
 	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/system"
-	_ "knative.dev/pkg/system/testing"
 	tracingconfig "knative.dev/pkg/tracing/config"
+	apicfg "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/queue"
 	"knative.dev/serving/pkg/reconciler/revision/config"
+
+	_ "knative.dev/pkg/metrics/testing"
+	_ "knative.dev/pkg/system/testing"
 )
 
 var (
@@ -73,9 +75,11 @@ var (
 	logConfig        logging.Config
 	obsConfig        metrics.ObservabilityConfig
 	traceConfig      tracingconfig.Config
+	defaults, _      = apicfg.NewDefaultsConfigFromMap(nil)
 	revCfg           = config.Config{
 		Autoscaler:    &asConfig,
 		Deployment:    &deploymentConfig,
+		Defaults:      defaults,
 		Logging:       &logConfig,
 		Network:       &network.Config{},
 		Observability: &obsConfig,

--- a/pkg/webhook/podspec_dryrun.go
+++ b/pkg/webhook/podspec_dryrun.go
@@ -23,9 +23,11 @@ import (
 	"strings"
 
 	"go.uber.org/zap"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	"knative.dev/pkg/apis"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/logging"
@@ -51,13 +53,13 @@ func validatePodSpec(ctx context.Context, ps v1.RevisionSpec, namespace string, 
 		Namespace:    namespace,
 	}
 
-	// Create a sample Revision from the template
+	// Create a sample Revision from the template.
 	rev := &v1.Revision{
 		ObjectMeta: om,
 		Spec:       ps,
 	}
 	rev.SetDefaults(ctx)
-	podSpec := resources.BuildPodSpec(rev, resources.BuildUserContainers(rev))
+	podSpec := resources.BuildPodSpec(rev, resources.BuildUserContainers(rev), nil /*configs*/)
 
 	// Make a sample pod with the template Revisions & PodSpec and dryrun call to API-server
 	pod := &corev1.Pod{


### PR DESCRIPTION
This is the next step for #8563.

Here we set the EnableServiceLink to the default value set in the CM.
Right now it will match 1 to 1 to what is set on the revision.
But in future, when we change the default (in the next PR) this is
going to alter the existing deployments, keeping the
service/config/revision spec intact.

This also required changing dry run code, but it is done in webhook
and does not really rely on configmaps, so a nil is passed there.

/assign @dprotaso 