### PR TITLE
Add stepping logic to compute min next time and re-enqueue

### DIFF
--- a/pkg/reconciler/route/controller.go
+++ b/pkg/reconciler/route/controller.go
@@ -93,6 +93,7 @@ func newControllerWithClock(
 		configStore.WatchConfigs(cmw)
 		return controller.Options{ConfigStore: configStore}
 	})
+	c.enqueueAfter = impl.EnqueueAfter
 
 	logger.Info("Setting up event handlers")
 	routeInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))

--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -78,12 +78,19 @@ func (c *Reconciler) reconcileIngress(
 			ingress.Annotations[networking.RolloutAnnotationKey])
 
 		// And recompute the rollout state.
-		now := int(c.clock.Now().UnixNano())
+		now := c.clock.Now().UnixNano()
 		effectiveRO, nextStepTime := curRO.Step(prevRO, now)
 		logger := logging.FromContext(ctx).Desugar()
 		if nextStepTime > 0 {
 			nextStepTime -= now
 			c.enqueueAfter(r, time.Duration(nextStepTime))
+		}
+
+		// Now check if the ingress status changed from not ready to ready.
+		rtView := r.Status.GetCondition(v1.RouteConditionIngressReady)
+		if ingress.IsReady() && !rtView.IsTrue() {
+			logger.Debug("Observing Ingress not-ready to ready switch condition for rollout")
+			effectiveRO.ObserveReady(now)
 		}
 
 		// Comparing and diffing isn't cheap so do it only if we're going
@@ -92,13 +99,6 @@ func (c *Reconciler) reconcileIngress(
 		if logger.Core().Enabled(zapcore.DebugLevel) && !cmp.Equal(prevRO, effectiveRO) {
 			logger.Debug("Rollout diff:(-was,+now)",
 				zap.String("diff", cmp.Diff(prevRO, effectiveRO)))
-		}
-
-		// Now check if the ingress status changed from not ready to ready.
-		rtView := r.Status.GetCondition(v1.RouteConditionIngressReady)
-		if ingress.IsReady() && !rtView.IsTrue() {
-			logger.Debug("Observing Ingress not-ready to ready switch condition for rollout")
-			effectiveRO.ObserveReady(int(c.clock.Now().UnixNano()))
 		}
 
 		desired, err := resources.MakeIngressWithRollout(ctx, r, tc, effectiveRO,

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	kubelabels "k8s.io/apimachinery/pkg/labels"
@@ -70,7 +71,8 @@ type Reconciler struct {
 	certificateLister   networkinglisters.CertificateLister
 	tracker             tracker.Interface
 
-	clock system.Clock
+	clock        system.Clock
+	enqueueAfter func(interface{}, time.Duration)
 }
 
 // Check that our Reconciler implements routereconciler.Interface

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -435,10 +435,10 @@ func TestReconcile(t *testing.T) {
 					RevisionName: "config-00001", Percent: 1,
 				}}, fakeCurTime.Add(-3*time.Second),
 					func(r *traffic.Rollout) {
-						// Step duration is 3s (now - (now-3s)).
-						r.Configurations[0].StepParams.StepDuration = 3
-						// 120 / 3 = 40 steps. floor(100/40) = 2.
-						r.Configurations[0].StepParams.StepSize = 2
+						numSteps := 120 / 3 // 40
+						// Step duration is 3s (duration / numSteps = 120/40)
+						r.Configurations[0].StepParams.StepDuration = int(time.Second) * 120 / numSteps // 3s in ns.
+						r.Configurations[0].StepParams.StepSize = (100 - 1) / numSteps                  // 2
 						// StepDuration is 3, and so next step is `now` + 3.
 						r.Configurations[0].StepParams.NextStepTime = int(fakeCurTime.Add(3 * time.Second).UnixNano())
 					},

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -435,12 +435,12 @@ func TestReconcile(t *testing.T) {
 					RevisionName: "config-00001", Percent: 1,
 				}}, fakeCurTime.Add(-3*time.Second),
 					func(r *traffic.Rollout) {
-						numSteps := 120 / 3 // 40
+						const numSteps = 120 / 3 // 40
 						// Step duration is 3s (duration / numSteps = 120/40)
-						r.Configurations[0].StepParams.StepDuration = int(time.Second) * 120 / numSteps // 3s in ns.
-						r.Configurations[0].StepParams.StepSize = (100 - 1) / numSteps                  // 2
+						r.Configurations[0].StepParams.StepDuration = int64(time.Second) * 120 / numSteps // 3s in ns.
+						r.Configurations[0].StepParams.StepSize = (100 - 1) / numSteps                    // 2
 						// StepDuration is 3, and so next step is `now` + 3.
-						r.Configurations[0].StepParams.NextStepTime = int(fakeCurTime.Add(3 * time.Second).UnixNano())
+						r.Configurations[0].StepParams.NextStepTime = fakeCurTime.Add(3 * time.Second).UnixNano()
 					},
 				)),
 		}, {
@@ -2695,7 +2695,7 @@ func simpleRollout(cfg string, revs []traffic.RevisionRollout,
 			Configurations: []traffic.ConfigurationRollout{{
 				ConfigurationName: cfg,
 				StepParams: traffic.RolloutParams{
-					StartTime: int(now.UnixNano()),
+					StartTime: now.UnixNano(),
 				},
 				Percent:   100,
 				Revisions: revs,

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -35,7 +35,7 @@ func TestStep(t *testing.T) {
 	tests := []struct {
 		name            string
 		prev, cur, want *Rollout
-		wantNextStep    int
+		wantNextStep    int64
 	}{{
 		name: "no prev",
 		cur:  &Rollout{},
@@ -1064,18 +1064,18 @@ func TestObserveReady(t *testing.T) {
 			Percent:           100,
 			StepParams: RolloutParams{
 				StartTime:    oldenDays,
-				StepDuration: int(3 * time.Second),
+				StepDuration: int64(3 * time.Second),
 				StepSize:     100 / 40,
-				NextStepTime: now + 3*int(time.Second),
+				NextStepTime: now + 3*int64(time.Second),
 			},
 		}, {
 			ConfigurationName: "Percent not 100%",
 			Percent:           50,
 			StepParams: RolloutParams{
 				StartTime:    oldenDays,
-				StepDuration: int(3 * time.Second),
+				StepDuration: int64(3 * time.Second),
 				StepSize:     50 / 40,
-				NextStepTime: now + 3*int(time.Second),
+				NextStepTime: now + 3*int64(time.Second),
 			},
 		}},
 	}
@@ -1376,7 +1376,7 @@ func TestJSONRoundtrip(t *testing.T) {
 func TestStepRevisions(t *testing.T) {
 	tests := []struct {
 		name string
-		now  int
+		now  int64
 		cfg  *ConfigurationRollout
 		want *ConfigurationRollout
 	}{{

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -35,6 +35,7 @@ func TestStep(t *testing.T) {
 	tests := []struct {
 		name            string
 		prev, cur, want *Rollout
+		wantNextStep    int
 	}{{
 		name: "no prev",
 		cur:  &Rollout{},
@@ -116,12 +117,6 @@ func TestStep(t *testing.T) {
 					RevisionName: "let-it-bleed",
 					Percent:      100,
 				}},
-				StepParams: RolloutParams{
-					NextStepTime: 2009,
-					StepDuration: 2020,
-					StartTime:    2004,
-					StepSize:     14,
-				},
 			}},
 		},
 		prev: &Rollout{
@@ -155,13 +150,198 @@ func TestStep(t *testing.T) {
 					Percent:      8, // +3
 				}},
 				StepParams: RolloutParams{
-					NextStepTime: 2020 + 5, // now + duration.
+					NextStepTime: now + 5, // now + duration.
 					StepDuration: 5,
 					StartTime:    2004,
 					StepSize:     3,
 				},
 			}},
 		},
+		wantNextStep: now + 5,
+	}, {
+		name: "multiple configs step",
+		cur: &Rollout{
+			Configurations: []ConfigurationRollout{{
+				ConfigurationName: "mick",
+				Percent:           42,
+				Revisions: []RevisionRollout{{
+					RevisionName: "let-it-bleed",
+					Percent:      42,
+				}},
+			}, {
+				ConfigurationName: "keith",
+				Percent:           52,
+				Revisions: []RevisionRollout{{
+					RevisionName: "beggars-banquet",
+					Percent:      52,
+				}},
+			}},
+			// 6% allocated to the revision direct, say.
+		},
+		prev: &Rollout{
+			Configurations: []ConfigurationRollout{{
+				ConfigurationName: "mick",
+				Percent:           42,
+				StepParams: RolloutParams{
+					NextStepTime: 2019,
+					StepDuration: 43,
+					StartTime:    1961,
+					StepSize:     3,
+				},
+				Revisions: []RevisionRollout{{
+					RevisionName: "their-satanic-majesties-request",
+					Percent:      37,
+				}, {
+					RevisionName: "let-it-bleed",
+					Percent:      5,
+				}},
+			}, {
+				ConfigurationName: "keith",
+				Percent:           52,
+				StepParams: RolloutParams{
+					NextStepTime: 2018,
+					StepDuration: 55,
+					StartTime:    1971,
+					StepSize:     4,
+				},
+				Revisions: []RevisionRollout{{
+					RevisionName: "sticky-fingers",
+					Percent:      36,
+				}, {
+					RevisionName: "beggars-banquet",
+					Percent:      16,
+				}},
+			}},
+		},
+		want: &Rollout{
+			// Note: order will change, since we sort.
+			Configurations: []ConfigurationRollout{{
+				ConfigurationName: "keith",
+				Percent:           52,
+				StepParams: RolloutParams{
+					NextStepTime: now + 55,
+					StepDuration: 55,
+					StartTime:    1971,
+					StepSize:     4,
+				},
+				Revisions: []RevisionRollout{{
+					RevisionName: "sticky-fingers",
+					Percent:      32,
+				}, {
+					RevisionName: "beggars-banquet",
+					Percent:      20,
+				}},
+			}, {
+				ConfigurationName: "mick",
+				Percent:           42,
+				Revisions: []RevisionRollout{{
+					RevisionName: "their-satanic-majesties-request",
+					Percent:      34, // -3
+				}, {
+					RevisionName: "let-it-bleed",
+					Percent:      8, // +3
+				}},
+				StepParams: RolloutParams{
+					NextStepTime: now + 43, // now + duration.
+					StepDuration: 43,
+					StartTime:    1961,
+					StepSize:     3,
+				},
+			}},
+		},
+		wantNextStep: now + 43, // the min of the two.
+	}, {
+		name: "multiple configs step and roll",
+		cur: &Rollout{
+			Configurations: []ConfigurationRollout{{
+				ConfigurationName: "mick",
+				Percent:           42,
+				Revisions: []RevisionRollout{{
+					RevisionName: "let-it-bleed",
+					Percent:      42,
+				}},
+			}, {
+				ConfigurationName: "keith",
+				Percent:           52,
+				Revisions: []RevisionRollout{{
+					RevisionName: "tattoo-you",
+					Percent:      52,
+				}},
+			}},
+			// 6% allocated to the revision direct, say.
+		},
+		prev: &Rollout{
+			Configurations: []ConfigurationRollout{{
+				ConfigurationName: "mick",
+				Percent:           42,
+				StepParams: RolloutParams{
+					NextStepTime: 2019,
+					StepDuration: 43,
+					StartTime:    1961,
+					StepSize:     3,
+				},
+				Revisions: []RevisionRollout{{
+					RevisionName: "their-satanic-majesties-request",
+					Percent:      37,
+				}, {
+					RevisionName: "let-it-bleed",
+					Percent:      5,
+				}},
+			}, {
+				ConfigurationName: "keith",
+				Percent:           52,
+				StepParams: RolloutParams{
+					NextStepTime: 2018,
+					StepDuration: 55,
+					StartTime:    1971,
+					StepSize:     4,
+				},
+				Revisions: []RevisionRollout{{
+					RevisionName: "sticky-fingers",
+					Percent:      36,
+				}, {
+					RevisionName: "beggars-banquet",
+					Percent:      16,
+				}},
+			}},
+		},
+		want: &Rollout{
+			// Note: order will change, since we sort.
+			Configurations: []ConfigurationRollout{{
+				ConfigurationName: "keith",
+				Percent:           52,
+				StepParams: RolloutParams{
+					StartTime: 2020,
+				},
+				Revisions: []RevisionRollout{{
+					RevisionName: "sticky-fingers",
+					Percent:      36,
+				}, {
+					RevisionName: "beggars-banquet",
+					Percent:      15,
+				}, {
+					RevisionName: "tattoo-you",
+					Percent:      1,
+				}},
+			}, {
+				ConfigurationName: "mick",
+				Percent:           42,
+				Revisions: []RevisionRollout{{
+					RevisionName: "their-satanic-majesties-request",
+					Percent:      34, // -3
+				}, {
+					RevisionName: "let-it-bleed",
+					Percent:      8, // +3
+				}},
+				StepParams: RolloutParams{
+					NextStepTime: now + 43, // now + duration.
+					StepDuration: 43,
+					StartTime:    1961,
+					StepSize:     3,
+				},
+			}},
+		},
+		wantNextStep: now + 43, // the min of the two.
 	}, {
 		name: "simplest, step, when stepsize=0",
 		cur: &Rollout{
@@ -185,10 +365,8 @@ func TestStep(t *testing.T) {
 				ConfigurationName: "mick",
 				Percent:           100,
 				StepParams: RolloutParams{
-					NextStepTime: 2019, // <- Those should be reset and/or updated.
-					StartTime:    2004,
-					StepDuration: 5,
-					StepSize:     0,
+					StartTime: 2004,
+					// The other fields should not be set yet.
 				},
 				Revisions: []RevisionRollout{{
 					RevisionName: "their-satanic-majesties-request",
@@ -211,10 +389,7 @@ func TestStep(t *testing.T) {
 					Percent:      5,
 				}},
 				StepParams: RolloutParams{
-					NextStepTime: 2019,
-					StartTime:    2004,
-					StepDuration: 5,
-					StepSize:     0,
+					StartTime: 2004,
 				},
 			}},
 		},
@@ -302,6 +477,7 @@ func TestStep(t *testing.T) {
 				}},
 				StepParams: RolloutParams{ // <- Those should be thrown out.
 					NextStepTime: 1984,
+					StartTime:    1981,
 					StepDuration: 1988,
 					StepSize:     11,
 				},
@@ -814,12 +990,15 @@ func TestStep(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := tc.cur.Step(tc.prev, now)
+			got, gotNS := tc.cur.Step(tc.prev, now)
 			if want := tc.want; !cmp.Equal(got, want, cmpopts.EquateEmpty()) {
 				t.Errorf("Wrong rolled rollout, diff(-want,+got):\n%s", cmp.Diff(want, got))
 			}
 			if !got.Validate() {
 				t.Errorf("Step returned an invalid config:\n%#v", got)
+			}
+			if got, want := gotNS, tc.wantNextStep; got != want {
+				t.Errorf("Incorrect NextStepTime = %d, want: %d", got, want)
 			}
 		})
 	}
@@ -876,16 +1055,16 @@ func TestObserveReady(t *testing.T) {
 			Percent:           100,
 			StepParams: RolloutParams{
 				StartTime:    200620092020,
-				StepDuration: 2,
+				StepDuration: 1212121212,
 				StepSize:     1,
-				NextStepTime: now + int(2*time.Second),
+				NextStepTime: now + 1212121212,
 			},
 		}, {
 			ConfigurationName: "step-begin > 1s",
 			Percent:           100,
 			StepParams: RolloutParams{
 				StartTime:    oldenDays,
-				StepDuration: 3,
+				StepDuration: int(3 * time.Second),
 				StepSize:     100 / 40,
 				NextStepTime: now + 3*int(time.Second),
 			},
@@ -894,7 +1073,7 @@ func TestObserveReady(t *testing.T) {
 			Percent:           50,
 			StepParams: RolloutParams{
 				StartTime:    oldenDays,
-				StepDuration: 3,
+				StepDuration: int(3 * time.Second),
 				StepSize:     50 / 40,
 				NextStepTime: now + 3*int(time.Second),
 			},


### PR DESCRIPTION
Start returning minimal next time from the `Step`.
Then reenque at that time to ensure we reconcile the route
again to step some more.

/assign @tcnghia 

/hold
For #10334 to merge (probably will need merge conflicts :().