### PR TITLE
Reconcile Ingress when label was different from desired

### DIFF
--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -32,7 +32,6 @@ import (
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler/route/config"
@@ -54,39 +53,25 @@ func (c *Reconciler) reconcileIngress(ctx context.Context, r *v1.Route, desired 
 		return ingress, nil
 	} else if err != nil {
 		return nil, err
+	} else if !equality.Semantic.DeepEqual(ingress.Spec, desired.Spec) ||
+		!equality.Semantic.DeepEqual(ingress.Annotations, desired.Annotations) {
+		// It is notable that one reason for differences here may be defaulting.
+		// When that is the case, the Update will end up being a nop because the
+		// webhook will bring them into alignment and no new reconciliation will occur.
+		// Also, compare annotation in case ingress.Class is updated.
+
+		// Don't modify the informers copy
+		origin := ingress.DeepCopy()
+		origin.Spec = desired.Spec
+		origin.Annotations = desired.Annotations
+		updated, err := c.netclient.NetworkingV1alpha1().Ingresses(origin.Namespace).Update(ctx, origin, metav1.UpdateOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to update Ingress: %w", err)
+		}
+		return updated, nil
 	}
 
-	if equal, err := ingressSemanticEquals(ctx, desired, ingress); err != nil {
-		return nil, err
-	} else if equal {
-		return ingress, nil
-	}
-
-	// Don't modify the informers copy
-	origin := ingress.DeepCopy()
-	origin.Spec = desired.Spec
-	origin.Annotations = desired.Annotations
-	origin.Labels = desired.Labels
-	return c.netclient.NetworkingV1alpha1().Ingresses(origin.Namespace).Update(ctx, origin, metav1.UpdateOptions{})
-}
-
-func ingressSemanticEquals(ctx context.Context, desiredIngress, ingress *netv1alpha1.Ingress) (bool, error) {
-	logger := logging.FromContext(ctx)
-	specDiff, err := kmp.SafeDiff(desiredIngress.Spec, ingress.Spec)
-	if err != nil {
-		logger.Errorw("Error diffing ingress spec", zap.Error(err))
-		return false, fmt.Errorf("failed to diff ingress: %w", err)
-	} else if specDiff != "" {
-		logger.Info("Reconciling ingress diff (-desired, +observed):\n", specDiff)
-	}
-	// It is notable that one reason for differences here may be defaulting.
-	// When that is the case, the Update will end up being a nop because the
-	// webhook will bring them into alignment and no new reconciliation will occur.
-	// Also, compare annotation in case ingress.Class is updated.
-	return equality.Semantic.DeepEqual(desiredIngress.Spec, ingress.Spec) &&
-		equality.Semantic.DeepEqual(desiredIngress.Labels, ingress.Labels) &&
-		equality.Semantic.DeepEqual(desiredIngress.Annotations, ingress.Annotations) &&
-		specDiff == "", nil
+	return ingress, err
 }
 
 func (c *Reconciler) deleteServices(ctx context.Context, namespace string, serviceNames sets.String) error {

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -599,7 +599,7 @@ func TestReconcile(t *testing.T) {
 			{
 				Object: simpleReadyIngress(
 					Route("default", "different-domain", WithConfigTarget("config"),
-						WithAnotherDomain, WithRouteGeneration(1)),
+						WithAnotherDomain, WithRouteGeneration(1), WithRouteLabel(map[string]string{"app": "prod"})),
 					&traffic.Config{
 						Targets: map[string]traffic.RevisionTargets{
 							traffic.DefaultTarget: {{
@@ -825,8 +825,7 @@ func TestReconcile(t *testing.T) {
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleIngress(
 				Route("default", "becomes-public", WithConfigTarget("config"),
-					WithRouteUID("65-23"), WithRouteGeneration(1), WithRouteObservedGeneration,
-					WithRouteLabel(map[string]string{network.VisibilityLabelKey: "cluster-local"})),
+					WithRouteUID("65-23"), WithRouteGeneration(1), WithRouteObservedGeneration),
 				&traffic.Config{
 					Targets: map[string]traffic.RevisionTargets{
 						traffic.DefaultTarget: {{


### PR DESCRIPTION
## Proposed Changes

As per subject, this patch changes to reconcile Ingress when
it was different from desired.

**Release Note**

```release-note
Ingress is reconciled when label was different from desired.
```

/cc @markusthoemmes @mattmoor  @tcnghia
