### PR TITLE
Add domainmapping name validation

### DIFF
--- a/pkg/apis/serving/v1alpha1/domainmapping_validation.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation.go
@@ -18,7 +18,10 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/apis/serving"
 )
@@ -37,6 +40,11 @@ func (dm *DomainMapping) Validate(ctx context.Context) *apis.FieldError {
 func (dm *DomainMapping) validateMetadata(ctx context.Context) (errs *apis.FieldError) {
 	if dm.GenerateName != "" {
 		errs = errs.Also(apis.ErrDisallowedFields("generateName"))
+	}
+
+	err := validation.IsFullyQualifiedDomainName(field.NewPath("name"), dm.Name)
+	if err != nil {
+		errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("invalid name %q: %s", dm.Name, err.ToAggregate()), "name"))
 	}
 
 	if apis.IsInUpdate(ctx) {


### PR DESCRIPTION
This patch adds domain validation by k8s's IsFullyQualifiedDomainName.
Currently It is easy to create invalid domain by DomainMapping.

For example, this domainmapping

```
cat <<EOF | kubectl apply -f - 
apiVersion: serving.knative.dev/v1alpha1
kind: DomainMapping
metadata:
 name: mydomain
 namespace: default
spec:
 ref:
   name: hello-example
   kind: Service
   apiVersion: serving.knative.dev/v1
EOF
```

will get the following validation error.

`Error from server (BadRequest): error when creating "STDIN": admission webhook "validation.webhook.domainmapping.serving.knative.dev" denied the request: validation failed: invalid name "mydomain": name: Invalid value: "mydomain": should be a domain with at least two segments separated by dots: metadata.name`

**Release Note**

```release-note
DomainMapping name is validated if the domain name is fully qualified.
```

/cc @julz @markusthoemmes @dprotaso  
