### PR TITLE
Pay the debt of the test coverage for ingress

### DIFF
--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -137,13 +137,13 @@ func TestMakeIngressWithRollout(t *testing.T) {
 		},
 		OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(r)},
 	}
-	ia, err := MakeIngress(testContext(), r, cfg, nil, ingressClass)
+	ing, err := MakeIngress(testContext(), r, cfg, nil, ingressClass)
 	if err != nil {
 		t.Error("Unexpected error", err)
 	}
 
-	if !cmp.Equal(expected, ia.ObjectMeta) {
-		t.Error("Unexpected metadata (-want, +got):", cmp.Diff(expected, ia.ObjectMeta))
+	if !cmp.Equal(expected, ing.ObjectMeta) {
+		t.Error("Unexpected metadata (-want, +got):", cmp.Diff(expected, ing.ObjectMeta))
 	}
 }
 
@@ -153,11 +153,11 @@ func TestIngressNoKubectlAnnotation(t *testing.T) {
 		networking.IngressClassAnnotationKey: testIngressClass,
 		corev1.LastAppliedConfigAnnotation:   testAnnotationValue,
 	}), WithRouteUID("1234-5678"), WithURL)
-	ia, err := MakeIngress(testContext(), r, &traffic.Config{Targets: targets}, nil, testIngressClass)
+	ing, err := MakeIngress(testContext(), r, &traffic.Config{Targets: targets}, nil, testIngressClass)
 	if err != nil {
 		t.Error("Unexpected error", err)
 	}
-	if v, ok := ia.Annotations[corev1.LastAppliedConfigAnnotation]; ok {
+	if v, ok := ing.Annotations[corev1.LastAppliedConfigAnnotation]; ok {
 		t.Errorf("Annotation %s = %q, want empty", corev1.LastAppliedConfigAnnotation, v)
 	}
 }

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -56,11 +56,11 @@ const (
 )
 
 func TestMakeIngressCorrectMetadata(t *testing.T) {
-	targets := map[string]traffic.RevisionTargets{}
 	const (
 		ingressClass         = "ng-ingress"
 		passdownIngressClass = "ok-ingress"
 	)
+	targets := map[string]traffic.RevisionTargets{}
 	r := Route(ns, "test-route", WithRouteLabel(map[string]string{
 		serving.RouteLabelKey:          "try-to-override",
 		serving.RouteNamespaceLabelKey: "try-to-override",
@@ -96,6 +96,10 @@ func TestMakeIngressCorrectMetadata(t *testing.T) {
 }
 
 func TestMakeIngressWithRollout(t *testing.T) {
+	const (
+		ingressClass         = "ng-ingress"
+		passdownIngressClass = "ok-ingress"
+	)
 	cfg := &traffic.Config{
 		Targets: map[string]traffic.RevisionTargets{
 			traffic.DefaultTarget: {{
@@ -109,10 +113,6 @@ func TestMakeIngressWithRollout(t *testing.T) {
 			}},
 		},
 	}
-	const (
-		ingressClass         = "ng-ingress"
-		passdownIngressClass = "ok-ingress"
-	)
 	r := Route(ns, "test-route", WithRouteLabel(map[string]string{
 		serving.RouteLabelKey:          "try-to-override",
 		serving.RouteNamespaceLabelKey: "try-to-override",


### PR DESCRIPTION
In the original impl there was no test coverage for the `MakeIngress`
except for the the empty case.
That wasn't very kosher, so I've added the missing test.

/assign @tcnghia 