### PR TITLE
Only run v1alpha1 tests for ingress provider actually implementing it

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -90,11 +90,17 @@ sleep 30
 
 # Run conformance and e2e tests.
 
+# Currently only Istio and Contour implement the alpha features.
+alpha=""
+if [[ -z "${INGRESS_CLASS}" || "${INGRESS_CLASS}" == "istio.ingress.networking.knative.dev" || "${INGRESS_CLASS}" == "contour.ingress.networking.knative.dev" ]]; then
+  alpha="--enable-alpha"
+fi
+
 go_test_e2e -timeout=30m \
  ./test/conformance/api/... ./test/conformance/runtime/... \
  ./test/e2e \
   ${parallelism} \
-  --enable-alpha \
+  ${alpha} \
   --enable-beta \
   "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -91,6 +91,7 @@ sleep 30
 # Run conformance and e2e tests.
 
 # Currently only Istio and Contour implement the alpha features.
+# TODO(#9874): Remove this guard once other ingresses implement these too.
 alpha=""
 if [[ -z "${INGRESS_CLASS}" || "${INGRESS_CLASS}" == "istio.ingress.networking.knative.dev" || "${INGRESS_CLASS}" == "contour.ingress.networking.knative.dev" ]]; then
   alpha="--enable-alpha"


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Currently, only Istio and Contour implement domain mapping and all other ingresses are failing the nightlies, which is a little unfortunate. This should guard these to only those cases where they actually have a chance to pass.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz 
