### PR TITLE
Remove unused constants and make some other small tidy-ups

### DIFF
--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -37,7 +37,7 @@ const (
 
 	// QueueAdminPortName specifies the port name for
 	// health check and lifecycle hooks for queue-proxy.
-	QueueAdminPortName string = "http-queueadm"
+	QueueAdminPortName = "http-queueadm"
 
 	// AutoscalingQueueMetricsPortName specifies the port name to use for metrics
 	// emitted by queue-proxy for autoscaler.
@@ -48,15 +48,8 @@ const (
 	UserQueueMetricsPortName = "http-usermetric"
 )
 
-const (
-	// AnnotationParseErrorTypeMissing is the value of the Type field for
-	// AnnotationParseErrors which indicate an annotation was missing.
-	AnnotationParseErrorTypeMissing = "Missing"
-
-	// AnnotationParseErrorTypeInvalid is the value of the Type field for
-	// AnnotationParseErrors which indicate an annotation was invalid.
-	AnnotationParseErrorTypeInvalid = "Invalid"
-)
+// RoutingState represents states of a revision with regards to serving a route.
+type RoutingState string
 
 const (
 	// RoutingStateUnset is the empty value for routing state, this state is unexpected.
@@ -67,28 +60,12 @@ const (
 	// of revision garbage collection.
 	RoutingStatePending RoutingState = "pending"
 
-	// RoutingStateActive is a state for a revision which are actively referenced by a Route.
+	// RoutingStateActive is a state for a revision which is actively referenced by a Route.
 	RoutingStateActive RoutingState = "active"
 
 	// RoutingStateReserve is a state for a revision which is no longer referenced by a Route,
 	// and is scaled down, but may be rapidly pinned to a route to be made active again.
 	RoutingStateReserve RoutingState = "reserve"
-)
-
-type (
-	// RoutingState represents states of a revision with regards to serving a route.
-	RoutingState string
-
-	// +k8s:deepcopy-gen=false
-
-	// AnnotationParseError is the error type representing failures to parse annotations.
-	AnnotationParseError struct {
-		Type  string
-		Value string
-		Err   error
-	}
-
-	// +k8s:deepcopy-gen=false
 )
 
 // GetContainer returns a pointer to the relevant corev1.Container field.
@@ -168,8 +145,6 @@ func (r *Revision) GetProtocol() net.ProtocolType {
 
 // IsActivationRequired returns true if activation is required.
 func (rs *RevisionStatus) IsActivationRequired() bool {
-	if c := revisionCondSet.Manage(rs).GetCondition(RevisionConditionActive); c != nil {
-		return c.Status != corev1.ConditionTrue
-	}
-	return false
+	c := revisionCondSet.Manage(rs).GetCondition(RevisionConditionActive)
+	return c != nil && c.Status != corev1.ConditionTrue
 }

--- a/pkg/apis/serving/v1/revision_helpers_test.go
+++ b/pkg/apis/serving/v1/revision_helpers_test.go
@@ -181,10 +181,7 @@ func TestRevisionGetProtocol(t *testing.T) {
 				},
 			}
 
-			got := r.GetProtocol()
-			want := tt.protocol
-
-			if got != want {
+			if got, want := r.GetProtocol(), tt.protocol; got != want {
 				t.Errorf("Protocol = %v, want: %v", got, want)
 			}
 		})


### PR DESCRIPTION
- Drop some now-unused constants (`AnnotationParseError.*`, unused since GCv1 was removed in #10084)
- Move type definition for constant block above consts.
- Drop unnecessary explicit `string` type that can be inferred instead.
- Collapse got/want declaration into `if`.
- Use slightly nicer condition with boolean math instead of if/fallback.

/assign @markusthoemmes @whaught 
