### PR TITLE
Add the fields to the Rollout API required by the algorithm.

### DIFF
--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -56,9 +56,6 @@ type ConfigurationRollout struct {
 	// Note: that it is not 100% of the route traffic, in more complex cases.
 	Revisions []RevisionRollout `json:"revisions,omitempty"`
 
-	// TODO(vagababov): more rollout fields here, e.g. duration
-	// next step time, etc.
-
 	// Deadline is the Unix timestamp by when (+/- reconcile precision)
 	// the Rollout shoud be complete.
 	Deadline int `json:"deadline,omitempty"`

--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -58,6 +58,19 @@ type ConfigurationRollout struct {
 
 	// TODO(vagababov): more rollout fields here, e.g. duration
 	// next step time, etc.
+
+	// Deadline is the Unix timestamp by when (+/- reconcile precision)
+	// the Rollout shoud be complete.
+	Deadline int `json:"deadline,omitempty"`
+
+	// LastStepTimeStamp is the Unix timestamp when the last
+	// rollout step was performed.
+	LastStepTime int `json:"lastStep,omitempty"`
+
+	// StepDuration is a rounded up number of seconds how long it took
+	// for ingress to successfully move first 1% of traffic to the new revision.
+	// Note, that his number does not include any coldstart, etc timing.
+	StepDuration int `json:"stepDuration,omitempty"`
 }
 
 // RevisionRollout describes the revision in the config rollout.


### PR DESCRIPTION
Algorithm refresher here:
https://docs.google.com/document/d/1CpQRCu_uIzXr6HxGJqx3-jP24O5Jluo_1_D3fUH3-bI/edit#heading=h.b2silzyodza9

This just adds the API fields for the next prs.

/assign mattmoor @tcnghia  