### PR TITLE
Second level cleanups of the config code

### DIFF
--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -43,9 +43,7 @@ func MakeConfigurationFromExisting(service *v1.Service, existing *v1.Configurati
 
 	routeName := names.Route(service)
 	set := labelerv2.GetListAnnValue(existing.Annotations, serving.RoutesAnnotationKey)
-	if !set.Has(routeName) {
-		set.Insert(routeName)
-	}
+	set.Insert(routeName)
 	anns[serving.RoutesAnnotationKey] = strings.Join(set.UnsortedList(), ",")
 
 	return &v1.Configuration{

--- a/pkg/reconciler/service/resources/configuration_test.go
+++ b/pkg/reconciler/service/resources/configuration_test.go
@@ -80,6 +80,6 @@ func TestConfigurationHasNoKubectlAnnotation(t *testing.T) {
 	s := createServiceWithKubectlAnnotation()
 	c := MakeConfiguration(s)
 	if v, ok := c.Annotations[corev1.LastAppliedConfigAnnotation]; ok {
-		t.Errorf("Annotation %s = %q, want empty", corev1.LastAppliedConfigAnnotation, v)
+		t.Errorf(`Annotation[%s] = %q, want: ""`, corev1.LastAppliedConfigAnnotation, v)
 	}
 }

--- a/pkg/reconciler/service/resources/shared_test.go
+++ b/pkg/reconciler/service/resources/shared_test.go
@@ -40,7 +40,7 @@ const (
 func expectOwnerReferencesSetCorrectly(t *testing.T, ownerRefs []metav1.OwnerReference) {
 	t.Helper()
 	if got, want := len(ownerRefs), 1; got != want {
-		t.Errorf("expected %d owner refs got %d", want, got)
+		t.Errorf("|Owner refs| = %d, want: %d", got, want)
 		return
 	}
 


### PR DESCRIPTION
- clean the test to be readable
- remove has check, since it's a set, it won't insert a duplicate and insert has a 'Has' check inside
- othwer small things

/assign @tcnghia @dprotaso 