### PR TITLE
Drop all capabilities from our pods

### DIFF
--- a/config/core/deployments/activator.yaml
+++ b/config/core/deployments/activator.yaml
@@ -78,6 +78,9 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
 
         ports:
         - name: metrics

--- a/config/core/deployments/autoscaler.yaml
+++ b/config/core/deployments/autoscaler.yaml
@@ -83,6 +83,9 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
 
         ports:
         - name: metrics

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -79,6 +79,9 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
 
         ports:
         - name: metrics

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -83,6 +83,9 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
 
         ports:
         - name: metrics

--- a/config/domain-mapping/controller.yaml
+++ b/config/domain-mapping/controller.yaml
@@ -73,6 +73,11 @@ spec:
 
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
 
         ports:
         - name: metrics

--- a/config/hpa-autoscaling/controller.yaml
+++ b/config/hpa-autoscaling/controller.yaml
@@ -74,6 +74,11 @@ spec:
 
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
 
         ports:
         - name: metrics

--- a/config/namespace-wildcard-certs/controller.yaml
+++ b/config/namespace-wildcard-certs/controller.yaml
@@ -74,6 +74,11 @@ spec:
 
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all
 
         ports:
         - name: metrics


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As per title, we don't seem to need any of the "extra" capabilities (i.e. we're not spawning sockets < 1024 etc.), so let's use the smallest surface area possible.

I'll check if this might be worth doing for the queue-proxy too.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
All of our deployments run with a minimal set of kernel capabilities.
```

/assign @julz @mattmoor 
