### PR TITLE
Extend resources.MakeIngress to take TLS and ACME challenges params

### DIFF
--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -94,7 +94,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, dm *v1alpha1.DomainMappi
 
 	// Reconcile the Ingress resource corresponding to the requested Mapping.
 	logger.Debugf("Mapping %s to ref %s/%s (host: %q, svc: %q)", url, dm.Spec.Ref.Namespace, dm.Spec.Ref.Name, targetHost, targetBackendSvc)
-	desired := resources.MakeIngress(dm, targetBackendSvc, targetHost, ingressClass, []netv1alpha1.IngressTLS{})
+	desired := resources.MakeIngress(dm, targetBackendSvc, targetHost, ingressClass, nil /* tls */)
 	ingress, err := r.reconcileIngress(ctx, dm, desired)
 	if err != nil {
 		return err

--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -94,7 +94,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, dm *v1alpha1.DomainMappi
 
 	// Reconcile the Ingress resource corresponding to the requested Mapping.
 	logger.Debugf("Mapping %s to ref %s/%s (host: %q, svc: %q)", url, dm.Spec.Ref.Namespace, dm.Spec.Ref.Name, targetHost, targetBackendSvc)
-	desired := resources.MakeIngress(dm, targetBackendSvc, targetHost, ingressClass)
+	desired := resources.MakeIngress(dm, targetBackendSvc, targetHost, ingressClass, []netv1alpha1.IngressTLS{})
 	ingress, err := r.reconcileIngress(ctx, dm, desired)
 	if err != nil {
 		return err

--- a/pkg/reconciler/domainmapping/resources/ingress.go
+++ b/pkg/reconciler/domainmapping/resources/ingress.go
@@ -27,6 +27,7 @@ import (
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving"
 	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+	routeresources "knative.dev/serving/pkg/reconciler/route/resources"
 )
 
 // MakeIngress creates an Ingress object for a DomainMapping.  The Ingress is
@@ -34,7 +35,7 @@ import (
 // backend is always in the same namespace also (as this is required by
 // KIngress).  The created ingress will contain a RewriteHost rule to cause the
 // given hostName to be used as the host.
-func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, hostName, ingressClass string) *netv1alpha1.Ingress {
+func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, hostName, ingressClass string, tls []netv1alpha1.IngressTLS, acmeChallenges ...netv1alpha1.HTTP01Challenge) *netv1alpha1.Ingress {
 	return &netv1alpha1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kmeta.ChildName(dm.GetName(), ""),
@@ -50,11 +51,12 @@ func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, hostName
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(dm)},
 		},
 		Spec: netv1alpha1.IngressSpec{
+			TLS: tls,
 			Rules: []netv1alpha1.IngressRule{{
 				Hosts:      []string{dm.Name},
 				Visibility: netv1alpha1.IngressVisibilityExternalIP,
 				HTTP: &netv1alpha1.HTTPIngressRuleValue{
-					Paths: []netv1alpha1.HTTPIngressPath{{
+					Paths: append([]netv1alpha1.HTTPIngressPath{{
 						RewriteHost: hostName,
 						Splits: []netv1alpha1.IngressBackendSplit{{
 							Percent: 100,
@@ -67,7 +69,7 @@ func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, hostName
 								ServicePort:      intstr.FromInt(80),
 							},
 						}},
-					}},
+					}}, routeresources.MakeACMEIngressPaths(acmeChallenges, dm.GetName())...),
 				},
 			}},
 		},

--- a/pkg/reconciler/domainmapping/resources/ingress_test.go
+++ b/pkg/reconciler/domainmapping/resources/ingress_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	network "knative.dev/networking/pkg"
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
+	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving"
@@ -32,63 +33,203 @@ import (
 )
 
 func TestMakeIngress(t *testing.T) {
-	dm := &v1alpha1.DomainMapping{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mapping.com",
-			Namespace: "the-namespace",
-			Annotations: map[string]string{
-				"some.annotation":                  "some.value",
-				corev1.LastAppliedConfigAnnotation: "blah",
-			},
-		},
-		Spec: v1alpha1.DomainMappingSpec{
-			Ref: duckv1.KReference{
+	for _, tc := range []struct {
+		name           string
+		dm             v1alpha1.DomainMapping
+		want           netv1alpha1.Ingress
+		tls            []netv1alpha1.IngressTLS
+		acmeChallenges []netv1alpha1.HTTP01Challenge
+	}{{
+		name: "basic",
+		dm: v1alpha1.DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mapping.com",
 				Namespace: "the-namespace",
-				Name:      "the-name",
-			},
-		},
-	}
-
-	got := MakeIngress(dm, "the-target-svc", "the-rewrite-host", "the-ingress-class")
-
-	want := &netv1alpha1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mapping.com",
-			Namespace: "the-namespace",
-			Annotations: map[string]string{
-				"networking.knative.dev/ingress.class": "the-ingress-class",
-				"some.annotation":                      "some.value",
-			},
-			Labels: kmeta.UnionMaps(dm.Labels, map[string]string{
-				serving.DomainMappingLabelKey: dm.Name,
-			}),
-			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(dm)},
-		},
-		Spec: netv1alpha1.IngressSpec{
-			Rules: []netv1alpha1.IngressRule{{
-				Hosts:      []string{"mapping.com"},
-				Visibility: netv1alpha1.IngressVisibilityExternalIP,
-				HTTP: &netv1alpha1.HTTPIngressRuleValue{
-					Paths: []netv1alpha1.HTTPIngressPath{{
-						RewriteHost: "the-rewrite-host",
-						Splits: []netv1alpha1.IngressBackendSplit{{
-							Percent: 100,
-							AppendHeaders: map[string]string{
-								network.OriginalHostHeader: "mapping.com",
-							},
-							IngressBackend: netv1alpha1.IngressBackend{
-								ServiceName:      "the-target-svc",
-								ServiceNamespace: "the-namespace",
-								ServicePort:      intstr.FromInt(80),
-							},
-						}},
-					}},
+				Annotations: map[string]string{
+					"some.annotation":                  "some.value",
+					corev1.LastAppliedConfigAnnotation: "blah",
 				},
-			}},
+			},
+			Spec: v1alpha1.DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Namespace: "the-namespace",
+					Name:      "the-name",
+				},
+			},
 		},
+		want: netv1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mapping.com",
+				Namespace: "the-namespace",
+				Annotations: map[string]string{
+					"networking.knative.dev/ingress.class": "the-ingress-class",
+					"some.annotation":                      "some.value",
+				},
+			},
+			Spec: netv1alpha1.IngressSpec{
+				Rules: []netv1alpha1.IngressRule{{
+					Hosts:      []string{"mapping.com"},
+					Visibility: netv1alpha1.IngressVisibilityExternalIP,
+					HTTP: &netv1alpha1.HTTPIngressRuleValue{
+						Paths: []netv1alpha1.HTTPIngressPath{{
+							RewriteHost: "the-rewrite-host",
+							Splits: []netv1alpha1.IngressBackendSplit{{
+								Percent: 100,
+								AppendHeaders: map[string]string{
+									network.OriginalHostHeader: "mapping.com",
+								},
+								IngressBackend: netv1alpha1.IngressBackend{
+									ServiceName:      "the-target-svc",
+									ServiceNamespace: "the-namespace",
+									ServicePort:      intstr.FromInt(80),
+								},
+							}},
+						}},
+					},
+				}},
+			},
+		},
+	}, {
+		name: "tls",
+		dm: v1alpha1.DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mapping.com",
+				Namespace: "the-namespace",
+				Annotations: map[string]string{
+					"some.annotation":                  "some.value",
+					corev1.LastAppliedConfigAnnotation: "blah",
+				},
+			},
+			Spec: v1alpha1.DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Namespace: "the-namespace",
+					Name:      "the-name",
+				},
+			},
+		},
+		tls: []netv1alpha1.IngressTLS{{
+			Hosts:      []string{"mapping.com"},
+			SecretName: "secret",
+		}},
+		want: netv1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mapping.com",
+				Namespace: "the-namespace",
+				Annotations: map[string]string{
+					"networking.knative.dev/ingress.class": "the-ingress-class",
+					"some.annotation":                      "some.value",
+				},
+			},
+			Spec: netv1alpha1.IngressSpec{
+				Rules: []netv1alpha1.IngressRule{{
+					Hosts:      []string{"mapping.com"},
+					Visibility: netv1alpha1.IngressVisibilityExternalIP,
+					HTTP: &netv1alpha1.HTTPIngressRuleValue{
+						Paths: []netv1alpha1.HTTPIngressPath{{
+							RewriteHost: "the-rewrite-host",
+							Splits: []netv1alpha1.IngressBackendSplit{{
+								Percent: 100,
+								AppendHeaders: map[string]string{
+									network.OriginalHostHeader: "mapping.com",
+								},
+								IngressBackend: netv1alpha1.IngressBackend{
+									ServiceName:      "the-target-svc",
+									ServiceNamespace: "the-namespace",
+									ServicePort:      intstr.FromInt(80),
+								},
+							}},
+						}},
+					},
+				}},
+				TLS: []netv1alpha1.IngressTLS{{
+					Hosts:      []string{"mapping.com"},
+					SecretName: "secret",
+				}},
+			},
+		},
+	}, {
+		name: "challenges",
+		dm: v1alpha1.DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mapping.com",
+				Namespace: "the-namespace",
+				Annotations: map[string]string{
+					"some.annotation":                  "some.value",
+					corev1.LastAppliedConfigAnnotation: "blah",
+				},
+			},
+			Spec: v1alpha1.DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Namespace: "the-namespace",
+					Name:      "the-name",
+				},
+			},
+		},
+		acmeChallenges: []netv1alpha1.HTTP01Challenge{{
+			ServiceNamespace: "test-ns",
+			ServiceName:      "cm-solver",
+			ServicePort:      intstr.FromInt(8090),
+			URL: &apis.URL{
+				Scheme: "http",
+				Path:   "/.well-known/acme-challenge/challenge-token",
+				Host:   "mapping.com",
+			},
+		}},
+		want: netv1alpha1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mapping.com",
+				Namespace: "the-namespace",
+				Annotations: map[string]string{
+					"networking.knative.dev/ingress.class": "the-ingress-class",
+					"some.annotation":                      "some.value",
+				},
+			},
+			Spec: netv1alpha1.IngressSpec{
+				Rules: []netv1alpha1.IngressRule{{
+					Hosts:      []string{"mapping.com"},
+					Visibility: netv1alpha1.IngressVisibilityExternalIP,
+					HTTP: &netv1alpha1.HTTPIngressRuleValue{
+						Paths: []netv1alpha1.HTTPIngressPath{{
+							RewriteHost: "the-rewrite-host",
+							Splits: []netv1alpha1.IngressBackendSplit{{
+								Percent: 100,
+								AppendHeaders: map[string]string{
+									network.OriginalHostHeader: "mapping.com",
+								},
+								IngressBackend: netv1alpha1.IngressBackend{
+									ServiceName:      "the-target-svc",
+									ServiceNamespace: "the-namespace",
+									ServicePort:      intstr.FromInt(80),
+								},
+							}},
+						}, {
+							Path: "/.well-known/acme-challenge/challenge-token",
+							Splits: []netv1alpha1.IngressBackendSplit{{
+								IngressBackend: netv1alpha1.IngressBackend{
+									ServiceNamespace: "test-ns",
+									ServiceName:      "cm-solver",
+									ServicePort:      intstr.FromInt(8090),
+								},
+								Percent: 100,
+							}},
+						}},
+					},
+				}},
+			},
+		},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.want.Labels = kmeta.UnionMaps(tc.dm.Labels, map[string]string{
+				serving.DomainMappingLabelKey: tc.dm.Name,
+			})
+			tc.want.OwnerReferences = []metav1.OwnerReference{*kmeta.NewControllerRef(&tc.dm)}
+			got := *MakeIngress(&tc.dm,
+				"the-target-svc", "the-rewrite-host", "the-ingress-class",
+				tc.tls, tc.acmeChallenges...)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Unexpected Ingress (-want, +got):\n%s", diff)
+			}
+		})
 	}
 
-	if !cmp.Equal(want, got) {
-		t.Errorf("Unexpected Ingress (-want, +got):\n%s", cmp.Diff(want, got))
-	}
 }

--- a/pkg/reconciler/domainmapping/table_test.go
+++ b/pkg/reconciler/domainmapping/table_test.go
@@ -81,7 +81,7 @@ func TestReconcile(t *testing.T) {
 		SkipNamespaceValidation: true, // allow creation of ClusterDomainClaim.
 		WantCreates: []runtime.Object{
 			resources.MakeDomainClaim(domainMapping("default", "first-reconcile.com", withRef("default", "target"))),
-			resources.MakeIngress(domainMapping("default", "first-reconcile.com", withRef("default", "target")), "the-target-svc", "the-target-svc.default.svc.cluster.local", "the-ingress-class", []netv1alpha1.IngressTLS{}),
+			resources.MakeIngress(domainMapping("default", "first-reconcile.com", withRef("default", "target")), "the-target-svc", "the-target-svc.default.svc.cluster.local", "the-ingress-class", nil /* tls */),
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "first-reconcile.com"),
@@ -109,7 +109,7 @@ func TestReconcile(t *testing.T) {
 			resources.MakeDomainClaim(domainMapping("default", "first-reconcile.com", withRef("default", "target", withAPIVersionKind("v1", "Service")))),
 			resources.MakeIngress(
 				domainMapping("default", "first-reconcile.com", withRef("default", "target", withAPIVersionKind("v1", "Service"))),
-				"target", "target.default.svc.cluster.local", "the-ingress-class", []netv1alpha1.IngressTLS{}),
+				"target", "target.default.svc.cluster.local", "the-ingress-class", nil /* tls */),
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "first-reconcile.com"),
@@ -233,7 +233,7 @@ func TestReconcile(t *testing.T) {
 			),
 		}},
 		WantCreates: []runtime.Object{
-			resources.MakeIngress(domainMapping("default", "first-reconcile.com", withRef("default", "target")), "the-target-svc", "the-target-svc.default.svc.cluster.local", "the-ingress-class", []netv1alpha1.IngressTLS{}),
+			resources.MakeIngress(domainMapping("default", "first-reconcile.com", withRef("default", "target")), "the-target-svc", "the-target-svc.default.svc.cluster.local", "the-ingress-class", nil /* tls */),
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "first-reconcile.com"),
@@ -317,7 +317,7 @@ func TestReconcile(t *testing.T) {
 		WantCreates: []runtime.Object{
 			resources.MakeDomainClaim(domainMapping("default", "ingressclass.first-reconcile.com", withRef("default", "target"))),
 			resources.MakeIngress(domainMapping("default", "ingressclass.first-reconcile.com", withRef("default", "target")),
-				"the-target-svc", "the-target-svc.default.svc.cluster.local", "overridden-ingress-class", []netv1alpha1.IngressTLS{}),
+				"the-target-svc", "the-target-svc.default.svc.cluster.local", "overridden-ingress-class", nil /* tls */),
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "ingressclass.first-reconcile.com"),
@@ -328,7 +328,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			ksvc("default", "changed", "changed.default.svc.cluster.local", ""),
 			domainMapping("default", "ingress-exists.org", withRef("default", "changed")),
-			resources.MakeIngress(domainMapping("default", "ingress-exists.org", withRef("default", "changed")), "previous", "previous.default.svc.cluster.local", "the-ingress-class", []netv1alpha1.IngressTLS{}),
+			resources.MakeIngress(domainMapping("default", "ingress-exists.org", withRef("default", "changed")), "previous", "previous.default.svc.cluster.local", "the-ingress-class", nil /* tls */),
 			resources.MakeDomainClaim(domainMapping("default", "ingress-exists.org", withRef("default", "changed"))),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -636,7 +636,7 @@ func withObservedGeneration(dm *v1alpha1.DomainMapping) {
 }
 
 func ingress(dm *v1alpha1.DomainMapping, ingressClass string, opt ...IngressOption) *netv1alpha1.Ingress {
-	ing := resources.MakeIngress(dm, dm.Spec.Ref.Name, dm.Spec.Ref.Name+"."+dm.Spec.Ref.Namespace+".svc.cluster.local", ingressClass, []netv1alpha1.IngressTLS{})
+	ing := resources.MakeIngress(dm, dm.Spec.Ref.Name, dm.Spec.Ref.Name+"."+dm.Spec.Ref.Namespace+".svc.cluster.local", ingressClass, nil /* tls */)
 	for _, o := range opt {
 		o(ing)
 	}

--- a/pkg/reconciler/domainmapping/table_test.go
+++ b/pkg/reconciler/domainmapping/table_test.go
@@ -81,7 +81,7 @@ func TestReconcile(t *testing.T) {
 		SkipNamespaceValidation: true, // allow creation of ClusterDomainClaim.
 		WantCreates: []runtime.Object{
 			resources.MakeDomainClaim(domainMapping("default", "first-reconcile.com", withRef("default", "target"))),
-			resources.MakeIngress(domainMapping("default", "first-reconcile.com", withRef("default", "target")), "the-target-svc", "the-target-svc.default.svc.cluster.local", "the-ingress-class"),
+			resources.MakeIngress(domainMapping("default", "first-reconcile.com", withRef("default", "target")), "the-target-svc", "the-target-svc.default.svc.cluster.local", "the-ingress-class", []netv1alpha1.IngressTLS{}),
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "first-reconcile.com"),
@@ -109,7 +109,7 @@ func TestReconcile(t *testing.T) {
 			resources.MakeDomainClaim(domainMapping("default", "first-reconcile.com", withRef("default", "target", withAPIVersionKind("v1", "Service")))),
 			resources.MakeIngress(
 				domainMapping("default", "first-reconcile.com", withRef("default", "target", withAPIVersionKind("v1", "Service"))),
-				"target", "target.default.svc.cluster.local", "the-ingress-class"),
+				"target", "target.default.svc.cluster.local", "the-ingress-class", []netv1alpha1.IngressTLS{}),
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "first-reconcile.com"),
@@ -233,7 +233,7 @@ func TestReconcile(t *testing.T) {
 			),
 		}},
 		WantCreates: []runtime.Object{
-			resources.MakeIngress(domainMapping("default", "first-reconcile.com", withRef("default", "target")), "the-target-svc", "the-target-svc.default.svc.cluster.local", "the-ingress-class"),
+			resources.MakeIngress(domainMapping("default", "first-reconcile.com", withRef("default", "target")), "the-target-svc", "the-target-svc.default.svc.cluster.local", "the-ingress-class", []netv1alpha1.IngressTLS{}),
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "first-reconcile.com"),
@@ -317,7 +317,7 @@ func TestReconcile(t *testing.T) {
 		WantCreates: []runtime.Object{
 			resources.MakeDomainClaim(domainMapping("default", "ingressclass.first-reconcile.com", withRef("default", "target"))),
 			resources.MakeIngress(domainMapping("default", "ingressclass.first-reconcile.com", withRef("default", "target")),
-				"the-target-svc", "the-target-svc.default.svc.cluster.local", "overridden-ingress-class"),
+				"the-target-svc", "the-target-svc.default.svc.cluster.local", "overridden-ingress-class", []netv1alpha1.IngressTLS{}),
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Created", "Created Ingress %q", "ingressclass.first-reconcile.com"),
@@ -328,7 +328,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			ksvc("default", "changed", "changed.default.svc.cluster.local", ""),
 			domainMapping("default", "ingress-exists.org", withRef("default", "changed")),
-			resources.MakeIngress(domainMapping("default", "ingress-exists.org", withRef("default", "changed")), "previous", "previous.default.svc.cluster.local", "the-ingress-class"),
+			resources.MakeIngress(domainMapping("default", "ingress-exists.org", withRef("default", "changed")), "previous", "previous.default.svc.cluster.local", "the-ingress-class", []netv1alpha1.IngressTLS{}),
 			resources.MakeDomainClaim(domainMapping("default", "ingress-exists.org", withRef("default", "changed"))),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -636,7 +636,7 @@ func withObservedGeneration(dm *v1alpha1.DomainMapping) {
 }
 
 func ingress(dm *v1alpha1.DomainMapping, ingressClass string, opt ...IngressOption) *netv1alpha1.Ingress {
-	ing := resources.MakeIngress(dm, dm.Spec.Ref.Name, dm.Spec.Ref.Name+"."+dm.Spec.Ref.Namespace+".svc.cluster.local", ingressClass)
+	ing := resources.MakeIngress(dm, dm.Spec.Ref.Name, dm.Spec.Ref.Name+"."+dm.Spec.Ref.Namespace+".svc.cluster.local", ingressClass, []netv1alpha1.IngressTLS{})
 	for _, o := range opt {
 		o(ing)
 	}

--- a/pkg/reconciler/route/resources/ingress.go
+++ b/pkg/reconciler/route/resources/ingress.go
@@ -135,7 +135,6 @@ func makeIngressSpec(
 	sort.Strings(names)
 	// The routes are matching rule based on domain name to traffic split targets.
 	rules := make([]netv1alpha1.IngressRule, 0, len(names))
-	challengeHosts := getChallengeHosts(acmeChallenges)
 
 	featuresConfig := config.FromContextOrDefaults(ctx).Features
 
@@ -188,7 +187,7 @@ func makeIngressSpec(
 			// If this is a public rule, we need to configure ACME challenge paths.
 			if visibility == netv1alpha1.IngressVisibilityExternalIP {
 				rule.HTTP.Paths = append(
-					makeACMEIngressPaths(challengeHosts, domains), rule.HTTP.Paths...)
+					MakeACMEIngressPaths(acmeChallenges, domains...), rule.HTTP.Paths...)
 			}
 			rules = append(rules, rule)
 		}
@@ -231,7 +230,10 @@ func routeDomain(ctx context.Context, targetName string, r *servingv1.Route, vis
 	return domains, err
 }
 
-func makeACMEIngressPaths(challenges map[string]netv1alpha1.HTTP01Challenge, domains []string) []netv1alpha1.HTTPIngressPath {
+// MakeACMEIngressPaths returns a set of netv1alpha1.HTTPIngressPath
+// that can be used to perform ACME challenges.
+func MakeACMEIngressPaths(acmeChallenges []netv1alpha1.HTTP01Challenge, domains ...string) []netv1alpha1.HTTPIngressPath {
+	challenges := getChallengeHosts(acmeChallenges)
 	paths := make([]netv1alpha1.HTTPIngressPath, 0, len(challenges))
 	for _, domain := range domains {
 		challenge, ok := challenges[domain]


### PR DESCRIPTION
Part of #10247 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Extend resources.MakeIngress to take TLS and ACME challenges params. When these are not specified the result is backward compatible with previous behavior.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
