### PR TITLE
Use explicit revID parameter in Throttler

### DIFF
--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -64,7 +64,7 @@ type fakeThrottler struct {
 	err error
 }
 
-func (ft fakeThrottler) Try(_ context.Context, f func(string) error) error {
+func (ft fakeThrottler) Try(_ context.Context, _ types.NamespacedName, f func(string) error) error {
 	if ft.err != nil {
 		return ft.err
 	}

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -40,7 +40,6 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
 	"knative.dev/pkg/reconciler"
-	"knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
@@ -518,8 +517,8 @@ func (t *Throttler) run(updateCh <-chan revisionDestsUpdate) {
 }
 
 // Try waits for capacity and then executes function, passing in a l4 dest to send a request
-func (t *Throttler) Try(ctx context.Context, function func(string) error) error {
-	rt, err := t.getOrCreateRevisionThrottler(util.RevIDFrom(ctx))
+func (t *Throttler) Try(ctx context.Context, revID types.NamespacedName, function func(string) error) error {
+	rt, err := t.getOrCreateRevisionThrottler(revID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The revisionID is fundamental to what Throttler is doing, so better to
be explicit and not smuggle it in via context. This decouples throttler a
bit and makes it a bit more generic while making its actual API explicit.

This also avoids having to do util.WithRevID(ctx) stuff in
the tests, but more importantly means we can (in a follow-on PR) move
util.WithRevID and util.RevIDFrom back in to `handler` and make them
private, setting us up to get rid of the `util` package and reducing surface
area a bit.

/assign @markusthoemmes @vagababov 
