### PR TITLE
Add a 1% special case and corresponding unit-test

### DIFF
--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -150,8 +150,10 @@ func (cur *Rollout) Step(prev *Rollout) *Rollout {
 				switch p := ccfgs[i].Percent; {
 				case p > 1:
 					ret = append(ret, *stepConfig(ccfgs[i], pcfgs[j]))
-				case p == 0:
-					ret = append(ret, ccfgs[i])
+				case p == 1:
+					// Skip all the work if it's a common A/B scenario where the test config
+					// receives just 1% of traffic.
+					ret = append(ret, *ccfgs[i])
 				}
 				i++
 				j++
@@ -211,12 +213,6 @@ func stepConfig(goal, prev *ConfigurationRollout) *ConfigurationRollout {
 		Tag:               goal.Tag,
 		Percent:           goal.Percent,
 		Revisions:         goal.Revisions,
-	}
-
-	// Skip all the work if it's a common A/B scenario where the test config
-	// receives just 1% of traffic.
-	if goal.Percent == 1 {
-		return ret
 	}
 
 	if len(prev.Revisions) > 0 {

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -311,7 +311,7 @@ func TestStep(t *testing.T) {
 			}},
 		},
 	}, {
-		name: "roll with two existing, no deletes",
+		name: "roll with two existing revisions, no deletes",
 		cur: &Rollout{
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
@@ -505,6 +505,62 @@ func TestStep(t *testing.T) {
 				Revisions: []RevisionRollout{{
 					RevisionName: "it's-only-rock-n-roll",
 					Percent:      100,
+				}},
+			}},
+		},
+	}, {
+		name: "a/b config, roll both",
+		cur: &Rollout{
+			Configurations: []ConfigurationRollout{{
+				ConfigurationName: "keith",
+				Percent:           99,
+				Revisions: []RevisionRollout{{
+					RevisionName: "black-on-blue",
+					Percent:      99,
+				}},
+			}, {
+				ConfigurationName: "mick",
+				Percent:           1,
+				Revisions: []RevisionRollout{{
+					RevisionName: "it's-only-rock-n-roll",
+					Percent:      1,
+				}},
+			}},
+		},
+		prev: &Rollout{
+			Configurations: []ConfigurationRollout{{
+				ConfigurationName: "keith",
+				Percent:           99,
+				Revisions: []RevisionRollout{{
+					RevisionName: "can't-get-no-satisfaction",
+					Percent:      99,
+				}},
+			}, {
+				ConfigurationName: "mick",
+				Percent:           1,
+				Revisions: []RevisionRollout{{
+					RevisionName: "get-off-my-cloud",
+					Percent:      1,
+				}},
+			}},
+		},
+		want: &Rollout{
+			Configurations: []ConfigurationRollout{{
+				ConfigurationName: "keith",
+				Percent:           99,
+				Revisions: []RevisionRollout{{ // <-- note this one actually rolls.
+					RevisionName: "can't-get-no-satisfaction",
+					Percent:      98,
+				}, {
+					RevisionName: "black-on-blue",
+					Percent:      1,
+				}},
+			}, {
+				ConfigurationName: "mick",
+				Percent:           1,
+				Revisions: []RevisionRollout{{
+					RevisionName: "it's-only-rock-n-roll",
+					Percent:      1,
 				}},
 			}},
 		},


### PR DESCRIPTION
Special case a popular A/B testing scenario, where experimental traffic split is 99/1.
It's much easier to rollout 1% -- all traffic goes there immediately, so stop doing rest of the algorithm.

/assign @tcnghia mattmoor