### PR TITLE
Nits in the code formatting

### DIFF
--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -101,7 +101,7 @@ const (
 	QueueSideCarResourcePercentageAnnotation = "queue.sidecar." + GroupName + "/resourcePercentage"
 
 	// VisibilityLabelKeyObsolete is the obsolete VisibilityLabelKey.
-	// This will move over to VisibilityLabelKey in networking repo..
+	// This will move over to VisibilityLabelKey in networking repo.
 	VisibilityLabelKeyObsolete = "serving.knative.dev/visibility"
 
 	// VisibilityClusterLocal is the label value for VisibilityLabelKey

--- a/pkg/apis/serving/v1/service_validation.go
+++ b/pkg/apis/serving/v1/service_validation.go
@@ -47,8 +47,9 @@ func (s *Service) Validate(ctx context.Context) (errs *apis.FieldError) {
 			apis.ValidateCreatorAndModifier(
 				original.Spec, s.Spec, original.GetAnnotations(),
 				s.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
-		errs = errs.Also(s.Spec.ConfigurationSpec.Template.VerifyNameChange(ctx,
-			&original.Spec.ConfigurationSpec.Template)).ViaField("spec.template")
+		errs = errs.Also(
+			s.Spec.ConfigurationSpec.Template.VerifyNameChange(ctx,
+				&original.Spec.ConfigurationSpec.Template).ViaField("spec.template"))
 	}
 	return errs
 }

--- a/pkg/apis/serving/v1/service_validation.go
+++ b/pkg/apis/serving/v1/service_validation.go
@@ -43,11 +43,12 @@ func (s *Service) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 	if apis.IsInUpdate(ctx) {
 		original := apis.GetBaseline(ctx).(*Service)
-		errs = errs.Also(apis.ValidateCreatorAndModifier(original.Spec, s.Spec, original.GetAnnotations(),
-			s.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
-		err := s.Spec.ConfigurationSpec.Template.VerifyNameChange(ctx,
-			&original.Spec.ConfigurationSpec.Template)
-		errs = errs.Also(err.ViaField("spec.template"))
+		errs = errs.Also(
+			apis.ValidateCreatorAndModifier(
+				original.Spec, s.Spec, original.GetAnnotations(),
+				s.GetAnnotations(), serving.GroupName).ViaField("metadata.annotations"))
+		errs = errs.Also(s.Spec.ConfigurationSpec.Template.VerifyNameChange(ctx,
+			&original.Spec.ConfigurationSpec.Template)).ViaField("spec.template")
 	}
 	return errs
 }


### PR DESCRIPTION
Avoid creating a new variable, when we can just call `Also`.

/assign @tcnghia @dprotaso 