### PR TITLE
Add Route status update to mark rollout in progress

### DIFF
--- a/pkg/apis/serving/v1/route_lifecycle.go
+++ b/pkg/apis/serving/v1/route_lifecycle.go
@@ -70,6 +70,13 @@ func (rs *RouteStatus) MarkServiceNotOwned(name string) {
 		fmt.Sprintf("There is an existing placeholder Service %q that we do not own.", name))
 }
 
+// MarkIngressRolloutInProgress changes the IngressReady condition to be unknown to reflect
+// that a gradual rollout of the latest new revision (or stacked revisions) is in progress.
+func (rs *RouteStatus) MarkIngressRolloutInProgress() {
+	routeCondSet.Manage(rs).MarkUnknown(RouteConditionIngressReady,
+		"RolloutInProgress", "A gradual rollout of the latest revision(s) is in progress.")
+}
+
 // MarkIngressNotConfigured changes the IngressReady condition to be unknown to reflect
 // that the Ingress does not yet have a Status
 func (rs *RouteStatus) MarkIngressNotConfigured() {

--- a/pkg/apis/serving/v1/route_lifecycle_test.go
+++ b/pkg/apis/serving/v1/route_lifecycle_test.go
@@ -479,3 +479,11 @@ func TestIngressNotConfigured(t *testing.T) {
 
 	apistest.CheckConditionOngoing(r, RouteConditionIngressReady, t)
 }
+
+func TestMarkInRollout(t *testing.T) {
+	r := &RouteStatus{}
+	r.InitializeConditions()
+	r.MarkIngressRolloutInProgress()
+
+	apistest.CheckConditionOngoing(r, RouteConditionIngressReady, t)
+}

--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -104,9 +104,20 @@ func (cur *Rollout) RolloutsByTag(t string) []*ConfigurationRollout {
 	return ret
 }
 
-// Done returns true if there is no active rollout going on
+// Done returns true if all the Configuration rollouts in this
+// Rollout have completed.
+func (cur *Rollout) Done() bool {
+	for i := range cur.Configurations {
+		if !cur.Configurations[i].done() {
+			return false
+		}
+	}
+	return true
+}
+
+// done returns true if there is no active rollout going on
 // for the configuration.
-func (cur *ConfigurationRollout) Done() bool {
+func (cur *ConfigurationRollout) done() bool {
 	// Zero or just one revision.
 	return len(cur.Revisions) < 2
 }

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -1310,6 +1310,9 @@ func TestValidateFailures(t *testing.T) {
 func TestConfigDone(t *testing.T) {
 	r := &Rollout{
 		Configurations: []ConfigurationRollout{{
+			ConfigurationName: "nil",
+			Percent:           100,
+		}, {
 			ConfigurationName: "one",
 			Percent:           100,
 			Revisions: []RevisionRollout{{
@@ -1332,14 +1335,24 @@ func TestConfigDone(t *testing.T) {
 			}},
 		}},
 	}
-	if !r.Configurations[0].Done() {
+	if !r.Configurations[0].done() {
+		t.Error("Nil revision slice rollout is not `Done`")
+	}
+	if !r.Configurations[1].done() {
 		t.Error("Single revision rollout is not `Done`")
 	}
-	if !r.Configurations[1].Done() {
+	if !r.Configurations[2].done() {
 		t.Error("Zero revisions rollout is not `Done`")
 	}
-	if r.Configurations[2].Done() {
+	if r.Configurations[3].done() {
 		t.Error("Many revisions rollout is `Done`")
+	}
+	if r.Done() {
+		t.Error("Whole Rollout was marked done, but it's not")
+	}
+	r.Configurations = r.Configurations[:3]
+	if !r.Done() {
+		t.Error("Updated Rollout without the last one was marked not done, but it is")
 	}
 }
 

--- a/pkg/testing/v1/route.go
+++ b/pkg/testing/v1/route.go
@@ -221,6 +221,11 @@ func MarkIngressReady(r *v1.Route) {
 	})
 }
 
+// MarkInRollout marks the route to be in process of rolling out.
+func MarkInRollout(r *v1.Route) {
+	r.Status.MarkIngressRolloutInProgress()
+}
+
 // MarkIngressNotConfigured calls the method of the same name on .Status
 func MarkIngressNotConfigured(r *v1.Route) {
 	r.Status.MarkIngressNotConfigured()


### PR DESCRIPTION
- mark route pending when rollout is ongoing, even if ingress is ready
- ignress not ready has priority
- tests
- modify Done to be on rollout object

/assign @tcnghia 