### PR TITLE
Re-introduce maxprocs (but quieter) for queue proxy

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"go.opencensus.io/plugin/ochttp"
+	"go.uber.org/automaxprocs/maxprocs"
 	"go.uber.org/zap"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -96,6 +97,10 @@ type config struct {
 	TracingConfigSampleRate           float64                   `split_words:"true"` // optional
 	TracingConfigZipkinEndpoint       string                    `split_words:"true"` // optional
 	TracingConfigStackdriverProjectID string                    `split_words:"true"` // optional
+}
+
+func init() {
+	maxprocs.Set()
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/tsenart/vegeta v12.7.1-0.20190725001342-b5f4fca92137+incompatible
 	go.opencensus.io v0.22.4
 	go.uber.org/atomic v1.6.0
+	go.uber.org/automaxprocs v1.3.0
 	go.uber.org/zap v1.15.0
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -325,6 +325,7 @@ go.opencensus.io/trace/tracestate
 ## explicit
 go.uber.org/atomic
 # go.uber.org/automaxprocs v1.3.0
+## explicit
 go.uber.org/automaxprocs
 go.uber.org/automaxprocs/internal/cgroups
 go.uber.org/automaxprocs/internal/runtime


### PR DESCRIPTION
We shushed the messages from `automaxprocs` in https://github.com/knative/serving/pull/9788, but at the cost of no longer actually setting up GOMAXPROCS for QP at all (there were other benefits to that change tho - we no longer pull in all the sharedmain stuff for no reason, which is good). I think we probably _do_ want to still set GOMAXPROCS tho (after all, QP is often running on a super big host with lots of cpus, but with a small cpu quota set..), we just want it to not be making noise in the logs. [This does that](https://github.com/uber-go/automaxprocs/blob/master/maxprocs/maxprocs.go#L56-L57).

/assign @vagababov @mattmoor 