### PR TITLE
Add percentage to the main config object.

### DIFF
--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -44,7 +44,7 @@ type ConfigurationRollout struct {
 	Tag               string `json:"tag,omitempty"`
 
 	// Percent denotes the total percentage for this configuration.
-	// The individual percentages of the Reivisions below will sum to this
+	// The individual percentages of the Revisions below will sum to this
 	// number.
 	Percent int `json:"percent"`
 

--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -43,6 +43,11 @@ type ConfigurationRollout struct {
 	ConfigurationName string `json:"configurationName"`
 	Tag               string `json:"tag,omitempty"`
 
+	// Percent denotes the total percentage for this configuration.
+	// The individual percentages of the Reivisions below will sum to this
+	// number.
+	Percent int `json:"percent"`
+
 	// The revisions in the rollout. In steady state this should
 	// contain 0 (no revision is ready) or 1 (rollout done).
 	// During the actual rollout it will contain N revisions

--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -167,6 +167,8 @@ func newBuilder(
 
 // BuildRollout builds the current rollout state.
 // It is expected to be invoked after applySpecTraffic.
+// Returned Rollout will be sorted by tag and within tag by configuration
+// (only default tag can have more than configuration object attached).
 // TODO(vagababov): actually deal with rollouts, vs just report desired state.
 func (cfg *Config) BuildRollout() *Rollout {
 	rollout := &Rollout{}
@@ -205,9 +207,12 @@ func buildRolloutForTag(r *Rollout, tag string, rts RevisionTargets) {
 		r.Configurations = append(r.Configurations, ConfigurationRollout{
 			ConfigurationName: rt.ConfigurationName,
 			Tag:               tag,
+			Percent:           int(valIfNil(0, rt.Percent)),
 			Revisions: []RevisionRollout{{
 				RevisionName: rt.RevisionName,
-				Percent:      int(valIfNil(0, rt.Percent)),
+				// Note: this will match config value in steady state, but
+				// during rollout it will be overridden by the rollout logic.
+				Percent: int(valIfNil(0, rt.Percent)),
 			}},
 		})
 	}

--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -207,12 +207,12 @@ func buildRolloutForTag(r *Rollout, tag string, rts RevisionTargets) {
 		r.Configurations = append(r.Configurations, ConfigurationRollout{
 			ConfigurationName: rt.ConfigurationName,
 			Tag:               tag,
-			Percent:           int(valIfNil(0, rt.Percent)),
+			Percent:           int(zeroIfNil(rt.Percent)),
 			Revisions: []RevisionRollout{{
 				RevisionName: rt.RevisionName,
 				// Note: this will match config value in steady state, but
 				// during rollout it will be overridden by the rollout logic.
-				Percent: int(valIfNil(0, rt.Percent)),
+				Percent: int(zeroIfNil(rt.Percent)),
 			}},
 		})
 	}
@@ -345,10 +345,10 @@ func (cb *configBuilder) addRevisionTarget(tt *v1.TrafficTarget) error {
 	return nil
 }
 
-// valIfNil returns `val` if `ptr==nil`, or `*ptr` otherwise.
-func valIfNil(val int64, ptr *int64) int64 {
+// zeroIfNil returns `0` if `ptr==nil`, or `*ptr` otherwise.
+func zeroIfNil(ptr *int64) int64 {
 	if ptr == nil {
-		return val
+		return 0
 	}
 	return *ptr
 }
@@ -359,7 +359,7 @@ func mergeIfNecessary(rts RevisionTargets, rt RevisionTarget) RevisionTargets {
 	for i := range rts {
 		if rts[i].Tag == rt.Tag && rts[i].RevisionName == rt.RevisionName &&
 			*rt.LatestRevision == *rts[i].LatestRevision {
-			rts[i].Percent = ptr.Int64(valIfNil(0, rts[i].Percent) + valIfNil(0, rt.Percent))
+			rts[i].Percent = ptr.Int64(zeroIfNil(rts[i].Percent) + zeroIfNil(rt.Percent))
 			return rts
 		}
 	}

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -179,6 +179,7 @@ func TestBuildTrafficConfigurationVanilla(t *testing.T) {
 	wantR := &Rollout{
 		Configurations: []ConfigurationRollout{{
 			ConfigurationName: goodConfig.Name,
+			Percent:           100,
 			Revisions: []RevisionRollout{{
 				RevisionName: goodNewRev.Name,
 				Percent:      100,
@@ -282,6 +283,7 @@ func TestBuildTrafficConfigurationVanillaScaledToZero(t *testing.T) {
 	wantR := &Rollout{
 		Configurations: []ConfigurationRollout{{
 			ConfigurationName: inactiveConfig.Name,
+			Percent:           100,
 			Revisions: []RevisionRollout{{
 				RevisionName: inactiveRev.Name,
 				Percent:      100,
@@ -432,6 +434,7 @@ func TestBuildTrafficConfigurationTwoEntriesSameConfig(t *testing.T) {
 	wantR := &Rollout{
 		Configurations: []ConfigurationRollout{{
 			ConfigurationName: niceConfig.Name,
+			Percent:           100,
 			Revisions: []RevisionRollout{{
 				RevisionName: niceNewRev.Name,
 				Percent:      100,
@@ -566,18 +569,21 @@ func TestBuildTrafficConfigThreeConfigs(t *testing.T) {
 		// Default tag configs are sorted as well.
 		Configurations: []ConfigurationRollout{{
 			ConfigurationName: goodConfig.Name,
+			Percent:           35,
 			Revisions: []RevisionRollout{{
 				RevisionName: goodNewRev.Name,
 				Percent:      35,
 			}},
 		}, {
 			ConfigurationName: inactiveConfig.Name,
+			Percent:           35,
 			Revisions: []RevisionRollout{{
 				RevisionName: inactiveRev.Name,
 				Percent:      35,
 			}},
 		}, {
 			ConfigurationName: niceConfig.Name,
+			Percent:           30,
 			Revisions: []RevisionRollout{{
 				RevisionName: niceNewRev.Name,
 				Percent:      30,
@@ -586,6 +592,7 @@ func TestBuildTrafficConfigThreeConfigs(t *testing.T) {
 			// Note sorting flipped these two.
 			ConfigurationName: inactiveConfig.Name,
 			Tag:               "jackson",
+			Percent:           100,
 			Revisions: []RevisionRollout{{
 				RevisionName: inactiveRev.Name,
 				Percent:      100,
@@ -593,6 +600,7 @@ func TestBuildTrafficConfigThreeConfigs(t *testing.T) {
 		}, {
 			ConfigurationName: goodConfig.Name,
 			Tag:               "robert",
+			Percent:           100,
 			Revisions: []RevisionRollout{{
 				RevisionName: goodNewRev.Name,
 				Percent:      100,
@@ -675,6 +683,7 @@ func TestBuildTrafficConfigurationTwoEntriesSameConfigDifferentTags(t *testing.T
 	wantR := &Rollout{
 		Configurations: []ConfigurationRollout{{
 			ConfigurationName: niceConfig.Name,
+			Percent:           100,
 			Revisions: []RevisionRollout{{
 				RevisionName: niceNewRev.Name,
 				Percent:      100,
@@ -682,6 +691,7 @@ func TestBuildTrafficConfigurationTwoEntriesSameConfigDifferentTags(t *testing.T
 		}, {
 			ConfigurationName: niceConfig.Name,
 			Tag:               "robert",
+			Percent:           100,
 			Revisions: []RevisionRollout{{
 				RevisionName: niceNewRev.Name,
 				Percent:      100,


### PR DESCRIPTION
When writing the actual rollout logic I found that it'll be much easier to have the target % provided,
especially if it can change. Rather than summing and comparing the individual revision rollout % values.

For #9765

/assign @tcnghia mattmoor