### PR TITLE
Add customdomain flag for domainmapping test's custom domain

### DIFF
--- a/test/conformance/api/shared/util.go
+++ b/test/conformance/api/shared/util.go
@@ -181,8 +181,8 @@ func checkResponses(t testing.TB, num, min int, domain string, expectedResponses
 
 // CheckDistribution sends "num" requests to "domain", then validates that
 // we see each body in "expectedResponses" at least "min" times.
-func CheckDistribution(ctx context.Context, t testing.TB, clients *test.Clients, url *url.URL, num, min int, expectedResponses []string) error {
-	client, err := pkgTest.NewSpoofingClient(ctx, clients.KubeClient, t.Logf, url.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(ctx, t.Logf, clients, test.ServingFlags.HTTPS))
+func CheckDistribution(ctx context.Context, t testing.TB, clients *test.Clients, url *url.URL, num, min int, expectedResponses []string, resolvable bool) error {
+	client, err := pkgTest.NewSpoofingClient(ctx, clients.KubeClient, t.Logf, url.Hostname(), resolvable, test.AddRootCAtoTransport(ctx, t.Logf, clients, test.ServingFlags.HTTPS))
 	if err != nil {
 		return err
 	}

--- a/test/conformance/api/v1/blue_green_test.go
+++ b/test/conformance/api/v1/blue_green_test.go
@@ -146,15 +146,15 @@ func TestBlueGreenRoute(t *testing.T) {
 	g, egCtx := errgroup.WithContext(context.Background())
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinSplitPercentage))
-		return shared.CheckDistribution(egCtx, t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen})
+		return shared.CheckDistribution(egCtx, t, clients, tealURL, test.ConcurrentRequests, min, []string{expectedBlue, expectedGreen}, test.ServingFlags.ResolvableDomain)
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return shared.CheckDistribution(egCtx, t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue})
+		return shared.CheckDistribution(egCtx, t, clients, blueURL, test.ConcurrentRequests, min, []string{expectedBlue}, test.ServingFlags.ResolvableDomain)
 	})
 	g.Go(func() error {
 		min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-		return shared.CheckDistribution(egCtx, t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen})
+		return shared.CheckDistribution(egCtx, t, clients, greenURL, test.ConcurrentRequests, min, []string{expectedGreen}, test.ServingFlags.ResolvableDomain)
 	})
 	if err := g.Wait(); err != nil {
 		t.Fatal("Error sending requests:", err)

--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -83,13 +83,13 @@ func validateDomains(t testing.TB, clients *test.Clients, baseDomain *url.URL,
 			minBasePercentage = test.MinDirectPercentage
 		}
 		min := int(math.Floor(test.ConcurrentRequests * minBasePercentage))
-		return shared.CheckDistribution(egCtx, t, clients, baseDomain, test.ConcurrentRequests, min, baseExpected)
+		return shared.CheckDistribution(egCtx, t, clients, baseDomain, test.ConcurrentRequests, min, baseExpected, test.ServingFlags.ResolvableDomain)
 	})
 	for i, subdomain := range subdomains {
 		i, subdomain := i, subdomain
 		g.Go(func() error {
 			min := int(math.Floor(test.ConcurrentRequests * test.MinDirectPercentage))
-			return shared.CheckDistribution(egCtx, t, clients, subdomain, test.ConcurrentRequests, min, []string{targetsExpected[i]})
+			return shared.CheckDistribution(egCtx, t, clients, subdomain, test.ConcurrentRequests, min, []string{targetsExpected[i]}, test.ServingFlags.ResolvableDomain)
 		})
 	}
 	if err := g.Wait(); err != nil {

--- a/test/conformance/api/v1alpha1/domain_mapping_test.go
+++ b/test/conformance/api/v1alpha1/domain_mapping_test.go
@@ -58,8 +58,14 @@ func TestDomainMapping(t *testing.T) {
 
 	// Using fixed hostnames can lead to conflicts when multiple tests run at
 	// once, so include the svc name to avoid collisions.
-	host := svc.Service.Name + ".mapping.com"
+	host := svc.Service.Name + ".example.org"
+	// Set resolvabledomain for custom domain to false by default.
+	resolvableCustomDomain := false
 
+	if test.ServingFlags.CustomDomain != "" {
+		host = svc.Service.Name + "." + test.ServingFlags.CustomDomain
+		resolvableCustomDomain = true
+	}
 	// Point DomainMapping at our service.
 	var dm *v1alpha1.DomainMapping
 	if err := reconciler.RetryTestErrors(func(int) error {
@@ -100,7 +106,7 @@ func TestDomainMapping(t *testing.T) {
 	}
 
 	// Should be able to access the test image text via the mapped domain.
-	if err := shared.CheckDistribution(ctx, t, clients, &url.URL{Host: host, Scheme: "http"}, test.ConcurrentRequests, test.ConcurrentRequests, []string{test.PizzaPlanetText1}); err != nil {
+	if err := shared.CheckDistribution(ctx, t, clients, &url.URL{Host: host, Scheme: "http"}, test.ConcurrentRequests, test.ConcurrentRequests, []string{test.PizzaPlanetText1}, resolvableCustomDomain); err != nil {
 		t.Errorf("CheckDistribution=%v, expected no error", err)
 	}
 
@@ -158,7 +164,7 @@ func TestDomainMapping(t *testing.T) {
 	}
 
 	// Because the second DomainMapping collided with the first, it should not have taken effect.
-	if err := shared.CheckDistribution(ctx, t, clients, &url.URL{Host: host, Scheme: "http"}, test.ConcurrentRequests, test.ConcurrentRequests, []string{test.PizzaPlanetText1}); err != nil {
+	if err := shared.CheckDistribution(ctx, t, clients, &url.URL{Host: host, Scheme: "http"}, test.ConcurrentRequests, test.ConcurrentRequests, []string{test.PizzaPlanetText1}, resolvableCustomDomain); err != nil {
 		t.Errorf("CheckDistribution=%v, expected no error", err)
 	}
 
@@ -181,7 +187,7 @@ func TestDomainMapping(t *testing.T) {
 	}
 
 	// The domain name should now point to the second service.
-	if err := shared.CheckDistribution(ctx, t, clients, &url.URL{Host: host, Scheme: "http"}, test.ConcurrentRequests, test.ConcurrentRequests, []string{test.PizzaPlanetText2}); err != nil {
+	if err := shared.CheckDistribution(ctx, t, clients, &url.URL{Host: host, Scheme: "http"}, test.ConcurrentRequests, test.ConcurrentRequests, []string{test.PizzaPlanetText2}, resolvableCustomDomain); err != nil {
 		t.Errorf("CheckDistribution=%v, expected no error", err)
 	}
 }

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -34,6 +34,7 @@ var ServingFlags = initializeServingFlags()
 // ServingEnvironmentFlags holds the e2e flags needed only by the serving repo.
 type ServingEnvironmentFlags struct {
 	ResolvableDomain    bool   // Resolve Route controller's `domainSuffix`
+	CustomDomain        string // Indicaates the `domainSuffix` for custom domain test.
 	HTTPS               bool   // Indicates where the test service will be created with https
 	IngressClass        string // Indicates the class of Ingress provider to test.
 	CertificateClass    string // Indicates the class of Certificate provider to test.
@@ -56,6 +57,15 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 			"Set this flag to true if you have configured the `domainSuffix` on your Route controller to a domain that will resolve to your test cluster.")
 	} else {
 		f.ResolvableDomain = fl.Value.(flag.Getter).Get().(bool)
+	}
+
+	if fl := flag.Lookup("customdomain"); fl == nil {
+		flag.StringVar(&f.CustomDomain,
+			"customdomain",
+			"",
+			"Set this flag to the custom domain suffix for domainmapping test.")
+	} else {
+		f.CustomDomain = fl.Value.String()
 	}
 
 	if fl := flag.Lookup("https"); fl == nil {


### PR DESCRIPTION
Although `mapping.com` is used in `TestDomainMapping`, the domain is reserved and 
so domainmapping test always fails when `--resolvabledomain` is enabled.

Hence this patch introduces `--customdomain` flag for domainsuffix in
domainmapping test.

- If `--customdomain` is empty (default), `example.org` is used with `resolvabledomain` false for the custom domain.
- If `--customdomain` is specified, the specified domain is used for the custom domain.

**Release Note**

```release-note
NONE
```
