### PR TITLE
At 100ms we still see failures on prow

### DIFF
--- a/cmd/queue/execprobe_test.go
+++ b/cmd/queue/execprobe_test.go
@@ -124,7 +124,7 @@ func TestProbeQueueTimeout(t *testing.T) {
 		probed.Store(true)
 
 		select {
-		case <-time.After(1 * time.Second):
+		case <-time.After(time.Second):
 		case <-r.Context().Done():
 		}
 
@@ -134,7 +134,7 @@ func TestProbeQueueTimeout(t *testing.T) {
 	t.Cleanup(func() { os.Unsetenv(queuePortEnvVar) })
 	os.Setenv(queuePortEnvVar, strconv.Itoa(port))
 
-	if rv := standaloneProbeMain(100*time.Millisecond, nil); rv == 0 {
+	if rv := standaloneProbeMain(300*time.Millisecond, nil); rv == 0 {
 		t.Error("Unexpected return value from standaloneProbeMain:", rv)
 	}
 


### PR DESCRIPTION
So raise it once more for now, while I am thinking about a nice channel way to do this.

ref: https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_serving/10624/pull-knative-serving-unit-tests/1353818280392921088

/assign @tcnghia @markusthoemmes

