### PR TITLE
Run v1alpha1 tests (and deploy DomainMapping component) in github actions

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -25,6 +25,7 @@ jobs:
         test-suite:
         - ./test/conformance/runtime
         - ./test/conformance/api/v1
+        - ./test/conformance/api/v1alpha1
         - ./test/e2e
 
         # Map between K8s and KinD versions.
@@ -43,6 +44,8 @@ jobs:
           kind-version: v0.9.0
           kind-image-sha: sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
           kingress: contour
+        - test-suite: ./test/conformance/api/v1alpha1
+          test-flags: "--enable-alpha"
 
     env:
       GOPATH: ${{ github.workspace }}
@@ -155,6 +158,9 @@ jobs:
         sudo echo "127.0.0.1 $REGISTRY_NAME" | sudo tee -a /etc/hosts
 
     - name: Install Knative Serving
+      env:
+        GO111MODULE: on
+        GOFLAGS: -mod=vendor
       run: |
         set -o pipefail
 
@@ -162,8 +168,6 @@ jobs:
         kubectl apply -f config/core/300-imagecache.yaml
 
         # Build and Publish our containers to the docker daemon (including test assets)
-        export GO111MODULE=on
-        export GOFLAGS=-mod=vendor
         ko apply --platform=all -Pf test/config/
         ko apply --platform=all -PRf config/core
 
@@ -175,6 +179,14 @@ jobs:
 
         # Be KinD to these tests.
         kubectl scale -nknative-serving deployment/chaosduck --replicas=0
+
+    - name: Install Alpha Components
+      if: contains(matrix.test-flags, '--enable-alpha')
+      env:
+        GO111MODULE: on
+        GOFLAGS: -mod=vendor
+      run: |
+        ko apply --platform=all -PRf config/domain-mapping
 
     - name: Wait for Webhook to be up
       run: |
@@ -251,4 +263,5 @@ jobs:
 
         # Run the tests tagged as e2e on the KinD cluster.
         go test -race -count=1 -timeout=20m -tags=e2e ${{ matrix.test-suite }} \
-           --ingressendpoint="${IPS[0]}"
+           --ingressendpoint="${IPS[0]}" \
+           ${{ matrix.test-flags }}

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -28,10 +28,10 @@ jobs:
         - ./test/conformance/api/v1alpha1
         - ./test/e2e
 
-        # Map between K8s and KinD versions.
-        # This is attempting to make it a bit clearer what's being tested.
-        # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0
         include:
+          # Map between K8s and KinD versions.
+          # This is attempting to make it a bit clearer what's being tested.
+          # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0
         - k8s-version: v1.17.11
           kind-version: v0.9.0
           kind-image-sha: sha256:5240a7a2c34bf241afb54ac05669f8a46661912eab05705d660971eeb12f6555
@@ -44,6 +44,9 @@ jobs:
           kind-version: v0.9.0
           kind-image-sha: sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
           kingress: contour
+
+          # The tests in api/v1alpha1 require the --enable-alpha flag to be set,
+          # and alpha components to be deployed.
         - test-suite: ./test/conformance/api/v1alpha1
           test-flags: "--enable-alpha"
 

--- a/test/conformance/api/v1alpha1/placeholder.go
+++ b/test/conformance/api/v1alpha1/placeholder.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1alpha1 is a placeholder until we add some actual tests here.
+package v1alpha1


### PR DESCRIPTION
Since we'll be [adding some tests](https://github.com/knative/serving/pull/9780) to this suite gated by the enable-alpha flag as part of the [DomainMapping work](https://github.com/knative/serving/issues/9713).

I think I'm holding GitHub actions right, but it's my first time trying so 🤷.

Example running on my fork here: https://github.com/julz/serving/runs/1258795911?check_suite_focus=true.

/assign @mattmoor @markusthoemmes 