### PR TITLE
Update serving module to Go 1.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/serving
 
-go 1.14
+go 1.15
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
* Update serving module to Go 1.15

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
