### PR TITLE
Use latest kourier version in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -214,7 +214,7 @@ Knative supports a variety of Ingress solutions.
 For simplicity, you can just run the following command to install Kourier.
 
 ```
-kubectl apply -f https://github.com/knative/net-kourier/releases/download/v0.18.0/kourier.yaml
+kubectl apply -f ./third_party/kourier-latest/kourier.yaml
 
 kubectl patch configmap/config-network \
   -n knative-serving \
@@ -277,7 +277,7 @@ You can delete all of the service components with:
 ```shell
 ko delete --ignore-not-found=true \
   -Rf config/core/ \
-  -f https://github.com/knative/net-kourier/releases/download/v0.18.0/kourier.yaml \
+  -f ./third_party/kourier-latest/kourier.yaml \
   -f ./third_party/cert-manager-latest/cert-manager.yaml
 ```
 


### PR DESCRIPTION
We need at least v0.19.0 of net-kourier for the RewriteHost feature so that DomainMapping works. We currently have 0.18.0 hard-coded in dev.md but think we should just use the nightly from `third_party/` anyway like we do with cert-manager.

/assign @markusthoemmes @mattmoor 