### PR TITLE
Relax empty logging config tests

### DIFF
--- a/pkg/logging/config_test.go
+++ b/pkg/logging/config_test.go
@@ -50,9 +50,7 @@ func TestNewConfigNoEntry(t *testing.T) {
 	if diff := cmp.Diff(cm, c); diff != "" {
 		t.Fatalf("Config mismatch: diff(-want,+got):\n%s", diff)
 	}
-	if got := c.LoggingConfig; got == "" {
-		t.Error("LoggingConfig = empty, want not empty")
-	}
+	// TODO: assert that c.LoggingConfig is empty.
 	if got, want := len(c.LoggingLevel), 0; got != want {
 		t.Errorf("len(LoggingLevel) = %d, want %d", got, want)
 	}


### PR DESCRIPTION
Allows an empty LoggingConfig to be represented by an empty string
rather than requiring defaults to be populated. This allows defaults
to be populated when the real logging config is built rather than
being encoded in the LoggingConfig string. Needed to allow changes to LoggingConfig parsing made in https://github.com/knative/pkg/pull/1773.
