### PR TITLE
don't add the UID labels since it breaks downgrading

### DIFF
--- a/pkg/reconciler/configuration/resources/revision.go
+++ b/pkg/reconciler/configuration/resources/revision.go
@@ -64,8 +64,9 @@ func updateRevisionLabels(rev, config metav1.Object) {
 		serving.ConfigurationLabelKey,
 		serving.ServiceLabelKey,
 		serving.ConfigurationGenerationLabelKey,
-		serving.ConfigurationUIDLabelKey,
-		serving.ServiceUIDLabelKey,
+		// TODO: Add in 0.22 see: https://github.com/knative/serving/issues/10614
+		// serving.ConfigurationUIDLabelKey,
+		// serving.ServiceUIDLabelKey,
 	} {
 		labels[key] = RevisionLabelValueForKey(key, config)
 	}

--- a/pkg/reconciler/configuration/resources/revision_test.go
+++ b/pkg/reconciler/configuration/resources/revision_test.go
@@ -49,10 +49,6 @@ func TestMakeRevisions(t *testing.T) {
 				Namespace:  "no",
 				Name:       "build",
 				Generation: 10,
-				Labels: map[string]string{
-					serving.ServiceUIDLabelKey: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-				},
-				UID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			},
 			Spec: v1.ConfigurationSpec{
 				Template: v1.RevisionTemplateSpec{
@@ -76,15 +72,12 @@ func TestMakeRevisions(t *testing.T) {
 					Name:               "build",
 					Controller:         ptr.Bool(true),
 					BlockOwnerDeletion: ptr.Bool(true),
-					UID:                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 				}},
 				Labels: map[string]string{
 					serving.ConfigurationLabelKey:           "build",
 					serving.ConfigurationGenerationLabelKey: "10",
-					serving.ConfigurationUIDLabelKey:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 					serving.RoutingStateLabelKey:            "pending",
 					serving.ServiceLabelKey:                 "",
-					serving.ServiceUIDLabelKey:              "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
 				},
 				Annotations: map[string]string{
 					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(clock),
@@ -105,10 +98,6 @@ func TestMakeRevisions(t *testing.T) {
 				Namespace:  "with",
 				Name:       "labels",
 				Generation: 100,
-				Labels: map[string]string{
-					serving.ServiceUIDLabelKey: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-				},
-				UID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			},
 			Spec: v1.ConfigurationSpec{
 				Template: v1.RevisionTemplateSpec{
@@ -141,15 +130,12 @@ func TestMakeRevisions(t *testing.T) {
 					Name:               "labels",
 					Controller:         ptr.Bool(true),
 					BlockOwnerDeletion: ptr.Bool(true),
-					UID:                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 				}},
 				Labels: map[string]string{
 					serving.ConfigurationLabelKey:           "labels",
 					serving.ConfigurationGenerationLabelKey: "100",
-					serving.ConfigurationUIDLabelKey:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 					serving.RoutingStateLabelKey:            "pending",
 					serving.ServiceLabelKey:                 "",
-					serving.ServiceUIDLabelKey:              "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
 					"foo":                                   "bar",
 					"baz":                                   "blah",
 				},
@@ -169,10 +155,6 @@ func TestMakeRevisions(t *testing.T) {
 				Namespace:  "with",
 				Name:       "annotations",
 				Generation: 100,
-				Labels: map[string]string{
-					serving.ServiceUIDLabelKey: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-				},
-				UID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			},
 			Spec: v1.ConfigurationSpec{
 				Template: v1.RevisionTemplateSpec{
@@ -202,15 +184,12 @@ func TestMakeRevisions(t *testing.T) {
 					Name:               "annotations",
 					Controller:         ptr.Bool(true),
 					BlockOwnerDeletion: ptr.Bool(true),
-					UID:                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 				}},
 				Labels: map[string]string{
 					serving.ConfigurationLabelKey:           "annotations",
 					serving.ConfigurationGenerationLabelKey: "100",
-					serving.ConfigurationUIDLabelKey:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 					serving.RoutingStateLabelKey:            "pending",
 					serving.ServiceLabelKey:                 "",
-					serving.ServiceUIDLabelKey:              "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
 				},
 				Annotations: map[string]string{
 					"foo": "bar",
@@ -238,11 +217,7 @@ func TestMakeRevisions(t *testing.T) {
 					"serving.knative.dev/lastModifier": "someone",
 					serving.RoutesAnnotationKey:        "route",
 				},
-				Labels: map[string]string{
-					serving.ServiceUIDLabelKey: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-				},
 				Generation: 10,
-				UID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			},
 			Spec: v1.ConfigurationSpec{
 				Template: v1.RevisionTemplateSpec{
@@ -271,15 +246,12 @@ func TestMakeRevisions(t *testing.T) {
 					Name:               "config",
 					Controller:         ptr.Bool(true),
 					BlockOwnerDeletion: ptr.Bool(true),
-					UID:                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 				}},
 				Labels: map[string]string{
 					serving.ConfigurationLabelKey:           "config",
 					serving.ConfigurationGenerationLabelKey: "10",
-					serving.ConfigurationUIDLabelKey:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 					serving.RoutingStateLabelKey:            "active",
 					serving.ServiceLabelKey:                 "",
-					serving.ServiceUIDLabelKey:              "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
 				},
 			},
 			Spec: v1.RevisionSpec{
@@ -300,11 +272,7 @@ func TestMakeRevisions(t *testing.T) {
 					"serving.knative.dev/creator":      "admin",
 					"serving.knative.dev/lastModifier": "someone",
 				},
-				Labels: map[string]string{
-					serving.ServiceUIDLabelKey: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
-				},
 				Generation: 10,
-				UID:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			},
 			Spec: v1.ConfigurationSpec{
 				Template: v1.RevisionTemplateSpec{
@@ -340,15 +308,12 @@ func TestMakeRevisions(t *testing.T) {
 					Name:               "config",
 					Controller:         ptr.Bool(true),
 					BlockOwnerDeletion: ptr.Bool(true),
-					UID:                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 				}},
 				Labels: map[string]string{
 					serving.ConfigurationLabelKey:           "config",
 					serving.ConfigurationGenerationLabelKey: "10",
-					serving.ConfigurationUIDLabelKey:        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 					serving.RoutingStateLabelKey:            "pending",
 					serving.ServiceLabelKey:                 "",
-					serving.ServiceUIDLabelKey:              "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
 				},
 			},
 			Spec: v1.RevisionSpec{


### PR DESCRIPTION
Part of https://github.com/knative/serving/issues/10614

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Leaves the validation in 0.21
* We'll add the labels in 0.22

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @duglin 