### PR TITLE
Cleanup certificate unit test

### DIFF
--- a/pkg/reconciler/accessor/networking/certificate_test.go
+++ b/pkg/reconciler/accessor/networking/certificate_test.go
@@ -94,48 +94,54 @@ func (f *FakeAccessor) GetCertificateLister() listers.CertificateLister {
 }
 
 func TestReconcileCertificateCreate(t *testing.T) {
-	ctx, accessor, done := setup([]*v1alpha1.Certificate{}, t)
-	defer done()
+	ctx, accessor := setup(nil, t)
 
 	ReconcileCertificate(ctx, ownerObj, desired, accessor)
 
-	certInformer := fakecertinformer.Get(ctx)
+	lister := fakecertinformer.Get(ctx).Lister()
 	if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
-		cert, err := certInformer.Lister().Certificates(desired.Namespace).Get(desired.Name)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return false, nil
-			}
+		cert, err := lister.Certificates(desired.Namespace).Get(desired.Name)
+		if errors.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
 			return false, err
 		}
-		return cmp.Equal(cert, desired), nil
+
+		if !cmp.Equal(cert, desired) {
+			t.Log("Certificate not yet as expected, diff:", cmp.Diff(cert, desired))
+		}
+		return true, nil
 	}); err != nil {
-		t.Error("Failed seeing creation of cert:", err)
+		t.Fatal("Failed seeing creation of cert:", err)
 	}
 }
 
 func TestReconcileCertificateUpdate(t *testing.T) {
-	ctx, accessor, done := setup([]*v1alpha1.Certificate{origin}, t)
-	defer done()
+	ctx, accessor := setup([]*v1alpha1.Certificate{origin}, t)
 
 	ReconcileCertificate(ctx, ownerObj, desired, accessor)
-	certInformer := fakecertinformer.Get(ctx)
+
+	lister := fakecertinformer.Get(ctx).Lister()
 	if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
-		cert, err := certInformer.Lister().Certificates(desired.Namespace).Get(desired.Name)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return false, nil
-			}
+		cert, err := lister.Certificates(desired.Namespace).Get(desired.Name)
+		if errors.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
 			return false, err
 		}
-		return cmp.Equal(cert, desired), nil
+
+		if !cmp.Equal(cert, desired) {
+			t.Log("Certificate not yet as expected, diff:", cmp.Diff(cert, desired))
+		}
+		return true, nil
 	}); err != nil {
-		t.Error("Failed seeing creation of cert:", err)
+		t.Fatal("Failed seeing creation of cert:", err)
 	}
 }
 
-func setup(certs []*v1alpha1.Certificate, t *testing.T) (context.Context, *FakeAccessor, func()) {
-	ctx, cancel, _ := SetupFakeContextWithCancel(t)
+func setup(certs []*v1alpha1.Certificate, t *testing.T) (context.Context, *FakeAccessor) {
+	ctx, cancel, informers := SetupFakeContextWithCancel(t)
+
 	fake := fakenetworkingclient.Get(ctx)
 	certInformer := fakecertinformer.Get(ctx)
 
@@ -144,16 +150,17 @@ func setup(certs []*v1alpha1.Certificate, t *testing.T) (context.Context, *FakeA
 		certInformer.Informer().GetIndexer().Add(cert)
 	}
 
-	waitInformers, err := controller.RunInformers(ctx.Done(), certInformer.Informer())
+	waitInformers, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
-		t.Fatal("failed to start Certificate informer:", err)
+		t.Fatal("failed to start informers:", err)
 	}
+	t.Cleanup(func() {
+		cancel()
+		waitInformers()
+	})
 
 	return ctx, &FakeAccessor{
-			netclient:  fake,
-			certLister: certInformer.Lister(),
-		}, func() {
-			cancel()
-			waitInformers()
-		}
+		netclient:  fake,
+		certLister: certInformer.Lister(),
+	}
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Failed for me here: https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_serving/9646/pull-knative-serving-unit-tests/1313077562636767233

- Used t.Cleanup in the setup helper to avoid passing through done functions.
- Used the readily available informers variable to start all informers.
- Added log output to the poll to be able to know if the test failed because the certificate wasn't as expected or not there at all.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @julz 