### PR TITLE
Add DomainMapping labels to Ingress

### DIFF
--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -75,6 +75,14 @@ const (
 	// which Service they are created.
 	ServiceLabelKey = GroupName + "/service"
 
+	// DomainMappingLabelKey is the label key attached to Ingress resources to indicate
+	// which DomainMapping triggered their creation.
+	DomainMappingLabelKey = GroupName + "/domainmapping"
+
+	// DomainMappingNamespaceLabelKey is the label key attached to a Ingress
+	// by a DomainMapping to indicate which namespace the DomainMapping was created in.
+	DomainMappingNamespaceLabelKey = GroupName + "/domainmappingNamespace"
+
 	// ConfigurationGenerationLabelKey is the label key attached to a Revision indicating the
 	// metadata generation of the Configuration that created this revision
 	ConfigurationGenerationLabelKey = GroupName + "/configurationGeneration"

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -79,10 +79,6 @@ const (
 	// which DomainMapping triggered their creation.
 	DomainMappingLabelKey = GroupName + "/domainmapping"
 
-	// DomainMappingNamespaceLabelKey is the label key attached to a Ingress
-	// by a DomainMapping to indicate which namespace the DomainMapping was created in.
-	DomainMappingNamespaceLabelKey = GroupName + "/domainmappingNamespace"
-
 	// ConfigurationGenerationLabelKey is the label key attached to a Revision indicating the
 	// metadata generation of the Configuration that created this revision
 	ConfigurationGenerationLabelKey = GroupName + "/configurationGeneration"

--- a/pkg/reconciler/domainmapping/resources/ingress.go
+++ b/pkg/reconciler/domainmapping/resources/ingress.go
@@ -25,6 +25,7 @@ import (
 	"knative.dev/networking/pkg/apis/networking"
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
+	"knative.dev/serving/pkg/apis/serving"
 	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
@@ -42,6 +43,10 @@ func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, hostName
 				networking.IngressClassAnnotationKey: ingressClass,
 			}, dm.GetAnnotations()), func(key string) bool {
 				return key == corev1.LastAppliedConfigAnnotation
+			}),
+			Labels: kmeta.UnionMaps(dm.Labels, map[string]string{
+				serving.DomainMappingLabelKey:          dm.Name,
+				serving.DomainMappingNamespaceLabelKey: dm.Namespace,
 			}),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(dm)},
 		},

--- a/pkg/reconciler/domainmapping/resources/ingress.go
+++ b/pkg/reconciler/domainmapping/resources/ingress.go
@@ -45,8 +45,7 @@ func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, hostName
 				return key == corev1.LastAppliedConfigAnnotation
 			}),
 			Labels: kmeta.UnionMaps(dm.Labels, map[string]string{
-				serving.DomainMappingLabelKey:          dm.Name,
-				serving.DomainMappingNamespaceLabelKey: dm.Namespace,
+				serving.DomainMappingLabelKey: dm.Name,
 			}),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(dm)},
 		},

--- a/pkg/reconciler/domainmapping/resources/ingress_test.go
+++ b/pkg/reconciler/domainmapping/resources/ingress_test.go
@@ -27,6 +27,7 @@ import (
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
+	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
@@ -58,6 +59,10 @@ func TestMakeIngress(t *testing.T) {
 				"networking.knative.dev/ingress.class": "the-ingress-class",
 				"some.annotation":                      "some.value",
 			},
+			Labels: kmeta.UnionMaps(dm.Labels, map[string]string{
+				serving.DomainMappingLabelKey:          dm.Name,
+				serving.DomainMappingNamespaceLabelKey: dm.Namespace,
+			}),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(dm)},
 		},
 		Spec: netv1alpha1.IngressSpec{

--- a/pkg/reconciler/domainmapping/resources/ingress_test.go
+++ b/pkg/reconciler/domainmapping/resources/ingress_test.go
@@ -60,8 +60,7 @@ func TestMakeIngress(t *testing.T) {
 				"some.annotation":                      "some.value",
 			},
 			Labels: kmeta.UnionMaps(dm.Labels, map[string]string{
-				serving.DomainMappingLabelKey:          dm.Name,
-				serving.DomainMappingNamespaceLabelKey: dm.Namespace,
+				serving.DomainMappingLabelKey: dm.Name,
 			}),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(dm)},
 		},


### PR DESCRIPTION
When DomainMapping controller creates Ingress, Ingress does not have
the label who created it.
It is not consistent with Ingress created by Route and so it is
difficult to list Ingresses resources created by DomainMapping.

To fix it, this patch adds the DomainMapping labels to Ingress.

BEFORE:
```
$ kubectl get king --show-labels
NAME            READY   REASON   LABELS
hello-example   True             serving.knative.dev/route=hello-example,serving.knative.dev/routeNamespace=default,serving.knative.dev/service=hello-example
mydomain.com    True             <none>
```

AFTER:
```
$ kubectl get king --show-labels
NAME            READY   REASON   LABELS
hello-example   True             serving.knative.dev/route=hello-example,serving.knative.dev/routeNamespace=default,serving.knative.dev/service=hello-example
mydomain.com    True             serving.knative.dev/domainmapping=mydomain.com
```

**Release Note**

```release-note
Introduce `serving.knative.dev/domainmapping` label for Ingress generated by DomainMapping.
```

/cc @julz @markusthoemmes 
