### PR TITLE
Determine ingress backend service by parsing addressable URI

### DIFF
--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -138,7 +138,7 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, dm *v1alpha1.DomainMa
 	return ingress, err
 }
 
-func (r *Reconciler) resolveRef(ctx context.Context, dm *v1alpha1.DomainMapping) (host string, backendSvc string, err error) {
+func (r *Reconciler) resolveRef(ctx context.Context, dm *v1alpha1.DomainMapping) (host, backendSvc string, err error) {
 	resolved, err := r.resolver.URIFromKReference(ctx, &dm.Spec.Ref, dm)
 	if err != nil {
 		dm.Status.MarkReferenceNotResolved(err.Error())

--- a/pkg/reconciler/domainmapping/resources/ingress_test.go
+++ b/pkg/reconciler/domainmapping/resources/ingress_test.go
@@ -48,7 +48,7 @@ func TestMakeIngress(t *testing.T) {
 		},
 	}
 
-	got := MakeIngress(dm, "the-rewrite-host", "the-ingress-class")
+	got := MakeIngress(dm, "the-target-svc", "the-rewrite-host", "the-ingress-class")
 
 	want := &netv1alpha1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -73,7 +73,7 @@ func TestMakeIngress(t *testing.T) {
 								network.OriginalHostHeader: "mapping.com",
 							},
 							IngressBackend: netv1alpha1.IngressBackend{
-								ServiceName:      "the-name",
+								ServiceName:      "the-target-svc",
 								ServiceNamespace: "the-namespace",
 								ServicePort:      intstr.FromInt(80),
 							},


### PR DESCRIPTION
Part of #9713.

Properly parses the backend service to use from the resolved Addressable URI rather than assuming it's named the same as the ref. This assumes the resolved address is of the form `{name}.{namespace}.svc.{cluster.local.suffix}`, and validates that this is the case. I think this should be fine for most things we care about - when we want to support other types of targets we'll need to synthesise an ExternalName, but that's left for a future PR. 

Note: as of now the validation will still (now unnecessarily) insist the target is a ksvc; I'll relax that in the next PR.

/assign @mattmoor @vagababov 