### PR TITLE
Get webhook name from env

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -154,7 +154,7 @@ func newConfigValidationController(ctx context.Context, cmw configmap.Watcher) *
 func main() {
 	// Set up a signal context with our webhook options
 	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
-		ServiceName: "webhook",
+		ServiceName: webhook.NameFromEnv(),
 		Port:        webhook.PortFromEnv(8443),
 		SecretName:  "webhook-certs",
 	})

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -72,6 +72,8 @@ spec:
           value: config-logging
         - name: CONFIG_OBSERVABILITY_NAME
           value: config-observability
+        - name: WEBHOOK_NAME
+          value: webhook
         - name: WEBHOOK_PORT
           value: "8443"
 


### PR DESCRIPTION
Signed-off-by: Arghya Sadhu <arghya88@gmail.com>

Ref https://github.com/knative/eventing/issues/4530

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Remove hardcoded wehbook name and get it from env

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Removes wehbook name from code and set webhook name in webhook deployment yaml using key WEBHOOK_NAME
```
