### PR TITLE
Try to fix flakiness of Autoscaler HA test

### DIFF
--- a/test/ha/autoscaler_test.go
+++ b/test/ha/autoscaler_test.go
@@ -92,8 +92,7 @@ func TestAutoscalerHA(t *testing.T) {
 	t.Log("Verifying the old revision can still be scaled from 0 after leader change")
 	// Use WaitForEndpointState for scaling from 0. This is because WaitForEndpointState uses a much larger request
 	// timeout value than the one used by AssertAutoscaleUpToNumPods. AssertAutoscaleUpToNumPods uses the default
-	// vegeta request timeout value, which could result in non 200 responses when waiting for the pods scaling from
-	// zero.
+	// vegeta request timeout value, which could result in non-200 responses when scaling from 0.
 	url := resources.Route.Status.URL.URL()
 	if _, err := pkgTest.WaitForEndpointState(
 		context.Background(),


### PR DESCRIPTION
The test failed with `Error: request success rate under SLO: total = 58, errors = 3, rate = 0.948276, SLO = 0.999000`. The non-200 responses happened during scaling from 0.

So split to two steps: scaling from 0 to 1 and scaling 1 to 3. Use `WaitForEndpointState` for scaling from 0 which has a large timeout value.

/assign @vagababov 