### PR TITLE
Optimize param passing a bit.

### DIFF
--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -880,8 +880,8 @@ func TestMakeIngressRuleVanilla(t *testing.T) {
 		},
 	}
 	ro := tc.BuildRollout()
-	rule := makeIngressRule(domains, ns, traffic.DefaultTarget,
-		netv1alpha1.IngressVisibilityExternalIP, targets, ro)
+	rule := makeIngressRule(domains, ns,
+		netv1alpha1.IngressVisibilityExternalIP, targets, ro.RolloutsByTag(traffic.DefaultTarget))
 	expected := netv1alpha1.IngressRule{
 		Hosts: []string{
 			"a.com",
@@ -934,8 +934,8 @@ func TestMakeIngressRuleZeroPercentTarget(t *testing.T) {
 		},
 	}
 	ro := tc.BuildRollout()
-	rule := makeIngressRule(domains, ns, traffic.DefaultTarget,
-		netv1alpha1.IngressVisibilityExternalIP, targets, ro)
+	rule := makeIngressRule(domains, ns,
+		netv1alpha1.IngressVisibilityExternalIP, targets, ro.RolloutsByTag(traffic.DefaultTarget))
 	expected := netv1alpha1.IngressRule{
 		Hosts: []string{"test.org"},
 		HTTP: &netv1alpha1.HTTPIngressRuleValue{
@@ -986,7 +986,8 @@ func TestMakeIngressRuleTwoTargets(t *testing.T) {
 	}
 	ro := tc.BuildRollout()
 	domains := []string{"test.org"}
-	rule := makeIngressRule(domains, ns, "a-tag", netv1alpha1.IngressVisibilityExternalIP, targets, ro)
+	rule := makeIngressRule(domains, ns, netv1alpha1.IngressVisibilityExternalIP,
+		targets, ro.RolloutsByTag("a-tag"))
 	expected := netv1alpha1.IngressRule{
 		Hosts: []string{"test.org"},
 		HTTP: &netv1alpha1.HTTPIngressRuleValue{


### PR DESCRIPTION
In fact there's no need to pass the `tag` to the lower calls,
it is only used to query rollouts for the tag, which
can be done in the top `makeIngressSpec` call.

/assign @tcnghia 