### PR TITLE
Preallocate sets before filling them with endpoints

### DIFF
--- a/pkg/activator/net/helpers.go
+++ b/pkg/activator/net/helpers.go
@@ -34,6 +34,7 @@ func healthyAddresses(endpoints *corev1.Endpoints, portName string) sets.String 
 		for _, port := range es.Ports {
 			if port.Name == portName {
 				addresses += len(es.Addresses)
+				break
 			}
 		}
 	}
@@ -63,6 +64,7 @@ func endpointsToDests(endpoints *corev1.Endpoints, portName string) (ready, notR
 			if port.Name == portName {
 				readyAddresses += len(es.Addresses)
 				nonReadyAddresses += len(es.NotReadyAddresses)
+				break
 			}
 		}
 	}

--- a/pkg/activator/net/helpers.go
+++ b/pkg/activator/net/helpers.go
@@ -29,7 +29,16 @@ import (
 // healthyAddresses takes an endpoints object and a port name and return the set
 // of addresses that implement this port.
 func healthyAddresses(endpoints *corev1.Endpoints, portName string) sets.String {
-	ready := sets.NewString()
+	var addresses int
+	for _, es := range endpoints.Subsets {
+		for _, port := range es.Ports {
+			if port.Name == portName {
+				addresses += len(es.Addresses)
+			}
+		}
+	}
+
+	ready := make(sets.String, addresses)
 
 	for _, es := range endpoints.Subsets {
 		for _, port := range es.Ports {
@@ -48,8 +57,18 @@ func healthyAddresses(endpoints *corev1.Endpoints, portName string) sets.String 
 // endpointsToDests takes an endpoints object and a port name and returns two sets of
 // ready and non-ready l4 dests in the endpoints object which have that port.
 func endpointsToDests(endpoints *corev1.Endpoints, portName string) (ready, notReady sets.String) {
-	ready = sets.NewString()
-	notReady = sets.NewString()
+	var readyAddresses, nonReadyAddresses int
+	for _, es := range endpoints.Subsets {
+		for _, port := range es.Ports {
+			if port.Name == portName {
+				readyAddresses += len(es.Addresses)
+				nonReadyAddresses += len(es.NotReadyAddresses)
+			}
+		}
+	}
+
+	ready = make(sets.String, readyAddresses)
+	notReady = make(sets.String, nonReadyAddresses)
 
 	for _, es := range endpoints.Subsets {
 		for _, port := range es.Ports {

--- a/pkg/activator/net/helpers_test.go
+++ b/pkg/activator/net/helpers_test.go
@@ -172,7 +172,7 @@ func TestGetServicePort(t *testing.T) {
 
 func BenchmarkHealthyAddresses(b *testing.B) {
 	for _, n := range []int{1, 10, 100, 1000, 10000} {
-		b.Run(fmt.Sprintf("addresses-%d", n), func(b *testing.B) {
+		b.Run(fmt.Sprint("addresses-", n), func(b *testing.B) {
 			ep := eps(10, n)
 			for i := 0; i < b.N; i++ {
 				healthyAddresses(ep, networking.ServicePortNameHTTP1)
@@ -183,7 +183,7 @@ func BenchmarkHealthyAddresses(b *testing.B) {
 
 func BenchmarkEndpointsToDests(b *testing.B) {
 	for _, n := range []int{1, 10, 100, 1000, 10000} {
-		b.Run(fmt.Sprintf("addresses-%d", n), func(b *testing.B) {
+		b.Run(fmt.Sprint("addresses-", n), func(b *testing.B) {
 			ep := eps(10, n)
 			for i := 0; i < b.N; i++ {
 				endpointsToDests(ep, networking.ServicePortNameHTTP1)


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

The endpoints we scan have a lowish number of subsets and ports but a potentially **very** high number of endpoints, so I wanted to know if it's worth looping through first to find the eventual number and preallocate.

Turns out: It is! So here we go.

## Results

```
benchmark                                        old ns/op     new ns/op     delta
BenchmarkHealthyAddresses/addresses-1-16         839           586           -30.15%
BenchmarkHealthyAddresses/addresses-10-16        1866          1069          -42.71%
BenchmarkHealthyAddresses/addresses-100-16       13905         6266          -54.94%
BenchmarkHealthyAddresses/addresses-1000-16      117758        51546         -56.23%
BenchmarkHealthyAddresses/addresses-10000-16     1021727       481029        -52.92%

benchmark                                        old allocs     new allocs     delta
BenchmarkHealthyAddresses/addresses-1-16         3              2              -33.33%
BenchmarkHealthyAddresses/addresses-10-16        4              2              -50.00%
BenchmarkHealthyAddresses/addresses-100-16       11             3              -72.73%
BenchmarkHealthyAddresses/addresses-1000-16      35             3              -91.43%
BenchmarkHealthyAddresses/addresses-10000-16     241            15             -93.78%

benchmark                                        old bytes     new bytes     delta
BenchmarkHealthyAddresses/addresses-1-16         489           345           -29.45%
BenchmarkHealthyAddresses/addresses-10-16        1117          647           -42.08%
BenchmarkHealthyAddresses/addresses-100-16       10860         5456          -49.76%
BenchmarkHealthyAddresses/addresses-1000-16      85507         41043         -52.00%
BenchmarkHealthyAddresses/addresses-10000-16     676939        319897        -52.74%
```

```
benchmark                                        old ns/op     new ns/op     delta
BenchmarkEndpointsToDests/addresses-1-16         1939          1598          -17.59%
BenchmarkEndpointsToDests/addresses-10-16        4893          3482          -28.84%
BenchmarkEndpointsToDests/addresses-100-16       36609         23345         -36.23%
BenchmarkEndpointsToDests/addresses-1000-16      387984        223823        -42.31%
BenchmarkEndpointsToDests/addresses-10000-16     3226679       2076486       -35.65%

benchmark                                        old allocs     new allocs     delta
BenchmarkEndpointsToDests/addresses-1-16         19             18             -5.26%
BenchmarkEndpointsToDests/addresses-10-16        39             36             -7.69%
BenchmarkEndpointsToDests/addresses-100-16       234            218            -6.84%
BenchmarkEndpointsToDests/addresses-1000-16      2084           2019           -3.12%
BenchmarkEndpointsToDests/addresses-10000-16     20632          20123          -2.47%

benchmark                                        old bytes     new bytes     delta
BenchmarkEndpointsToDests/addresses-1-16         894           750           -16.11%
BenchmarkEndpointsToDests/addresses-10-16        2240          1626          -27.41%
BenchmarkEndpointsToDests/addresses-100-16       21249         13311         -37.36%
BenchmarkEndpointsToDests/addresses-1000-16      219238        130276        -40.58%
BenchmarkEndpointsToDests/addresses-10000-16     1838628       1122537       -38.95%
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
