### PR TITLE
Prevent DomainMapping collisions using ClusterDomainClaim

### DIFF
--- a/config/domain-mapping/300-resources/domain-claim.yaml
+++ b/config/domain-mapping/300-resources/domain-claim.yaml
@@ -1,0 +1,1 @@
+../../../vendor/knative.dev/networking/config/domain-claim.yaml

--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -32,7 +32,6 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -132,12 +131,7 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, dm *v1alpha1.DomainMa
 func (r *Reconciler) reconcileDomainClaim(ctx context.Context, dm *v1alpha1.DomainMapping) error {
 	dc, err := r.netclient.NetworkingV1alpha1().ClusterDomainClaims().Get(ctx, dm.Name, metav1.GetOptions{})
 	if apierrs.IsNotFound(err) {
-		if dc, err = r.netclient.NetworkingV1alpha1().ClusterDomainClaims().Create(ctx, &netv1alpha1.ClusterDomainClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            dm.Name,
-				OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(dm)},
-			},
-		}, metav1.CreateOptions{}); err != nil {
+		if dc, err = r.netclient.NetworkingV1alpha1().ClusterDomainClaims().Create(ctx, resources.MakeDomainClaim(dm), metav1.CreateOptions{}); err != nil {
 			return fmt.Errorf("failed to create ClusterDomainClaim: %w", err)
 		}
 	} else if err != nil {

--- a/pkg/reconciler/domainmapping/resources/domainclaim.go
+++ b/pkg/reconciler/domainmapping/resources/domainclaim.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/pkg/kmeta"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+)
+
+// MakeDomainClaim creates a ClusterDomainClaim named after and owned by the
+// given DomainMapping.
+func MakeDomainClaim(dm *v1alpha1.DomainMapping) *netv1alpha1.ClusterDomainClaim {
+	return &netv1alpha1.ClusterDomainClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            dm.Name,
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(dm)},
+		},
+	}
+}

--- a/pkg/reconciler/domainmapping/resources/domainclaim_test.go
+++ b/pkg/reconciler/domainmapping/resources/domainclaim_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/pkg/kmeta"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+)
+
+func TestMakeDomainClaim(t *testing.T) {
+	dm := &v1alpha1.DomainMapping{ObjectMeta: metav1.ObjectMeta{Name: "mapping.com"}}
+	got := MakeDomainClaim(dm)
+
+	want := &netv1alpha1.ClusterDomainClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "mapping.com",
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(dm)},
+		},
+	}
+
+	if !cmp.Equal(want, got) {
+		t.Errorf("Unexpected DomainClaim (-want, +got):\n%s", cmp.Diff(want, got))
+	}
+}


### PR DESCRIPTION
Part of https://github.com/knative/serving/issues/9713.

Use the new ClusterDomainClaim CRD to prevent domain name collisions. At this point, we auto-create the CDC as part of reconciling the DM.

/assign @mattmoor @vagababov 
