### PR TITLE
Remove unnecessary imagePullPolicy patches

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -230,7 +230,6 @@ jobs:
         # Apply a kingress option.
         ko resolve -f third_party/kourier-latest | \
           sed 's/LoadBalancer/NodePort/g' | \
-          sed 's/imagePullPolicy:/# DISABLED: imagePullPolicy:/g' | \
           kubectl apply -f -
 
         # This tells the tests what namespace to look in for our kingress LB.
@@ -245,8 +244,7 @@ jobs:
         source test/e2e-networking-library.sh
 
         PATCHED_YAML=$(mktemp)
-        ko resolve -f third_party/net-istio.yaml | \
-          sed 's/imagePullPolicy:/# DISABLED: imagePullPolicy:/g' > $PATCHED_YAML
+        ko resolve -f third_party/net-istio.yaml > $PATCHED_YAML
 
         # TODO: figure out how to use e2e-common.sh directly even if no
         # custom namespace is used here.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As per title, none of the relevant YAMLs prescribe a pull policy anymore, so we should be fine with the defaults.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @nak3 @mattmoor 
