### PR TITLE
Remove sideEffects workaround for istio-sidecar-injection

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -50,8 +50,6 @@ parallelism=""
 use_https=""
 if (( MESH )); then
   parallelism="-parallel 1"
-  # This is a workaround until Istio fixes https://github.com/istio/istio/issues/23485.
-  kubectl patch mutatingwebhookconfigurations istio-sidecar-injector -p '{"webhooks": [{"name": "sidecar-injector.istio.io", "sideEffects": "None"}]}'
 fi
 
 if (( HTTPS )); then


### PR DESCRIPTION
## Proposed Changes

This patch removes workaround for
https://github.com/istio/istio/issues/23485.

It was fixed by Istio 1.6 and our CI is using Istio 1.7.

**Release Note**

```release-note
NONE
```

/cc @arturenault @JRBANCEL @ZhiminXiang 