### PR TITLE
Support non-LE replication of the autoscaler.

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -259,7 +259,7 @@ func componentConfigAndIP(ctx context.Context) leaderelection.ComponentConfig {
 	// Set up leader election config
 	leaderElectionConfig, err := sharedmain.GetLeaderElectionConfig(ctx)
 	if err != nil {
-		logging.FromContext(ctx).Fatal("Error loading leader election configuration: ", err)
+		logging.FromContext(ctx).Fatalw("Error loading leader election configuration", zap.Error(err))
 	}
 
 	cc := leaderElectionConfig.GetComponentConfig(component)

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29
 	knative.dev/caching v0.0.0-20201209181541-0e55b559628c
 	knative.dev/hack v0.0.0-20201201234937-fddbf732e450
-	knative.dev/networking v0.0.0-20201210074041-cdd0e325c1a9
-	knative.dev/pkg v0.0.0-20201210014142-0c53297607c6
+	knative.dev/networking v0.0.0-20201209181441-896c0e7c4864
+	knative.dev/pkg v0.0.0-20201209172941-9b9407a76df1
 )

--- a/go.sum
+++ b/go.sum
@@ -1220,12 +1220,10 @@ knative.dev/caching v0.0.0-20201209181541-0e55b559628c h1:8Z08V3wrbHq04dnLdRDedk
 knative.dev/caching v0.0.0-20201209181541-0e55b559628c/go.mod h1:RVYUjyxzWfX/l/FEi6YKcYZ3ngjT6qIxpTtiIvFMBg0=
 knative.dev/hack v0.0.0-20201201234937-fddbf732e450 h1:IyitWF7OzfunCgE4b9ZsJAeIRoQ6JOyqDrz/19X4iS4=
 knative.dev/hack v0.0.0-20201201234937-fddbf732e450/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
-knative.dev/networking v0.0.0-20201210074041-cdd0e325c1a9 h1:3KYbAGte/h3y1XbI3mAGWdDTVE6/icYXKkoVBqAQjFw=
-knative.dev/networking v0.0.0-20201210074041-cdd0e325c1a9/go.mod h1:s+q5zIi9skLPnC7T3R6W4enZRnT8I/eIwWuys8gGJm4=
+knative.dev/networking v0.0.0-20201209181441-896c0e7c4864 h1:eSfdkI4Y3UWq49mM9K+dL4J8KvRx0TNQ9Zg+gYhETkI=
+knative.dev/networking v0.0.0-20201209181441-896c0e7c4864/go.mod h1:s+q5zIi9skLPnC7T3R6W4enZRnT8I/eIwWuys8gGJm4=
 knative.dev/pkg v0.0.0-20201209172941-9b9407a76df1 h1:whfizV9at+XvlOK66xm1WfiiPhybrRa9LbZa4uXbWIs=
 knative.dev/pkg v0.0.0-20201209172941-9b9407a76df1/go.mod h1:Jtbz2/1gB8EZgZA4VvabTxM+AcDt2WL2P0RaFnKcOX8=
-knative.dev/pkg v0.0.0-20201210014142-0c53297607c6 h1:7fJ52FZ7BLwQf1NtK9SfRm16wdBCdwW5ZY/u3tOa904=
-knative.dev/pkg v0.0.0-20201210014142-0c53297607c6/go.mod h1:Jtbz2/1gB8EZgZA4VvabTxM+AcDt2WL2P0RaFnKcOX8=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/pkg/autoscaler/bucket/bucket.go
+++ b/pkg/autoscaler/bucket/bucket.go
@@ -52,16 +52,26 @@ func AutoscalerBucketSet(total uint32) *hash.BucketSet {
 	return hash.NewBucketSet(names)
 }
 
-// Identity returns a identify for this Autoscaler pod used as the Lease holder
-// identity. It's in the format of <POD-NAME>_<POD-IP> whose information is ready from
-// environment variables.
-func Identity() (string, error) {
+// PodIP returns the IP address of the current pod, or an error
+// if it wasn't properly projected.
+func PodIP() (string, error) {
 	selfIP, existing := os.LookupEnv("POD_IP")
 	if !existing {
 		return "", errors.New("POD_IP environment variable not set")
 	}
 	if selfIP == "" {
 		return "", errors.New("POD_IP environment variable is empty")
+	}
+	return selfIP, nil
+}
+
+// Identity returns a identify for this Autoscaler pod used as the Lease holder
+// identity. It's in the format of <POD-NAME>_<POD-IP> whose information is ready from
+// environment variables.
+func Identity() (string, error) {
+	selfIP, err := PodIP()
+	if err != nil {
+		return "", err
 	}
 
 	podName, existing := os.LookupEnv("POD_NAME")

--- a/pkg/autoscaler/statforwarder/forwarder.go
+++ b/pkg/autoscaler/statforwarder/forwarder.go
@@ -23,24 +23,10 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	coordinationv1 "k8s.io/api/coordination/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
-	corev1listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
-	leaseinformer "knative.dev/pkg/client/injection/kube/informers/coordination/v1/lease"
-	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
-	"knative.dev/pkg/controller"
 	"knative.dev/pkg/hash"
+	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
 	"knative.dev/pkg/network"
-	"knative.dev/pkg/system"
-	"knative.dev/serving/pkg/autoscaler/bucket"
 	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
 )
 
@@ -92,11 +78,13 @@ type Forwarder struct {
 }
 
 // New creates a new Forwarder.
-func New(ctx context.Context, logger *zap.SugaredLogger, kc kubernetes.Interface, selfIP string, bs *hash.BucketSet, accept statProcessor) *Forwarder {
+// This must be configured with a mechanism for setting up its "processors",
+// such as LeaseBasedProcessor or StatefulSetBasedProcessor, which correlates
+// with the mechanism of leader election being used.
+func New(ctx context.Context, bs *hash.BucketSet) *Forwarder {
 	bkts := bs.Buckets()
-	endpointsInformer := endpointsinformer.Get(ctx)
 	f := &Forwarder{
-		logger:     logger,
+		logger:     logging.FromContext(ctx),
 		bs:         bs,
 		processors: make(map[string]bucketProcessor, len(bkts)),
 		statCh:     make(chan stat, 1000),
@@ -106,252 +94,7 @@ func New(ctx context.Context, logger *zap.SugaredLogger, kc kubernetes.Interface
 	f.processingWg.Add(1)
 	go f.process()
 
-	lt := &leaseTracker{
-		logger:          logger,
-		selfIP:          selfIP,
-		bs:              bs,
-		kc:              kc,
-		endpointsLister: endpointsInformer.Lister(),
-		id2ip:           make(map[string]string),
-		accept:          accept,
-		fwd:             f,
-	}
-
-	leaseInformer := leaseinformer.Get(ctx)
-	leaseInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: lt.filterFunc(system.Namespace()),
-		Handler: cache.ResourceEventHandlerFuncs{
-			AddFunc:    lt.leaseUpdated,
-			UpdateFunc: controller.PassNew(lt.leaseUpdated),
-			// TODO(yanweiguo): Set up DeleteFunc.
-		},
-	})
-
 	return f
-}
-
-// leaseTracker monitors lease resources to update the Forwarder's processor configuration(s)
-// with the appropriate owner's stats endpoint.  When we own the lease, a localProcessor is
-// used, and when someone else owns the lease a remoteProcessor is used with their stats
-// endpoint.
-type leaseTracker struct {
-	logger *zap.SugaredLogger
-	selfIP string
-	// bs is the BucketSet including all Autoscaler buckets.
-	bs *hash.BucketSet
-
-	kc              kubernetes.Interface
-	endpointsLister corev1listers.EndpointsLister
-
-	// id2ip stores the IP extracted from the holder identity to avoid
-	// string split each time.
-	id2ip map[string]string
-
-	// `accept` is the function to process a StatMessage which doesn't need
-	// to be forwarded.
-	accept statProcessor
-
-	fwd *Forwarder
-}
-
-func (f *leaseTracker) extractIP(holder string) (string, error) {
-	if ip, ok := f.id2ip[holder]; ok {
-		return ip, nil
-	}
-
-	_, ip, err := bucket.ExtractPodNameAndIP(holder)
-	if err == nil {
-		f.id2ip[holder] = ip
-	}
-	return ip, err
-}
-
-func (f *leaseTracker) filterFunc(namespace string) func(interface{}) bool {
-	return func(obj interface{}) bool {
-		l := obj.(*coordinationv1.Lease)
-
-		if l.Namespace != namespace {
-			return false
-		}
-
-		if !f.bs.HasBucket(l.Name) {
-			// Not for Autoscaler.
-			return false
-		}
-
-		if l.Spec.HolderIdentity == nil || *l.Spec.HolderIdentity == "" {
-			// No holder yet.
-			return false
-		}
-
-		// The holder identity is in format of <POD-NAME>_<POD-IP>.
-		holder := *l.Spec.HolderIdentity
-		_, err := f.extractIP(holder)
-		if err != nil {
-			f.logger.Warn("Found invalid Lease holder identify ", holder)
-			return false
-		}
-		if p := f.fwd.getProcessor(l.Name); p != nil && p.is(holder) {
-			return false
-		}
-
-		return true
-	}
-}
-
-func (f *leaseTracker) leaseUpdated(obj interface{}) {
-	l := obj.(*coordinationv1.Lease)
-	ns, n := l.Namespace, l.Name
-	ctx := context.Background()
-
-	if l.Spec.HolderIdentity == nil {
-		// This shouldn't happen as we filter it out when queueing.
-		// Add a nil point check for safety.
-		f.logger.Warnf("Lease %s/%s with nil HolderIdentity got enqueued", ns, n)
-		return
-	}
-
-	// Close existing connection if there's one. The target address won't
-	// be the same as the IP has changed.
-	if p := f.fwd.getProcessor(n); p != nil {
-		p.shutdown()
-	}
-
-	holder := *l.Spec.HolderIdentity
-	// The map should have the IP because of the operations in the filter when queueing.
-	ip, ok := f.id2ip[holder]
-	if !ok {
-		// This shouldn't happen because we store the value into the map in the filter
-		// when queueing. Add a log here in case something unexpected happens.
-		f.logger.Warn("IP not found in cached map for ", holder)
-		return
-	}
-
-	if ip != f.selfIP {
-		f.fwd.setProcessor(n, newForwardProcessor(f.logger.With(zap.String("bucket", n)), n, holder,
-			fmt.Sprintf("ws://%s:%d", ip, autoscalerPort),
-			fmt.Sprintf("ws://%s.%s.%s", n, ns, svcURLSuffix)))
-
-		// Skip creating/updating Service and Endpoints if not the leader.
-		return
-	}
-
-	f.fwd.setProcessor(n, &localProcessor{
-		bkt:    n,
-		holder: holder,
-		logger: f.logger.With(zap.String("bucket", n)),
-		accept: f.accept,
-	})
-
-	if err := f.createService(ctx, ns, n); err != nil {
-		f.logger.Fatalf("Failed to create Service for Lease %s/%s: %v", ns, n, err)
-		return
-	}
-	f.logger.Infof("Created Service for Lease %s/%s", ns, n)
-
-	if err := f.createOrUpdateEndpoints(ctx, ns, n); err != nil {
-		f.logger.Fatalf("Failed to create Endpoints for Lease %s/%s: %v", ns, n, err)
-		return
-	}
-	f.logger.Infof("Created Endpoints for Lease %s/%s", ns, n)
-}
-
-func (f *leaseTracker) createService(ctx context.Context, ns, n string) error {
-	var lastErr error
-	if err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
-		_, lastErr = f.kc.CoreV1().Services(ns).Create(ctx, &corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      n,
-				Namespace: ns,
-			},
-			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{{
-					Name:       autoscalerPortName,
-					Port:       autoscalerPort,
-					TargetPort: intstr.FromInt(autoscalerPort),
-				}},
-			},
-		}, metav1.CreateOptions{})
-
-		if apierrs.IsAlreadyExists(lastErr) {
-			return true, nil
-		}
-
-		// Do not return the error to cause a retry.
-		return lastErr == nil, nil
-	}); err != nil {
-		return lastErr
-	}
-
-	return nil
-}
-
-// createOrUpdateEndpoints creates an Endpoints object with the given namespace and
-// name, and the Forwarder.selfIP. If the Endpoints object already
-// exists, it will update the Endpoints with the Forwarder.selfIP.
-func (f *leaseTracker) createOrUpdateEndpoints(ctx context.Context, ns, n string) error {
-	wantSubsets := []corev1.EndpointSubset{{
-		Addresses: []corev1.EndpointAddress{{
-			IP: f.selfIP,
-		}},
-		Ports: []corev1.EndpointPort{{
-			Name:     autoscalerPortName,
-			Port:     autoscalerPort,
-			Protocol: corev1.ProtocolTCP,
-		}}},
-	}
-
-	exists := true
-	var lastErr error
-	if err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
-		e, err := f.endpointsLister.Endpoints(ns).Get(n)
-		if apierrs.IsNotFound(err) {
-			exists = false
-			return true, nil
-		}
-
-		if err != nil {
-			lastErr = err
-			// Do not return the error to cause a retry.
-			return false, nil
-		}
-
-		if equality.Semantic.DeepEqual(wantSubsets, e.Subsets) {
-			return true, nil
-		}
-
-		want := e.DeepCopy()
-		want.Subsets = wantSubsets
-		if _, lastErr = f.kc.CoreV1().Endpoints(ns).Update(ctx, want, metav1.UpdateOptions{}); lastErr != nil {
-			// Do not return the error to cause a retry.
-			return false, nil
-		}
-
-		f.logger.Infof("Bucket Endpoints %s updated with IP %s", n, f.selfIP)
-		return true, nil
-	}); err != nil {
-		return lastErr
-	}
-
-	if exists {
-		return nil
-	}
-
-	if err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
-		_, lastErr = f.kc.CoreV1().Endpoints(ns).Create(ctx, &corev1.Endpoints{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      n,
-				Namespace: ns,
-			},
-			Subsets: wantSubsets,
-		}, metav1.CreateOptions{})
-		// Do not return the error to cause a retry.
-		return lastErr == nil, nil
-	}); err != nil {
-		return lastErr
-	}
-
-	return nil
 }
 
 func (f *Forwarder) getProcessor(bkt string) bucketProcessor {

--- a/pkg/autoscaler/statforwarder/leases.go
+++ b/pkg/autoscaler/statforwarder/leases.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statforwarder
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	leaseinformer "knative.dev/pkg/client/injection/kube/informers/coordination/v1/lease"
+	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/hash"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/system"
+	"knative.dev/serving/pkg/autoscaler/bucket"
+)
+
+// LeaseBasedProcessor tracks leases and decodes the holder's identity in order to set the
+// appropriate "processor" on the Forwarder.
+func LeaseBasedProcessor(ctx context.Context, f *Forwarder, accept statProcessor) error {
+	selfIP, err := bucket.PodIP()
+	if err != nil {
+		return err
+	}
+	endpointsInformer := endpointsinformer.Get(ctx)
+	lt := &leaseTracker{
+		logger:          logging.FromContext(ctx),
+		selfIP:          selfIP,
+		bs:              f.bs,
+		kc:              kubeclient.Get(ctx),
+		endpointsLister: endpointsInformer.Lister(),
+		id2ip:           make(map[string]string),
+		accept:          accept,
+		fwd:             f,
+	}
+
+	leaseInformer := leaseinformer.Get(ctx)
+	leaseInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: lt.filterFunc(system.Namespace()),
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc:    lt.leaseUpdated,
+			UpdateFunc: controller.PassNew(lt.leaseUpdated),
+			// TODO(yanweiguo): Set up DeleteFunc.
+		},
+	})
+
+	return nil
+}
+
+// leaseTracker monitors lease resources to update the Forwarder's processor configuration(s)
+// with the appropriate owner's stats endpoint.  When we own the lease, a localProcessor is
+// used, and when someone else owns the lease a remoteProcessor is used with their stats
+// endpoint.
+type leaseTracker struct {
+	logger *zap.SugaredLogger
+	selfIP string
+	// bs is the BucketSet including all Autoscaler buckets.
+	bs *hash.BucketSet
+
+	kc              kubernetes.Interface
+	endpointsLister corev1listers.EndpointsLister
+
+	// id2ip stores the IP extracted from the holder identity to avoid
+	// string split each time.
+	id2ip map[string]string
+
+	// `accept` is the function to process a StatMessage which doesn't need
+	// to be forwarded.
+	accept statProcessor
+
+	fwd *Forwarder
+}
+
+func (f *leaseTracker) extractIP(holder string) (string, error) {
+	if ip, ok := f.id2ip[holder]; ok {
+		return ip, nil
+	}
+
+	_, ip, err := bucket.ExtractPodNameAndIP(holder)
+	if err == nil {
+		f.id2ip[holder] = ip
+	}
+	return ip, err
+}
+
+func (f *leaseTracker) filterFunc(namespace string) func(interface{}) bool {
+	return func(obj interface{}) bool {
+		l := obj.(*coordinationv1.Lease)
+
+		if l.Namespace != namespace {
+			return false
+		}
+
+		if !f.bs.HasBucket(l.Name) {
+			// Not for Autoscaler.
+			return false
+		}
+
+		if l.Spec.HolderIdentity == nil || *l.Spec.HolderIdentity == "" {
+			// No holder yet.
+			return false
+		}
+
+		// The holder identity is in format of <POD-NAME>_<POD-IP>.
+		holder := *l.Spec.HolderIdentity
+		_, err := f.extractIP(holder)
+		if err != nil {
+			f.logger.Warn("Found invalid Lease holder identify ", holder)
+			return false
+		}
+		if p := f.fwd.getProcessor(l.Name); p != nil && p.is(holder) {
+			return false
+		}
+
+		return true
+	}
+}
+
+func (f *leaseTracker) leaseUpdated(obj interface{}) {
+	l := obj.(*coordinationv1.Lease)
+	ns, n := l.Namespace, l.Name
+	ctx := context.Background()
+
+	if l.Spec.HolderIdentity == nil {
+		// This shouldn't happen as we filter it out when queueing.
+		// Add a nil point check for safety.
+		f.logger.Warnf("Lease %s/%s with nil HolderIdentity got enqueued", ns, n)
+		return
+	}
+
+	// Close existing connection if there's one. The target address won't
+	// be the same as the IP has changed.
+	if p := f.fwd.getProcessor(n); p != nil {
+		p.shutdown()
+	}
+
+	holder := *l.Spec.HolderIdentity
+	// The map should have the IP because of the operations in the filter when queueing.
+	ip, ok := f.id2ip[holder]
+	if !ok {
+		// This shouldn't happen because we store the value into the map in the filter
+		// when queueing. Add a log here in case something unexpected happens.
+		f.logger.Warn("IP not found in cached map for ", holder)
+		return
+	}
+
+	if ip != f.selfIP {
+		f.fwd.setProcessor(n, newForwardProcessor(f.logger.With(zap.String("bucket", n)), n, holder,
+			fmt.Sprintf("ws://%s:%d", ip, autoscalerPort),
+			fmt.Sprintf("ws://%s.%s.%s", n, ns, svcURLSuffix)))
+
+		// Skip creating/updating Service and Endpoints if not the leader.
+		return
+	}
+
+	f.fwd.setProcessor(n, &localProcessor{
+		bkt:    n,
+		holder: holder,
+		logger: f.logger.With(zap.String("bucket", n)),
+		accept: f.accept,
+	})
+
+	if err := f.createService(ctx, ns, n); err != nil {
+		f.logger.Fatalf("Failed to create Service for Lease %s/%s: %v", ns, n, err)
+		return
+	}
+	f.logger.Infof("Created Service for Lease %s/%s", ns, n)
+
+	if err := f.createOrUpdateEndpoints(ctx, ns, n); err != nil {
+		f.logger.Fatalf("Failed to create Endpoints for Lease %s/%s: %v", ns, n, err)
+		return
+	}
+	f.logger.Infof("Created Endpoints for Lease %s/%s", ns, n)
+}
+
+func (f *leaseTracker) createService(ctx context.Context, ns, n string) error {
+	var lastErr error
+	if err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+		_, lastErr = f.kc.CoreV1().Services(ns).Create(ctx, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      n,
+				Namespace: ns,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{
+					Name:       autoscalerPortName,
+					Port:       autoscalerPort,
+					TargetPort: intstr.FromInt(autoscalerPort),
+				}},
+			},
+		}, metav1.CreateOptions{})
+
+		if apierrs.IsAlreadyExists(lastErr) {
+			return true, nil
+		}
+
+		// Do not return the error to cause a retry.
+		return lastErr == nil, nil
+	}); err != nil {
+		return lastErr
+	}
+
+	return nil
+}
+
+// createOrUpdateEndpoints creates an Endpoints object with the given namespace and
+// name, and the Forwarder.selfIP. If the Endpoints object already
+// exists, it will update the Endpoints with the Forwarder.selfIP.
+func (f *leaseTracker) createOrUpdateEndpoints(ctx context.Context, ns, n string) error {
+	wantSubsets := []corev1.EndpointSubset{{
+		Addresses: []corev1.EndpointAddress{{
+			IP: f.selfIP,
+		}},
+		Ports: []corev1.EndpointPort{{
+			Name:     autoscalerPortName,
+			Port:     autoscalerPort,
+			Protocol: corev1.ProtocolTCP,
+		}}},
+	}
+
+	exists := true
+	var lastErr error
+	if err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+		e, err := f.endpointsLister.Endpoints(ns).Get(n)
+		if apierrs.IsNotFound(err) {
+			exists = false
+			return true, nil
+		}
+
+		if err != nil {
+			lastErr = err
+			// Do not return the error to cause a retry.
+			return false, nil
+		}
+
+		if equality.Semantic.DeepEqual(wantSubsets, e.Subsets) {
+			return true, nil
+		}
+
+		want := e.DeepCopy()
+		want.Subsets = wantSubsets
+		if _, lastErr = f.kc.CoreV1().Endpoints(ns).Update(ctx, want, metav1.UpdateOptions{}); lastErr != nil {
+			// Do not return the error to cause a retry.
+			return false, nil
+		}
+
+		f.logger.Infof("Bucket Endpoints %s updated with IP %s", n, f.selfIP)
+		return true, nil
+	}); err != nil {
+		return lastErr
+	}
+
+	if exists {
+		return nil
+	}
+
+	if err := wait.PollImmediate(retryInterval, retryTimeout, func() (bool, error) {
+		_, lastErr = f.kc.CoreV1().Endpoints(ns).Create(ctx, &corev1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      n,
+				Namespace: ns,
+			},
+			Subsets: wantSubsets,
+		}, metav1.CreateOptions{})
+		// Do not return the error to cause a retry.
+		return lastErr == nil, nil
+	}); err != nil {
+		return lastErr
+	}
+
+	return nil
+}

--- a/pkg/autoscaler/statforwarder/statefulset.go
+++ b/pkg/autoscaler/statforwarder/statefulset.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statforwarder
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"knative.dev/pkg/leaderelection"
+)
+
+// StatefulSetBasedProcessor configured "processors" for each of the statefulset ordinals.
+func StatefulSetBasedProcessor(ctx context.Context, f *Forwarder, accept statProcessor) error {
+	id, bs, err := leaderelection.NewStatefulSetBucketAndSet(len(f.bs.BucketList()))
+	if err != nil {
+		return err
+	}
+	for _, b := range bs.Buckets() {
+		n := b.Name()
+		if n == id.Name() {
+			f.setProcessor(n, &localProcessor{
+				bkt:    n,
+				logger: f.logger.With(zap.String("bucket", n)),
+				accept: accept,
+			})
+		} else {
+			f.setProcessor(n, newForwardProcessor(f.logger.With(zap.String("bucket", n)), n, "unused", n))
+		}
+	}
+	return nil
+}

--- a/pkg/autoscaler/statforwarder/statefulset.go
+++ b/pkg/autoscaler/statforwarder/statefulset.go
@@ -30,8 +30,7 @@ func StatefulSetBasedProcessor(ctx context.Context, f *Forwarder, accept statPro
 		return err
 	}
 	for _, b := range bs.Buckets() {
-		n := b.Name()
-		if n == id.Name() {
+		if n := b.Name(); n == id.Name() {
 			f.setProcessor(n, &localProcessor{
 				bkt:    n,
 				logger: f.logger.With(zap.String("bucket", n)),

--- a/vendor/knative.dev/networking/test/conformance/ingress/util.go
+++ b/vendor/knative.dev/networking/test/conformance/ingress/util.go
@@ -298,6 +298,81 @@ func CreateTimeoutService(ctx context.Context, t *testing.T, clients *test.Clien
 	return name, port, createPodAndService(ctx, t, clients, pod, svc)
 }
 
+// CreateFlakyService creates a Kubernetes service where the backing pod will
+// succeed only every Nth request.
+func CreateFlakyService(ctx context.Context, t *testing.T, clients *test.Clients, period int) (string, int, context.CancelFunc) {
+	t.Helper()
+	name := test.ObjectNameForTest(t)
+
+	// Avoid zero, but pick a low port number.
+	port := 50 + rand.Intn(50)
+	t.Logf("[%s] Using port %d", name, port)
+
+	// Pick a high port number.
+	containerPort := 8000 + rand.Intn(100)
+	t.Logf("[%s] Using containerPort %d", name, containerPort)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:            "foo",
+				Image:           pkgTest.ImagePath("flaky"),
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Ports: []corev1.ContainerPort{{
+					Name:          networking.ServicePortNameHTTP1,
+					ContainerPort: int32(containerPort),
+				}},
+				// This is needed by the runtime image we are using.
+				Env: []corev1.EnvVar{{
+					Name:  "PORT",
+					Value: strconv.Itoa(containerPort),
+				}, {
+					Name:  "PERIOD",
+					Value: strconv.Itoa(period),
+				}},
+				ReadinessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/",
+							Port: intstr.FromInt(containerPort),
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: "ClusterIP",
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameHTTP1,
+				Port:       int32(port),
+				TargetPort: intstr.FromInt(containerPort),
+			}},
+			Selector: map[string]string{
+				"test-pod": name,
+			},
+		},
+	}
+
+	return name, port, createPodAndService(ctx, t, clients, pod, svc)
+}
+
 // CreateWebsocketService creates a Kubernetes service that will upgrade the connection
 // to use websockets and echo back the received messages with the provided suffix.
 func CreateWebsocketService(ctx context.Context, t *testing.T, clients *test.Clients, suffix string) (string, int, context.CancelFunc) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -978,7 +978,7 @@ knative.dev/caching/pkg/client/listers/caching/v1alpha1
 # knative.dev/hack v0.0.0-20201201234937-fddbf732e450
 ## explicit
 knative.dev/hack
-# knative.dev/networking v0.0.0-20201210074041-cdd0e325c1a9
+# knative.dev/networking v0.0.0-20201209181441-896c0e7c4864
 ## explicit
 knative.dev/networking/config
 knative.dev/networking/pkg
@@ -1012,7 +1012,7 @@ knative.dev/networking/test/conformance/ingress
 knative.dev/networking/test/defaultsystem
 knative.dev/networking/test/test_images/grpc-ping/proto
 knative.dev/networking/test/types
-# knative.dev/pkg v0.0.0-20201210014142-0c53297607c6
+# knative.dev/pkg v0.0.0-20201209172941-9b9407a76df1
 ## explicit
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate


### PR DESCRIPTION
This change continues the march of my prior changes to separate the awareness of how ownership of a bucket is established from how the bucket ownership information is consumed.

With this change, the `leaseTracker` is moved into its own file and no longer invoked by `statsforwarder.New`, but depending on the method of HA employed by the entrypoint the resulting `Forwarder` may be passed to either `LeaseBasedProcessor` or `StatefulSetBasedProcessor` to configure the Forwarder's processors on an ongoing basis.

This change also implements the `StatefulSetBaseProcessor`, and configures the autoscalers entrypoint to dynamically configure the appropriate HA mode based on the provided environment variables.


This is WIP because I'm including changes to run the autoscaler as a statefulset here as a sanity check that it works.  This is also still based on https://github.com/knative/serving/pull/10329 which needs to land first.