### PR TITLE
Enabling reusing probe connection in activator

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -132,9 +132,17 @@ func main() {
 
 	logger.Info("Starting the knative activator")
 
+	// Create the transport used by both the activator->QP probe and the proxy.
+	// It's important that the throttler and the activatorhandler share this
+	// transport so that throttler probe connections can be reused after probing
+	// (via keep-alive) to send real requests, avoiding needing an extra
+	// reconnect for the first request after the probe succeeds.
+	logger.Debugf("MaxIdleProxyConns: %d, MaxIdleProxyConnsPerHost: %d", env.MaxIdleProxyConns, env.MaxIdleProxyConnsPerHost)
+	transport := pkgnet.NewAutoTransport(env.MaxIdleProxyConns, env.MaxIdleProxyConnsPerHost)
+
 	// Start throttler.
 	throttler := activatornet.NewThrottler(ctx, env.PodIP)
-	go throttler.Run(ctx)
+	go throttler.Run(ctx, transport)
 
 	oct := tracing.NewOpenCensusTracer(tracing.WithExporterFull(networking.ActivatorServiceName, env.PodIP, logger))
 
@@ -165,12 +173,9 @@ func main() {
 	concurrencyReporter := activatorhandler.NewConcurrencyReporter(ctx, env.PodName, statCh)
 	go concurrencyReporter.Run(ctx.Done())
 
-	logger.Debugf("MaxIdleProxyConns: %d, MaxIdleProxyConnsPerHost: %d", env.MaxIdleProxyConns, env.MaxIdleProxyConnsPerHost)
-	proxyTransport := pkgnet.NewAutoTransport(env.MaxIdleProxyConns, env.MaxIdleProxyConnsPerHost)
-
 	// Create activation handler chain
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first
-	var ah http.Handler = activatorhandler.New(ctx, throttler, proxyTransport)
+	var ah http.Handler = activatorhandler.New(ctx, throttler, transport)
 	ah = concurrencyReporter.Handler(ah)
 	ah = tracing.HTTPSpanMiddleware(ah)
 	ah = configStore.HTTPMiddleware(ah)

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"math"
 	"math/rand"
+	"net/http"
 	"sort"
 	"sync"
 
@@ -38,7 +39,6 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
-	"knative.dev/pkg/network"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/apis/serving"
@@ -496,8 +496,8 @@ func NewThrottler(ctx context.Context, ipAddr string) *Throttler {
 }
 
 // Run starts the throttler and blocks until the context is done.
-func (t *Throttler) Run(ctx context.Context) {
-	rbm := newRevisionBackendsManager(ctx, network.AutoTransport)
+func (t *Throttler) Run(ctx context.Context, probeTransport http.RoundTripper) {
+	rbm := newRevisionBackendsManager(ctx, probeTransport)
 	// Update channel is closed when ctx is done.
 	t.run(rbm.updates())
 }


### PR DESCRIPTION
When a pod shows up in endpoints, the activator [probes it with the `K-Network-Probe` header](https://github.com/knative/serving/blob/d16dfead3480900db8e4a6a95ad4c8059c0287f5/pkg/activator/net/revision_backends.go#L163) to establish readiness before it proxies over requests. Since the probe (before this change) did not share a `transport` (and therefore a keep-alive connection pool) with the proxy, the probe connections couldn't be reused for the actual requests, meaning we're ending up pointlessly doing the (relatively expensive) connection dance twice on pod startup. 

This change shares the `transport` (and therefore the keep-alive pool) between the throttler and the activator handler, allowing probe connections to be reused for actual requests, and avoiding the extra reconnect. 

Note: before and after this change all transports are created via `pkg/network.NewAutoTransport`, so the actual transport options should be the same (other than the keep alive pool size and the fact it's now being shared) after this PR as before.

```release-note
Enables connection reuse between activator probe and proxy to improve first request performance after cold starts
```

/assign @markusthoemmes @vagababov 
