### PR TITLE
Resolve remaining lint complaints

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,6 +29,10 @@ linters:
     - errcheck
 
 issues:
+  include:
+    # Disable excluding issues about comments from golint.
+    - EXC0002
+
   exclude-rules:
     - path: test # Excludes /test, *_test.go etc.
       linters:
@@ -51,3 +55,8 @@ issues:
       text: "receiver name"
       linters:
         - golint
+
+    # This check has quite a few false positives where there isn't much value in the package comment.
+    - text: "ST1000: at least one file in a package should have a package comment"
+      linters:
+        - stylecheck

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -23,6 +23,7 @@ import (
 	cm "knative.dev/pkg/configmap"
 )
 
+// Flag is a string value which can be either Enabled, Disabled, or Allowed.
 type Flag string
 
 const (

--- a/pkg/apis/doc.go
+++ b/pkg/apis/doc.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Api versions allow the api contract for a resource to be changed while keeping
-// backward compatibility by support multiple concurrent versions
-// of the same resource
-
 // +k8s:deepcopy-gen=package
+
+// Package apis contains the knative serving and autoscaling apis.
+// Api versions allow the api contract for a resource to be changed while keeping
+// backward compatibility by supporting multiple concurrent versions
+// of the same resource
 package apis

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -81,6 +81,7 @@ var (
 	)
 )
 
+// ValidateVolumes validates the Volumes of a PodSpec.
 func ValidateVolumes(vs []corev1.Volume, mountedVolumes sets.String) (sets.String, *apis.FieldError) {
 	volumes := make(sets.String, len(vs))
 	var errs *apis.FieldError
@@ -628,6 +629,7 @@ func validateProbe(p *corev1.Probe) *apis.FieldError {
 	return errs
 }
 
+// ValidateNamespacedObjectReference validates an ObjectReference which may not contain a namespace.
 func ValidateNamespacedObjectReference(p *corev1.ObjectReference) *apis.FieldError {
 	if p == nil {
 		return nil
@@ -699,7 +701,7 @@ func ValidatePodSecurityContext(ctx context.Context, sc *corev1.PodSecurityConte
 // being validated.
 type userContainer struct{}
 
-// WithUserContainer notes on the context that further validation or defaulting
+// WithinUserContainer notes on the context that further validation or defaulting
 // is within the context of a user container in the revision.
 func WithinUserContainer(ctx context.Context) context.Context {
 	return context.WithValue(ctx, userContainer{}, struct{}{})
@@ -715,7 +717,7 @@ func WithinSidecarContainer(ctx context.Context) context.Context {
 	return context.WithValue(ctx, sidecarContainer{}, struct{}{})
 }
 
-// Check if we are in the context of a sidecar container in the revision.
+// IsInSidecarContainer checks if we are in the context of a sidecar container in the revision.
 func IsInSidecarContainer(ctx context.Context) bool {
 	return ctx.Value(sidecarContainer{}) != nil
 }

--- a/pkg/apis/serving/v1/configuration_lifecycle.go
+++ b/pkg/apis/serving/v1/configuration_lifecycle.go
@@ -70,6 +70,9 @@ func (cs *ConfigurationSpec) GetTemplate() *RevisionTemplateSpec {
 	return &cs.Template
 }
 
+// SetLatestCreatedRevisionName sets the LatestCreatedRevisionName on the
+// revision and sets the ConfigurationConditionReady state to unknown if this
+// does not match the LatestReadyRevisionName.
 func (cs *ConfigurationStatus) SetLatestCreatedRevisionName(name string) {
 	cs.LatestCreatedRevisionName = name
 	if cs.LatestReadyRevisionName != name {
@@ -78,6 +81,9 @@ func (cs *ConfigurationStatus) SetLatestCreatedRevisionName(name string) {
 	}
 }
 
+// SetLatestReadyRevisionName sets the LatestReadyRevisionName on the revision.
+// If this matches the LatestCreatedRevisionName, the
+// ConfigurationConditionReady condition is set to true.
 func (cs *ConfigurationStatus) SetLatestReadyRevisionName(name string) {
 	cs.LatestReadyRevisionName = name
 	if cs.LatestReadyRevisionName == cs.LatestCreatedRevisionName {
@@ -85,6 +91,8 @@ func (cs *ConfigurationStatus) SetLatestReadyRevisionName(name string) {
 	}
 }
 
+// MarkLatestCreatedFailed marks the ConfigurationConditionReady condition to
+// indicate that the Revision failed.
 func (cs *ConfigurationStatus) MarkLatestCreatedFailed(name, message string) {
 	configCondSet.Manage(cs).MarkFalse(
 		ConfigurationConditionReady,
@@ -92,6 +100,8 @@ func (cs *ConfigurationStatus) MarkLatestCreatedFailed(name, message string) {
 		"Revision %q failed with message: %s.", name, message)
 }
 
+// MarkRevisionCreationFailed marks the ConfigurationConditionReady condition
+// to indicate the Revision creation failed.
 func (cs *ConfigurationStatus) MarkRevisionCreationFailed(message string) {
 	configCondSet.Manage(cs).MarkFalse(
 		ConfigurationConditionReady,
@@ -99,6 +109,8 @@ func (cs *ConfigurationStatus) MarkRevisionCreationFailed(message string) {
 		"Revision creation failed with message: %s.", message)
 }
 
+// MarkLatestReadyDeleted marks the ConfigurationConditionReady condition to
+// indicate that the Revision was deleted.
 func (cs *ConfigurationStatus) MarkLatestReadyDeleted() {
 	configCondSet.Manage(cs).MarkFalse(
 		ConfigurationConditionReady,

--- a/pkg/apis/serving/v1/configuration_types.go
+++ b/pkg/apis/serving/v1/configuration_types.go
@@ -73,6 +73,7 @@ const (
 	ConfigurationConditionReady = apis.ConditionReady
 )
 
+// IsConfigurationCondition returns true if the given ConditionType is a ConfigurationCondition.
 func IsConfigurationCondition(t apis.ConditionType) bool {
 	return t == ConfigurationConditionReady
 }

--- a/pkg/apis/serving/v1/doc.go
+++ b/pkg/apis/serving/v1/doc.go
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains the Serving v1 API types.
-
 // +k8s:deepcopy-gen=package
 // +groupName=serving.knative.dev
+
+// Package v1 contains the Serving v1 API types.
 package v1

--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -48,11 +48,16 @@ const (
 	// UserQueueMetricsPortName specifies the port name to use for metrics
 	// emitted by queue-proxy for end user.
 	UserQueueMetricsPortName = "http-usermetric"
+)
 
+const (
+	// AnnotationParseErrorTypeMissing is the value of the Type field for
+	// AnnotationParseErrors which indicate an annotation was missing.
 	AnnotationParseErrorTypeMissing = "Missing"
+
+	// AnnotationParseErrorTypeInvalid is the value of the Type field for
+	// AnnotationParseErrors which indicate an annotation was invalid.
 	AnnotationParseErrorTypeInvalid = "Invalid"
-	LabelParserErrorTypeMissing     = "Missing"
-	LabelParserErrorTypeInvalid     = "Invalid"
 )
 
 const (
@@ -77,6 +82,8 @@ type (
 	RoutingState string
 
 	// +k8s:deepcopy-gen=false
+
+	// AnnotationParseError is the error type representing failures to parse annotations.
 	AnnotationParseError struct {
 		Type  string
 		Value string
@@ -84,6 +91,9 @@ type (
 	}
 
 	// +k8s:deepcopy-gen=false
+
+	// LastPinnedParseError is the error returned when the lastPinned annotation
+	// could not be parsed.
 	LastPinnedParseError AnnotationParseError
 )
 

--- a/pkg/apis/serving/v1/route_lifecycle.go
+++ b/pkg/apis/serving/v1/route_lifecycle.go
@@ -77,60 +77,83 @@ func (rs *RouteStatus) MarkIngressNotConfigured() {
 		"IngressNotConfigured", "Ingress has not yet been reconciled.")
 }
 
+// MarkTrafficAssigned marks the RouteConditionAllTrafficAssigned condition true.
 func (rs *RouteStatus) MarkTrafficAssigned() {
 	routeCondSet.Manage(rs).MarkTrue(RouteConditionAllTrafficAssigned)
 }
 
+// MarkUnknownTrafficError marks the RouteConditionAllTrafficAssigned condition
+// to indicate an error has occurred.
 func (rs *RouteStatus) MarkUnknownTrafficError(msg string) {
 	routeCondSet.Manage(rs).MarkUnknown(RouteConditionAllTrafficAssigned, "Unknown", msg)
 }
 
+// MarkConfigurationNotReady marks the RouteConditionAllTrafficAssigned
+// condition to indiciate the Revision is not yet ready.
 func (rs *RouteStatus) MarkConfigurationNotReady(name string) {
 	routeCondSet.Manage(rs).MarkUnknown(RouteConditionAllTrafficAssigned,
 		"RevisionMissing",
 		"Configuration %q is waiting for a Revision to become ready.", name)
 }
 
+// MarkConfigurationFailed marks the RouteConditionAllTrafficAssigned condition
+// to indicate the Revision has failed.
 func (rs *RouteStatus) MarkConfigurationFailed(name string) {
 	routeCondSet.Manage(rs).MarkFalse(RouteConditionAllTrafficAssigned,
 		"RevisionMissing",
 		"Configuration %q does not have any ready Revision.", name)
 }
 
+// MarkRevisionNotReady marks the RouteConditionAllTrafficAssigned condition to
+// indiciate the Revision is not yet ready.
 func (rs *RouteStatus) MarkRevisionNotReady(name string) {
 	routeCondSet.Manage(rs).MarkUnknown(RouteConditionAllTrafficAssigned,
 		"RevisionMissing",
 		"Revision %q is not yet ready.", name)
 }
 
+// MarkRevisionFailed marks the RouteConditionAllTrafficAssigned condition to
+// indiciate the Revision has failed.
 func (rs *RouteStatus) MarkRevisionFailed(name string) {
 	routeCondSet.Manage(rs).MarkFalse(RouteConditionAllTrafficAssigned,
 		"RevisionMissing",
 		"Revision %q failed to become ready.", name)
 }
 
+// MarkMissingTrafficTarget marks the RouteConditionAllTrafficAssigned
+// condition to indicate a reference traffic target was not found.
 func (rs *RouteStatus) MarkMissingTrafficTarget(kind, name string) {
 	routeCondSet.Manage(rs).MarkFalse(RouteConditionAllTrafficAssigned,
 		kind+"Missing",
 		"%s %q referenced in traffic not found.", kind, name)
 }
 
+// MarkCertificateProvisionFailed marks the
+// RouteConditionCertificateProvisioned condition to indicate that the
+// Certificate provisioning failed.
 func (rs *RouteStatus) MarkCertificateProvisionFailed(name string) {
 	routeCondSet.Manage(rs).MarkFalse(RouteConditionCertificateProvisioned,
 		"CertificateProvisionFailed",
 		"Certificate %s fails to be provisioned.", name)
 }
 
+// MarkCertificateReady marks the RouteConditionCertificateProvisioned
+// condition to indicate that the Certificate is ready.
 func (rs *RouteStatus) MarkCertificateReady(name string) {
 	routeCondSet.Manage(rs).MarkTrue(RouteConditionCertificateProvisioned)
 }
 
+// MarkCertificateNotReady marks the RouteConditionCertificateProvisioned
+// condition to indicate that the Certificate is not ready.
 func (rs *RouteStatus) MarkCertificateNotReady(name string) {
 	routeCondSet.Manage(rs).MarkUnknown(RouteConditionCertificateProvisioned,
 		"CertificateNotReady",
 		"Certificate %s is not ready.", name)
 }
 
+// MarkCertificateNotOwned changes the RouteConditionCertificateProvisioned
+// status to be false with the reason being that there is an existing
+// certificate with the name we wanted to use.
 func (rs *RouteStatus) MarkCertificateNotOwned(name string) {
 	routeCondSet.Manage(rs).MarkFalse(RouteConditionCertificateProvisioned,
 		"CertificateNotOwned",
@@ -138,7 +161,14 @@ func (rs *RouteStatus) MarkCertificateNotOwned(name string) {
 }
 
 const (
-	AutoTLSNotEnabledMessage            = "autoTLS is not enabled"
+	// AutoTLSNotEnabledMessage is the message which is set on the
+	// RouteConditionCertificateProvisioned condition when it is set to True
+	// because AutoTLS was not enabled.
+	AutoTLSNotEnabledMessage = "autoTLS is not enabled"
+
+	// TLSNotEnabledForClusterLocalMessage is the message which is set on the
+	// RouteConditionCertificateProvisioned condition when it is set to True
+	// because the domain is cluster-local.
 	TLSNotEnabledForClusterLocalMessage = "TLS is not enabled for cluster-local"
 )
 

--- a/pkg/apis/serving/v1alpha1/doc.go
+++ b/pkg/apis/serving/v1alpha1/doc.go
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +k8s:deepcopy-gen=package
+// +groupName=serving.knative.dev
+
+// Package v1alpha1 contains the v1alpha1 versions of the serving apis.
 // Api versions allow the api contract for a resource to be changed while keeping
 // backward compatibility by support multiple concurrent versions
 // of the same resource
-
-// +k8s:deepcopy-gen=package
-// +groupName=serving.knative.dev
 package v1alpha1

--- a/pkg/apis/serving/v1alpha1/register.go
+++ b/pkg/apis/serving/v1alpha1/register.go
@@ -38,8 +38,10 @@ func Resource(resource string) schema.GroupResource {
 }
 
 var (
+	// SchemeBuilder registers the addKnownTypes function.
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
+	// AddToScheme applies all the stored functions to the scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
 )
 
 // Adds the list of known types to Scheme.

--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -56,7 +56,7 @@ type TimedFloat64Buckets struct {
 	windowTotal float64
 }
 
-// Implements stringer interface.
+// String implements the Stringer interface.
 func (t *TimedFloat64Buckets) String() string {
 	return spew.Sdump(t.buckets)
 }

--- a/pkg/autoscaler/config/autoscalerconfig/doc.go
+++ b/pkg/autoscaler/config/autoscalerconfig/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 
+// Package autoscalerconfig contains the config struct for the autoscaler.
 package autoscalerconfig

--- a/pkg/deployment/doc.go
+++ b/pkg/deployment/doc.go
@@ -16,4 +16,5 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 
+// Package deployment manages the deployment config.
 package deployment

--- a/pkg/gc/config.go
+++ b/pkg/gc/config.go
@@ -30,12 +30,17 @@ import (
 )
 
 const (
+	// ConfigName is the name of the config map for garbage collection.
 	ConfigName = "config-gc"
-	Disabled   = -1
+
+	// Disabled is the value (-1) used by various config map values to indicate
+	// the setting is disabled.
+	Disabled = -1
 
 	disabled = "disabled"
 )
 
+// Config defines the tunable parameters for Garbage Collection.
 type Config struct {
 	// Delay duration after a revision create before considering it for GC
 	StaleRevisionCreateDelay time.Duration
@@ -79,6 +84,7 @@ func defaultConfig() *Config {
 	}
 }
 
+// NewConfigFromConfigMapFunc creates a Config from the supplied ConfigMap func.
 func NewConfigFromConfigMapFunc(ctx context.Context) func(configMap *corev1.ConfigMap) (*Config, error) {
 	logger := logging.FromContext(ctx)
 	minRevisionTimeout := controller.GetResyncPeriod(ctx)

--- a/pkg/gc/doc.go
+++ b/pkg/gc/doc.go
@@ -15,5 +15,6 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
+
 // Package gc manages garbage collection of old resources.
 package gc

--- a/pkg/leaderelection/config.go
+++ b/pkg/leaderelection/config.go
@@ -20,4 +20,6 @@ import (
 	kle "knative.dev/pkg/leaderelection"
 )
 
+// ValidateConfig re-exports the NewConfigFromConfigMap function from pkg/leaderelection
+// in order for config_test.go to validate the config map.
 var ValidateConfig = kle.NewConfigFromConfigMap

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -47,6 +47,7 @@ type Reconciler struct {
 // Check that our Reconciler implements pareconciler.Interface
 var _ pareconciler.Interface = (*Reconciler)(nil)
 
+// ReconcileKind implements Interface.ReconcileKind.
 func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutoscaler) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 	logger.Debug("PA exists")

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -72,6 +72,7 @@ type Reconciler struct {
 // Check that our Reconciler implements pareconciler.Interface
 var _ pareconciler.Interface = (*Reconciler)(nil)
 
+// ReconcileKind implements Interface.ReconcileKind.
 func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutoscaler) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -54,6 +54,7 @@ type Reconciler struct {
 // Check that our Reconciler implements configreconciler.Interface
 var _ configreconciler.Interface = (*Reconciler)(nil)
 
+// ReconcileKind implements Interface.ReconcileKind.
 func (c *Reconciler) ReconcileKind(ctx context.Context, config *v1.Configuration) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 	recorder := controller.GetEventRecorder(ctx)

--- a/pkg/reconciler/gc/config/store.go
+++ b/pkg/reconciler/gc/config/store.go
@@ -27,27 +27,33 @@ import (
 
 type cfgKey struct{}
 
+// Config is the configuration for GC.
 type Config struct {
 	RevisionGC *gc.Config
 	Features   *apiconfig.Features
 }
 
+// FromContext fetches the config from the context.
 func FromContext(ctx context.Context) *Config {
 	return ctx.Value(cfgKey{}).(*Config)
 }
 
+// ToContext adds config to the given context.
 func ToContext(ctx context.Context, c *Config) context.Context {
 	return context.WithValue(ctx, cfgKey{}, c)
 }
 
+// Store is a configmap.UntypedStore based config store.
 type Store struct {
 	*configmap.UntypedStore
 }
 
+// ToContext adds config to given context.
 func (s *Store) ToContext(ctx context.Context) context.Context {
 	return ToContext(ctx, s.Load())
 }
 
+// Load fetches config from Store.
 func (s *Store) Load() *Config {
 	return &Config{
 		RevisionGC: s.UntypedLoad(gc.ConfigName).(*gc.Config).DeepCopy(),
@@ -55,6 +61,7 @@ func (s *Store) Load() *Config {
 	}
 }
 
+// NewStore creates a configmap.UntypedStore based config store.
 func NewStore(ctx context.Context, onAfterStore ...func(name string, value interface{})) *Store {
 	return &Store{
 		UntypedStore: configmap.NewUntypedStore(

--- a/pkg/reconciler/gc/reconciler.go
+++ b/pkg/reconciler/gc/reconciler.go
@@ -41,6 +41,7 @@ type reconciler struct {
 // Check that our reconciler implements configreconciler.Interface
 var _ configreconciler.Interface = (*reconciler)(nil)
 
+// ReconcileKind implements Interface.ReconcileKind.
 func (c *reconciler) ReconcileKind(ctx context.Context, config *v1.Configuration) pkgreconciler.Event {
 	switch configns.FromContext(ctx).Features.ResponsiveRevisionGC {
 

--- a/pkg/reconciler/metric/metric.go
+++ b/pkg/reconciler/metric/metric.go
@@ -34,6 +34,7 @@ type reconciler struct {
 // Check that our Reconciler implements metricreconciler.Interface
 var _ metricreconciler.Interface = (*reconciler)(nil)
 
+// ReconcileKind implements Interface.ReconcileKind.
 func (r *reconciler) ReconcileKind(ctx context.Context, metric *v1alpha1.Metric) pkgreconciler.Event {
 	if err := r.collector.CreateOrUpdate(metric); err != nil {
 		switch err {

--- a/pkg/reconciler/nscert/nscert.go
+++ b/pkg/reconciler/nscert/nscert.go
@@ -62,6 +62,7 @@ func certClass(ctx context.Context, r *corev1.Namespace) string {
 	return config.FromContext(ctx).Network.DefaultCertificateClass
 }
 
+// ReconcileKind implements Interface.ReconcileKind.
 func (c *reconciler) ReconcileKind(ctx context.Context, ns *corev1.Namespace) pkgreconciler.Event {
 	cfg := config.FromContext(ctx)
 

--- a/pkg/reconciler/revision/config/store.go
+++ b/pkg/reconciler/revision/config/store.go
@@ -50,6 +50,7 @@ func ToContext(ctx context.Context, c *Config) context.Context {
 	return context.WithValue(ctx, cfgKey{}, c)
 }
 
+// Store is a typed wrapper around configmap.UntypedStore to handle our configmaps.
 // +k8s:deepcopy-gen=false
 type Store struct {
 	*configmap.UntypedStore
@@ -76,6 +77,9 @@ func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value i
 	return store
 }
 
+// WatchConfigs uses the provided configmap.Watcher
+// to setup watches for the config names provided in the
+// Constructors map
 func (s *Store) WatchConfigs(cmw configmap.Watcher) {
 	s.UntypedStore.WatchConfigs(cmw)
 	s.apiStore.WatchConfigs(cmw)

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -121,6 +121,7 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) (boo
 	return false, nil
 }
 
+// ReconcileKind implements Interface.ReconcileKind.
 func (c *Reconciler) ReconcileKind(ctx context.Context, rev *v1.Revision) pkgreconciler.Event {
 	readyBeforeReconcile := rev.IsReady()
 	c.updateRevisionLoggingURL(ctx, rev)

--- a/pkg/reconciler/route/config/doc.go
+++ b/pkg/reconciler/route/config/doc.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
+
 // Package config holds the typed objects that define the schemas for
 // assorted ConfigMap objects on which the Route controller depends.
 package config

--- a/pkg/reconciler/route/config/store.go
+++ b/pkg/reconciler/route/config/store.go
@@ -28,6 +28,7 @@ import (
 
 type cfgKey struct{}
 
+// Config is the configuration for the route reconciler.
 // +k8s:deepcopy-gen=false
 type Config struct {
 	Domain   *Domain
@@ -36,6 +37,7 @@ type Config struct {
 	Features *cfgmap.Features
 }
 
+// FromContext obtains a Config injected into the passed context.
 func FromContext(ctx context.Context) *Config {
 	return ctx.Value(cfgKey{}).(*Config)
 }
@@ -55,6 +57,7 @@ func FromContextOrDefaults(ctx context.Context) *Config {
 	return cfg
 }
 
+// ToContext stores the configuration Config in the passed context.
 func ToContext(ctx context.Context, c *Config) context.Context {
 	return context.WithValue(ctx, cfgKey{}, c)
 }
@@ -96,10 +99,12 @@ func NewStore(ctx context.Context, onAfterStore ...func(name string, value inter
 	return store
 }
 
+// ToContext stores the configuration Store in the passed context.
 func (s *Store) ToContext(ctx context.Context) context.Context {
 	return ToContext(ctx, s.Load())
 }
 
+// Load creates a Config for this store.
 func (s *Store) Load() *Config {
 	config := &Config{
 		Domain:   s.UntypedLoad(DomainConfigName).(*Domain).DeepCopy(),

--- a/pkg/reconciler/route/resources/names/names.go
+++ b/pkg/reconciler/route/resources/names/names.go
@@ -21,10 +21,12 @@ import (
 	"knative.dev/pkg/network"
 )
 
+// K8sService returns the name of the K8sService for a given route.
 func K8sService(route kmeta.Accessor) string {
 	return route.GetName()
 }
 
+// K8sServiceFullname returns the full name of the K8sService for a given route.
 func K8sServiceFullname(route kmeta.Accessor) string {
 	return network.GetServiceHostname(K8sService(route), route.GetNamespace())
 }

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -104,6 +104,7 @@ func (c *Reconciler) getServices(route *v1.Route) ([]*corev1.Service, error) {
 	return serviceCopy, nil
 }
 
+// ReconcileKind implements Interface.ReconcileKind.
 func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 	logger.Debugf("Reconciling route: %#v", r.Spec)

--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -36,7 +36,7 @@ type Rollout struct {
 	Configurations []ConfigurationRollout `json:"configurations,omitempty"`
 }
 
-// ConfigRollout describes the rollout state for a given config+tag pair.
+// ConfigurationRollout describes the rollout state for a given config+tag pair.
 type ConfigurationRollout struct {
 	// Name + tag pair uniquely identifies the rollout target.
 	// `tag` will be empty, if this is the `DefaultTarget`.

--- a/pkg/reconciler/service/resources/names/names.go
+++ b/pkg/reconciler/service/resources/names/names.go
@@ -18,10 +18,12 @@ package names
 
 import "knative.dev/pkg/kmeta"
 
+// Configuration returns a configuration name based on a given service name.
 func Configuration(service kmeta.Accessor) string {
 	return service.GetName()
 }
 
+// Route returns a route name based on a given service name.
 func Route(service kmeta.Accessor) string {
 	return service.GetName()
 }

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -56,6 +56,7 @@ type Reconciler struct {
 // Check that our Reconciler implements ksvcreconciler.Interface
 var _ ksvcreconciler.Interface = (*Reconciler)(nil)
 
+// ReconcileKind implements Interface.ReconcileKind.
 func (c *Reconciler) ReconcileKind(ctx context.Context, service *v1.Service) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 

--- a/pkg/reconciler/testing/v1/listers.go
+++ b/pkg/reconciler/testing/v1/listers.go
@@ -50,10 +50,12 @@ var clientSetSchemes = []func(*runtime.Scheme) error{
 	fakeservingclientset.AddToScheme,
 }
 
+// Listers provides access to Listers for various objects.
 type Listers struct {
 	sorter testing.ObjectSorter
 }
 
+// NewListers returns a new Listers.
 func NewListers(objs []runtime.Object) Listers {
 	scheme := NewScheme()
 
@@ -66,6 +68,7 @@ func NewListers(objs []runtime.Object) Listers {
 	return ls
 }
 
+// NewScheme returns a new runtime.Scheme.
 func NewScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 
@@ -75,6 +78,7 @@ func NewScheme() *runtime.Scheme {
 	return scheme
 }
 
+// NewScheme returns a new runtime.Scheme.
 func (*Listers) NewScheme() *runtime.Scheme {
 	return NewScheme()
 }
@@ -84,30 +88,37 @@ func (l *Listers) IndexerFor(obj runtime.Object) cache.Indexer {
 	return l.sorter.IndexerForObjectType(obj)
 }
 
+// GetKubeObjects returns the runtime.Objects from the fakekubeclientset.
 func (l *Listers) GetKubeObjects() []runtime.Object {
 	return l.sorter.ObjectsForSchemeFunc(fakekubeclientset.AddToScheme)
 }
 
+// GetCachingObjects returns the runtime.Objects from the fakecachingclientset.
 func (l *Listers) GetCachingObjects() []runtime.Object {
 	return l.sorter.ObjectsForSchemeFunc(fakecachingclientset.AddToScheme)
 }
 
+// GetServingObjects returns the runtime.Objects from the fakeservingclientset.
 func (l *Listers) GetServingObjects() []runtime.Object {
 	return l.sorter.ObjectsForSchemeFunc(fakeservingclientset.AddToScheme)
 }
 
+// GetNetworkingObjects returns the runtime.Objects from the fakenetworkingclientset.
 func (l *Listers) GetNetworkingObjects() []runtime.Object {
 	return l.sorter.ObjectsForSchemeFunc(fakenetworkingclientset.AddToScheme)
 }
 
+// GetServiceLister returns a lister for Service objects.
 func (l *Listers) GetServiceLister() servinglisters.ServiceLister {
 	return servinglisters.NewServiceLister(l.IndexerFor(&v1.Service{}))
 }
 
+// GetRouteLister returns a lister for Route objects.
 func (l *Listers) GetRouteLister() servinglisters.RouteLister {
 	return servinglisters.NewRouteLister(l.IndexerFor(&v1.Route{}))
 }
 
+// GetDomainMappingLister returns a lister for DomainMapping objects.
 func (l *Listers) GetDomainMappingLister() servingv1alpha1listers.DomainMappingLister {
 	return servingv1alpha1listers.NewDomainMappingLister(l.IndexerFor(&v1alpha1.DomainMapping{}))
 }
@@ -117,14 +128,17 @@ func (l *Listers) GetServerlessServiceLister() networkinglisters.ServerlessServi
 	return networkinglisters.NewServerlessServiceLister(l.IndexerFor(&networking.ServerlessService{}))
 }
 
+// GetConfigurationLister gets the Configuration lister.
 func (l *Listers) GetConfigurationLister() servinglisters.ConfigurationLister {
 	return servinglisters.NewConfigurationLister(l.IndexerFor(&v1.Configuration{}))
 }
 
+// GetRevisionLister gets the Revision lister.
 func (l *Listers) GetRevisionLister() servinglisters.RevisionLister {
 	return servinglisters.NewRevisionLister(l.IndexerFor(&v1.Revision{}))
 }
 
+// GetPodAutoscalerLister gets the PodAutoscaler lister.
 func (l *Listers) GetPodAutoscalerLister() palisters.PodAutoscalerLister {
 	return palisters.NewPodAutoscalerLister(l.IndexerFor(&av1alpha1.PodAutoscaler{}))
 }
@@ -154,18 +168,22 @@ func (l *Listers) GetKnCertificateLister() networkinglisters.CertificateLister {
 	return networkinglisters.NewCertificateLister(l.IndexerFor(&networking.Certificate{}))
 }
 
+// GetImageLister returns a lister for Image objects.
 func (l *Listers) GetImageLister() cachinglisters.ImageLister {
 	return cachinglisters.NewImageLister(l.IndexerFor(&cachingv1alpha1.Image{}))
 }
 
+// GetDeploymentLister returns a lister for Deployment objects.
 func (l *Listers) GetDeploymentLister() appsv1listers.DeploymentLister {
 	return appsv1listers.NewDeploymentLister(l.IndexerFor(&appsv1.Deployment{}))
 }
 
+// GetK8sServiceLister returns a lister for K8sService objects.
 func (l *Listers) GetK8sServiceLister() corev1listers.ServiceLister {
 	return corev1listers.NewServiceLister(l.IndexerFor(&corev1.Service{}))
 }
 
+// GetEndpointsLister returns a lister for Endpoints objects.
 func (l *Listers) GetEndpointsLister() corev1listers.EndpointsLister {
 	return corev1listers.NewEndpointsLister(l.IndexerFor(&corev1.Endpoints{}))
 }

--- a/test/e2e/autotls/config/util.go
+++ b/test/e2e/autotls/config/util.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+// EnvConfig is the config parsed from environment variables by envconfig.
 type EnvConfig struct {
 	FullHostName                  string `envconfig:"full_host_name" required:"true"`
 	DomainName                    string `envconfig:"domain_name" required:"true"`
@@ -36,11 +37,13 @@ type EnvConfig struct {
 	IngressIP                     string `envconfig:"ingress_ip" required:"true"`
 }
 
+// DNSRecord represents an IP and Domain.
 type DNSRecord struct {
 	IP     string
 	Domain string
 }
 
+// MakeRecordSet creates a dns.ResourceRecordSet for a DNSRecord.
 func MakeRecordSet(record *DNSRecord) *dns.ResourceRecordSet {
 	dnsName := record.Domain + "."
 	return &dns.ResourceRecordSet{

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -175,6 +175,9 @@ func waitForActivatorEndpoints(ctx *TestContext) error {
 	return nil
 }
 
+// CreateAndVerifyInitialScaleConfiguration creates a Configuration with the
+// `initialScale` annotation set and validates the `wantPods` number of pods
+// are created.
 func CreateAndVerifyInitialScaleConfiguration(t *testing.T, clients *test.Clients, names test.ResourceNames, wantPods int) {
 	t.Log("Creating a new Configuration.", "configuration", names.Config)
 	_, err := v1test.CreateConfiguration(t, clients, names, func(configuration *v1.Configuration) {

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -52,6 +52,8 @@ func abortOnTimeout(ctx context.Context) spoof.ResponseChecker {
 	}
 }
 
+// ScaleToWithin creates `scale` services in parallel subtests and reports the
+// time taken to `latencies`.
 func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies Latencies) {
 	// These are the local (per-probe) and global (all probes) targets for the scale test.
 	// 95 = 19/20, so allow one failure within the minimum number of probes, but expect

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -33,7 +33,9 @@ import (
 )
 
 const (
-	NumControllerReconcilers = 7 // Keep in sync with ./cmd/controller/main.go
+	// NumControllerReconcilers is the number of controllers run by ./cmd/controller/main.go.
+	// It is exported so the tests from cmd/controller/main.go can ensure we keep it in sync.
+	NumControllerReconcilers = 7
 )
 
 func createPizzaPlanetService(t *testing.T, fopt ...rtesting.ServiceOption) (test.ResourceNames, *v1test.ResourceObjects) {

--- a/test/types/runtime.go
+++ b/test/types/runtime.go
@@ -173,6 +173,7 @@ type UserInfo struct {
 	Cwd  *Cwd `json:"cwd"`
 }
 
+// Cwd represents the Current Working Directory for a user.
 type Cwd struct {
 	Directory string `json:"directory"`
 	Error     string `json:"error"`


### PR DESCRIPTION
After this change `golint ./...` runs clean except source/sink receiver
names and context position in test args, where golint is legit just wrong :).

To keep us clean, this also un-disables lint checks for missing comments on
exported methods/fields. The code-base is generally pretty good about commenting
exported methods and fields so this seems worth doing (in fact in most places
that things weren't already commented, most of the other exported fields in
the same file were, or the ~same copy-pasted file elsewhere was). We can
always disable this if it becomes painful, but I think it's quite useful
to err on the side of commenting things as we go, and I think we've generally
been benefiting from being quite aggressive about enabling linters.

Kept the exclusion for package comments because these throw up more
false positives than they're worth for us (and they don't worry `golint ./...` anyway).

/assign @markusthoemmes 