### PR TITLE
Rever the 100ms to 1ms change, since it flakes a lot

### DIFF
--- a/cmd/queue/execprobe_test.go
+++ b/cmd/queue/execprobe_test.go
@@ -134,7 +134,7 @@ func TestProbeQueueTimeout(t *testing.T) {
 	t.Cleanup(func() { os.Unsetenv(queuePortEnvVar) })
 	os.Setenv(queuePortEnvVar, strconv.Itoa(port))
 
-	if rv := standaloneProbeMain(1*time.Millisecond, nil); rv == 0 {
+	if rv := standaloneProbeMain(100*time.Millisecond, nil); rv == 0 {
 		t.Error("Unexpected return value from standaloneProbeMain:", rv)
 	}
 


### PR DESCRIPTION
This basically expects the test server to reply within 1ms
which is not possible in many cases, especially on prow.
This should not matter anyway, since all the other test cases use 10s
anyway (which is the default).

/assign @julz @markusthoemmes 