### PR TITLE
Export MESH env value in test script

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -34,7 +34,7 @@ KO_FLAGS="--platform=linux/amd64"
 KAIL_LOG_FILE="${ARTIFACTS}/k8s.log-$(basename "${E2E_SCRIPT}").txt"
 
 HTTPS=0
-MESH=0
+export MESH=0
 
 # List of custom YAMLs to install, if specified (space-separated).
 INSTALL_CUSTOM_YAMLS=""


### PR DESCRIPTION
`test/e2e-networking-library.sh` executes external script as:

```
  ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/install-istio.sh ${ISTIO_PROFILE}
```

And `install-istio.sh` uses `MESH` value but `MESH` is not exported so the
value is always empty in [this condition](https://github.com/knative-sandbox/net-istio/blob/36d9877077af10c902c0d1cdb4529c0e613bf8f8/third_party/istio-latest/install-istio.sh#L27).

Due to this, mTLS STRICT mode is not used in current test. This patch
fixes it.

**Release Note**

```release-note
NONE
```

/cc @ZhiminXiang @JRBANCEL @arturenault 
