### PR TITLE
Drop support for JSON messages in websocket server

### DIFF
--- a/pkg/autoscaler/statserver/server.go
+++ b/pkg/autoscaler/statserver/server.go
@@ -17,9 +17,7 @@ limitations under the License.
 package statserver
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"net"
 	"net/http"
@@ -175,8 +173,6 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// We accept either protobuf-encoded or JSON-encoded messages depending on the
-		// message type to ensure safe upgrades.
 		switch messageType {
 		case websocket.BinaryMessage:
 			var wsms metrics.WireStatMessages
@@ -195,16 +191,6 @@ func (s *Server) Handler(w http.ResponseWriter, r *http.Request) {
 				s.logger.Debugf("Received stat message: %+v", sm)
 				s.statsCh <- sm
 			}
-		case websocket.TextMessage:
-			dec := json.NewDecoder(bytes.NewBuffer(msg))
-			var sm metrics.StatMessage
-			if err = dec.Decode(&sm); err != nil {
-				s.logger.Errorw("Failed to decode json", zap.Error(err))
-				continue
-			}
-
-			s.logger.Debugf("Received stat message: %+v", sm)
-			s.statsCh <- sm
 		default:
 			s.logger.Error("Dropping unknown message type.")
 			continue


### PR DESCRIPTION
As per title. We don't need to support JSON messages anymore (protobuf support has been live since 0.17), so we can safely drop this.

/assign @vagababov @julz 