### PR TITLE
Add more defaulting and validation for DomainMapping

### DIFF
--- a/pkg/apis/serving/v1alpha1/domainmapping_defaults.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_defaults.go
@@ -20,10 +20,17 @@ import (
 	"context"
 
 	"knative.dev/pkg/apis"
+	"knative.dev/serving/pkg/apis/serving"
 )
 
 // SetDefaults implements apis.Defaultable.
 func (dm *DomainMapping) SetDefaults(ctx context.Context) {
 	ctx = apis.WithinParent(ctx, dm.ObjectMeta)
 	dm.Spec.Ref.SetDefaults(apis.WithinSpec(ctx))
+
+	if apis.IsInUpdate(ctx) {
+		serving.SetUserInfo(ctx, apis.GetBaseline(ctx).(*DomainMapping).Spec, dm.Spec, dm)
+	} else {
+		serving.SetUserInfo(ctx, nil, dm.Spec, dm)
+	}
 }

--- a/pkg/apis/serving/v1alpha1/domainmapping_defaults.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_defaults.go
@@ -18,11 +18,12 @@ package v1alpha1
 
 import (
 	"context"
+
+	"knative.dev/pkg/apis"
 )
 
 // SetDefaults implements apis.Defaultable.
 func (dm *DomainMapping) SetDefaults(ctx context.Context) {
-	if dm.Spec.Ref.Namespace == "" {
-		dm.Spec.Ref.Namespace = dm.Namespace
-	}
+	ctx = apis.WithinParent(ctx, dm.ObjectMeta)
+	dm.Spec.Ref.SetDefaults(apis.WithinSpec(ctx))
 }

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation.go
@@ -39,7 +39,7 @@ func (dm *DomainMapping) Validate(ctx context.Context) *apis.FieldError {
 // validateMetadata validates the metadata section of a DomainMapping.
 func (dm *DomainMapping) validateMetadata(ctx context.Context) (errs *apis.FieldError) {
 	if dm.GenerateName != "" {
-		errs = errs.Also(apis.ErrDisallowedFields("GenerateName"))
+		errs = errs.Also(apis.ErrDisallowedFields("generateName"))
 	}
 
 	if apis.IsInUpdate(ctx) {

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation.go
@@ -38,8 +38,8 @@ func (dm *DomainMapping) Validate(ctx context.Context) *apis.FieldError {
 
 // validateMetadata validates the metadata section of a DomainMapping.
 func (dm *DomainMapping) validateMetadata(ctx context.Context) (errs *apis.FieldError) {
-	if dm.Name == "" {
-		errs = errs.Also(apis.ErrMissingField("name"))
+	if dm.GenerateName != "" {
+		errs = errs.Also(apis.ErrDisallowedFields("GenerateName"))
 	}
 
 	if apis.IsInUpdate(ctx) {

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation.go
@@ -18,15 +18,18 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/serving/pkg/apis/serving"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 // Validate makes sure that DomainMapping is properly configured.
 func (dm *DomainMapping) Validate(ctx context.Context) *apis.FieldError {
-	errs := validateMetadata(dm.ObjectMeta).ViaField("metadata")
+	errs := validateMetadata(&dm.ObjectMeta).ViaField("metadata")
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*DomainMapping)
@@ -43,11 +46,26 @@ func (dm *DomainMapping) Validate(ctx context.Context) *apis.FieldError {
 
 // Validate makes sure the DomainMappingSpec is properly configured.
 func (spec *DomainMappingSpec) Validate(ctx context.Context) *apis.FieldError {
-	return spec.Ref.Validate(ctx).ViaField("ref")
+	return spec.validateRef(ctx, spec.Ref).ViaField("ref")
+}
+
+// validateRef validates the Ref section of the DomainMappingSpec.
+func (spec *DomainMappingSpec) validateRef(ctx context.Context, ref duckv1.KReference) *apis.FieldError {
+	errs := ref.Validate(ctx)
+
+	// For now, ref must be a serving.knative.dev/v1 Service.
+	if ref.Kind != "Service" {
+		errs = errs.Also(apis.ErrGeneric(`must be "Service"`, "kind"))
+	}
+	if ref.APIVersion != v1.SchemeGroupVersion.Identifier() {
+		errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("must be %q", v1.SchemeGroupVersion.Identifier()), "apiVersion"))
+	}
+
+	return errs
 }
 
 // validateMetadata validates the metadata section of a DomainMapping.
-func validateMetadata(md metav1.ObjectMeta) (errs *apis.FieldError) {
+func validateMetadata(md *metav1.ObjectMeta) (errs *apis.FieldError) {
 	if md.Name == "" {
 		return errs.Also(apis.ErrMissingField("name"))
 	}

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation.go
@@ -21,67 +21,57 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/validation"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 // Validate makes sure that DomainMapping is properly configured.
 func (dm *DomainMapping) Validate(ctx context.Context) *apis.FieldError {
-	errs := validateMetadata(&dm.ObjectMeta).ViaField("metadata")
-
-	if apis.IsInUpdate(ctx) {
-		original := apis.GetBaseline(ctx).(*DomainMapping)
-		errs = errs.Also(
-			apis.ValidateCreatorAndModifier(original.Spec, dm.Spec,
-				original.GetAnnotations(), dm.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"),
-		)
-	}
+	errs := dm.validateMetadata(ctx).ViaField("metadata")
 
 	ctx = apis.WithinParent(ctx, dm.ObjectMeta)
 	errs = errs.Also(dm.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
-	return errs
-}
-
-// Validate makes sure the DomainMappingSpec is properly configured.
-func (spec *DomainMappingSpec) Validate(ctx context.Context) *apis.FieldError {
-	return spec.validateRef(ctx, spec.Ref).ViaField("ref")
-}
-
-// validateRef validates the Ref section of the DomainMappingSpec.
-func (spec *DomainMappingSpec) validateRef(ctx context.Context, ref duckv1.KReference) *apis.FieldError {
-	errs := ref.Validate(ctx)
-
-	// For now, ref must be a serving.knative.dev/v1 Service.
-	if ref.Kind != "Service" {
-		errs = errs.Also(apis.ErrGeneric(`must be "Service"`, "kind"))
-	}
-	if ref.APIVersion != v1.SchemeGroupVersion.Identifier() {
-		errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("must be %q", v1.SchemeGroupVersion.Identifier()), "apiVersion"))
-	}
-
-	// Since we currently construct the rewritten host from the name/namespace, make sure they're valid.
-	ns := ref.Namespace
-	if ns == "" {
-		ns = apis.ParentMeta(ctx).Namespace
-	}
-	if msgs := validation.NameIsDNS1035Label(ref.Name, false); len(msgs) > 0 {
-		errs = errs.Also(apis.ErrInvalidValue(fmt.Sprint("not a DNS 1035 label prefix: ", msgs), "name"))
-	}
-	if msgs := validation.ValidateNamespaceName(ns, false); len(msgs) > 0 {
-		errs = errs.Also(apis.ErrInvalidValue(fmt.Sprint("not a valid namespace: ", msgs), "namespace"))
-	}
 
 	return errs
 }
 
 // validateMetadata validates the metadata section of a DomainMapping.
-func validateMetadata(md *metav1.ObjectMeta) (errs *apis.FieldError) {
-	if md.Name == "" {
-		return errs.Also(apis.ErrMissingField("name"))
+func (dm *DomainMapping) validateMetadata(ctx context.Context) (errs *apis.FieldError) {
+	if dm.Name == "" {
+		errs = errs.Also(apis.ErrMissingField("name"))
 	}
 
-	return nil
+	if apis.IsInUpdate(ctx) {
+		original := apis.GetBaseline(ctx).(*DomainMapping)
+		errs = errs.Also(
+			apis.ValidateCreatorAndModifier(original.Spec, dm.Spec,
+				original.GetAnnotations(), dm.GetAnnotations(), serving.GroupName).ViaField("annotations"),
+		)
+	}
+
+	return errs
+}
+
+// Validate makes sure the DomainMappingSpec is properly configured.
+func (spec *DomainMappingSpec) Validate(ctx context.Context) *apis.FieldError {
+	errs := spec.Ref.Validate(ctx).ViaField("ref")
+
+	// For now, ref must be a serving.knative.dev/v1 Service.
+	if spec.Ref.Kind != "Service" {
+		errs = errs.Also(apis.ErrGeneric(`must be "Service"`, "ref.kind"))
+	}
+	if spec.Ref.APIVersion != v1.SchemeGroupVersion.Identifier() {
+		errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("must be %q", v1.SchemeGroupVersion.Identifier()), "ref.apiVersion"))
+	}
+
+	// Since we currently construct the rewritten host from the name/namespace, make sure they're valid.
+	if msgs := validation.NameIsDNS1035Label(spec.Ref.Name, false); len(msgs) > 0 {
+		errs = errs.Also(apis.ErrInvalidValue(fmt.Sprint("not a DNS 1035 label prefix: ", msgs), "ref.name"))
+	}
+	if msgs := validation.ValidateNamespaceName(spec.Ref.Namespace, false); len(msgs) > 0 {
+		errs = errs.Also(apis.ErrInvalidValue(fmt.Sprint("not a valid namespace: ", msgs), "ref.namespace"))
+	}
+
+	return errs
 }

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
@@ -40,7 +40,9 @@ func TestDomainMappingValidation(t *testing.T) {
 			},
 			Spec: DomainMappingSpec{
 				Ref: duckv1.KReference{
-					Name: "some-name",
+					Name:       "some-name",
+					APIVersion: "serving.knative.dev/v1",
+					Kind:       "Service",
 				},
 			},
 		},
@@ -51,12 +53,19 @@ func TestDomainMappingValidation(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "missing-ref",
 			},
+			Spec: DomainMappingSpec{
+				Ref: duckv1.KReference{
+					APIVersion: "serving.knative.dev/v1",
+					Kind:       "Service",
+				},
+			},
 		},
 	}, {
 		name: "ref in wrong namespace",
 		want: &apis.FieldError{
 			Paths:   []string{"spec.ref.namespace"},
-			Message: `Ref namespace must be empty or equal to the domain mapping namespace "good-namespace"`,
+			Details: `parent namespace: "good-namespace" does not match ref: "bad-namespace"`,
+			Message: `mismatched namespaces`,
 		},
 		dm: &DomainMapping{
 			ObjectMeta: metav1.ObjectMeta{
@@ -65,8 +74,10 @@ func TestDomainMappingValidation(t *testing.T) {
 			},
 			Spec: DomainMappingSpec{
 				Ref: duckv1.KReference{
-					Name:      "some-name",
-					Namespace: "bad-namespace",
+					Name:       "some-name",
+					Namespace:  "bad-namespace",
+					APIVersion: "serving.knative.dev/v1",
+					Kind:       "Service",
 				},
 			},
 		},

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
@@ -81,6 +81,7 @@ func TestDomainMappingValidation(t *testing.T) {
 			Spec: DomainMappingSpec{
 				Ref: duckv1.KReference{
 					Name:       "some-name",
+					Namespace:  "ns",
 					APIVersion: "serving.knative.dev/v1",
 					Kind:       "BadService",
 				},
@@ -97,6 +98,7 @@ func TestDomainMappingValidation(t *testing.T) {
 			Spec: DomainMappingSpec{
 				Ref: duckv1.KReference{
 					Name:       "some-name",
+					Namespace:  "ns",
 					APIVersion: "bad.version/v1",
 					Kind:       "Service",
 				},

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
@@ -82,6 +82,38 @@ func TestDomainMappingValidation(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "ref wrong Kind",
+		want: apis.ErrGeneric(`must be "Service"`, "spec.ref.kind"),
+		dm: &DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "wrong-kind",
+				Namespace: "ns",
+			},
+			Spec: DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Name:       "some-name",
+					APIVersion: "serving.knative.dev/v1",
+					Kind:       "BadService",
+				},
+			},
+		},
+	}, {
+		name: "ref wrong ApiVersion",
+		want: apis.ErrGeneric(`must be "serving.knative.dev/v1"`, "spec.ref.apiVersion"),
+		dm: &DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "wrong-version",
+				Namespace: "ns",
+			},
+			Spec: DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Name:       "some-name",
+					APIVersion: "bad.version/v1",
+					Kind:       "Service",
+				},
+			},
+		},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
@@ -38,26 +38,14 @@ func TestDomainMappingValidation(t *testing.T) {
 		dm: &DomainMapping{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "cant-use-this",
+				Namespace:    "ns",
 			},
 			Spec: DomainMappingSpec{
 				Ref: duckv1.KReference{
 					Name:       "some-name",
 					APIVersion: "serving.knative.dev/v1",
 					Kind:       "Service",
-				},
-			},
-		},
-	}, {
-		name: "missing ref name",
-		want: apis.ErrMissingField("spec.ref.name"),
-		dm: &DomainMapping{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "missing-ref",
-			},
-			Spec: DomainMappingSpec{
-				Ref: duckv1.KReference{
-					APIVersion: "serving.knative.dev/v1",
-					Kind:       "Service",
+					Namespace:  "ns",
 				},
 			},
 		},
@@ -114,6 +102,42 @@ func TestDomainMappingValidation(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "ref name not valid DNS subdomain",
+		want: apis.ErrInvalidValue(
+			"not a DNS 1035 label prefix: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]",
+			"spec.ref.name"),
+		dm: &DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "wrong-version",
+				Namespace: "ns",
+			},
+			Spec: DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Name:       "this is not valid",
+					Namespace:  "ns",
+					APIVersion: "serving.knative.dev/v1",
+					Kind:       "Service",
+				},
+			},
+		},
+	}, {
+		name: "ref namespace not valid",
+		want: apis.ErrInvalidValue("not a valid namespace: [a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]", "spec.ref.namespace"),
+		dm: &DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "wrong-version",
+				Namespace: "dots.not.allowed",
+			},
+			Spec: DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Name:       "name",
+					APIVersion: "serving.knative.dev/v1",
+					Namespace:  "dots.not.allowed",
+					Kind:       "Service",
+				},
+			},
+		},
 	}}
 
 	for _, test := range tests {
@@ -137,6 +161,7 @@ func TestDomainMappingAnnotationUpdate(t *testing.T) {
 		return DomainMappingSpec{
 			Ref: duckv1.KReference{
 				Name:       name,
+				Namespace:  "ns",
 				Kind:       "Service",
 				APIVersion: "serving.knative.dev/v1",
 			},
@@ -151,7 +176,8 @@ func TestDomainMappingAnnotationUpdate(t *testing.T) {
 		name: "update creator annotation",
 		this: &DomainMapping{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "valid",
+				Name:      "valid",
+				Namespace: "ns",
 				Annotations: map[string]string{
 					serving.CreatorAnnotation: u2,
 					serving.UpdaterAnnotation: u1,
@@ -161,7 +187,8 @@ func TestDomainMappingAnnotationUpdate(t *testing.T) {
 		},
 		prev: &DomainMapping{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "valid",
+				Name:      "valid",
+				Namespace: "ns",
 				Annotations: map[string]string{
 					serving.CreatorAnnotation: u1,
 					serving.UpdaterAnnotation: u1,
@@ -175,7 +202,8 @@ func TestDomainMappingAnnotationUpdate(t *testing.T) {
 		name: "update creator annotation with spec changes",
 		this: &DomainMapping{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "valid",
+				Name:      "valid",
+				Namespace: "ns",
 				Annotations: map[string]string{
 					serving.CreatorAnnotation: u2,
 					serving.UpdaterAnnotation: u1,
@@ -185,7 +213,8 @@ func TestDomainMappingAnnotationUpdate(t *testing.T) {
 		},
 		prev: &DomainMapping{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "valid",
+				Name:      "valid",
+				Namespace: "ns",
 				Annotations: map[string]string{
 					serving.CreatorAnnotation: u1,
 					serving.UpdaterAnnotation: u1,
@@ -199,7 +228,8 @@ func TestDomainMappingAnnotationUpdate(t *testing.T) {
 		name: "update lastModifier annotation without spec changes",
 		this: &DomainMapping{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "valid",
+				Name:      "valid",
+				Namespace: "ns",
 				Annotations: map[string]string{
 					serving.CreatorAnnotation: u1,
 					serving.UpdaterAnnotation: u2,
@@ -209,7 +239,8 @@ func TestDomainMappingAnnotationUpdate(t *testing.T) {
 		},
 		prev: &DomainMapping{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "valid",
+				Name:      "valid",
+				Namespace: "ns",
 				Annotations: map[string]string{
 					serving.CreatorAnnotation: u1,
 					serving.UpdaterAnnotation: u1,
@@ -222,7 +253,8 @@ func TestDomainMappingAnnotationUpdate(t *testing.T) {
 		name: "update lastModifier annotation with spec changes",
 		this: &DomainMapping{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "valid",
+				Name:      "valid",
+				Namespace: "ns",
 				Annotations: map[string]string{
 					serving.CreatorAnnotation: u1,
 					serving.UpdaterAnnotation: u3,
@@ -232,7 +264,8 @@ func TestDomainMappingAnnotationUpdate(t *testing.T) {
 		},
 		prev: &DomainMapping{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "valid",
+				Name:      "valid",
+				Namespace: "ns",
 				Annotations: map[string]string{
 					serving.CreatorAnnotation: u1,
 					serving.UpdaterAnnotation: u1,

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
@@ -34,7 +34,7 @@ func TestDomainMappingValidation(t *testing.T) {
 		want *apis.FieldError
 	}{{
 		name: "uses GenerateName rather than Name",
-		want: apis.ErrMissingField("metadata.name"),
+		want: apis.ErrDisallowedFields("metadata.GenerateName"),
 		dm: &DomainMapping{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "cant-use-this",

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
@@ -34,7 +34,7 @@ func TestDomainMappingValidation(t *testing.T) {
 		want *apis.FieldError
 	}{{
 		name: "uses GenerateName rather than Name",
-		want: apis.ErrDisallowedFields("metadata.GenerateName"),
+		want: apis.ErrDisallowedFields("metadata.generateName"),
 		dm: &DomainMapping{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "cant-use-this",

--- a/pkg/reconciler/domainmapping/table_test.go
+++ b/pkg/reconciler/domainmapping/table_test.go
@@ -307,6 +307,8 @@ func withRef(namespace, name string) domainMappingOption {
 	return func(dm *v1alpha1.DomainMapping) {
 		dm.Spec.Ref.Namespace = namespace
 		dm.Spec.Ref.Name = name
+		dm.Spec.Ref.APIVersion = "serving.knative.dev/v1"
+		dm.Spec.Ref.Kind = "Service"
 	}
 }
 

--- a/test/conformance/api/v1alpha1/domain_mapping_test.go
+++ b/test/conformance/api/v1alpha1/domain_mapping_test.go
@@ -66,8 +66,10 @@ func TestDomainMapping(t *testing.T) {
 		},
 		Spec: v1alpha1.DomainMappingSpec{
 			Ref: duckv1.KReference{
-				Namespace: svc.Service.Namespace,
-				Name:      svc.Service.Name,
+				Namespace:  svc.Service.Namespace,
+				Name:       svc.Service.Name,
+				APIVersion: "serving.knative.dev/v1",
+				Kind:       "Service",
 			},
 		},
 	}, metav1.CreateOptions{})


### PR DESCRIPTION
Part 700ish of https://github.com/knative/serving/issues/9713.

Adds more validation and defaulting. Now:

- uses pkg for kreference validation/defaulting
- sets and validates lastModifier/creator annotations
- adds some defensive validation that kind and apiVersion are set to the only currently-allowed values, for now.
- checks ref name/namespace are valid since we rely on them when constructing the rewriteHost host etc.

This is probably a bit big, but it's mostly test boilerplate. I'd very happily split out some smaller PRs if anyone feels it's too painful to review, though.

/assign @mattmoor @dprotaso 