### PR TITLE
Move responsive gc to enabled by default

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "f31ab799"
+    knative.dev/example-checksum: "2d4c16b9"
 data:
   _example: |
     ################################
@@ -114,7 +114,7 @@ data:
     # dereferenced by Routes. This allows us to reap revisions shortly after
     # they are no longer active.
     # See: https://knative.dev/docs/serving/feature-flags/#responsive-revision-garbage-collector
-    responsive-revision-gc: "allowed"
+    responsive-revision-gc: "enabled"
 
     # Controls whether tag header based routing feature are enabled or not.
     # 1. Enabled: enabling tag header based routing

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -48,7 +48,7 @@ func defaultFeaturesConfig() *Features {
 		PodSpecRuntimeClassName: Disabled,
 		PodSpecSecurityContext:  Disabled,
 		PodSpecTolerations:      Disabled,
-		ResponsiveRevisionGC:    Allowed,
+		ResponsiveRevisionGC:    Enabled,
 		TagHeaderBasedRouting:   Disabled,
 	}
 }

--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -32,7 +32,7 @@ import (
 
 // MakeConfiguration creates a Configuration from a Service object.
 func MakeConfiguration(service *v1.Service) (*v1.Configuration, error) {
-	return MakeConfigurationFromExisting(service, &v1.Configuration{}, cfgmap.Allowed)
+	return MakeConfigurationFromExisting(service, &v1.Configuration{}, cfgmap.Enabled)
 }
 
 // MakeConfigurationFromExisting creates a Configuration from a Service object given an existing Configuration.

--- a/pkg/reconciler/service/resources/configuration_test.go
+++ b/pkg/reconciler/service/resources/configuration_test.go
@@ -41,7 +41,7 @@ func TestConfigurationSpec(t *testing.T) {
 	}
 	expectOwnerReferencesSetCorrectly(t, c.OwnerReferences)
 
-	if got, want := len(c.Labels), 2; got != want {
+	if got, want := len(c.Labels), 1; got != want {
 		t.Errorf("expected %d labels got %d", want, got)
 	}
 	if got, want := c.Labels[serving.ServiceLabelKey], testServiceName; got != want {

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -351,14 +351,12 @@ func TestReconcile(t *testing.T) {
 			// Mutate the Service to add some more labels
 			DefaultService("update-child-labels-ignore-route-label", "foo",
 				WithRunLatestRollout, WithInitSvcConditions, WithServiceLabel("new-label", "new-value")),
-			config("update-child-labels-ignore-route-label", "foo",
-				WithRunLatestRollout, WithConfigLabel("serving.knative.dev/route", "update-child-labels-ignore-route-label")),
+			config("update-child-labels-ignore-route-label", "foo", WithRunLatestRollout),
 			route("update-child-labels-ignore-route-label", "foo", WithRunLatestRollout),
 		},
 		Key: "foo/update-child-labels-ignore-route-label",
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: config("update-child-labels-ignore-route-label", "foo", WithRunLatestRollout, WithConfigLabel("new-label", "new-value"),
-				WithConfigLabel("serving.knative.dev/route", "update-child-labels-ignore-route-label")),
+			Object: config("update-child-labels-ignore-route-label", "foo", WithRunLatestRollout, WithConfigLabel("new-label", "new-value")),
 		}, {
 			Object: route("update-child-labels-ignore-route-label", "foo", WithRunLatestRollout, WithRouteLabel(map[string]string{"new-label": "new-value",
 				"serving.knative.dev/service": "update-child-labels-ignore-route-label"})),

--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -210,7 +210,7 @@ func validateAnnotations(objs *v1test.ResourceObjects, extraKeys ...string) erro
 		}
 	}
 	anns = objs.Config.GetAnnotations()
-	for _, a := range append([]string{serving.RoutesAnnotationKey, serving.CreatorAnnotation, serving.UpdaterAnnotation}, extraKeys...) {
+	for _, a := range append([]string{serving.CreatorAnnotation, serving.UpdaterAnnotation}, extraKeys...) {
 		if got := anns[a]; got == "" {
 			return fmt.Errorf("config expected %s annotation to be set, but was empty", a)
 		}

--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -183,9 +183,6 @@ func validateLabelsPropagation(t pkgTest.T, objects v1test.ResourceObjects, name
 	if config.Labels["serving.knative.dev/service"] != names.Service {
 		return fmt.Errorf("expect Service name in Configuration label %q but got %q ", names.Service, config.Labels["serving.knative.dev/service"])
 	}
-	if config.Labels["serving.knative.dev/route"] != names.Route {
-		return fmt.Errorf("expect Route name in Configuration label %q but got %q ", names.Route, config.Labels["serving.knative.dev/route"])
-	}
 
 	t.Log("Validate Labels on Route Object")
 	route := objects.Route
@@ -213,7 +210,7 @@ func validateAnnotations(objs *v1test.ResourceObjects, extraKeys ...string) erro
 		}
 	}
 	anns = objs.Config.GetAnnotations()
-	for _, a := range append([]string{serving.CreatorAnnotation, serving.UpdaterAnnotation}, extraKeys...) {
+	for _, a := range append([]string{serving.RoutesAnnotationKey, serving.CreatorAnnotation, serving.UpdaterAnnotation}, extraKeys...) {
 		if got := anns[a]; got == "" {
 			return fmt.Errorf("config expected %s annotation to be set, but was empty", a)
 		}


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/8208

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Move ResponsiveRevisionGC to "enabled" by default
    * This baked as 'allowed' for .18 which continues to run the old GC along with the new. This allowed for it to be easily disabled without losing data about last-refresh.
* The LastPinned annotation will no longer be updated on resync
    * In a future release we will remove the flag altogether along with this deprecated annotation.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
ResponsiveRevisionGC is enabled by default
```
