### PR TITLE
Fix tiny typo in TestMakePA

### DIFF
--- a/pkg/reconciler/revision/resources/pa_test.go
+++ b/pkg/reconciler/revision/resources/pa_test.go
@@ -315,7 +315,7 @@ func TestMakePA(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := MakePA(test.rev)
 			if !cmp.Equal(got, test.want) {
-				t.Error("MakeK8sService (-want, +got) =", cmp.Diff(test.want, got))
+				t.Error("MakePA (-want, +got) =", cmp.Diff(test.want, got))
 			}
 		})
 	}


### PR DESCRIPTION
This patch fixes a super tiny typo in TestMakePA.

**Release Note**

```release-note
NONE
```

/cc @vagababov @markusthoemmes @julz 
