### PR TITLE
Add the new annotation for the rollout duration and its validation

### DIFF
--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -51,6 +51,12 @@ const (
 	// referenced by one or many routes. The value is a comma separated list of Route names.
 	RoutesAnnotationKey = GroupName + "/routes"
 
+	// RolloutDurationKey is an annotation attached to a Route to indicate the duration
+	// of the rollout of the latest revision. The value must be a valid positive
+	// Golang time.Duration value serialized to string.
+	// The value can be specified with at most with a second precision.
+	RolloutDurationKey = GroupName + "/rolloutDuration"
+
 	// RoutingStateLabelKey is the label attached to a Revision indicating
 	// its state in relation to serving a Route.
 	RoutingStateLabelKey = GroupName + "/routingState"

--- a/pkg/apis/serving/v1/service_validation.go
+++ b/pkg/apis/serving/v1/service_validation.go
@@ -34,7 +34,8 @@ func (s *Service) Validate(ctx context.Context) (errs *apis.FieldError) {
 	if !apis.IsInStatusUpdate(ctx) {
 		errs = errs.Also(serving.ValidateObjectMetadata(ctx, s.GetObjectMeta()))
 		errs = errs.Also(s.validateLabels().ViaField("labels"))
-		errs = errs.Also(serving.ValidateHasNoAutoscalingAnnotation(s.GetAnnotations()).ViaField("annotations"))
+		errs = errs.Also(serving.ValidateHasNoAutoscalingAnnotation(
+			s.GetAnnotations()).ViaField("annotations"))
 		errs = errs.ViaField("metadata")
 
 		ctx = apis.WithinParent(ctx, s.ObjectMeta)


### PR DESCRIPTION
Add the new validation. Given that users might specify longer durations,
e.g. in minutes or even hours, make it a time.Duration format.

Add validation and related tests.

Also sort the permitted annotation list.

Next: invoke validation in service and route.
Change-Id: Ic96786bad34cf17e29de142194d942f43e75e19c

For #10505.

/assign @tcnghia @dprotaso mattmoor