### PR TITLE
Simplify and optimise proxy header pruning

### DIFF
--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -266,7 +266,7 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 
 func sendRequest(namespace, revName string, handler http.Handler, store *activatorconfig.Store) *httptest.ResponseRecorder {
 	resp := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/", nil)
 	ctx := store.ToContext(req.Context())
 	ctx = util.WithRevID(ctx, types.NamespacedName{Namespace: namespace, Name: revName})
 	handler.ServeHTTP(resp, req.WithContext(ctx))


### PR DESCRIPTION
Adds a util.NewHeaderPruningReverseProxy method directly returning a
httputil.ReverseProxy that strips activator headers. 

This avoids needing util.SetupHeaderPruning which was pulling out the
inner Director func from NewSingleHostReverseProxy and wrapping a
closure around it (the Director func we need to write instead is super
trivial since we don't need base paths/query strings so we were calling
[httputil.NewSingleHostReverseProxy](https://github.com/golang/go/blob/9c017ff30dd21bbdcdb11f39458d3944db530d7e/src/net/http/httputil/reverseproxy.go#L142) and introducing a closure just to save
writing four or so lines before).

Additionally since we never want to proxy at a different base path or
scheme or with extra query string params we can accept a string
targetHost here which avoids having to create a garbage url.URL on each
request in throttler.

Doing this removes a little bit of duplication since the same code
needed to be in both QP and activator.  Also it's a bit faster, saves a
couple allocations on every request and (I think) it's clearer.

~~~~
name                                 old time/op    new time/op    delta
Handler/002k-resp-len-sequential-16    2.37µs ± 5%    2.28µs ± 5%     ~     (p=0.130 n=8+8)
Handler/002k-resp-len-parallel-16       736ns ± 4%     677ns ± 5%   -8.03%  (p=0.000 n=8+8)
Handler/016k-resp-len-sequential-16    2.79µs ± 4%    2.59µs ± 3%   -7.25%  (p=0.001 n=7+7)
Handler/016k-resp-len-parallel-16       744ns ± 6%     707ns ± 3%   -5.04%  (p=0.003 n=8+8)
Handler/032k-resp-len-sequential-16    3.17µs ± 8%    2.98µs ± 6%   -6.04%  (p=0.021 n=8+8)
Handler/032k-resp-len-parallel-16       792ns ± 2%     728ns ± 2%   -8.12%  (p=0.001 n=6+7)
Handler/064k-resp-len-sequential-16    4.02µs ± 5%    3.66µs ± 2%   -9.08%  (p=0.001 n=7+7)
Handler/064k-resp-len-parallel-16       888ns ± 4%     826ns ± 8%   -7.04%  (p=0.006 n=7+8)
Handler/128k-resp-len-sequential-16    6.01µs ±17%    5.36µs ± 5%  -10.93%  (p=0.020 n=8+8)
Handler/128k-resp-len-parallel-16      1.09µs ± 3%    1.03µs ± 6%   -5.20%  (p=0.005 n=8+8)

name                                 old alloc/op   new alloc/op   delta
Handler/002k-resp-len-sequential-16    1.77kB ± 0%    1.60kB ± 0%   -9.38%  (p=0.000 n=8+8)
Handler/002k-resp-len-parallel-16      1.77kB ± 0%    1.60kB ± 0%   -9.31%  (p=0.000 n=8+8)
Handler/016k-resp-len-sequential-16    1.76kB ± 0%    1.60kB ± 0%   -9.14%  (p=0.000 n=8+7)
Handler/016k-resp-len-parallel-16      1.77kB ± 0%    1.61kB ± 0%   -9.24%  (p=0.000 n=7+8)
Handler/032k-resp-len-sequential-16    1.76kB ± 0%    1.60kB ± 0%   -9.24%  (p=0.000 n=8+8)
Handler/032k-resp-len-parallel-16      1.78kB ± 0%    1.62kB ± 0%   -9.16%  (p=0.000 n=8+8)
Handler/064k-resp-len-sequential-16    1.76kB ± 0%    1.60kB ± 0%   -9.26%  (p=0.000 n=8+7)
Handler/064k-resp-len-parallel-16      1.79kB ± 0%    1.63kB ± 0%   -9.34%  (p=0.000 n=8+8)
Handler/128k-resp-len-sequential-16    1.76kB ± 0%    1.60kB ± 0%   -9.21%  (p=0.000 n=8+8)
Handler/128k-resp-len-parallel-16      1.80kB ± 0%    1.63kB ± 0%   -9.36%  (p=0.000 n=8+7)

name                                 old allocs/op  new allocs/op  delta
Handler/002k-resp-len-sequential-16      22.0 ± 0%      20.0 ± 0%   -9.09%  (p=0.000 n=8+8)
Handler/002k-resp-len-parallel-16        22.0 ± 0%      20.0 ± 0%   -9.09%  (p=0.000 n=8+8)
Handler/016k-resp-len-sequential-16      22.0 ± 0%      20.0 ± 0%   -9.09%  (p=0.000 n=8+8)
Handler/016k-resp-len-parallel-16        22.0 ± 0%      20.0 ± 0%   -9.09%  (p=0.000 n=8+8)
Handler/032k-resp-len-sequential-16      22.0 ± 0%      20.0 ± 0%   -9.09%  (p=0.000 n=8+8)
Handler/032k-resp-len-parallel-16        22.0 ± 0%      20.0 ± 0%   -9.09%  (p=0.000 n=8+8)
Handler/064k-resp-len-sequential-16      22.0 ± 0%      20.0 ± 0%   -9.09%  (p=0.000 n=8+8)
Handler/064k-resp-len-parallel-16        22.0 ± 0%      20.0 ± 0%   -9.09%  (p=0.000 n=8+8)
Handler/128k-resp-len-sequential-16      22.0 ± 0%      20.0 ± 0%   -9.09%  (p=0.000 n=8+8)
Handler/128k-resp-len-parallel-16        22.0 ± 0%      20.0 ± 0%   -9.09%  (p=0.000 n=8+8)
~~~~

/assign @markusthoemmes @vagababov 