### PR TITLE
Add more tests to cover various durations.

### DIFF
--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -170,8 +170,8 @@ func TestReconcileIngressUpdateReenqueueRollout(t *testing.T) {
 			// 5s of the duration already spent.
 			totalDuration := float64(rd - 5)
 			// Step count is minimum of % points of traffic allocated to the config (1% already shifted).
-			steps := math.Min(float64(totalDuration/5), allocatedTraffic-1)
-			stepSize := math.Max(1, math.Round(float64((allocatedTraffic-1)/steps))) // we round the step size.
+			steps := math.Min(totalDuration/5, allocatedTraffic-1)
+			stepSize := math.Max(1, math.Round((allocatedTraffic-1)/steps)) // we round the step size.
 			stepDuration := time.Duration(int(totalDuration * float64(time.Second) / steps))
 
 			_, updRO, err = reconciler.reconcileIngress(ctx, r, tc, tls, "foo-ingress")

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -330,8 +330,8 @@ func TestReconcileIngressUpdateReenqueueRolloutAnnotation(t *testing.T) {
 			// 5s of the duration already spent.
 			totalDuration := float64(rd - 5)
 			// Step count is minimum of % points of traffic allocated to the config (1% already shifted).
-			steps := math.Min(float64(totalDuration/5), allocatedTraffic-1)
-			stepSize := math.Max(1, math.Round(float64((allocatedTraffic-1)/steps))) // we round the step size.
+			steps := math.Min(totalDuration/5, allocatedTraffic-1)
+			stepSize := math.Max(1, math.Round((allocatedTraffic-1)/steps)) // we round the step size.
 			stepDuration := time.Duration(int(totalDuration * float64(time.Second) / steps))
 
 			_, updRO, err = reconciler.reconcileIngress(ctx, r, tc, tls, "foo-ingress")

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -234,7 +234,7 @@ func TestReconcileIngressUpdateReenqueueRolloutAnnotation(t *testing.T) {
 	})
 	defer cancel()
 
-	for _, rd := range []int{120, 600, 3600} {
+	for _, rd := range []int{240, 666, 7200} {
 		rds := strconv.Itoa(rd)
 		t.Run(rds, func(t *testing.T) {
 			r := Route("test-ns-"+rds, "rollout-route")


### PR DESCRIPTION
Increase test coverage to use different durations of rollouts.
5 more different values introduced and tested.

It has been uncovered that there's some rounding, so I had to introduce
5ns leeway in the tests.
In reality nothing is more than 2ns, but still.

/assign @tcnghia mattmoor
