### PR TITLE
Deploy DomainMappings and Enable Alpha tests in e2e tests

### DIFF
--- a/cmd/domain-mapping/main.go
+++ b/cmd/domain-mapping/main.go
@@ -25,5 +25,5 @@ import (
 )
 
 func main() {
-	sharedmain.Main("controller", domainmapping.NewController)
+	sharedmain.Main("domainmapping", domainmapping.NewController)
 }

--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -52,6 +52,8 @@ readonly SERVING_CORE_YAML=${YAML_OUTPUT_DIR}/serving-core.yaml
 readonly SERVING_DEFAULT_DOMAIN_YAML=${YAML_OUTPUT_DIR}/serving-default-domain.yaml
 readonly SERVING_STORAGE_VERSION_MIGRATE_YAML=${YAML_OUTPUT_DIR}/serving-storage-version-migration.yaml
 readonly SERVING_HPA_YAML=${YAML_OUTPUT_DIR}/serving-hpa.yaml
+readonly SERVING_DOMAINMAPPING_YAML=${YAML_OUTPUT_DIR}/serving-domainmapping.yaml
+readonly SERVING_DOMAINMAPPING_CRD_YAML=${YAML_OUTPUT_DIR}/serving-domainmapping-crds.yaml
 readonly SERVING_CRD_YAML=${YAML_OUTPUT_DIR}/serving-crds.yaml
 readonly SERVING_NSCERT_YAML=${YAML_OUTPUT_DIR}/serving-nscert.yaml
 readonly SERVING_POST_INSTALL_JOBS_YAML=${YAML_OUTPUT_DIR}/serving-post-install-jobs.yaml
@@ -91,6 +93,10 @@ ko resolve ${KO_YAML_FLAGS} -f config/core/300-resources/ -f config/core/300-ima
 # Create hpa-class autoscaling related yaml
 ko resolve ${KO_YAML_FLAGS} -f config/hpa-autoscaling/ | "${LABEL_YAML_CMD[@]}" > "${SERVING_HPA_YAML}"
 
+# Create domain mapping related yaml
+ko resolve ${KO_YAML_FLAGS} -f config/domain-mapping/ | "${LABEL_YAML_CMD[@]}" > "${SERVING_DOMAINMAPPING_YAML}"
+ko resolve ${KO_YAML_FLAGS} -f config/domain-mapping/300-resources/ | "${LABEL_YAML_CMD[@]}" > "${SERVING_DOMAINMAPPING_CRD_YAML}"
+
 # Create nscert related yaml
 ko resolve ${KO_YAML_FLAGS} -f config/namespace-wildcard-certs | "${LABEL_YAML_CMD[@]}" > "${SERVING_NSCERT_YAML}"
 
@@ -117,6 +123,8 @@ ${SERVING_DEFAULT_DOMAIN_YAML}
 ${SERVING_STORAGE_VERSION_MIGRATE_YAML}
 ${SERVING_POST_INSTALL_JOBS_YAML}
 ${SERVING_HPA_YAML}
+${SERVING_DOMAINMAPPING_YAML}
+${SERVING_DOMAINMAPPING_CRD_YAML}
 ${SERVING_CRD_YAML}
 ${SERVING_NSCERT_YAML}
 EOF

--- a/test/config/config-logging.yaml
+++ b/test/config/config-logging.yaml
@@ -53,6 +53,7 @@ data:
   loglevel.webhook: "debug"
   loglevel.activator: "debug"
   loglevel.hpaautoscaler: "debug"
+  loglevel.domainmapping: "debug"
   loglevel.certcontroller: "debug"
   loglevel.istiocontroller: "debug"
   loglevel.nscontroller: "debug"

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -196,6 +196,10 @@ function install_knative_serving_standard() {
     echo "CRD YAML: ${SERVING_CRD_YAML}"
     kubectl apply -f "${SERVING_CRD_YAML}" || return 1
     UNINSTALL_LIST+=( "${SERVING_CRD_YAML}" )
+
+    echo "DOMAIN MAPPING CRD YAML: ${SERVING_DOMAINMAPPING_CRD_YAML}"
+    kubectl apply -f "${SERVING_DOMAINMAPPING_CRD_YAML}" || return 1
+    UNINSTALL_LIST+=( "${SERVING_DOMAINMAPPING_CRD_YAML}" )
   else
     # Download the latest release of Knative Serving.
     local url="https://github.com/knative/serving/releases/download/${LATEST_SERVING_RELEASE_VERSION}"
@@ -267,14 +271,17 @@ function install_knative_serving_standard() {
     sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${SERVING_CORE_YAML} > ${CORE_YAML_NAME}
     local HPA_YAML_NAME=${TMP_DIR}/${SERVING_HPA_YAML##*/}
     sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${SERVING_HPA_YAML} > ${HPA_YAML_NAME}
+    local DOMAINMAPPING_YAML_NAME=${TMP_DIR}/${SERVING_DOMAINMAPPING_YAML##*/}
+    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${SERVING_DOMAINMAPPING_YAML} > ${DOMAINMAPPING_YAML_NAME}
     local POST_INSTALL_JOBS_YAML_NAME=${TMP_DIR}/${SERVING_POST_INSTALL_JOBS_YAML##*/}
     sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${SERVING_POST_INSTALL_JOBS_YAML} > ${POST_INSTALL_JOBS_YAML_NAME}
 
-    echo "Knative YAML: ${CORE_YAML_NAME} and ${HPA_YAML_NAME}"
+    echo "Knative YAML: ${CORE_YAML_NAME} and ${HPA_YAML_NAME} and ${DOMAINMAPPING_YAML_NAME}"
     kubectl apply \
 	    -f "${CORE_YAML_NAME}" \
+	    -f "${DOMAINMAPPING_YAML_NAME}" \
 	    -f "${HPA_YAML_NAME}" || return 1
-    UNINSTALL_LIST+=( "${CORE_YAML_NAME}" "${HPA_YAML_NAME}" )
+    UNINSTALL_LIST+=( "${CORE_YAML_NAME}" "${HPA_YAML_NAME}" "${DOMAINMAPPING_YAML_NAME}" )
     kubectl create -f ${POST_INSTALL_JOBS_YAML_NAME}
   else
     echo "Knative YAML: ${SERVING_RELEASE_YAML}"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -94,6 +94,8 @@ go_test_e2e -timeout=30m \
  ./test/conformance/api/... ./test/conformance/runtime/... \
  ./test/e2e \
   ${parallelism} \
+  --enable-alpha \
+  --enable-beta \
   "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 
 if (( HTTPS )); then


### PR DESCRIPTION
Part of https://github.com/knative/serving/issues/9713.

Adds `--enable-alpha` and `--enable-beta` (might as well) flags to e2e tests, and deploys DomainMappings.

Once this lands we should be unblocked on landing https://github.com/knative/serving/pull/9780.