### PR TITLE
Add logging of the percentage for the two revisions in the rollout probe

### DIFF
--- a/test/performance/benchmarks/rollout-probe/dev.config
+++ b/test/performance/benchmarks/rollout-probe/dev.config
@@ -71,3 +71,11 @@ metric_info_list: {
   value_key: "ap"
   label: "available-pods"
 }
+metric_info_list: {
+  value_key: "t1"
+  label: "tarffic-old"
+}
+metric_info_list: {
+  value_key: "t2"
+  label: "tarffic-new"
+}

--- a/test/performance/metrics/runtime.go
+++ b/test/performance/metrics/runtime.go
@@ -27,6 +27,8 @@ import (
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	sksinformer "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/serverlessservice"
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	routeinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/route"
 
 	// Mysteriously required to support GCP auth (required by k8s libs).
 	// Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/242
@@ -66,6 +68,33 @@ func FetchDeploymentStatus(
 		}
 		return []*appsv1.Deployment{d}, nil
 	})
+}
+
+// RouteStatus contains the traffic distribution at the probe time.
+type RouteStatus struct {
+	Traffic []v1.TrafficTarget
+	Time    time.Time
+}
+
+// FetchRouteStatus returns a channel that will contain the traffic distribution
+// at regular time intervals.
+func FetchRouteStatus(ctx context.Context, namespace, name string, duration time.Duration) <-chan RouteStatus {
+	rl := routeinformer.Get(ctx).Lister().Routes(namespace)
+	ch := make(chan RouteStatus)
+	startTick(duration, ctx.Done(), func(t time.Time) error {
+		r, err := rl.Get(name)
+		r.DeepCopy()
+		if err != nil {
+			return err
+		}
+		rs := RouteStatus{
+			Traffic: r.Status.Traffic,
+			Time:    t,
+		}
+		ch <- rs
+		return nil
+	})
+	return ch
 }
 
 func fetchStatusInternal(ctx context.Context, duration time.Duration,


### PR DESCRIPTION
Basically report the traffic stanza from the informer.
And then report as `t1` and `t2`.

/assign @tcnghia mattmoor