### PR TITLE
Make TestHTTPProbeTimeoutFailure more reliable

### DIFF
--- a/pkg/queue/health/probe_test.go
+++ b/pkg/queue/health/probe_test.go
@@ -127,7 +127,11 @@ func TestHTTPSchemeProbeSuccess(t *testing.T) {
 
 func TestHTTPProbeTimeoutFailure(t *testing.T) {
 	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(50 * time.Millisecond)
+		select {
+		case <-time.After(1 * time.Second):
+		case <-r.Context().Done():
+		}
+
 		w.WriteHeader(http.StatusOK)
 	})
 

--- a/pkg/queue/health/probe_test.go
+++ b/pkg/queue/health/probe_test.go
@@ -126,14 +126,13 @@ func TestHTTPSchemeProbeSuccess(t *testing.T) {
 }
 
 func TestHTTPProbeTimeoutFailure(t *testing.T) {
-	timeout := 10 * time.Millisecond
 	server := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(timeout * 5)
+		time.Sleep(50 * time.Millisecond)
 		w.WriteHeader(http.StatusOK)
 	})
 
 	config := HTTPProbeConfigOptions{
-		Timeout:       timeout,
+		Timeout:       1 * time.Millisecond,
 		HTTPGetAction: newHTTPGetAction(t, server.URL),
 	}
 	if err := HTTPProbe(config); err == nil {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As per title, this test was a bit flaky in CI after my recent rework on making the timeouts more aggressive. This should help. Passed 1000 times locally.

Example failure https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_serving/10604/pull-knative-serving-unit-tests/1352511776486330368

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @julz 
