### PR TITLE
Relax validation to allow Ref to be things other than Ksvc

### DIFF
--- a/pkg/apis/serving/v1alpha1/domainmapping_validation.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation.go
@@ -18,12 +18,9 @@ package v1alpha1
 
 import (
 	"context"
-	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/validation"
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/serving"
-	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
 // Validate makes sure that DomainMapping is properly configured.
@@ -55,23 +52,5 @@ func (dm *DomainMapping) validateMetadata(ctx context.Context) (errs *apis.Field
 
 // Validate makes sure the DomainMappingSpec is properly configured.
 func (spec *DomainMappingSpec) Validate(ctx context.Context) *apis.FieldError {
-	errs := spec.Ref.Validate(ctx).ViaField("ref")
-
-	// For now, ref must be a serving.knative.dev/v1 Service.
-	if spec.Ref.Kind != "Service" {
-		errs = errs.Also(apis.ErrGeneric(`must be "Service"`, "ref.kind"))
-	}
-	if spec.Ref.APIVersion != v1.SchemeGroupVersion.Identifier() {
-		errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("must be %q", v1.SchemeGroupVersion.Identifier()), "ref.apiVersion"))
-	}
-
-	// Since we currently construct the rewritten host from the name/namespace, make sure they're valid.
-	if msgs := validation.NameIsDNS1035Label(spec.Ref.Name, false); len(msgs) > 0 {
-		errs = errs.Also(apis.ErrInvalidValue(fmt.Sprint("not a DNS 1035 label prefix: ", msgs), "ref.name"))
-	}
-	if msgs := validation.ValidateNamespaceName(spec.Ref.Namespace, false); len(msgs) > 0 {
-		errs = errs.Also(apis.ErrInvalidValue(fmt.Sprint("not a valid namespace: ", msgs), "ref.namespace"))
-	}
-
-	return errs
+	return spec.Ref.Validate(ctx).ViaField("ref")
 }

--- a/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
@@ -71,8 +71,8 @@ func TestDomainMappingValidation(t *testing.T) {
 			},
 		},
 	}, {
-		name: "ref wrong Kind",
-		want: apis.ErrGeneric(`must be "Service"`, "spec.ref.kind"),
+		name: "ref missing Kind",
+		want: apis.ErrMissingField("spec.ref.kind"),
 		dm: &DomainMapping{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "wrong-kind",
@@ -83,13 +83,12 @@ func TestDomainMappingValidation(t *testing.T) {
 					Name:       "some-name",
 					Namespace:  "ns",
 					APIVersion: "serving.knative.dev/v1",
-					Kind:       "BadService",
 				},
 			},
 		},
 	}, {
-		name: "ref wrong ApiVersion",
-		want: apis.ErrGeneric(`must be "serving.knative.dev/v1"`, "spec.ref.apiVersion"),
+		name: "ref missing ApiVersion",
+		want: apis.ErrMissingField("spec.ref.apiVersion"),
 		dm: &DomainMapping{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "wrong-version",
@@ -97,46 +96,9 @@ func TestDomainMappingValidation(t *testing.T) {
 			},
 			Spec: DomainMappingSpec{
 				Ref: duckv1.KReference{
-					Name:       "some-name",
-					Namespace:  "ns",
-					APIVersion: "bad.version/v1",
-					Kind:       "Service",
-				},
-			},
-		},
-	}, {
-		name: "ref name not valid DNS subdomain",
-		want: apis.ErrInvalidValue(
-			"not a DNS 1035 label prefix: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]",
-			"spec.ref.name"),
-		dm: &DomainMapping{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "wrong-version",
-				Namespace: "ns",
-			},
-			Spec: DomainMappingSpec{
-				Ref: duckv1.KReference{
-					Name:       "this is not valid",
-					Namespace:  "ns",
-					APIVersion: "serving.knative.dev/v1",
-					Kind:       "Service",
-				},
-			},
-		},
-	}, {
-		name: "ref namespace not valid",
-		want: apis.ErrInvalidValue("not a valid namespace: [a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]", "spec.ref.namespace"),
-		dm: &DomainMapping{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "wrong-version",
-				Namespace: "dots.not.allowed",
-			},
-			Spec: DomainMappingSpec{
-				Ref: duckv1.KReference{
-					Name:       "name",
-					APIVersion: "serving.knative.dev/v1",
-					Namespace:  "dots.not.allowed",
-					Kind:       "Service",
+					Name:      "some-name",
+					Namespace: "ns",
+					Kind:      "Service",
 				},
 			},
 		},

--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -147,7 +147,7 @@ func (r *Reconciler) resolveRef(ctx context.Context, dm *v1alpha1.DomainMapping)
 
 	// Since we do not support path-based routing in domain mappings, we cannot
 	// support target references that contain a path.
-	if resolved.Path != "" {
+	if strings.TrimSuffix(resolved.Path, "/") != "" {
 		dm.Status.MarkReferenceNotResolved(fmt.Sprintf("resolved URI %q contains a path", resolved))
 		return "", "", fmt.Errorf("resolved URI %q contains a path", resolved)
 	}


### PR DESCRIPTION
Something something #9713.

Relaxes the validation since we now support DomainMapping targets that aren't KSvcs.

As well as relaxing the api type validation, this also relaxes the validation in the reconciler to permit a single '/' for the Path, since it turns out the addressable resolver returns this for services.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
DomainMappings now support arbitrary target references, rather than only Knative Services. The target must conform to the Addressable contract (including Kubernetes Services), and the resolved URI must be of the form `{name}.{namespace}.svc.{cluster-suffix}`.
```

/assign @mattmoor @vagababov 
