### PR TITLE
Deprecate the service name on the revision.

### DIFF
--- a/pkg/apis/serving/v1/revision_types.go
+++ b/pkg/apis/serving/v1/revision_types.go
@@ -122,10 +122,14 @@ func IsRevisionCondition(t apis.ConditionType) bool {
 type RevisionStatus struct {
 	duckv1.Status `json:",inline"`
 
-	// ServiceName holds the name of a core Kubernetes Service resource that
+	// DeprecatedServiceName holds the name of a core Kubernetes Service resource that
 	// load balances over the pods backing this Revision.
+	// DEPRECATED: revision service name is effectively equal to the revision name,
+	// as per #10540.
+	// 0.23 — stop populating
+	// 0.25 — remove.
 	// +optional
-	ServiceName string `json:"serviceName,omitempty"`
+	DeprecatedServiceName string `json:"serviceName,omitempty"`
 
 	// LogURL specifies the generated logging url for this particular revision
 	// based on the revision url template specified in the controller's config.

--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -174,7 +174,7 @@ func (c *Reconciler) reconcilePA(ctx context.Context, rev *v1.Revision) error {
 
 	// The public service name is always equal to the revision name itself.
 	// Historically it's been acquired from the PA object, so the assignment is here.
-	rev.Status.ServiceName = rev.Name
+	rev.Status.DeprecatedServiceName = rev.Name
 
 	logger.Debugf("Observed PA Status=%#v", pa.Status)
 	rev.Status.PropagateAutoscalerStatus(&pa.Status)

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -225,7 +225,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      rev.Status.ServiceName,
+							ServiceName:      rev.Status.DeprecatedServiceName,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 100,
@@ -246,7 +246,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      rev.Status.ServiceName,
+							ServiceName:      rev.Status.DeprecatedServiceName,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 100,
@@ -353,7 +353,7 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      cfgrev.Status.ServiceName,
+							ServiceName:      cfgrev.Status.DeprecatedServiceName,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 90,
@@ -364,7 +364,7 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 					}, {
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      rev.Status.ServiceName,
+							ServiceName:      rev.Status.DeprecatedServiceName,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 10,
@@ -385,7 +385,7 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      cfgrev.Status.ServiceName,
+							ServiceName:      cfgrev.Status.DeprecatedServiceName,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 90,
@@ -396,7 +396,7 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 					}, {
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      rev.Status.ServiceName,
+							ServiceName:      rev.Status.DeprecatedServiceName,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 10,
@@ -470,7 +470,7 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      cfgrev.Status.ServiceName,
+							ServiceName:      cfgrev.Status.DeprecatedServiceName,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 90,
@@ -481,7 +481,7 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 					}, {
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      rev.Status.ServiceName,
+							ServiceName:      rev.Status.DeprecatedServiceName,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 10,
@@ -502,7 +502,7 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      cfgrev.Status.ServiceName,
+							ServiceName:      cfgrev.Status.DeprecatedServiceName,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 90,
@@ -513,7 +513,7 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 					}, {
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      rev.Status.ServiceName,
+							ServiceName:      rev.Status.DeprecatedServiceName,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 10,

--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -364,7 +364,7 @@ func (cb *configBuilder) addConfigurationTarget(tt *v1.TrafficTarget) error {
 	target := RevisionTarget{
 		TrafficTarget: *ntt,
 		Protocol:      rev.GetProtocol(),
-		ServiceName:   rev.Status.ServiceName,
+		ServiceName:   rev.Status.DeprecatedServiceName,
 	}
 	target.TrafficTarget.RevisionName = rev.Name
 	cb.addFlattenedTarget(target)
@@ -383,7 +383,7 @@ func (cb *configBuilder) addRevisionTarget(tt *v1.TrafficTarget) error {
 	target := RevisionTarget{
 		TrafficTarget: *ntt,
 		Protocol:      rev.GetProtocol(),
-		ServiceName:   rev.Status.ServiceName,
+		ServiceName:   rev.Status.DeprecatedServiceName,
 	}
 	if configName, ok := rev.Labels[serving.ConfigurationLabelKey]; ok {
 		target.TrafficTarget.ConfigurationName = configName

--- a/pkg/testing/v1/revision.go
+++ b/pkg/testing/v1/revision.go
@@ -52,7 +52,7 @@ func WithRevName(name string) RevisionOption {
 // WithServiceName propagates the given service name to the revision status.
 func WithServiceName(sn string) RevisionOption {
 	return func(rev *v1.Revision) {
-		rev.Status.ServiceName = sn
+		rev.Status.DeprecatedServiceName = sn
 	}
 }
 
@@ -139,7 +139,7 @@ func MarkActive(r *v1.Revision) {
 
 // WithK8sServiceName applies sn to the revision status field.
 func WithK8sServiceName(r *v1.Revision) {
-	r.Status.ServiceName = r.Name
+	r.Status.DeprecatedServiceName = r.Name
 }
 
 // MarkInactive calls .Status.MarkInactive on the Revision.

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -153,7 +153,8 @@ func TestTargetBurstCapacity(t *testing.T) {
 	// uniformness with one above.
 	if err := wait.Poll(250*time.Millisecond, 2*cfg.StableWindow, func() (bool, error) {
 		svcEps, err := ctx.clients.KubeClient.CoreV1().Endpoints(test.ServingNamespace).Get(
-			context.Background(), ctx.resources.Revision.Status.ServiceName, metav1.GetOptions{})
+			context.Background(), ctx.resources.Revision.Name, /* revision service name is equal to revision name*/
+			metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -131,7 +131,7 @@ func waitForActivatorEndpoints(ctx *TestContext) error {
 		}
 
 		svcEps, err := ctx.clients.KubeClient.CoreV1().Endpoints(test.ServingNamespace).Get(
-			context.Background(), ctx.resources.Revision.Status.ServiceName, metav1.GetOptions{})
+			context.Background(), ctx.resources.Revision.Status.DeprecatedServiceName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
So far there is going to be no changes to it, besides internal name.
But after 0.23 cuts we can stop populating and then it'll be gone.

/assign @dprotaso @tcnghia 

For #10540
