### PR TITLE
[POC] Enable pod addressability even for meshes

### DIFF
--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -135,6 +135,11 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 				// port queue-proxy listens on.
 				TargetPort: targetPort(sks),
 			}, {
+				Name:       pkgnet.ServicePortName(sks.Spec.ProtocolType) + "-istio",
+				Protocol:   corev1.ProtocolTCP,
+				Port:       targetPort(sks).IntVal,
+				TargetPort: targetPort(sks),
+			}, {
 				Name:       servingv1.AutoscalingQueueMetricsPortName,
 				Protocol:   corev1.ProtocolTCP,
 				Port:       networking.AutoscalingQueueMetricsPort,

--- a/vendor/knative.dev/networking/config/config-network.yaml
+++ b/vendor/knative.dev/networking/config/config-network.yaml
@@ -22,6 +22,7 @@ metadata:
   annotations:
     knative.dev/example-checksum: "15954d34"
 data:
+  enable-mesh-pod-addressability: "true"
   _example: |
     ################################
     #                              #


### PR DESCRIPTION
This is a super ugly hack for now and if this works (CI will tell) then I'll write up a proper feature track and whatnot.

Here's the gist:
1. We create a VirtualService and a DestinationRule for the private service, that allows us to configure passthrough loadbalancing, which allows direct pod access.
2. We configure the autoscaler (and in step 2 the activator) with the correct HTTP request "spoofing" to make the loadbalancers pick that up.
3. No more specialized mesh code!

**Caveat:** It seems that this only works if the service's port == the pod's port, so we'd have to add a new port to the private service, that equals the serving port of the qp. A small price to pay imo.
