### PR TITLE
Add buckets to _example of leader election configmap

### DIFF
--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -20,9 +20,9 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "a255a6cc"
+    knative.dev/example-checksum: "4d4d74d3"
 data:
-  _example: |
+  _example: |-
     ################################
     #                              #
     #    EXAMPLE CONFIGURATION     #
@@ -49,3 +49,7 @@ data:
     # retryPeriod is how long the leader election client waits between tries of
     # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
+
+    # buckets is the number of buckets used to partition key space of each
+    # Reconciler.
+    buckets: "1"

--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "4d4d74d3"
+    knative.dev/example-checksum: "96896b00"
 data:
   _example: |-
     ################################

--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -51,5 +51,8 @@ data:
     retryPeriod: "2s"
 
     # buckets is the number of buckets used to partition key space of each
-    # Reconciler.
+    # Reconciler. If this number is M and the replica number of the controller
+    # is N, the N replicas will compete for the M buckets. The owner of a
+    # bucket will take care of the reconciling for the keys partitioned into
+    # that bucket.
     buckets: "1"

--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -22,7 +22,7 @@ metadata:
   annotations:
     knative.dev/example-checksum: "96896b00"
 data:
-  _example: |-
+  _example: |
     ################################
     #                              #
     #    EXAMPLE CONFIGURATION     #

--- a/pkg/leaderelection/config_test.go
+++ b/pkg/leaderelection/config_test.go
@@ -31,7 +31,7 @@ import (
 
 func okConfig() *kle.Config {
 	return &kle.Config{
-		Buckets:       1,
+		Buckets:       5,
 		LeaseDuration: 15 * time.Second,
 		RenewDeadline: 10 * time.Second,
 		RetryPeriod:   2 * time.Second,
@@ -40,6 +40,7 @@ func okConfig() *kle.Config {
 
 func okData() map[string]string {
 	return map[string]string{
+		"buckets": "5",
 		// values in this data come from the defaults suggested in the
 		// code:
 		// https://github.com/kubernetes/client-go/blob/kubernetes-1.16.0/tools/leaderelection/leaderelection.go


### PR DESCRIPTION
This flag is actually exposed to operators to set for leader election. However we don't have it in _example. So add it.

/assign @mattmoor 