### PR TITLE
wip - Replace placeholder service type ExternalName with ClusterIP by mirroring KIngress's svc

### DIFF
--- a/pkg/reconciler/route/controller.go
+++ b/pkg/reconciler/route/controller.go
@@ -23,6 +23,7 @@ import (
 	certificateinformer "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/certificate"
 	ingressinformer "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/ingress"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration"
@@ -64,6 +65,7 @@ func newControllerWithClock(
 	ctx = servingreconciler.AnnotateLoggerWithName(ctx, controllerAgentName)
 	logger := logging.FromContext(ctx)
 	serviceInformer := serviceinformer.Get(ctx)
+	endpointsInformer := endpointsinformer.Get(ctx)
 	routeInformer := routeinformer.Get(ctx)
 	configInformer := configurationinformer.Get(ctx)
 	revisionInformer := revisioninformer.Get(ctx)
@@ -77,6 +79,7 @@ func newControllerWithClock(
 		configurationLister: configInformer.Lister(),
 		revisionLister:      revisionInformer.Lister(),
 		serviceLister:       serviceInformer.Lister(),
+		endpointsLister:     endpointsInformer.Lister(),
 		ingressLister:       ingressInformer.Lister(),
 		certificateLister:   certificateInformer.Lister(),
 		clock:               clock,
@@ -102,6 +105,7 @@ func newControllerWithClock(
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	}
 	serviceInformer.Informer().AddEventHandler(handleControllerOf)
+	endpointsInformer.Informer().AddEventHandler(handleControllerOf)
 	certificateInformer.Informer().AddEventHandler(handleControllerOf)
 	ingressInformer.Informer().AddEventHandler(handleControllerOf)
 

--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -18,24 +18,19 @@ package resources
 
 import (
 	"context"
-	"errors"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking"
-	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler/route/domains"
 )
-
-var errLoadBalancerNotFound = errors.New("failed to fetch loadbalancer domain/IP from ingress status")
 
 // GetNames returns a set of service names.
 func GetNames(services []*corev1.Service) sets.String {
@@ -56,48 +51,23 @@ func SelectorFromRoute(route *v1.Route) labels.Selector {
 // MakeK8sPlaceholderService creates a placeholder Service to prevent naming collisions. It's owned by the
 // provided v1.Route.
 func MakeK8sPlaceholderService(ctx context.Context, route *v1.Route, targetName string) (*corev1.Service, error) {
-	hostname, err := domains.HostnameFromTemplate(ctx, route.Name, targetName)
-	if err != nil {
-		return nil, err
-	}
-	fullName, err := domains.DomainNameFromTemplate(ctx, route.ObjectMeta, hostname)
-	if err != nil {
-		return nil, err
-	}
-
 	service, err := makeK8sService(ctx, route, targetName)
 	if err != nil {
 		return nil, err
 	}
 	service.Spec = corev1.ServiceSpec{
-		Type:            corev1.ServiceTypeExternalName,
-		ExternalName:    fullName,
+		Type:            corev1.ServiceTypeClusterIP,
 		SessionAffinity: corev1.ServiceAffinityNone,
-		Ports: []corev1.ServicePort{{
-			Name:       networking.ServicePortNameH2C,
-			Port:       int32(80),
-			TargetPort: intstr.FromInt(80),
-		}},
+		Ports:           defaultServicePort,
 	}
 
 	return service, nil
 }
 
-// MakeK8sService creates a Service that redirect to the loadbalancer specified
-// in Ingress status. It's owned by the provided v1.Route.
-func MakeK8sService(ctx context.Context, route *v1.Route, targetName string, ingress *netv1alpha1.Ingress, isPrivate bool, clusterIP string) (*corev1.Service, error) {
-	svcSpec, err := makeServiceSpec(ingress, isPrivate, clusterIP)
-	if err != nil {
-		return nil, err
-	}
-
-	service, err := makeK8sService(ctx, route, targetName)
-	if err != nil {
-		return nil, err
-	}
-	service.Spec = *svcSpec
-	return service, nil
-}
+var defaultServicePort = []corev1.ServicePort{{
+	Name: networking.ServicePortNameHTTP1,
+	Port: networking.ServiceHTTPPort,
+}}
 
 func makeK8sService(ctx context.Context, route *v1.Route, targetName string) (*corev1.Service, error) {
 	hostname, err := domains.HostnameFromTemplate(ctx, route.Name, targetName)
@@ -127,69 +97,26 @@ func makeK8sService(ctx context.Context, route *v1.Route, targetName string) (*c
 	}, nil
 }
 
-func makeServiceSpec(ingress *netv1alpha1.Ingress, isPrivate bool, clusterIP string) (*corev1.ServiceSpec, error) {
-	ingressStatus := ingress.Status
-
-	lbStatus := ingressStatus.PublicLoadBalancer
-	if isPrivate || ingressStatus.PrivateLoadBalancer != nil {
-		// Always use private load balancer if it exists,
-		// because k8s service is only useful for inter-cluster communication.
-		// External communication will be handle via ingress gateway, which won't be affected by what is configured here.
-		lbStatus = ingressStatus.PrivateLoadBalancer
+// MakeEndpoints constructs a K8s Endpoints by copying the subsets from KIngress's endpoints.
+func MakeEndpoints(ctx context.Context, svc *corev1.Service, route *v1.Route, src *corev1.Endpoints) *corev1.Endpoints {
+	svcLabels := map[string]string{
+		serving.RouteLabelKey: route.Name,
 	}
-
-	if lbStatus == nil || len(lbStatus.Ingress) == 0 {
-		return nil, errLoadBalancerNotFound
+	return &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svc.Name, // Name of Endpoints must match that of Service.
+			Namespace: svc.Namespace,
+			Labels: kmeta.UnionMaps(kmeta.FilterMap(route.GetLabels(), func(key string) bool {
+				// Do not propagate the visibility label from Route as users may want to set the label
+				// in the specific k8s svc for subroute. see https://github.com/knative/serving/pull/4560.
+				return (key == network.VisibilityLabelKey || key == serving.VisibilityLabelKeyObsolete)
+			}), svcLabels),
+			Annotations: route.GetAnnotations(),
+			OwnerReferences: []metav1.OwnerReference{
+				// This service is owned by the Route.
+				*kmeta.NewControllerRef(route),
+			},
+		},
+		Subsets: src.Subsets,
 	}
-	if len(lbStatus.Ingress) > 1 {
-		// Return error as we only support one LoadBalancer currently.
-		return nil, errors.New(
-			"more than one ingress are specified in status(LoadBalancer) of Ingress " + ingress.GetName())
-	}
-	balancer := lbStatus.Ingress[0]
-
-	// Here we decide LoadBalancer information in the order of
-	// DomainInternal > Domain > LoadBalancedIP to prioritize cluster-local,
-	// and domain (since it would change less than IP).
-	switch {
-	case balancer.DomainInternal != "":
-		return &corev1.ServiceSpec{
-			Type:            corev1.ServiceTypeExternalName,
-			ExternalName:    balancer.DomainInternal,
-			SessionAffinity: corev1.ServiceAffinityNone,
-			Ports: []corev1.ServicePort{{
-				Name:       networking.ServicePortNameH2C,
-				Port:       int32(80),
-				TargetPort: intstr.FromInt(80),
-			}},
-		}, nil
-	case balancer.Domain != "":
-		return &corev1.ServiceSpec{
-			Type:         corev1.ServiceTypeExternalName,
-			ExternalName: balancer.Domain,
-			Ports: []corev1.ServicePort{{
-				Name:       networking.ServicePortNameH2C,
-				Port:       int32(80),
-				TargetPort: intstr.FromInt(80),
-			}},
-		}, nil
-	case balancer.MeshOnly:
-		// The Ingress is loadbalanced through a Service mesh.
-		// We won't have a specific LB endpoint to route traffic to,
-		// but we still need to create a ClusterIP service to make
-		// sure the domain name is available for access within the
-		// mesh.
-		return &corev1.ServiceSpec{
-			Type:      corev1.ServiceTypeClusterIP,
-			ClusterIP: clusterIP,
-			Ports: []corev1.ServicePort{{
-				Name: networking.ServicePortNameHTTP1,
-				Port: networking.ServiceHTTPPort,
-			}},
-		}, nil
-	case balancer.IP != "":
-		// TODO(lichuqiang): deal with LoadBalancer IP.
-		// We'll also need ports info to make it take effect.
-	}
-	return nil, errLoadBalancerNotFound
 }

--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -104,13 +104,9 @@ func MakeEndpoints(ctx context.Context, svc *corev1.Service, route *v1.Route, sr
 	}
 	return &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      svc.Name, // Name of Endpoints must match that of Service.
-			Namespace: svc.Namespace,
-			Labels: kmeta.UnionMaps(kmeta.FilterMap(route.GetLabels(), func(key string) bool {
-				// Do not propagate the visibility label from Route as users may want to set the label
-				// in the specific k8s svc for subroute. see https://github.com/knative/serving/pull/4560.
-				return (key == network.VisibilityLabelKey || key == serving.VisibilityLabelKeyObsolete)
-			}), svcLabels),
+			Name:        svc.Name, // Name of Endpoints must match that of Service.
+			Namespace:   svc.Namespace,
+			Labels:      kmeta.UnionMaps(route.GetLabels(), svcLabels),
 			Annotations: route.GetAnnotations(),
 			OwnerReferences: []metav1.OwnerReference{
 				// This service is owned by the Route.

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -67,6 +67,7 @@ type Reconciler struct {
 	configurationLister listers.ConfigurationLister
 	revisionLister      listers.RevisionLister
 	serviceLister       corev1listers.ServiceLister
+	endpointsLister     corev1listers.EndpointsLister
 	ingressLister       networkinglisters.IngressLister
 	certificateLister   networkinglisters.CertificateLister
 	tracker             tracker.Interface
@@ -155,7 +156,6 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconcil
 
 	// Reconcile ingress and its children resources.
 	ingress, err := c.reconcileIngressResources(ctx, r, traffic, tls, ingressClassForRoute(ctx, r), acmeChallenges...)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -27,6 +27,7 @@ import (
 	fakenetworkingclient "knative.dev/networking/pkg/client/injection/client/fake"
 	_ "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/certificate/fake"
 	fakeingressinformer "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/ingress/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/service/fake"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	fakecfginformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration/fake"

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -955,183 +955,100 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "default/update-ci-failure",
 	}, {
-		/*
-				Name: "reconcile service mutation",
-				Objects: []runtime.Object{
-					Route("default", "svc-mutation", WithConfigTarget("config"),
-						WithURL, WithAddress, WithRouteConditionsAutoTLSDisabled, WithRouteGeneration(1),
-						MarkTrafficAssigned, MarkIngressReady, WithRouteObservedGeneration, WithRouteFinalizer, WithStatusTraffic(
-							v1.TrafficTarget{
-								RevisionName:   "config-00001",
-								Percent:        ptr.Int64(100),
-								LatestRevision: ptr.Bool(true),
-							})),
-					cfg("default", "config",
-						WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
-						// The Route controller attaches our label to this Configuration.
-						WithConfigLabel("serving.knative.dev/route", "svc-mutation"),
-					),
-					rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
-					simpleReadyIngress(
-						Route("default", "svc-mutation", WithConfigTarget("config"), WithURL),
-						&traffic.Config{
-							Targets: map[string]traffic.RevisionTargets{
-								traffic.DefaultTarget: {{
-									TrafficTarget: v1.TrafficTarget{
-										RevisionName:      "config-00001",
-										ConfigurationName: "config",
-										LatestRevision:    ptr.Bool(true),
-										Percent:           ptr.Int64(100),
-									},
-								}},
+		Name: "reconcile service mutation",
+		Objects: []runtime.Object{
+			Route("default", "svc-mutation", WithConfigTarget("config"),
+				WithURL, WithAddress, WithRouteConditionsAutoTLSDisabled, WithRouteGeneration(1),
+				MarkTrafficAssigned, MarkIngressReady, WithRouteObservedGeneration, WithRouteFinalizer, WithStatusTraffic(
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
+					})),
+			cfg("default", "config",
+				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
+				// The Route controller attaches our label to this Configuration.
+				WithConfigLabel("serving.knative.dev/route", "svc-mutation"),
+			),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
+			simpleReadyIngress(
+				Route("default", "svc-mutation", WithConfigTarget("config"), WithURL),
+				&traffic.Config{
+					Targets: map[string]traffic.RevisionTargets{
+						traffic.DefaultTarget: {{
+							TrafficTarget: v1.TrafficTarget{
+								RevisionName:      "config-00001",
+								ConfigurationName: "config",
+								LatestRevision:    ptr.Bool(true),
+								Percent:           ptr.Int64(100),
 							},
-						},
-					),
-					simpleK8sService(Route("default", "svc-mutation", WithConfigTarget("config")), kingressService(kingressEndpoints()), MutateK8sService),
-					kingressEndpoints(),
-					kingressService(kingressEndpoints()),
-					localEndpoints(simpleK8sService(Route("default", "svc-mutation", WithConfigTarget("config")), nil, MutateK8sService), kingressEndpoints()),
+						}},
+					},
 				},
-				WantUpdates: []clientgotesting.UpdateActionImpl{{
-					Object: simpleK8sService(Route("default", "svc-mutation", WithConfigTarget("config")), kingressService(kingressEndpoints())),
-				}},
-				Key: "default/svc-mutation",
-			}, {
-					Name: "failure updating k8s service",
-					// We start from the service mutation test, but induce a failure updating the service resource.
-					WantErr: true,
-					WithReactors: []clientgotesting.ReactionFunc{
-						InduceFailure("update", "services"),
-					},
-					Objects: []runtime.Object{
-						Route("default", "svc-mutation", WithConfigTarget("config"), WithRouteFinalizer,
-							WithURL, WithAddress, WithRouteConditionsAutoTLSDisabled, WithRouteGeneration(1),
-							MarkTrafficAssigned, MarkIngressReady, WithRouteObservedGeneration, WithStatusTraffic(
-								v1.TrafficTarget{
-									RevisionName:   "config-00001",
-									Percent:        ptr.Int64(100),
-									LatestRevision: ptr.Bool(true),
-								})),
-						cfg("default", "config",
-							WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
-							// The Route controller attaches our label to this Configuration.
-							WithConfigLabel("serving.knative.dev/route", "svc-mutation"),
-						),
-						rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
-						simpleReadyIngress(
-							Route("default", "svc-mutation", WithConfigTarget("config"), WithURL),
-							&traffic.Config{
-								Targets: map[string]traffic.RevisionTargets{
-									traffic.DefaultTarget: {{
-										TrafficTarget: v1.TrafficTarget{
-											ConfigurationName: "config",
-											LatestRevision:    ptr.Bool(true),
-											RevisionName:      "config-00001",
-											Percent:           ptr.Int64(100),
-										},
-									}},
-								},
+			),
+			simpleK8sService(Route("default", "svc-mutation", WithConfigTarget("config")), kingressService(kingressEndpoints()), MutateK8sService),
+			kingressEndpoints(),
+			kingressService(kingressEndpoints()),
+			localEndpoints(simpleK8sService(Route("default", "svc-mutation", WithConfigTarget("config")), kingressService(kingressEndpoints()), MutateK8sService), Route("default", "svc-mutation", WithConfigTarget("config")), kingressEndpoints()),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: simpleK8sService(Route("default", "svc-mutation", WithConfigTarget("config")), kingressService(kingressEndpoints())),
+		}},
+		Key: "default/svc-mutation",
+	}, {
+		Name: "failure updating k8s service",
+		// We start from the service mutation test, but induce a failure updating the service resource.
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			InduceFailure("update", "services"),
+		},
+		Objects: []runtime.Object{
+			Route("default", "svc-mutation", WithConfigTarget("config"), WithRouteFinalizer,
+				WithURL, WithAddress, WithRouteConditionsAutoTLSDisabled, WithRouteGeneration(1),
+				MarkTrafficAssigned, MarkIngressReady, WithRouteObservedGeneration, WithStatusTraffic(
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
+					})),
+			cfg("default", "config",
+				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
+				// The Route controller attaches our label to this Configuration.
+				WithConfigLabel("serving.knative.dev/route", "svc-mutation"),
+			),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
+			simpleReadyIngress(
+				Route("default", "svc-mutation", WithConfigTarget("config"), WithURL),
+				&traffic.Config{
+					Targets: map[string]traffic.RevisionTargets{
+						traffic.DefaultTarget: {{
+							TrafficTarget: v1.TrafficTarget{
+								ConfigurationName: "config",
+								LatestRevision:    ptr.Bool(true),
+								RevisionName:      "config-00001",
+								Percent:           ptr.Int64(100),
 							},
-						),
-						simpleK8sService(Route("default", "svc-mutation",
-							WithConfigTarget("config")), kingressService(kingressEndpoints()), MutateK8sService),
-						kingressEndpoints(),
-						kingressService(kingressEndpoints()),
-						localEndpoints(
-							simpleK8sService(Route("default", "svc-mutation",
-								WithConfigTarget("config")), kingressService(kingressEndpoints()), MutateK8sService),
-							kingressEndpoints()),
+						}},
 					},
-					WantUpdates: []clientgotesting.UpdateActionImpl{{
-						Object: simpleK8sService(Route("default", "svc-mutation", WithConfigTarget("config")), kingressService(kingressEndpoints())),
-					}},
-					WantEvents: []string{
-						Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for update services"),
-					},
-					Key: "default/svc-mutation",
-						}, {
-							// In #1789 we switched this to an ExternalName Service. Services created in
-							// 0.1 will still have ClusterIP set, which is Forbidden for ExternalName
-							// Services. Ensure that we drop the ClusterIP if it is set in the spec.
-							Name: "drop cluster ip",
-							Objects: []runtime.Object{
-								Route("default", "cluster-ip", WithConfigTarget("config"), WithRouteFinalizer,
-									WithURL, WithAddress, WithRouteConditionsAutoTLSDisabled, WithRouteGeneration(1),
-									MarkTrafficAssigned, MarkIngressReady, WithRouteObservedGeneration, WithStatusTraffic(
-										v1.TrafficTarget{
-											RevisionName:   "config-00001",
-											Percent:        ptr.Int64(100),
-											LatestRevision: ptr.Bool(true),
-										})),
-								cfg("default", "config",
-									WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
-									// The Route controller attaches our label to this Configuration.
-									WithConfigLabel("serving.knative.dev/route", "cluster-ip"),
-								),
-								rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
-								simpleReadyIngress(
-									Route("default", "cluster-ip", WithConfigTarget("config"), WithURL),
-									&traffic.Config{
-										Targets: map[string]traffic.RevisionTargets{
-											traffic.DefaultTarget: {{
-												TrafficTarget: v1.TrafficTarget{
-													ConfigurationName: "config",
-													LatestRevision:    ptr.Bool(true),
-													RevisionName:      "config-00001",
-													Percent:           ptr.Int64(100),
-												},
-											}},
-										},
-									},
-								),
-								simpleK8sService(Route("default", "cluster-ip",
-									WithConfigTarget("config")), WithClusterIP("127.0.0.1")),
-							},
-							WantUpdates: []clientgotesting.UpdateActionImpl{{
-								Object: simpleK8sService(Route("default", "cluster-ip", WithConfigTarget("config"))),
-							}},
-							Key: "default/cluster-ip",
-						}, {
-							// Make sure we fix the external name if something messes with it.
-							Name: "fix external name",
-							Objects: []runtime.Object{
-								Route("default", "external-name", WithConfigTarget("config"), WithRouteFinalizer,
-									WithURL, WithAddress, WithRouteConditionsAutoTLSDisabled, WithRouteGeneration(1),
-									MarkTrafficAssigned, MarkIngressReady, WithRouteObservedGeneration, WithStatusTraffic(
-										v1.TrafficTarget{
-											RevisionName:   "config-00001",
-											Percent:        ptr.Int64(100),
-											LatestRevision: ptr.Bool(true),
-										})),
-								cfg("default", "config",
-									WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001"),
-									// The Route controller attaches our label to this Configuration.
-									WithConfigLabel("serving.knative.dev/route", "external-name"),
-								),
-								rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
-								simpleReadyIngress(
-									Route("default", "external-name", WithConfigTarget("config"), WithURL),
-									&traffic.Config{
-										Targets: map[string]traffic.RevisionTargets{
-											traffic.DefaultTarget: {{
-												TrafficTarget: v1.TrafficTarget{
-													ConfigurationName: "config",
-													LatestRevision:    ptr.Bool(true),
-													RevisionName:      "config-00001",
-													Percent:           ptr.Int64(100),
-												},
-											}},
-										},
-									},
-								),
-								simpleK8sService(Route("default", "external-name",
-									WithConfigTarget("config")), WithExternalName("this-is-the-wrong-name")),
-							},
-							WantUpdates: []clientgotesting.UpdateActionImpl{{
-								Object: simpleK8sService(Route("default", "external-name", WithConfigTarget("config"))),
-							}},
-							Key: "default/external-name",
-		*/
+				},
+			),
+			simpleK8sService(Route("default", "svc-mutation",
+				WithConfigTarget("config")), kingressService(kingressEndpoints()), MutateK8sService),
+			kingressEndpoints(),
+			kingressService(kingressEndpoints()),
+			localEndpoints(
+				simpleK8sService(Route("default", "svc-mutation",
+					WithConfigTarget("config")), kingressService(kingressEndpoints()), MutateK8sService),
+				Route("default", "svc-mutation", WithConfigTarget("config")),
+				kingressEndpoints()),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: simpleK8sService(Route("default", "svc-mutation", WithConfigTarget("config")), kingressService(kingressEndpoints())),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeWarning, "InternalError", "inducing failure for update services"),
+		},
+		Key: "default/svc-mutation",
 	}, {
 		Name: "reconcile ingress mutation",
 		Objects: []runtime.Object{

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -632,6 +632,9 @@ func TestReconcile(t *testing.T) {
 					"different-domain.default.another-example.com",
 				),
 			),
+		}, {
+			Object: simpleK8sService(Route("default", "different-domain", WithConfigTarget("config"),
+				WithRouteLabel(map[string]string{"app": "prod"})), kingressService(kingressEndpoints())),
 		}},
 		Key: "default/different-domain",
 	}, {


### PR DESCRIPTION
As discussed in https://knative.slack.com/archives/CA9RHBGJX/p1600668320002300 (a few months ago),
this patch tries to Replace k8s service type ExternalName with ClusterIP by mirroring KIngress's svc.

The main flow is:

1. Create ClusterIP service.
2. Create Ingress object.
3. Create Endpoints by copying KIngress's endpoints.
4. Update ClusterIP's ports by KIngress's service.

**Release Note**

```release-note
TODO
```

/cc
