### PR TITLE
Patch config-istio after the configmap is actually created

### DIFF
--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -70,13 +70,7 @@ function install_istio() {
     echo "net-istio patched YAML: $YAML_NAME"
     ko apply -f "${YAML_NAME}" --selector=networking.knative.dev/ingress-provider=istio || return 1
 
-    if [[ $MESH -eq 1 ]]; then
-      kubectl patch configmap/config-istio -n ${SYSTEM_NAMESPACE} --patch='{"data":{"local-gateway.mesh":"mesh"}}'
-    fi
-
-    if [[ $ENABLE_VIRTUALSERVICE_STATUS -eq 1 ]]; then
-      kubectl patch configmap/config-istio -n ${SYSTEM_NAMESPACE} --patch='{"data":{"enable-virtualservice-status":"true"}}'
-    fi
+    ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/extras/configure-istio.sh
 
     UNINSTALL_LIST+=( "${YAML_NAME}" )
   fi

--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -69,6 +69,15 @@ function install_istio() {
     sed "s/namespace: \"*${KNATIVE_DEFAULT_NAMESPACE}\"*/namespace: ${SYSTEM_NAMESPACE}/g" ${1} > ${YAML_NAME}
     echo "net-istio patched YAML: $YAML_NAME"
     ko apply -f "${YAML_NAME}" --selector=networking.knative.dev/ingress-provider=istio || return 1
+
+    if [[ $MESH -eq 1 ]]; then
+      kubectl patch configmap/config-istio -n ${SYSTEM_NAMESPACE} --patch='{"data":{"local-gateway.mesh":"mesh"}}'
+    fi
+
+    if [[ $ENABLE_VIRTUALSERVICE_STATUS -eq 1 ]]; then
+      kubectl patch configmap/config-istio -n ${SYSTEM_NAMESPACE} --patch='{"data":{"enable-virtualservice-status":"true"}}'
+    fi
+
     UNINSTALL_LIST+=( "${YAML_NAME}" )
   fi
 }


### PR DESCRIPTION
## Proposed Changes

* Fix bug where a few config patches in our tests don't actually get applied.
* Currently these patches happen in [install-istio.sh](https://github.com/knative-sandbox/net-istio/blob/master/third_party/istio-latest/install-istio.sh), which is before the configmaps are created.

/assign @JRBANCEL @nak3 