### PR TITLE
Revert "Patch config-istio after the configmap is actually... (#10450)"

### DIFF
--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -69,9 +69,6 @@ function install_istio() {
     sed "s/namespace: \"*${KNATIVE_DEFAULT_NAMESPACE}\"*/namespace: ${SYSTEM_NAMESPACE}/g" ${1} > ${YAML_NAME}
     echo "net-istio patched YAML: $YAML_NAME"
     ko apply -f "${YAML_NAME}" --selector=networking.knative.dev/ingress-provider=istio || return 1
-
-    ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/extras/configure-istio.sh
-
     UNINSTALL_LIST+=( "${YAML_NAME}" )
   fi
 }


### PR DESCRIPTION
Reverting commit fa5a97a6d28c0c5a194cabb9437d5bc5bddbd325 (causing test breakage in KinD e2e tests for K8s version 1.17.1)

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Reverting commit fa5a97a6d28c0c5a194cabb9437d5bc5bddbd325
cc @arturenault 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
