### PR TITLE
Stop rolling when we're done with the config rollout

### DIFF
--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -293,7 +293,13 @@ func stepRevisions(goal *ConfigurationRollout, nowTS int) {
 	// And cull the tail portion of it.
 	goal.Revisions = goal.Revisions[:writePos+1]
 	// Also set the next time.
-	goal.NextStepTime = nowTS + goal.StepDuration
+	if len(goal.Revisions) > 1 {
+		goal.NextStepTime = nowTS + goal.StepDuration
+	} else {
+		// This is the last step, we're done!
+		goal.NextStepTime = 0
+		goal.StartTime = 0
+	}
 }
 
 // stepConfig takes previous and goal configuration shapes and returns a new

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -1090,6 +1090,7 @@ func TestStepRevisions(t *testing.T) {
 		now:  1982,
 		cfg: &ConfigurationRollout{
 			NextStepTime: 1984,
+			StepDuration: 10,
 			StepSize:     10,
 			Revisions: []RevisionRollout{{
 				Percent: 10,
@@ -1097,6 +1098,7 @@ func TestStepRevisions(t *testing.T) {
 		},
 		want: &ConfigurationRollout{
 			NextStepTime: 1984,
+			StepDuration: 10,
 			StepSize:     10,
 			Revisions: []RevisionRollout{{
 				Percent: 10,
@@ -1176,9 +1178,38 @@ func TestStepRevisions(t *testing.T) {
 		},
 		want: &ConfigurationRollout{
 			Percent:      15,
-			NextStepTime: 1988 + 77,
+			NextStepTime: 0,
 			StepDuration: 77,
 			StepSize:     10,
+			Revisions: []RevisionRollout{{
+				Percent: 15,
+			}},
+		},
+	}, {
+		name: "the very last step",
+		now:  2006,
+		cfg: &ConfigurationRollout{
+			NextStepTime: 1984,
+			Percent:      15,
+			StartTime:    1977,
+			StepDuration: 77,
+			StepSize:     8,
+			Revisions: []RevisionRollout{{
+				Percent: 5,
+			}, {
+				Percent: 1,
+			}, {
+				Percent: 1,
+			}, {
+				Percent: 8,
+			}},
+		},
+		want: &ConfigurationRollout{
+			NextStepTime: 0,
+			Percent:      15,
+			StartTime:    0,
+			StepDuration: 77,
+			StepSize:     8,
 			Revisions: []RevisionRollout{{
 				Percent: 15,
 			}},


### PR DESCRIPTION
Ensure we reset next step time to 0, so nothing more happens to this rollout
The same with the starttime.

/assign @tcnghia 

For #9766