### PR TITLE
Optimize code: pass by pointer

### DIFF
--- a/pkg/apis/serving/v1/configuration_validation.go
+++ b/pkg/apis/serving/v1/configuration_validation.go
@@ -51,7 +51,7 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 			errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, c.Spec, original.GetAnnotations(),
 				c.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
 		}
-		err := c.Spec.Template.VerifyNameChange(ctx, original.Spec.Template)
+		err := c.Spec.Template.VerifyNameChange(ctx, &original.Spec.Template)
 		errs = errs.Also(err.ViaField("spec.template"))
 	}
 

--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -70,7 +70,7 @@ func (rts *RevisionTemplateSpec) Validate(ctx context.Context) *apis.FieldError 
 
 // VerifyNameChange checks that if a user brought their own name previously that it
 // changes at the appropriate times.
-func (rts *RevisionTemplateSpec) VerifyNameChange(ctx context.Context, og RevisionTemplateSpec) *apis.FieldError {
+func (rts *RevisionTemplateSpec) VerifyNameChange(ctx context.Context, og *RevisionTemplateSpec) *apis.FieldError {
 	if rts.Name == "" {
 		// We only check that Name changes when the RevisionTemplate changes.
 		return nil
@@ -80,13 +80,15 @@ func (rts *RevisionTemplateSpec) VerifyNameChange(ctx context.Context, og Revisi
 		return nil
 	}
 
-	if diff, err := kmp.ShortDiff(&og, rts); err != nil {
+	diff, err := kmp.ShortDiff(og, rts)
+	if err != nil {
 		return &apis.FieldError{
 			Message: "Failed to diff RevisionTemplate",
 			Paths:   []string{apis.CurrentField},
 			Details: err.Error(),
 		}
-	} else if diff != "" {
+	}
+	if diff != "" {
 		return &apis.FieldError{
 			Message: "Saw the following changes without a name change (-old +new)",
 			Paths:   []string{"metadata.name"},

--- a/pkg/apis/serving/v1/service_validation.go
+++ b/pkg/apis/serving/v1/service_validation.go
@@ -48,7 +48,7 @@ func (s *Service) Validate(ctx context.Context) (errs *apis.FieldError) {
 		errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, s.Spec, original.GetAnnotations(),
 			s.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
 		err := s.Spec.ConfigurationSpec.Template.VerifyNameChange(ctx,
-			original.Spec.ConfigurationSpec.Template)
+			&original.Spec.ConfigurationSpec.Template)
 		errs = errs.Also(err.ViaField("spec.template"))
 	}
 	return errs


### PR DESCRIPTION
pod spec is huge and now we can have multiple containers
and this happens 3 times on every service reconcile
probably worth cutting that copying around

/assign @dprotaso mattmoor