### PR TITLE
Stop the bleeding in queue-proxy.

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -56,6 +56,7 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
       GO111MODULE: off
+      GOFLAGS: -tags=nostackdriver
       # https://github.com/google/go-containerregistry/pull/125 allows insecure registry for
       # '*.local' hostnames. This works both for `ko` and our own tag-to-digest resolution logic,
       # thus allowing us to test without bypassing tag-to-digest resolution.

--- a/cmd/queue/nodeps_test.go
+++ b/cmd/queue/nodeps_test.go
@@ -24,11 +24,6 @@ import (
 
 func TestNoDeps(t *testing.T) {
 	depcheck.AssertNoDependency(t, map[string][]string{
-		"knative.dev/serving/cmd/queue": {
-			"k8s.io/apimachinery/pkg/api/apitesting/fuzzer",
-			// TODO(https://github.com/knative/serving/issues/9957): Remove these dependencies.
-			// "k8s.io/client-go/informers",
-			// "k8s.io/client-go/kubernetes",
-		},
-	})
+		"knative.dev/serving/cmd/queue": depcheck.KnownHeavyDependencies,
+	}, "-tags=nostackdriver")
 }

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,6 @@ require (
 	knative.dev/caching v0.0.0-20201221023403-116224f358cd
 	knative.dev/hack v0.0.0-20201214230143-4ed1ecb8db24
 	knative.dev/networking v0.0.0-20201223042504-b9e08949dfbc
-	knative.dev/pkg v0.0.0-20201223002104-9d0775512af8
+	knative.dev/pkg v0.0.0-20201224024804-27db5ac24cfb
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1230,8 +1230,8 @@ knative.dev/hack v0.0.0-20201214230143-4ed1ecb8db24/go.mod h1:PHt8x8yX5Z9pPquBEf
 knative.dev/networking v0.0.0-20201223042504-b9e08949dfbc h1:I9oJW2LwMaZ/e2MwClWLTVxSVF9457o4qSJTzGK6CP8=
 knative.dev/networking v0.0.0-20201223042504-b9e08949dfbc/go.mod h1:MTHF/89uQ3XDklu7Uny5TuobSC9UkHBWmMvFWgnZ5Rk=
 knative.dev/pkg v0.0.0-20201218185703-e41409af6cff/go.mod h1:hckgW978SdzPA2H5EDvRPY8xsnPuDZLJLbPf8Jte7Q0=
-knative.dev/pkg v0.0.0-20201223002104-9d0775512af8 h1:0UaGaAn57/Egp7cfD/Cq6tNYr2QYyGZ8KSzC46CxYq4=
-knative.dev/pkg v0.0.0-20201223002104-9d0775512af8/go.mod h1:hckgW978SdzPA2H5EDvRPY8xsnPuDZLJLbPf8Jte7Q0=
+knative.dev/pkg v0.0.0-20201224024804-27db5ac24cfb h1:XVcmpSvfDMZ5Z+1pebSm5Msq5sQey/V4NHF2+dFNU1o=
+knative.dev/pkg v0.0.0-20201224024804-27db5ac24cfb/go.mod h1:hckgW978SdzPA2H5EDvRPY8xsnPuDZLJLbPf8Jte7Q0=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/knative.dev/pkg/metrics/gcp_metadata.go
+++ b/vendor/knative.dev/pkg/metrics/gcp_metadata.go
@@ -1,3 +1,5 @@
+// +build !nostackdriver
+
 /*
 Copyright 2019 The Knative Authors
 

--- a/vendor/knative.dev/pkg/metrics/nostackdriver.go
+++ b/vendor/knative.dev/pkg/metrics/nostackdriver.go
@@ -1,5 +1,7 @@
+// +build nostackdriver
+
 /*
-Copyright 2020 The Knative Authors
+Copyright 2019 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,15 +18,18 @@ limitations under the License.
 
 package metrics
 
-const (
-	testComponent = "testComponent"
+import (
+	"context"
+	"errors"
+
+	"go.opencensus.io/stats/view"
+	"go.uber.org/zap"
 )
 
-// InitForTesting initialize the necessary global variables for unit tests.
-func InitForTesting() {
-	setCurMetricsConfig(&metricsConfig{
-		backendDestination: prometheus,
-		component:          "test",
-		domain:             "test",
-	})
+func sdinit(ctx context.Context, m map[string]string, mc *metricsConfig, ops ExporterOptions) error {
+	return errors.New("Stackdriver support is not included")
+}
+
+func newStackdriverExporter(config *metricsConfig, logger *zap.SugaredLogger) (view.Exporter, ResourceExporterFactory, error) {
+	return nil, nil, errors.New("Stackdriver support is not included")
 }

--- a/vendor/knative.dev/pkg/tracing/nostackdriver.go
+++ b/vendor/knative.dev/pkg/tracing/nostackdriver.go
@@ -1,3 +1,5 @@
+// +build nostackdriver
+
 /*
 Copyright 2020 The Knative Authors
 
@@ -14,17 +16,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metrics
+package tracing
 
-const (
-	testComponent = "testComponent"
+import (
+	"errors"
+
+	"go.opencensus.io/trace"
+	"knative.dev/pkg/tracing/config"
 )
 
-// InitForTesting initialize the necessary global variables for unit tests.
-func InitForTesting() {
-	setCurMetricsConfig(&metricsConfig{
-		backendDestination: prometheus,
-		component:          "test",
-		domain:             "test",
-	})
+func newStackdriver(cfg *config.Config) (trace.Exporter, error) {
+	return nil, errors.New("Stackdriver is not configured")
 }

--- a/vendor/knative.dev/pkg/tracing/opencensus.go
+++ b/vendor/knative.dev/pkg/tracing/opencensus.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package tracing
 
 import (
@@ -7,9 +23,8 @@ import (
 	"os"
 	"sync"
 
-	"contrib.go.opencensus.io/exporter/stackdriver"
 	oczipkin "contrib.go.opencensus.io/exporter/zipkin"
-	zipkin "github.com/openzipkin/zipkin-go"
+	"github.com/openzipkin/zipkin-go"
 	httpreporter "github.com/openzipkin/zipkin-go/reporter/http"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
@@ -128,17 +143,14 @@ func WithExporterFull(name, host string, logger *zap.SugaredLogger) ConfigOption
 		var (
 			exporter trace.Exporter
 			closer   io.Closer
+			err      error
 		)
 		switch cfg.Backend {
 		case config.Stackdriver:
-			exp, err := stackdriver.NewExporter(stackdriver.Options{
-				ProjectID: cfg.StackdriverProjectID,
-			})
+			exporter, err = newStackdriver(cfg)
 			if err != nil {
-				logger.Errorw("error reading project-id from metadata", zap.Error(err))
 				return err
 			}
-			exporter = exp
 		case config.Zipkin:
 			// If host isn't specified, then zipkin.NewEndpoint will return an error saying that it
 			// can't find the host named ''. So, if not specified, default it to this machine's
@@ -161,6 +173,7 @@ func WithExporterFull(name, host string, logger *zap.SugaredLogger) ConfigOption
 			reporter := httpreporter.NewReporter(cfg.ZipkinEndpoint)
 			exporter = oczipkin.NewExporter(reporter, zipEP)
 			closer = reporter
+
 		default:
 			// Disables tracing.
 		}

--- a/vendor/knative.dev/pkg/tracing/stackdriver.go
+++ b/vendor/knative.dev/pkg/tracing/stackdriver.go
@@ -1,3 +1,5 @@
+// +build !nostackdriver
+
 /*
 Copyright 2020 The Knative Authors
 
@@ -14,17 +16,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metrics
+package tracing
 
-const (
-	testComponent = "testComponent"
+import (
+	"contrib.go.opencensus.io/exporter/stackdriver"
+	"go.opencensus.io/trace"
+	"knative.dev/pkg/tracing/config"
 )
 
-// InitForTesting initialize the necessary global variables for unit tests.
-func InitForTesting() {
-	setCurMetricsConfig(&metricsConfig{
-		backendDestination: prometheus,
-		component:          "test",
-		domain:             "test",
+func newStackdriver(cfg *config.Config) (trace.Exporter, error) {
+	return stackdriver.NewExporter(stackdriver.Options{
+		ProjectID: cfg.StackdriverProjectID,
 	})
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1021,7 +1021,7 @@ knative.dev/networking/test/conformance/ingress
 knative.dev/networking/test/defaultsystem
 knative.dev/networking/test/test_images/grpc-ping/proto
 knative.dev/networking/test/types
-# knative.dev/pkg v0.0.0-20201223002104-9d0775512af8
+# knative.dev/pkg v0.0.0-20201224024804-27db5ac24cfb
 ## explicit
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate


### PR DESCRIPTION
The queue-proxy binary is currently massive and roughly 40% of the current
binary size comes in through our stackdriver integration (which is also the
only thing left pulling in the k8s clients).

Two prior changes in knative.dev/pkg (https://github.com/knative/pkg/pull/1974,
https://github.com/knative/pkg/pull/1975) added a "nostackdriver" tag, and
testing that with that tag the tracing and metrics libraries respectively
have no known heavy dependencies.

This change pulls those in, and adds a depcheck test that with `nostackdriver`
the queue proxy also has no known heavy dependencies.

The ultimate goal of this change is to "stop the bleeding" and ensure that
no new reliance on these heavy libraries is introduced while we continue
towards eliminating the priorietary integrations from being linked in entirely.
This change also enables downstreams with no interest in stackdriver
integration to drop their queue-proxy binary size ~40% now by specifying:
```
GOFLAGS=-tags=nostackdriver
```
