### PR TITLE
Stamp the start time when the rollout starts

### DIFF
--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -39,6 +39,9 @@ import (
 	"knative.dev/serving/pkg/reconciler/route/traffic"
 )
 
+// For mocking in tests.
+var rolloutClock rolloutClock.RealClock
+
 func (c *Reconciler) reconcileIngress(
 	ctx context.Context, r *v1.Route, tc *traffic.Config,
 	tls []netv1alpha1.IngressTLS,
@@ -75,7 +78,7 @@ func (c *Reconciler) reconcileIngress(
 			ingress.Annotations[networking.RolloutAnnotationKey])
 
 		// And recompute the rollout state.
-		effectiveRO := curRO.Step(prevRO)
+		effectiveRO := curRO.Step(prevRO, rolloutClock)
 		desired, err := resources.MakeIngressWithRollout(ctx, r, tc, effectiveRO,
 			tls, ingressClass, acmeChallenges...)
 		if err != nil {

--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -39,9 +39,6 @@ import (
 	"knative.dev/serving/pkg/reconciler/route/traffic"
 )
 
-// For mocking in tests.
-var rolloutClock rolloutClock.RealClock
-
 func (c *Reconciler) reconcileIngress(
 	ctx context.Context, r *v1.Route, tc *traffic.Config,
 	tls []netv1alpha1.IngressTLS,
@@ -78,7 +75,7 @@ func (c *Reconciler) reconcileIngress(
 			ingress.Annotations[networking.RolloutAnnotationKey])
 
 		// And recompute the rollout state.
-		effectiveRO := curRO.Step(prevRO, rolloutClock)
+		effectiveRO := curRO.Step(prevRO, c.clock)
 		desired, err := resources.MakeIngressWithRollout(ctx, r, tc, effectiveRO,
 			tls, ingressClass, acmeChallenges...)
 		if err != nil {

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -717,7 +717,7 @@ func TestReconcile(t *testing.T) {
 					RevisionName: "config-00001", Percent: 99,
 				}, {
 					RevisionName: "config-00002", Percent: 1,
-				}})),
+				}}, fakeCurTime)),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: Route("default", "new-latest-ready", WithConfigTarget("config"),
@@ -921,7 +921,7 @@ func TestReconcile(t *testing.T) {
 					RevisionName: "config-00001", Percent: 99,
 				}, {
 					RevisionName: "config-00002", Percent: 1,
-				}})),
+				}}, fakeCurTime)),
 		}},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: Route("default", "update-ci-failure", WithConfigTarget("config"),
@@ -2603,11 +2603,12 @@ func url(s string) *apis.URL {
 	return url
 }
 
-func simpleRollout(cfg string, revs []traffic.RevisionRollout) IngressOption {
+func simpleRollout(cfg string, revs []traffic.RevisionRollout, now time.Time) IngressOption {
 	return func(i *netv1alpha1.Ingress) {
 		r := &traffic.Rollout{
 			Configurations: []traffic.ConfigurationRollout{{
 				ConfigurationName: cfg,
+				StartTime:         int(now.Unix()),
 				Percent:           100,
 				Revisions:         revs,
 			}},

--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -24,7 +24,7 @@ package traffic
 import (
 	"sort"
 
-	"k8s.io/apimachinery/pkg/util/clock"
+	"knative.dev/pkg/system"
 )
 
 // Rollout encapsulates the current rollout state of the system.
@@ -120,7 +120,7 @@ func (cur *Rollout) Validate() bool {
 // At the end of the call the returned object will contain the
 // desired traffic shape.
 // Step will return cur if no previous state was available.
-func (cur *Rollout) Step(prev *Rollout, clk clock.Clock) *Rollout {
+func (cur *Rollout) Step(prev *Rollout, clk system.Clock) *Rollout {
 	if prev == nil || len(prev.Configurations) == 0 {
 		return cur
 	}
@@ -223,7 +223,7 @@ func adjustPercentage(goal int, cr *ConfigurationRollout) {
 
 // stepConfig takes previous and goal configuration shapes and returns a new
 // config rollout, after computing the percetage allocations.
-func stepConfig(goal, prev *ConfigurationRollout, clk clock.Clock) *ConfigurationRollout {
+func stepConfig(goal, prev *ConfigurationRollout, clk system.Clock) *ConfigurationRollout {
 	pc := len(prev.Revisions)
 	ret := &ConfigurationRollout{
 		ConfigurationName: goal.ConfigurationName,

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -28,12 +28,14 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"k8s.io/apimachinery/pkg/util/clock"
+	ptest "knative.dev/pkg/reconciler/testing"
 )
 
 func TestStep(t *testing.T) {
 	now := time.Now()
-	clk := clock.NewFakeClock(now)
+	clk := ptest.FakeClock{
+		Time: now,
+	}
 	tests := []struct {
 		name            string
 		prev, cur, want *Rollout

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -24,12 +24,16 @@ package traffic
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/util/clock"
 )
 
 func TestStep(t *testing.T) {
+	now := time.Now()
+	clk := clock.NewFakeClock(now)
 	tests := []struct {
 		name            string
 		prev, cur, want *Rollout
@@ -201,6 +205,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
+				StartTime:         int(now.Unix()),
 				Revisions: []RevisionRollout{{
 					RevisionName: "goat-head-soup",
 					Percent:      99,
@@ -239,6 +244,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           33,
+				StartTime:         int(now.Unix()),
 				Revisions: []RevisionRollout{{
 					RevisionName: "goat-head-soup",
 					Percent:      2,
@@ -279,6 +285,7 @@ func TestStep(t *testing.T) {
 		want: &Rollout{
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
+				StartTime:         int(now.Unix()),
 				Percent:           75,
 				Revisions: []RevisionRollout{{
 					RevisionName: "goat-head-soup",
@@ -318,6 +325,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "brian",
 				Percent:           70,
+				StartTime:         int(now.Unix()),
 				Revisions: []RevisionRollout{{
 					RevisionName: "exile-on-main-st",
 					Percent:      69,
@@ -343,6 +351,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
+				StartTime:         int(now.Unix()) - 1982, // A rollout in progress, this would be set.
 				Revisions: []RevisionRollout{{
 					RevisionName: "goat-head-soup",
 					Percent:      95,
@@ -356,6 +365,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
+				StartTime:         int(now.Unix()),
 				Revisions: []RevisionRollout{{
 					RevisionName: "goat-head-soup",
 					Percent:      95,
@@ -384,6 +394,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
+				StartTime:         int(now.Unix()) - 1984, // A rollout in progress, this would be set.
 				Revisions: []RevisionRollout{{
 					RevisionName: "goat-head-soup",
 					Percent:      99,
@@ -396,6 +407,7 @@ func TestStep(t *testing.T) {
 		want: &Rollout{
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
+				StartTime:         int(now.Unix()),
 				Percent:           100,
 				Revisions: []RevisionRollout{{
 					RevisionName: "goat-head-soup",
@@ -565,6 +577,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "keith",
 				Percent:           99,
+				StartTime:         int(now.Unix()),
 				Revisions: []RevisionRollout{{ // <-- note this one actually rolls.
 					RevisionName: "can't-get-no-satisfaction",
 					Percent:      98,
@@ -677,7 +690,7 @@ func TestStep(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := tc.cur.Step(tc.prev)
+			got := tc.cur.Step(tc.prev, clk)
 			if want := tc.want; !cmp.Equal(got, want, cmpopts.EquateEmpty()) {
 				t.Errorf("Wrong rolled rollout, diff(-want,+got):\n%s", cmp.Diff(want, got))
 			}


### PR DESCRIPTION
We need to stamp the rollout with when it started, so when the ingress becomes ready,
we can set the rollout step time.

/assign @tcnghia 