### PR TITLE
Remove some -1 here and there and compute it once.

### DIFF
--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -466,7 +466,7 @@ func (cur *ConfigurationRollout) computeProperties(nowTS, minStepSec, durationSe
 	// E.g. 100% in 4 steps. 1% -> 26% -> 51% -> 76% -> 100%.
 	// In addition, ensure that we don't have step size larger than total
 	//  percentage for the configuration.
-	stepSize := math.Min(pf, math.Round(pf/numSteps))
+	stepSize := math.Round(pf / numSteps)
 
 	// The time we sleep between the steps.
 	stepDuration := durationSecs / numSteps * float64(time.Second)

--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -451,13 +451,13 @@ func (cur *ConfigurationRollout) computeProperties(nowTS, minStepSec, durationSe
 	// at 1s, so we just do 1 step.
 	durationSecs = math.Max(1, durationSecs-minStepSec)
 	numSteps := math.Max(1, durationSecs/minStepSec)
-	pf := float64(cur.Percent)
 
 	// The smallest step is 1%, so if we can fit more steps
-	// than we have percents, we'll make c.Percent-1 steps
+	// than we have percents, we'll make pf = c.Percent-1 steps
 	// each equal to 1%. -1, since we already moved 1% of the traffic.
+	pf := float64(cur.Percent - 1)
 	if pf < numSteps {
-		numSteps = pf - 1
+		numSteps = pf
 	}
 
 	// We're moving traffic in equal steps.
@@ -466,7 +466,7 @@ func (cur *ConfigurationRollout) computeProperties(nowTS, minStepSec, durationSe
 	// E.g. 100% in 4 steps. 1% -> 26% -> 51% -> 76% -> 100%.
 	// In addition, ensure that we don't have step size larger than total
 	//  percentage for the configuration.
-	stepSize := math.Min(pf-1, math.Round((pf-1)/numSteps))
+	stepSize := math.Min(pf, math.Round(pf/numSteps))
 
 	// The time we sleep between the steps.
 	stepDuration := durationSecs / numSteps * float64(time.Second)

--- a/pkg/reconciler/route/traffic/rollout.go
+++ b/pkg/reconciler/route/traffic/rollout.go
@@ -455,9 +455,9 @@ func (cur *ConfigurationRollout) computeProperties(nowTS, minStepSec, durationSe
 	// The smallest step is 1%, so if we can fit more steps
 	// than we have percents, we'll make pf = c.Percent-1 steps
 	// each equal to 1%. -1, since we already moved 1% of the traffic.
-	pf := float64(cur.Percent - 1)
-	if pf < numSteps {
-		numSteps = pf
+	remPercent := float64(cur.Percent - 1)
+	if remPercent < numSteps {
+		numSteps = remPercent
 	}
 
 	// We're moving traffic in equal steps.
@@ -466,7 +466,7 @@ func (cur *ConfigurationRollout) computeProperties(nowTS, minStepSec, durationSe
 	// E.g. 100% in 4 steps. 1% -> 26% -> 51% -> 76% -> 100%.
 	// In addition, ensure that we don't have step size larger than total
 	//  percentage for the configuration.
-	stepSize := math.Round(pf / numSteps)
+	stepSize := math.Round(remPercent / numSteps)
 
 	// The time we sleep between the steps.
 	stepDuration := durationSecs / numSteps * float64(time.Second)


### PR DESCRIPTION
No need to do `pf-1` since that is all that we're using.
Also, remove the `math.min` call since `#steps` is always at least 1 so `pf/#steps` it will never be larger than `pf` in first place, so min is redundant.

/assign @tcnghia mattmoor