### PR TITLE
Sort both configs and tags within rollouts

### DIFF
--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -182,6 +182,10 @@ func (cfg *Config) BuildRollout() *Rollout {
 // from run to run, since input to the process is map iterator.
 func sortRollout(r *Rollout) {
 	sort.Slice(r.Configurations, func(i, j int) bool {
+		// Sort by tag and within tag sort by config name.
+		if r.Configurations[i].Tag == r.Configurations[j].Tag {
+			return r.Configurations[i].ConfigurationName < r.Configurations[j].ConfigurationName
+		}
 		return r.Configurations[i].Tag < r.Configurations[j].Tag
 	})
 }


### PR DESCRIPTION
Revisions should not be sorted, since they are sorted by 'age'.

/assign @tcnghia 