### PR TITLE
Add domain mapping webhook to HA Components

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -265,7 +265,7 @@ function install_knative_serving_standard() {
   UNINSTALL_LIST+=( "${CERT_YAML_NAME}" )
 
   echo ">> Installing Knative serving"
-  HA_COMPONENTS+=( "controller" "webhook" "autoscaler-hpa" "autoscaler")
+  HA_COMPONENTS+=( "controller" "webhook" "autoscaler-hpa" "autoscaler" "domainmapping-webhook" )
   if [[ "$1" == "HEAD" ]]; then
     local CORE_YAML_NAME=${TMP_DIR}/${SERVING_CORE_YAML##*/}
     sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${SERVING_CORE_YAML} > ${CORE_YAML_NAME}


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/9911.

This should make the domain mapping conformance test more resilient to chaos quacks (such as happened in  https://github.com/knative/serving/issues/9911). Also, use [RetryTestErrors helper](https://github.com/knative/serving/blob/3a8ea47afb5494175844a0657c5b3bae1e7b602b/vendor/knative.dev/pkg/reconciler/retry.go#L50) in test: I don't think we've seen a flake that would be fixed by this yet, but might as well.

/assign @vagababov @mattmoor 