### PR TITLE
Patch config-istio after the configmap is actually created

### DIFF
--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -70,7 +70,12 @@ function install_istio() {
     echo "net-istio patched YAML: $YAML_NAME"
     ko apply -f "${YAML_NAME}" --selector=networking.knative.dev/ingress-provider=istio || return 1
 
-    ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/extras/configure-istio.sh
+    CONFIGURE_ISTIO=${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/extras/configure-istio.sh
+    if [[ -f "$CONFIGURE_ISTIO" ]]; then
+      $CONFIGURE_ISTIO
+    else
+      echo "configure-istio.sh not found; skipping."
+    fi
 
     UNINSTALL_LIST+=( "${YAML_NAME}" )
   fi

--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -69,6 +69,9 @@ function install_istio() {
     sed "s/namespace: \"*${KNATIVE_DEFAULT_NAMESPACE}\"*/namespace: ${SYSTEM_NAMESPACE}/g" ${1} > ${YAML_NAME}
     echo "net-istio patched YAML: $YAML_NAME"
     ko apply -f "${YAML_NAME}" --selector=networking.knative.dev/ingress-provider=istio || return 1
+
+    ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/extras/configure-istio.sh
+
     UNINSTALL_LIST+=( "${YAML_NAME}" )
   fi
 }


### PR DESCRIPTION
## Proposed Changes

* Fix bug where a few config patches in our tests don't actually get applied.
* Currently these patches happen in [install-istio.sh](https://github.com/knative-sandbox/net-istio/blob/master/third_party/istio-latest/install-istio.sh), which is before the configmaps are created.
* Check that script actually exists first (otherwise we'll break test runs pinned to an earlier version) 

/assign @JRBANCEL @nak3 