### PR TITLE
Match the progress deadline to that of k8s

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -190,6 +190,12 @@ jobs:
           --type merge \
           --patch '{"data":{"ingress.class":"${{ matrix.kingress }}.ingress.networking.knative.dev"}}'
 
+        # Reduce the progress deadline so failure tests don't take forever.
+        kubectl patch configmap/config-deployment \
+          --namespace knative-serving \
+          --type merge \
+          --patch '{"data":{"progressDeadline":"120s"}}'
+
         # Be KinD to these tests.
         kubectl scale -nknative-serving deployment/chaosduck --replicas=0
 

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -50,7 +50,7 @@ data:
 
     # ProgressDeadline is the duration we wait for the deployment to
     # be ready before considering it failed.
-    progressDeadline: "120s"
+    progressDeadline: "600s"
 
     # queueSidecarCPURequest is the requests.cpu to set for the queue proxy sidecar container.
     # If omitted, a default value (currently "25m"), is used.

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "52900e59"
+    knative.dev/example-checksum: "fa67b403"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -36,8 +36,8 @@ const (
 	QueueSidecarImageKey = "queueSidecarImage"
 
 	// ProgressDeadlineDefault is the default value for the config's
-	// ProgressDeadlineSeconds. This does not match the K8s default value of 600s.
-	ProgressDeadlineDefault = 120 * time.Second
+	// ProgressDeadlineSeconds. This matches the K8s default value of 600s.
+	ProgressDeadlineDefault = 600 * time.Second
 
 	// ProgressDeadlineKey is the key to configure deployment progress deadline.
 	ProgressDeadlineKey = "progressDeadline"

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -422,6 +422,10 @@ function test_setup() {
     kubectl label namespace serving-tests-alt istio-injection=enabled
   fi
 
+  # Setting deadline progress to a shorter value.
+  kubectl patch cm "config-deployment" -n "${SYSTEM_NAMESPACE}" \
+    -p '{"data":{"'progressDeadline'":"'120s'"}}'
+
   echo ">> Uploading test images..."
   ${REPO_ROOT_DIR}/test/upload-test-images.sh || return 1
 
@@ -531,9 +535,6 @@ function install_latest_release() {
       || fail_test "Knative latest release installation failed"
   test_logging_config_setup
 
-  # Setting deadline progress to a shorter value.
-  kubectl patch cm "config-deployment" -n "${SYSTEM_NAMESPACE}" -p '{"data":{"'progressDeadline'":"'120s'"}}'
-
   wait_until_pods_running ${SYSTEM_NAMESPACE}
   wait_until_batch_job_complete ${SYSTEM_NAMESPACE}
 }
@@ -544,9 +545,6 @@ function install_head_reuse_ingress() {
   # makes ongoing requests fail.
   REUSE_INGRESS=true install_knative_serving || fail_test "Knative head release installation failed"
   test_logging_config_setup
-
-  # Setting deadline progress to a shorter value.
-  kubectl patch cm "config-deployment" -n "${SYSTEM_NAMESPACE}" -p '{"data":{"'progressDeadline'":"'120s'"}}'
 
   wait_until_pods_running ${SYSTEM_NAMESPACE}
   wait_until_batch_job_complete ${SYSTEM_NAMESPACE}

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -530,7 +530,7 @@ function install_latest_release() {
   install_knative_serving latest-release \
       || fail_test "Knative latest release installation failed"
   test_logging_config_setup
-  
+
   # Setting deadline progress to a shorter value.
   kubectl patch cm "config-deployment" -n "${SYSTEM_NAMESPACE}" -p '{"data":{"'progressDeadline'":"'120s'"}}'
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -530,6 +530,10 @@ function install_latest_release() {
   install_knative_serving latest-release \
       || fail_test "Knative latest release installation failed"
   test_logging_config_setup
+  
+  # Setting deadline progress to a shorter value.
+  kubectl patch cm "config-deployment" -n "${SYSTEM_NAMESPACE}" -p '{"data":{"'progressDeadline'":"'120s'"}}'
+
   wait_until_pods_running ${SYSTEM_NAMESPACE}
   wait_until_batch_job_complete ${SYSTEM_NAMESPACE}
 }
@@ -540,6 +544,10 @@ function install_head_reuse_ingress() {
   # makes ongoing requests fail.
   REUSE_INGRESS=true install_knative_serving || fail_test "Knative head release installation failed"
   test_logging_config_setup
+
+  # Setting deadline progress to a shorter value.
+  kubectl patch cm "config-deployment" -n "${SYSTEM_NAMESPACE}" -p '{"data":{"'progressDeadline'":"'120s'"}}'
+
   wait_until_pods_running ${SYSTEM_NAMESPACE}
   wait_until_batch_job_complete ${SYSTEM_NAMESPACE}
 }


### PR DESCRIPTION
As defined here: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#progress-deadline-seconds

And as discussed here: https://github.com/knative/serving/issues/10344