### PR TITLE
update podIPTrackers to podTrackers in comments for it has been renamed in code

### DIFF
--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -153,7 +153,7 @@ type revisionThrottler struct {
 	podTrackers []*podTracker
 
 	// Effective trackers that are assigned to this Activator.
-	// This is a subset of podIPTrackers.
+	// This is a subset of podTrackers.
 	assignedTrackers []*podTracker
 
 	// If we don't have a healthy clusterIPTracker this is set to nil, otherwise
@@ -412,7 +412,7 @@ func (rt *revisionThrottler) handleUpdate(update revisionDestsUpdate) {
 		zap.String("ClusterIP", update.ClusterIPDest), zap.Object("dests", logging.StringSet(update.Dests)))
 
 	// ClusterIP is not yet ready, so we want to send requests directly to the pods.
-	// NB: this will not be called in parallel, thus we can build a new podIPTrackers
+	// NB: this will not be called in parallel, thus we can build a new podTrackers
 	// array before taking out a lock.
 	if update.ClusterIPDest == "" {
 		// Create a map for fast lookup of existing trackers.


### PR DESCRIPTION
`podIPTrackers` has been renamed to `podTrackers` in commit https://github.com/knative/serving/commit/cc391e43969a91f642becba86645c531cddd32e9#diff-3c6c186f32eb539d52eb3cb9ff72e8183bc28906c450f06960642fd7712dd9ee,
there are still 2 old names in comments.