### PR TITLE
Relax the timing a bit

### DIFF
--- a/test/e2e/autoscale.go
+++ b/test/e2e/autoscale.go
@@ -49,6 +49,7 @@ const (
 	// Concurrency must be high enough to avoid the problems with sampling
 	// but not high enough to generate scheduling problems.
 	containerConcurrency = 6
+	rpsTarget            = 10
 	targetUtilization    = 0.7
 	successRateSLO       = 0.999
 	autoscaleSleep       = 500

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -69,7 +69,7 @@ func runAutoscaleUpCountPods(t *testing.T, class, metric string) {
 
 	ctx.t.Log("The autoscaler spins up additional replicas when traffic increases.")
 	// Note: without the warm-up / gradual increase of load the test is
-	// receving 503 responses (overload) from the envoy.
+	// receiving 503 responses (overload) from the envoy.
 
 	// Increase workload for 2 replicas for 90s. It takes longer on a weak
 	// boskos cluster to propagate the state. See #10218.

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -74,7 +74,7 @@ func runAutoscaleUpCountPods(t *testing.T, class, metric string) {
 	// Increase workload for 2 replicas for 90s. It takes longer on a weak
 	// boskos cluster to propagate the state. See #10218.
 	// Assert the number of expected replicas is between n-1 and n+1, where n is the # of desired replicas for 60s.
-	// Assert the number of expected replicas is n and n+1 at the end of 60s, where n is the # of desired replicas.
+	// Assert the number of expected replicas is n and n+1 at the end of 90s, where n is the # of desired replicas.
 	AssertAutoscaleUpToNumPods(ctx, 1, 2, time.After(90*time.Second), true /* quick */)
 	// Increase workload scale to 3 replicas, assert between [n-1, n+1] during scale up, assert between [n, n+1] after scaleup.
 	AssertAutoscaleUpToNumPods(ctx, 2, 3, time.After(90*time.Second), true /* quick */)

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -62,22 +62,24 @@ func TestRPSBasedAutoscaleUpCountPods(t *testing.T) {
 func runAutoscaleUpCountPods(t *testing.T, class, metric string) {
 	target := containerConcurrency
 	if metric == autoscaling.RPS {
-		target = 10
+		target = rpsTarget
 	}
 
 	ctx := SetupSvc(t, class, metric, target, targetUtilization)
 
 	ctx.t.Log("The autoscaler spins up additional replicas when traffic increases.")
-	// note: without the warm-up / gradual increase of load the test is retrieving a 503 (overload) from the envoy
+	// Note: without the warm-up / gradual increase of load the test is
+	// receving 503 responses (overload) from the envoy.
 
-	// Increase workload for 2 replicas for 60s
+	// Increase workload for 2 replicas for 90s. It takes longer on a weak
+	// boskos cluster to propagate the state. See #10218.
 	// Assert the number of expected replicas is between n-1 and n+1, where n is the # of desired replicas for 60s.
 	// Assert the number of expected replicas is n and n+1 at the end of 60s, where n is the # of desired replicas.
-	AssertAutoscaleUpToNumPods(ctx, 1, 2, time.After(60*time.Second), true /* quick */)
+	AssertAutoscaleUpToNumPods(ctx, 1, 2, time.After(90*time.Second), true /* quick */)
 	// Increase workload scale to 3 replicas, assert between [n-1, n+1] during scale up, assert between [n, n+1] after scaleup.
-	AssertAutoscaleUpToNumPods(ctx, 2, 3, time.After(60*time.Second), true /* quick */)
+	AssertAutoscaleUpToNumPods(ctx, 2, 3, time.After(90*time.Second), true /* quick */)
 	// Increase workload scale to 4 replicas, assert between [n-1, n+1] during scale up, assert between [n, n+1] after scaleup.
-	AssertAutoscaleUpToNumPods(ctx, 3, 4, time.After(60*time.Second), true /* quick */)
+	AssertAutoscaleUpToNumPods(ctx, 3, 4, time.After(90*time.Second), true /* quick */)
 }
 
 func TestAutoscaleSustaining(t *testing.T) {


### PR DESCRIPTION
See analysis in the #10218. It seems the things work as expected, but it takes longer
to mark the endpoints in k8s ready than the test expects them to be.

Fixes #10218

/assign @julz @markusthoemmes mattmoor