### PR TITLE
Add bash v4 to requirements

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -31,6 +31,9 @@ You must install these tools:
 1. [`ko`](https://github.com/google/ko): For development.
 1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): For
    managing development environments.
+1. [`bash`](https://www.gnu.org/software/bash/) v4 or later. On MacOS the
+   default bash is too old, you can use [Homebrew](https://brew.sh) to install
+   a later version.
 
 If you're working on and changing `.proto` files:
 


### PR DESCRIPTION
The requirement of some of our dev scripts on bash v4+ confused at least one person in https://github.com/knative/serving/issues/9792, so seems worth documenting.

/assign @n3wscott @mattmoor 