### PR TITLE
Return the actual applied rollout from reconcile resources

### DIFF
--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -147,7 +147,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconcil
 	}
 
 	// Reconcile ingress and its children resources.
-	ingress, err := c.reconcileIngress(ctx, r, traffic, tls, ingressClassForRoute(ctx, r), acmeChallenges...)
+	ingress, _, err := c.reconcileIngress(ctx, r, traffic, tls, ingressClassForRoute(ctx, r), acmeChallenges...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This will be used to compute Route status.traffic and Route.status.Ready

/assign @tcnghia 