### PR TITLE
Fix edge case in domain validation

### DIFF
--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -150,7 +150,7 @@ func (r *Reconciler) resolveRef(ctx context.Context, dm *v1alpha1.DomainMapping)
 		return nil, fmt.Errorf("resolved URI %q contains a path", resolved)
 	}
 
-	suffix := "svc." + network.GetClusterDomainName()
+	suffix := ".svc." + network.GetClusterDomainName()
 	if !strings.HasSuffix(resolved.Host, suffix) {
 		dm.Status.MarkReferenceNotResolved(fmt.Sprintf("resolved URI %q must end in %q", resolved, suffix))
 		return nil, fmt.Errorf("resolved URI %q must end in %q", resolved, suffix)

--- a/pkg/reconciler/domainmapping/table_test.go
+++ b/pkg/reconciler/domainmapping/table_test.go
@@ -139,7 +139,7 @@ func TestReconcile(t *testing.T) {
 		Name: "first reconcile, ref doesn't end in cluster suffix",
 		Key:  "default/first-reconcile.com",
 		Objects: []runtime.Object{
-			ksvc("default", "target", "not-cluster.local", ""),
+			ksvc("default", "target", "notasvc.cluster.local", ""),
 			domainMapping("default", "first-reconcile.com", withRef("default", "target")),
 		},
 		WantErr: true,
@@ -150,7 +150,7 @@ func TestReconcile(t *testing.T) {
 				withAddress("http", "first-reconcile.com"),
 				withInitDomainMappingConditions,
 				withDomainClaimed,
-				withReferenceNotResolved(`resolved URI "http://not-cluster.local" must end in "svc.cluster.local"`),
+				withReferenceNotResolved(`resolved URI "http://notasvc.cluster.local" must end in ".svc.cluster.local"`),
 			),
 		}},
 		SkipNamespaceValidation: true, // allow creation of ClusterDomainClaim.
@@ -158,7 +158,7 @@ func TestReconcile(t *testing.T) {
 			resources.MakeDomainClaim(domainMapping("default", "first-reconcile.com", withRef("default", "target"))),
 		},
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", `resolved URI "http://not-cluster.local" must end in "svc.cluster.local"`),
+			Eventf(corev1.EventTypeWarning, "InternalError", `resolved URI "http://notasvc.cluster.local" must end in ".svc.cluster.local"`),
 		},
 	}, {
 		Name: "first reconcile, pre-owned domain claim",


### PR DESCRIPTION
Check the domain mapping ref resolves to `*.svc.cluster.local` rather than `*svc.cluster.local` to avoid the theoretical possibility of e.g. "notasvc.cluster.local", and because I'm feeling particularly pedantic this morning :).