### PR TITLE
Document GATEWAY_OVERRIDE for kourier

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -227,6 +227,18 @@ If you have configured your cluster to use a resolvable domain, you can use the
 `--resolvabledomain` flag to indicate that the test should make requests
 directly against `Route.Status.Domain` and does not need to spoof the `Host`.
 
+### Overriding the gateway used for spoofing
+
+If you are using an ingress provider other than Istio, and have not set up a
+resolvable domain (above), you will also need to set the `GATEWAY_OVERRIDE` and
+`GATEWAY_NAMESPACE_OVERRIDE` environment variables to allow the gateway to be
+discovered for spoofing. For example, for kourier you would do:
+
+```
+export GATEWAY_OVERRIDE=kourier
+export GATEWAY_NAMESPACE_OVERRIDE=kourier-system
+```
+
 ### Using https
 
 You can use the `--https` flag to have all tests run with https.


### PR DESCRIPTION
Now that kourier is [the documented ingress in DEVELOPMENT.md](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#deploy-knative-ingress), we should make sure to document the env vars needed for the tests to work against it -- I ran in to this after swapping my local dev cluster to use kourier instead of istio. Without setting these env vars, following the dev instructions and running tests results in `failed get the cluster endpoint: services "kourier" not found`.

(I guess we may also want to consider changing [the defaults in pkg](https://github.com/knative/serving/blob/f23b78989a1cea8cfd1933d12369190ef7bf2b33/vendor/knative.dev/pkg/test/ingress/ingress.go#L31-L32) to match the new defaults in the dev instructions, but that seems like a bigger change (and would break people with working clusters)).

/assign @mattmoor @ZhiminXiang 