### PR TITLE
Replace arbitrary short sleeps with short-circuited long sleeps

### DIFF
--- a/pkg/queue/readiness/probe_test.go
+++ b/pkg/queue/readiness/probe_test.go
@@ -312,7 +312,11 @@ func TestHTTPManyParallel(t *testing.T) {
 
 func TestHTTPTimeout(t *testing.T) {
 	tsURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(time.Second + 10*time.Millisecond)
+		select {
+		case <-time.After(10 * time.Second):
+		case <-r.Context().Done():
+		}
+
 		w.WriteHeader(http.StatusOK)
 	})
 
@@ -465,7 +469,11 @@ func TestKnHTTPSuccessWithThresholdAndFailure(t *testing.T) {
 
 func TestKnHTTPTimeoutFailure(t *testing.T) {
 	tsURL := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(aggressiveProbeTimeout + 10*time.Millisecond)
+		select {
+		case <-time.After(1 * time.Second):
+		case <-r.Context().Done():
+		}
+
 		w.WriteHeader(http.StatusOK)
 	})
 

--- a/pkg/reconciler/revision/background_test.go
+++ b/pkg/reconciler/revision/background_test.go
@@ -124,7 +124,10 @@ func TestResolveInBackground(t *testing.T) {
 		timeout: ptr.Duration(10 * time.Millisecond),
 		resolver: func(ctx context.Context, img string, _ k8schain.Options, _ sets.String) (string, error) {
 			if img == "second-image" {
-				time.Sleep(500 * time.Millisecond)
+				select {
+				case <-time.After(10 * time.Second):
+				case <-ctx.Done():
+				}
 			}
 
 			return img + "-digest", ctx.Err()


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This should make the tests less prone to random failures as the timeouts can be chosen super long, but we don't actually have to pay in terms of test runtime, as the tests are able to finish as soon as the respective requests finish.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
