### PR TITLE
Backfill missing test

### DIFF
--- a/pkg/activator/net/helpers_test.go
+++ b/pkg/activator/net/helpers_test.go
@@ -109,6 +109,33 @@ func TestEndpointsToDests(t *testing.T) {
 			}},
 		},
 		expectReady: sets.NewString("128.0.0.1:1234"),
+	}, {
+		name:     "multiple endpoint, different protocol",
+		protocol: networking.ProtocolH2C,
+		endpoints: corev1.Endpoints{
+			Subsets: []corev1.EndpointSubset{{
+				Addresses: []corev1.EndpointAddress{{
+					IP: "128.0.0.1",
+				}, {
+					IP: "128.0.0.2",
+				}},
+				Ports: []corev1.EndpointPort{{
+					Name: networking.ServicePortNameHTTP1,
+					Port: 1234,
+				}},
+			}, {
+				Addresses: []corev1.EndpointAddress{{
+					IP: "128.0.0.3",
+				}, {
+					IP: "128.0.0.4",
+				}},
+				Ports: []corev1.EndpointPort{{
+					Name: networking.ServicePortNameH2C,
+					Port: 5678,
+				}},
+			}},
+		},
+		expectReady: sets.NewString("128.0.0.3:5678", "128.0.0.4:5678"),
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.protocol == "" {


### PR DESCRIPTION
We have [a protocol field in the table](https://github.com/julz/serving/blob/51c0cd5dca6f4ce6d20614656fb512f7a5c68d4d/pkg/activator/net/helpers_test.go#L33), but it isn't actually used in any of the rows. Might as well add a test case that actually uses the parameter.

/assign @markusthoemmes 