### PR TITLE
Ensure we execute cleanup

### DIFF
--- a/test/performance/benchmarks/rollout-probe/continuous/main.go
+++ b/test/performance/benchmarks/rollout-probe/continuous/main.go
@@ -117,6 +117,9 @@ func main() {
 
 	// After a minute, update the Ksvc.
 	updateSvc := time.After(30 * time.Second)
+
+	// Since we might qfatal in the end, this would not execute the deferred calls
+	// thus failing the restore. So bind and execute explicitly.
 	var restoreFn func()
 LOOP:
 	for {


### PR DESCRIPTION
Bind and explicitly execute the cleanup lambda,
since if mako storage fails, then we `fatal` and that
does not execute deferred calls, basically skipping the cleanup.

/assign @tcnghia mattmoor