### PR TITLE
Rename common k8s imports using a common alias

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_defaults_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_defaults_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/serving/pkg/apis/autoscaling"
@@ -54,19 +54,19 @@ func TestPodAutoscalerDefaulting(t *testing.T) {
 		in:   &PodAutoscaler{},
 		wc: func(ctx context.Context) context.Context {
 			s := config.NewStore(logtesting.TestLogger(t))
-			s.OnConfigChanged(&v1.ConfigMap{
+			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: config.DefaultsConfigName,
 				},
 				Data: map[string]string{},
 			})
-			s.OnConfigChanged(&v1.ConfigMap{
+			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: config.FeaturesConfigName,
 				},
 				Data: map[string]string{},
 			})
-			s.OnConfigChanged(&v1.ConfigMap{
+			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: autoscalerconfig.ConfigName,
 				},

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	net "knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/apis"
@@ -157,7 +157,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 	}{{
 		name: "valid",
 		r: &PodAutoscaler{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{
@@ -173,7 +173,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 	}, {
 		name: "bad protocol",
 		r: &PodAutoscaler{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: "valid",
 				Annotations: map[string]string{
 					autoscaling.MinScaleAnnotationKey: "2",
@@ -192,7 +192,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 	}, {
 		name: "bad scale bounds",
 		r: &PodAutoscaler{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: "valid",
 				Annotations: map[string]string{
 					autoscaling.MinScaleAnnotationKey: "FOO",
@@ -211,7 +211,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 	}, {
 		name: "empty spec",
 		r: &PodAutoscaler{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: "valid",
 			},
 		},
@@ -219,7 +219,7 @@ func TestPodAutoscalerValidation(t *testing.T) {
 	}, {
 		name: "nested spec error",
 		r: &PodAutoscaler{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: "valid",
 			},
 			Spec: PodAutoscalerSpec{

--- a/pkg/autoscaler/statforwarder/forwarder.go
+++ b/pkg/autoscaler/statforwarder/forwarder.go
@@ -24,7 +24,7 @@ import (
 
 	"go.uber.org/zap"
 	coordinationv1 "k8s.io/api/coordination/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -228,13 +228,13 @@ func (f *Forwarder) leaseUpdated(obj interface{}) {
 func (f *Forwarder) createService(ctx context.Context, ns, n string) error {
 	var lastErr error
 	if err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
-		_, lastErr = f.kc.CoreV1().Services(ns).Create(ctx, &v1.Service{
+		_, lastErr = f.kc.CoreV1().Services(ns).Create(ctx, &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      n,
 				Namespace: ns,
 			},
-			Spec: v1.ServiceSpec{
-				Ports: []v1.ServicePort{{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{
 					Name:       autoscalerPortName,
 					Port:       autoscalerPort,
 					TargetPort: intstr.FromInt(autoscalerPort),
@@ -259,14 +259,14 @@ func (f *Forwarder) createService(ctx context.Context, ns, n string) error {
 // name, and the Forwarder.selfIP. If the Endpoints object already
 // exists, it will update the Endpoints with the Forwarder.selfIP.
 func (f *Forwarder) createOrUpdateEndpoints(ctx context.Context, ns, n string) error {
-	wantSubsets := []v1.EndpointSubset{{
-		Addresses: []v1.EndpointAddress{{
+	wantSubsets := []corev1.EndpointSubset{{
+		Addresses: []corev1.EndpointAddress{{
 			IP: f.selfIP,
 		}},
-		Ports: []v1.EndpointPort{{
+		Ports: []corev1.EndpointPort{{
 			Name:     autoscalerPortName,
 			Port:     autoscalerPort,
-			Protocol: v1.ProtocolTCP,
+			Protocol: corev1.ProtocolTCP,
 		}}},
 	}
 
@@ -307,7 +307,7 @@ func (f *Forwarder) createOrUpdateEndpoints(ctx context.Context, ns, n string) e
 	}
 
 	if err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
-		_, lastErr = f.kc.CoreV1().Endpoints(ns).Create(ctx, &v1.Endpoints{
+		_, lastErr = f.kc.CoreV1().Endpoints(ns).Create(ctx, &corev1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      n,
 				Namespace: ns,

--- a/pkg/autoscaler/statforwarder/forwarder_test.go
+++ b/pkg/autoscaler/statforwarder/forwarder_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	coordinationv1 "k8s.io/api/coordination/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -115,14 +115,14 @@ func TestForwarderReconcile(t *testing.T) {
 		t.Fatal("Timeout to get the Service:", lastErr)
 	}
 
-	wantSubsets := []v1.EndpointSubset{{
-		Addresses: []v1.EndpointAddress{{
+	wantSubsets := []corev1.EndpointSubset{{
+		Addresses: []corev1.EndpointAddress{{
 			IP: testIP1,
 		}},
-		Ports: []v1.EndpointPort{{
+		Ports: []corev1.EndpointPort{{
 			Name:     autoscalerPortName,
 			Port:     autoscalerPort,
-			Protocol: v1.ProtocolTCP,
+			Protocol: corev1.ProtocolTCP,
 		}}},
 	}
 
@@ -284,7 +284,7 @@ func TestForwarderRetryOnEndpointsUpdateFailure(t *testing.T) {
 		},
 	)
 
-	e := &v1.Endpoints{
+	e := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      bucket1,
 			Namespace: testNs,

--- a/pkg/reconciler/route/resources/labels/labels.go
+++ b/pkg/reconciler/route/resources/labels/labels.go
@@ -17,18 +17,18 @@ limitations under the License.
 package labels
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	network "knative.dev/networking/pkg"
 	"knative.dev/serving/pkg/apis/serving"
 )
 
 // IsObjectLocalVisibility returns whether an ObjectMeta is of cluster-local visibility
-func IsObjectLocalVisibility(meta *v1.ObjectMeta) bool {
+func IsObjectLocalVisibility(meta *metav1.ObjectMeta) bool {
 	return meta.Labels[network.VisibilityLabelKey] != "" || meta.Labels[serving.VisibilityLabelKeyObsolete] != ""
 }
 
 // SetVisibility sets the visibility on an ObjectMeta
-func SetVisibility(meta *v1.ObjectMeta, isClusterLocal bool) {
+func SetVisibility(meta *metav1.ObjectMeta, isClusterLocal bool) {
 	if isClusterLocal {
 		SetLabel(meta, network.VisibilityLabelKey, serving.VisibilityClusterLocal)
 	} else {
@@ -37,7 +37,7 @@ func SetVisibility(meta *v1.ObjectMeta, isClusterLocal bool) {
 }
 
 // SetLabel sets/update the label of the an ObjectMeta
-func SetLabel(meta *v1.ObjectMeta, key, value string) {
+func SetLabel(meta *metav1.ObjectMeta, key, value string) {
 	if meta.Labels == nil {
 		meta.Labels = make(map[string]string, 1)
 	}
@@ -46,6 +46,6 @@ func SetLabel(meta *v1.ObjectMeta, key, value string) {
 }
 
 // DeleteLabel removes a label from the ObjectMeta
-func DeleteLabel(meta *v1.ObjectMeta, key string) {
+func DeleteLabel(meta *metav1.ObjectMeta, key string) {
 	delete(meta.Labels, key)
 }

--- a/pkg/reconciler/route/resources/labels/labels_test.go
+++ b/pkg/reconciler/route/resources/labels/labels_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	network "knative.dev/networking/pkg"
 	"knative.dev/serving/pkg/apis/serving"
 )
@@ -28,29 +28,29 @@ import (
 func TestIsObjectLocalVisibility(t *testing.T) {
 	tests := []struct {
 		name string
-		meta *v1.ObjectMeta
+		meta *metav1.ObjectMeta
 		want bool
 	}{{
 		name: "nil",
-		meta: &v1.ObjectMeta{},
+		meta: &metav1.ObjectMeta{},
 	}, {
 		name: "empty labels",
-		meta: &v1.ObjectMeta{
+		meta: &metav1.ObjectMeta{
 			Labels: map[string]string{},
 		},
 	}, {
 		name: "no matching labels",
-		meta: &v1.ObjectMeta{
+		meta: &metav1.ObjectMeta{
 			Labels: map[string]string{"frankie-goes": "to-hollywood"},
 		},
 	}, {
 		name: "false",
-		meta: &v1.ObjectMeta{
+		meta: &metav1.ObjectMeta{
 			Labels: map[string]string{network.VisibilityLabelKey: ""},
 		},
 	}, {
 		name: "true",
-		meta: &v1.ObjectMeta{
+		meta: &metav1.ObjectMeta{
 			Labels: map[string]string{network.VisibilityLabelKey: "set"},
 		},
 		want: true,
@@ -68,30 +68,30 @@ func TestIsObjectLocalVisibility(t *testing.T) {
 func TestDeleteLabel(t *testing.T) {
 	tests := []struct {
 		name string
-		meta *v1.ObjectMeta
+		meta *metav1.ObjectMeta
 		key  string
-		want v1.ObjectMeta
+		want metav1.ObjectMeta
 	}{{
 		name: "No labels in object meta",
-		meta: &v1.ObjectMeta{},
+		meta: &metav1.ObjectMeta{},
 		key:  "key",
-		want: v1.ObjectMeta{},
+		want: metav1.ObjectMeta{},
 	}, {
 		name: "No matching key",
-		meta: &v1.ObjectMeta{
+		meta: &metav1.ObjectMeta{
 			Labels: map[string]string{"some label": "some value"},
 		},
 		key: "unknown",
-		want: v1.ObjectMeta{
+		want: metav1.ObjectMeta{
 			Labels: map[string]string{"some label": "some value"},
 		},
 	}, {
 		name: "Has matching key",
-		meta: &v1.ObjectMeta{
+		meta: &metav1.ObjectMeta{
 			Labels: map[string]string{"some label": "some value"},
 		},
 		key: "some label",
-		want: v1.ObjectMeta{
+		want: metav1.ObjectMeta{
 			Labels: map[string]string{},
 		},
 	}}
@@ -110,36 +110,36 @@ func TestDeleteLabel(t *testing.T) {
 func TestSetLabel(t *testing.T) {
 	tests := []struct {
 		name  string
-		meta  *v1.ObjectMeta
+		meta  *metav1.ObjectMeta
 		key   string
 		value string
-		want  v1.ObjectMeta
+		want  metav1.ObjectMeta
 	}{{
 		name:  "No labels in object meta",
-		meta:  &v1.ObjectMeta{},
+		meta:  &metav1.ObjectMeta{},
 		key:   "key",
 		value: "value",
-		want: v1.ObjectMeta{
+		want: metav1.ObjectMeta{
 			Labels: map[string]string{"key": "value"},
 		},
 	}, {
 		name: "Empty labels",
-		meta: &v1.ObjectMeta{
+		meta: &metav1.ObjectMeta{
 			Labels: map[string]string{},
 		},
 		key:   "key",
 		value: "value",
-		want: v1.ObjectMeta{
+		want: metav1.ObjectMeta{
 			Labels: map[string]string{"key": "value"},
 		},
 	}, {
 		name: "Conflicting labels",
-		meta: &v1.ObjectMeta{
+		meta: &metav1.ObjectMeta{
 			Labels: map[string]string{"key": "old value"},
 		},
 		key:   "key",
 		value: "new value",
-		want: v1.ObjectMeta{
+		want: metav1.ObjectMeta{
 			Labels: map[string]string{"key": "new value"},
 		},
 	}}
@@ -158,18 +158,18 @@ func TestSetLabel(t *testing.T) {
 func TestSetVisibility(t *testing.T) {
 	tests := []struct {
 		name           string
-		meta           *v1.ObjectMeta
+		meta           *metav1.ObjectMeta
 		isClusterLocal bool
-		want           v1.ObjectMeta
+		want           metav1.ObjectMeta
 	}{{
 		name:           "Set cluster local true",
-		meta:           &v1.ObjectMeta{},
+		meta:           &metav1.ObjectMeta{},
 		isClusterLocal: true,
-		want:           v1.ObjectMeta{Labels: map[string]string{network.VisibilityLabelKey: serving.VisibilityClusterLocal}},
+		want:           metav1.ObjectMeta{Labels: map[string]string{network.VisibilityLabelKey: serving.VisibilityClusterLocal}},
 	}, {
 		name: "Set cluster local false",
-		meta: &v1.ObjectMeta{Labels: map[string]string{network.VisibilityLabelKey: serving.VisibilityClusterLocal}},
-		want: v1.ObjectMeta{Labels: map[string]string{}},
+		meta: &metav1.ObjectMeta{Labels: map[string]string{network.VisibilityLabelKey: serving.VisibilityClusterLocal}},
+		want: metav1.ObjectMeta{Labels: map[string]string{}},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/test/clients.go
+++ b/test/clients.go
@@ -21,7 +21,7 @@ package test
 import (
 	"context"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -168,7 +168,7 @@ func newServingClients(cfg *rest.Config, namespace string) (*ServingClients, err
 func (clients *ServingClients) Delete(routes, configs, services []string) []error {
 	deletions := []struct {
 		client interface {
-			Delete(ctx context.Context, name string, options v1.DeleteOptions) error
+			Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
 		}
 		items []string
 	}{
@@ -179,8 +179,8 @@ func (clients *ServingClients) Delete(routes, configs, services []string) []erro
 		{clients.Configs, configs},
 	}
 
-	propPolicy := v1.DeletePropagationForeground
-	dopt := v1.DeleteOptions{
+	propPolicy := metav1.DeletePropagationForeground
+	dopt := metav1.DeleteOptions{
 		PropagationPolicy: &propPolicy,
 	}
 

--- a/test/performance/performance.go
+++ b/test/performance/performance.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -69,7 +69,7 @@ func WaitForScaleToZero(ctx context.Context, namespace string, selector labels.S
 		}
 		for _, pod := range pods {
 			// Pending or Running w/o deletion timestamp (i.e. terminating).
-			if pod.Status.Phase == v1.PodPending || pod.Status.Phase == v1.PodRunning && pod.ObjectMeta.DeletionTimestamp == nil {
+			if pod.Status.Phase == corev1.PodPending || pod.Status.Phase == corev1.PodRunning && pod.ObjectMeta.DeletionTimestamp == nil {
 				return false, nil
 			}
 		}


### PR DESCRIPTION
## Proposed Changes

I hate having to do the roundtrip to the import section to figure out what is what exactly. These are usually named `corev1`/`metav1` respectively, so let's make it so everywhere.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @julz 
