### PR TITLE
Ensure step size is validated and add tests

### DIFF
--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -137,6 +137,10 @@ func (cur *Rollout) Validate() bool {
 		if c.Percent > 100 {
 			return false
 		}
+		// Ensure step size is valid.
+		if c.StepParams.StepSize < 0 || c.StepParams.StepSize > c.Percent {
+			return false
+		}
 		// If total % values in the revision do not add up — discard.
 		tot := 0
 		for _, r := range c.Revisions {

--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -1274,6 +1274,36 @@ func TestValidateFailures(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "step larger than total",
+		r: &Rollout{
+			Configurations: []*ConfigurationRollout{{
+				ConfigurationName: "keith",
+				Percent:           71,
+				StepParams: RolloutParams{
+					StepSize: 75,
+				},
+				Revisions: []RevisionRollout{{
+					RevisionName: "black-on-blue",
+					Percent:      71,
+				}},
+			}},
+		},
+	}, {
+		name: "step negative",
+		r: &Rollout{
+			Configurations: []*ConfigurationRollout{{
+				ConfigurationName: "keith",
+				Percent:           71,
+				StepParams: RolloutParams{
+					StepSize: -1,
+				},
+				Revisions: []RevisionRollout{{
+					RevisionName: "black-on-blue",
+					Percent:      71,
+				}},
+			}},
+		},
+	}, {
 		name: "rev more than config",
 		r: &Rollout{
 			Configurations: []*ConfigurationRollout{{


### PR DESCRIPTION
Cover one more thing that users can break by manually editing the annotation.

/assign @tcnghia 