### PR TITLE
Use the latest commit ID of release 0.18 of net-istio

### DIFF
--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -15,8 +15,6 @@
 # limitations under the License.
 
 function install_istio() {
-  export ISTIO_VERSION="latest"
-
   # TODO: Figure out the commit of net-istio.yaml from net-istio.yaml
   local NET_ISTIO_COMMIT=0aab2b296f1347785ab5ebec82c27e6f90e1fce5
 
@@ -37,9 +35,9 @@ function install_istio() {
   fi
 
   echo ">> Installing Istio"
-  echo "Istio version: ${ISTIO_VERSION}"
+  echo "Istio version: latest"
   echo "Istio profile: ${ISTIO_PROFILE}"
-  ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/install-istio.sh ${ISTIO_PROFILE}
+  ${NET_ISTIO_DIR}/third_party/istio-latest/install-istio.sh ${ISTIO_PROFILE}
 
   if [[ -n "$1" ]]; then
     echo ">> Installing net-istio"

--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -48,7 +48,7 @@ function install_istio() {
     echo "net-istio original YAML: ${1}"
     # Create temp copy in which we replace knative-serving by the test's system namespace.
     local YAML_NAME=$(mktemp -p $TMP_DIR --suffix=.$(basename "$1"))
-    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${1} > ${YAML_NAME}
+    sed -E "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}|namespace: \"${KNATIVE_DEFAULT_NAMESPACE}\"/namespace: ${SYSTEM_NAMESPACE}/g" ${1} > ${YAML_NAME}
     echo "net-istio patched YAML: $YAML_NAME"
     ko apply -f "${YAML_NAME}" --selector=networking.knative.dev/ingress-provider=istio || return 1
     UNINSTALL_LIST+=( "${YAML_NAME}" )

--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -20,7 +20,7 @@ function install_istio() {
   fi
 
   # TODO: Figure out the commit of net-istio.yaml from net-istio.yaml
-  local NET_ISTIO_COMMIT=f64ed34d3776a444372483dddc15a330c6c1ac53
+  local NET_ISTIO_COMMIT=0aab2b296f1347785ab5ebec82c27e6f90e1fce5
 
   # And checkout the setup script based on that commit.
   local NET_ISTIO_DIR=$(mktemp -d)

--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -16,7 +16,7 @@
 
 function install_istio() {
   if [[ -z "${ISTIO_VERSION}" ]]; then
-    readonly ISTIO_VERSION="stable"
+    readonly ISTIO_VERSION="latest"
   fi
 
   # TODO: Figure out the commit of net-istio.yaml from net-istio.yaml

--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -15,9 +15,7 @@
 # limitations under the License.
 
 function install_istio() {
-  if [[ -z "${ISTIO_VERSION}" ]]; then
-    readonly ISTIO_VERSION="latest"
-  fi
+  export ISTIO_VERSION="latest"
 
   # TODO: Figure out the commit of net-istio.yaml from net-istio.yaml
   local NET_ISTIO_COMMIT=0aab2b296f1347785ab5ebec82c27e6f90e1fce5

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -29,7 +29,7 @@ source $(dirname $0)/../e2e-networking-library.sh
 export MESH=0
 export KNATIVE_DEFAULT_NAMESPACE="knative-serving"
 export SYSTEM_NAMESPACE="knative-serving"
-export ISTIO_VERSION="stable"
+export ISTIO_VERSION="latest"
 export UNINSTALL_LIST=()
 export TMP_DIR=$(mktemp -d -t ci-$(date +%Y-%m-%d-%H-%M-%S)-XXXXXXXXXX)
 


### PR DESCRIPTION
This is to fix the failed upgrading E2E test when doing cherrypick to release 0.18.

See https://github.com/knative/serving/pull/10134#issuecomment-729885769 for the details.


<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->


