### PR TITLE
Fix nil-pointer on accessing condition in autoscaler

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -149,7 +149,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutosc
 		pa.Status.MarkSKSReady()
 	} else {
 		logger.Debug("SKS is not ready, marking SKS status not ready")
-		pa.Status.MarkSKSNotReady(sks.Status.GetCondition(nv1alpha1.ServerlessServiceConditionReady).Message)
+		pa.Status.MarkSKSNotReady(sks.Status.GetCondition(nv1alpha1.ServerlessServiceConditionReady).GetMessage())
 	}
 
 	logger.Infof("PA scale got=%d, want=%d, desiredPods=%d ebc=%d", ready, want,
@@ -235,7 +235,7 @@ func computeActiveCondition(ctx context.Context, pa *pav1alpha1.PodAutoscaler, p
 	// In pre-0.17 we could have scaled down normally without ever setting ScaleTargetInitialized.
 	// In this case we'll be in the NoTraffic/inactive state.
 	// TODO(taragu): remove after 0.19
-	alreadyScaledDownSuccessfully := minReady > 0 && pa.Status.GetCondition(pav1alpha1.PodAutoscalerConditionActive).Reason == noTrafficReason
+	alreadyScaledDownSuccessfully := minReady > 0 && pa.Status.GetCondition(pav1alpha1.PodAutoscalerConditionActive).GetReason() == noTrafficReason
 	if (pc.ready >= minReady || alreadyScaledDownSuccessfully) && pa.Status.ServiceName != "" {
 		pa.Status.MarkScaleTargetInitialized()
 	}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Seen in the wild as

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x60 pc=0x17b7be5]

goroutine 156 [running]:
knative.dev/serving/pkg/reconciler/autoscaling/kpa.(*Reconciler).ReconcileKind(0xc00066d6b0, 0x2030d40, 0xc001767c50, 0xc0017026c0, 0x1ff71a0, 0xc001702878)
	/go/src/knative.dev/serving/pkg/reconciler/autoscaling/kpa/kpa.go:151 +0x1335
knative.dev/serving/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler.(*reconcilerImpl).Reconcile(0xc0003f5130, 0x2030d40, 0xc001767bc0, 0xc0024d6150, 0x21, 0xc001686db0, 0x2030d40)
	/go/src/knative.dev/serving/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler/reconciler.go:253 +0x146c
knative.dev/pkg/controller.(*Impl).processNextWorkItem(0xc0006b01c0, 0x0)
	/go/src/knative.dev/serving/vendor/knative.dev/pkg/controller/controller.go:511 +0x728
knative.dev/pkg/controller.(*Impl).RunContext.func3(0xc0016e1860, 0xc0006b01c0)
	/go/src/knative.dev/serving/vendor/knative.dev/pkg/controller/controller.go:449 +0x53
created by knative.dev/pkg/controller.(*Impl).RunContext
	/go/src/knative.dev/serving/vendor/knative.dev/pkg/controller/controller.go:447 +0x1f5
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixed a rare nil-pointer exception in the autoscaler
```

/assign @julz @vagababov 
