### PR TITLE
Only upload the kail log file when the e2e test flow fails

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -222,4 +222,7 @@ delete_dns_record
 subheader "Cleanup auto tls"
 cleanup_auto_tls_common
 
+# Remove the kail log file if the test flow passes.
+# This is for preventing too many large log files to be uploaded to GCS in CI.
+rm "${KAIL_LOG_FILE}"
 success

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -29,6 +29,8 @@ CONTOUR_VERSION=""
 CERTIFICATE_CLASS=""
 # Only build linux/amd64 bit images
 KO_FLAGS="--platform=linux/amd64"
+# The file name to store logs captured by kail
+KAIL_LOG_FILE="${ARTIFACTS}/k8s.log-$(basename "${E2E_SCRIPT}").txt"
 
 HTTPS=0
 MESH=0
@@ -386,7 +388,7 @@ function test_setup() {
   fi
 
   # Capture all logs.
-  kail > ${ARTIFACTS}/k8s.log-$(basename ${E2E_SCRIPT}).txt &
+  kail > "${KAIL_LOG_FILE}" &
   local kail_pid=$!
   # Clean up kail so it doesn't interfere with job shutting down
   add_trap "kill $kail_pid || true" EXIT

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -142,4 +142,7 @@ go_test_e2e -timeout=25m -failfast -parallel=1 ./test/ha \
 
 (( failed )) && fail_test
 
+# Remove the kail log file if the test flow passes.
+# This is for preventing too many large log files to be uploaded to GCS in CI.
+rm "${KAIL_LOG_FILE}"
 success

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -120,4 +120,7 @@ echo "done" > /tmp/autoscaling-tbc-signal
 header "Waiting for prober test"
 wait ${PROBER_PID} || fail_test "Prober failed"
 
+# Remove the kail log file if the test flow passes.
+# This is for preventing too many large log files to be uploaded to GCS in CI.
+rm "${KAIL_LOG_FILE}"
 success


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Only upload the kail log file when the e2e test flow fails:

* The log file produced by `kail` for one Prow e2e test job is now >2GB (see one example [here](https://pantheon.corp.google.com/storage/browser/knative-prow/pr-logs/pull/knative_serving/10365/pull-knative-serving-istio-stable-no-mesh/1338582402011762688/artifacts/5847d45a-3e4b-11eb-8fee-f23821ec9c13?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&prefix=&forceOnObjectsSortingFiltering=false)), that means we can easily produced >1TB logs for only serving within a few days... This is quite unreasonable waste of resources , and I doubt people will download the log files and check it in detail on their local machine. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```