### PR TITLE
Temporarily add peerauthentication CRD in order to make upgrade test happy

### DIFF
--- a/test/config/security/peerauthentication_crd.yaml
+++ b/test/config/security/peerauthentication_crd.yaml
@@ -1,0 +1,87 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    heritage: Tiller
+    install.operator.istio.io/owning-resource: installed-state
+    install.operator.istio.io/owning-resource-namespace: istio-system
+    istio: security
+    istio.io/rev: default
+    operator.istio.io/component: Base
+    operator.istio.io/managed: Reconcile
+    operator.istio.io/version: 1.7.1
+    release: istio
+  name: peerauthentications.security.istio.io
+spec:
+  conversion:
+    strategy: None
+  group: security.istio.io
+  names:
+    categories:
+    - istio-io
+    - security-istio-io
+    kind: PeerAuthentication
+    listKind: PeerAuthenticationList
+    plural: peerauthentications
+    shortNames:
+    - pa
+    singular: peerauthentication
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: PeerAuthentication defines how traffic will be tunneled (or
+              not) to the sidecar.
+            properties:
+              mtls:
+                description: Mutual TLS settings for workload.
+                properties:
+                  mode:
+                    description: Defines the mTLS mode used for peer authentication.
+                    enum:
+                    - UNSET
+                    - DISABLE
+                    - PERMISSIVE
+                    - STRICT
+                    type: string
+                type: object
+              portLevelMtls:
+                additionalProperties:
+                  properties:
+                    mode:
+                      description: Defines the mTLS mode used for peer authentication.
+                      enum:
+                      - UNSET
+                      - DISABLE
+                      - PERMISSIVE
+                      - STRICT
+                      type: string
+                  type: object
+                description: Port specific mutual TLS settings.
+                type: object
+              selector:
+                description: The selector determines the workloads to apply the ChannelAuthentication
+                  on.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -50,7 +50,7 @@ function install_istio() {
     echo "net-istio original YAML: ${1}"
     # Create temp copy in which we replace knative-serving by the test's system namespace.
     local YAML_NAME=$(mktemp -p $TMP_DIR --suffix=.$(basename "$1"))
-    sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${1} > ${YAML_NAME}
+    sed -E "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}|namespace: \"${KNATIVE_DEFAULT_NAMESPACE}\"/namespace: ${SYSTEM_NAMESPACE}/g" ${1} > ${YAML_NAME}
     echo "net-istio patched YAML: $YAML_NAME"
     ko apply -f "${YAML_NAME}" --selector=networking.knative.dev/ingress-provider=istio || return 1
     UNINSTALL_LIST+=( "${YAML_NAME}" )

--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -42,6 +42,8 @@ function install_istio() {
   echo "Istio version: ${ISTIO_VERSION}"
   echo "Istio profile: ${ISTIO_PROFILE}"
   ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/install-istio.sh ${ISTIO_PROFILE}
+  
+  kubectl apply -f ./test/config/security/peerauthentication_crd.yaml | return 1
 
   if [[ -n "$1" ]]; then
     echo ">> Installing net-istio"

--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -43,6 +43,8 @@ function install_istio() {
   echo "Istio profile: ${ISTIO_PROFILE}"
   ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/install-istio.sh ${ISTIO_PROFILE}
   
+  # This is a temporary workaound for allowing installing PeerAuthentication
+  # in order to let upgrading test pass.
   kubectl apply -f ./test/config/security/peerauthentication_crd.yaml | return 1
 
   if [[ -n "$1" ]]; then


### PR DESCRIPTION
This PR adds PeerAuthentication CRD  to fix the failed upgrading E2E test when doing cherrypick to release 0.18.

The upgrading test fails because the PeerAuthentication is not recognized by Istio 1.4.



