### PR TITLE
Add defaulting and validation infrastructure for DomainMappings

### DIFF
--- a/cmd/domain-mapping-webhook/main.go
+++ b/cmd/domain-mapping-webhook/main.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/cmd/domain-mapping-webhook/main.go
+++ b/cmd/domain-mapping-webhook/main.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/pkg/signals"
+	"knative.dev/pkg/webhook"
+	"knative.dev/pkg/webhook/certificates"
+	"knative.dev/pkg/webhook/resourcesemantics"
+	"knative.dev/pkg/webhook/resourcesemantics/defaulting"
+	"knative.dev/pkg/webhook/resourcesemantics/validation"
+	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	"knative.dev/serving/pkg/reconciler/domainmapping/config"
+)
+
+var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
+	servingv1alpha1.SchemeGroupVersion.WithKind("DomainMapping"): &servingv1alpha1.DomainMapping{},
+}
+
+func newDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	// Decorate contexts with the current state of the config.
+	store := config.NewStore(ctx)
+	store.WatchConfigs(cmw)
+
+	return defaulting.NewAdmissionController(ctx,
+
+		// Name of the resource webhook.
+		"webhook.domainmapping.serving.knative.dev",
+
+		// The path on which to serve the webhook.
+		"/defaulting",
+
+		// The resources to default.
+		types,
+
+		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
+		store.ToContext,
+
+		// Whether to disallow unknown fields.
+		true,
+	)
+}
+
+func newValidatingAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	// Decorate contexts with the current state of the config.
+	store := config.NewStore(ctx)
+	store.WatchConfigs(cmw)
+
+	return validation.NewAdmissionController(ctx,
+
+		// Name of the resource webhook.
+		"validation.webhook.domainmapping.serving.knative.dev",
+
+		// The path on which to serve the webhook.
+		"/resource-validation",
+
+		// The resources to validate.
+		types,
+
+		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
+		store.ToContext,
+
+		// Whether to disallow unknown fields.
+		true,
+	)
+}
+
+func main() {
+	// Set up a signal context with our webhook options
+	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
+		ServiceName: "domainmapping-webhook",
+		Port:        webhook.PortFromEnv(8443),
+		SecretName:  "domainmapping-webhook-certs",
+	})
+
+	sharedmain.WebhookMainWithContext(ctx, "domainmapping-webhook",
+		certificates.NewController,
+		newDefaultingAdmissionController,
+		newValidatingAdmissionController,
+	)
+}

--- a/config/domain-mapping/placeholder.go
+++ b/config/domain-mapping/placeholder.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package domainmapping is a placeholder that allows us to pull in config files
+// via go mod vendor.
+package domainmapping

--- a/config/domain-mapping/webhook.yaml
+++ b/config/domain-mapping/webhook.yaml
@@ -1,0 +1,132 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: domainmapping-webhook
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  selector:
+    matchLabels:
+      app: domainmapping-webhook
+      role: domainmapping-webhook
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: domainmapping-webhook
+        role: domainmapping-webhook
+        serving.knative.dev/release: devel
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: domainmapping-webhook
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+
+      serviceAccountName: controller
+      containers:
+      - name: domainmapping-webhook
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: ko://knative.dev/serving/cmd/domain-mapping-webhook
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 500m
+            memory: 500Mi
+
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: WEBHOOK_PORT
+          value: "8443"
+
+        # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+
+        securityContext:
+          allowPrivilegeEscalation: false
+
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        - name: https-webhook
+          containerPort: 8443
+
+        readinessProbe: &probe
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "webhook"
+        livenessProbe:
+          <<: *probe
+          failureThreshold: 6
+          initialDelaySeconds: 20
+
+      # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
+      # high value that we respect whatever value it has configured for the lame duck grace period.
+      terminationGracePeriodSeconds: 300
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    role: domainmapping-webhook
+    serving.knative.dev/release: devel
+  name: domainmapping-webhook
+  namespace: knative-serving
+spec:
+  ports:
+  # Define metrics and profiling for them to be accessible within service meshes.
+  - name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  - name: https-webhook
+    port: 443
+    targetPort: 8443
+  selector:
+    role: domainmapping-webhook

--- a/config/domain-mapping/webhooks/defaulting.yaml
+++ b/config/domain-mapping/webhooks/defaulting.yaml
@@ -1,0 +1,30 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: webhook.domainmapping.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions: ["v1", "v1beta1"]
+  clientConfig:
+    service:
+      name: domainmapping-webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: webhook.domainmapping.serving.knative.dev
+  timeoutSeconds: 10

--- a/config/domain-mapping/webhooks/placeholder.go
+++ b/config/domain-mapping/webhooks/placeholder.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package webhooks is a placeholder that allows us to pull in config files
+// via go mod vendor.
+package webhooks

--- a/config/domain-mapping/webhooks/secret.yaml
+++ b/config/domain-mapping/webhooks/secret.yaml
@@ -1,0 +1,22 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: domainmapping-webhook-certs
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+# The data is populated at install time.

--- a/config/domain-mapping/webhooks/validation.yaml
+++ b/config/domain-mapping/webhooks/validation.yaml
@@ -1,0 +1,30 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.webhook.domainmapping.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions: ["v1", "v1beta1"]
+  clientConfig:
+    service:
+      name: domainmapping-webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: validation.webhook.domainmapping.serving.knative.dev
+  timeoutSeconds: 10

--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -94,7 +94,7 @@ ko resolve ${KO_YAML_FLAGS} -f config/core/300-resources/ -f config/core/300-ima
 ko resolve ${KO_YAML_FLAGS} -f config/hpa-autoscaling/ | "${LABEL_YAML_CMD[@]}" > "${SERVING_HPA_YAML}"
 
 # Create domain mapping related yaml
-ko resolve ${KO_YAML_FLAGS} -f config/domain-mapping/ | "${LABEL_YAML_CMD[@]}" > "${SERVING_DOMAINMAPPING_YAML}"
+ko resolve ${KO_YAML_FLAGS} -R -f config/domain-mapping/ | "${LABEL_YAML_CMD[@]}" > "${SERVING_DOMAINMAPPING_YAML}"
 ko resolve ${KO_YAML_FLAGS} -f config/domain-mapping/300-resources/ | "${LABEL_YAML_CMD[@]}" > "${SERVING_DOMAINMAPPING_CRD_YAML}"
 
 # Create nscert related yaml

--- a/pkg/apis/serving/v1alpha1/domainmapping_defaults.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_defaults.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1alpha1
 
 import (

--- a/pkg/apis/serving/v1alpha1/domainmapping_defaults.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_defaults.go
@@ -1,0 +1,12 @@
+package v1alpha1
+
+import (
+	"context"
+)
+
+// SetDefaults implements apis.Defaultable.
+func (r *DomainMapping) SetDefaults(ctx context.Context) {
+	if r.Spec.Ref.Namespace == "" {
+		r.Spec.Ref.Namespace = r.Namespace
+	}
+}

--- a/pkg/apis/serving/v1alpha1/domainmapping_defaults.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_defaults.go
@@ -5,8 +5,8 @@ import (
 )
 
 // SetDefaults implements apis.Defaultable.
-func (r *DomainMapping) SetDefaults(ctx context.Context) {
-	if r.Spec.Ref.Namespace == "" {
-		r.Spec.Ref.Namespace = r.Namespace
+func (dm *DomainMapping) SetDefaults(ctx context.Context) {
+	if dm.Spec.Ref.Namespace == "" {
+		dm.Spec.Ref.Namespace = dm.Namespace
 	}
 }

--- a/pkg/apis/serving/v1alpha1/domainmapping_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_defaults_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1alpha1
 
 import (

--- a/pkg/apis/serving/v1alpha1/domainmapping_defaults_test.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_defaults_test.go
@@ -1,0 +1,69 @@
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+func TestDomainMappingDefaulting(t *testing.T) {
+	tests := []struct {
+		name    string
+		in, out *DomainMapping
+	}{{
+		name: "empty",
+		in:   &DomainMapping{},
+		out:  &DomainMapping{},
+	}, {
+		name: "empty ref namespace",
+		in: &DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "some-namespace",
+			},
+		},
+		out: &DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "some-namespace",
+			},
+			Spec: DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Namespace: "some-namespace",
+				},
+			},
+		},
+	}, {
+		name: "explicit ref namespace",
+		in: &DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "some-namespace",
+			},
+			Spec: DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Namespace: "explicit-namespace",
+				},
+			},
+		},
+		out: &DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "some-namespace",
+			},
+			Spec: DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Namespace: "explicit-namespace",
+				},
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		ctx := context.Background()
+
+		test.in.SetDefaults(ctx)
+		if !cmp.Equal(test.out, test.in) {
+			t.Errorf("SetDefaults (-want, +got):\n%s", cmp.Diff(test.out, test.in))
+		}
+	}
+}

--- a/pkg/apis/serving/v1alpha1/domainmapping_types.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_types.go
@@ -48,6 +48,10 @@ type DomainMapping struct {
 
 // Verify that DomainMapping adheres to the appropriate interfaces.
 var (
+	// Check that Route may be validated and defaulted.
+	_ apis.Validatable = (*DomainMapping)(nil)
+	_ apis.Defaultable = (*DomainMapping)(nil)
+
 	// Check that the type conforms to the duck Knative Resource shape.
 	_ duckv1.KRShaped = (*DomainMapping)(nil)
 )

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1alpha1
 
 import (

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation.go
@@ -12,16 +12,16 @@ import (
 // Validate makes sure that DomainMapping is properly configured.
 func (dm *DomainMapping) Validate(ctx context.Context) *apis.FieldError {
 	return validateMetadata(ctx, dm.ObjectMeta).ViaField("metadata").
-		Also(validateSpec(ctx, dm.Spec, dm.ObjectMeta).ViaField("spec"))
+		Also(validateSpec(dm.Spec, dm.ObjectMeta).ViaField("spec"))
 }
 
 // validateSpec validates the Spec of a DomainMapping.
-func validateSpec(ctx context.Context, spec DomainMappingSpec, md metav1.ObjectMeta) (errs *apis.FieldError) {
-	return errs.Also(validateRef(ctx, spec.Ref, md).ViaField("ref"))
+func validateSpec(spec DomainMappingSpec, md metav1.ObjectMeta) (errs *apis.FieldError) {
+	return errs.Also(validateRef(spec.Ref, md).ViaField("ref"))
 }
 
 // validateRef validates the Ref field of a DomainMapping.
-func validateRef(ctx context.Context, ref duckv1.KReference, md metav1.ObjectMeta) (errs *apis.FieldError) {
+func validateRef(ref duckv1.KReference, md metav1.ObjectMeta) (errs *apis.FieldError) {
 	if ref.Name == "" {
 		errs = errs.Also(apis.ErrMissingField("name"))
 	}

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation.go
@@ -1,0 +1,46 @@
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+// Validate makes sure that DomainMapping is properly configured.
+func (dm *DomainMapping) Validate(ctx context.Context) *apis.FieldError {
+	return validateMetadata(ctx, dm.ObjectMeta).ViaField("metadata").
+		Also(validateSpec(ctx, dm.Spec, dm.ObjectMeta).ViaField("spec"))
+}
+
+// validateSpec validates the Spec of a DomainMapping.
+func validateSpec(ctx context.Context, spec DomainMappingSpec, md metav1.ObjectMeta) (errs *apis.FieldError) {
+	return errs.Also(validateRef(ctx, spec.Ref, md).ViaField("ref"))
+}
+
+// validateRef validates the Ref field of a DomainMapping.
+func validateRef(ctx context.Context, ref duckv1.KReference, md metav1.ObjectMeta) (errs *apis.FieldError) {
+	if ref.Name == "" {
+		errs = errs.Also(apis.ErrMissingField("name"))
+	}
+
+	if ref.Namespace != "" && ref.Namespace != md.Namespace {
+		errs = errs.Also(&apis.FieldError{
+			Message: fmt.Sprintf("Ref namespace must be empty or equal to the domain mapping namespace %q", md.Namespace),
+			Paths:   []string{"namespace"},
+		})
+	}
+
+	return errs
+}
+
+// validateMetadata validates the metadata section of a DomainMapping.
+func validateMetadata(ctx context.Context, md metav1.ObjectMeta) (errs *apis.FieldError) {
+	if md.Name == "" {
+		errs = errs.Also(apis.ErrMissingField("name"))
+	}
+
+	return errs
+}

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation.go
@@ -26,8 +26,8 @@ import (
 )
 
 // Validate makes sure that DomainMapping is properly configured.
-func (dm *DomainMapping) Validate(ctx context.Context) *apis.FieldError {
-	return validateMetadata(ctx, dm.ObjectMeta).ViaField("metadata").
+func (dm *DomainMapping) Validate(_ context.Context) *apis.FieldError {
+	return validateMetadata(dm.ObjectMeta).ViaField("metadata").
 		Also(validateSpec(dm.Spec, dm.ObjectMeta).ViaField("spec"))
 }
 
@@ -53,7 +53,7 @@ func validateRef(ref duckv1.KReference, md metav1.ObjectMeta) (errs *apis.FieldE
 }
 
 // validateMetadata validates the metadata section of a DomainMapping.
-func validateMetadata(ctx context.Context, md metav1.ObjectMeta) (errs *apis.FieldError) {
+func validateMetadata(md metav1.ObjectMeta) (errs *apis.FieldError) {
 	if md.Name == "" {
 		errs = errs.Also(apis.ErrMissingField("name"))
 	}

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v1alpha1
 
 import (

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
@@ -1,0 +1,68 @@
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+)
+
+func TestDomainMappingValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		dm   *DomainMapping
+		want *apis.FieldError
+	}{{
+		name: "uses GenerateName rather than Name",
+		want: apis.ErrMissingField("metadata.name"),
+		dm: &DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "cant-use-this",
+			},
+			Spec: DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Name: "some-name",
+				},
+			},
+		},
+	}, {
+		name: "missing ref name",
+		want: apis.ErrMissingField("spec.ref.name"),
+		dm: &DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "missing-ref",
+			},
+		},
+	}, {
+		name: "ref in wrong namespace",
+		want: &apis.FieldError{
+			Paths:   []string{"spec.ref.namespace"},
+			Message: "Ref namespace must be empty or equal to the domain mapping namespace \"good-namespace\"",
+		},
+		dm: &DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "wrong-ref-ns",
+				Namespace: "good-namespace",
+			},
+			Spec: DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Name:      "some-name",
+					Namespace: "bad-namespace",
+				},
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			got := test.dm.Validate(ctx)
+			if !cmp.Equal(test.want.Error(), got.Error()) {
+				t.Errorf("Validate (-want, +got):\n%s", cmp.Diff(test.want.Error(), got.Error()))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part I-lost-count of #9713.

This commit adds the basic infrastructure for defaulting and validation and a minimal amount of defaulting/validation to make sure it all works. More validation/defaulting to follow in next PR.

/assign @mattmoor @vagababov 
