### PR TITLE
Add more tests to ensure the proper reconcile paths are covered.

### DIFF
--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -382,7 +382,7 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "default/becomes-ready",
 	}, {
-		Name: "### simple route when ingress becomes ready",
+		Name: "simple route rollout when ingress becomes ready",
 		Objects: []runtime.Object{
 			Route("default", "becomes-ready", WithConfigTarget("config"),
 				WithRouteGeneration(2009), MarkIngressNotConfigured),

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -382,6 +382,92 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "default/becomes-ready",
 	}, {
+		Name: "### simple route when ingress becomes ready",
+		Objects: []runtime.Object{
+			Route("default", "becomes-ready", WithConfigTarget("config"),
+				WithRouteGeneration(2009), MarkIngressNotConfigured),
+			cfg("default", "config",
+				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
+			simpleReadyIngress(
+				Route("default", "becomes-ready", WithConfigTarget("config"), WithURL),
+				&traffic.Config{
+					Targets: map[string]traffic.RevisionTargets{
+						traffic.DefaultTarget: {{
+							TrafficTarget: v1.TrafficTarget{
+								ConfigurationName: "config",
+								RevisionName:      "config-00001",
+								Percent:           ptr.Int64(100),
+								LatestRevision:    ptr.Bool(true),
+							},
+						}},
+					},
+				},
+				simpleRollout("config", []traffic.RevisionRollout{{
+					RevisionName: "config-00000", Percent: 99,
+				}, {
+					RevisionName: "config-00001", Percent: 1,
+				}}, fakeCurTime.Add(-3*time.Second)),
+			),
+		},
+		WantCreates: []runtime.Object{
+			simplePlaceholderK8sService(getContext(), Route("default", "becomes-ready", WithConfigTarget("config")), ""),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{
+			{
+				// ingress should be updated with the new rollout data.
+				Object: simpleReadyIngress(
+					Route("default", "becomes-ready", WithConfigTarget("config"), WithURL),
+					&traffic.Config{
+						Targets: map[string]traffic.RevisionTargets{
+							traffic.DefaultTarget: {{
+								TrafficTarget: v1.TrafficTarget{
+									ConfigurationName: "config",
+									RevisionName:      "config-00001",
+									Percent:           ptr.Int64(100),
+									LatestRevision:    ptr.Bool(true),
+								},
+							}},
+						},
+					},
+					simpleRollout("config", []traffic.RevisionRollout{{
+						RevisionName: "config-00000", Percent: 99,
+					}, {
+						RevisionName: "config-00001", Percent: 1,
+					}}, fakeCurTime.Add(-3*time.Second),
+						func(r *traffic.Rollout) {
+							// Step duration is 3s (now - (now-3s)).
+							r.Configurations[0].StepDuration = 3
+							// 120 / 3 = 40 steps. floor(100/40) = 2.
+							r.Configurations[0].StepSize = 2
+							// StepDuration is 3, and so next step is `now` + 3.
+							r.Configurations[0].NextStepTime = int(fakeCurTime.Add(3 * time.Second).UnixNano())
+						},
+					)),
+			},
+			{
+				Object: simpleK8sService(
+					Route("default", "becomes-ready", WithConfigTarget("config")),
+				),
+			},
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: Route("default", "becomes-ready", WithConfigTarget("config"),
+				// Populated by reconciliation when the route becomes ready.
+				WithURL, WithAddress, WithRouteConditionsAutoTLSDisabled,
+				WithRouteGeneration(2009), WithRouteObservedGeneration,
+				MarkTrafficAssigned, MarkIngressReady, WithStatusTraffic(
+					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(100),
+						LatestRevision: ptr.Bool(true),
+					})),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, "Created", "Created placeholder service %q", "becomes-ready"),
+		},
+		Key: "default/becomes-ready",
+	}, {
 		Name: "failure creating k8s placeholder service",
 		// We induce a failure creating the placeholder service.
 		WantErr: true,
@@ -2603,7 +2689,10 @@ func url(s string) *apis.URL {
 	return url
 }
 
-func simpleRollout(cfg string, revs []traffic.RevisionRollout, now time.Time) IngressOption {
+type rolloutOption func(*traffic.Rollout)
+
+func simpleRollout(cfg string, revs []traffic.RevisionRollout,
+	now time.Time, ros ...rolloutOption) IngressOption {
 	return func(i *netv1alpha1.Ingress) {
 		r := &traffic.Rollout{
 			Configurations: []traffic.ConfigurationRollout{{
@@ -2612,6 +2701,9 @@ func simpleRollout(cfg string, revs []traffic.RevisionRollout, now time.Time) In
 				Percent:           100,
 				Revisions:         revs,
 			}},
+		}
+		for _, ro := range ros {
+			ro(r)
 		}
 		i.Annotations[networking.RolloutAnnotationKey] = func() string {
 			d, _ := json.Marshal(r)

--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -69,7 +69,7 @@ type ConfigurationRollout struct {
 
 	// NextStepTime is the Unix timestamp when the next
 	// rollout step should performed.
-	NextStepTime int `json:"lastStep,omitempty"`
+	NextStepTime int `json:"nextStepTime,omitempty"`
 
 	// StepDuration is a rounded up number of seconds how long it took
 	// for ingress to successfully move first 1% of traffic to the new revision.


### PR DESCRIPTION
existing tests were not ensuring that we properly roundtrip and call
observe and populate the timing and % fields.
This test does that.

/assign @tcnghia 