### PR TITLE
Cut down queue health tests from 2s to basically nothing

### DIFF
--- a/pkg/queue/health/probe_test.go
+++ b/pkg/queue/health/probe_test.go
@@ -126,13 +126,14 @@ func TestHTTPSchemeProbeSuccess(t *testing.T) {
 }
 
 func TestHTTPProbeTimeoutFailure(t *testing.T) {
+	timeout := 10 * time.Millisecond
 	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(2 * time.Second)
+		time.Sleep(timeout * 5)
 		w.WriteHeader(http.StatusOK)
 	})
 
 	config := HTTPProbeConfigOptions{
-		Timeout:       time.Second,
+		Timeout:       timeout,
 		HTTPGetAction: newHTTPGetAction(t, server.URL),
 	}
 	if err := HTTPProbe(config); err == nil {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

The usual dance of collapsing the timeout to something a lot shorter. There's really no need to wait 2 seconds in a test here.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @julz 
