### PR TITLE
[Automated] Update net-certmanager nightly

### DIFF
--- a/third_party/cert-manager-latest/net-certmanager.yaml
+++ b/third_party/cert-manager-latest/net-certmanager.yaml
@@ -18,7 +18,7 @@ metadata:
   # These are the permissions needed by the `cert-manager` `Certificate` implementation.
   name: knative-serving-certmanager
   labels:
-    serving.knative.dev/release: "v20201009-8dfe165"
+    serving.knative.dev/release: "v20201014-dd6df9a"
     serving.knative.dev/controller: "true"
     networking.knative.dev/certificate-provider: cert-manager
 rules:
@@ -49,7 +49,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.net-certmanager.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v20201009-8dfe165"
+    serving.knative.dev/release: "v20201014-dd6df9a"
 webhooks:
   - admissionReviewVersions:
       - v1beta1
@@ -86,7 +86,7 @@ metadata:
   name: net-certmanager-webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20201009-8dfe165"
+    serving.knative.dev/release: "v20201014-dd6df9a"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -109,7 +109,7 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20201009-8dfe165"
+    serving.knative.dev/release: "v20201014-dd6df9a"
     networking.knative.dev/certificate-provider: cert-manager
 data:
   _example: |
@@ -156,7 +156,7 @@ metadata:
   name: networking-certmanager
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20201009-8dfe165"
+    serving.knative.dev/release: "v20201014-dd6df9a"
     networking.knative.dev/certificate-provider: cert-manager
 spec:
   selector:
@@ -168,14 +168,14 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: networking-certmanager
-        serving.knative.dev/release: "v20201009-8dfe165"
+        serving.knative.dev/release: "v20201014-dd6df9a"
     spec:
       serviceAccountName: controller
       containers:
         - name: networking-certmanager
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/controller@sha256:2cac47b66294eeda9f5fa54eebaf78e233031033eb18b7c666f9f5229d424b8a
+          image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/controller@sha256:278becd1f5816342ef954d5ffdaaaaba01b57151e26db8610d6201d020f79ad5
           resources:
             requests:
               cpu: 30m
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   labels:
     app: networking-certmanager
-    serving.knative.dev/release: "v20201009-8dfe165"
+    serving.knative.dev/release: "v20201014-dd6df9a"
     networking.knative.dev/certificate-provider: cert-manager
   name: networking-certmanager
   namespace: knative-serving
@@ -245,7 +245,7 @@ metadata:
   name: net-certmanager-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20201009-8dfe165"
+    serving.knative.dev/release: "v20201014-dd6df9a"
 spec:
   selector:
     matchLabels:
@@ -258,14 +258,14 @@ spec:
       labels:
         app: net-certmanager-webhook
         role: net-certmanager-webhook
-        serving.knative.dev/release: "v20201009-8dfe165"
+        serving.knative.dev/release: "v20201014-dd6df9a"
     spec:
       serviceAccountName: controller
       containers:
         - name: webhook
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/webhook@sha256:4e4694d7f20e2a44afc3614ba479c561ddaff21fbf86060f99009f839aca0913
+          image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/webhook@sha256:acf0b634402350cd20d2b84e46b7dbf30ca720a165428ee63bb9f110ebe479c8
           resources:
             requests:
               cpu: 20m
@@ -319,7 +319,7 @@ metadata:
   namespace: knative-serving
   labels:
     role: net-certmanager-webhook
-    serving.knative.dev/release: "v20201009-8dfe165"
+    serving.knative.dev/release: "v20201014-dd6df9a"
 spec:
   ports:
     # Define metrics and profiling for them to be accessible within service meshes.


### PR DESCRIPTION
Produced via:
```shell
for x in net-certmanager.yaml; do
  curl https://storage.googleapis.com/knative-nightly/net-certmanager/latest/$x > ${GITHUB_WORKSPACE}/./third_party/cert-manager-latest/$x
done
```
/assign tcnghia nak3 ZhiminXiang