### PR TITLE
add Traffic fields to the Service Schema

### DIFF
--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -58,6 +58,44 @@ spec:
                 items:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                  properties:
+                    revisionName:
+                      type: string
+                      description: |
+                        A specific revision to which to send this portion
+                        of traffic.
+                        This is mutually exclusive with configurationName.
+                    configurationName:
+                      type: string
+                      description: |
+                        ConfigurationName of a configuration to whose latest revision we will send
+                        this portion of traffic. When the "status.latestReadyRevisionName" of the
+                        referenced configuration changes, we will automatically migrate traffic
+                        from the prior "latest ready" revision to the new one.  This field is never
+                        set in Route's status, only its spec.
+                        This is mutually exclusive with RevisionName.
+                    latestRevision:
+                      type: boolean
+                      description: |
+                        `latestRevision` may be optionally provided to indicate
+                        that the latest ready Revision of the Configuration should be used
+                        for this traffic target. When provided latestRevision MUST be true
+                        if revisionName is empty, and it MUST be false when revisionName is non-empty.
+                    tag:
+                      type: string
+                      description: |
+                        Tag is optionally used to expose a dedicated URL for
+                        referencing this target exclusively. The dedicated URL MUST include
+                        in it the string provided by tag.
+                    percent:
+                      type: integer
+                      description: |
+                        The percentage of requests which should be allocated
+                        from the main Route domain name to the specified `revisionName` or
+                        `configurationName`.
+                        All `percent` values in `traffic` MUST sum to 100.
+                      minimum: 0
+                      maximum: 100
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
Related to #912 

## Proposed Changes

* This adds just the Traffic section to the Service schema. 

**Release Note**

```release-note
Updated the Service schema to include the Traffic fields.
```