### PR TITLE
Compute and set the Route.Status to match rollout status

### DIFF
--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -470,8 +470,13 @@ func TestReconcile(t *testing.T) {
 				WithRouteGeneration(2009), WithRouteObservedGeneration,
 				MarkTrafficAssigned, MarkInRollout, WithStatusTraffic(
 					v1.TrafficTarget{
+						RevisionName:   "config-00000",
+						Percent:        ptr.Int64(99),
+						LatestRevision: ptr.Bool(true),
+					},
+					v1.TrafficTarget{
 						RevisionName:   "config-00001",
-						Percent:        ptr.Int64(100),
+						Percent:        ptr.Int64(1),
 						LatestRevision: ptr.Bool(true),
 					})),
 		}},
@@ -911,8 +916,13 @@ func TestReconcile(t *testing.T) {
 				WithURL, WithAddress, WithRouteConditionsAutoTLSDisabled, WithRouteGeneration(1),
 				MarkTrafficAssigned, MarkInRollout, WithRouteObservedGeneration, WithRouteFinalizer, WithStatusTraffic(
 					v1.TrafficTarget{
+						RevisionName:   "config-00001",
+						Percent:        ptr.Int64(99),
+						LatestRevision: ptr.Bool(true),
+					},
+					v1.TrafficTarget{
 						RevisionName:   "config-00002",
-						Percent:        ptr.Int64(100),
+						Percent:        ptr.Int64(1),
 						LatestRevision: ptr.Bool(true),
 					})),
 		}},

--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -149,7 +149,8 @@ func (cfg *Config) targetToStatus(ctx context.Context, r *v1.Route, tt *Revision
 // GetRevisionTrafficTargets returns a list of TrafficTarget flattened to the RevisionName, and having ConfigurationName cleared out.
 func (cfg *Config) GetRevisionTrafficTargets(ctx context.Context, r *v1.Route, ro *Rollout) ([]v1.TrafficTarget, error) {
 	results := make([]v1.TrafficTarget, 0, len(cfg.revisionTargets))
-	for _, tt := range cfg.revisionTargets {
+	for i := range cfg.revisionTargets {
+		tt := &cfg.revisionTargets[i]
 		var (
 			roCfg *ConfigurationRollout
 			revs  []RevisionRollout
@@ -171,7 +172,7 @@ func (cfg *Config) GetRevisionTrafficTargets(ctx context.Context, r *v1.Route, r
 		} else {
 			revs = roCfg.Revisions
 		}
-		results, err = cfg.targetToStatus(ctx, r, &tt, revs, results)
+		results, err = cfg.targetToStatus(ctx, r, tt, revs, results)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Basically apply similar logic when computing the splits in the ingress,
but slightly simpler.

If there's a matching rollout, then pass its revisions to the code that
existed already for a single target (now it's a loop -- but otherwise
basically the same).

For tagged routes during rollout it will display the split over the
tagged route (it feels more natural that way).

/assign @tcnghia 