### PR TITLE
Apply test/config/config-logging.yaml for upgrade e2e tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -420,6 +420,12 @@ function test_setup() {
   wait_until_ingress_running || return 1
 }
 
+# Apply the logging config for testing. This should be called after test_setup has been triggered.
+function test_logging_config_setup() {
+  echo ">> Setting up test logging config..."
+  ko apply ${KO_FLAGS} -f ${TMP_DIR}/test/config/config/config-logging.yaml || return 1
+}
+
 # Delete test resources
 function test_teardown() {
   local TEST_CONFIG_DIR=${TMP_DIR}/test/config

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -53,6 +53,7 @@ function install_latest_release() {
 
   install_knative_serving latest-release \
       || fail_test "Knative latest release installation failed"
+  test_logging_config_setup
   wait_until_pods_running ${SYSTEM_NAMESPACE}
   wait_until_batch_job_complete ${SYSTEM_NAMESPACE}
 }
@@ -60,6 +61,7 @@ function install_latest_release() {
 function install_head() {
   header "Installing Knative head release"
   install_knative_serving || fail_test "Knative head release installation failed"
+  test_logging_config_setup
   wait_until_pods_running ${SYSTEM_NAMESPACE}
   wait_until_batch_job_complete ${SYSTEM_NAMESPACE}
 }


### PR DESCRIPTION
In upgrade e2e tests, after upgrade and downgrade, the config map for logging will be overwritten to default `info` level. So explicitly apply test config file after upgrade and downgrade to set to `debug` level.