### PR TITLE
Report first and second revision metrics separately and deleted old rev.

### DIFF
--- a/test/performance/benchmarks/rollout-probe/dev.config
+++ b/test/performance/benchmarks/rollout-probe/dev.config
@@ -72,6 +72,14 @@ metric_info_list: {
   label: "available-pods"
 }
 metric_info_list: {
+  value_key: "dp2"
+  label: "desired-pods-new"
+}
+metric_info_list: {
+  value_key: "ap2"
+  label: "available-pods-new"
+}
+metric_info_list: {
   value_key: "t1"
   label: "tarffic-old"
 }

--- a/test/performance/metrics/runtime.go
+++ b/test/performance/metrics/runtime.go
@@ -39,6 +39,7 @@ import (
 type DeploymentStatus struct {
 	DesiredReplicas int32
 	ReadyReplicas   int32
+	DeploymentName  string
 	// Time is the time when the status is fetched
 	Time time.Time
 }
@@ -112,6 +113,7 @@ func fetchStatusInternal(ctx context.Context, duration time.Duration,
 			ds := DeploymentStatus{
 				DesiredReplicas: *d.Spec.Replicas,
 				ReadyReplicas:   d.Status.ReadyReplicas,
+				DeploymentName:  d.ObjectMeta.Name,
 				Time:            t,
 			}
 			ch <- ds


### PR DESCRIPTION
- Proactively delete the _old_ revision at the end of the test.
  We know it won't receive traffic and won't be part of any rollout
  anymore.
- Report deployment name along with the deployment stat value. This
  permits us to determine which metric to emit (first or second
  revision).
- From the route we can infer the current revision names to uses and
  then use these names when trying to match deployment to revision.

Example run, not the best run, but still pretty telling:
https://mako.dev/run?run_key=4658321219911680&~dp=1&~ap=1&~ap2=1&~dp2=1

Once can see:
- 100 -> 110 -> 100 hump which disappears (ideal number 103 pods, but
  there's probably some initial queueing happening at activator, which
  pushes the value a bit higher
- for the second revision it is more obvious where the spike goes to a
  higher value before dropping and then climbing back again. Latency vs
  pods chart shows that in a pretty way here:
  https://mako.dev/run?run_key=4658321219911680&~ac=1&~dp2=1&~ap2=1

/assign @tcnghia mattmoor