### PR TITLE
Disable revision stepping for now

### DIFF
--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -335,10 +335,6 @@ func stepConfig(goal, prev *ConfigurationRollout, nowTS int) *ConfigurationRollo
 			ret.StepDuration = prev.StepDuration
 			ret.StartTime = prev.StartTime
 			ret.StepSize = prev.StepSize
-			// adjustPercentage above would've already accounted if target for the
-			// whole Configuration changed up or down. So here we should just redistribute
-			// the existing values.
-			stepRevisions(ret, nowTS)
 		}
 		return ret
 	}


### PR DESCRIPTION
This should fix our horrible flake rate for now to allow us to fix things calmly.