### PR TITLE
Add validation to the route and service annotations for rollout duration

### DIFF
--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -84,6 +84,7 @@ func ValidateRolloutDurationAnnotation(annos map[string]string) (errs *apis.Fiel
 func validateKnativeAnnotations(annotations map[string]string) (errs *apis.FieldError) {
 	for key := range annotations {
 		if !allowedAnnotations.Has(key) && strings.HasPrefix(key, GroupNamePrefix) {
+			fmt.Println("#### failed for ", key)
 			errs = errs.Also(apis.ErrInvalidKeyName(key, apis.CurrentField))
 		}
 	}

--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -84,7 +84,6 @@ func ValidateRolloutDurationAnnotation(annos map[string]string) (errs *apis.Fiel
 func validateKnativeAnnotations(annotations map[string]string) (errs *apis.FieldError) {
 	for key := range annotations {
 		if !allowedAnnotations.Has(key) && strings.HasPrefix(key, GroupNamePrefix) {
-			fmt.Println("#### failed for ", key)
 			errs = errs.Also(apis.ErrInvalidKeyName(key, apis.CurrentField))
 		}
 	}

--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -30,7 +30,10 @@ import (
 // Validate makes sure that Route is properly configured.
 func (r *Route) Validate(ctx context.Context) *apis.FieldError {
 	errs := serving.ValidateObjectMetadata(ctx, r.GetObjectMeta()).Also(
-		r.validateLabels().ViaField("labels")).ViaField("metadata")
+		r.validateLabels().ViaField("labels"))
+	errs = errs.Also(serving.ValidateRolloutDurationAnnotation(
+		r.GetAnnotations()).ViaField("annotations"))
+	errs = errs.ViaField("metadata")
 	errs = errs.Also(r.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 
 	if apis.IsInUpdate(ctx) {

--- a/pkg/apis/serving/v1/route_validation_test.go
+++ b/pkg/apis/serving/v1/route_validation_test.go
@@ -41,8 +41,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 			RevisionName: "bar",
 			Percent:      ptr.Int64(12),
 		},
-		wc:   apis.WithinSpec,
-		want: nil,
+		wc: apis.WithinSpec,
 	}, {
 		name: "valid with revisionName and name (spec)",
 		tt: &TrafficTarget{
@@ -50,8 +49,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 			RevisionName: "bar",
 			Percent:      ptr.Int64(12),
 		},
-		wc:   apis.WithinSpec,
-		want: nil,
+		wc: apis.WithinSpec,
 	}, {
 		name: "valid with revisionName and name (status)",
 		tt: &TrafficTarget{
@@ -63,8 +61,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 				Host:   "foo.bar.com",
 			},
 		},
-		wc:   apis.WithinStatus,
-		want: nil,
+		wc: apis.WithinStatus,
 	}, {
 		name: "invalid with revisionName and name (status)",
 		tt: &TrafficTarget{
@@ -90,8 +87,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 			LatestRevision: ptr.Bool(false),
 			Percent:        ptr.Int64(12),
 		},
-		wc:   apis.WithinSpec,
-		want: nil,
+		wc: apis.WithinSpec,
 	}, {
 		name: "invalid with revisionName and latestRevision (spec)",
 		tt: &TrafficTarget{
@@ -108,16 +104,14 @@ func TestTrafficTargetValidation(t *testing.T) {
 			LatestRevision: ptr.Bool(true),
 			Percent:        ptr.Int64(12),
 		},
-		wc:   apis.WithinStatus,
-		want: nil,
+		wc: apis.WithinStatus,
 	}, {
 		name: "valid with configurationName",
 		tt: &TrafficTarget{
 			ConfigurationName: "bar",
 			Percent:           ptr.Int64(37),
 		},
-		wc:   apis.WithinSpec,
-		want: nil,
+		wc: apis.WithinSpec,
 	}, {
 		name: "valid with configurationName and name (spec)",
 		tt: &TrafficTarget{
@@ -125,8 +119,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 			ConfigurationName: "bar",
 			Percent:           ptr.Int64(37),
 		},
-		wc:   apis.WithinSpec,
-		want: nil,
+		wc: apis.WithinSpec,
 	}, {
 		name: "invalid with bad configurationName",
 		tt: &TrafficTarget{
@@ -143,8 +136,7 @@ func TestTrafficTargetValidation(t *testing.T) {
 			LatestRevision:    ptr.Bool(true),
 			Percent:           ptr.Int64(37),
 		},
-		wc:   apis.WithinSpec,
-		want: nil,
+		wc: apis.WithinSpec,
 	}, {
 		name: "invalid with configurationName and latestRevision",
 		tt: &TrafficTarget{
@@ -170,7 +162,6 @@ func TestTrafficTargetValidation(t *testing.T) {
 		wc: func(ctx context.Context) context.Context {
 			return WithDefaultConfigurationName(apis.WithinSpec(ctx))
 		},
-		want: nil,
 	}, {
 		name: "valid with default configurationName and latestRevision",
 		tt: &TrafficTarget{
@@ -180,7 +171,6 @@ func TestTrafficTargetValidation(t *testing.T) {
 		wc: func(ctx context.Context) context.Context {
 			return WithDefaultConfigurationName(apis.WithinSpec(ctx))
 		},
-		want: nil,
 	}, {
 		name: "invalid with default configurationName and latestRevision",
 		tt: &TrafficTarget{
@@ -197,35 +187,30 @@ func TestTrafficTargetValidation(t *testing.T) {
 			RevisionName: "bar",
 			Percent:      ptr.Int64(12),
 		},
-		wc:   WithDefaultConfigurationName,
-		want: nil,
+		wc: WithDefaultConfigurationName,
 	}, {
 		name: "valid with no percent",
 		tt: &TrafficTarget{
 			ConfigurationName: "booga",
 		},
-		want: nil,
 	}, {
 		name: "valid with nil percent",
 		tt: &TrafficTarget{
 			ConfigurationName: "booga",
 			Percent:           nil,
 		},
-		want: nil,
 	}, {
 		name: "valid with zero percent",
 		tt: &TrafficTarget{
 			ConfigurationName: "booga",
 			Percent:           ptr.Int64(0),
 		},
-		want: nil,
 	}, {
 		name: "valid with no name",
 		tt: &TrafficTarget{
 			ConfigurationName: "booga",
 			Percent:           ptr.Int64(100),
 		},
-		want: nil,
 	}, {
 		name: "invalid with both",
 		tt: &TrafficTarget{
@@ -319,7 +304,6 @@ func TestRouteValidation(t *testing.T) {
 				},
 			},
 		},
-		want: nil,
 	}, {
 		name: "valid split",
 		r: &Route{
@@ -338,7 +322,6 @@ func TestRouteValidation(t *testing.T) {
 				}},
 			},
 		},
-		want: nil,
 	}, {
 		name: "valid split without tags",
 		r: &Route{
@@ -355,7 +338,6 @@ func TestRouteValidation(t *testing.T) {
 				}},
 			},
 		},
-		want: nil,
 	}, {
 		name: "invalid traffic entry (missing oneof)",
 		r: &Route{
@@ -508,7 +490,6 @@ func TestRouteLabelValidation(t *testing.T) {
 			},
 			Spec: validRouteSpec,
 		},
-		want: nil,
 	}, {
 		name: "invalid visibility name",
 		r: &Route{
@@ -537,7 +518,6 @@ func TestRouteLabelValidation(t *testing.T) {
 			},
 			Spec: validRouteSpec,
 		},
-		want: nil,
 	}, {
 		name: "invalid knative service name",
 		r: &Route{
@@ -645,10 +625,10 @@ func TestRouteAnnotationUpdate(t *testing.T) {
 		u3 = "vaca@knative.dev"
 	)
 	tests := []struct {
-		name string
-		prev *Route
-		this *Route
-		want *apis.FieldError
+		name    string
+		prev    *Route
+		this    *Route
+		wantErr *apis.FieldError
 	}{{
 		name: "update creator annotation",
 		this: &Route{
@@ -671,7 +651,7 @@ func TestRouteAnnotationUpdate(t *testing.T) {
 			},
 			Spec: getRouteSpec("old"),
 		},
-		want: (&apis.FieldError{Message: "annotation value is immutable",
+		wantErr: (&apis.FieldError{Message: "annotation value is immutable",
 			Paths: []string{serving.CreatorAnnotation}}).ViaField("metadata.annotations"),
 	}, {
 		name: "update creator annotation with spec changes",
@@ -695,7 +675,7 @@ func TestRouteAnnotationUpdate(t *testing.T) {
 			},
 			Spec: getRouteSpec("old"),
 		},
-		want: (&apis.FieldError{Message: "annotation value is immutable",
+		wantErr: (&apis.FieldError{Message: "annotation value is immutable",
 			Paths: []string{serving.CreatorAnnotation}}).ViaField("metadata.annotations"),
 	}, {
 		name: "update lastModifier annotation without spec changes",
@@ -719,7 +699,7 @@ func TestRouteAnnotationUpdate(t *testing.T) {
 			},
 			Spec: getRouteSpec("old"),
 		},
-		want: apis.ErrInvalidValue(u2, serving.UpdaterAnnotation).ViaField("metadata.annotations"),
+		wantErr: apis.ErrInvalidValue(u2, serving.UpdaterAnnotation).ViaField("metadata.annotations"),
 	}, {
 		name: "update lastModifier annotation with spec changes",
 		this: &Route{
@@ -742,7 +722,29 @@ func TestRouteAnnotationUpdate(t *testing.T) {
 			},
 			Spec: getRouteSpec("old"),
 		},
-		want: nil,
+	}, {
+		name: "rollout duration validation",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.RolloutDurationKey: "123s",
+				},
+			},
+			Spec: getRouteSpec("new"),
+		},
+	}, {
+		name: "rollout duration validation, fail",
+		this: &Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "valid",
+				Annotations: map[string]string{
+					serving.RolloutDurationKey: "three hours and seventeen seconds",
+				},
+			},
+			Spec: getRouteSpec("new"),
+		},
+		wantErr: apis.ErrInvalidValue("three hours and seventeen seconds", serving.RolloutDurationKey).ViaField("metadata.annotations"),
 	}, {
 		name: "no validation for lastModifier annotation even after update without spec changes as route owned by service",
 		this: &Route{
@@ -769,7 +771,6 @@ func TestRouteAnnotationUpdate(t *testing.T) {
 			},
 			Spec: getRouteSpec("old"),
 		},
-		want: nil,
 	}, {
 		name: "no validation for creator annotation even after update as route owned by service",
 		this: &Route{
@@ -796,13 +797,14 @@ func TestRouteAnnotationUpdate(t *testing.T) {
 			},
 			Spec: getRouteSpec("old"),
 		},
-		want: nil,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
-			ctx = apis.WithinUpdate(ctx, test.prev)
-			if diff := cmp.Diff(test.want.Error(), test.this.Validate(ctx).Error()); diff != "" {
+			if test.prev != nil {
+				ctx = apis.WithinUpdate(ctx, test.prev)
+			}
+			if diff := cmp.Diff(test.wantErr.Error(), test.this.Validate(ctx).Error()); diff != "" {
 				t.Error("Validate (-want, +got) =", diff)
 			}
 		})

--- a/pkg/apis/serving/v1/service_validation.go
+++ b/pkg/apis/serving/v1/service_validation.go
@@ -34,6 +34,8 @@ func (s *Service) Validate(ctx context.Context) (errs *apis.FieldError) {
 	if !apis.IsInStatusUpdate(ctx) {
 		errs = errs.Also(serving.ValidateObjectMetadata(ctx, s.GetObjectMeta()))
 		errs = errs.Also(s.validateLabels().ViaField("labels"))
+		errs = errs.Also(serving.ValidateRolloutDurationAnnotation(
+			s.GetAnnotations()).ViaField("annotations"))
 		errs = errs.Also(serving.ValidateHasNoAutoscalingAnnotation(
 			s.GetAnnotations()).ViaField("annotations"))
 		errs = errs.ViaField("metadata")


### PR DESCRIPTION
- add the validation logic
- add the tests
- update the tests a bit to be more concise
- rename some `want`s to `wanterr`s for more precision.

/assign @tcnghia mattmoor @dprotaso 