### PR TITLE
Move observe before step

### DIFF
--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -1797,6 +1797,7 @@ func TestReconcile(t *testing.T) {
 			ingressLister:       listers.GetIngressLister(),
 			tracker:             ctx.Value(TrackerKey).(tracker.Interface),
 			clock:               FakeClock{Time: fakeCurTime},
+			enqueueAfter:        func(interface{}, time.Duration) {},
 		}
 
 		return routereconciler.NewReconciler(ctx, logging.FromContext(ctx), servingclient.Get(ctx),


### PR DESCRIPTION
Move observe to apply to prev before step.
Why? Because:

- otherwise we'll need observe to duplicate the same logic to compute minimal returned next step time,
  right now it doesn't and that is a bug

Is it safe?
- Yes it is. Since it only applies to existing rollouts. If an existing rollout is being `obeserved` and then a new revision is added, the stats will just be reset at the `Step` call. If `prev` is `nil` — check is added for that.

That required to change the table tests to setup the `enqueueAfter`
since now that is triggered by the table tests.

/assign @tcnghia 