### PR TITLE
Move the functions that have only single use to the private package

### DIFF
--- a/pkg/apis/serving/metadata_validation_test.go
+++ b/pkg/apis/serving/metadata_validation_test.go
@@ -18,7 +18,6 @@ package serving
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -249,94 +248,6 @@ func TestValidateHasNoAutoscalingAnnotation(t *testing.T) {
 	}
 }
 
-func TestValidateQueueSidecarAnnotation(t *testing.T) {
-	cases := []struct {
-		name       string
-		annotation map[string]string
-		expectErr  *apis.FieldError
-	}{{
-		name: "too small",
-		annotation: map[string]string{
-			QueueSideCarResourcePercentageAnnotation: "0.01982",
-		},
-		expectErr: &apis.FieldError{
-			Message: "expected 0.1 <= 0.01982 <= 100",
-			Paths:   []string{fmt.Sprintf("[%s]", QueueSideCarResourcePercentageAnnotation)},
-		},
-	}, {
-		name: "too big for Queue sidecar resource percentage annotation",
-		annotation: map[string]string{
-			QueueSideCarResourcePercentageAnnotation: "100.0001",
-		},
-		expectErr: &apis.FieldError{
-			Message: "expected 0.1 <= 100.0001 <= 100",
-			Paths:   []string{fmt.Sprintf("[%s]", QueueSideCarResourcePercentageAnnotation)},
-		},
-	}, {
-		name: "Invalid queue sidecar resource percentage annotation",
-		annotation: map[string]string{
-			QueueSideCarResourcePercentageAnnotation: "",
-		},
-		expectErr: &apis.FieldError{
-			Message: "invalid value: ",
-			Paths:   []string{fmt.Sprintf("[%s]", QueueSideCarResourcePercentageAnnotation)},
-		},
-	}, {
-		name:       "empty annotation",
-		annotation: map[string]string{},
-	}, {
-		name: "different annotation other than QueueSideCarResourcePercentageAnnotation",
-		annotation: map[string]string{
-			CreatorAnnotation: "umph",
-		},
-	}, {
-		name: "valid value for Queue sidecar resource percentage annotation",
-		annotation: map[string]string{
-			QueueSideCarResourcePercentageAnnotation: "0.1",
-		},
-	}, {
-		name: "valid value for Queue sidecar resource percentage annotation",
-		annotation: map[string]string{
-			QueueSideCarResourcePercentageAnnotation: "100",
-		},
-	}}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			err := ValidateQueueSidecarAnnotation(c.annotation)
-			if got, want := err.Error(), c.expectErr.Error(); got != want {
-				t.Errorf("\nGot:  %q\nwant: %q", got, want)
-			}
-		})
-	}
-}
-
-func TestValidateTimeoutSecond(t *testing.T) {
-	cases := []struct {
-		name      string
-		timeout   *int64
-		expectErr *apis.FieldError
-	}{{
-		name:    "exceed max timeout",
-		timeout: ptr.Int64(6000),
-		expectErr: apis.ErrOutOfBoundsValue(
-			6000, 0, config.DefaultMaxRevisionTimeoutSeconds,
-			"timeoutSeconds"),
-	}, {
-		name:    "valid timeout value",
-		timeout: ptr.Int64(100),
-	}}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			err := ValidateTimeoutSeconds(context.Background(), *c.timeout)
-			if got, want := err.Error(), c.expectErr.Error(); got != want {
-				t.Errorf("\nGot:  %q\nwant: %q", got, want)
-			}
-		})
-	}
-}
-
 func cfg(m map[string]string) *config.Config {
 	d, _ := config.NewDefaultsConfigFromMap(m)
 	return &config.Config{
@@ -420,7 +331,7 @@ func TestValidateClusterVisibilityLabel(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := ValidateClusterVisibilityLabel(test.label, network.VisibilityLabelKey)
+			err := validateClusterVisibilityLabel(test.label, network.VisibilityLabelKey)
 			if got, want := err.Error(), test.expectErr.Error(); got != want {
 				t.Errorf("\nGot:  %q\nwant: %q", got, want)
 			}
@@ -556,57 +467,6 @@ func TestAnnotationUpdate(t *testing.T) {
 			if !cmp.Equal(test.this.Annotations, test.want) {
 				t.Errorf("Annotations = %v, want: %v, diff (-want, +got):\n%s", test.this.Annotations, test.want,
 					cmp.Diff(test.want, test.this.Annotations))
-			}
-		})
-	}
-}
-
-func TestValidateRevisionName(t *testing.T) {
-	cases := []struct {
-		name            string
-		revName         string
-		revGenerateName string
-		objectMeta      metav1.ObjectMeta
-		expectErr       *apis.FieldError
-	}{{
-		name:            "invalid revision generateName - dots",
-		revGenerateName: "foo.bar",
-		expectErr: apis.ErrInvalidValue("not a DNS 1035 label prefix: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]",
-			"metadata.generateName"),
-	}, {
-		name:    "invalid revision name - dots",
-		revName: "foo.bar",
-		expectErr: apis.ErrInvalidValue("not a DNS 1035 label: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]",
-			"metadata.name"),
-	}, {
-		name: "invalid name (not prefixed)",
-		objectMeta: metav1.ObjectMeta{
-			Name: "bar",
-		},
-		revName: "foo",
-		expectErr: apis.ErrInvalidValue(`"foo" must have prefix "bar-"`,
-			"metadata.name"),
-	}, {
-		name: "invalid name (with generateName)",
-		objectMeta: metav1.ObjectMeta{
-			GenerateName: "foo-bar-",
-		},
-		revName:   "foo-bar-foo",
-		expectErr: apis.ErrDisallowedFields("metadata.name"),
-	}, {
-		name: "valid name",
-		objectMeta: metav1.ObjectMeta{
-			Name: "valid",
-		},
-		revName: "valid-name",
-	}}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			ctx := apis.WithinParent(context.Background(), c.objectMeta)
-			err := ValidateRevisionName(ctx, c.revName, c.revGenerateName)
-			if got, want := err.Error(), c.expectErr.Error(); got != want {
-				t.Errorf("\nGot:  %q\nwant: %q", got, want)
 			}
 		})
 	}

--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -27,7 +27,6 @@ import (
 	"knative.dev/pkg/kmp"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/config"
-	apisconfig "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 )
 
@@ -62,7 +61,7 @@ func (r *Revision) Validate(ctx context.Context) *apis.FieldError {
 // Validate implements apis.Validatable
 func (rts *RevisionTemplateSpec) Validate(ctx context.Context) *apis.FieldError {
 	errs := rts.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec")
-	errs = errs.Also(autoscaling.ValidateAnnotations(ctx, apisconfig.FromContextOrDefaults(ctx).Autoscaler,
+	errs = errs.Also(autoscaling.ValidateAnnotations(ctx, config.FromContextOrDefaults(ctx).Autoscaler,
 		rts.GetAnnotations()).ViaField("metadata.annotations"))
 
 	// If the RevisionTemplateSpec has a name specified, then check that

--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -18,11 +18,15 @@ package v1
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/validation"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmp"
 	"knative.dev/serving/pkg/apis/autoscaling"
+	"knative.dev/serving/pkg/apis/config"
 	apisconfig "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 )
@@ -63,8 +67,8 @@ func (rts *RevisionTemplateSpec) Validate(ctx context.Context) *apis.FieldError 
 
 	// If the RevisionTemplateSpec has a name specified, then check that
 	// it follows the requirements on the name.
-	errs = errs.Also(serving.ValidateRevisionName(ctx, rts.Name, rts.GenerateName))
-	errs = errs.Also(serving.ValidateQueueSidecarAnnotation(rts.Annotations).ViaField("metadata.annotations"))
+	errs = errs.Also(validateRevisionName(ctx, rts.Name, rts.GenerateName))
+	errs = errs.Also(validateQueueSidecarAnnotation(rts.Annotations).ViaField("metadata.annotations"))
 	return errs
 }
 
@@ -103,7 +107,7 @@ func (rs *RevisionSpec) Validate(ctx context.Context) *apis.FieldError {
 	errs := serving.ValidatePodSpec(ctx, rs.PodSpec)
 
 	if rs.TimeoutSeconds != nil {
-		errs = errs.Also(serving.ValidateTimeoutSeconds(ctx, *rs.TimeoutSeconds))
+		errs = errs.Also(validateTimeoutSeconds(ctx, *rs.TimeoutSeconds))
 	}
 
 	if rs.ContainerConcurrency != nil {
@@ -136,4 +140,73 @@ func (r *Revision) ValidateLabels() (errs *apis.FieldError) {
 		}
 	}
 	return
+}
+
+// validateRevisionName validates name and generateName for the revisionTemplate
+func validateRevisionName(ctx context.Context, name, generateName string) *apis.FieldError {
+	if generateName != "" {
+		if msgs := validation.NameIsDNS1035Label(generateName, true); len(msgs) > 0 {
+			return apis.ErrInvalidValue(
+				fmt.Sprint("not a DNS 1035 label prefix: ", msgs),
+				"metadata.generateName")
+		}
+	}
+	if name != "" {
+		if msgs := validation.NameIsDNS1035Label(name, false); len(msgs) > 0 {
+			return apis.ErrInvalidValue(
+				fmt.Sprint("not a DNS 1035 label: ", msgs),
+				"metadata.name")
+		}
+		om := apis.ParentMeta(ctx)
+		prefix := om.Name + "-"
+		if om.Name != "" {
+			// Even if there is GenerateName, allow the use
+			// of Name post-creation.
+		} else if om.GenerateName != "" {
+			// We disallow bringing your own name when the parent
+			// resource uses generateName (at creation).
+			return apis.ErrDisallowedFields("metadata.name")
+		}
+
+		if !strings.HasPrefix(name, prefix) {
+			return apis.ErrInvalidValue(
+				fmt.Sprintf("%q must have prefix %q", name, prefix),
+				"metadata.name")
+		}
+	}
+	return nil
+}
+
+// validateTimeoutSeconds validates timeout by comparing MaxRevisionTimeoutSeconds
+func validateTimeoutSeconds(ctx context.Context, timeoutSeconds int64) *apis.FieldError {
+	if timeoutSeconds != 0 {
+		cfg := config.FromContextOrDefaults(ctx)
+		if timeoutSeconds > cfg.Defaults.MaxRevisionTimeoutSeconds || timeoutSeconds < 0 {
+			return apis.ErrOutOfBoundsValue(timeoutSeconds, 0,
+				cfg.Defaults.MaxRevisionTimeoutSeconds,
+				"timeoutSeconds")
+		}
+	}
+	return nil
+}
+
+// validateQueueSidecarAnnotation validates QueueSideCarResourcePercentageAnnotation
+func validateQueueSidecarAnnotation(annotations map[string]string) *apis.FieldError {
+	if len(annotations) == 0 {
+		return nil
+	}
+	v, ok := annotations[serving.QueueSideCarResourcePercentageAnnotation]
+	if !ok {
+		return nil
+	}
+	value, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return apis.ErrInvalidValue(v, apis.CurrentField).
+			ViaKey(serving.QueueSideCarResourcePercentageAnnotation)
+	}
+	if value < 0.1 || value > 100 {
+		return apis.ErrOutOfBoundsValue(value, 0.1, 100.0, apis.CurrentField).
+			ViaKey(serving.QueueSideCarResourcePercentageAnnotation)
+	}
+	return nil
 }


### PR DESCRIPTION
Some validation functions are used only from `Validate` on `Revision`
objects and there's no need to keep them in public space, thus
increasing the API surface, number of exported objects, etc.

So move them to the revision implementation file along with the tests.


/assign @dprotaso mattmoor