### PR TITLE
Relax the upper bound for autoscaling e2e tests to reduce flakiness

### DIFF
--- a/test/e2e/autoscale.go
+++ b/test/e2e/autoscale.go
@@ -370,7 +370,7 @@ func AssertAutoscaleUpToNumPods(ctx *TestContext, curPods, targetPods float64, d
 	// Relax the bounds to reduce the flakiness caused by sampling in the autoscaling algorithm.
 	// Also adjust the values by the target utilization values.
 	minPods := math.Floor(curPods/ctx.targetUtilization) - 1
-	maxPods := math.Ceil(targetPods/ctx.targetUtilization) + 1
+	maxPods := math.Ceil(math.Ceil(targetPods/ctx.targetUtilization) * 1.1)
 
 	stopChan := make(chan struct{})
 	var grp errgroup.Group


### PR DESCRIPTION
For #9720 

Instead of a fixed number 1 for upper bound, use 1.1 multiplier. It will relax the upper bound when the desired pod is > 10.

/assign @vagababov  
