### PR TITLE
Make docs about cluster local domains more accurate

### DIFF
--- a/config/core/configmaps/domain.yaml
+++ b/config/core/configmaps/domain.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "f8e5beb4"
+    knative.dev/example-checksum: "74c3fc6a"
 data:
   _example: |
     ################################
@@ -49,9 +49,10 @@ data:
       selector:
         app: nonprofit
 
-    # Routes having domain suffix of 'svc.cluster.local' will not be exposed
-    # through Ingress. You can define your own label selector to assign that
-    # domain suffix to your Route here, or you can set the label
+    # Routes having the cluster domain suffix (by default 'svc.cluster.local')
+    # will not be exposed through Ingress. You can define your own label
+    # selector to assign that domain suffix to your Route here, or you can set
+    # the label
     #    "serving.knative.dev/visibility=cluster-local"
     # to achieve the same effect.  This shows how to make routes having
     # the label app=secret only exposed to the local cluster.


### PR DESCRIPTION
The current config map example docs [are only true if the default cluster domain is being used](https://github.com/knative/serving/blob/7398ed7b7e45bb751e6aa475a8d2f2ab15398e44/pkg/reconciler/route/visibility/visibility.go#L68).