### PR TITLE
 Unify the params to all be in nanoseconds.

### DIFF
--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -148,7 +147,6 @@ func TestMakeIngressWithRollout(t *testing.T) {
 		OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(r)},
 	}
 	ing, err := MakeIngress(testContext(), r, cfg, nil, ingressClass)
-	fmt.Println("####\n" + ing.Annotations[networking.RolloutAnnotationKey])
 	if err != nil {
 		t.Error("Unexpected error", err)
 	}

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -141,12 +142,13 @@ func TestMakeIngressWithRollout(t *testing.T) {
 		Annotations: map[string]string{
 			// Make sure to get passdownIngressClass instead of ingressClass
 			networking.IngressClassAnnotationKey: passdownIngressClass,
-			networking.RolloutAnnotationKey:      `{"configurations":[{"configurationName":"valhalla","percent":100,"revisions":[{"revisionName":"valhalla-01982","percent":100}]},{"configurationName":"thor","tag":"tagged","percent":100,"revisions":[{"revisionName":"thor-02020","percent":100}]}]}`,
+			networking.RolloutAnnotationKey:      `{"configurations":[{"configurationName":"valhalla","percent":100,"revisions":[{"revisionName":"valhalla-01982","percent":100}],"params":{}},{"configurationName":"thor","tag":"tagged","percent":100,"revisions":[{"revisionName":"thor-02020","percent":100}],"params":{}}]}`,
 			"test-annotation":                    "bar",
 		},
 		OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(r)},
 	}
 	ing, err := MakeIngress(testContext(), r, cfg, nil, ingressClass)
+	fmt.Println("####\n" + ing.Annotations[networking.RolloutAnnotationKey])
 	if err != nil {
 		t.Error("Unexpected error", err)
 	}

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -141,7 +141,7 @@ func TestMakeIngressWithRollout(t *testing.T) {
 		Annotations: map[string]string{
 			// Make sure to get passdownIngressClass instead of ingressClass
 			networking.IngressClassAnnotationKey: passdownIngressClass,
-			networking.RolloutAnnotationKey:      `{"configurations":[{"configurationName":"valhalla","percent":100,"revisions":[{"revisionName":"valhalla-01982","percent":100}],"params":{}},{"configurationName":"thor","tag":"tagged","percent":100,"revisions":[{"revisionName":"thor-02020","percent":100}],"params":{}}]}`,
+			networking.RolloutAnnotationKey:      `{"configurations":[{"configurationName":"valhalla","percent":100,"revisions":[{"revisionName":"valhalla-01982","percent":100}],"stepParams":{}},{"configurationName":"thor","tag":"tagged","percent":100,"revisions":[{"revisionName":"thor-02020","percent":100}],"stepParams":{}}]}`,
 			"test-annotation":                    "bar",
 		},
 		OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(r)},

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -436,11 +436,11 @@ func TestReconcile(t *testing.T) {
 				}}, fakeCurTime.Add(-3*time.Second),
 					func(r *traffic.Rollout) {
 						// Step duration is 3s (now - (now-3s)).
-						r.Configurations[0].Params.StepDuration = 3
+						r.Configurations[0].StepParams.StepDuration = 3
 						// 120 / 3 = 40 steps. floor(100/40) = 2.
-						r.Configurations[0].Params.StepSize = 2
+						r.Configurations[0].StepParams.StepSize = 2
 						// StepDuration is 3, and so next step is `now` + 3.
-						r.Configurations[0].Params.NextStepTime = int(fakeCurTime.Add(3 * time.Second).UnixNano())
+						r.Configurations[0].StepParams.NextStepTime = int(fakeCurTime.Add(3 * time.Second).UnixNano())
 					},
 				)),
 		}, {
@@ -2694,7 +2694,7 @@ func simpleRollout(cfg string, revs []traffic.RevisionRollout,
 		r := &traffic.Rollout{
 			Configurations: []traffic.ConfigurationRollout{{
 				ConfigurationName: cfg,
-				Params: traffic.RolloutParams{
+				StepParams: traffic.RolloutParams{
 					StartTime: int(now.UnixNano()),
 				},
 				Percent:   100,

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -435,10 +435,10 @@ func TestReconcile(t *testing.T) {
 					RevisionName: "config-00001", Percent: 1,
 				}}, fakeCurTime.Add(-3*time.Second),
 					func(r *traffic.Rollout) {
-						// Step duration is 3s (now - (now-3s)).
-						r.Configurations[0].StepParams.StepDuration = 3
-						// 120 / 3 = 40 steps. floor(100/40) = 2.
-						r.Configurations[0].StepParams.StepSize = 2
+						numSteps := 120 / 3 // 40
+						// Step duration is 3s (duration / numSteps = 120/40)
+						r.Configurations[0].StepParams.StepDuration = int(time.Second) * 120 / numSteps // 3s in ns.
+						r.Configurations[0].StepParams.StepSize = (100 - 1) / numSteps                  // 2
 						// StepDuration is 3, and so next step is `now` + 3.
 						r.Configurations[0].StepParams.NextStepTime = int(fakeCurTime.Add(3 * time.Second).UnixNano())
 					},

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -436,11 +436,11 @@ func TestReconcile(t *testing.T) {
 				}}, fakeCurTime.Add(-3*time.Second),
 					func(r *traffic.Rollout) {
 						// Step duration is 3s (now - (now-3s)).
-						r.Configurations[0].StepDuration = 3
+						r.Configurations[0].Params.StepDuration = 3
 						// 120 / 3 = 40 steps. floor(100/40) = 2.
-						r.Configurations[0].StepSize = 2
+						r.Configurations[0].Params.StepSize = 2
 						// StepDuration is 3, and so next step is `now` + 3.
-						r.Configurations[0].NextStepTime = int(fakeCurTime.Add(3 * time.Second).UnixNano())
+						r.Configurations[0].Params.NextStepTime = int(fakeCurTime.Add(3 * time.Second).UnixNano())
 					},
 				)),
 		}, {
@@ -2694,9 +2694,11 @@ func simpleRollout(cfg string, revs []traffic.RevisionRollout,
 		r := &traffic.Rollout{
 			Configurations: []traffic.ConfigurationRollout{{
 				ConfigurationName: cfg,
-				StartTime:         int(now.UnixNano()),
-				Percent:           100,
-				Revisions:         revs,
+				Params: traffic.RolloutParams{
+					StartTime: int(now.UnixNano()),
+				},
+				Percent:   100,
+				Revisions: revs,
 			}},
 		}
 		for _, ro := range ros {

--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -58,8 +58,8 @@ type ConfigurationRollout struct {
 	// Note: that it is not 100% of the route traffic, in more complex cases.
 	Revisions []RevisionRollout `json:"revisions,omitempty"`
 
-	// Params describes rollout params for the configuration.
-	Params RolloutParams `json:"params"`
+	// StepParams describes rollout params for the configuration.
+	StepParams RolloutParams `json:"stepParams"`
 }
 
 // RolloutParams contains the timing and sizing parameters for the
@@ -131,10 +131,10 @@ const durationSecs = 120.0
 func (cur *Rollout) ObserveReady(nowTS int) {
 	for i := range cur.Configurations {
 		c := &cur.Configurations[i]
-		if c.Params.StepDuration == 0 && c.Params.StartTime > 0 {
+		if c.StepParams.StepDuration == 0 && c.StepParams.StartTime > 0 {
 			// In really ceil(nowTS-params.StartTime) should always give 1s, but
 			// given possible time drift, we'll ensure that at least 1s is returned.
-			minStepSec := math.Max(1, math.Ceil(time.Duration(nowTS-c.Params.StartTime).Seconds()))
+			minStepSec := math.Max(1, math.Ceil(time.Duration(nowTS-c.StepParams.StartTime).Seconds()))
 			c.computeProperties(float64(nowTS), minStepSec, durationSecs)
 		}
 	}
@@ -251,12 +251,12 @@ func adjustPercentage(goal int, cr *ConfigurationRollout) {
 func stepRevisions(goal *ConfigurationRollout, nowTS int) {
 	// Not yet ready to adjust the steps or we're done
 	// (shouldn't really be here, but better be defensive).
-	if nowTS < goal.Params.NextStepTime || len(goal.Revisions) < 2 {
+	if nowTS < goal.StepParams.NextStepTime || len(goal.Revisions) < 2 {
 		return
 	}
 
 	revLen := len(goal.Revisions)
-	remaining := goal.Params.StepSize
+	remaining := goal.StepParams.StepSize
 	writePos := revLen - 1
 	// readPos is guaranteed to be >= 0, due to the check above.
 	readPos := revLen - 2
@@ -286,7 +286,7 @@ func stepRevisions(goal *ConfigurationRollout, nowTS int) {
 	// Copy the last one to the write pos
 	goal.Revisions[writePos] = goal.Revisions[revLen-1]
 
-	goal.Revisions[writePos].Percent += goal.Params.StepSize
+	goal.Revisions[writePos].Percent += goal.StepParams.StepSize
 	// This can happen if step is now larger than total allocation, see the
 	// note above.
 	// E.g. with example above R2 = 20, and ro we have to cap it at 15.
@@ -297,10 +297,10 @@ func stepRevisions(goal *ConfigurationRollout, nowTS int) {
 	goal.Revisions = goal.Revisions[:writePos+1]
 	// Also set the next time.
 	if len(goal.Revisions) > 1 {
-		goal.Params.NextStepTime = nowTS + goal.Params.StepDuration
+		goal.StepParams.NextStepTime = nowTS + goal.StepParams.StepDuration
 	} else {
 		// This is the last step, we're done! Clear the params out.
-		goal.Params = RolloutParams{}
+		goal.StepParams = RolloutParams{}
 	}
 }
 
@@ -336,10 +336,10 @@ func stepConfig(goal, prev *ConfigurationRollout, nowTS int) *ConfigurationRollo
 
 			// Copy various rollout stats from the previous when no new revision
 			// has been created.
-			ret.Params = prev.Params
+			ret.StepParams = prev.StepParams
 			// We might end up here before `ObserveReady` is called.
 			// In that case don't step individual revisions just yet.
-			if ret.Params.StepSize > 0 {
+			if ret.StepParams.StepSize > 0 {
 				// adjustPercentage above would've already accounted if target for the
 				// whole Configuration changed up or down. So here we should just redistribute
 				// the existing values.
@@ -352,7 +352,7 @@ func stepConfig(goal, prev *ConfigurationRollout, nowTS int) *ConfigurationRollo
 	// Otherwise we start a rollout, which means we need to stamp the starttime,
 	// the rest of the fields will remain unset and `ObserveReady` will
 	// compute them when the ingress becomes ready.
-	ret.Params.StartTime = nowTS
+	ret.StepParams.StartTime = nowTS
 
 	// Go backwards and find first revision with traffic assignment > 0.
 	// Reduce it by one, so we can give that 1% to the new revision.
@@ -415,9 +415,9 @@ func (cur *ConfigurationRollout) computeProperties(nowTS, minStepSec, durationSe
 	// than slightly shorter.
 	stepDuration := math.Ceil(durationSecs / numSteps)
 
-	cur.Params.StepDuration = int(stepDuration)
-	cur.Params.StepSize = int(stepSize)
-	cur.Params.NextStepTime = int(nowTS + stepDuration*float64(time.Second))
+	cur.StepParams.StepDuration = int(stepDuration)
+	cur.StepParams.StepSize = int(stepSize)
+	cur.StepParams.NextStepTime = int(nowTS + stepDuration*float64(time.Second))
 }
 
 // sortRollout sorts the rollout based on tag so it's consistent

--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -65,18 +65,17 @@ type ConfigurationRollout struct {
 // RolloutParams contains the timing and sizing parameters for the
 // ConfigurationRollout.
 type RolloutParams struct {
-	// StartTime is the Unix timestamp by when (+/- reconcile precision)
+	// StartTime is the Unix timestamp in ns by when (+/- reconcile precision)
 	// the Rollout has started.
 	// This is required to compute step time and deadline.
 	StartTime int `json:"starttime,omitempty"`
 
-	// NextStepTime is the Unix timestamp when the next
+	// NextStepTime is the Unix timestamp in ns when the next
 	// rollout step should performed.
 	NextStepTime int `json:"nextStepTime,omitempty"`
 
-	// StepDuration is a rounded up number of seconds how long it took
-	// for ingress to successfully move first 1% of traffic to the new revision.
-	// Note, that his number does not include any coldstart, etc timing.
+	// StepDuration is the number of nanoseconds between two successive steps
+	// of rollout.
 	StepDuration int `json:"stepDuration,omitempty"`
 
 	// How much traffic to move in a single step.
@@ -411,13 +410,11 @@ func (cur *ConfigurationRollout) computeProperties(nowTS, minStepSec, durationSe
 	stepSize := math.Floor((pf - 1) / numSteps)
 
 	// The time we sleep between the steps.
-	// We round up here since it's better to roll slightly longer,
-	// than slightly shorter.
-	stepDuration := math.Ceil(durationSecs / numSteps)
+	stepDuration := durationSecs / numSteps * float64(time.Second)
 
 	cur.StepParams.StepDuration = int(stepDuration)
 	cur.StepParams.StepSize = int(stepSize)
-	cur.StepParams.NextStepTime = int(nowTS + stepDuration*float64(time.Second))
+	cur.StepParams.NextStepTime = int(nowTS + stepDuration)
 }
 
 // sortRollout sorts the rollout based on tag so it's consistent

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -876,16 +876,16 @@ func TestObserveReady(t *testing.T) {
 			Percent:           100,
 			StepParams: RolloutParams{
 				StartTime:    200620092020,
-				StepDuration: 2,
+				StepDuration: 1212121212, // 120/99
 				StepSize:     1,
-				NextStepTime: now + int(2*time.Second),
+				NextStepTime: now + 1212121212,
 			},
 		}, {
 			ConfigurationName: "step-begin > 1s",
 			Percent:           100,
 			StepParams: RolloutParams{
 				StartTime:    oldenDays,
-				StepDuration: 3,
+				StepDuration: 3 * int(time.Second),
 				StepSize:     100 / 40,
 				NextStepTime: now + 3*int(time.Second),
 			},
@@ -894,7 +894,7 @@ func TestObserveReady(t *testing.T) {
 			Percent:           50,
 			StepParams: RolloutParams{
 				StartTime:    oldenDays,
-				StepDuration: 3,
+				StepDuration: 3 * int(time.Second),
 				StepSize:     50 / 40,
 				NextStepTime: now + 3*int(time.Second),
 			},

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -1335,8 +1335,8 @@ func TestStepRevisions(t *testing.T) {
 			}},
 		},
 		want: &ConfigurationRollout{
-			Percent: 15,
-			StepParams:  RolloutParams{
+			Percent:    15,
+			StepParams: RolloutParams{
 				// we reset rollout params, since we're done now.
 			},
 			Revisions: []RevisionRollout{{
@@ -1365,8 +1365,8 @@ func TestStepRevisions(t *testing.T) {
 			}},
 		},
 		want: &ConfigurationRollout{
-			Percent: 15,
-			StepParams:  RolloutParams{
+			Percent:    15,
+			StepParams: RolloutParams{
 				// we reset rollout params, since we're done now.
 			},
 			Revisions: []RevisionRollout{{

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -78,11 +78,12 @@ func TestStep(t *testing.T) {
 					RevisionName: "let-it-bleed",
 					Percent:      100,
 				}},
-				Deadline:     2006, // <- Those should be kept.
-				NextStepTime: 2009,
-				StepDuration: 2020,
-				StartTime:    2004,
-				StepSize:     14,
+				Params: RolloutParams{ // <- Those should be kept.
+					NextStepTime: 2009,
+					StepDuration: 2020,
+					StartTime:    2004,
+					StepSize:     14,
+				},
 			}},
 		},
 		prev: &Rollout{
@@ -115,20 +116,24 @@ func TestStep(t *testing.T) {
 					RevisionName: "let-it-bleed",
 					Percent:      100,
 				}},
-				NextStepTime: 2009,
-				StepDuration: 2020,
-				StartTime:    2004,
-				StepSize:     14,
+				Params: RolloutParams{
+					NextStepTime: 2009,
+					StepDuration: 2020,
+					StartTime:    2004,
+					StepSize:     14,
+				},
 			}},
 		},
 		prev: &Rollout{
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
-				NextStepTime:      2019,
-				StepDuration:      5,
-				StartTime:         2004,
-				StepSize:          3,
+				Params: RolloutParams{
+					NextStepTime: 2019,
+					StepDuration: 5,
+					StartTime:    2004,
+					StepSize:     3,
+				},
 				Revisions: []RevisionRollout{{
 					RevisionName: "their-satanic-majesties-request",
 					Percent:      95,
@@ -149,10 +154,12 @@ func TestStep(t *testing.T) {
 					RevisionName: "let-it-bleed",
 					Percent:      8, // +3
 				}},
-				NextStepTime: 2020 + 5, // now + duration.
-				StepDuration: 5,
-				StartTime:    2004,
-				StepSize:     3,
+				Params: RolloutParams{
+					NextStepTime: 2020 + 5, // now + duration.
+					StepDuration: 5,
+					StartTime:    2004,
+					StepSize:     3,
+				},
 			}},
 		},
 	}, {
@@ -165,21 +172,24 @@ func TestStep(t *testing.T) {
 					RevisionName: "let-it-bleed",
 					Percent:      100,
 				}},
-				Deadline:     2006,
-				NextStepTime: 2009,
-				StepDuration: 2020,
-				StartTime:    2004,
-				StepSize:     14,
+				Params: RolloutParams{
+					NextStepTime: 2009,
+					StepDuration: 2020,
+					StartTime:    2004,
+					StepSize:     14,
+				},
 			}},
 		},
 		prev: &Rollout{
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
-				NextStepTime:      2019, // <- Those should be reset and/or updated.
-				StartTime:         2004,
-				StepDuration:      5,
-				StepSize:          0,
+				Params: RolloutParams{
+					NextStepTime: 2019, // <- Those should be reset and/or updated.
+					StartTime:    2004,
+					StepDuration: 5,
+					StepSize:     0,
+				},
 				Revisions: []RevisionRollout{{
 					RevisionName: "their-satanic-majesties-request",
 					Percent:      95,
@@ -200,10 +210,12 @@ func TestStep(t *testing.T) {
 					RevisionName: "let-it-bleed",
 					Percent:      5,
 				}},
-				NextStepTime: 2019,
-				StartTime:    2004,
-				StepDuration: 5,
-				StepSize:     0,
+				Params: RolloutParams{
+					NextStepTime: 2019,
+					StartTime:    2004,
+					StepDuration: 5,
+					StepSize:     0,
+				},
 			}},
 		},
 	}, {
@@ -288,17 +300,20 @@ func TestStep(t *testing.T) {
 					RevisionName: "goat-head-soup",
 					Percent:      100,
 				}},
-				Deadline:     1982, // <- Those should be thrown out.
-				NextStepTime: 1984,
-				StepDuration: 1988,
-				StepSize:     11,
+				Params: RolloutParams{ // <- Those should be thrown out.
+					NextStepTime: 1984,
+					StepDuration: 1988,
+					StepSize:     11,
+				},
 			}},
 		},
 		want: &Rollout{
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
-				StartTime:         now,
+				Params: RolloutParams{
+					StartTime: now,
+				},
 				Revisions: []RevisionRollout{{
 					RevisionName: "goat-head-soup",
 					Percent:      99,
@@ -337,7 +352,9 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           33,
-				StartTime:         now,
+				Params: RolloutParams{
+					StartTime: now,
+				},
 				Revisions: []RevisionRollout{{
 					RevisionName: "goat-head-soup",
 					Percent:      2,
@@ -378,8 +395,10 @@ func TestStep(t *testing.T) {
 		want: &Rollout{
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
-				StartTime:         now,
-				Percent:           75,
+				Params: RolloutParams{
+					StartTime: now,
+				},
+				Percent: 75,
 				Revisions: []RevisionRollout{{
 					RevisionName: "goat-head-soup",
 					Percent:      11,
@@ -418,7 +437,9 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "brian",
 				Percent:           70,
-				StartTime:         now,
+				Params: RolloutParams{
+					StartTime: now,
+				},
 				Revisions: []RevisionRollout{{
 					RevisionName: "exile-on-main-st",
 					Percent:      69,
@@ -444,7 +465,9 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
-				StartTime:         now - 1982, // A rollout in progress, this would be set.
+				Params: RolloutParams{
+					StartTime: now - 1982, // A rollout in progress, this would be set.
+				},
 				Revisions: []RevisionRollout{{
 					RevisionName: "goat-head-soup",
 					Percent:      95,
@@ -458,7 +481,9 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
-				StartTime:         now,
+				Params: RolloutParams{
+					StartTime: now,
+				},
 				Revisions: []RevisionRollout{{
 					RevisionName: "goat-head-soup",
 					Percent:      95,
@@ -487,7 +512,9 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
-				StartTime:         now - 1984, // A rollout in progress, this would be set.
+				Params: RolloutParams{
+					StartTime: now - 1984, // A rollout in progress, this would be set.
+				},
 				Revisions: []RevisionRollout{{
 					RevisionName: "goat-head-soup",
 					Percent:      99,
@@ -500,8 +527,10 @@ func TestStep(t *testing.T) {
 		want: &Rollout{
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
-				StartTime:         now,
-				Percent:           100,
+				Params: RolloutParams{
+					StartTime: now,
+				},
+				Percent: 100,
 				Revisions: []RevisionRollout{{
 					RevisionName: "goat-head-soup",
 					Percent:      99,
@@ -670,7 +699,9 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "keith",
 				Percent:           99,
-				StartTime:         now,
+				Params: RolloutParams{
+					StartTime: now,
+				},
 				Revisions: []RevisionRollout{{ // <-- note this one actually rolls.
 					RevisionName: "can't-get-no-satisfaction",
 					Percent:      98,
@@ -803,22 +834,30 @@ func TestObserveReady(t *testing.T) {
 		Configurations: []ConfigurationRollout{{
 			Percent:           100,
 			ConfigurationName: "has-step",
-			StepDuration:      11,
+			Params: RolloutParams{
+				StepDuration: 11,
+			},
 		}, {
 			ConfigurationName: "no-step-no-begin",
 			Percent:           100,
 		}, {
 			ConfigurationName: "step-begin < 1s",
-			StartTime:         200620092020,
-			Percent:           100,
+			Params: RolloutParams{
+				StartTime: 200620092020,
+			},
+			Percent: 100,
 		}, {
 			ConfigurationName: "step-begin > 1s",
-			StartTime:         oldenDays,
-			Percent:           100,
+			Params: RolloutParams{
+				StartTime: oldenDays,
+			},
+			Percent: 100,
 		}, {
 			ConfigurationName: "Percent not 100%",
-			StartTime:         oldenDays,
-			Percent:           50,
+			Params: RolloutParams{
+				StartTime: oldenDays,
+			},
+			Percent: 50,
 		}},
 	}
 
@@ -826,31 +865,39 @@ func TestObserveReady(t *testing.T) {
 		Configurations: []ConfigurationRollout{{
 			Percent:           100,
 			ConfigurationName: "has-step",
-			StepDuration:      11,
+			Params: RolloutParams{
+				StepDuration: 11,
+			},
 		}, {
 			ConfigurationName: "no-step-no-begin",
 			Percent:           100,
 		}, {
 			ConfigurationName: "step-begin < 1s",
 			Percent:           100,
-			StartTime:         200620092020,
-			StepDuration:      2,
-			StepSize:          1,
-			NextStepTime:      now + int(2*time.Second),
+			Params: RolloutParams{
+				StartTime:    200620092020,
+				StepDuration: 2,
+				StepSize:     1,
+				NextStepTime: now + int(2*time.Second),
+			},
 		}, {
 			ConfigurationName: "step-begin > 1s",
 			Percent:           100,
-			StartTime:         oldenDays,
-			StepDuration:      3,
-			StepSize:          100 / 40,
-			NextStepTime:      now + 3*int(time.Second),
+			Params: RolloutParams{
+				StartTime:    oldenDays,
+				StepDuration: 3,
+				StepSize:     100 / 40,
+				NextStepTime: now + 3*int(time.Second),
+			},
 		}, {
 			ConfigurationName: "Percent not 100%",
 			Percent:           50,
-			StartTime:         oldenDays,
-			StepDuration:      3,
-			StepSize:          50 / 40,
-			NextStepTime:      now + 3*int(time.Second),
+			Params: RolloutParams{
+				StartTime:    oldenDays,
+				StepDuration: 3,
+				StepSize:     50 / 40,
+				NextStepTime: now + 3*int(time.Second),
+			},
 		}},
 	}
 
@@ -1110,10 +1157,11 @@ func TestJSONRoundtrip(t *testing.T) {
 				RevisionName: "roy",
 				Percent:      100,
 			}},
-			StartTime:    1955,
-			Deadline:     2006,
-			NextStepTime: 1988,
-			StepDuration: 1984,
+			Params: RolloutParams{
+				StartTime:    1955,
+				NextStepTime: 1988,
+				StepDuration: 1984,
+			},
 		}, {
 			ConfigurationName: "no",
 			Percent:           0,
@@ -1156,8 +1204,10 @@ func TestStepRevisions(t *testing.T) {
 		name: "noop (1): too soon",
 		now:  1982,
 		cfg: &ConfigurationRollout{
-			NextStepTime: 1984,
-			StepSize:     10,
+			Params: RolloutParams{
+				NextStepTime: 1984,
+				StepSize:     10,
+			},
 			Revisions: []RevisionRollout{{
 				Percent: 10,
 			}, {
@@ -1167,8 +1217,10 @@ func TestStepRevisions(t *testing.T) {
 			}},
 		},
 		want: &ConfigurationRollout{
-			NextStepTime: 1984,
-			StepSize:     10,
+			Params: RolloutParams{
+				NextStepTime: 1984,
+				StepSize:     10,
+			},
 			Revisions: []RevisionRollout{{
 				Percent: 10,
 			}, {
@@ -1181,17 +1233,21 @@ func TestStepRevisions(t *testing.T) {
 		name: "noop (2): done",
 		now:  1982,
 		cfg: &ConfigurationRollout{
-			NextStepTime: 1984,
-			StepDuration: 10,
-			StepSize:     10,
+			Params: RolloutParams{
+				NextStepTime: 1984,
+				StepDuration: 10,
+				StepSize:     10,
+			},
 			Revisions: []RevisionRollout{{
 				Percent: 10,
 			}},
 		},
 		want: &ConfigurationRollout{
-			NextStepTime: 1984,
-			StepDuration: 10,
-			StepSize:     10,
+			Params: RolloutParams{
+				NextStepTime: 1984,
+				StepDuration: 10,
+				StepSize:     10,
+			},
 			Revisions: []RevisionRollout{{
 				Percent: 10,
 			}},
@@ -1200,10 +1256,12 @@ func TestStepRevisions(t *testing.T) {
 		name: "step last, exact time",
 		now:  1984,
 		cfg: &ConfigurationRollout{
-			NextStepTime: 1984,
-			StepSize:     10,
-			StepDuration: 55,
-			Percent:      90,
+			Params: RolloutParams{
+				NextStepTime: 1984,
+				StepSize:     10,
+				StepDuration: 55,
+			},
+			Percent: 90,
 			Revisions: []RevisionRollout{{
 				Percent: 30,
 			}, {
@@ -1211,10 +1269,12 @@ func TestStepRevisions(t *testing.T) {
 			}},
 		},
 		want: &ConfigurationRollout{
-			Percent:      90,
-			NextStepTime: 1984 + 55,
-			StepDuration: 55,
-			StepSize:     10,
+			Percent: 90,
+			Params: RolloutParams{
+				NextStepTime: 1984 + 55,
+				StepDuration: 55,
+				StepSize:     10,
+			},
 			Revisions: []RevisionRollout{{
 				Percent: 20,
 			}, {
@@ -1225,10 +1285,12 @@ func TestStepRevisions(t *testing.T) {
 		name: "step last, delete some",
 		now:  1988,
 		cfg: &ConfigurationRollout{
-			Percent:      90,
-			NextStepTime: 1984,
-			StepSize:     10,
-			StepDuration: 55,
+			Percent: 90,
+			Params: RolloutParams{
+				NextStepTime: 1984,
+				StepSize:     10,
+				StepDuration: 55,
+			},
 			Revisions: []RevisionRollout{{
 				Percent: 22,
 			}, {
@@ -1240,10 +1302,12 @@ func TestStepRevisions(t *testing.T) {
 			}},
 		},
 		want: &ConfigurationRollout{
-			Percent:      90,
-			NextStepTime: 1988 + 55,
-			StepDuration: 55,
-			StepSize:     10,
+			Percent: 90,
+			Params: RolloutParams{
+				NextStepTime: 1988 + 55,
+				StepDuration: 55,
+				StepSize:     10,
+			},
 			Revisions: []RevisionRollout{{
 				Percent: 20,
 			}, {
@@ -1254,10 +1318,12 @@ func TestStepRevisions(t *testing.T) {
 		name: "over target now",
 		now:  1988,
 		cfg: &ConfigurationRollout{
-			Percent:      15,
-			NextStepTime: 1984,
-			StepSize:     10,
-			StepDuration: 77,
+			Percent: 15,
+			Params: RolloutParams{
+				NextStepTime: 1984,
+				StepSize:     10,
+				StepDuration: 77,
+			},
 			Revisions: []RevisionRollout{{
 				Percent: 5,
 			}, {
@@ -1269,10 +1335,10 @@ func TestStepRevisions(t *testing.T) {
 			}},
 		},
 		want: &ConfigurationRollout{
-			Percent:      15,
-			NextStepTime: 0,
-			StepDuration: 77,
-			StepSize:     10,
+			Percent: 15,
+			Params:  RolloutParams{
+				// we reset rollout params, since we're done now.
+			},
 			Revisions: []RevisionRollout{{
 				Percent: 15,
 			}},
@@ -1281,11 +1347,13 @@ func TestStepRevisions(t *testing.T) {
 		name: "the very last step",
 		now:  2006,
 		cfg: &ConfigurationRollout{
-			NextStepTime: 1984,
-			Percent:      15,
-			StartTime:    1977,
-			StepDuration: 77,
-			StepSize:     8,
+			Percent: 15,
+			Params: RolloutParams{
+				NextStepTime: 1984,
+				StartTime:    1977,
+				StepDuration: 77,
+				StepSize:     8,
+			},
 			Revisions: []RevisionRollout{{
 				Percent: 5,
 			}, {
@@ -1297,11 +1365,10 @@ func TestStepRevisions(t *testing.T) {
 			}},
 		},
 		want: &ConfigurationRollout{
-			NextStepTime: 0,
-			Percent:      15,
-			StartTime:    0,
-			StepDuration: 77,
-			StepSize:     8,
+			Percent: 15,
+			Params:  RolloutParams{
+				// we reset rollout params, since we're done now.
+			},
 			Revisions: []RevisionRollout{{
 				Percent: 15,
 			}},

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -78,7 +78,7 @@ func TestStep(t *testing.T) {
 					RevisionName: "let-it-bleed",
 					Percent:      100,
 				}},
-				Params: RolloutParams{ // <- Those should be kept.
+				StepParams: RolloutParams{ // <- Those should be kept.
 					NextStepTime: 2009,
 					StepDuration: 2020,
 					StartTime:    2004,
@@ -116,7 +116,7 @@ func TestStep(t *testing.T) {
 					RevisionName: "let-it-bleed",
 					Percent:      100,
 				}},
-				Params: RolloutParams{
+				StepParams: RolloutParams{
 					NextStepTime: 2009,
 					StepDuration: 2020,
 					StartTime:    2004,
@@ -128,7 +128,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
-				Params: RolloutParams{
+				StepParams: RolloutParams{
 					NextStepTime: 2019,
 					StepDuration: 5,
 					StartTime:    2004,
@@ -154,7 +154,7 @@ func TestStep(t *testing.T) {
 					RevisionName: "let-it-bleed",
 					Percent:      8, // +3
 				}},
-				Params: RolloutParams{
+				StepParams: RolloutParams{
 					NextStepTime: 2020 + 5, // now + duration.
 					StepDuration: 5,
 					StartTime:    2004,
@@ -172,7 +172,7 @@ func TestStep(t *testing.T) {
 					RevisionName: "let-it-bleed",
 					Percent:      100,
 				}},
-				Params: RolloutParams{
+				StepParams: RolloutParams{
 					NextStepTime: 2009,
 					StepDuration: 2020,
 					StartTime:    2004,
@@ -184,7 +184,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
-				Params: RolloutParams{
+				StepParams: RolloutParams{
 					NextStepTime: 2019, // <- Those should be reset and/or updated.
 					StartTime:    2004,
 					StepDuration: 5,
@@ -210,7 +210,7 @@ func TestStep(t *testing.T) {
 					RevisionName: "let-it-bleed",
 					Percent:      5,
 				}},
-				Params: RolloutParams{
+				StepParams: RolloutParams{
 					NextStepTime: 2019,
 					StartTime:    2004,
 					StepDuration: 5,
@@ -300,7 +300,7 @@ func TestStep(t *testing.T) {
 					RevisionName: "goat-head-soup",
 					Percent:      100,
 				}},
-				Params: RolloutParams{ // <- Those should be thrown out.
+				StepParams: RolloutParams{ // <- Those should be thrown out.
 					NextStepTime: 1984,
 					StepDuration: 1988,
 					StepSize:     11,
@@ -311,7 +311,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
-				Params: RolloutParams{
+				StepParams: RolloutParams{
 					StartTime: now,
 				},
 				Revisions: []RevisionRollout{{
@@ -352,7 +352,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           33,
-				Params: RolloutParams{
+				StepParams: RolloutParams{
 					StartTime: now,
 				},
 				Revisions: []RevisionRollout{{
@@ -395,7 +395,7 @@ func TestStep(t *testing.T) {
 		want: &Rollout{
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
-				Params: RolloutParams{
+				StepParams: RolloutParams{
 					StartTime: now,
 				},
 				Percent: 75,
@@ -437,7 +437,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "brian",
 				Percent:           70,
-				Params: RolloutParams{
+				StepParams: RolloutParams{
 					StartTime: now,
 				},
 				Revisions: []RevisionRollout{{
@@ -465,7 +465,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
-				Params: RolloutParams{
+				StepParams: RolloutParams{
 					StartTime: now - 1982, // A rollout in progress, this would be set.
 				},
 				Revisions: []RevisionRollout{{
@@ -481,7 +481,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
-				Params: RolloutParams{
+				StepParams: RolloutParams{
 					StartTime: now,
 				},
 				Revisions: []RevisionRollout{{
@@ -512,7 +512,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
 				Percent:           100,
-				Params: RolloutParams{
+				StepParams: RolloutParams{
 					StartTime: now - 1984, // A rollout in progress, this would be set.
 				},
 				Revisions: []RevisionRollout{{
@@ -527,7 +527,7 @@ func TestStep(t *testing.T) {
 		want: &Rollout{
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "mick",
-				Params: RolloutParams{
+				StepParams: RolloutParams{
 					StartTime: now,
 				},
 				Percent: 100,
@@ -699,7 +699,7 @@ func TestStep(t *testing.T) {
 			Configurations: []ConfigurationRollout{{
 				ConfigurationName: "keith",
 				Percent:           99,
-				Params: RolloutParams{
+				StepParams: RolloutParams{
 					StartTime: now,
 				},
 				Revisions: []RevisionRollout{{ // <-- note this one actually rolls.
@@ -834,7 +834,7 @@ func TestObserveReady(t *testing.T) {
 		Configurations: []ConfigurationRollout{{
 			Percent:           100,
 			ConfigurationName: "has-step",
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				StepDuration: 11,
 			},
 		}, {
@@ -842,19 +842,19 @@ func TestObserveReady(t *testing.T) {
 			Percent:           100,
 		}, {
 			ConfigurationName: "step-begin < 1s",
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				StartTime: 200620092020,
 			},
 			Percent: 100,
 		}, {
 			ConfigurationName: "step-begin > 1s",
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				StartTime: oldenDays,
 			},
 			Percent: 100,
 		}, {
 			ConfigurationName: "Percent not 100%",
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				StartTime: oldenDays,
 			},
 			Percent: 50,
@@ -865,7 +865,7 @@ func TestObserveReady(t *testing.T) {
 		Configurations: []ConfigurationRollout{{
 			Percent:           100,
 			ConfigurationName: "has-step",
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				StepDuration: 11,
 			},
 		}, {
@@ -874,7 +874,7 @@ func TestObserveReady(t *testing.T) {
 		}, {
 			ConfigurationName: "step-begin < 1s",
 			Percent:           100,
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				StartTime:    200620092020,
 				StepDuration: 2,
 				StepSize:     1,
@@ -883,7 +883,7 @@ func TestObserveReady(t *testing.T) {
 		}, {
 			ConfigurationName: "step-begin > 1s",
 			Percent:           100,
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				StartTime:    oldenDays,
 				StepDuration: 3,
 				StepSize:     100 / 40,
@@ -892,7 +892,7 @@ func TestObserveReady(t *testing.T) {
 		}, {
 			ConfigurationName: "Percent not 100%",
 			Percent:           50,
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				StartTime:    oldenDays,
 				StepDuration: 3,
 				StepSize:     50 / 40,
@@ -1157,7 +1157,7 @@ func TestJSONRoundtrip(t *testing.T) {
 				RevisionName: "roy",
 				Percent:      100,
 			}},
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				StartTime:    1955,
 				NextStepTime: 1988,
 				StepDuration: 1984,
@@ -1204,7 +1204,7 @@ func TestStepRevisions(t *testing.T) {
 		name: "noop (1): too soon",
 		now:  1982,
 		cfg: &ConfigurationRollout{
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				NextStepTime: 1984,
 				StepSize:     10,
 			},
@@ -1217,7 +1217,7 @@ func TestStepRevisions(t *testing.T) {
 			}},
 		},
 		want: &ConfigurationRollout{
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				NextStepTime: 1984,
 				StepSize:     10,
 			},
@@ -1233,7 +1233,7 @@ func TestStepRevisions(t *testing.T) {
 		name: "noop (2): done",
 		now:  1982,
 		cfg: &ConfigurationRollout{
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				NextStepTime: 1984,
 				StepDuration: 10,
 				StepSize:     10,
@@ -1243,7 +1243,7 @@ func TestStepRevisions(t *testing.T) {
 			}},
 		},
 		want: &ConfigurationRollout{
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				NextStepTime: 1984,
 				StepDuration: 10,
 				StepSize:     10,
@@ -1256,7 +1256,7 @@ func TestStepRevisions(t *testing.T) {
 		name: "step last, exact time",
 		now:  1984,
 		cfg: &ConfigurationRollout{
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				NextStepTime: 1984,
 				StepSize:     10,
 				StepDuration: 55,
@@ -1270,7 +1270,7 @@ func TestStepRevisions(t *testing.T) {
 		},
 		want: &ConfigurationRollout{
 			Percent: 90,
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				NextStepTime: 1984 + 55,
 				StepDuration: 55,
 				StepSize:     10,
@@ -1286,7 +1286,7 @@ func TestStepRevisions(t *testing.T) {
 		now:  1988,
 		cfg: &ConfigurationRollout{
 			Percent: 90,
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				NextStepTime: 1984,
 				StepSize:     10,
 				StepDuration: 55,
@@ -1303,7 +1303,7 @@ func TestStepRevisions(t *testing.T) {
 		},
 		want: &ConfigurationRollout{
 			Percent: 90,
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				NextStepTime: 1988 + 55,
 				StepDuration: 55,
 				StepSize:     10,
@@ -1319,7 +1319,7 @@ func TestStepRevisions(t *testing.T) {
 		now:  1988,
 		cfg: &ConfigurationRollout{
 			Percent: 15,
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				NextStepTime: 1984,
 				StepSize:     10,
 				StepDuration: 77,
@@ -1336,7 +1336,7 @@ func TestStepRevisions(t *testing.T) {
 		},
 		want: &ConfigurationRollout{
 			Percent: 15,
-			Params:  RolloutParams{
+			StepParams:  RolloutParams{
 				// we reset rollout params, since we're done now.
 			},
 			Revisions: []RevisionRollout{{
@@ -1348,7 +1348,7 @@ func TestStepRevisions(t *testing.T) {
 		now:  2006,
 		cfg: &ConfigurationRollout{
 			Percent: 15,
-			Params: RolloutParams{
+			StepParams: RolloutParams{
 				NextStepTime: 1984,
 				StartTime:    1977,
 				StepDuration: 77,
@@ -1366,7 +1366,7 @@ func TestStepRevisions(t *testing.T) {
 		},
 		want: &ConfigurationRollout{
 			Percent: 15,
-			Params:  RolloutParams{
+			StepParams:  RolloutParams{
 				// we reset rollout params, since we're done now.
 			},
 			Revisions: []RevisionRollout{{


### PR DESCRIPTION
- fix comments, which were a bit off
- switch all fields to nanoseconds (some already were)
- This removes lots of rounding and makes the process more precise and easier
to reason about. Ceil(1.1) = 2s, over 40% of difference — so avoid that.

/hold
For the base pr to merge

/assign @tcnghia 