### PR TITLE
Fix the bug when the rollout was in a busy loop preventing ingress from being ready

### DIFF
--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -80,7 +80,7 @@ func (c *Reconciler) reconcileIngress(
 		effectiveRO := curRO.Step(prevRO, int(c.clock.Now().UnixNano()))
 
 		// Comparing and diffing isn't cheap so do it only if we're going
-		// to actually log the messagd.
+		// to actually log the message.
 		// Those are well known types, cmp won't panic.
 		logger := logging.FromContext(ctx).Desugar()
 		if logger.Core().Enabled(zapcore.DebugLevel) && !cmp.Equal(prevRO, effectiveRO) {

--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -323,7 +323,7 @@ func stepConfig(goal, prev *ConfigurationRollout, nowTS int) *ConfigurationRollo
 	// If it matches the last revision of the previous rollout state (or there were no revisions)
 	// then no new rollout has begun for this configuration.
 	if len(prev.Revisions) == 0 || goal.Revisions[0].RevisionName == prev.Revisions[pc-1].RevisionName {
-		// So if |prev.revisions| == 0 => then there was no rolloutm —
+		// So if |prev.revisions| == 0 => then there was no rollout —
 		// nothing is required to step.
 		// If |prev.revisions| == 1 and it matches current revision then
 		// we're done.


### PR DESCRIPTION
The bug was introduced, thanks for @markusthoemmes for finding it, when
I added `stepRevisions` call.
That call would compute the next rollout step time and update the
corresponding field on the rollout.
Unfortunately this can happen before `ObserveReady` is called and the
rest of the rollout params are computed.
This lead to `step=0`, which meant we'd never progress and constantly
update the next step time, creating a busy loop of sorts.

The fix is to not step revisions until we have computed the rest of the
stats, basically by gating `stepSize > 0`, which is guaranteed to be at
least 1, when the readiness is observed.

Also added some logging to help with this rollout debugging.