### PR TITLE
Use an interface for bucketProcessor.

### DIFF
--- a/pkg/autoscaler/statforwarder/forwarder.go
+++ b/pkg/autoscaler/statforwarder/forwarder.go
@@ -172,6 +172,9 @@ func (f *Forwarder) filterFunc(namespace string) func(interface{}) bool {
 			f.logger.Warn("Found invalid Lease holder identify ", holder)
 			return false
 		}
+		if p := f.getProcessor(l.Name); p != nil && p.is(holder) {
+			return false
+		}
 
 		return true
 	}
@@ -335,6 +338,7 @@ func (f *Forwarder) createProcessor(ns, bkt, ip, holder string) bucketProcessor 
 	if ip == f.selfIP {
 		return &localProcessor{
 			bkt:    bkt,
+			holder: holder,
 			logger: f.logger.With(zap.String("bucket", bkt)),
 			accept: f.accept,
 		}

--- a/pkg/autoscaler/statforwarder/forwarder_test.go
+++ b/pkg/autoscaler/statforwarder/forwarder_test.go
@@ -437,7 +437,8 @@ func TestProcess(t *testing.T) {
 
 	if err := wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (bool, error) {
 		_, p1owned := f.getProcessor(bucket1).(*localProcessor)
-		return p1owned, nil
+		_, p2notowned := f.getProcessor(bucket2).(*remoteProcessor)
+		return p1owned && p2notowned, nil
 	}); err != nil {
 		t.Fatalf("Timeout waiting f.processors got updated")
 	}

--- a/pkg/autoscaler/statforwarder/processor.go
+++ b/pkg/autoscaler/statforwarder/processor.go
@@ -33,9 +33,34 @@ import (
 // accessed by IP address directly due to the network mesh.
 const establishTimeout = 500 * time.Millisecond
 
-// bucketProcessor includes the information about how to process
-// the StatMessage owned by a bucket.
-type bucketProcessor struct {
+type bucketProcessor interface {
+	process(asmetrics.StatMessage) error
+	shutdown()
+}
+
+// localProcessor implements bucketProcessor for an owned bucket.
+type localProcessor struct {
+	logger *zap.SugaredLogger
+	// The name of the bucket
+	bkt string
+	// `accept` is the function to process a StatMessage which doesn't need
+	// to be forwarded.
+	accept statProcessor
+}
+
+var _ bucketProcessor = (*localProcessor)(nil)
+
+func (p *localProcessor) process(sm asmetrics.StatMessage) error {
+	l := p.logger.With(zap.String(logkey.Key, sm.Key.String()))
+	l.Debug("Accept stat as owner of bucket ", p.bkt)
+	p.accept(sm)
+	return nil
+}
+
+func (p *localProcessor) shutdown() {}
+
+// remoteProcessor implements bucketProcessor for an unowned bucket.
+type remoteProcessor struct {
 	logger *zap.SugaredLogger
 	// The name of the bucket
 	bkt string
@@ -45,12 +70,11 @@ type bucketProcessor struct {
 	connLock sync.RWMutex
 	// conn is the WebSocket connection to the holder pod.
 	conn *websocket.ManagedConnection
-	// `accept` is the function to process a StatMessage which doesn't need
-	// to be forwarded.
-	accept statProcessor
 }
 
-func newForwardProcessor(logger *zap.SugaredLogger, bkt, holder, podDNS, svcDNS string) *bucketProcessor {
+var _ bucketProcessor = (*remoteProcessor)(nil)
+
+func newForwardProcessor(logger *zap.SugaredLogger, bkt, holder, podDNS, svcDNS string) *remoteProcessor {
 	// First try to connect via Pod IP address synchronously. If the connection can
 	// not be established within `establishTimeout`, we assume the pods can not be
 	// accessed by IP address. Then try to connect via Pod IP address synchronously.
@@ -60,7 +84,7 @@ func newForwardProcessor(logger *zap.SugaredLogger, bkt, holder, podDNS, svcDNS 
 		logger.Info("Autoscaler pods can't be accessed by IP address. Connecting to Autoscaler bucket at ", svcDNS)
 		c, _ = websocket.NewDurableSendingConnectionGuaranteed(svcDNS, establishTimeout, logger)
 	}
-	return &bucketProcessor{
+	return &remoteProcessor{
 		logger: logger,
 		bkt:    bkt,
 		holder: holder,
@@ -69,25 +93,20 @@ func newForwardProcessor(logger *zap.SugaredLogger, bkt, holder, podDNS, svcDNS 
 	}
 }
 
-func (p *bucketProcessor) getConn() *websocket.ManagedConnection {
+func (p *remoteProcessor) getConn() *websocket.ManagedConnection {
 	p.connLock.RLock()
 	defer p.connLock.RUnlock()
 	return p.conn
 }
 
-func (p *bucketProcessor) setConn(conn *websocket.ManagedConnection) {
+func (p *remoteProcessor) setConn(conn *websocket.ManagedConnection) {
 	p.connLock.Lock()
 	defer p.connLock.Unlock()
 	p.conn = conn
 }
 
-func (p *bucketProcessor) process(sm asmetrics.StatMessage) error {
+func (p *remoteProcessor) process(sm asmetrics.StatMessage) error {
 	l := p.logger.With(zap.String(logkey.Key, sm.Key.String()))
-	if p.accept != nil {
-		l.Debug("Accept stat as owner of bucket ", p.bkt)
-		p.accept(sm)
-		return nil
-	}
 
 	l.Debugf("Forward stat of bucket %s to the holder %s", p.bkt, p.holder)
 	wsms := asmetrics.ToWireStatMessages([]asmetrics.StatMessage{sm})
@@ -108,7 +127,7 @@ func (p *bucketProcessor) process(sm asmetrics.StatMessage) error {
 	return c.SendRaw(gorillawebsocket.BinaryMessage, b)
 }
 
-func (p *bucketProcessor) shutdown() {
+func (p *remoteProcessor) shutdown() {
 	if c := p.getConn(); c != nil {
 		c.Shutdown()
 	}

--- a/pkg/autoscaler/statforwarder/processor.go
+++ b/pkg/autoscaler/statforwarder/processor.go
@@ -35,7 +35,10 @@ const establishTimeout = 500 * time.Millisecond
 
 type bucketProcessor interface {
 	process(asmetrics.StatMessage) error
+
+	// is returns whether the current processor *is* the specified holder.
 	is(holder string) bool
+
 	shutdown()
 }
 


### PR DESCRIPTION
_This is the first (small) piece of what is bound to become a much bigger refactor._

This converts `bucketProcessor` into an interface, and splits the two conflated implementations of the struct into distinct implementations of this interface: `localProcessor` and `remoteProcessor`.

/assign @vagababov @markusthoemmes @yanweiguo 