### PR TITLE
Use route rather than routestatus IsReady function

### DIFF
--- a/pkg/apis/serving/v1/route_lifecycle.go
+++ b/pkg/apis/serving/v1/route_lifecycle.go
@@ -42,11 +42,6 @@ func (r *Route) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("Route")
 }
 
-// IsReady returns if the route is ready to serve the requested configuration.
-func (rs *RouteStatus) IsReady() bool {
-	return routeCondSet.Manage(rs).IsHappy()
-}
-
 // IsReady returns true if the Status condition RouteConditionReady
 // is true and the latest spec has been observed.
 func (r *Route) IsReady() bool {

--- a/pkg/apis/serving/v1/route_lifecycle_test.go
+++ b/pkg/apis/serving/v1/route_lifecycle_test.go
@@ -163,7 +163,8 @@ func TestRouteIsReady(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if e, a := tc.isReady, tc.status.IsReady(); e != a {
+			r := Route{Status: tc.status}
+			if e, a := tc.isReady, r.IsReady(); e != a {
 				t.Errorf("%q expected: %v got: %v", tc.name, e, a)
 			}
 		})

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -184,7 +184,7 @@ func routeTrafficHTTPS(route *servingv1.Route) (bool, error) {
 			return false, nil
 		}
 	}
-	return route.Status.IsReady(), nil
+	return route.IsReady(), nil
 }
 
 func routeURLHTTP(route *servingv1.Route) (bool, error) {

--- a/test/v1/route.go
+++ b/test/v1/route.go
@@ -115,7 +115,7 @@ func CheckRouteState(client *test.ServingClients, name string, inState func(r *v
 // IsRouteReady will check the status conditions of the route and return true if the route is
 // ready.
 func IsRouteReady(r *v1.Route) (bool, error) {
-	return r.Generation == r.Status.ObservedGeneration && r.Status.IsReady(), nil
+	return r.IsReady(), nil
 }
 
 // IsRouteFailed will check the status conditions of the route and return true if the route is


### PR DESCRIPTION
To be consistent with how we check [Service](https://github.com/knative/serving/blob/6c3bf7a46210651936df9922fba1dd3d6a3962e3/test/v1/service.go#L284), [Revision](https://github.com/knative/serving/blob/6c3bf7a46210651936df9922fba1dd3d6a3962e3/test/v1/revision.go#L76) & [Configuration](https://github.com/knative/serving/blob/6c3bf7a46210651936df9922fba1dd3d6a3962e3/test/v1/configuration.go#L194) `IsReady` in the tests, use the [IsReady function on Route](https://github.com/knative/serving/blob/6c3bf7a46210651936df9922fba1dd3d6a3962e3/pkg/apis/serving/v1/route_lifecycle.go#L54) (which already does the ObservedGeneration check) rather than on RouteStatus.

After this, RouteStatus.IsReady is unused, so removed it. (I think this is OK as it doesn't change any of the yaml, and looks like we already removed the other status.IsReady functions in https://github.com/knative/serving/pull/8204).


/assign @markusthoemmes @mattmoor @whaught 