### PR TITLE
increase duration of our HA tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -132,7 +132,7 @@ go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
 
 # Run HA tests separately as they're stopping core Knative Serving pods
 # Define short -spoofinterval to ensure frequent probing while stopping pods
-go_test_e2e -timeout=15m -failfast -parallel=1 ./test/ha \
+go_test_e2e -timeout=25m -failfast -parallel=1 ./test/ha \
 	    -replicas="${REPLICAS:-1}" -buckets="${BUCKETS:-1}" -spoofinterval="10ms" || failed=1
 
 (( failed )) && fail_test


### PR DESCRIPTION

Addressing some HA flakiness

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Prior we had one HA test enabled with a duration of 15 minutes. Now we have three (controller, activator, autoscaler) and I'm seeing test timeouts.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
