### PR TITLE
Take 1% time into account

### DIFF
--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -450,10 +451,10 @@ func TestReconcile(t *testing.T) {
 					RevisionName: "config-00001", Percent: 1,
 				}}, fakeCurTime.Add(-3*time.Second),
 					func(r *traffic.Rollout) {
-						const numSteps = 120 / 3 // 40
-						// Step duration is 3s (duration / numSteps = 120/40)
-						r.Configurations[0].StepParams.StepDuration = int64(time.Second) * 120 / numSteps // 3s in ns.
-						r.Configurations[0].StepParams.StepSize = (100 - 1) / numSteps                    // 2
+						const numSteps = (120 - 3) / 3 // 39
+						// Step duration is 3s (duration - 3)/ numSteps = 120/40)
+						r.Configurations[0].StepParams.StepDuration = int64(time.Second) * (120 - 3) / numSteps   // 3s in ns.
+						r.Configurations[0].StepParams.StepSize = int(math.Round((100. - 1) / float64(numSteps))) // 3
 						// StepDuration is 3, and so next step is `now` + 3.
 						r.Configurations[0].StepParams.NextStepTime = fakeCurTime.Add(3 * time.Second).UnixNano()
 					},

--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -438,6 +438,11 @@ func stepConfig(ctx context.Context, goal, prev *ConfigurationRollout, nowTS int
 func (cur *ConfigurationRollout) computeProperties(nowTS, minStepSec, durationSecs float64) {
 	// First compute number of steps. If it takes more time to step 1% than the
 	// whole allotted time for the rollout, do it in 1 step.
+	// Take into account that we already used minStepSecs to move first
+	// 1% so the overall rollout duration is shorter by this amount.
+	// If it took longer than duration it might be negative, so cap it
+	// at 1s, so we just do 1 step.
+	durationSecs = math.Max(1, durationSecs-minStepSec)
 	numSteps := math.Max(1, durationSecs/minStepSec)
 	pf := float64(cur.Percent)
 

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -1011,7 +1011,9 @@ func TestObserveReady(t *testing.T) {
 	const (
 		now         = 200620092020 + 1982
 		oldenDays   = 198219841988
+		oldenStep   = float64(now-oldenDays) / float64(time.Second)
 		ancientDays = 14921812
+		ancientStep = float64(now-ancientDays) / float64(time.Second)
 		duration    = 120.
 	)
 	ro := Rollout{
@@ -1050,7 +1052,8 @@ func TestObserveReady(t *testing.T) {
 			Percent: 50,
 		}, {
 			// This covers the case when duration of a step is larger
-			// than duration of the whole rollout.
+			// than duration of the whole rollout. Which means we'll
+			// do the whole rollout in one final step.
 			ConfigurationName: "días antiguos",
 			StepParams: RolloutParams{
 				StartTime: ancientDays,
@@ -1074,9 +1077,9 @@ func TestObserveReady(t *testing.T) {
 			Percent:           100,
 			StepParams: RolloutParams{
 				StartTime:    200620092020,
-				StepDuration: 1212121212, // 120/99
+				StepDuration: 1202020202, // (120s-1984ns)/99
 				StepSize:     1,
-				NextStepTime: now + 1212121212,
+				NextStepTime: now + 1202020202,
 			},
 		}, {
 			ConfigurationName: "step-begin > 1s",
@@ -1084,7 +1087,7 @@ func TestObserveReady(t *testing.T) {
 			StepParams: RolloutParams{
 				StartTime:    oldenDays,
 				StepDuration: int64(3 * time.Second),
-				StepSize:     100 / 40,
+				StepSize:     3, // int(100. / ((duration - oldenStep) / oldenStep)),
 				NextStepTime: now + 3*int64(time.Second),
 			},
 		}, {
@@ -1110,9 +1113,9 @@ func TestObserveReady(t *testing.T) {
 			Percent:           13,
 			StepParams: RolloutParams{
 				StartTime:    ancientDays,
-				StepDuration: int64(duration * time.Second),
+				StepDuration: int64(time.Second), // The minimal possible.
 				StepSize:     12,
-				NextStepTime: now + int64(duration*time.Second),
+				NextStepTime: now + int64(time.Second),
 			},
 		}},
 	}


### PR DESCRIPTION
When computing rollout properties, take into account the duration
of the first step. Especially, if the first step is noticeably large
compared to the overall rollout duration, or even larger than it.
Before we'd rollout in possibly much longer than duration time,
with this, we'd be much closer to that time.

/assign @tcnghia mattmoor