### PR TITLE
add feature flag for hostAliases

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "2d4c16b9"
+    knative.dev/example-checksum: "4437b773"
 data:
   _example: |
     ################################
@@ -49,6 +49,12 @@ data:
     # WARNING: Cannot safely be disabled once enabled.
     # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-node-affinity
     kubernetes.podspec-affinity: "disabled"
+
+    # Indicates whether Kubernetes hostAliases support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-host-aliases
+    kubernetes.podspec-hostaliases: "disabled"
 
     # Indicates whether Kubernetes nodeSelector support is enabled
     #

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -44,6 +44,7 @@ func defaultFeaturesConfig() *Features {
 		MultiContainer:          Enabled,
 		PodSpecAffinity:         Disabled,
 		PodSpecDryRun:           Allowed,
+		PodSpecHostAliases:      Disabled,
 		PodSpecFieldRef:         Disabled,
 		PodSpecNodeSelector:     Disabled,
 		PodSpecRuntimeClassName: Disabled,
@@ -61,6 +62,7 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 		asFlag("multi-container", &nc.MultiContainer),
 		asFlag("kubernetes.podspec-affinity", &nc.PodSpecAffinity),
 		asFlag("kubernetes.podspec-dryrun", &nc.PodSpecDryRun),
+		asFlag("kubernetes.podspec-hostaliases", &nc.PodSpecHostAliases),
 		asFlag("kubernetes.podspec-fieldref", &nc.PodSpecFieldRef),
 		asFlag("kubernetes.podspec-nodeselector", &nc.PodSpecNodeSelector),
 		asFlag("kubernetes.podspec-runtimeclassname", &nc.PodSpecRuntimeClassName),
@@ -83,6 +85,7 @@ type Features struct {
 	PodSpecAffinity         Flag
 	PodSpecDryRun           Flag
 	PodSpecFieldRef         Flag
+	PodSpecHostAliases      Flag
 	PodSpecNodeSelector     Flag
 	PodSpecRuntimeClassName Flag
 	PodSpecSecurityContext  Flag

--- a/pkg/apis/config/features_test.go
+++ b/pkg/apis/config/features_test.go
@@ -62,6 +62,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 			MultiContainer:          Enabled,
 			PodSpecAffinity:         Enabled,
 			PodSpecDryRun:           Enabled,
+			PodSpecHostAliases:      Enabled,
 			PodSpecNodeSelector:     Enabled,
 			PodSpecRuntimeClassName: Enabled,
 			PodSpecSecurityContext:  Enabled,
@@ -72,6 +73,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 			"multi-container":                     "Enabled",
 			"kubernetes.podspec-affinity":         "Enabled",
 			"kubernetes.podspec-dryrun":           "Enabled",
+			"kubernetes.podspec-hostaliases":      "Enabled",
 			"kubernetes.podspec-nodeselector":     "Enabled",
 			"kubernetes.podspec-runtimeclassname": "Enabled",
 			"kubernetes.podspec-securitycontext":  "Enabled",
@@ -159,6 +161,33 @@ func TestFeaturesConfiguration(t *testing.T) {
 		}),
 		data: map[string]string{
 			"kubernetes.podspec-dryrun": "Disabled",
+		},
+	}, {
+		name:    "kubernetes.podspec-hostaliases Disabled",
+		wantErr: false,
+		wantFeatures: defaultWith(&Features{
+			PodSpecHostAliases: Disabled,
+		}),
+		data: map[string]string{
+			"kubernetes.podspec-hostaliases": "Disabled",
+		},
+	}, {
+		name:    "kubernetes.podspec-hostaliases Allowed",
+		wantErr: false,
+		wantFeatures: defaultWith(&Features{
+			PodSpecHostAliases: Allowed,
+		}),
+		data: map[string]string{
+			"kubernetes.podspec-hostaliases": "Allowed",
+		},
+	}, {
+		name:    "kubernetes.podspec-hostaliases Enabled",
+		wantErr: false,
+		wantFeatures: defaultWith(&Features{
+			PodSpecHostAliases: Enabled,
+		}),
+		data: map[string]string{
+			"kubernetes.podspec-hostaliases": "Enabled",
 		},
 	}, {
 		name:    "kubernetes.podspec-nodeselector Allowed",

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -176,6 +176,9 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	if cfg.Features.PodSpecAffinity != config.Disabled {
 		out.Affinity = in.Affinity
 	}
+	if cfg.Features.PodSpecHostAliases != config.Disabled {
+		out.HostAliases = in.HostAliases
+	}
 	if cfg.Features.PodSpecNodeSelector != config.Disabled {
 		out.NodeSelector = in.NodeSelector
 	}
@@ -205,7 +208,6 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.Hostname = ""
 	out.Subdomain = ""
 	out.SchedulerName = ""
-	out.HostAliases = nil
 	out.PriorityClassName = ""
 	out.Priority = nil
 	out.DNSConfig = nil

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -55,6 +55,13 @@ func withPodSpecAffinityEnabled() configOption {
 	}
 }
 
+func withPodSpecHostAliasesEnabled() configOption {
+	return func(cfg *config.Config) *config.Config {
+		cfg.Features.PodSpecHostAliases = config.Enabled
+		return cfg
+	}
+}
+
 func withPodSpecNodeSelectorEnabled() configOption {
 	return func(cfg *config.Config) *config.Config {
 		cfg.Features.PodSpecNodeSelector = config.Enabled
@@ -579,6 +586,19 @@ func TestPodSpecFeatureValidation(t *testing.T) {
 			Paths:   []string{"affinity"},
 		},
 		cfgOpts: []configOption{withPodSpecAffinityEnabled()},
+	}, {
+		name: "HostAliases",
+		featureSpec: corev1.PodSpec{
+			HostAliases: []corev1.HostAlias{{
+				IP:        "127.0.0.1",
+				Hostnames: []string{"foo.remote", "bar.remote"},
+			}},
+		},
+		err: &apis.FieldError{
+			Message: "must not set the field(s)",
+			Paths:   []string{"hostAliases"},
+		},
+		cfgOpts: []configOption{withPodSpecHostAliasesEnabled()},
 	}, {
 		name: "NodeSelector",
 		featureSpec: corev1.PodSpec{

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -383,6 +383,7 @@ func testConfig() *config.Config {
 			PodSpecAffinity:       apiConfig.Disabled,
 			PodSpecFieldRef:       apiConfig.Disabled,
 			PodSpecDryRun:         apiConfig.Enabled,
+			PodSpecHostAliases:    apiConfig.Disabled,
 			PodSpecNodeSelector:   apiConfig.Disabled,
 			PodSpecTolerations:    apiConfig.Disabled,
 			TagHeaderBasedRouting: apiConfig.Disabled,

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -2653,6 +2653,7 @@ func reconcilerTestConfig(enableAutoTLS bool) *config.Config {
 			PodSpecAffinity:       cfgmap.Disabled,
 			PodSpecFieldRef:       cfgmap.Disabled,
 			PodSpecDryRun:         cfgmap.Enabled,
+			PodSpecHostAliases:    cfgmap.Disabled,
 			PodSpecNodeSelector:   cfgmap.Disabled,
 			PodSpecTolerations:    cfgmap.Disabled,
 			TagHeaderBasedRouting: cfgmap.Disabled,


### PR DESCRIPTION
Fixes #9415 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds a flag kubernetes.podspec-hostaliases in config-features with a default of `disabled`
* Adds unit tests for this feature flag

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
A feature flag is now available to enable hostAliases for Knative Services. See config-features for details.

```
