### PR TITLE
Name revisions consistently to avoid creating the same revision twice

### DIFF
--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -59,14 +59,14 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, config *v1.Configuration
 	recorder := controller.GetEventRecorder(ctx)
 
 	// First, fetch the revision that should exist for the current generation.
-	lcr, err := c.latestCreatedRevision(ctx, config)
+	lcr, err := c.latestCreatedRevision(config)
 	if errors.IsNotFound(err) {
 		lcr, err = c.createRevision(ctx, config)
 		if errors.IsAlreadyExists(err) {
 			// Newer revisions with a consistent naming scheme can theoretically hit this
 			// path during normal operation so we don't actually report any failures to
 			// the user.
-			// We fail reconcilation anyway to make sure we get the correct revision for
+			// We fail reconciliation anyway to make sure we get the correct revision for
 			// further processing.
 			return fmt.Errorf("failed to create Revision: %w", err)
 		} else if err != nil {
@@ -245,7 +245,7 @@ func CheckNameAvailability(config *v1.Configuration, lister listers.RevisionList
 	return rev, nil
 }
 
-func (c *Reconciler) latestCreatedRevision(ctx context.Context, config *v1.Configuration) (*v1.Revision, error) {
+func (c *Reconciler) latestCreatedRevision(config *v1.Configuration) (*v1.Revision, error) {
 	if rev, err := CheckNameAvailability(config, c.revisionLister); rev != nil || err != nil {
 		return rev, err
 	}

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -63,14 +63,13 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, config *v1.Configuration
 	if errors.IsNotFound(err) {
 		lcr, err = c.createRevision(ctx, config)
 		if err != nil {
-			recorder.Eventf(config, corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision: %v", err)
-
 			if !errors.IsAlreadyExists(err) {
 				// Mark the Configuration as not-Ready since creating
 				// its latest revision failed.
 				// Newer revisions with a consistent naming scheme can theoretically
 				// hit this path during normal operation so we don't do this if the
 				// revision we tried to create already existed.
+				recorder.Eventf(config, corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision: %v", err)
 				config.Status.MarkRevisionCreationFailed(err.Error())
 			}
 

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -120,15 +120,15 @@ func test(t *testing.T) {
 			Object: cfg("no-revisions-yet", "foo", 1234,
 				// The following properties are set when we first reconcile a
 				// Configuration and a Revision is created.
-				WithLatestCreated("no-revisions-yet-00001"), WithConfigObservedGen),
+				WithLatestCreated("no-revisions-yet-01234"), WithConfigObservedGen),
 		}, {
 			Object: cfg("no-revisions-yet", "foo", 1234,
 				// The following properties are set when we first reconcile a
 				// Configuration and a Revision is created.
-				WithLatestCreated("no-revisions-yet-00001"), WithConfigObservedGen),
+				WithLatestCreated("no-revisions-yet-01234"), WithConfigObservedGen),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "Created", "Created Revision %q", "no-revisions-yet-00001"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created Revision %q", "no-revisions-yet-01234"),
 		},
 		Key: "foo/no-revisions-yet",
 	}, {
@@ -388,10 +388,10 @@ func test(t *testing.T) {
 				// These would be the status updates after a first
 				// reconcile, which we use to trigger the update
 				// where we've induced a failure.
-				WithLatestCreated("update-config-failure-00001"), WithConfigObservedGen),
+				WithLatestCreated("update-config-failure-01234"), WithConfigObservedGen),
 		}},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeNormal, "Created", "Created Revision %q", "update-config-failure-00001"),
+			Eventf(corev1.EventTypeNormal, "Created", "Created Revision %q", "update-config-failure-01234"),
 			Eventf(corev1.EventTypeWarning, "UpdateFailed", `Failed to update status for "update-config-failure": inducing failure for update configurations`),
 		},
 		Key: "foo/update-config-failure",

--- a/pkg/reconciler/configuration/resources/revision.go
+++ b/pkg/reconciler/configuration/resources/revision.go
@@ -40,7 +40,7 @@ func MakeRevision(ctx context.Context, configuration *v1.Configuration, clock cl
 	rev.Namespace = configuration.Namespace
 
 	if rev.Name == "" {
-		rev.GenerateName = configuration.Name + "-"
+		rev.Name = kmeta.ChildName(configuration.Name, fmt.Sprintf("-%05d", configuration.Generation))
 	}
 
 	// Pending tells the labeler that we have not processed this revision.

--- a/pkg/reconciler/configuration/resources/revision_test.go
+++ b/pkg/reconciler/configuration/resources/revision_test.go
@@ -66,8 +66,8 @@ func TestMakeRevisions(t *testing.T) {
 		},
 		want: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    "no",
-				GenerateName: "build-",
+				Namespace: "no",
+				Name:      "build-00010",
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Configuration",
@@ -121,9 +121,9 @@ func TestMakeRevisions(t *testing.T) {
 		},
 		want: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    "with",
-				GenerateName: "labels-",
-				Annotations:  map[string]string{},
+				Namespace:   "with",
+				Name:        "labels-00100",
+				Annotations: map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Configuration",
@@ -175,8 +175,8 @@ func TestMakeRevisions(t *testing.T) {
 		},
 		want: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    "with",
-				GenerateName: "annotations-",
+				Namespace: "with",
+				Name:      "annotations-00100",
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Configuration",
@@ -230,8 +230,8 @@ func TestMakeRevisions(t *testing.T) {
 		},
 		want: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    "anno",
-				GenerateName: "config-",
+				Namespace: "anno",
+				Name:      "config-00010",
 				Annotations: map[string]string{
 					"serving.knative.dev/creator":             "someone",
 					serving.RoutesAnnotationKey:               "route",
@@ -291,8 +291,8 @@ func TestMakeRevisions(t *testing.T) {
 		},
 		want: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    "anno",
-				GenerateName: "config-",
+				Namespace: "anno",
+				Name:      "config-00010",
 				Annotations: map[string]string{
 					"serving.knative.dev/creator": "someone",
 					"foo":                         "bar",


### PR DESCRIPTION
Fixes #9736

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

See the linked issue for a detailed description. This avoids edge-cases where we would create the same revision twice and be able to do so because we've been using `generateName`. Using a consistent name allows us to rely on K8s to make sure we're not creating the same thing twice.

I believe there are some bits in this reconciler that can be greatly simplified after this change, but I opted towards a safe way of doing this change first and then optimize the reconciler after, just to not mix concerns too much. It'll require some care to pull things apart to make sure not to introduce a backwards incompatible change.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Revisions are now named more clearly and consistently.
```

/assign @dprotaso @mattmoor 
