### PR TITLE
[Automated] Update net-certmanager nightly

### DIFF
--- a/third_party/cert-manager-latest/net-certmanager.yaml
+++ b/third_party/cert-manager-latest/net-certmanager.yaml
@@ -18,7 +18,7 @@ metadata:
   # These are the permissions needed by the `cert-manager` `Certificate` implementation.
   name: knative-serving-certmanager
   labels:
-    serving.knative.dev/release: "v20201020-c88bec6"
+    serving.knative.dev/release: "v20201021-2e52564"
     serving.knative.dev/controller: "true"
     networking.knative.dev/certificate-provider: cert-manager
 rules:
@@ -49,7 +49,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.net-certmanager.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v20201020-c88bec6"
+    serving.knative.dev/release: "v20201021-2e52564"
 webhooks:
   - admissionReviewVersions:
       - v1beta1
@@ -86,7 +86,7 @@ metadata:
   name: net-certmanager-webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20201020-c88bec6"
+    serving.knative.dev/release: "v20201021-2e52564"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -109,7 +109,7 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20201020-c88bec6"
+    serving.knative.dev/release: "v20201021-2e52564"
     networking.knative.dev/certificate-provider: cert-manager
 data:
   _example: |
@@ -156,7 +156,7 @@ metadata:
   name: networking-certmanager
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20201020-c88bec6"
+    serving.knative.dev/release: "v20201021-2e52564"
     networking.knative.dev/certificate-provider: cert-manager
 spec:
   selector:
@@ -168,14 +168,14 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: networking-certmanager
-        serving.knative.dev/release: "v20201020-c88bec6"
+        serving.knative.dev/release: "v20201021-2e52564"
     spec:
       serviceAccountName: controller
       containers:
         - name: networking-certmanager
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/controller@sha256:1fb3e323f90bd0a4e77e011723c7941b6473bf9979e2c40d8549b0bc8ac9e3f7
+          image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/controller@sha256:7622c50042159188109dad481ffc42361f2a0763b79719f6e8a1b3d904d0379b
           resources:
             requests:
               cpu: 30m
@@ -208,7 +208,7 @@ kind: Service
 metadata:
   labels:
     app: networking-certmanager
-    serving.knative.dev/release: "v20201020-c88bec6"
+    serving.knative.dev/release: "v20201021-2e52564"
     networking.knative.dev/certificate-provider: cert-manager
   name: networking-certmanager
   namespace: knative-serving
@@ -245,7 +245,7 @@ metadata:
   name: net-certmanager-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20201020-c88bec6"
+    serving.knative.dev/release: "v20201021-2e52564"
 spec:
   selector:
     matchLabels:
@@ -258,14 +258,14 @@ spec:
       labels:
         app: net-certmanager-webhook
         role: net-certmanager-webhook
-        serving.knative.dev/release: "v20201020-c88bec6"
+        serving.knative.dev/release: "v20201021-2e52564"
     spec:
       serviceAccountName: controller
       containers:
         - name: webhook
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/webhook@sha256:0555b9229662cdb7ac38738ac06cab2119d937e52838551a21f5173e17e60118
+          image: gcr.io/knative-nightly/knative.dev/net-certmanager/cmd/webhook@sha256:079d6d679b5719e9ee83347872aecb7cea10dafc5aaaffc3d262a66e221f2046
           resources:
             requests:
               cpu: 20m
@@ -319,7 +319,7 @@ metadata:
   namespace: knative-serving
   labels:
     role: net-certmanager-webhook
-    serving.knative.dev/release: "v20201020-c88bec6"
+    serving.knative.dev/release: "v20201021-2e52564"
 spec:
   ports:
     # Define metrics and profiling for them to be accessible within service meshes.


### PR DESCRIPTION
Produced via:
```shell
for x in net-certmanager.yaml; do
  curl https://storage.googleapis.com/knative-nightly/net-certmanager/latest/$x > ${GITHUB_WORKSPACE}/./third_party/cert-manager-latest/$x
done
```
/assign tcnghia nak3 ZhiminXiang