### PR TITLE
Increase the number of replicas for Istio deployments in performance testing

### DIFF
--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -49,9 +49,9 @@ function update_knative() {
 
   # Overprovision the Istio gateways and pilot.
   kubectl patch hpa -n istio-system istio-ingressgateway \
-    --patch '{"spec": {"minReplicas": 10, "maxReplicas": 10}}'
+    --patch '{"spec": {"minReplicas": 15, "maxReplicas": 15}}'
   kubectl patch deploy -n istio-system cluster-local-gateway \
-    --patch '{"spec": {"replicas": 10}}'
+    --patch '{"spec": {"replicas": 15}}'
 
   echo ">> Updating serving"
   # Retry installation for at most three times as there can sometime be a race condition when applying serving CRDs


### PR DESCRIPTION
…testing

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
* Increase the number of replicas for Istio deployments in performance testing, as discussed in https://knative.slack.com/archives/C94SPR60H/p1602520615090400?thread_ts=1601836070.072800&cid=C94SPR60H

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vagababov 
