### PR TITLE
Remove the old constant since the new one has been since August 2020

### DIFF
--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -100,10 +100,6 @@ const (
 	// It has to be in [0.1,100]
 	QueueSideCarResourcePercentageAnnotation = "queue.sidecar." + GroupName + "/resourcePercentage"
 
-	// VisibilityLabelKeyObsolete is the obsolete VisibilityLabelKey.
-	// This will move over to VisibilityLabelKey in networking repo..
-	VisibilityLabelKeyObsolete = "serving.knative.dev/visibility"
-
 	// VisibilityClusterLocal is the label value for VisibilityLabelKey
 	// that will result to the Route/KService getting a cluster local
 	// domain suffix.

--- a/pkg/apis/serving/v1/configuration_validation.go
+++ b/pkg/apis/serving/v1/configuration_validation.go
@@ -65,7 +65,7 @@ func (cs *ConfigurationSpec) Validate(ctx context.Context) *apis.FieldError {
 func (c *Configuration) validateLabels() (errs *apis.FieldError) {
 	for key, val := range c.GetLabels() {
 		switch key {
-		case serving.RouteLabelKey, serving.VisibilityLabelKeyObsolete:
+		case serving.RouteLabelKey:
 			// Known valid labels.
 		case serving.ServiceLabelKey:
 			errs = errs.Also(verifyLabelOwnerRef(val, serving.ServiceLabelKey, "Service", c.GetOwnerReferences()))

--- a/pkg/apis/serving/v1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1/configuration_validation_test.go
@@ -290,18 +290,6 @@ func TestConfigurationLabelValidation(t *testing.T) {
 		c    *Configuration
 		want *apis.FieldError
 	}{{
-		name: "valid obsolete visibility name",
-		c: &Configuration{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "byo-name",
-				Labels: map[string]string{
-					serving.VisibilityLabelKeyObsolete: "cluster-local",
-				},
-			},
-			Spec: validConfigSpec,
-		},
-		want: nil,
-	}, {
 		name: "valid route name",
 		c: &Configuration{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -202,7 +202,7 @@ func validateClusterVisibilityLabel(label string) (errs *apis.FieldError) {
 func (r *Route) validateLabels() (errs *apis.FieldError) {
 	for key, val := range r.GetLabels() {
 		switch key {
-		case serving.VisibilityLabelKeyObsolete, network.VisibilityLabelKey:
+		case network.VisibilityLabelKey:
 			errs = errs.Also(validateClusterVisibilityLabel(val))
 		case serving.ServiceLabelKey:
 			errs = errs.Also(verifyLabelOwnerRef(val, serving.ServiceLabelKey, "Service", r.GetOwnerReferences()))

--- a/pkg/apis/serving/v1/service_validation.go
+++ b/pkg/apis/serving/v1/service_validation.go
@@ -64,7 +64,7 @@ func (ss *ServiceSpec) Validate(ctx context.Context) *apis.FieldError {
 func (s *Service) validateLabels() (errs *apis.FieldError) {
 	for key, val := range s.GetLabels() {
 		switch {
-		case key == network.VisibilityLabelKey || key == serving.VisibilityLabelKeyObsolete:
+		case key == network.VisibilityLabelKey:
 			errs = errs.Also(validateClusterVisibilityLabel(val))
 		case strings.HasPrefix(key, serving.GroupNamePrefix):
 			errs = errs.Also(apis.ErrInvalidKeyName(key, apis.CurrentField))

--- a/pkg/reconciler/route/config/domain.go
+++ b/pkg/reconciler/route/config/domain.go
@@ -99,11 +99,11 @@ func (c *Domain) LookupDomainForLabels(labels map[string]string) string {
 	specificity := -1
 	// If we see VisibilityLabelKey sets with VisibilityClusterLocal, that
 	// will take precedence and the route will get a Cluster's Domain Name.
-	if labels[netpkg.VisibilityLabelKey] == serving.VisibilityClusterLocal ||
-		labels[serving.VisibilityLabelKeyObsolete] == serving.VisibilityClusterLocal {
+	if labels[netpkg.VisibilityLabelKey] == serving.VisibilityClusterLocal {
 		return "svc." + network.GetClusterDomainName()
 	}
 	for k, selector := range c.Domains {
+
 		// Ignore if selector doesn't match, or decrease the specificity.
 		if !selector.Matches(labels) || selector.specificity() < specificity {
 			continue

--- a/pkg/reconciler/route/config/domain_test.go
+++ b/pkg/reconciler/route/config/domain_test.go
@@ -20,12 +20,15 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	. "knative.dev/pkg/configmap/testing"
+
+	netpkg "knative.dev/networking/pkg"
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/system"
 
+	. "knative.dev/pkg/configmap/testing"
 	_ "knative.dev/pkg/system/testing"
 )
 
@@ -172,7 +175,7 @@ func TestLookupDomainForLabels(t *testing.T) {
 		labels: map[string]string{},
 		domain: "default.com",
 	}, {
-		labels: map[string]string{"serving.knative.dev/visibility": "cluster-local"},
+		labels: map[string]string{netpkg.VisibilityLabelKey: "cluster-local"},
 		domain: "svc." + network.GetClusterDomainName(),
 	}}
 

--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -86,8 +86,7 @@ func DomainNameFromTemplate(ctx context.Context, r metav1.ObjectMeta, name strin
 	var templ *template.Template
 	// If the route is "cluster local" then don't use the user-defined
 	// domain template, use the default one
-	if rLabels[network.VisibilityLabelKey] == serving.VisibilityClusterLocal ||
-		rLabels[serving.VisibilityLabelKeyObsolete] == serving.VisibilityClusterLocal {
+	if rLabels[network.VisibilityLabelKey] == serving.VisibilityClusterLocal {
 		templ = template.Must(template.New("domain-template").Parse(
 			network.DefaultDomainTemplate))
 	} else {

--- a/pkg/reconciler/route/resources/filters.go
+++ b/pkg/reconciler/route/resources/filters.go
@@ -24,6 +24,5 @@ import (
 
 // IsClusterLocalService returns whether a service is cluster local.
 func IsClusterLocalService(svc *corev1.Service) bool {
-	return svc.GetLabels()[network.VisibilityLabelKey] == serving.VisibilityClusterLocal ||
-		svc.GetLabels()[serving.VisibilityLabelKeyObsolete] == serving.VisibilityClusterLocal
+	return svc.GetLabels()[network.VisibilityLabelKey] == serving.VisibilityClusterLocal
 }

--- a/pkg/reconciler/route/resources/labels/labels.go
+++ b/pkg/reconciler/route/resources/labels/labels.go
@@ -24,7 +24,7 @@ import (
 
 // IsObjectLocalVisibility returns whether an ObjectMeta is of cluster-local visibility
 func IsObjectLocalVisibility(meta *metav1.ObjectMeta) bool {
-	return meta.Labels[network.VisibilityLabelKey] != "" || meta.Labels[serving.VisibilityLabelKeyObsolete] != ""
+	return meta.Labels[network.VisibilityLabelKey] != ""
 }
 
 // SetVisibility sets the visibility on an ObjectMeta

--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -120,7 +120,7 @@ func makeK8sService(ctx context.Context, route *v1.Route, targetName string) (*c
 			Labels: kmeta.UnionMaps(kmeta.FilterMap(route.GetLabels(), func(key string) bool {
 				// Do not propagate the visibility label from Route as users may want to set the label
 				// in the specific k8s svc for subroute. see https://github.com/knative/serving/pull/4560.
-				return (key == network.VisibilityLabelKey || key == serving.VisibilityLabelKeyObsolete)
+				return key == network.VisibilityLabelKey
 			}), svcLabels),
 			Annotations: route.GetAnnotations(),
 		},


### PR DESCRIPTION
So 0.18, 0.19 and 0.20 have both labes, enough time now to deprecate the
old one.

/assign mattmoor @dprotaso @tcnghia 
