### PR TITLE
Add RetryingRouteInconsistency to TestHelloHttp2WithEmptyPortName

### DIFF
--- a/test/e2e/http2_test.go
+++ b/test/e2e/http2_test.go
@@ -20,7 +20,7 @@ package e2e
 
 import (
 	"context"
-	"http"
+	"net/http"
 	"testing"
 
 	pkgTest "knative.dev/pkg/test"

--- a/test/e2e/http2_test.go
+++ b/test/e2e/http2_test.go
@@ -105,4 +105,6 @@ func TestHelloHttp2WithEmptyPortName(t *testing.T) {
 	); err != nil {
 		t.Fatalf("The endpoint %s for Route %s didn't serve the expected status code %v: %v", url, names.Route, http.StatusUpgradeRequired, err)
 	}
+
+	t.Skip("HTP2 with empty port name is not implemented yet. See: https://github.com/knative/serving/issues/4283")
 }

--- a/test/e2e/http2_test.go
+++ b/test/e2e/http2_test.go
@@ -20,6 +20,7 @@ package e2e
 
 import (
 	"context"
+	"http"
 	"testing"
 
 	pkgTest "knative.dev/pkg/test"
@@ -97,11 +98,11 @@ func TestHelloHttp2WithEmptyPortName(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		url,
-		pkgTest.IsOneOfStatusCodes(426),
+		v1test.RetryingRouteInconsistency(pkgTest.MatchesAllOf(pkgTest.IsOneOfStatusCodes(http.StatusUpgradeRequired))),
 		"HelloHttp2ServesTextWithEmptyPort",
 		test.ServingFlags.ResolvableDomain,
 		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
 	); err != nil {
-		t.Fatalf("The endpoint %s for Route %s didn't serve the expected status code 426: %v", url, names.Route, err)
+		t.Fatalf("The endpoint %s for Route %s didn't serve the expected status code %v: %v", url, names.Route, http.StatusUpgradeRequired, err)
 	}
 }


### PR DESCRIPTION
This patch changes:

- to add RetryingRouteInconsistency to TestHelloHttp2WithEmptyPortName
  - RetryingRouteInconsistency is needed until https://github.com/knative/serving/issues/5573 was solved.
- to use http.StatusUpgradeRequired for 426 status code
- to change to skip test at the end instead of expose it as "success".
  - difficult to notice in https://testgrid.knative.dev/serving that the feature is not implemented yet if it shows "success" status.

**Release Note**

```release-note
NONE
```

/cc @rafaeltello @tcnghia @markusthoemmes 