### PR TITLE
Copy the  values from the previous rollout state to the new state.

### DIFF
--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -213,6 +213,8 @@ func stepConfig(goal, prev *ConfigurationRollout) *ConfigurationRollout {
 		Tag:               goal.Tag,
 		Percent:           goal.Percent,
 		Revisions:         goal.Revisions,
+
+		// If there is a new revision, then timing information should be reset.
 	}
 
 	if len(prev.Revisions) > 0 {
@@ -222,10 +224,16 @@ func stepConfig(goal, prev *ConfigurationRollout) *ConfigurationRollout {
 	// If it matches the last revision of the previous rollout state (or there were no revisions)
 	// then no new rollout has begun for this configuration.
 	if len(prev.Revisions) == 0 || goal.Revisions[0].RevisionName == prev.Revisions[pc-1].RevisionName {
-		// TODO(vagababov): here would go the logic to compute new percentages for the rollout,
-		// i.e step function, so return value will change, depending on that.
 		if len(prev.Revisions) > 0 {
 			ret.Revisions = prev.Revisions
+
+			// TODO(vagababov): here would go the logic to compute new percentages for the rollout,
+			// i.e step function, so return value will change, depending on that.
+			// Copy the duration info from the previous when no new revision
+			// has been created.
+			ret.Deadline = prev.Deadline
+			ret.LastStepTime = prev.LastStepTime
+			ret.StepDuration = prev.StepDuration
 		}
 		return ret
 	}

--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -215,6 +215,7 @@ func stepConfig(goal, prev *ConfigurationRollout) *ConfigurationRollout {
 		Revisions:         goal.Revisions,
 
 		// If there is a new revision, then timing information should be reset.
+		// So leave them empty here and populate below, if necessary.
 	}
 
 	if len(prev.Revisions) > 0 {

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -74,6 +74,9 @@ func TestStep(t *testing.T) {
 					RevisionName: "let-it-bleed",
 					Percent:      100,
 				}},
+				Deadline:     2006, // <- Those should be ignored.
+				LastStepTime: 2009,
+				StepDuration: 2020,
 			}},
 		},
 		prev: &Rollout{
@@ -84,6 +87,9 @@ func TestStep(t *testing.T) {
 					RevisionName: "let-it-bleed",
 					Percent:      100,
 				}},
+				Deadline:     1982, // <- Those should be copied.
+				LastStepTime: 1984,
+				StepDuration: 1988,
 			}},
 		},
 		want: &Rollout{
@@ -94,6 +100,9 @@ func TestStep(t *testing.T) {
 					RevisionName: "let-it-bleed",
 					Percent:      100,
 				}},
+				Deadline:     1982,
+				LastStepTime: 1984,
+				StepDuration: 1988,
 			}},
 		},
 	}, {
@@ -178,6 +187,9 @@ func TestStep(t *testing.T) {
 					RevisionName: "goat-head-soup",
 					Percent:      100,
 				}},
+				Deadline:     1982, // <- Those should be thrown out.
+				LastStepTime: 1984,
+				StepDuration: 1988,
 			}},
 		},
 		want: &Rollout{


### PR DESCRIPTION
We should clear the values when a new revision is created, but
retain the previous values from the prev (or, in future PR calculate
the new percentage values and new time for the next step).

/assign @tcnghia 