### PR TITLE
Update documentation for DomainMapping ref field

### DIFF
--- a/pkg/apis/serving/v1alpha1/domainmapping_types.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_types.go
@@ -72,8 +72,15 @@ type DomainMappingList struct {
 
 // DomainMappingSpec describes the DomainMapping the user wishes to exist.
 type DomainMappingSpec struct {
-	// Ref points to an Addressable.
-	// Currently, Ref must be a KSvc.
+	// Ref specifies the target of the Domain Mapping.
+	//
+	// The object identified by the Ref must be an Addressable with a URL of the
+	// form `{name}.{namespace}.{domain}` where `{domain}` is the cluster domain,
+	// and `{name}` and `{namespace}` are the name and namespace of a Kubernetes
+	// Service.
+	//
+	// This contract is satisfied by Knative types such as Knative Services and
+	// Knative Routes, and by Kubernetes Services.
 	Ref duckv1.KReference `json:"ref"`
 }
 


### PR DESCRIPTION
Since we relaxed requirements for DomainMapping.Spec.Ref, update doc comment with current contract.

/assign @tcnghia @mattmoor 