### PR TITLE
Add delete permission for internal resources to namespaced roles

### DIFF
--- a/config/core/200-roles/clusterrole-namespaced.yaml
+++ b/config/core/200-roles/clusterrole-namespaced.yaml
@@ -25,7 +25,7 @@ rules:
     verbs: ["*"]
   - apiGroups: ["networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
     resources: ["*"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "delete"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -40,7 +40,7 @@ rules:
     verbs: ["create", "update", "patch", "delete"]
   - apiGroups: ["networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
     resources: ["*"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "delete"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This patch adds "delete" permission to edit and admin namespaced role.

#### An usecase for this permission:

When we add a new label to Ksvc, Route takes over the label but Ingres does not because Ingress is not reconciled automatically.

e.g.
```
$ kubectl label ksvc hello-example "foo=bar"
service.serving.knative.dev/hello-example labeled


$ kubectl get ksvc,rt,king --show-labels 
NAME                                        URL                                        LATESTCREATED           LATESTREADY             READY   REASON   LABELS
service.serving.knative.dev/hello-example   http://hello-example.default.example.com   hello-example-zkjvz-1   hello-example-zkjvz-1   True             foo=bar

NAME                                      URL                                        READY   REASON   LABELS
route.serving.knative.dev/hello-example   http://hello-example.default.example.com   True             foo=bar,serving.knative.dev/service=hello-example

NAME                                                    READY   REASON   LABELS
ingress.networking.internal.knative.dev/hello-example   True             serving.knative.dev/route=hello-example,serving.knative.dev/routeNamespace=default,serving.knative.dev/service=hello-example
```

To apply the label to the ingress, we need to refresh the ingress by deleting it.
Hence namespaced role needs the delete permission.

**Release Note**

```release-note
serving-core.yaml adds delete permission to the internal resources for aggregated cluserroles, admin and edit.
```

/cc @markusthoemmes @mattmoor 
