### PR TITLE
Widen sleep for TestProbeQueueTimeout to harden it

### DIFF
--- a/cmd/queue/execprobe_test.go
+++ b/cmd/queue/execprobe_test.go
@@ -54,7 +54,7 @@ func TestProbeQueueNotReady(t *testing.T) {
 		w.WriteHeader(http.StatusBadRequest)
 	})
 
-	err := probeQueueHealthPath(2*aggressivePollInterval, port, http.DefaultTransport)
+	err := probeQueueHealthPath(100*time.Millisecond, port, http.DefaultTransport)
 
 	if err == nil || err.Error() != "probe returned not ready" {
 		t.Error("Unexpected not ready error:", err)
@@ -122,14 +122,14 @@ func TestProbeQueueTimeout(t *testing.T) {
 	var probed atomic.Bool
 	port := newProbeTestServer(t, func(w http.ResponseWriter) {
 		probed.Store(true)
-		time.Sleep(aggressivePollInterval * 3)
+		time.Sleep(200 * time.Millisecond)
 		w.WriteHeader(http.StatusOK)
 	})
 
 	t.Cleanup(func() { os.Unsetenv(queuePortEnvVar) })
 	os.Setenv(queuePortEnvVar, strconv.Itoa(port))
 
-	if rv := standaloneProbeMain(aggressivePollInterval, nil); rv == 0 {
+	if rv := standaloneProbeMain(100*time.Millisecond, nil); rv == 0 {
 		t.Error("Unexpected return value from standaloneProbeMain:", rv)
 	}
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This test failed on me straight away in https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_serving/10546/pull-knative-serving-unit-tests/1349706712986161152. This passed 250 times in a row locally.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @julz 