### PR TITLE
Use the new annotation to take care of reachability computation

### DIFF
--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -164,6 +164,7 @@ func (r *Revision) GetRoutingStateModified() time.Time {
 // IsReachable returns whether or not the revision can be reached by a route.
 func (r *Revision) IsReachable() bool {
 	return r.Labels[serving.RouteLabelKey] != "" ||
+		r.Annotations[serving.RoutesAnnotationKey] != "" ||
 		RoutingState(r.Labels[serving.RoutingStateLabelKey]) == RoutingStateActive
 }
 

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -62,7 +62,7 @@ func TestMinScale(t *testing.T) {
 	t.Log("Creating configuration")
 	cfg, err := v1test.CreateConfiguration(t, clients, names, withMinScale(minScale),
 		// Pass low resource requirements to avoid Pod scheduling problems
-		// on busy clusters.  This is adapted from ./test/e2e/scale.go
+		// on busy clusters. This is adapted from ./test/e2e/scale.go
 		func(svc *v1.Configuration) {
 			svc.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{


### PR DESCRIPTION
After new GC code the old label is no longer set.
So use the new annotation.


For #7727

/assign @yanweiguo mattmoor @markusthoemmes 