### PR TITLE
Use the new config value to set the rollout duration

### DIFF
--- a/pkg/reconciler/route/reconcile_resources.go
+++ b/pkg/reconciler/route/reconcile_resources.go
@@ -37,6 +37,7 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/reconciler/route/config"
 	"knative.dev/serving/pkg/reconciler/route/resources"
 	"knative.dev/serving/pkg/reconciler/route/resources/names"
 	"knative.dev/serving/pkg/reconciler/route/traffic"
@@ -84,8 +85,10 @@ func (c *Reconciler) reconcileIngress(
 		rtView := r.Status.GetCondition(v1.RouteConditionIngressReady)
 		logger := logging.FromContext(ctx).Desugar()
 		if prevRO != nil && ingress.IsReady() && !rtView.IsTrue() {
-			logger.Debug("Observing Ingress not-ready to ready switch condition for rollout")
-			prevRO.ObserveReady(now)
+			cfg := config.FromContext(ctx)
+			logger.Debug("Observing Ingress not-ready to ready switch condition for rollout",
+				zap.Int("durationSecs", cfg.Network.RolloutDurationSecs))
+			prevRO.ObserveReady(now, float64(cfg.Network.RolloutDurationSecs))
 		}
 
 		effectiveRO, nextStepTime := curRO.Step(prevRO, now)

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -383,6 +383,7 @@ func TestReconcile(t *testing.T) {
 		Key: "default/becomes-ready",
 	}, {
 		Name: "simple route rollout when ingress becomes ready",
+		Ctx:  context.WithValue(context.Background(), "rolloutDuration", 120),
 		Objects: []runtime.Object{
 			Route("default", "becomes-ready", WithConfigTarget("config"),
 				WithRouteGeneration(2009), MarkIngressNotConfigured),
@@ -1800,9 +1801,16 @@ func TestReconcile(t *testing.T) {
 			enqueueAfter:        func(interface{}, time.Duration) {},
 		}
 
+		cfg := reconcilerTestConfig(false)
+		if v := ctx.Value("rolloutDuration"); v != nil {
+			cfg.Network.RolloutDurationSecs = v.(int)
+		}
+
 		return routereconciler.NewReconciler(ctx, logging.FromContext(ctx), servingclient.Get(ctx),
 			listers.GetRouteLister(), controller.GetEventRecorder(ctx), r,
-			controller.Options{ConfigStore: &testConfigStore{config: reconcilerTestConfig(false)}})
+			controller.Options{
+				ConfigStore: &testConfigStore{config: cfg},
+			})
 	}))
 }
 

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -63,6 +63,8 @@ const TestIngressClass = "ingress-class-foo"
 
 var fakeCurTime = time.Unix(1e9, 0)
 
+var rolloutDurationKey = struct{}{}
+
 // This is heavily based on the way the OpenShift Ingress controller tests its reconciliation method.
 func TestReconcile(t *testing.T) {
 	table := TableTest{{
@@ -383,7 +385,7 @@ func TestReconcile(t *testing.T) {
 		Key: "default/becomes-ready",
 	}, {
 		Name: "simple route rollout when ingress becomes ready",
-		Ctx:  context.WithValue(context.Background(), "rolloutDuration", 120),
+		Ctx:  context.WithValue(context.Background(), rolloutDurationKey, 120),
 		Objects: []runtime.Object{
 			Route("default", "becomes-ready", WithConfigTarget("config"),
 				WithRouteGeneration(2009), MarkIngressNotConfigured),
@@ -1802,7 +1804,7 @@ func TestReconcile(t *testing.T) {
 		}
 
 		cfg := reconcilerTestConfig(false)
-		if v := ctx.Value("rolloutDuration"); v != nil {
+		if v := ctx.Value(rolloutDurationKey); v != nil {
 			cfg.Network.RolloutDurationSecs = v.(int)
 		}
 

--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -120,14 +120,10 @@ func (cur *Rollout) Validate() bool {
 	return true
 }
 
-// TODO(vagababov): default fake rollout duration in use, while we
-// only modify the annotation and do not actually modify the traffic.
-const durationSecs = 120.0
-
 // ObserveReady traverses the configs and the ones that are in rollout
 // but have not observed step time yet, will have it set, to
 // max(1, nowTS-cfg.StartTime).
-func (cur *Rollout) ObserveReady(nowTS int64) {
+func (cur *Rollout) ObserveReady(nowTS int64, durationSecs float64) {
 	for i := range cur.Configurations {
 		c := &cur.Configurations[i]
 		if c.StepParams.StepDuration == 0 && c.StepParams.StartTime > 0 {

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -1008,6 +1008,7 @@ func TestObserveReady(t *testing.T) {
 	const (
 		now       = 200620092020 + 1982
 		oldenDays = 198219841988
+		duration  = 120.
 	)
 	ro := Rollout{
 		Configurations: []ConfigurationRollout{{
@@ -1096,7 +1097,7 @@ func TestObserveReady(t *testing.T) {
 	}
 
 	// This works in place.
-	ro.ObserveReady(now)
+	ro.ObserveReady(now, duration)
 
 	if !cmp.Equal(ro, want) {
 		t.Errorf("ObserveReady generated mismatched config: diff(-want,+got):\n%s",


### PR DESCRIPTION
rather than the constant we had originally.

- improve logging
- cleanup contexts

/assign @tcnghia 
