### PR TITLE
Set useragent for digest resolver

### DIFF
--- a/pkg/reconciler/revision/resolve.go
+++ b/pkg/reconciler/revision/resolve.go
@@ -35,6 +35,7 @@ import (
 type digestResolver struct {
 	client    kubernetes.Interface
 	transport http.RoundTripper
+	userAgent string
 }
 
 const (
@@ -95,7 +96,7 @@ func (r *digestResolver) Resolve(
 		return "", nil
 	}
 
-	desc, err := remote.Head(tag, remote.WithContext(ctx), remote.WithTransport(r.transport), remote.WithAuthFromKeychain(kc))
+	desc, err := remote.Head(tag, remote.WithContext(ctx), remote.WithTransport(r.transport), remote.WithAuthFromKeychain(kc), remote.WithUserAgent(r.userAgent))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This takes advantage of a somewhat recent addition to ggcr that added
remote.WithUserAgent as an option. Setting this string will wrap the
User-Agent header with additional go-containerregistry version
information, when present, which is a nice thing to do as a citizen of
the internet.

Prior to this, we would send:

`User-Agent: go-containerregistry[/${VERSION}]`

Now we will send:

`User-Agent: knative[/${COMMIT}] (github.com/knative/serving) go-containerregistry[/${VERSION}]`

Note that sometimes version information is not available. In some cases,
we do our best and just send a string without version information.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Include a more specific user-agent in the digest resolution requests.

This is helpful for identifying the source of traffic to a registry, and we have been known to accidentally send obscene amounts of traffic to registries (see https://github.com/knative/serving/pull/10237).

By all means, feel free to bikeshed the exact strings.

I managed to get coverage on both branches manually with:
```
export KO_DATA_PATH=$(pwd)/cmd/controller/kodata/
```

Let me know if you think it's worth adding a unit test that hits the `err == nil` path for `changeset.Get()` -- it seems that I'll need to set the `KO_DATA_PATH` env and call `newControllerWithOptions`, which is doable, but a little annoying 😄 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Update the User-Agent used during tag resolution
```
