### PR TITLE
Backfill a little extra test coverage for IsReady

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/metric_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/metric_lifecycle_test.go
@@ -128,6 +128,12 @@ func TestMetricIsReady(t *testing.T) {
 			if e, a := tc.isReady, m.IsReady(); e != a {
 				t.Errorf("Ready = %v, want: %v", a, e)
 			}
+
+			m.Generation = 1
+			m.Status.ObservedGeneration = 2
+			if m.IsReady() {
+				t.Error("Expected IsReady() to be false when Generation != ObservedGeneration")
+			}
 		})
 	}
 }

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -475,6 +475,12 @@ func TestIsReady(t *testing.T) {
 			if got, want := pa.IsReady(), tc.isReady; got != want {
 				t.Errorf("IsReady = %v, want: %v", got, want)
 			}
+
+			pa.Generation = 1
+			pa.Status.ObservedGeneration = 2
+			if pa.IsReady() {
+				t.Error("Expected IsReady() to be false when Generation != ObservedGeneration")
+			}
 		})
 	}
 }

--- a/pkg/apis/serving/v1/configuration_lifecycle_test.go
+++ b/pkg/apis/serving/v1/configuration_lifecycle_test.go
@@ -166,6 +166,12 @@ func TestConfigurationIsReady(t *testing.T) {
 			if e, a := tc.isReady, c.IsReady(); e != a {
 				t.Errorf("%q expected: %v got: %v", tc.name, e, a)
 			}
+
+			c.Generation = 1
+			c.Status.ObservedGeneration = 2
+			if c.IsReady() {
+				t.Error("Expected IsReady() to be false when Generation != ObservedGeneration")
+			}
 		})
 	}
 }

--- a/pkg/apis/serving/v1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1/revision_lifecycle_test.go
@@ -193,6 +193,12 @@ func TestRevisionIsReady(t *testing.T) {
 			if got, want := r.IsReady(), tc.isReady; got != want {
 				t.Errorf("isReady =  %v want: %v", got, want)
 			}
+
+			r.Generation = 1
+			r.Status.ObservedGeneration = 2
+			if r.IsReady() {
+				t.Error("Expected IsReady() to be false when Generation != ObservedGeneration")
+			}
 		})
 	}
 }

--- a/pkg/apis/serving/v1/route_lifecycle_test.go
+++ b/pkg/apis/serving/v1/route_lifecycle_test.go
@@ -167,6 +167,12 @@ func TestRouteIsReady(t *testing.T) {
 			if e, a := tc.isReady, r.IsReady(); e != a {
 				t.Errorf("%q expected: %v got: %v", tc.name, e, a)
 			}
+
+			r.Generation = 1
+			r.Status.ObservedGeneration = 2
+			if r.IsReady() {
+				t.Error("Expected IsReady() to be false when Generation != ObservedGeneration")
+			}
 		})
 	}
 }

--- a/pkg/apis/serving/v1/service_lifecycle_test.go
+++ b/pkg/apis/serving/v1/service_lifecycle_test.go
@@ -166,6 +166,12 @@ func TestServiceIsReady(t *testing.T) {
 		if e, a := tc.isReady, s.IsReady(); e != a {
 			t.Errorf("%q expected: %v got: %v", tc.name, e, a)
 		}
+
+		s.Generation = 1
+		s.Status.ObservedGeneration = 2
+		if s.IsReady() {
+			t.Error("Expected IsReady() to be false when Generation != ObservedGeneration")
+		}
 	}
 }
 


### PR DESCRIPTION
The IsReady methods are responsible for checking Generation matches ObservedGeneration nowadays, so update the tests to cover that case.

/assign @markusthoemmes @whaught 