### PR TITLE
Fix one more theoretical NPE

### DIFF
--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -104,7 +104,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, config *v1.Configuration
 	case rc.IsFalse():
 		logger.Infof("Revision %q of configuration has failed: Reason=%s Message=%q", revName, rc.Reason, rc.Message)
 		beforeReady := config.Status.GetCondition(v1.ConfigurationConditionReady)
-		config.Status.MarkLatestCreatedFailed(lcr.Name, rc.Message)
+		config.Status.MarkLatestCreatedFailed(lcr.Name, rc.GetMessage())
 
 		if !equality.Semantic.DeepEqual(beforeReady, config.Status.GetCondition(v1.ConfigurationConditionReady)) {
 			recorder.Eventf(config, corev1.EventTypeWarning, "LatestCreatedFailed",


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

I reviewed all of our usage of conditions that could potentially be `nil` and this was the only one that seemed sufficiently unguarded against an NPE.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 
