### PR TITLE
Insert "wokeignore:rule" where it is not modified by prettier

### DIFF
--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -504,7 +504,8 @@ changes.
 From the OCI spec:
 
 > `rootfsPropagation` (string, OPTIONAL) sets the rootfs's mount propagation.
-> Its value is either slave, private, shared or unbindable. The <!-- wokeignore:rule=slave -->
+> Its value is either slave,<!-- wokeignore:rule=slave --> private, shared or
+> unbindable. The
 > [Shared Subtrees](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt)
 > article in the kernel documentation has more information about mount
 > propagation.


### PR DESCRIPTION
Please refer to https://github.com/knative/serving/pull/10104.

`prettier` breaks line if the line is too long. Due to it,
`<!-- wokeignore:rule=slave -->` moved to next line and it starts failing.

This patch fixes it by changing the place of `<!-- wokeignore:rule=slave -->`.

The comment does not effect on markdown - https://github.com/nak3/serving/blob/fix-10104/docs/runtime-contract.md

**Release Note**

```release-note
NONE
```

/cc @markusthoemmes @vagababov 