### PR TITLE
Rather than `ceil` do `round` on the step size.

### DIFF
--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -162,7 +162,8 @@ func TestReconcileIngressUpdateReenqueueRollout(t *testing.T) {
 		t.Errorf("NextStepTime = %d, want: %d", got, want)
 	}
 
-	if got, want := ro.Configurations[0].StepParams.StepSize, 1; got != want {
+	// Rounding up, so step size should be 2.
+	if got, want := ro.Configurations[0].StepParams.StepSize, 47/24+1; got != want {
 		t.Errorf("StepSize = %d, want: %d", got, want)
 	}
 	if !wasReenqueued {

--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -416,11 +416,10 @@ func (cur *ConfigurationRollout) computeProperties(nowTS, minStepSec, durationSe
 	}
 
 	// We're moving traffic in equal steps.
-	// The last step can be larger, since it's more likely to
-	// easily accommodate the traffic jump, due to built in
-	// spare capacity.
-	// E.g. 100% in 4 steps. 1% -> 25% -> 49% -> 74% -> 100%, last jump being 26%.
-	stepSize := math.Floor((pf - 1) / numSteps)
+	// For bigger jumps this might yield slightly bigger moves
+	// but rounding down makes 1.9 => 1, which basically doubles the rollout time.
+	// E.g. 100% in 4 steps. 1% -> 26% -> 51% -> 76% -> 100%.
+	stepSize := math.Round((pf - 1) / numSteps)
 
 	// The time we sleep between the steps.
 	stepDuration := durationSecs / numSteps * float64(time.Second)

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -1032,6 +1032,12 @@ func TestObserveReady(t *testing.T) {
 			},
 			Percent: 100,
 		}, {
+			ConfigurationName: "step-begin > 1s, step size round up",
+			StepParams: RolloutParams{
+				StartTime: oldenDays,
+			},
+			Percent: 75,
+		}, {
 			ConfigurationName: "Percent not 100%",
 			StepParams: RolloutParams{
 				StartTime: oldenDays,
@@ -1066,6 +1072,15 @@ func TestObserveReady(t *testing.T) {
 				StartTime:    oldenDays,
 				StepDuration: int64(3 * time.Second),
 				StepSize:     100 / 40,
+				NextStepTime: now + 3*int64(time.Second),
+			},
+		}, {
+			ConfigurationName: "step-begin > 1s, step size round up",
+			Percent:           75,
+			StepParams: RolloutParams{
+				StartTime:    oldenDays,
+				StepDuration: int64(3 * time.Second),
+				StepSize:     75/40 + 1,
 				NextStepTime: now + 3*int64(time.Second),
 			},
 		}, {


### PR DESCRIPTION
Current floor is too conservative, with 1.9 -> 1 basically doubling
the lenght of the rollout.
So rather round to make those more reasonable.

Update the tests that are affected and add a new one.

/assign @tcnghia 