### PR TITLE
Populate the bucket ownership from StatForwarder to StatServer

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -137,10 +137,6 @@ func main() {
 		metric.NewController(ctx, cmw, collector),
 	}
 
-	// Set up a statserver.
-	// TODO(yanweiguo): Populate the isBktOwner from statfowarder.Forwarder.
-	statsServer := statserver.New(statsServerAddr, statsCh, logger, nil /* isBktOwner*/)
-
 	// Start watching the configs.
 	if err := cmw.Start(ctx.Done()); err != nil {
 		logger.Fatalw("Failed to start watching configs", zap.Error(err))
@@ -160,6 +156,9 @@ func main() {
 		multiScaler.Poke(sm.Key, sm.Stat)
 	}
 	f := statforwarder.New(ctx, logger, kubeClient, cc.Identity, bucket.AutoscalerBucketSet(cc.Buckets), accept)
+
+	// Set up a statserver.
+	statsServer := statserver.New(statsServerAddr, statsCh, logger, f.IsBktOwner)
 
 	defer f.Cancel()
 

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -148,7 +148,7 @@ func main() {
 	}
 
 	cc := componentConfig(ctx, logger)
-	ctx = leaderelection.WithDynamicLeaderElectorBuilder(ctx, kubeClient, cc)
+	ctx = leaderelection.WithStandardLeaderElectorBuilder(ctx, kubeClient, cc)
 
 	// accept is the func to call when this pod owns the Revision for this StatMessage.
 	accept := func(sm asmetrics.StatMessage) {

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -158,7 +158,7 @@ func main() {
 	f := statforwarder.New(ctx, logger, kubeClient, cc.Identity, bucket.AutoscalerBucketSet(cc.Buckets), accept)
 
 	// Set up a statserver.
-	statsServer := statserver.New(statsServerAddr, statsCh, logger, f.IsBktOwner)
+	statsServer := statserver.New(statsServerAddr, statsCh, logger, f.IsBucketOwner)
 
 	defer f.Cancel()
 

--- a/pkg/autoscaler/statforwarder/forwarder.go
+++ b/pkg/autoscaler/statforwarder/forwarder.go
@@ -393,12 +393,9 @@ func (f *Forwarder) Cancel() {
 	close(f.statCh)
 }
 
-// IsBktOwner returns true if this Autoscaler pod is the owner of the given bucket.
-func (f *Forwarder) IsBktOwner(bkt string) bool {
+// IsBucketOwner returns true if this Autoscaler pod is the owner of the given bucket.
+func (f *Forwarder) IsBucketOwner(bkt string) bool {
 	p := f.getProcessor(bkt)
-	if p == nil {
-		return false
-	}
 	// The accept func is not nil iif this Autoscaler is the owner.
-	return p.accept != nil
+	return p != nil && p.accept != nil
 }

--- a/pkg/autoscaler/statforwarder/forwarder.go
+++ b/pkg/autoscaler/statforwarder/forwarder.go
@@ -392,3 +392,13 @@ func (f *Forwarder) Cancel() {
 	f.processingWg.Wait()
 	close(f.statCh)
 }
+
+// IsBktOwner returns true if this Autoscaler pod is the owner of the given bucket.
+func (f *Forwarder) IsBktOwner(bkt string) bool {
+	p := f.getProcessor(bkt)
+	if p == nil {
+		return false
+	}
+	// The accept func is not nil iif this Autoscaler is the owner.
+	return p.accept != nil
+}

--- a/pkg/autoscaler/statforwarder/forwarder_test.go
+++ b/pkg/autoscaler/statforwarder/forwarder_test.go
@@ -142,20 +142,6 @@ func TestForwarderReconcile(t *testing.T) {
 		t.Fatal("Timeout to get the Endpoints:", lastErr)
 	}
 
-	// f1 is the owner of bucket1 while bucket2 has no owner.
-	if got := f1.IsBktOwner(bucket1); got != true {
-		t.Errorf("IsBktOwner(bucket1) = %v, want true", got)
-	}
-	if got := f1.IsBktOwner(bucket2); got != false {
-		t.Errorf("IsBktOwner(bucket1) = %v, want false", got)
-	}
-	if got := f2.IsBktOwner(bucket1); got != false {
-		t.Errorf("IsBktOwner(bucket1) = %v, want false", got)
-	}
-	if got := f2.IsBktOwner(bucket2); got != false {
-		t.Errorf("IsBktOwner(bucket1) = %v, want false", got)
-	}
-
 	// Lease holder gets changed.
 	l := testLease.DeepCopy()
 	l.Spec.HolderIdentity = &testIP2
@@ -179,14 +165,6 @@ func TestForwarderReconcile(t *testing.T) {
 		return true, nil
 	}); err != nil {
 		t.Fatal("Timeout to get the Endpoints:", lastErr)
-	}
-
-	// f2 is the owner of bucket1.
-	if got := f1.IsBktOwner(bucket1); got != false {
-		t.Errorf("IsBktOwner(bucket1) = %v, want false", got)
-	}
-	if got := f2.IsBktOwner(bucket1); got != true {
-		t.Errorf("IsBktOwner(bucket1) = %v, want true", got)
 	}
 }
 
@@ -480,4 +458,28 @@ func TestProcess(t *testing.T) {
 
 	// Make sure Cancel can be called without crash.
 	f.Cancel()
+}
+
+func TestIsBktOwner(t *testing.T) {
+	f := Forwarder{
+		processors: map[string]*bucketProcessor{
+			bucket1: {
+				bkt:    bucket1,
+				accept: noOp,
+			},
+			bucket2: {
+				bkt: bucket2,
+			},
+		},
+	}
+
+	if got := f.IsBktOwner(bucket1); got != true {
+		t.Errorf("IsBktOwner(bucket1) = %v, want false", got)
+	}
+	if got := f.IsBktOwner(bucket2); got != false {
+		t.Errorf("IsBktOwner(bucket2) = %v, want true", got)
+	}
+	if got := f.IsBktOwner("not-in-record"); got != false {
+		t.Errorf("IsBktOwner(not-in-record) = %v, want true", got)
+	}
 }

--- a/pkg/autoscaler/statforwarder/forwarder_test.go
+++ b/pkg/autoscaler/statforwarder/forwarder_test.go
@@ -460,7 +460,7 @@ func TestProcess(t *testing.T) {
 	f.Cancel()
 }
 
-func TestIsBktOwner(t *testing.T) {
+func TestIsBucketOwner(t *testing.T) {
 	f := Forwarder{
 		processors: map[string]*bucketProcessor{
 			bucket1: {
@@ -473,13 +473,13 @@ func TestIsBktOwner(t *testing.T) {
 		},
 	}
 
-	if got := f.IsBktOwner(bucket1); got != true {
+	if got := f.IsBucketOwner(bucket1); got != true {
 		t.Errorf("IsBktOwner(bucket1) = %v, want false", got)
 	}
-	if got := f.IsBktOwner(bucket2); got != false {
+	if got := f.IsBucketOwner(bucket2); got != false {
 		t.Errorf("IsBktOwner(bucket2) = %v, want true", got)
 	}
-	if got := f.IsBktOwner("not-in-record"); got != false {
+	if got := f.IsBucketOwner("not-in-record"); got != false {
 		t.Errorf("IsBktOwner(not-in-record) = %v, want true", got)
 	}
 }

--- a/pkg/autoscaler/statforwarder/forwarder_test.go
+++ b/pkg/autoscaler/statforwarder/forwarder_test.go
@@ -142,6 +142,20 @@ func TestForwarderReconcile(t *testing.T) {
 		t.Fatal("Timeout to get the Endpoints:", lastErr)
 	}
 
+	// f1 is the owner of bucket1 while bucket2 has no owner.
+	if got := f1.IsBktOwner(bucket1); got != true {
+		t.Errorf("IsBktOwner(bucket1) = %v, want true", got)
+	}
+	if got := f1.IsBktOwner(bucket2); got != false {
+		t.Errorf("IsBktOwner(bucket1) = %v, want false", got)
+	}
+	if got := f2.IsBktOwner(bucket1); got != false {
+		t.Errorf("IsBktOwner(bucket1) = %v, want false", got)
+	}
+	if got := f2.IsBktOwner(bucket2); got != false {
+		t.Errorf("IsBktOwner(bucket1) = %v, want false", got)
+	}
+
 	// Lease holder gets changed.
 	l := testLease.DeepCopy()
 	l.Spec.HolderIdentity = &testIP2
@@ -165,6 +179,14 @@ func TestForwarderReconcile(t *testing.T) {
 		return true, nil
 	}); err != nil {
 		t.Fatal("Timeout to get the Endpoints:", lastErr)
+	}
+
+	// f2 is the owner of bucket1.
+	if got := f1.IsBktOwner(bucket1); got != false {
+		t.Errorf("IsBktOwner(bucket1) = %v, want false", got)
+	}
+	if got := f2.IsBktOwner(bucket1); got != true {
+		t.Errorf("IsBktOwner(bucket1) = %v, want true", got)
 	}
 }
 


### PR DESCRIPTION
StatServer needs this to reject a connection if the pod is not the owner of the bucket.

/assign @vagababov 
