### PR TITLE
Fail the autoscaler e2e tests faster

### DIFF
--- a/test/e2e/autoscale.go
+++ b/test/e2e/autoscale.go
@@ -389,6 +389,6 @@ func AssertAutoscaleUpToNumPods(ctx *TestContext, curPods, targetPods float64, d
 	})
 
 	if err := grp.Wait(); err != nil {
-		ctx.t.Errorf("Error: %v", err)
+		ctx.t.Fatal("Error: ", err)
 	}
 }

--- a/third_party/net-istio.yaml
+++ b/third_party/net-istio.yaml
@@ -18,7 +18,7 @@ metadata:
   # These are the permissions needed by the Istio Ingress implementation.
   name: knative-serving-istio
   labels:
-    serving.knative.dev/release: "v20201026-0bcca766"
+    serving.knative.dev/release: "v20201102-c76cf600"
     serving.knative.dev/controller: "true"
     networking.knative.dev/ingress-provider: istio
 rules:
@@ -48,7 +48,7 @@ metadata:
   name: knative-ingress-gateway
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20201026-0bcca766"
+    serving.knative.dev/release: "v20201102-c76cf600"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -85,7 +85,7 @@ metadata:
   name: cluster-local-gateway
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20201026-0bcca766"
+    serving.knative.dev/release: "v20201102-c76cf600"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -104,7 +104,7 @@ metadata:
   name: knative-local-gateway
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20201026-0bcca766"
+    serving.knative.dev/release: "v20201102-c76cf600"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -121,9 +121,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: knative-local-gateway
-  namespace: knative-serving
+  namespace: istio-system
   labels:
-    serving.knative.dev/release: "v20201026-0bcca766"
+    serving.knative.dev/release: "v20201102-c76cf600"
     networking.knative.dev/ingress-provider: istio
 spec:
   type: ClusterIP
@@ -181,7 +181,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.istio.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v20201026-0bcca766"
+    serving.knative.dev/release: "v20201102-c76cf600"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:
@@ -217,7 +217,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.istio.networking.internal.knative.dev
   labels:
-    serving.knative.dev/release: "v20201026-0bcca766"
+    serving.knative.dev/release: "v20201102-c76cf600"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:
@@ -255,7 +255,7 @@ metadata:
   name: istio-webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20201026-0bcca766"
+    serving.knative.dev/release: "v20201102-c76cf600"
     networking.knative.dev/ingress-provider: istio
 
 ---
@@ -279,7 +279,7 @@ metadata:
   name: config-istio
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20201026-0bcca766"
+    serving.knative.dev/release: "v20201102-c76cf600"
     networking.knative.dev/ingress-provider: istio
 data:
   _example: |
@@ -349,7 +349,7 @@ metadata:
   name: networking-istio
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20201026-0bcca766"
+    serving.knative.dev/release: "v20201102-c76cf600"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -365,14 +365,14 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: networking-istio
-        serving.knative.dev/release: "v20201026-0bcca766"
+        serving.knative.dev/release: "v20201102-c76cf600"
     spec:
       serviceAccountName: controller
       containers:
         - name: networking-istio
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/controller@sha256:386ecc00d87b893778856aa5f5a5ca0b389fa9e37ea9222496f2da1a41880a95
+          image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/controller@sha256:889af1da0e07bd4d89950e4ed282afedb83d67c72d6561f041df3c2f965fd898
           resources:
             requests:
               cpu: 30m
@@ -394,6 +394,11 @@ spec:
               value: knative.dev/net-istio
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - all
           ports:
             - name: metrics
               containerPort: 9090
@@ -424,7 +429,7 @@ metadata:
   name: istio-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20201026-0bcca766"
+    serving.knative.dev/release: "v20201102-c76cf600"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -438,14 +443,14 @@ spec:
       labels:
         app: istio-webhook
         role: istio-webhook
-        serving.knative.dev/release: "v20201026-0bcca766"
+        serving.knative.dev/release: "v20201102-c76cf600"
     spec:
       serviceAccountName: controller
       containers:
         - name: webhook
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/webhook@sha256:21db77728117be38d31bd13e0a8a7b5709782be2656456395858e1f89631f1b1
+          image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/webhook@sha256:2faccf2a8ebaafbe6dc10481bbb166a4a1c1d3fbf8ab3471d12599ee56a726ca
           resources:
             requests:
               cpu: 20m
@@ -499,7 +504,7 @@ metadata:
   namespace: knative-serving
   labels:
     role: istio-webhook
-    serving.knative.dev/release: "v20201026-0bcca766"
+    serving.knative.dev/release: "v20201102-c76cf600"
     networking.knative.dev/ingress-provider: istio
 spec:
   ports:


### PR DESCRIPTION
The code is used for Autoscaler relative e2e tests. If something is wrong, we can fail the test earlier and it's easier to for the error reason from the logs.

/assign @vagababov 