### PR TITLE
Split apart the forwarder.

### DIFF
--- a/pkg/autoscaler/statforwarder/forwarder.go
+++ b/pkg/autoscaler/statforwarder/forwarder.go
@@ -130,6 +130,10 @@ func New(ctx context.Context, logger *zap.SugaredLogger, kc kubernetes.Interface
 	return f
 }
 
+// leaseTracker monitors lease resources to update the Forwarder's processor configuration(s)
+// with the appropriate owner's stats endpoint.  When we own the lease, a localProcessor is
+// used, and when someone else owns the lease a remoteProcessor is used with their stats
+// endpoint.
 type leaseTracker struct {
 	logger *zap.SugaredLogger
 	selfIP string

--- a/pkg/autoscaler/statforwarder/processor.go
+++ b/pkg/autoscaler/statforwarder/processor.go
@@ -74,8 +74,13 @@ type remoteProcessor struct {
 	// The name of the bucket
 	bkt string
 	// holder is the HolderIdentity of a Lease for a bucket.
-	holder   string
-	addrs    []string
+	holder string
+
+	// addrs contains the list of addresses for the remote to try in the order to try them.
+	// The first address to establish a successful connection will be used until things reset
+	// at which point the order is re-evaluated.
+	addrs []string
+
 	connLock sync.RWMutex
 	// conn is the WebSocket connection to the holder pod.
 	conn *websocket.ManagedConnection

--- a/pkg/autoscaler/statforwarder/processor_test.go
+++ b/pkg/autoscaler/statforwarder/processor_test.go
@@ -79,7 +79,7 @@ func TestProcessorForwardingViaSvcRetry(t *testing.T) {
 	}
 
 	// Change to a working URL
-	p.svcDNS = "ws" + strings.TrimPrefix(s.URL, "http")
+	p.addrs = []string{"ws" + strings.TrimPrefix(s.URL, "http")}
 	p.process(stat1)
 
 	select {


### PR DESCRIPTION
The forwarder currently conflates two separable things:
1. Resolving the current owner of a bucket.
2. Forwarding stats to the owner of a bucket.

This builds on https://github.com/knative/serving/pull/10313 and splits the lease tracking logic off of Forwarder.

Ultimately the goals (not realized here!) of this are multi-fold:
1. The forwarder doesn't understand anything about leases or bucket anatomy, it uses an "oracle" of sorts to tell it where to send things.
2. The lease tracker implements the "oracle" functionality above by decoding lease holder identities.
3. As a proof-point of the abstraction, we can plug in StatefulSets as an alternative bucketing mechanism (and forgo LE entirely).
