### PR TITLE
Use more consistent constant name

### DIFF
--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -77,9 +77,9 @@ const (
 	// its unique identifier
 	RevisionUID = GroupName + "/revisionUID"
 
-	// ConfigUIDLabelKey is the label key attached to a pod to reference its
+	// ConfigurationUIDLabelKey is the label key attached to a pod to reference its
 	// Knative Configuration by its unique UID
-	ConfigUIDLabelKey = GroupName + "/configurationUID"
+	ConfigurationUIDLabelKey = GroupName + "/configurationUID"
 
 	// ServiceUIDLabelKey is the label key attached to a pod to reference its
 	// Knative Service by its unique UID

--- a/pkg/apis/serving/v1/configuration_validation.go
+++ b/pkg/apis/serving/v1/configuration_validation.go
@@ -66,7 +66,7 @@ func (c *Configuration) validateLabels() (errs *apis.FieldError) {
 	for key, val := range c.GetLabels() {
 		switch key {
 		case serving.RouteLabelKey,
-			serving.ConfigUIDLabelKey,
+			serving.ConfigurationUIDLabelKey,
 			serving.ServiceUIDLabelKey:
 			// Known valid labels - so just skip them
 		case serving.ServiceLabelKey:

--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -128,7 +128,7 @@ func (r *Revision) ValidateLabels() (errs *apis.FieldError) {
 		case serving.RoutingStateLabelKey,
 			serving.RouteLabelKey,
 			serving.ServiceLabelKey,
-			serving.ConfigUIDLabelKey,
+			serving.ConfigurationUIDLabelKey,
 			serving.ServiceUIDLabelKey,
 			serving.ConfigurationGenerationLabelKey:
 			// Known valid labels.

--- a/pkg/reconciler/configuration/resources/revision.go
+++ b/pkg/reconciler/configuration/resources/revision.go
@@ -64,7 +64,7 @@ func updateRevisionLabels(rev, config metav1.Object) {
 		serving.ConfigurationLabelKey,
 		serving.ServiceLabelKey,
 		serving.ConfigurationGenerationLabelKey,
-		serving.ConfigUIDLabelKey,
+		serving.ConfigurationUIDLabelKey,
 		serving.ServiceUIDLabelKey,
 	} {
 		labels[key] = RevisionLabelValueForKey(key, config)
@@ -103,7 +103,7 @@ func RevisionLabelValueForKey(key string, config metav1.Object) string {
 		return config.GetLabels()[serving.ServiceLabelKey]
 	case serving.ConfigurationGenerationLabelKey:
 		return fmt.Sprint(config.GetGeneration())
-	case serving.ConfigUIDLabelKey:
+	case serving.ConfigurationUIDLabelKey:
 		return string(config.GetUID())
 	case serving.ServiceUIDLabelKey:
 		return config.GetLabels()[serving.ServiceUIDLabelKey]

--- a/pkg/reconciler/configuration/resources/revision_test.go
+++ b/pkg/reconciler/configuration/resources/revision_test.go
@@ -81,7 +81,7 @@ func TestMakeRevisions(t *testing.T) {
 				Labels: map[string]string{
 					serving.ConfigurationLabelKey:           "build",
 					serving.ConfigurationGenerationLabelKey: "10",
-					serving.ConfigUIDLabelKey:               "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+					serving.ConfigurationUIDLabelKey:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 					serving.RoutingStateLabelKey:            "pending",
 					serving.ServiceLabelKey:                 "",
 					serving.ServiceUIDLabelKey:              "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
@@ -146,7 +146,7 @@ func TestMakeRevisions(t *testing.T) {
 				Labels: map[string]string{
 					serving.ConfigurationLabelKey:           "labels",
 					serving.ConfigurationGenerationLabelKey: "100",
-					serving.ConfigUIDLabelKey:               "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+					serving.ConfigurationUIDLabelKey:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 					serving.RoutingStateLabelKey:            "pending",
 					serving.ServiceLabelKey:                 "",
 					serving.ServiceUIDLabelKey:              "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
@@ -207,7 +207,7 @@ func TestMakeRevisions(t *testing.T) {
 				Labels: map[string]string{
 					serving.ConfigurationLabelKey:           "annotations",
 					serving.ConfigurationGenerationLabelKey: "100",
-					serving.ConfigUIDLabelKey:               "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+					serving.ConfigurationUIDLabelKey:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 					serving.RoutingStateLabelKey:            "pending",
 					serving.ServiceLabelKey:                 "",
 					serving.ServiceUIDLabelKey:              "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
@@ -276,7 +276,7 @@ func TestMakeRevisions(t *testing.T) {
 				Labels: map[string]string{
 					serving.ConfigurationLabelKey:           "config",
 					serving.ConfigurationGenerationLabelKey: "10",
-					serving.ConfigUIDLabelKey:               "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+					serving.ConfigurationUIDLabelKey:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 					serving.RoutingStateLabelKey:            "active",
 					serving.ServiceLabelKey:                 "",
 					serving.ServiceUIDLabelKey:              "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
@@ -345,7 +345,7 @@ func TestMakeRevisions(t *testing.T) {
 				Labels: map[string]string{
 					serving.ConfigurationLabelKey:           "config",
 					serving.ConfigurationGenerationLabelKey: "10",
-					serving.ConfigUIDLabelKey:               "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+					serving.ConfigurationUIDLabelKey:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 					serving.RoutingStateLabelKey:            "pending",
 					serving.ServiceLabelKey:                 "",
 					serving.ServiceUIDLabelKey:              "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",


### PR DESCRIPTION
Spotted just after https://github.com/knative/serving/pull/10579 merged. Since we renamed the actual label we might as well rename the `ConfigUIDLabelKey` constant name to match `ConfigurationLabelKey` and `ConfigurationGenerationLabelKey` in same file.

/assign @duglin @dprotaso  