### PR TITLE
Don't propagate the rollout duration annotation to Configurations and Revisions

### DIFF
--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -41,7 +41,9 @@ func MakeConfigurationFromExisting(service *v1.Service, existing *v1.Configurati
 		serving.ServiceUIDLabelKey: string(service.ObjectMeta.UID),
 	}
 	anns := kmeta.FilterMap(service.GetAnnotations(), func(key string) bool {
-		return key == corev1.LastAppliedConfigAnnotation
+		return key == corev1.LastAppliedConfigAnnotation ||
+			// Configs & Revisions don't use rollout information, it is only for routes.
+			key == serving.RolloutDurationKey
 	})
 
 	routeName := names.Route(service)

--- a/pkg/reconciler/service/resources/configuration_test.go
+++ b/pkg/reconciler/service/resources/configuration_test.go
@@ -24,11 +24,18 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 
+	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving"
 )
 
 func TestConfigurationSpec(t *testing.T) {
 	s := createService()
+	s.Annotations = kmeta.UnionMaps(s.Annotations,
+		map[string]string{
+			serving.RolloutDurationKey: "2021s",
+		},
+	)
+
 	c := MakeConfiguration(s)
 	if got, want := c.Name, testServiceName; got != want {
 		t.Errorf("Service name = %q; want: %q", got, want)
@@ -41,7 +48,10 @@ func TestConfigurationSpec(t *testing.T) {
 	}
 	expectOwnerReferencesSetCorrectly(t, c.OwnerReferences)
 
-	if got, want := c.Labels, map[string]string{serving.ServiceLabelKey: testServiceName, serving.ServiceUIDLabelKey: "cccccccc-cccc-cccc-cccc-cccccccccccc"}; !cmp.Equal(got, want) {
+	if got, want := c.Labels, map[string]string{
+		serving.ServiceLabelKey:    testServiceName,
+		serving.ServiceUIDLabelKey: "cccccccc-cccc-cccc-cccc-cccccccccccc",
+	}; !cmp.Equal(got, want) {
 		t.Errorf("Labels mismatch: diff(-want,+got):\n%s", cmp.Diff(want, got))
 	}
 	if got, want := c.Annotations, map[string]string{

--- a/pkg/reconciler/service/resources/route_test.go
+++ b/pkg/reconciler/service/resources/route_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -30,6 +31,12 @@ import (
 
 func TestRouteSpec(t *testing.T) {
 	s := createService()
+	s.Annotations = kmeta.UnionMaps(s.Annotations,
+		map[string]string{
+			serving.RolloutDurationKey: "2021s",
+		},
+	)
+
 	testConfigName := names.Configuration(s)
 	r := MakeRoute(s)
 	if got, want := r.Name, testServiceName; got != want {
@@ -56,6 +63,13 @@ func TestRouteSpec(t *testing.T) {
 	}
 	if got, want := r.Labels[serving.ServiceLabelKey], testServiceName; got != want {
 		t.Errorf("expected %q labels got %q", want, got)
+	}
+	if got, want := len(r.Annotations), 1; got != want {
+		t.Fatalf("expected %d labels got %d", want, got)
+	}
+	// Would fatal if annotations is not set.
+	if got, want := r.Annotations[serving.RolloutDurationKey], "2021s"; got != want {
+		t.Errorf("r.Annotations[%s] = %q, want: %q", serving.RolloutDurationKey, got, want)
 	}
 }
 


### PR DESCRIPTION
They don't utilize it, so no need to propagate it there.

/assign @dprotaso @tcnghia mattmoor