### PR TITLE
Drop back to single-arch to speed builds.

### DIFF
--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -31,7 +31,7 @@ function upload_test_images() {
   # ko resolve is being used for the side-effect of publishing images,
   # so the resulting yaml produced is ignored.
   # We limit the number of concurrent builds (jobs) to avoid OOMs.
-  ko resolve --platform=all --jobs=4 ${tag_option} -RBf "${image_dir}" > /dev/null
+  ko resolve --jobs=4 ${tag_option} -RBf "${image_dir}" > /dev/null
 }
 
 : ${KO_DOCKER_REPO:?"You must set 'KO_DOCKER_REPO', see DEVELOPMENT.md"}


### PR DESCRIPTION
Now that distroless is 4 architectures, this is much more costly.  We have gotten the mileage I had wanted through the multi-arch path, so optimize this for better presubmit latency.
