### PR TITLE
Add starttime and done.

### DIFF
--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -63,7 +63,7 @@ type ConfigurationRollout struct {
 	// StartTime is the Unix timestamp by when (+/- reconcile precision)
 	// the Rollout has started.
 	// This is required to compute step time and deadline.
-	StartTime int `json:"deadline,omitempty"`
+	StartTime int `json:"starttime,omitempty"`
 
 	// LastStepTimeStamp is the Unix timestamp when the last
 	// rollout step was performed.


### PR DESCRIPTION
- start time is required in the beginning to compute step time
- done is required to ignore the rollouts that are completed during
  reconciliation.

/assign @tcnghia 