### PR TITLE
Propagate Ingress status to DomainMapping

### DIFF
--- a/pkg/apis/serving/v1alpha1/domainmapping_lifecycle_test.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_lifecycle_test.go
@@ -19,10 +19,13 @@ package v1alpha1
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	apistest "knative.dev/pkg/apis/testing"
 )
 
 func TestDomainMappingDuckTypes(t *testing.T) {
@@ -62,4 +65,48 @@ func TestDomainMappingGetGroupVersionKind(t *testing.T) {
 	if got := r.GetGroupVersionKind(); got != want {
 		t.Errorf("got: %v, want: %v", got, want)
 	}
+}
+
+func TestPropagateIngressStatus(t *testing.T) {
+	dms := &DomainMappingStatus{}
+
+	dms.InitializeConditions()
+	apistest.CheckConditionOngoing(dms, DomainMappingConditionIngressReady, t)
+	apistest.CheckConditionOngoing(dms, DomainMappingConditionReady, t)
+
+	dms.PropagateIngressStatus(netv1alpha1.IngressStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   netv1alpha1.IngressConditionReady,
+				Status: corev1.ConditionFalse,
+			}},
+		},
+	})
+
+	apistest.CheckConditionFailed(dms, DomainMappingConditionIngressReady, t)
+	apistest.CheckConditionFailed(dms, DomainMappingConditionReady, t)
+
+	dms.PropagateIngressStatus(netv1alpha1.IngressStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   netv1alpha1.IngressConditionReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	})
+
+	apistest.CheckConditionSucceeded(dms, DomainMappingConditionIngressReady, t)
+	apistest.CheckConditionSucceeded(dms, DomainMappingConditionReady, t)
+
+	dms.PropagateIngressStatus(netv1alpha1.IngressStatus{
+		Status: duckv1.Status{
+			Conditions: duckv1.Conditions{{
+				Type:   netv1alpha1.IngressConditionReady,
+				Status: corev1.ConditionUnknown,
+			}},
+		},
+	})
+
+	apistest.CheckConditionOngoing(dms, DomainMappingConditionIngressReady, t)
+	apistest.CheckConditionOngoing(dms, DomainMappingConditionReady, t)
 }

--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -53,6 +53,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, dm *v1alpha1.DomainMappi
 	logger := logging.FromContext(ctx)
 	logger.Debugf("Reconciling DomainMapping %s/%s", dm.Namespace, dm.Name)
 
+	// Defensively assume the ingress is not configured until we manage to
+	// successfully reconcile it below. This avoids error cases where we fail
+	// before we've reconciled the ingress and get a new ObservedGeneration but
+	// still have Ingress Ready: True.
+	if dm.GetObjectMeta().GetGeneration() != dm.Status.ObservedGeneration {
+		dm.Status.MarkIngressNotConfigured()
+	}
+
 	// Mapped URL is the metadata.name of the DomainMapping.
 	url := &apis.URL{
 		Scheme: "http",
@@ -67,7 +75,17 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, dm *v1alpha1.DomainMappi
 
 	logger.Debugf("Mapping %s to %s/%s", url, dm.Spec.Ref.Namespace, dm.Spec.Ref.Name)
 	desired := resources.MakeIngress(dm, ingressClass)
-	_, err := r.reconcileIngress(ctx, dm, desired)
+	ingress, err := r.reconcileIngress(ctx, dm, desired)
+	if err != nil {
+		return err
+	}
+
+	if ingress.GetObjectMeta().GetGeneration() != ingress.Status.ObservedGeneration {
+		dm.Status.MarkIngressNotConfigured()
+	} else {
+		dm.Status.PropagateIngressStatus(ingress.Status)
+	}
+
 	return err
 }
 

--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -80,6 +80,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, dm *v1alpha1.DomainMappi
 		return err
 	}
 
+	// Check that the Ingress status reflects the latest ingress applied and propagate if so.
 	if ingress.GetObjectMeta().GetGeneration() != ingress.Status.ObservedGeneration {
 		dm.Status.MarkIngressNotConfigured()
 	} else {

--- a/pkg/reconciler/domainmapping/resources/ingress_test.go
+++ b/pkg/reconciler/domainmapping/resources/ingress_test.go
@@ -27,7 +27,7 @@ import (
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
-	pkgnet "knative.dev/pkg/network"
+	pkgnetwork "knative.dev/pkg/network"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
@@ -67,7 +67,7 @@ func TestMakeIngress(t *testing.T) {
 				Visibility: netv1alpha1.IngressVisibilityExternalIP,
 				HTTP: &netv1alpha1.HTTPIngressRuleValue{
 					Paths: []netv1alpha1.HTTPIngressPath{{
-						RewriteHost: pkgnet.GetServiceHostname("the-name", "the-namespace"),
+						RewriteHost: pkgnetwork.GetServiceHostname("the-name", "the-namespace"),
 						Splits: []netv1alpha1.IngressBackendSplit{{
 							Percent: 100,
 							AppendHeaders: map[string]string{


### PR DESCRIPTION
Third part of #9713.

This gets things working end-to-end (without domain claims, validation, ability to set ingress class etc etc of course), so should be able to land the initial conformance test after this.

/assign @mattmoor @dprotaso 