### PR TITLE
Introduce DomainMapping ConfigStore and allow configuring IngressClass

### DIFF
--- a/pkg/reconciler/domainmapping/config/doc.go
+++ b/pkg/reconciler/domainmapping/config/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config holds the typed objects that define the schemas for
+// assorted ConfigMap objects on which the DomainMapping controller depends.
+package config

--- a/pkg/reconciler/domainmapping/config/store.go
+++ b/pkg/reconciler/domainmapping/config/store.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+
+	network "knative.dev/networking/pkg"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/logging"
+)
+
+type cfgKey struct{}
+
+// Config holds the collection of configurations that we attach to contexts.
+type Config struct {
+	Network *network.Config
+}
+
+// FromContext extracts a Config from the provided context.
+func FromContext(ctx context.Context) *Config {
+	return ctx.Value(cfgKey{}).(*Config)
+}
+
+// ToContext attaches the provided Config to the provided context, returning the
+// new context with the Config attached.
+func ToContext(ctx context.Context, c *Config) context.Context {
+	return context.WithValue(ctx, cfgKey{}, c)
+}
+
+// Store is a typed wrapper around configmap.Untyped store to handle our configmaps.
+type Store struct {
+	*configmap.UntypedStore
+}
+
+// ToContext attaches the current Config state to the provided context.
+func (s *Store) ToContext(ctx context.Context) context.Context {
+	return ToContext(ctx, s.Load())
+}
+
+// Load creates a Config from the current config state of the Store.
+func (s *Store) Load() *Config {
+	return &Config{
+		Network: s.UntypedLoad(network.ConfigName).(*network.Config).DeepCopy(),
+	}
+}
+
+// NewStore creates a new store of Configs and optionally calls functions when ConfigMaps are updated.
+func NewStore(ctx context.Context, onAfterStore ...func(name string, value interface{})) *Store {
+	return &Store{
+		UntypedStore: configmap.NewUntypedStore(
+			"domainmapping",
+			logging.FromContext(ctx),
+			configmap.Constructors{
+				network.ConfigName: network.NewConfigFromConfigMap,
+			},
+			onAfterStore...,
+		),
+	}
+}

--- a/pkg/reconciler/domainmapping/config/store_test.go
+++ b/pkg/reconciler/domainmapping/config/store_test.go
@@ -40,7 +40,7 @@ func TestStoreLoadWithContext(t *testing.T) {
 	t.Run("network", func(t *testing.T) {
 		expected, _ := network.NewConfigFromConfigMap(networkConfig)
 		if diff := cmp.Diff(expected, config.Network); diff != "" {
-			t.Errorf("Unexpected controller config (-want, +got): %v", diff)
+			t.Errorf("Unexpected network config (-want, +got):\n%v", diff)
 		}
 	})
 }

--- a/pkg/reconciler/domainmapping/config/store_test.go
+++ b/pkg/reconciler/domainmapping/config/store_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	network "knative.dev/networking/pkg"
+	logtesting "knative.dev/pkg/logging/testing"
+
+	. "knative.dev/pkg/configmap/testing"
+)
+
+func TestStoreLoadWithContext(t *testing.T) {
+	ctx := logtesting.TestContextWithLogger(t)
+	store := NewStore(ctx)
+
+	networkConfig := ConfigMapFromTestFile(t, network.ConfigName)
+	store.OnConfigChanged(networkConfig)
+
+	config := FromContext(store.ToContext(context.Background()))
+
+	t.Run("network", func(t *testing.T) {
+		expected, _ := network.NewConfigFromConfigMap(networkConfig)
+		if diff := cmp.Diff(expected, config.Network); diff != "" {
+			t.Errorf("Unexpected controller config (-want, +got): %v", diff)
+		}
+	})
+}

--- a/pkg/reconciler/domainmapping/config/testdata/config-network.yaml
+++ b/pkg/reconciler/domainmapping/config/testdata/config-network.yaml
@@ -1,0 +1,1 @@
+../../../../../config/core/configmaps/network.yaml


### PR DESCRIPTION
Fifth part of #9713.

Respect the default ingressClass in network.yaml and allow overriding via annotation, analogously to Route.

/assign @mattmoor @dprotaso