### PR TITLE
Simplify test server creation through pkg helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	go.uber.org/atomic v1.6.0
 	go.uber.org/automaxprocs v1.3.0
 	go.uber.org/zap v1.15.0
-	golang.org/x/net v0.0.0-20200904194848-62affa334b73
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	google.golang.org/api v0.31.0

--- a/test/util.go
+++ b/test/util.go
@@ -23,11 +23,10 @@ import (
 	"net/http"
 	"time"
 
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/kmeta"
+	pkgnet "knative.dev/pkg/network"
 	"knative.dev/pkg/signals"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
@@ -59,7 +58,7 @@ func ListenAndServeGracefully(addr string, handler func(w http.ResponseWriter, r
 // and handles incoming requests with the given handler.
 // It blocks until SIGTERM is received and the underlying server has shutdown gracefully.
 func ListenAndServeGracefullyWithHandler(addr string, handler http.Handler) {
-	server := http.Server{Addr: addr, Handler: h2c.NewHandler(handler, &http2.Server{})}
+	server := pkgnet.NewServer(addr, handler)
 	go server.ListenAndServe()
 
 	<-signals.SetupSignalHandler()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -356,7 +356,6 @@ golang.org/x/crypto/ssh/terminal
 golang.org/x/mod/module
 golang.org/x/mod/semver
 # golang.org/x/net v0.0.0-20200904194848-62affa334b73
-## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

It's not necessary to create these servers manually if we already use this helper in the activator etc. to achieve the very same goal. So :shrug:. Also removes the direct dependency on `golang.org/x/net` :slightly_smiling_face:.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz 
