### PR TITLE
Fix the defaulting of the tristate flag

### DIFF
--- a/pkg/apis/config/defaults.go
+++ b/pkg/apis/config/defaults.go
@@ -85,7 +85,7 @@ func defaultDefaultsConfig() *Defaults {
 	}
 }
 
-func asTriState(key string, target **bool, defVal *bool) cm.ParseFunc {
+func asTriState(key string, target **bool, defValue *bool) cm.ParseFunc {
 	return func(data map[string]string) error {
 		if raw, ok := data[key]; ok {
 			switch {
@@ -94,7 +94,7 @@ func asTriState(key string, target **bool, defVal *bool) cm.ParseFunc {
 			case strings.EqualFold(raw, "false"):
 				*target = ptr.Bool(false)
 			default:
-				*target = defVal
+				*target = defValue
 			}
 		}
 		return nil

--- a/pkg/apis/config/defaults.go
+++ b/pkg/apis/config/defaults.go
@@ -85,7 +85,7 @@ func defaultDefaultsConfig() *Defaults {
 	}
 }
 
-func asTriState(key string, target **bool) cm.ParseFunc {
+func asTriState(key string, target **bool, defVal *bool) cm.ParseFunc {
 	return func(data map[string]string) error {
 		if raw, ok := data[key]; ok {
 			switch {
@@ -93,6 +93,8 @@ func asTriState(key string, target **bool) cm.ParseFunc {
 				*target = ptr.Bool(true)
 			case strings.EqualFold(raw, "false"):
 				*target = ptr.Bool(false)
+			default:
+				*target = defVal
 			}
 		}
 		return nil
@@ -107,7 +109,7 @@ func NewDefaultsConfigFromMap(data map[string]string) (*Defaults, error) {
 		cm.AsString("container-name-template", &nc.UserContainerNameTemplate),
 
 		cm.AsBool("allow-container-concurrency-zero", &nc.AllowContainerConcurrencyZero),
-		asTriState("enable-service-links", &nc.EnableServiceLinks),
+		asTriState("enable-service-links", &nc.EnableServiceLinks, nil),
 
 		cm.AsInt64("revision-timeout-seconds", &nc.RevisionTimeoutSeconds),
 		cm.AsInt64("max-revision-timeout-seconds", &nc.MaxRevisionTimeoutSeconds),

--- a/pkg/apis/config/defaults_test.go
+++ b/pkg/apis/config/defaults_test.go
@@ -104,6 +104,20 @@ func TestDefaultsConfiguration(t *testing.T) {
 			"enable-service-links": "false",
 		},
 	}, {
+		name:    "service links default",
+		wantErr: false,
+		wantDefaults: &Defaults{
+			RevisionTimeoutSeconds:        DefaultRevisionTimeoutSeconds,
+			MaxRevisionTimeoutSeconds:     DefaultMaxRevisionTimeoutSeconds,
+			UserContainerNameTemplate:     DefaultUserContainerName,
+			ContainerConcurrencyMaxLimit:  DefaultMaxRevisionContainerConcurrency,
+			AllowContainerConcurrencyZero: true,
+			EnableServiceLinks:            nil,
+		},
+		data: map[string]string{
+			"enable-service-links": "default",
+		},
+	}, {
 		name:    "invalid allow container concurrency zero flag value",
 		wantErr: true,
 		data: map[string]string{


### PR DESCRIPTION
This otherwise passthrough value is not possible for the ESL

/assign mattmoor @dprotaso 