### PR TITLE
Enable alpha conformance tests for Kourier too

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -53,12 +53,6 @@ jobs:
         - test-suite: ./test/conformance/api/v1alpha1
           test-flags: "--enable-alpha"
 
-        exclude:
-          # TODO(#9874): Un-exclude this when Kourier implements the
-          # RewriteHost feature DomainMappings relies on.
-        - test-suite: ./test/conformance/api/v1alpha1
-          k8s-version: v1.18.8
-
     env:
       GOPATH: ${{ github.workspace }}
       GO111MODULE: off

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -86,10 +86,12 @@ sleep 30
 
 # Run conformance and e2e tests.
 
-# Currently only Istio and Contour implement the alpha features.
-# TODO(#9874): Remove this guard once other ingresses implement these too.
+# Currently only Istio, Contour and Kourier implement the alpha features.
 alpha=""
-if [[ -z "${INGRESS_CLASS}" || "${INGRESS_CLASS}" == "istio.ingress.networking.knative.dev" || "${INGRESS_CLASS}" == "contour.ingress.networking.knative.dev" ]]; then
+if [[ -z "${INGRESS_CLASS}" \
+  || "${INGRESS_CLASS}" == "istio.ingress.networking.knative.dev" \
+  || "${INGRESS_CLASS}" == "contour.ingress.networking.knative.dev" \
+  || "${INGRESS_CLASS}" == "kourier.ingress.networking.knative.dev" ]]; then
   alpha="--enable-alpha"
 fi
 


### PR DESCRIPTION
The latest Kourier will support all alpha features, so enable those here.