### PR TITLE
Update the values for the Rollout benchmark QPS and CC

### DIFF
--- a/test/performance/benchmarks/rollout-probe/continuous/main.go
+++ b/test/performance/benchmarks/rollout-probe/continuous/main.go
@@ -95,7 +95,7 @@ func main() {
 	q.Input.ThresholdInputs = append(q.Input.ThresholdInputs, t.analyzers...)
 
 	// Send 1k QPS for the given duration with a 30s request timeout.
-	rate := vegeta.Rate{Freq: 1000, Per: time.Second}
+	rate := vegeta.Rate{Freq: 3600, Per: time.Second}
 	targeter := vegeta.NewStaticTargeter(t.target)
 	attacker := vegeta.NewAttacker(vegeta.Timeout(30 * time.Second))
 
@@ -157,7 +157,7 @@ LOOP:
 			svc.Spec.Template.Annotations["autoscaling.knative.dev/minScale"] = "1"
 			_, err = sc.ServingV1().Services(namespace).Update(context.Background(), svc, metav1.UpdateOptions{})
 			if err != nil {
-				log.Fatalf("Error updating ksvc %s: %v", *target, err)
+				fatalf("Error updating ksvc %s: %v", *target, err)
 			}
 			log.Println("Successfully updated the service.")
 		case res, ok := <-results:

--- a/test/performance/benchmarks/rollout-probe/continuous/rollout-probe-setup.yaml
+++ b/test/performance/benchmarks/rollout-probe/continuous/rollout-probe-setup.yaml
@@ -51,7 +51,7 @@ spec:
           limits:
             cpu: 50m
             memory: 50Mi
-      containerConcurrency: 1
+      containerConcurrency: 5
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -92,5 +92,5 @@ spec:
           limits:
             cpu: 50m
             memory: 50Mi
-      containerConcurrency: 1
+      containerConcurrency: 5
 ---


### PR DESCRIPTION
This gives a more interesting result.
With CC=1 we can't really raise the QPS much, since we buffer a lot.
With CC=5 we can go up to 3600QPS without much trouble.
And it still shows the issue with rollout disabled

/assign @tcnghia @chizhg mattmoor