### PR TITLE
Tidy up probe tests

### DIFF
--- a/pkg/queue/health/probe_test.go
+++ b/pkg/queue/health/probe_test.go
@@ -208,6 +208,8 @@ func newTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 }
 
 func newHTTPGetAction(t *testing.T, serverURL string) *corev1.HTTPGetAction {
+	t.Helper()
+
 	u, err := url.Parse(serverURL)
 	if err != nil {
 		t.Fatalf("Error parsing URL")

--- a/pkg/queue/health/probe_test.go
+++ b/pkg/queue/health/probe_test.go
@@ -199,6 +199,7 @@ func TestIsHTTPProbeShuttingDown(t *testing.T) {
 }
 
 func newTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		handler(w, r)
 	}))

--- a/pkg/queue/health/probe_test.go
+++ b/pkg/queue/health/probe_test.go
@@ -31,10 +31,9 @@ import (
 )
 
 func TestTCPProbe(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
+	})
 	config := TCPProbeConfigOptions{
 		Address:       server.Listener.Addr().String(),
 		SocketTimeout: time.Second,
@@ -60,7 +59,7 @@ func TestHTTPProbeSuccess(t *testing.T) {
 	}
 	var gotPath string
 	expectedPath := "/health"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		for headerKey, headerValue := range r.Header {
 			// Filtering for expectedHeader.TestKey to avoid other HTTP probe headers
 			if expectedHeader.Name == headerKey {
@@ -74,15 +73,15 @@ func TestHTTPProbeSuccess(t *testing.T) {
 
 		gotPath = r.URL.Path
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
-	httpGetAction := newHTTPGetAction(t, server.URL)
-	httpGetAction.Path = expectedPath
-	httpGetAction.HTTPHeaders = []corev1.HTTPHeader{expectedHeader}
+	})
+
+	action := newHTTPGetAction(t, server.URL)
+	action.Path = expectedPath
+	action.HTTPHeaders = []corev1.HTTPHeader{expectedHeader}
 
 	config := HTTPProbeConfigOptions{
 		Timeout:       time.Second,
-		HTTPGetAction: httpGetAction,
+		HTTPGetAction: action,
 	}
 	// Connecting to the server should work
 	if err := HTTPProbe(config); err != nil {
@@ -104,16 +103,16 @@ func TestHTTPProbeSuccess(t *testing.T) {
 	}
 }
 
-func TestHTTPsSchemeProbeSuccess(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestHTTPSchemeProbeSuccess(t *testing.T) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
+	})
 
 	config := HTTPProbeConfigOptions{
 		Timeout:       time.Second,
 		HTTPGetAction: newHTTPGetAction(t, server.URL),
 	}
+
 	// Connecting to the server should work
 	if err := HTTPProbe(config); err != nil {
 		t.Error("Expected probe to succeed but failed with error", err)
@@ -127,11 +126,10 @@ func TestHTTPsSchemeProbeSuccess(t *testing.T) {
 }
 
 func TestHTTPProbeTimeoutFailure(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(2 * time.Second)
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer server.Close()
+	})
 
 	config := HTTPProbeConfigOptions{
 		Timeout:       time.Second,
@@ -143,10 +141,9 @@ func TestHTTPProbeTimeoutFailure(t *testing.T) {
 }
 
 func TestHTTPProbeResponseStatusCodeFailure(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
-	}))
-	defer server.Close()
+	})
 
 	config := HTTPProbeConfigOptions{
 		Timeout:       time.Second,
@@ -201,26 +198,25 @@ func TestIsHTTPProbeShuttingDown(t *testing.T) {
 	}
 }
 
+func newTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	return server
+}
+
 func newHTTPGetAction(t *testing.T, serverURL string) *corev1.HTTPGetAction {
-	urlParsed, err := url.Parse(serverURL)
+	u, err := url.Parse(serverURL)
 	if err != nil {
 		t.Fatalf("Error parsing URL")
 	}
-	port := intstr.FromString(urlParsed.Port())
-
-	var uriScheme corev1.URIScheme
-	switch urlParsed.Scheme {
-	case "http":
-		uriScheme = corev1.URISchemeHTTP
-	case "https":
-		uriScheme = corev1.URISchemeHTTPS
-	default:
-		t.Fatal("Unsupported scheme", urlParsed.Scheme)
-	}
 
 	return &corev1.HTTPGetAction{
-		Host:   urlParsed.Hostname(),
-		Port:   port,
-		Scheme: uriScheme,
+		Host: u.Hostname(),
+		Port: intstr.FromString(u.Port()),
+		// We only ever use httptest.NewServer which is http.
+		Scheme: corev1.URISchemeHTTP,
 	}
 }

--- a/pkg/queue/readiness/probe_test.go
+++ b/pkg/queue/readiness/probe_test.go
@@ -608,6 +608,8 @@ func TestKnTCPProbeSuccessThresholdIncludesFailure(t *testing.T) {
 }
 
 func newTestServer(t *testing.T, h http.HandlerFunc) *url.URL {
+	t.Helper()
+
 	s := httptest.NewServer(h)
 	t.Cleanup(s.Close)
 

--- a/pkg/queue/readiness/probe_test.go
+++ b/pkg/queue/readiness/probe_test.go
@@ -135,17 +135,9 @@ func TestExecHandler(t *testing.T) {
 }
 
 func TestTCPSuccess(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tsURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	tsURL, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
-	}
-
-	t.Log("Port", tsURL.Port())
+	})
 
 	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
@@ -186,15 +178,9 @@ func TestHTTPFailureToConnect(t *testing.T) {
 }
 
 func TestHTTPBadResponse(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tsURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
-	}))
-	defer ts.Close()
-
-	tsURL, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
-	}
+	})
 
 	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
@@ -216,15 +202,9 @@ func TestHTTPBadResponse(t *testing.T) {
 }
 
 func TestHTTPSuccess(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tsURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	tsURL, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
-	}
+	})
 
 	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
@@ -247,18 +227,12 @@ func TestHTTPSuccess(t *testing.T) {
 
 func TestHTTPManyParallel(t *testing.T) {
 	var count atomic.Int32
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tsURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if count.Inc() == 1 {
 			// Add a small amount of work to allow the requests below to collapse into one.
 			time.Sleep(200 * time.Millisecond)
 		}
-	}))
-	defer ts.Close()
-
-	tsURL, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
-	}
+	})
 
 	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
@@ -297,16 +271,10 @@ func TestHTTPManyParallel(t *testing.T) {
 }
 
 func TestHTTPTimeout(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tsURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(3 * time.Second)
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	tsURL, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
-	}
+	})
 
 	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
@@ -328,16 +296,10 @@ func TestHTTPTimeout(t *testing.T) {
 }
 
 func TestHTTPSuccessWithDelay(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tsURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(200 * time.Millisecond)
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	tsURL, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
-	}
+	})
 
 	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
@@ -360,20 +322,14 @@ func TestHTTPSuccessWithDelay(t *testing.T) {
 
 func TestKnHTTPSuccessWithRetry(t *testing.T) {
 	var count atomic.Int32
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tsURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		// Fail the very first request.
 		if count.Inc() == 1 {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	tsURL, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
-	}
+	})
 
 	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,
@@ -398,16 +354,10 @@ func TestKnHTTPSuccessWithThreshold(t *testing.T) {
 	var threshold int32 = 3
 
 	var count atomic.Int32
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tsURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		count.Inc()
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	tsURL, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
-	}
+	})
 
 	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,
@@ -437,20 +387,14 @@ func TestKnHTTPSuccessWithThresholdAndFailure(t *testing.T) {
 	var requestFailure int32 = 2
 
 	var count atomic.Int32
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tsURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if count.Inc() == requestFailure {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	tsURL, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
-	}
+	})
 
 	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,
@@ -480,16 +424,10 @@ func TestKnHTTPSuccessWithThresholdAndFailure(t *testing.T) {
 }
 
 func TestKnHTTPTimeoutFailure(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tsURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(time.Second)
 		w.WriteHeader(http.StatusOK)
-	}))
-	defer ts.Close()
-
-	tsURL, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("Failed to parse URL %s: %v", ts.URL, err)
-	}
+	})
 
 	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,
@@ -552,6 +490,7 @@ func TestKnUnimplementedProbe(t *testing.T) {
 		t.Error("Got probe success. Wanted failure.")
 	}
 }
+
 func TestKnTCPProbeFailure(t *testing.T) {
 	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,
@@ -666,4 +605,16 @@ func TestKnTCPProbeSuccessThresholdIncludesFailure(t *testing.T) {
 	if got := pb.count; got < successThreshold {
 		t.Errorf("Count = %d, want: %d", got, successThreshold)
 	}
+}
+
+func newTestServer(t *testing.T, h http.HandlerFunc) *url.URL {
+	s := httptest.NewServer(h)
+	t.Cleanup(s.Close)
+
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse URL %s: %v", s.URL, err)
+	}
+
+	return u
 }


### PR DESCRIPTION
Since I had these open anyway.

- drop unneeded t.Log
- remove switch for scheme that was never used (the scheme is always http since we use httptest.NewServer)
- move `httptest.NewServer` calls into helper and use `t.Cleanup` to tidy up defers since it's the same in every test
- move url/port parsing in to helper in readiness/probe_test since it's used in every test

/assign @vagababov @markusthoemmes 