### PR TITLE
Narrow down the security profile of queue-proxy containers

### DIFF
--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -75,7 +75,7 @@ var (
 
 	queueSecurityContext = &corev1.SecurityContext{
 		AllowPrivilegeEscalation: ptr.Bool(false),
-		ReadOnlyRootFilesystem:   ptr.Bool(true),
+		ReadOnlyRootFilesystem:   ptr.Bool(false), // Needed to be able to generate the unix socket.
 		RunAsNonRoot:             ptr.Bool(true),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"all"},

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -75,6 +75,11 @@ var (
 
 	queueSecurityContext = &corev1.SecurityContext{
 		AllowPrivilegeEscalation: ptr.Bool(false),
+		ReadOnlyRootFilesystem:   ptr.Bool(true),
+		RunAsNonRoot:             ptr.Bool(true),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"all"},
+		},
 	}
 )
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Akin to our "main" deployments, this also narrows down the security surface of our queue-proxy containers. They shouldn't need any special capabilities.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
queue-proxies are no longer allow to run as root, they have a read-only root filesystem and have all capabilities dropped.
```

/assign @mattmoor @vagababov 
