### PR TITLE
Set knative-serving mTLS mode to STRICT for mesh tests

### DIFF
--- a/test/config/security/peerauthentication.yaml
+++ b/test/config/security/peerauthentication.yaml
@@ -43,4 +43,4 @@ metadata:
     test.knative.dev/dependency: istio-sidecar
 spec:
   mtls:
-    mode: PERMISSIVE
+    mode: STRICT


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* In local testing, running knative-serving in istio under mtls STRICT mode is equally as stable as under PERMISSIVE mode.
* STRICT mode is more secure than PERMISSIVE, and is necessarily a subset of it (i.e. anything that works under PERMISSIVE should work under STRICT)
* We should test this configuration now to potentially adopt it as default in the future.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
