### PR TITLE
Use HA_COMPONENTS environment variable for auto-tls tests

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -166,7 +166,7 @@ initialize "$@" --skip-istio-addon --min-nodes=4 --max-nodes=4
 
 header "Enabling high-availability"
 
-scale_controlplane controller autoscaler-hpa webhook
+scale_controlplane "${HA_COMPONENTS[@]}"
 
 # Wait for a new leader Controller to prevent race conditions during service reconciliation
 wait_for_leader_controller || failed=1


### PR DESCRIPTION
So more control plane components are set in leader election mode.

/asign @vagababov 