### PR TITLE
Remove parallel 1 option from https test

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -54,8 +54,6 @@ fi
 
 if (( HTTPS )); then
   use_https="--https"
-  # TODO: parallel 1 is necessary until https://github.com/knative/serving/issues/7406 is solved.
-  parallelism="-parallel 1"
   toggle_feature autoTLS Enabled config-network
   kubectl apply -f ${TMP_DIR}/test/config/autotls/certmanager/caissuer/
   add_trap "kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT


### PR DESCRIPTION
## Proposed Changes

This patch removes parallel 1 option from https test.

Although https test may still fail, it does not block new PRs. So we should
expose the failure on [test grid](https://testgrid.knative.dev/serving#https).

close https://github.com/knative/serving/issues/7406

**Release Note**

```release-note
NONE
```

/cc @arturenault @ZhiminXiang @tcnghia 
