### PR TITLE
Optimize allocation behavior of the autoscaler

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -144,6 +144,7 @@ func (a *autoscaler) Update(deciderSpec *DeciderSpec) {
 func (a *autoscaler) Scale(ctx context.Context, now time.Time) ScaleResult {
 	logger := logging.FromContext(ctx)
 	desugared := logger.Desugar()
+	debugEnabled := desugared.Core().Enabled(zapcore.DebugLevel)
 
 	spec := a.currentSpec()
 	originalReadyPodsCount, err := a.podCounter.ReadyCount()
@@ -190,7 +191,7 @@ func (a *autoscaler) Scale(ctx context.Context, now time.Time) ScaleResult {
 
 	dspc := math.Ceil(observedStableValue / spec.TargetValue)
 	dppc := math.Ceil(observedPanicValue / spec.TargetValue)
-	if desugared.Core().Enabled(zapcore.DebugLevel) {
+	if debugEnabled {
 		desugared.Debug(fmt.Sprintf("DesiredStablePodCount = %0.3f, DesiredPanicPodCount = %0.3f, ReadyEndpointCount = %d, MaxScaleUp = %0.3f, MaxScaleDown = %0.3f",
 			dspc, dppc, originalReadyPodsCount, maxScaleUp, maxScaleDown), zap.String("metric", metricName))
 	}
@@ -199,7 +200,7 @@ func (a *autoscaler) Scale(ctx context.Context, now time.Time) ScaleResult {
 	desiredStablePodCount := int32(math.Min(math.Max(dspc, maxScaleDown), maxScaleUp))
 	desiredPanicPodCount := int32(math.Min(math.Max(dppc, maxScaleDown), maxScaleUp))
 
-	if desugared.Core().Enabled(zapcore.DebugLevel) {
+	if debugEnabled {
 		desugared.Debug(fmt.Sprintf("Observed average scaling metric value: %0.3f, targeting %0.3f.",
 			observedStableValue, spec.TargetValue), zap.String("mode", "stable"), zap.String("metric", metricName))
 		desugared.Debug(fmt.Sprintf("Observed average scaling metric value: %0.3f, targeting %0.3f.",
@@ -291,7 +292,7 @@ func (a *autoscaler) Scale(ctx context.Context, now time.Time) ScaleResult {
 			math.Ceil(float64(originalReadyPodsCount)*a.deciderSpec.TotalValue/a.deciderSpec.ActivatorCapacity)))
 	}
 
-	if desugared.Core().Enabled(zapcore.DebugLevel) {
+	if debugEnabled {
 		desugared.Debug(fmt.Sprintf("PodCount=%d Total1PodCapacity=%0.3f ObsStableValue=%0.3f ObsPanicValue=%0.3f TargetBC=%0.3f ExcessBC=%0.3f NumActivators=%d",
 			originalReadyPodsCount, a.deciderSpec.TotalValue, observedStableValue,
 			observedPanicValue, a.deciderSpec.TargetBurstCapacity, excessBCF, numAct), zap.String("metric", metricName))


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This optimizes the autoscaler's allocation behavior by
1. Collapsing metric record calls, since that path is kind of expensive
2. Avoiding to build a new logger and instead only adding the metric key where relevant
3. Avoiding to build new loggers for the stable and panic debug logs
4. Avoiding to call formatting logs by checking the log levels first

With the benchmark shipped in #10374, this results in the following gains:

```
benchmark                  old ns/op     new ns/op     delta
BenchmarkAutoscaler-16     12246         3323          -72.86%

benchmark                  old allocs     new allocs     delta
BenchmarkAutoscaler-16     83             22             -73.49%

benchmark                  old bytes     new bytes     delta
BenchmarkAutoscaler-16     6131          920           -84.99%
```

Pulling in https://github.com/knative/pkg/pull/1964 will further reduce this to:

```
benchmark                  old ns/op     new ns/op     delta
BenchmarkAutoscaler-16     12246         2069          -83.10%

benchmark                  old allocs     new allocs     delta
BenchmarkAutoscaler-16     83             10             -87.95%

benchmark                  old bytes     new bytes     delta
BenchmarkAutoscaler-16     6131          632           -89.69%
```

/assign @vagababov 
