### PR TITLE
Reenable generation check in postupgrade tests

### DIFF
--- a/test/upgrade/service_postupgrade_test.go
+++ b/test/upgrade/service_postupgrade_test.go
@@ -41,12 +41,12 @@ func TestServicePostUpgrade(t *testing.T) {
 	// Before updating the service, the route and configuration objects should
 	// not be updated just because there has been an upgrade.
 	if hasGeneration, err := configHasGeneration(clients, serviceName, 1); err != nil {
-		t.Fatalf("Error comparing Configuration generation: %v", err)
+		t.Fatal("Error comparing Configuration generation", err)
 	} else if !hasGeneration {
 		t.Fatal("Configuration is updated after an upgrade.")
 	}
 	if hasGeneration, err := routeHasGeneration(clients, serviceName, 1); err != nil {
-		t.Fatalf("Error comparing Route generation: %v", err)
+		t.Fatal("Error comparing Route generation", err)
 	} else if !hasGeneration {
 		t.Fatal("Route is updated after an upgrade.")
 	}

--- a/test/upgrade/service_postupgrade_test.go
+++ b/test/upgrade/service_postupgrade_test.go
@@ -35,30 +35,27 @@ import (
 
 func TestServicePostUpgrade(t *testing.T) {
 	t.Parallel()
-	// Renable once our minimum K8s version includes a fix for CRD generation bumping
-	// See: https://github.com/knative/serving/issues/6984
-	//
-	// clients := e2e.Setup(t)
 
-	// // Before updating the service, the route and configuration objects should
-	// // not be updated just because there has been an upgrade.
-	// if hasGeneration, err := configHasGeneration(clients, serviceName, 1); err != nil {
-	// 	t.Fatalf("Error comparing Configuration generation: %v", err)
-	// } else if !hasGeneration {
-	// 	t.Fatal("Configuration is updated after an upgrade.")
-	// }
-	// if hasGeneration, err := routeHasGeneration(clients, serviceName, 1); err != nil {
-	// 	t.Fatalf("Error comparing Route generation: %v", err)
-	// } else if !hasGeneration {
-	// 	t.Fatal("Route is updated after an upgrade.")
-	// }
+	clients := e2e.Setup(t)
+
+	// Before updating the service, the route and configuration objects should
+	// not be updated just because there has been an upgrade.
+	if hasGeneration, err := configHasGeneration(clients, serviceName, 1); err != nil {
+		t.Fatalf("Error comparing Configuration generation: %v", err)
+	} else if !hasGeneration {
+		t.Fatal("Configuration is updated after an upgrade.")
+	}
+	if hasGeneration, err := routeHasGeneration(clients, serviceName, 1); err != nil {
+		t.Fatalf("Error comparing Route generation: %v", err)
+	} else if !hasGeneration {
+		t.Fatal("Route is updated after an upgrade.")
+	}
+
 	updateService(serviceName, t)
 }
 
-/*
-TODO(6984): uncomment those.
 func configHasGeneration(clients *test.Clients, serviceName string, generation int) (bool, error) {
-	configObj, err := clients.ServingClient.Configs.Get(serviceName, metav1.GetOptions{})
+	configObj, err := clients.ServingClient.Configs.Get(context.Background(), serviceName, metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -66,13 +63,12 @@ func configHasGeneration(clients *test.Clients, serviceName string, generation i
 }
 
 func routeHasGeneration(clients *test.Clients, serviceName string, generation int) (bool, error) {
-	routeObj, err := clients.ServingClient.Routes.Get(serviceName, metav1.GetOptions{})
+	routeObj, err := clients.ServingClient.Routes.Get(context.Background(), serviceName, metav1.GetOptions{})
 	if err != nil {
 		return false, err
 	}
 	return routeObj.Generation == int64(generation), nil
 }
-*/
 
 func TestServicePostUpgradeFromScaleToZero(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes #6984

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As per title. Our minimum version of 1.17 should allow for this to be stable now.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @dprotaso @mattmoor 
