### PR TITLE
Add DomainMappingReferenceResolved condition

### DIFF
--- a/pkg/apis/serving/v1alpha1/domainmapping_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_lifecycle.go
@@ -25,6 +25,7 @@ import (
 
 var domainMappingCondSet = apis.NewLivingConditionSet(
 	DomainMappingConditionDomainClaimed,
+	DomainMappingConditionReferenceResolved,
 	DomainMappingConditionIngressReady,
 )
 
@@ -81,6 +82,18 @@ func (dms *DomainMappingStatus) MarkDomainClaimNotOwned() {
 // condition to indicate that creating the ClusterDomainClaim failed.
 func (dms *DomainMappingStatus) MarkDomainClaimFailed(reason string) {
 	domainMappingCondSet.Manage(dms).MarkFalse(DomainMappingConditionDomainClaimed, "DomainClaimFailed", reason)
+}
+
+// MarkReferenceResolved sets the DomainMappingConditionReferenceResolved
+// condition to true.
+func (dms *DomainMappingStatus) MarkReferenceResolved() {
+	domainMappingCondSet.Manage(dms).MarkTrue(DomainMappingConditionReferenceResolved)
+}
+
+// MarkReferenceNotResolved sets the DomainMappingConditionReferenceResolved
+// condition to false.
+func (dms *DomainMappingStatus) MarkReferenceNotResolved(reason string) {
+	domainMappingCondSet.Manage(dms).MarkFalse(DomainMappingConditionReferenceResolved, "ResolveFailed", reason)
 }
 
 // PropagateIngressStatus updates the DomainMappingConditionIngressReady

--- a/pkg/apis/serving/v1alpha1/domainmapping_types.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_types.go
@@ -95,6 +95,10 @@ const (
 	// and the Ingress is ready.
 	DomainMappingConditionReady = apis.ConditionReady
 
+	// DomainMappingConditionReferenceResolved reflects whether the Ref
+	// has been successfully resolved to an existing object.
+	DomainMappingConditionReferenceResolved apis.ConditionType = "ReferenceResolved"
+
 	// DomainMappingConditionIngressReady reflects the readiness of the
 	// underlying Ingress resource.
 	DomainMappingConditionIngressReady apis.ConditionType = "IngressReady"

--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -79,6 +79,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, dm *v1alpha1.DomainMappi
 		return err
 	}
 
+	// Since we currently assume all DomainMapping References are KServices we
+	// don't do any resolution yet, so we'll just immediately mark the condition.
+	dm.Status.MarkReferenceResolved()
+
 	// Reconcile the Ingress resource corresponding to the requested Mapping.
 	logger.Debugf("Mapping %s to %s/%s", url, dm.Spec.Ref.Namespace, dm.Spec.Ref.Name)
 	desired := resources.MakeIngress(dm, ingressClass)

--- a/pkg/reconciler/domainmapping/table_test.go
+++ b/pkg/reconciler/domainmapping/table_test.go
@@ -71,7 +71,7 @@ func TestReconcile(t *testing.T) {
 				withInitDomainMappingConditions,
 				withDomainClaimed,
 				withIngressNotConfigured,
-				withDomainClaimed,
+				withReferenceResolved,
 			),
 		}},
 		SkipNamespaceValidation: true, // allow creation of ClusterDomainClaim.
@@ -97,6 +97,7 @@ func TestReconcile(t *testing.T) {
 				withInitDomainMappingConditions,
 				withIngressNotConfigured,
 				withDomainClaimed,
+				withReferenceResolved,
 			),
 		}},
 		WantCreates: []runtime.Object{
@@ -173,7 +174,7 @@ func TestReconcile(t *testing.T) {
 				withInitDomainMappingConditions,
 				withDomainClaimed,
 				withIngressNotConfigured,
-				withDomainClaimed,
+				withReferenceResolved,
 				withAnnotations(map[string]string{
 					networking.IngressClassAnnotationKey: "overridden-ingress-class",
 				}),
@@ -204,7 +205,7 @@ func TestReconcile(t *testing.T) {
 				withInitDomainMappingConditions,
 				withDomainClaimed,
 				withIngressNotConfigured,
-				withDomainClaimed,
+				withReferenceResolved,
 			),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -231,6 +232,7 @@ func TestReconcile(t *testing.T) {
 				withAddress("http", "ingress-failed.me"),
 				withInitDomainMappingConditions,
 				withDomainClaimed,
+				withReferenceResolved,
 				withPropagatedStatus(ingress(domainMapping("default", "ingress-failed.me"), "", WithLoadbalancerFailed("fell over", "hurt myself")).Status),
 			),
 		}},
@@ -255,6 +257,7 @@ func TestReconcile(t *testing.T) {
 				withAddress("http", "ingress-unknown.me"),
 				withInitDomainMappingConditions,
 				withDomainClaimed,
+				withReferenceResolved,
 				withPropagatedStatus(ingress(domainMapping("default", "ingress-unknown.me"), "", withIngressNotReady).Status),
 			),
 		}},
@@ -279,6 +282,7 @@ func TestReconcile(t *testing.T) {
 				withAddress("http", "ingress-ready.me"),
 				withInitDomainMappingConditions,
 				withDomainClaimed,
+				withReferenceResolved,
 				withPropagatedStatus(ingress(domainMapping("default", "ingress-ready.me"), "", withIngressReady).Status),
 			),
 		}},
@@ -295,6 +299,7 @@ func TestReconcile(t *testing.T) {
 				withAddress("http", "cantcreate.this"),
 				withInitDomainMappingConditions,
 				withDomainClaimed,
+				withReferenceResolved,
 				withGeneration(1),
 			),
 			resources.MakeDomainClaim(domainMapping("default", "cantcreate.this", withRef("default", "target"))),
@@ -311,6 +316,7 @@ func TestReconcile(t *testing.T) {
 				withAddress("http", "cantcreate.this"),
 				withInitDomainMappingConditions,
 				withDomainClaimed,
+				withReferenceResolved,
 				withIngressNotConfigured,
 				withGeneration(1),
 				withObservedGeneration,
@@ -333,6 +339,7 @@ func TestReconcile(t *testing.T) {
 				withAddress("http", "cantupdate.this"),
 				withInitDomainMappingConditions,
 				withDomainClaimed,
+				withReferenceResolved,
 				withGeneration(1),
 			),
 			ingress(domainMapping("default", "cantupdate.this", withRef("default", "previous-value")), "the-ingress-class"),
@@ -350,6 +357,7 @@ func TestReconcile(t *testing.T) {
 				withAddress("http", "cantupdate.this"),
 				withInitDomainMappingConditions,
 				withDomainClaimed,
+				withReferenceResolved,
 				withIngressNotConfigured,
 				withGeneration(1),
 				withObservedGeneration,
@@ -450,6 +458,10 @@ func withDomainClaimNotOwned(dm *v1alpha1.DomainMapping) {
 
 func withDomainClaimed(dm *v1alpha1.DomainMapping) {
 	dm.Status.MarkDomainClaimed()
+}
+
+func withReferenceResolved(dm *v1alpha1.DomainMapping) {
+	dm.Status.MarkReferenceResolved()
 }
 
 func withGeneration(generation int64) domainMappingOption {


### PR DESCRIPTION
Next part of #9713.

Adds a new `DomainMappingReferenceResolved` condition, analogous to [SubscriptionConditionReferencesResolved in eventing](https://github.com/knative/eventing/blob/2e5f36f317ac6dcca876c2a808bf66f325d21284/pkg/apis/messaging/v1/subscription_lifecycle.go#L32) to reflect whether the `Spec.Ref` of a DomainMapping has been successfully resolved to a URI.

Actually using pkg/resolver to resolve the spec.Ref (rather than making assumptions about ksvc URIs) will come in the next PR, so for now the reconciler just immediately marks this condition true.

/assign @mattmoor @vagababov 