### PR TITLE
Pin istio to an older version for performance tests

### DIFF
--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -19,8 +19,10 @@ function install_istio() {
     readonly ISTIO_VERSION="stable"
   fi
 
-  # TODO: Figure out the commit of net-istio.yaml from net-istio.yaml
-  local NET_ISTIO_COMMIT=6bbca066373b21689b5d90381c27920533809e82
+  if [[ -z "${NET_ISTIO_COMMIT}" ]]; then
+    # TODO: Figure out the commit of net-istio.yaml from net-istio.yaml
+    readonly NET_ISTIO_COMMIT="6bbca066373b21689b5d90381c27920533809e82"
+  fi
 
   # And checkout the setup script based on that commit.
   local NET_ISTIO_DIR=$(mktemp -d)

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -30,6 +30,9 @@ export MESH=0
 export KNATIVE_DEFAULT_NAMESPACE="knative-serving"
 export SYSTEM_NAMESPACE="knative-serving"
 export ISTIO_VERSION="stable"
+# Pin net-istio to a commit when the stable Istio version was 1.5.7
+# TODO(chizhg): unpin the version after https://github.com/knative/serving/issues/9673 is root caused and fixed
+export NET_ISTIO_COMMIT="63af963d05c1dddcfcb3ada717c832092cf3e7c7"
 export UNINSTALL_LIST=()
 export TMP_DIR=$(mktemp -d -t ci-$(date +%Y-%m-%d-%H-%M-%S)-XXXXXXXXXX)
 


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
* Pin istio to an older version for performance tests

Related: https://github.com/knative/serving/issues/9673

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
None
```

/cc @vagababov 