### PR TITLE
Make the port envvars string rather than int.

### DIFF
--- a/pkg/networking/constants.go
+++ b/pkg/networking/constants.go
@@ -20,10 +20,10 @@ import "knative.dev/networking/pkg/apis/networking"
 
 // The ports we setup on our services.
 const (
-	// BackendHTTPPort is the backend, i.e. `targetPort` that we setup for HTTP services.
+	// BackendHTTPPort is the backend, i.e. `targetPort` that we setup for HTTP/1 services.
 	BackendHTTPPort = 8012
 
-	// BackendHTTP2Port is the backend, i.e. `targetPort` that we setup for HTTP services.
+	// BackendHTTP2Port is the backend, i.e. `targetPort` that we setup for HTTP/2 services.
 	BackendHTTP2Port = 8013
 
 	// QueueAdminPort specifies the port number for


### PR DESCRIPTION
1. They are validated in layers above.
2. QP is only created via revision.
3. They only thing we do is convert them back to string, so avoid the
  dance from envvar string to int and back.
4. Other file comment improvement.

/assign @markusthoemmes @julz 