### PR TITLE
Make forceUpgrade annotation handling consistent with others

### DIFF
--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -38,7 +38,7 @@ var (
 		CreatorAnnotation,
 		RevisionLastPinnedAnnotationKey,
 		RoutingStateModifiedAnnotationKey,
-		GroupNamePrefix+"forceUpgrade",
+		ForceUpgradeAnnotationKey,
 		RevisionPreservedAnnotationKey,
 		RoutesAnnotationKey,
 	)

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -79,6 +79,12 @@ const (
 	// metadata generation of the Configuration that created this revision
 	ConfigurationGenerationLabelKey = GroupName + "/configurationGeneration"
 
+	// ForceUpgradeAnnotationKey is the annotation which was added to resources
+	// upgraded from v1alpha1.
+	// This annotation is no longer used since v1alpha1 was removed, but
+	// must continue to be allowed since it may be present on existing resources.
+	ForceUpgradeAnnotationKey = GroupName + "/forceUpgrade"
+
 	// CreatorAnnotation is the annotation key to describe the user that
 	// created the resource.
 	CreatorAnnotation = GroupName + "/creator"


### PR DESCRIPTION
Add `ForceUpgradeAnnotationKey` to register.go, just to be consistent with the other annotation keys.

/assign @markusthoemmes @dprotaso 