### PR TITLE
Create abstract socket in queue-proxy to make filesystem read-only

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -25,7 +25,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strconv"
 	"time"
 
@@ -63,7 +62,9 @@ const (
 
 var (
 	readinessProbeTimeout = flag.Duration("probe-period", -1, "run readiness probe with given timeout")
-	unixSocketPath        = filepath.Join(os.TempDir(), "queue.sock")
+
+	// This creates an abstract socket instead of an actual file.
+	unixSocketPath = "@/knative.dev/serving/queue.sock"
 )
 
 type config struct {

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -75,7 +75,7 @@ var (
 
 	queueSecurityContext = &corev1.SecurityContext{
 		AllowPrivilegeEscalation: ptr.Bool(false),
-		ReadOnlyRootFilesystem:   ptr.Bool(false), // Needed to be able to generate the unix socket.
+		ReadOnlyRootFilesystem:   ptr.Bool(true),
 		RunAsNonRoot:             ptr.Bool(true),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"all"},


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Making the unix socket in the queue-proxy an [abstract socket](https://www.man7.org/linux/man-pages/man7/unix.7.html) allows us to make its file-system read-only. Abstract sockets have quite a few security implications vs. file-based unix sockets, but that doesn't matter in this case, seeing as the server is surfaced via a tcp socket already anyway and this is strictly a performance improvement.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
