### PR TITLE
Observe start time and compute step time

### DIFF
--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -2608,7 +2608,7 @@ func simpleRollout(cfg string, revs []traffic.RevisionRollout, now time.Time) In
 		r := &traffic.Rollout{
 			Configurations: []traffic.ConfigurationRollout{{
 				ConfigurationName: cfg,
-				StartTime:         int(now.Unix()),
+				StartTime:         int(now.UnixNano()),
 				Percent:           100,
 				Revisions:         revs,
 			}},


### PR DESCRIPTION
Also refactor to accept time in nanonsecs directly, than pass in time.
This simplifies testing as well

/assign @tcnghia 
