### PR TITLE
Reconcile DomainMappings to Ingress

### DIFF
--- a/cmd/domain-mapping/main.go
+++ b/cmd/domain-mapping/main.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	// The set of controllers this controller process runs.
+	"knative.dev/serving/pkg/reconciler/domainmapping"
+
+	// This defines the shared main for injected controllers.
+	"knative.dev/pkg/injection/sharedmain"
+)
+
+func main() {
+	sharedmain.Main("controller", domainmapping.NewController)
+}

--- a/config/domain-mapping/controller.yaml
+++ b/config/domain-mapping/controller.yaml
@@ -1,0 +1,81 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: domain-mapping
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  selector:
+    matchLabels:
+      app: domain-mapping
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: domain-mapping
+        serving.knative.dev/release: devel
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: domain-mapping
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+
+      serviceAccountName: controller
+      containers:
+      - name: domain-mapping
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: ko://knative.dev/serving/cmd/domain-mapping
+
+        resources:
+          requests:
+            cpu: 30m
+            memory: 40Mi
+          limits:
+            cpu: 300m
+            memory: 400Mi
+
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+
+        # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+
+        securityContext:
+          allowPrivilegeEscalation: false
+
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008

--- a/pkg/apis/serving/v1alpha1/domainmapping_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_lifecycle.go
@@ -34,3 +34,8 @@ func (*DomainMapping) GetConditionSet() apis.ConditionSet {
 func (dm *DomainMapping) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("DomainMapping")
 }
+
+// InitializeConditions sets the initial values to the conditions.
+func (dms *DomainMappingStatus) InitializeConditions() {
+	domainMappingCondSet.Manage(dms).InitializeConditions()
+}

--- a/pkg/apis/serving/v1alpha1/domainmapping_types.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_types.go
@@ -69,6 +69,7 @@ type DomainMappingList struct {
 // DomainMappingSpec describes the DomainMapping the user wishes to exist.
 type DomainMappingSpec struct {
 	// Ref points to an Addressable.
+	// Currently, Ref must be a KSvc.
 	Ref duckv1.KReference `json:"ref"`
 }
 

--- a/pkg/reconciler/domainmapping/controller.go
+++ b/pkg/reconciler/domainmapping/controller.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package domainmapping
+
+import (
+	"context"
+
+	"k8s.io/client-go/tools/cache"
+	netclient "knative.dev/networking/pkg/client/injection/client"
+	ingressinformer "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/ingress"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	"knative.dev/serving/pkg/client/injection/informers/serving/v1alpha1/domainmapping"
+	kindreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1alpha1/domainmapping"
+)
+
+// NewController creates a new DomainMapping controller.
+func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	logger := logging.FromContext(ctx)
+	domainmappingInformer := domainmapping.Get(ctx)
+	ingressInformer := ingressinformer.Get(ctx)
+
+	r := &Reconciler{
+		ingressLister: ingressInformer.Lister(),
+		netclient:     netclient.Get(ctx),
+	}
+
+	impl := kindreconciler.NewImpl(ctx, r)
+
+	logger.Info("Setting up event handlers")
+	domainmappingInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+
+	handleControllerOf := cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterControllerGK(v1alpha1.Kind("DomainMapping")),
+		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+	}
+	ingressInformer.Informer().AddEventHandler(handleControllerOf)
+
+	return impl
+}

--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package domainmapping
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	network "knative.dev/networking/pkg"
+	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
+	netclientset "knative.dev/networking/pkg/client/clientset/versioned"
+	networkinglisters "knative.dev/networking/pkg/client/listers/networking/v1alpha1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/reconciler"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	domainmappingreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1alpha1/domainmapping"
+	"knative.dev/serving/pkg/reconciler/domainmapping/resources"
+)
+
+// Reconciler implements controller.Reconciler for DomainMapping resources.
+type Reconciler struct {
+	ingressLister networkinglisters.IngressLister
+	netclient     netclientset.Interface
+}
+
+// Check that our Reconciler implements Interface
+var _ domainmappingreconciler.Interface = (*Reconciler)(nil)
+
+// ReconcileKind implements Interface.ReconcileKind.
+func (r *Reconciler) ReconcileKind(ctx context.Context, dm *v1alpha1.DomainMapping) reconciler.Event {
+	logger := logging.FromContext(ctx)
+	logger.Debugf("Reconciling DomainMapping %s/%s", dm.Namespace, dm.Name)
+
+	// Mapped URL is the metadata.name of the DomainMapping.
+	url := &apis.URL{
+		Scheme: "http",
+		Host:   dm.Name,
+	}
+
+	dm.Status.URL = url
+	dm.Status.Address = &duckv1.Addressable{URL: url}
+
+	// TODO(jz) allow overriding via annotation, configmap.
+	ingressClass := network.IstioIngressClassName
+
+	logger.Debugf("Mapping %s to %s/%s", url, dm.Spec.Ref.Namespace, dm.Spec.Ref.Name)
+	desired := resources.MakeIngress(dm, ingressClass)
+	_, err := r.reconcileIngress(ctx, dm, desired)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *Reconciler) reconcileIngress(ctx context.Context, dm *v1alpha1.DomainMapping, desired *netv1alpha1.Ingress) (*netv1alpha1.Ingress, error) {
+	recorder := controller.GetEventRecorder(ctx)
+	ingress, err := r.ingressLister.Ingresses(desired.Namespace).Get(desired.Name)
+	if apierrs.IsNotFound(err) {
+		ingress, err = r.netclient.NetworkingV1alpha1().Ingresses(desired.Namespace).Create(ctx, desired, metav1.CreateOptions{})
+		if err != nil {
+			recorder.Eventf(dm, corev1.EventTypeWarning, "CreationFailed", "Failed to create Ingress: %v", err)
+			return nil, fmt.Errorf("failed to create Ingress: %w", err)
+		}
+
+		recorder.Eventf(dm, corev1.EventTypeNormal, "Created", "Created Ingress %q", ingress.GetName())
+		return ingress, nil
+	} else if err != nil {
+		return nil, err
+	} else if !equality.Semantic.DeepEqual(ingress.Spec, desired.Spec) ||
+		!equality.Semantic.DeepEqual(ingress.Annotations, desired.Annotations) {
+
+		// Don't modify the informers copy
+		origin := ingress.DeepCopy()
+		origin.Spec = desired.Spec
+		origin.Annotations = desired.Annotations
+		updated, err := r.netclient.NetworkingV1alpha1().Ingresses(origin.Namespace).Update(ctx, origin, metav1.UpdateOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to update Ingress: %w", err)
+		}
+		return updated, nil
+	}
+
+	return ingress, err
+}

--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -68,11 +68,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, dm *v1alpha1.DomainMappi
 	logger.Debugf("Mapping %s to %s/%s", url, dm.Spec.Ref.Namespace, dm.Spec.Ref.Name)
 	desired := resources.MakeIngress(dm, ingressClass)
 	_, err := r.reconcileIngress(ctx, dm, desired)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (r *Reconciler) reconcileIngress(ctx context.Context, dm *v1alpha1.DomainMapping, desired *netv1alpha1.Ingress) (*netv1alpha1.Ingress, error) {

--- a/pkg/reconciler/domainmapping/resources/ingress.go
+++ b/pkg/reconciler/domainmapping/resources/ingress.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking"
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
@@ -59,6 +60,9 @@ func MakeIngress(dm *servingv1alpha1.DomainMapping, ingressClass string) *netv1a
 						RewriteHost: targetHostName,
 						Splits: []netv1alpha1.IngressBackendSplit{{
 							Percent: 100,
+							AppendHeaders: map[string]string{
+								network.OriginalHostHeader: dm.Name,
+							},
 							IngressBackend: netv1alpha1.IngressBackend{
 								ServiceName:      targetServiceName,
 								ServiceNamespace: targetServiceNamespace,

--- a/pkg/reconciler/domainmapping/resources/ingress.go
+++ b/pkg/reconciler/domainmapping/resources/ingress.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"knative.dev/networking/pkg/apis/networking"
+	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/pkg/kmeta"
+	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+)
+
+// MakeIngress creates an Ingress object for a DomainMapping.
+func MakeIngress(dm *servingv1alpha1.DomainMapping, ingressClass string) *netv1alpha1.Ingress {
+	var (
+		targetServiceName      = dm.Spec.Ref.Name
+		targetServiceNamespace = dm.Spec.Ref.Namespace
+	)
+
+	// This assumes the target is a KSvc. To support arbitrary addressables
+	// we will need to resolve the reference to a URL in the same way that
+	// eventing does.
+	targetHostName := targetServiceName + "." + targetServiceNamespace + ".svc.cluster.local"
+
+	return &netv1alpha1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kmeta.ChildName(dm.GetName(), ""),
+			Namespace: dm.Namespace,
+			Annotations: kmeta.FilterMap(kmeta.UnionMaps(map[string]string{
+				networking.IngressClassAnnotationKey: ingressClass,
+			}, dm.GetAnnotations()), func(key string) bool {
+				return key == corev1.LastAppliedConfigAnnotation
+			}),
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(dm)},
+		},
+		Spec: netv1alpha1.IngressSpec{
+			Rules: []netv1alpha1.IngressRule{{
+				Hosts:      []string{dm.Name},
+				Visibility: netv1alpha1.IngressVisibilityExternalIP,
+				HTTP: &netv1alpha1.HTTPIngressRuleValue{
+					Paths: []netv1alpha1.HTTPIngressPath{{
+						RewriteHost: targetHostName,
+						Splits: []netv1alpha1.IngressBackendSplit{{
+							Percent: 100,
+							IngressBackend: netv1alpha1.IngressBackend{
+								ServiceName:      targetServiceName,
+								ServiceNamespace: targetServiceNamespace,
+								ServicePort:      intstr.FromInt(80),
+							},
+						}},
+					}},
+				},
+			}},
+		},
+	}
+}

--- a/pkg/reconciler/domainmapping/resources/ingress_test.go
+++ b/pkg/reconciler/domainmapping/resources/ingress_test.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	network "knative.dev/networking/pkg"
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
@@ -68,6 +69,9 @@ func TestMakeIngress(t *testing.T) {
 						RewriteHost: "the-name.the-namespace.svc.cluster.local",
 						Splits: []netv1alpha1.IngressBackendSplit{{
 							Percent: 100,
+							AppendHeaders: map[string]string{
+								network.OriginalHostHeader: "mapping.com",
+							},
 							IngressBackend: netv1alpha1.IngressBackend{
 								ServiceName:      "the-name",
 								ServiceNamespace: "the-namespace",

--- a/pkg/reconciler/domainmapping/resources/ingress_test.go
+++ b/pkg/reconciler/domainmapping/resources/ingress_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -32,7 +31,7 @@ import (
 
 func TestMakeIngress(t *testing.T) {
 	dm := &v1alpha1.DomainMapping{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mapping.com",
 			Namespace: "the-namespace",
 			Annotations: map[string]string{

--- a/pkg/reconciler/domainmapping/resources/ingress_test.go
+++ b/pkg/reconciler/domainmapping/resources/ingress_test.go
@@ -85,6 +85,6 @@ func TestMakeIngress(t *testing.T) {
 	}
 
 	if !cmp.Equal(want, got) {
-		t.Error("Unexpected Ingress (-want, +got):\n", cmp.Diff(want, got))
+		t.Errorf("Unexpected Ingress (-want, +got):\n%s", cmp.Diff(want, got))
 	}
 }

--- a/pkg/reconciler/domainmapping/resources/ingress_test.go
+++ b/pkg/reconciler/domainmapping/resources/ingress_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/kmeta"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+)
+
+func TestMakeIngress(t *testing.T) {
+	dm := &v1alpha1.DomainMapping{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "mapping.com",
+			Namespace: "the-namespace",
+			Annotations: map[string]string{
+				"some.annotation":                  "some.value",
+				corev1.LastAppliedConfigAnnotation: "blah",
+			},
+		},
+		Spec: v1alpha1.DomainMappingSpec{
+			Ref: duckv1.KReference{
+				Namespace: "the-namespace",
+				Name:      "the-name",
+			},
+		},
+	}
+
+	got := MakeIngress(dm, "the-ingress-class")
+
+	want := &netv1alpha1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mapping.com",
+			Namespace: "the-namespace",
+			Annotations: map[string]string{
+				"networking.knative.dev/ingress.class": "the-ingress-class",
+				"some.annotation":                      "some.value",
+			},
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(dm)},
+		},
+		Spec: netv1alpha1.IngressSpec{
+			Rules: []netv1alpha1.IngressRule{{
+				Hosts:      []string{"mapping.com"},
+				Visibility: netv1alpha1.IngressVisibilityExternalIP,
+				HTTP: &netv1alpha1.HTTPIngressRuleValue{
+					Paths: []netv1alpha1.HTTPIngressPath{{
+						RewriteHost: "the-name.the-namespace.svc.cluster.local",
+						Splits: []netv1alpha1.IngressBackendSplit{{
+							Percent: 100,
+							IngressBackend: netv1alpha1.IngressBackend{
+								ServiceName:      "the-name",
+								ServiceNamespace: "the-namespace",
+								ServicePort:      intstr.FromInt(80),
+							},
+						}},
+					}},
+				},
+			}},
+		},
+	}
+
+	if !cmp.Equal(want, got) {
+		t.Error("Unexpected Ingress (-want, +got):\n", cmp.Diff(want, got))
+	}
+}

--- a/pkg/reconciler/domainmapping/table_test.go
+++ b/pkg/reconciler/domainmapping/table_test.go
@@ -101,9 +101,9 @@ func TestReconcile(t *testing.T) {
 	}))
 }
 
-type DomainMappingOption func(dm *v1alpha1.DomainMapping)
+type domainMappingOption func(dm *v1alpha1.DomainMapping)
 
-func DomainMapping(namespace, name string, opt ...DomainMappingOption) *v1alpha1.DomainMapping {
+func DomainMapping(namespace, name string, opt ...domainMappingOption) *v1alpha1.DomainMapping {
 	dm := &v1alpha1.DomainMapping{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -116,20 +116,20 @@ func DomainMapping(namespace, name string, opt ...DomainMappingOption) *v1alpha1
 	return dm
 }
 
-func WithRef(namespace, name string) DomainMappingOption {
+func WithRef(namespace, name string) domainMappingOption {
 	return func(dm *v1alpha1.DomainMapping) {
 		dm.Spec.Ref.Namespace = namespace
 		dm.Spec.Ref.Name = name
 	}
 }
 
-func WithURL(scheme, host string) DomainMappingOption {
+func WithURL(scheme, host string) domainMappingOption {
 	return func(dm *v1alpha1.DomainMapping) {
 		dm.Status.URL = &apis.URL{Scheme: scheme, Host: host}
 	}
 }
 
-func WithAddress(scheme, host string) DomainMappingOption {
+func WithAddress(scheme, host string) domainMappingOption {
 	return func(dm *v1alpha1.DomainMapping) {
 		dm.Status.Address = &duckv1.Addressable{URL: &apis.URL{
 			Scheme: scheme,

--- a/pkg/reconciler/domainmapping/table_test.go
+++ b/pkg/reconciler/domainmapping/table_test.go
@@ -53,18 +53,18 @@ func TestReconcile(t *testing.T) {
 		Name: "first reconcile",
 		Key:  "default/first-reconcile.com",
 		Objects: []runtime.Object{
-			DomainMapping("default", "first-reconcile.com", WithRef("default", "target")),
+			DomainMapping("default", "first-reconcile.com", withRef("default", "target")),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: DomainMapping("default", "first-reconcile.com",
-				WithRef("default", "target"),
-				WithURL("http", "first-reconcile.com"),
-				WithAddress("http", "first-reconcile.com"),
-				WithInitDomainMappingConditions,
+				withRef("default", "target"),
+				withURL("http", "first-reconcile.com"),
+				withAddress("http", "first-reconcile.com"),
+				withInitDomainMappingConditions,
 			),
 		}},
 		WantCreates: []runtime.Object{
-			resources.MakeIngress(DomainMapping("default", "first-reconcile.com", WithRef("default", "target")), "istio.ingress.networking.knative.dev"),
+			resources.MakeIngress(DomainMapping("default", "first-reconcile.com", withRef("default", "target")), "istio.ingress.networking.knative.dev"),
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "first-reconcile.com"),
@@ -73,19 +73,19 @@ func TestReconcile(t *testing.T) {
 		Name: "reconcile changed ref",
 		Key:  "default/ingress-exists.org",
 		Objects: []runtime.Object{
-			DomainMapping("default", "ingress-exists.org", WithRef("default", "changed")),
-			resources.MakeIngress(DomainMapping("default", "ingress-exists.org", WithRef("default", "target")), "istio.ingress.networking.knative.dev"),
+			DomainMapping("default", "ingress-exists.org", withRef("default", "changed")),
+			resources.MakeIngress(DomainMapping("default", "ingress-exists.org", withRef("default", "target")), "istio.ingress.networking.knative.dev"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: DomainMapping("default", "ingress-exists.org",
-				WithRef("default", "changed"),
-				WithURL("http", "ingress-exists.org"),
-				WithAddress("http", "ingress-exists.org"),
-				WithInitDomainMappingConditions,
+				withRef("default", "changed"),
+				withURL("http", "ingress-exists.org"),
+				withAddress("http", "ingress-exists.org"),
+				withInitDomainMappingConditions,
 			),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: resources.MakeIngress(DomainMapping("default", "ingress-exists.org", WithRef("default", "changed")), "istio.ingress.networking.knative.dev"),
+			Object: resources.MakeIngress(DomainMapping("default", "ingress-exists.org", withRef("default", "changed")), "istio.ingress.networking.knative.dev"),
 		}},
 	}}
 
@@ -116,20 +116,20 @@ func DomainMapping(namespace, name string, opt ...domainMappingOption) *v1alpha1
 	return dm
 }
 
-func WithRef(namespace, name string) domainMappingOption {
+func withRef(namespace, name string) domainMappingOption {
 	return func(dm *v1alpha1.DomainMapping) {
 		dm.Spec.Ref.Namespace = namespace
 		dm.Spec.Ref.Name = name
 	}
 }
 
-func WithURL(scheme, host string) domainMappingOption {
+func withURL(scheme, host string) domainMappingOption {
 	return func(dm *v1alpha1.DomainMapping) {
 		dm.Status.URL = &apis.URL{Scheme: scheme, Host: host}
 	}
 }
 
-func WithAddress(scheme, host string) domainMappingOption {
+func withAddress(scheme, host string) domainMappingOption {
 	return func(dm *v1alpha1.DomainMapping) {
 		dm.Status.Address = &duckv1.Addressable{URL: &apis.URL{
 			Scheme: scheme,
@@ -138,6 +138,6 @@ func WithAddress(scheme, host string) domainMappingOption {
 	}
 }
 
-func WithInitDomainMappingConditions(dm *v1alpha1.DomainMapping) {
+func withInitDomainMappingConditions(dm *v1alpha1.DomainMapping) {
 	dm.Status.InitializeConditions()
 }

--- a/pkg/reconciler/domainmapping/table_test.go
+++ b/pkg/reconciler/domainmapping/table_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package domainmapping
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
+
+	networkingclient "knative.dev/networking/pkg/client/injection/client/fake"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	servingclient "knative.dev/serving/pkg/client/injection/client/fake"
+	domainmappingreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1alpha1/domainmapping"
+	"knative.dev/serving/pkg/reconciler/domainmapping/resources"
+
+	. "knative.dev/pkg/reconciler/testing"
+	. "knative.dev/serving/pkg/reconciler/testing/v1"
+)
+
+func TestReconcile(t *testing.T) {
+	table := TableTest{{
+		Name: "bad workqueue key",
+		// Make sure Reconcile handles bad keys.
+		Key: "too/many/parts",
+	}, {
+		Name: "key not found",
+		// Make sure Reconcile handles good keys that don't exist.
+		Key: "foo/not-found",
+	}, {
+		Name: "first reconcile",
+		Key:  "default/first-reconcile.com",
+		Objects: []runtime.Object{
+			DomainMapping("default", "first-reconcile.com", WithRef("default", "target")),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: DomainMapping("default", "first-reconcile.com",
+				WithRef("default", "target"),
+				WithURL("http", "first-reconcile.com"),
+				WithAddress("http", "first-reconcile.com"),
+				WithInitDomainMappingConditions,
+			),
+		}},
+		WantCreates: []runtime.Object{
+			resources.MakeIngress(DomainMapping("default", "first-reconcile.com", WithRef("default", "target")), "istio.ingress.networking.knative.dev"),
+		},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "first-reconcile.com"),
+		},
+	}, {
+		Name: "reconcile changed ref",
+		Key:  "default/ingress-exists.org",
+		Objects: []runtime.Object{
+			DomainMapping("default", "ingress-exists.org", WithRef("default", "changed")),
+			resources.MakeIngress(DomainMapping("default", "ingress-exists.org", WithRef("default", "target")), "istio.ingress.networking.knative.dev"),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: DomainMapping("default", "ingress-exists.org",
+				WithRef("default", "changed"),
+				WithURL("http", "ingress-exists.org"),
+				WithAddress("http", "ingress-exists.org"),
+				WithInitDomainMappingConditions,
+			),
+		}},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: resources.MakeIngress(DomainMapping("default", "ingress-exists.org", WithRef("default", "changed")), "istio.ingress.networking.knative.dev"),
+		}},
+	}}
+
+	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
+		r := &Reconciler{
+			netclient:     networkingclient.Get(ctx),
+			ingressLister: listers.GetIngressLister(),
+		}
+
+		return domainmappingreconciler.NewReconciler(ctx, logging.FromContext(ctx), servingclient.Get(ctx),
+			listers.GetDomainMappingLister(), controller.GetEventRecorder(ctx), r,
+		)
+	}))
+}
+
+type DomainMappingOption func(dm *v1alpha1.DomainMapping)
+
+func DomainMapping(namespace, name string, opt ...DomainMappingOption) *v1alpha1.DomainMapping {
+	dm := &v1alpha1.DomainMapping{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+	for _, o := range opt {
+		o(dm)
+	}
+	return dm
+}
+
+func WithRef(namespace, name string) DomainMappingOption {
+	return func(dm *v1alpha1.DomainMapping) {
+		dm.Spec.Ref.Namespace = namespace
+		dm.Spec.Ref.Name = name
+	}
+}
+
+func WithURL(scheme, host string) DomainMappingOption {
+	return func(dm *v1alpha1.DomainMapping) {
+		dm.Status.URL = &apis.URL{Scheme: scheme, Host: host}
+	}
+}
+
+func WithAddress(scheme, host string) DomainMappingOption {
+	return func(dm *v1alpha1.DomainMapping) {
+		dm.Status.Address = &duckv1.Addressable{URL: &apis.URL{
+			Scheme: scheme,
+			Host:   host,
+		}}
+	}
+}
+
+func WithInitDomainMappingConditions(dm *v1alpha1.DomainMapping) {
+	dm.Status.InitializeConditions()
+}

--- a/pkg/reconciler/testing/v1/listers.go
+++ b/pkg/reconciler/testing/v1/listers.go
@@ -35,9 +35,11 @@ import (
 	"knative.dev/pkg/reconciler/testing"
 	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	fakeservingclientset "knative.dev/serving/pkg/client/clientset/versioned/fake"
 	palisters "knative.dev/serving/pkg/client/listers/autoscaling/v1alpha1"
 	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
+	servingv1alpha1listers "knative.dev/serving/pkg/client/listers/serving/v1alpha1"
 )
 
 var clientSetSchemes = []func(*runtime.Scheme) error{
@@ -104,6 +106,10 @@ func (l *Listers) GetServiceLister() servinglisters.ServiceLister {
 
 func (l *Listers) GetRouteLister() servinglisters.RouteLister {
 	return servinglisters.NewRouteLister(l.IndexerFor(&v1.Route{}))
+}
+
+func (l *Listers) GetDomainMappingLister() servingv1alpha1listers.DomainMappingLister {
+	return servingv1alpha1listers.NewDomainMappingLister(l.IndexerFor(&v1alpha1.DomainMapping{}))
 }
 
 // GetServerlessServiceLister returns a lister for the ServerlessService objects.


### PR DESCRIPTION
Second part of #9713.

Reconciles DomainMappings to Ingresses. In the interests of keeping this PR small(-ish 😅) this only handles reconciling downwards, next PR will propagate the ingress status back up to the DomainMapping.

Also for now this assumes the target `ref` is a KSvc such that we can get the URL via `{ref.name}.{ref.namespace}.svc.cluster.local` (we also need that to be sure there's a k8s service for the target anyway). See #9713 for other todos.

/assign @mattmoor @dprotaso