### PR TITLE
Consistently use t.Parallel and lint it

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,7 @@ linters:
     - gosec
     - prealloc
     - stylecheck
+    - tparallel
     - unconvert
     - unparam
   disable:

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -101,6 +101,8 @@ func TestRevisionTimeout(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			names := test.ResourceNames{
 				Service: test.ObjectNameForTest(t),
 				Image:   test.Timeout,

--- a/test/conformance/runtime/envpropagation_test.go
+++ b/test/conformance/runtime/envpropagation_test.go
@@ -34,6 +34,8 @@ func TestSecretsViaEnv(t *testing.T) {
 	clients := test.Setup(t)
 
 	t.Run("env", func(t *testing.T) {
+		t.Parallel()
+
 		err := fetchEnvironmentAndVerify(t, clients, WithEnv(corev1.EnvVar{
 			Name: test.EnvKey,
 			ValueFrom: &corev1.EnvVarSource{
@@ -51,6 +53,8 @@ func TestSecretsViaEnv(t *testing.T) {
 	})
 
 	t.Run("envFrom", func(t *testing.T) {
+		t.Parallel()
+
 		err := fetchEnvironmentAndVerify(t, clients, WithEnvFrom(corev1.EnvFromSource{
 			SecretRef: &corev1.SecretEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{
@@ -70,6 +74,8 @@ func TestConfigsViaEnv(t *testing.T) {
 	clients := test.Setup(t)
 
 	t.Run("env", func(t *testing.T) {
+		t.Parallel()
+
 		err := fetchEnvironmentAndVerify(t, clients, WithEnv(corev1.EnvVar{
 			Name: test.EnvKey,
 			ValueFrom: &corev1.EnvVarSource{
@@ -87,6 +93,8 @@ func TestConfigsViaEnv(t *testing.T) {
 	})
 
 	t.Run("envFrom", func(t *testing.T) {
+		t.Parallel()
+
 		err := fetchEnvironmentAndVerify(t, clients, WithEnvFrom(corev1.EnvFromSource{
 			ConfigMapRef: &corev1.ConfigMapEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestProbeRuntime(t *testing.T) {
-
+	t.Parallel()
 	clients := test.Setup(t)
 
 	var testCases = []struct {

--- a/test/e2e/route_service_test.go
+++ b/test/e2e/route_service_test.go
@@ -79,6 +79,8 @@ func TestRoutesNotReady(t *testing.T) {
 }
 
 func TestRouteVisibilityChanges(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name            string
 		withTrafficSpec rtesting.ServiceOption

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -209,6 +209,8 @@ func TestServiceToServiceCall(t *testing.T) {
 			Path:   resources.Route.Status.URL.Path,
 		}
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			cancel := logstream.Start(t)
 			defer cancel()
 			testProxyToHelloworld(t, clients, helloworldURL, true /*inject*/, false /*accessible externally*/)
@@ -260,6 +262,8 @@ func TestSvcToSvcViaActivator(t *testing.T) {
 
 	for _, tc := range testInjection {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			cancel := logstream.Start(t)
 			defer cancel()
 			testSvcToSvcCallViaActivator(t, clients, tc.injectA, tc.injectB)
@@ -306,6 +310,8 @@ func TestCallToPublicService(t *testing.T) {
 
 	for _, tc := range gatewayTestCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			cancel := logstream.Start(t)
 			defer cancel()
 			testProxyToHelloworld(t, clients, tc.url, false /*inject*/, tc.accessibleExternally)

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -83,6 +83,7 @@ func TestSubrouteLocalSTS(t *testing.T) { // We can't use a longer more descript
 		helloworldURL := resources.Route.Status.Address.URL.URL()
 		helloworldURL.Host = strings.TrimSuffix(domain, tc.suffix)
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			testProxyToHelloworld(t, clients, helloworldURL, true, false)
 		})
 	}

--- a/test/e2e/tagheader/tag_header_based_routing_test.go
+++ b/test/e2e/tagheader/tag_header_based_routing_test.go
@@ -111,6 +111,8 @@ func TestTagHeaderBasedRouting(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			if _, err := pkgTest.WaitForEndpointState(
 				context.Background(),
 				clients.KubeClient,


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

And another useful new lint, that forces us to stay consistent. This caught a few occasions where we only called t.Parallel on the sub and not the top-level test.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov 

/hold
Until the linter version upgrade rolls through.
