### PR TITLE
Add prefix auto_tls_test_ for the env variables of auto tls test

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -22,13 +22,13 @@ function knative_setup() {
 
 function setup_auto_tls_env_variables() {
   # DNS zone for the testing domain.
-  export DNS_ZONE="knative-e2e"
+  export AUTO_TLS_TEST_DNS_ZONE="knative-e2e"
   # Google Cloud project that hosts the DNS server for the testing domain `kn-e2e.dev`
-  export CLOUD_DNS_PROJECT="knative-e2e-dns"
+  export AUTO_TLS_TEST_CLOUD_DNS_PROJECT="knative-e2e-dns"
   # The service account credential file used to access the DNS server.
-  export CLOUD_DNS_SERVICE_ACCOUNT_KEY_FILE="${GOOGLE_APPLICATION_CREDENTIALS}"
+  export AUTO_TLS_TEST_CLOUD_DNS_SERVICE_ACCOUNT_KEY_FILE="${GOOGLE_APPLICATION_CREDENTIALS}"
 
-  export DOMAIN_NAME="kn-e2e.dev"
+  export AUTO_TLS_TEST_DOMAIN_NAME="kn-e2e.dev"
 
   export CUSTOM_DOMAIN_SUFFIX="$(($RANDOM % 10000)).${E2E_PROJECT_ID}.${DOMAIN_NAME}"
 
@@ -43,7 +43,7 @@ function setup_auto_tls_env_variables() {
     INGRESS_SERVICE="istio-ingressgateway"
   fi
   local IP=$(kubectl get svc -n ${INGRESS_NAMESPACE} ${INGRESS_SERVICE} -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
-  export INGRESS_IP=${IP}
+  export AUTO_TLS_TEST_INGRESS_IP=${IP}
 }
 
 function setup_custom_domain() {
@@ -86,7 +86,7 @@ function setup_http01_auto_tls() {
   # Rely on the built-in naming (for logstream)
   unset TLS_SERVICE_NAME
   # The full host name of the Knative Service. This is used to configure the DNS record.
-  export FULL_HOST_NAME="*.${TLS_TEST_NAMESPACE}.${CUSTOM_DOMAIN_SUFFIX}"
+  export AUTO_TLS_TEST_FULL_HOST_NAME="*.${TLS_TEST_NAMESPACE}.${CUSTOM_DOMAIN_SUFFIX}"
 
   kubectl delete kcert --all -n "${TLS_TEST_NAMESPACE}"
 

--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -30,7 +30,7 @@ function setup_auto_tls_env_variables() {
 
   export AUTO_TLS_TEST_DOMAIN_NAME="kn-e2e.dev"
 
-  export CUSTOM_DOMAIN_SUFFIX="$(($RANDOM % 10000)).${E2E_PROJECT_ID}.${DOMAIN_NAME}"
+  export CUSTOM_DOMAIN_SUFFIX="$(($RANDOM % 10000)).${E2E_PROJECT_ID}.${AUTO_TLS_TEST_DOMAIN_NAME}"
 
   export TLS_TEST_NAMESPACE="tls"
 

--- a/test/e2e/autotls/config/dnscleanup/main.go
+++ b/test/e2e/autotls/config/dnscleanup/main.go
@@ -27,14 +27,14 @@ import (
 var env config.EnvConfig
 
 func main() {
-	if err := envconfig.Process("", &env); err != nil {
+	if err := envconfig.Process("auto_tls_test", &env); err != nil {
 		log.Fatalf("Failed to process environment variable: %v.", err)
 	}
 	record := &config.DNSRecord{
-		IP:     env.AutoTLSTestIngressIP,
-		Domain: env.AutoTLSTestFullHostName,
+		IP:     env.IngressIP,
+		Domain: env.FullHostName,
 	}
-	if err := config.DeleteDNSRecord(record, env.AutoTLSTestCloudDNSServiceAccountKeyFile, env.AutoTLSTestCloudDNSProject, env.AutoTLSTestDNSZone); err != nil {
+	if err := config.DeleteDNSRecord(record, env.CloudDNSServiceAccountKeyFile, env.CloudDNSProject, env.DNSZone); err != nil {
 		log.Fatal("Failed to setup DNS record: ", err)
 	}
 }

--- a/test/e2e/autotls/config/dnscleanup/main.go
+++ b/test/e2e/autotls/config/dnscleanup/main.go
@@ -31,10 +31,10 @@ func main() {
 		log.Fatalf("Failed to process environment variable: %v.", err)
 	}
 	record := &config.DNSRecord{
-		IP:     env.IngressIP,
-		Domain: env.FullHostName,
+		IP:     env.AutoTLSTestIngressIP,
+		Domain: env.AutoTLSTestFullHostName,
 	}
-	if err := config.DeleteDNSRecord(record, env.CloudDNSServiceAccountKeyFile, env.CloudDNSProject, env.DNSZone); err != nil {
+	if err := config.DeleteDNSRecord(record, env.AutoTLSTestCloudDNSServiceAccountKeyFile, env.AutoTLSTestCloudDNSProject, env.AutoTLSTestDNSZone); err != nil {
 		log.Fatal("Failed to setup DNS record: ", err)
 	}
 }

--- a/test/e2e/autotls/config/dnssetup/main.go
+++ b/test/e2e/autotls/config/dnssetup/main.go
@@ -46,14 +46,14 @@ func main() {
 
 func setupDNSRecord() error {
 	dnsRecord := &config.DNSRecord{
-		Domain: env.FullHostName,
-		IP:     env.IngressIP,
+		Domain: env.AutoTLSTestFullHostName,
+		IP:     env.AutoTLSTestIngressIP,
 	}
 	if err := createDNSRecord(dnsRecord); err != nil {
 		return err
 	}
 	if err := waitForDNSRecordVisible(dnsRecord); err != nil {
-		config.DeleteDNSRecord(dnsRecord, env.CloudDNSServiceAccountKeyFile, env.CloudDNSProject, env.DNSZone)
+		config.DeleteDNSRecord(dnsRecord, env.AutoTLSTestCloudDNSServiceAccountKeyFile, env.AutoTLSTestCloudDNSProject, env.AutoTLSTestDNSZone)
 		return err
 	}
 	return nil
@@ -61,13 +61,13 @@ func setupDNSRecord() error {
 
 func createDNSRecord(dnsRecord *config.DNSRecord) error {
 	record := config.MakeRecordSet(dnsRecord)
-	svc, err := config.GetCloudDNSSvc(env.CloudDNSServiceAccountKeyFile)
+	svc, err := config.GetCloudDNSSvc(env.AutoTLSTestCloudDNSServiceAccountKeyFile)
 	if err != nil {
 		return err
 	}
 	// Look for existing records.
 	if list, err := svc.ResourceRecordSets.List(
-		env.CloudDNSProject, env.DNSZone).Name(record.Name).Type("A").Do(); err != nil {
+		env.AutoTLSTestCloudDNSProject, env.AutoTLSTestDNSZone).Name(record.Name).Type("A").Do(); err != nil {
 		return err
 	} else if len(list.Rrsets) > 0 {
 		return fmt.Errorf("record for domain %s already exists", record.Name)
@@ -76,11 +76,11 @@ func createDNSRecord(dnsRecord *config.DNSRecord) error {
 	addition := &dns.Change{
 		Additions: []*dns.ResourceRecordSet{record},
 	}
-	return config.ChangeDNSRecord(addition, svc, env.CloudDNSProject, env.DNSZone)
+	return config.ChangeDNSRecord(addition, svc, env.AutoTLSTestCloudDNSProject, env.AutoTLSTestDNSZone)
 }
 
 func waitForDNSRecordVisible(record *config.DNSRecord) error {
-	nameservers, err := net.LookupNS(env.DomainName)
+	nameservers, err := net.LookupNS(env.AutoTLSTestDomainName)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/autotls/config/util.go
+++ b/test/e2e/autotls/config/util.go
@@ -28,12 +28,12 @@ import (
 )
 
 type EnvConfig struct {
-	AutoTLSTestFullHostName                  string `envconfig:"auto_tls_test_full_host_name" required:"true"`
-	AutoTLSTestDomainName                    string `envconfig:"auto_tls_test_domain_name" required:"true"`
-	AutoTLSTestDNSZone                       string `envconfig:"auto_tls_test_dns_zone" required:"true"`
-	AutoTLSTestCloudDNSServiceAccountKeyFile string `envconfig:"auto_tls_test_cloud_dns_service_account_key_file" required:"true"`
-	AutoTLSTestCloudDNSProject               string `envconfig:"auto_tls_test_cloud_dns_project" required:"true"`
-	AutoTLSTestIngressIP                     string `envconfig:"auto_tls_test_ingress_ip" required:"true"`
+	FullHostName                  string `envconfig:"full_host_name" required:"true"`
+	DomainName                    string `envconfig:"domain_name" required:"true"`
+	DNSZone                       string `envconfig:"dns_zone" required:"true"`
+	CloudDNSServiceAccountKeyFile string `envconfig:"cloud_dns_service_account_key_file" required:"true"`
+	CloudDNSProject               string `envconfig:"cloud_dns_project" required:"true"`
+	IngressIP                     string `envconfig:"ingress_ip" required:"true"`
 }
 
 type DNSRecord struct {

--- a/test/e2e/autotls/config/util.go
+++ b/test/e2e/autotls/config/util.go
@@ -28,12 +28,12 @@ import (
 )
 
 type EnvConfig struct {
-	FullHostName                  string `envconfig:"full_host_name" required:"true"`
-	DomainName                    string `envconfig:"domain_name" required:"true"`
-	DNSZone                       string `envconfig:"dns_zone" required:"true"`
-	CloudDNSServiceAccountKeyFile string `envconfig:"cloud_dns_service_account_key_file" required:"true"`
-	CloudDNSProject               string `envconfig:"cloud_dns_project" required:"true"`
-	IngressIP                     string `envconfig:"ingress_ip" required:"true"`
+	AutoTLSTestFullHostName                  string `envconfig:"auto_tls_test_full_host_name" required:"true"`
+	AutoTLSTestDomainName                    string `envconfig:"auto_tls_test_domain_name" required:"true"`
+	AutoTLSTestDNSZone                       string `envconfig:"auto_tls_test_dns_zone" required:"true"`
+	AutoTLSTestCloudDNSServiceAccountKeyFile string `envconfig:"auto_tls_test_cloud_dns_service_account_key_file" required:"true"`
+	AutoTLSTestCloudDNSProject               string `envconfig:"auto_tls_test_cloud_dns_project" required:"true"`
+	AutoTLSTestIngressIP                     string `envconfig:"auto_tls_test_ingress_ip" required:"true"`
 }
 
 type DNSRecord struct {


### PR DESCRIPTION
This is to try to make the auto tls test environment variables more explicit.
