### PR TITLE
Propagate and keep w3c header up to date

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -331,7 +331,7 @@ func buildTransport(env config, logger *zap.SugaredLogger, maxConns int) http.Ro
 
 	return &ochttp.Transport{
 		Base:        transport,
-		Propagation: tracecontextb3.B3Egress,
+		Propagation: tracecontextb3.TraceContextB3Egress,
 	}
 }
 

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -143,7 +143,7 @@ func TestQueueTraceSpans(t *testing.T) {
 				}
 				proxy.Transport = &ochttp.Transport{
 					Base:        pkgnet.AutoTransport,
-					Propagation: tracecontextb3.B3Egress,
+					Propagation: tracecontextb3.TraceContextB3Egress,
 				}
 
 				h := queue.ProxyHandler(breaker, network.NewRequestStats(time.Now()), true /*tracingEnabled*/, proxy)

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -58,7 +58,7 @@ func New(_ context.Context, t Throttler, transport http.RoundTripper) http.Handl
 		transport: transport,
 		tracingTransport: &ochttp.Transport{
 			Base:        transport,
-			Propagation: tracecontextb3.B3Egress,
+			Propagation: tracecontextb3.TraceContextB3Egress,
 		},
 		throttler:  t,
 		bufferPool: network.NewBufferPool(),

--- a/test/conformance/runtime/header_test.go
+++ b/test/conformance/runtime/header_test.go
@@ -91,7 +91,7 @@ func TestShouldHaveHeadersSet(t *testing.T) {
 		// We expect the value to be a 64-bit or 128-bit hex string
 		"x-b3-traceid": regexp.MustCompile("[0-9a-f]{16}|[0-9a-f]{32}"),
 
-		"Traceparent": regexp.MustCompile("[0-9]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9]{2}"),
+		"traceparent": regexp.MustCompile("[0-9]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9]{2}"),
 
 		// "x-b3-parentspanid" and "x-b3-sampled" are often present for tracing, but are not
 		// required for tracing so we do not validate them.

--- a/test/conformance/runtime/header_test.go
+++ b/test/conformance/runtime/header_test.go
@@ -91,6 +91,8 @@ func TestShouldHaveHeadersSet(t *testing.T) {
 		// We expect the value to be a 64-bit or 128-bit hex string
 		"x-b3-traceid": regexp.MustCompile("[0-9a-f]{16}|[0-9a-f]{32}"),
 
+		"Traceparent": regexp.MustCompile("[0-9]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9]{2}")
+
 		// "x-b3-parentspanid" and "x-b3-sampled" are often present for tracing, but are not
 		// required for tracing so we do not validate them.
 	}

--- a/test/conformance/runtime/header_test.go
+++ b/test/conformance/runtime/header_test.go
@@ -91,7 +91,7 @@ func TestShouldHaveHeadersSet(t *testing.T) {
 		// We expect the value to be a 64-bit or 128-bit hex string
 		"x-b3-traceid": regexp.MustCompile("[0-9a-f]{16}|[0-9a-f]{32}"),
 
-		"Traceparent": regexp.MustCompile("[0-9]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9]{2}")
+		"Traceparent": regexp.MustCompile("[0-9]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9]{2}"),
 
 		// "x-b3-parentspanid" and "x-b3-sampled" are often present for tracing, but are not
 		// required for tracing so we do not validate them.


### PR DESCRIPTION
Fixes # https://github.com/knative/serving/issues/10057


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
