### PR TITLE
Pin Istio to 1.4.6 for performance tests

### DIFF
--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -30,9 +30,9 @@ export MESH=0
 export KNATIVE_DEFAULT_NAMESPACE="knative-serving"
 export SYSTEM_NAMESPACE="knative-serving"
 export ISTIO_VERSION="stable"
-# Pin net-istio to a commit when the stable Istio version was 1.5.7
+# Pin net-istio to a commit when the stable Istio version was 1.4.6
 # TODO(chizhg): unpin the version after https://github.com/knative/serving/issues/9673 is root caused and fixed
-export NET_ISTIO_COMMIT="63af963d05c1dddcfcb3ada717c832092cf3e7c7"
+export NET_ISTIO_COMMIT="f64ed34d3776a444372483dddc15a330c6c1ac53"
 export UNINSTALL_LIST=()
 export TMP_DIR=$(mktemp -d -t ci-$(date +%Y-%m-%d-%H-%M-%S)-XXXXXXXXXX)
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
* Pin Istio to 1.4.6 for performance tests. This is the actual version we are running with now.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vagababov 
