### PR TITLE
Un-export WithRevID, RevIDFrom, WithRevision, RevisionFrom

### DIFF
--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -29,7 +29,6 @@ import (
 	"knative.dev/pkg/logging"
 	pkgmetrics "knative.dev/pkg/metrics"
 	"knative.dev/serving/pkg/activator"
-	"knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/apis/serving"
 	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
@@ -222,7 +221,7 @@ func (cr *ConcurrencyReporter) run(stopCh <-chan struct{}, reportCh <-chan time.
 // machinery.
 func (cr *ConcurrencyReporter) Handler(next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		revisionKey := util.RevIDFrom(r.Context())
+		revisionKey := revIDFrom(r.Context())
 		cr.handleEvent(network.ReqEvent{Key: revisionKey, Type: network.ReqIn, Time: time.Now()})
 		defer func() {
 			cr.handleEvent(network.ReqEvent{Key: revisionKey, Type: network.ReqOut, Time: time.Now()})

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -35,7 +35,6 @@ import (
 	"knative.dev/pkg/metrics/metricstest"
 	_ "knative.dev/pkg/metrics/testing"
 	rtesting "knative.dev/pkg/reconciler/testing"
-	"knative.dev/serving/pkg/activator/util"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
@@ -428,7 +427,7 @@ func TestConcurrencyReporterHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
-	rCtx := util.WithRevID(context.Background(), rev1)
+	rCtx := withRevID(context.Background(), rev1)
 
 	// Send a few requests.
 	handler.ServeHTTP(resp, req.WithContext(rCtx))
@@ -568,7 +567,7 @@ func BenchmarkConcurrencyReporterHandler(b *testing.B) {
 			Name:      testRevName + strconv.Itoa(i),
 		}
 		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
-		reqs = append(reqs, req.WithContext(util.WithRevID(context.Background(), key)))
+		reqs = append(reqs, req.WithContext(withRevID(context.Background(), key)))
 
 		// Create revisions in the fake clients to trigger report logic.
 		rev := revision(key.Namespace, key.Name)

--- a/pkg/activator/handler/context.go
+++ b/pkg/activator/handler/context.go
@@ -19,7 +19,7 @@ This file contains the context manipulation routines used within
 the activator binary.
 */
 
-package util
+package handler
 
 import (
 	"context"
@@ -33,22 +33,22 @@ type (
 	revIDKey    struct{}
 )
 
-// WithRevision attaches the Revision object to the context.
-func WithRevision(ctx context.Context, rev *v1.Revision) context.Context {
+// withRevision attaches the Revision object to the context.
+func withRevision(ctx context.Context, rev *v1.Revision) context.Context {
 	return context.WithValue(ctx, revisionKey{}, rev)
 }
 
-// RevisionFrom retrieves the Revision object from the context.
-func RevisionFrom(ctx context.Context) *v1.Revision {
+// revisionFrom retrieves the Revision object from the context.
+func revisionFrom(ctx context.Context) *v1.Revision {
 	return ctx.Value(revisionKey{}).(*v1.Revision)
 }
 
-// WithRevID attaches the the revisionID to the context.
-func WithRevID(ctx context.Context, revID types.NamespacedName) context.Context {
+// withRevID attaches the the revisionID to the context.
+func withRevID(ctx context.Context, revID types.NamespacedName) context.Context {
 	return context.WithValue(ctx, revIDKey{}, revID)
 }
 
-// RevIDFrom retrieves the the revisionID from the context.
-func RevIDFrom(ctx context.Context) types.NamespacedName {
+// revIDFrom retrieves the the revisionID from the context.
+func revIDFrom(ctx context.Context) types.NamespacedName {
 	return ctx.Value(revIDKey{}).(types.NamespacedName)
 }

--- a/pkg/activator/handler/context_handler.go
+++ b/pkg/activator/handler/context_handler.go
@@ -28,7 +28,6 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
 	"knative.dev/serving/pkg/activator"
-	"knative.dev/serving/pkg/activator/util"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
 )
@@ -65,8 +64,8 @@ func (h *contextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	ctx = logging.WithLogger(ctx, logger)
-	ctx = util.WithRevision(ctx, revision)
-	ctx = util.WithRevID(ctx, revID)
+	ctx = withRevision(ctx, revision)
+	ctx = withRevID(ctx, revID)
 
 	h.nextHandler.ServeHTTP(w, r.WithContext(ctx))
 }

--- a/pkg/activator/handler/context_handler_test.go
+++ b/pkg/activator/handler/context_handler_test.go
@@ -27,7 +27,6 @@ import (
 
 	rtesting "knative.dev/pkg/reconciler/testing"
 	"knative.dev/serving/pkg/activator"
-	"knative.dev/serving/pkg/activator/util"
 )
 
 func TestContextHandler(t *testing.T) {
@@ -38,11 +37,11 @@ func TestContextHandler(t *testing.T) {
 	revisionInformer(ctx, revision)
 
 	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := util.RevisionFrom(r.Context()); got != revision {
+		if got := revisionFrom(r.Context()); got != revision {
 			t.Errorf("revisionFrom() = %v, want %v", got, revision)
 		}
 
-		if got := util.RevIDFrom(r.Context()); got != revID {
+		if got := revIDFrom(r.Context()); got != revID {
 			t.Errorf("revIDFrom() = %v, want %v", got, revID)
 		}
 	})

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -74,7 +74,7 @@ func (a *activationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		tryContext, trySpan = trace.StartSpan(r.Context(), "throttler_try")
 	}
 
-	if err := a.throttler.Try(tryContext, util.RevIDFrom(r.Context()), func(dest string) error {
+	if err := a.throttler.Try(tryContext, revIDFrom(r.Context()), func(dest string) error {
 		trySpan.End()
 
 		proxyCtx, proxySpan := r.Context(), (*trace.Span)(nil)

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -41,7 +41,6 @@ import (
 	"knative.dev/serving/pkg/activator"
 	activatorconfig "knative.dev/serving/pkg/activator/config"
 	activatortest "knative.dev/serving/pkg/activator/testing"
-	"knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/queue"
@@ -135,7 +134,7 @@ func TestActivationHandler(t *testing.T) {
 			// Set up config store to populate context.
 			configStore := setupConfigStore(t, logging.FromContext(ctx))
 			ctx = configStore.ToContext(ctx)
-			ctx = util.WithRevID(ctx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
+			ctx = withRevID(ctx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
 
 			handler.ServeHTTP(resp, req.WithContext(ctx))
 
@@ -173,7 +172,7 @@ func TestActivationHandlerProxyHeader(t *testing.T) {
 	// Set up config store to populate context.
 	configStore := setupConfigStore(t, logging.FromContext(ctx))
 	ctx = configStore.ToContext(req.Context())
-	ctx = util.WithRevID(ctx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
+	ctx = withRevID(ctx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
 
 	handler.ServeHTTP(writer, req.WithContext(ctx))
 
@@ -268,7 +267,7 @@ func sendRequest(namespace, revName string, handler http.Handler, store *activat
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/", nil)
 	ctx := store.ToContext(req.Context())
-	ctx = util.WithRevID(ctx, types.NamespacedName{Namespace: namespace, Name: revName})
+	ctx = withRevID(ctx, types.NamespacedName{Namespace: namespace, Name: revName})
 	handler.ServeHTTP(resp, req.WithContext(ctx))
 	return resp
 }
@@ -319,7 +318,7 @@ func BenchmarkHandler(b *testing.B) {
 			req.Host = "test-host"
 
 			reqCtx := configStore.ToContext(context.Background())
-			reqCtx = util.WithRevID(reqCtx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
+			reqCtx = withRevID(reqCtx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
 			return req.WithContext(reqCtx)
 		}
 

--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -22,7 +22,6 @@ import (
 
 	pkgmetrics "knative.dev/pkg/metrics"
 	"knative.dev/serving/pkg/activator"
-	"knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/apis/serving"
 	pkghttp "knative.dev/serving/pkg/http"
 	"knative.dev/serving/pkg/metrics"
@@ -43,7 +42,7 @@ type MetricHandler struct {
 }
 
 func (h *MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	rev := util.RevisionFrom(r.Context())
+	rev := revisionFrom(r.Context())
 	reporterCtx, _ := metrics.PodRevisionContext(h.podName, activator.Name,
 		rev.Namespace, rev.Labels[serving.ServiceLabelKey], rev.Labels[serving.ConfigurationLabelKey], rev.Name)
 

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -31,7 +31,6 @@ import (
 	"knative.dev/pkg/metrics/metricstest"
 	_ "knative.dev/pkg/metrics/testing"
 	"knative.dev/serving/pkg/activator"
-	"knative.dev/serving/pkg/activator/util"
 	"knative.dev/serving/pkg/apis/serving"
 )
 
@@ -115,8 +114,8 @@ func TestRequestMetricHandler(t *testing.T) {
 				metricstest.AssertMetricExists(t, responseTimeInMsecM.Name())
 			}()
 
-			reqCtx := util.WithRevision(context.Background(), rev)
-			reqCtx = util.WithRevID(reqCtx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
+			reqCtx := withRevision(context.Background(), rev)
+			reqCtx = withRevID(reqCtx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
 			handler.ServeHTTP(resp, req.WithContext(reqCtx))
 		})
 	}
@@ -129,7 +128,7 @@ func reset() {
 
 func BenchmarkMetricHandler(b *testing.B) {
 	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	reqCtx := util.WithRevision(context.Background(), revision(testNamespace, testRevName))
+	reqCtx := withRevision(context.Background(), revision(testNamespace, testRevName))
 
 	handler := NewMetricHandler("benchPod", baseHandler)
 


### PR DESCRIPTION
These are now only used within `activator/handler`, so we can reduce
surface area a bit by moving them in to that package and
un-exporting them. This leaves only the HeaderPruningReverseProxy in the
util package, so next PR will rename that package something nicer.

/assign @markusthoemmes @vagababov 