### PR TITLE
Adhere to recommended docs

### DIFF
--- a/pkg/activator/net/lb_policy.go
+++ b/pkg/activator/net/lb_policy.go
@@ -34,7 +34,7 @@ type lbPolicy func(ctx context.Context, targets []*podTracker) (func(), *podTrac
 // randomLBPolicy is a load balancer policy that picks a random target.
 // This approximates the LB policy done by K8s Service (IPTables based).
 //
-// nolint // This is currently unused but kept here for posterity.
+//nolint // This is currently unused but kept here for posterity.
 func randomLBPolicy(_ context.Context, targets []*podTracker) (func(), *podTracker) {
 	return noop, targets[rand.Intn(len(targets))]
 }
@@ -53,8 +53,7 @@ func randomChoice2Policy(_ context.Context, targets []*podTracker) (func(), *pod
 	// Two trackers - we know both contestants,
 	// otherwise pick 2 random unequal integers.
 	if l > 2 {
-		// nolint:gosec // We don't need cryptographic randomness here.
-		r1, r2 = rand.Intn(l), rand.Intn(l-1)
+		r1, r2 = rand.Intn(l), rand.Intn(l-1) //nolint:gosec // We don't need cryptographic randomness here.
 		// shift second half of second rand.Intn down so we're picking
 		// from range of numbers other than r1.
 		// i.e. rand.Intn(l-1) range is now from range [0,r1),[r1+1,l).

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -58,7 +58,7 @@ func TCPProbe(config TCPProbeConfigOptions) error {
 var transport = func() *http.Transport {
 	t := http.DefaultTransport.(*http.Transport).Clone()
 	t.DisableKeepAlives = true
-	// nolint:gosec // We explicitly don't need to check certs here.
+	//nolint:gosec // We explicitly don't need to check certs here.
 	t.TLSClientConfig.InsecureSkipVerify = true
 	return t
 }()


### PR DESCRIPTION
As stated here: https://golangci-lint.run/usage/false-positives/ — machine readable ones
should be `//nolint`, not `// nolint`.
I noticed those actually would not even work a few times, when I was fixing pkg.
Also move the relevant ones on the same line, since otherise the nolint
applies to the whole block (or function).

/assign @markusthoemmes 