### PR TITLE
Add DomainClaimed Condition

### DIFF
--- a/pkg/apis/serving/v1alpha1/domainmapping_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_lifecycle.go
@@ -64,7 +64,7 @@ func (dms *DomainMappingStatus) MarkIngressNotConfigured() {
 }
 
 // MarkDomainClaimed updates the DomainMappingConditionDomainClaimed condition
-// to indicate that the domain was succesfully claimed.
+// to indicate that the domain was successfully claimed.
 func (dms *DomainMappingStatus) MarkDomainClaimed() {
 	domainMappingCondSet.Manage(dms).MarkTrue(DomainMappingConditionDomainClaimed)
 }

--- a/pkg/apis/serving/v1alpha1/domainmapping_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_lifecycle.go
@@ -24,6 +24,7 @@ import (
 )
 
 var domainMappingCondSet = apis.NewLivingConditionSet(
+	DomainMappingConditionDomainClaimed,
 	DomainMappingConditionIngressReady,
 )
 
@@ -60,6 +61,26 @@ func (dms *DomainMappingStatus) InitializeConditions() {
 func (dms *DomainMappingStatus) MarkIngressNotConfigured() {
 	domainMappingCondSet.Manage(dms).MarkUnknown(DomainMappingConditionIngressReady,
 		"IngressNotConfigured", "Ingress has not yet been reconciled.")
+}
+
+// MarkDomainClaimed updates the DomainMappingConditionDomainClaimed condition
+// to indicate that the domain was succesfully claimed.
+func (dms *DomainMappingStatus) MarkDomainClaimed() {
+	domainMappingCondSet.Manage(dms).MarkTrue(DomainMappingConditionDomainClaimed)
+}
+
+// MarkDomainClaimNotOwned updates the DomainMappingConditionDomainClaimed
+// condition to indicate that the domain is already in use by another
+// DomainMapping.
+func (dms *DomainMappingStatus) MarkDomainClaimNotOwned() {
+	domainMappingCondSet.Manage(dms).MarkFalse(DomainMappingConditionDomainClaimed, "DomainAlreadyClaimed",
+		"The domain name is already in use by another DomainMapping")
+}
+
+// MarkDomainClaimFailed updates the DomainMappingConditionDomainClaimed
+// condition to indicate that creating the ClusterDomainClaim failed.
+func (dms *DomainMappingStatus) MarkDomainClaimFailed(reason string) {
+	domainMappingCondSet.Manage(dms).MarkFalse(DomainMappingConditionDomainClaimed, "DomainClaimFailed", reason)
 }
 
 // PropagateIngressStatus updates the DomainMappingConditionIngressReady

--- a/pkg/apis/serving/v1alpha1/domainmapping_types.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_types.go
@@ -98,6 +98,10 @@ const (
 	// DomainMappingConditionIngressReady reflects the readiness of the
 	// underlying Ingress resource.
 	DomainMappingConditionIngressReady apis.ConditionType = "IngressReady"
+
+	// DomainMappingConditionDomainClaimed reflects that the ClusterDomainClaim
+	// for this DomainMapping exists, and is owned by this DomainMapping.
+	DomainMappingConditionDomainClaimed apis.ConditionType = "DomainClaimed"
 )
 
 // GetStatus retrieves the status of the DomainMapping. Implements the KRShaped interface.

--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -62,6 +62,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, dm *v1alpha1.DomainMappi
 		dm.Status.MarkIngressNotConfigured()
 	}
 
+	// TODO(jz) ClusterDomainClaim isn't fully implemented yet, so just mark it
+	// Claimed for now so we have the correct condition flow.
+	dm.Status.MarkDomainClaimed()
+
 	// Mapped URL is the metadata.name of the DomainMapping.
 	url := &apis.URL{Scheme: "http", Host: dm.Name}
 	dm.Status.URL = url

--- a/pkg/reconciler/domainmapping/table_test.go
+++ b/pkg/reconciler/domainmapping/table_test.go
@@ -68,6 +68,7 @@ func TestReconcile(t *testing.T) {
 				withURL("http", "first-reconcile.com"),
 				withAddress("http", "first-reconcile.com"),
 				withInitDomainMappingConditions,
+				withDomainClaimed,
 				withIngressNotConfigured,
 			),
 		}},
@@ -93,6 +94,7 @@ func TestReconcile(t *testing.T) {
 				withURL("http", "ingressclass.first-reconcile.com"),
 				withAddress("http", "ingressclass.first-reconcile.com"),
 				withInitDomainMappingConditions,
+				withDomainClaimed,
 				withIngressNotConfigured,
 				withAnnotations(map[string]string{
 					networking.IngressClassAnnotationKey: "overridden-ingress-class",
@@ -119,6 +121,7 @@ func TestReconcile(t *testing.T) {
 				withURL("http", "ingress-exists.org"),
 				withAddress("http", "ingress-exists.org"),
 				withInitDomainMappingConditions,
+				withDomainClaimed,
 				withIngressNotConfigured,
 			),
 		}},
@@ -133,7 +136,6 @@ func TestReconcile(t *testing.T) {
 				withRef("default", "failed"),
 				withURL("http", "ingress-failed.me"),
 				withAddress("http", "ingress-failed.me"),
-				withInitDomainMappingConditions,
 			),
 			ingress(domainMapping("default", "ingress-failed.me", withRef("default", "failed")), "the-ingress-class",
 				WithLoadbalancerFailed("fell over", "hurt myself"),
@@ -144,6 +146,8 @@ func TestReconcile(t *testing.T) {
 				withRef("default", "failed"),
 				withURL("http", "ingress-failed.me"),
 				withAddress("http", "ingress-failed.me"),
+				withInitDomainMappingConditions,
+				withDomainClaimed,
 				withPropagatedStatus(ingress(domainMapping("default", "ingress-failed.me"), "", WithLoadbalancerFailed("fell over", "hurt myself")).Status),
 			),
 		}},
@@ -155,7 +159,6 @@ func TestReconcile(t *testing.T) {
 				withRef("default", "unknown"),
 				withURL("http", "ingress-unknown.me"),
 				withAddress("http", "ingress-unknown.me"),
-				withInitDomainMappingConditions,
 			),
 			ingress(domainMapping("default", "ingress-unknown.me", withRef("default", "unknown")), "the-ingress-class",
 				withIngressNotReady,
@@ -166,6 +169,8 @@ func TestReconcile(t *testing.T) {
 				withRef("default", "unknown"),
 				withURL("http", "ingress-unknown.me"),
 				withAddress("http", "ingress-unknown.me"),
+				withInitDomainMappingConditions,
+				withDomainClaimed,
 				withPropagatedStatus(ingress(domainMapping("default", "ingress-unknown.me"), "", withIngressNotReady).Status),
 			),
 		}},
@@ -177,7 +182,6 @@ func TestReconcile(t *testing.T) {
 				withRef("default", "ready"),
 				withURL("http", "ingress-ready.me"),
 				withAddress("http", "ingress-ready.me"),
-				withInitDomainMappingConditions,
 			),
 			ingress(domainMapping("default", "ingress-ready.me", withRef("default", "ready")), "the-ingress-class",
 				withIngressReady,
@@ -188,6 +192,8 @@ func TestReconcile(t *testing.T) {
 				withRef("default", "ready"),
 				withURL("http", "ingress-ready.me"),
 				withAddress("http", "ingress-ready.me"),
+				withInitDomainMappingConditions,
+				withDomainClaimed,
 				withPropagatedStatus(ingress(domainMapping("default", "ingress-ready.me"), "", withIngressReady).Status),
 			),
 		}},
@@ -202,7 +208,6 @@ func TestReconcile(t *testing.T) {
 				withRef("default", "cantcreate"),
 				withURL("http", "cantcreate.this"),
 				withAddress("http", "cantcreate.this"),
-				withInitDomainMappingConditions,
 				withGeneration(1),
 			),
 		},
@@ -217,6 +222,7 @@ func TestReconcile(t *testing.T) {
 				withURL("http", "cantcreate.this"),
 				withAddress("http", "cantcreate.this"),
 				withInitDomainMappingConditions,
+				withDomainClaimed,
 				withIngressNotConfigured,
 				withGeneration(1),
 				withObservedGeneration,
@@ -237,7 +243,6 @@ func TestReconcile(t *testing.T) {
 				withRef("default", "cantupdate"),
 				withURL("http", "cantupdate.this"),
 				withAddress("http", "cantupdate.this"),
-				withInitDomainMappingConditions,
 				withGeneration(1),
 			),
 			ingress(domainMapping("default", "cantupdate.this", withRef("default", "previous-value")), "the-ingress-class"),
@@ -253,6 +258,7 @@ func TestReconcile(t *testing.T) {
 				withURL("http", "cantupdate.this"),
 				withAddress("http", "cantupdate.this"),
 				withInitDomainMappingConditions,
+				withDomainClaimed,
 				withIngressNotConfigured,
 				withGeneration(1),
 				withObservedGeneration,
@@ -339,6 +345,10 @@ func withPropagatedStatus(status netv1alpha1.IngressStatus) domainMappingOption 
 
 func withInitDomainMappingConditions(dm *v1alpha1.DomainMapping) {
 	dm.Status.InitializeConditions()
+}
+
+func withDomainClaimed(dm *v1alpha1.DomainMapping) {
+	dm.Status.MarkDomainClaimed()
 }
 
 func withGeneration(generation int64) domainMappingOption {


### PR DESCRIPTION
Part of https://github.com/knative/serving/issues/9713.

~~Adds the `ClusterDomainClaim` CRD and type, and adds a new `DomainMappingConditionDomainClaimed` condition to `DomainMapping` to surface whether the `ClusterDomainClaim` was/wasn't successfully "claimed" (i.e. created).~~

Moved the ClusterDomainClaim CRD into networking in https://github.com/knative/networking/pull/254. This PR now just introduces the DomainClaimed condition to DomainMapping.

/assign @mattmoor @vagababov 