### PR TITLE
Add a functional component test to verify proper reconcile of the rollout

### DIFF
--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -92,6 +92,7 @@ func (c *Reconciler) reconcileIngress(
 		if nextStepTime > 0 {
 			nextStepTime -= now
 			c.enqueueAfter(r, time.Duration(nextStepTime))
+			logger.Debug("Re-enqueuing after", zap.Duration("duration", time.Duration(nextStepTime)))
 		}
 
 		// Comparing and diffing isn't cheap so do it only if we're going

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -55,7 +55,7 @@ func TestReconcileIngressInsert(t *testing.T) {
 	}
 }
 
-func TestReconcileIngressUpdateRenqueueRollout(t *testing.T) {
+func TestReconcileIngressUpdateReenqueueRollout(t *testing.T) {
 	var reconciler *Reconciler
 	const (
 		fakeCurSecs = 19551982

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -1797,6 +1797,7 @@ func TestReconcile(t *testing.T) {
 			ingressLister:       listers.GetIngressLister(),
 			tracker:             ctx.Value(TrackerKey).(tracker.Interface),
 			clock:               FakeClock{Time: fakeCurTime},
+			enqueueAfter:        func(interface{}, time.Duration) {},
 		}
 
 		return routereconciler.NewReconciler(ctx, logging.FromContext(ctx), servingclient.Get(ctx),


### PR DESCRIPTION
Based on  #10347

Add a multi-step component integration tests for reconcileIngress to ensure
proper rollout procedures are followed.
This is hard to do within standard table test.

/hold
for diffbase merge