### PR TITLE
Make route stop using the `DeprecatedServiceName` field

### DIFF
--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -225,7 +225,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      rev.Status.DeprecatedServiceName,
+							ServiceName:      rev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 100,
@@ -246,7 +246,7 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      rev.Status.DeprecatedServiceName,
+							ServiceName:      rev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 100,
@@ -353,7 +353,7 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      cfgrev.Status.DeprecatedServiceName,
+							ServiceName:      cfgrev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 90,
@@ -364,7 +364,7 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 					}, {
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      rev.Status.DeprecatedServiceName,
+							ServiceName:      rev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 10,
@@ -385,7 +385,7 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      cfgrev.Status.DeprecatedServiceName,
+							ServiceName:      cfgrev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 90,
@@ -396,7 +396,7 @@ func TestCreateRouteWithMultipleTargets(t *testing.T) {
 					}, {
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      rev.Status.DeprecatedServiceName,
+							ServiceName:      rev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 10,
@@ -470,7 +470,7 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      cfgrev.Status.DeprecatedServiceName,
+							ServiceName:      cfgrev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 90,
@@ -481,7 +481,7 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 					}, {
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      rev.Status.DeprecatedServiceName,
+							ServiceName:      rev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 10,
@@ -502,7 +502,7 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 					Splits: []v1alpha1.IngressBackendSplit{{
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      cfgrev.Status.DeprecatedServiceName,
+							ServiceName:      cfgrev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 90,
@@ -513,7 +513,7 @@ func TestCreateRouteWithOneTargetReserve(t *testing.T) {
 					}, {
 						IngressBackend: v1alpha1.IngressBackend{
 							ServiceNamespace: testNamespace,
-							ServiceName:      rev.Status.DeprecatedServiceName,
+							ServiceName:      rev.Name,
 							ServicePort:      intstr.FromInt(80),
 						},
 						Percent: 10,

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -138,7 +138,7 @@ func TestReconcile(t *testing.T) {
 			cfg("default", "ing-unknown",
 				WithConfigGeneration(1), WithLatestCreated("ing-unknown-00001"),
 				WithLatestReady("ing-unknown-00001")),
-			rev("default", "ing-unknown", 1, MarkRevisionReady, WithRevName("ing-unknown-00001"), WithServiceName("mcd")),
+			rev("default", "ing-unknown", 1, MarkRevisionReady, WithRevName("ing-unknown-00001"), WithK8sServiceName),
 		},
 		WantCreates: []runtime.Object{
 			simpleIngress(
@@ -153,7 +153,7 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(100),
 								RevisionName:      "ing-unknown-00001",
 							},
-							ServiceName: "mcd",
+							ServiceName: "ing-unknown-00001",
 						}},
 					},
 				},
@@ -187,7 +187,7 @@ func TestReconcile(t *testing.T) {
 			Route("default", "ingress-failed", WithConfigTarget("config"), WithRouteUID("12-34"), WithRouteGeneration(1)),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			simpleIngress(
 				Route("default", "ingress-failed", WithConfigTarget("config"), WithURL,
 					WithRouteUID("12-34")),
@@ -200,7 +200,7 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(100),
 								LatestRevision:    ptr.Bool(true),
 							},
-							ServiceName: "mcd",
+							ServiceName: "config-00001",
 						}},
 					},
 				}, WithLoadbalancerFailed("TestFailure", "failure"),
@@ -208,8 +208,7 @@ func TestReconcile(t *testing.T) {
 			simplePlaceholderK8sService(
 				getContext(),
 				Route("default", "ingress-failed", WithConfigTarget("config"), WithRouteUID("12-34")),
-				"",
-			),
+				"" /*targetName*/),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: Route("default", "ingress-failed", WithConfigTarget("config"),
@@ -236,7 +235,7 @@ func TestReconcile(t *testing.T) {
 				WithRouteGeneration(1)),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("bk")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 		},
 		WantCreates: []runtime.Object{
 			ingressWithClass(
@@ -250,7 +249,7 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(100),
 								LatestRevision:    ptr.Bool(true),
 							},
-							ServiceName: "bk",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -260,8 +259,7 @@ func TestReconcile(t *testing.T) {
 				getContext(),
 				Route("default", "becomes-ready",
 					WithConfigTarget("config"), WithRouteUID("12-34"), WithIngressClass("custom-ingress-class")),
-				"",
-			),
+				"" /*targetName*/),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: Route("default", "becomes-ready", WithConfigTarget("config"),
@@ -289,7 +287,7 @@ func TestReconcile(t *testing.T) {
 				WithRouteUID("65-23"), WithRouteGeneration(1)),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("tb")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 		},
 		WantCreates: []runtime.Object{
 			simpleIngress(
@@ -305,7 +303,7 @@ func TestReconcile(t *testing.T) {
 								LatestRevision:    ptr.Bool(true),
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "tb",
+							ServiceName: "config-00001",
 						}},
 					},
 					Visibility: map[string]netv1alpha1.IngressVisibility{
@@ -357,6 +355,7 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(100),
 								LatestRevision:    ptr.Bool(true),
 							},
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -493,7 +492,7 @@ func TestReconcile(t *testing.T) {
 				WithRouteGeneration(2009), MarkInRollout),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			simpleReadyIngress(
 				Route("default", "becomes-ready", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
@@ -505,6 +504,7 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(100),
 								LatestRevision:    ptr.Bool(true),
 							},
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -537,6 +537,7 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(100),
 								LatestRevision:    ptr.Bool(true),
 							},
+							ServiceName: "config-00001",
 						}},
 					},
 				}),
@@ -612,7 +613,7 @@ func TestReconcile(t *testing.T) {
 			Route("default", "ingress-create-failure", WithConfigTarget("config"), WithRouteFinalizer, WithRouteGeneration(1)),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("astrid")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 		},
 		// We induce a failure creating the Ingress.
 		WantErr: true,
@@ -633,7 +634,7 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(100),
 								LatestRevision:    ptr.Bool(true),
 							},
-							ServiceName: "astrid",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -693,6 +694,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -757,7 +759,7 @@ func TestReconcile(t *testing.T) {
 				// The Route controller attaches our label to this Configuration.
 				WithConfigLabel("serving.knative.dev/route", "different-domain"),
 			),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("my-service")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			simpleReadyIngress(
 				Route("default", "different-domain", WithConfigTarget("config"),
 					WithAnotherDomain),
@@ -770,7 +772,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "my-service",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -790,14 +792,11 @@ func TestReconcile(t *testing.T) {
 								LatestRevision:    ptr.Bool(true),
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "my-service",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
-				WithHosts(
-					1,
-					"different-domain.default.another-example.com",
-				),
+				WithHosts(1, "different-domain.default.another-example.com"),
 			),
 		}},
 		Key: "default/different-domain",
@@ -816,7 +815,7 @@ func TestReconcile(t *testing.T) {
 				WithConfigGeneration(2), WithLatestReady("config-00001"), WithLatestCreated("config-00002"),
 				WithConfigLabel("serving.knative.dev/route", "new-latest-created"),
 			),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("daisy")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			// This is the name of the new revision we're referencing above.
 			rev("default", "config", 2, WithInitRevConditions, WithRevName("config-00002")),
 			simpleReadyIngress(
@@ -830,7 +829,7 @@ func TestReconcile(t *testing.T) {
 								LatestRevision:    ptr.Bool(true),
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "daisy",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -855,9 +854,9 @@ func TestReconcile(t *testing.T) {
 				// The Route controller attaches our label to this Configuration.
 				WithConfigLabel("serving.knative.dev/route", "new-latest-ready"),
 			),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("magnolia")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			// This is the name of the new revision we're referencing above.
-			rev("default", "config", 2, MarkRevisionReady, WithRevName("config-00002"), WithServiceName("belltown")),
+			rev("default", "config", 2, MarkRevisionReady, WithRevName("config-00002"), WithK8sServiceName),
 			simpleReadyIngress(
 				Route("default", "new-latest-ready", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
@@ -869,7 +868,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "magnolia",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -890,7 +889,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName: "config-00002",
 								Percent:      ptr.Int64(100),
 							},
-							ServiceName: "belltown",
+							ServiceName: "config-00002",
 						}},
 					},
 				},
@@ -943,9 +942,9 @@ func TestReconcile(t *testing.T) {
 				// The Route controller attaches our label to this Configuration.
 				WithConfigLabel("serving.knative.dev/route", "new-latest-ready"),
 			),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("magnolia")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			// This is the name of the new revision we're referencing above.
-			rev("default", "config", 2, MarkRevisionReady, WithRevName("config-00002"), WithServiceName("belltown")),
+			rev("default", "config", 2, MarkRevisionReady, WithRevName("config-00002"), WithK8sServiceName),
 			simpleReadyIngress(
 				Route("default", "new-latest-ready", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
@@ -957,7 +956,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "magnolia",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -978,7 +977,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName: "config-00002",
 								Percent:      ptr.Int64(100),
 							},
-							ServiceName: "belltown",
+							ServiceName: "config-00002",
 						}},
 					},
 				}),
@@ -1002,7 +1001,7 @@ func TestReconcile(t *testing.T) {
 				WithRouteUID("65-23")),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("tb")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			simpleIngress(
 				Route("default", "becomes-local", WithConfigTarget("config"), WithRouteUID("65-23")),
 				&traffic.Config{
@@ -1014,7 +1013,7 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(100),
 								LatestRevision:    ptr.Bool(true),
 							},
-							ServiceName: "tb",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -1037,7 +1036,7 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(100),
 								LatestRevision:    ptr.Bool(true),
 							},
-							ServiceName: "tb",
+							ServiceName: "config-00001",
 						}},
 					},
 					Visibility: map[string]netv1alpha1.IngressVisibility{
@@ -1067,7 +1066,7 @@ func TestReconcile(t *testing.T) {
 				WithRouteUID("65-23"), WithRouteGeneration(1)),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("tb")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			simpleIngress(
 				Route("default", "becomes-public", WithConfigTarget("config"), WithRouteUID("65-23"),
 					WithRouteLabel(map[string]string{network.VisibilityLabelKey: "cluster-local"})),
@@ -1080,7 +1079,7 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(100),
 								LatestRevision:    ptr.Bool(true),
 							},
-							ServiceName: "tb",
+							ServiceName: "config-00001",
 						}},
 					},
 					Visibility: map[string]netv1alpha1.IngressVisibility{
@@ -1104,7 +1103,7 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(100),
 								LatestRevision:    ptr.Bool(true),
 							},
-							ServiceName: "tb",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -1143,9 +1142,9 @@ func TestReconcile(t *testing.T) {
 				// The Route controller attaches our label to this Configuration.
 				WithConfigLabel("serving.knative.dev/route", "update-ci-failure"),
 			),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("fremont")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			// This is the name of the new revision we're referencing above.
-			rev("default", "config", 2, MarkRevisionReady, WithRevName("config-00002"), WithServiceName("wallingford")),
+			rev("default", "config", 2, MarkRevisionReady, WithRevName("config-00002"), WithK8sServiceName),
 			simpleReadyIngress(
 				Route("default", "update-ci-failure", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
@@ -1157,7 +1156,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "fremont",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -1177,7 +1176,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName: "config-00002",
 								Percent:      ptr.Int64(100),
 							},
-							ServiceName: "wallingford",
+							ServiceName: "config-00002",
 						}},
 					},
 				}),
@@ -1224,6 +1223,7 @@ func TestReconcile(t *testing.T) {
 								LatestRevision:    ptr.Bool(true),
 								Percent:           ptr.Int64(100),
 							},
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -1268,6 +1268,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -1313,6 +1314,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -1353,6 +1355,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -1380,7 +1383,7 @@ func TestReconcile(t *testing.T) {
 				// The Route controller attaches our label to this Configuration.
 				WithConfigLabel("serving.knative.dev/route", "ingress-mutation"),
 			),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("windermere")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			mutateIngress(simpleReadyIngress(
 				Route("default", "ingress-mutation", WithConfigTarget("config"), WithURL),
 				&traffic.Config{
@@ -1390,7 +1393,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName: "config-00001",
 								Percent:      ptr.Int64(100),
 							},
-							ServiceName: "magnusson-park",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -1409,7 +1412,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "windermere",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -1482,6 +1485,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName: "config-00001",
 								Percent:      ptr.Int64(100),
 							},
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -1515,8 +1519,8 @@ func TestReconcile(t *testing.T) {
 				WithConfigGeneration(1), WithLatestCreated("blue-00001"), WithLatestReady("blue-00001")),
 			cfg("default", "green",
 				WithConfigGeneration(1), WithLatestCreated("green-00001"), WithLatestReady("green-00001")),
-			rev("default", "blue", 1, MarkRevisionReady, WithRevName("blue-00001"), WithServiceName("blue-ridge")),
-			rev("default", "green", 1, MarkRevisionReady, WithRevName("green-00001"), WithServiceName("green-lake")),
+			rev("default", "blue", 1, MarkRevisionReady, WithRevName("blue-00001"), WithK8sServiceName),
+			rev("default", "green", 1, MarkRevisionReady, WithRevName("green-00001"), WithK8sServiceName),
 		},
 		WantCreates: []runtime.Object{
 			simpleIngress(
@@ -1537,7 +1541,7 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(50),
 								LatestRevision:    ptr.Bool(true),
 							},
-							ServiceName: "blue-ridge",
+							ServiceName: "blue-00001",
 						}, {
 							TrafficTarget: v1.TrafficTarget{
 								ConfigurationName: "green",
@@ -1545,7 +1549,7 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(50),
 								LatestRevision:    ptr.Bool(true),
 							},
-							ServiceName: "green-lake",
+							ServiceName: "green-00001",
 						}},
 					},
 				},
@@ -1609,7 +1613,7 @@ func TestReconcile(t *testing.T) {
 			cfg("default", "gray",
 				WithConfigGeneration(1), WithLatestCreated("gray-00001"), WithLatestReady("gray-00001")),
 			rev("default", "gray", 1, MarkRevisionReady, WithRevName("gray-00001"),
-				WithServiceName("shades")),
+				WithK8sServiceName),
 		},
 		WantCreates: []runtime.Object{
 			simpleIngress(
@@ -1633,7 +1637,7 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(100),
 								LatestRevision:    ptr.Bool(true),
 							},
-							ServiceName: "shades",
+							ServiceName: "gray-00001",
 						}},
 						"gray": {{
 							TrafficTarget: v1.TrafficTarget{
@@ -1642,14 +1646,14 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(100),
 								LatestRevision:    ptr.Bool(true),
 							},
-							ServiceName: "shades",
+							ServiceName: "gray-00001",
 						}},
 						"also-gray": {{
 							TrafficTarget: v1.TrafficTarget{
 								RevisionName: "gray-00001",
 								Percent:      ptr.Int64(100),
 							},
-							ServiceName: "shades",
+							ServiceName: "gray-00001",
 						}},
 					},
 				},
@@ -1767,8 +1771,8 @@ func TestReconcile(t *testing.T) {
 			),
 			cfg("default", "green",
 				WithConfigGeneration(2020), WithLatestCreated("green-02021"), WithLatestReady("green-02020")),
-			rev("default", "blue", 1, MarkRevisionReady, WithRevName("blue-00001"), WithServiceName("alki-beach")),
-			rev("default", "green", 2020, MarkRevisionReady, WithRevName("green-02020"), WithServiceName("rainier-beach")),
+			rev("default", "blue", 1, MarkRevisionReady, WithRevName("blue-00001"), WithK8sServiceName),
+			rev("default", "green", 2020, MarkRevisionReady, WithRevName("green-02020"), WithK8sServiceName),
 			simpleReadyIngress(
 				Route("default", "switch-configs", WithConfigTarget("blue"), WithURL),
 				&traffic.Config{
@@ -1781,7 +1785,7 @@ func TestReconcile(t *testing.T) {
 								Percent:           ptr.Int64(100),
 								LatestRevision:    ptr.Bool(true),
 							},
-							ServiceName: "alki-beach",
+							ServiceName: "blue-00001",
 						}},
 					},
 				},
@@ -1800,7 +1804,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName:      "green-02020",
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "rainier-beach",
+							ServiceName: "green-02020",
 						}},
 					},
 				},
@@ -1902,6 +1906,7 @@ func TestReconcile(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -1998,7 +2003,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 				WithRouteUID("12-34")),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 		},
 		WantCreates: []runtime.Object{
 			ingressWithTLS(
@@ -2013,7 +2018,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "mcd",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -2052,7 +2057,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 			Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 		},
 		WantCreates: []runtime.Object{
 			resources.MakeCertificates(Route("default", "becomes-ready", WithConfigTarget("config"), WithURL, WithRouteUID("12-34")),
@@ -2069,7 +2074,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "mcd",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -2105,7 +2110,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 			Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			certificateWithStatus(resources.MakeCertificates(Route("default", "becomes-ready", WithConfigTarget("config"), WithURL, WithRouteUID("12-34")),
 				map[string]string{"becomes-ready.default.example.com": ""}, network.CertManagerCertificateClassName)[0], readyCertStatus()),
 		},
@@ -2122,7 +2127,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "mcd",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -2163,7 +2168,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 			Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			// MakeCertificates will create a certificate with DNS name "*.test-ns.example.com" which is not the host name
 			// needed by the input Route.
 			&netv1alpha1.Certificate{
@@ -2198,7 +2203,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "mcd",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -2244,7 +2249,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 			Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			&netv1alpha1.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "route-12-34",
@@ -2289,7 +2294,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "mcd",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -2339,7 +2344,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 			Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34"), WithRouteGeneration(1)),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			&netv1alpha1.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "route-12-34",
@@ -2385,7 +2390,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 			Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34"), WithRouteGeneration(1)),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			// MakeCertificates will create a certificate with DNS name "*.test-ns.example.com" which is not the host name
 			// needed by the input Route.
 			&netv1alpha1.Certificate{
@@ -2420,7 +2425,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "mcd",
+							ServiceName: "config-00001",
 						}},
 					},
 				}, nil, nil),
@@ -2462,7 +2467,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 				WithRouteUID("65-23")),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("tb")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			simpleIngress(
 				Route("default", "becomes-local", WithConfigTarget("config"), WithRouteUID("65-23")),
 				&traffic.Config{
@@ -2474,7 +2479,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "tb",
+							ServiceName: "config-00001",
 						}},
 					},
 				},
@@ -2497,7 +2502,7 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "tb",
+							ServiceName: "config-00001",
 						}},
 					},
 					Visibility: map[string]netv1alpha1.IngressVisibility{
@@ -2568,7 +2573,7 @@ func TestReconcileEnableAutoTLSHTTPDisabled(t *testing.T) {
 			Route("default", "becomes-ready", WithConfigTarget("config"), WithRouteUID("12-34")),
 			cfg("default", "config",
 				WithConfigGeneration(1), WithLatestCreated("config-00001"), WithLatestReady("config-00001")),
-			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithServiceName("mcd")),
+			rev("default", "config", 1, MarkRevisionReady, WithRevName("config-00001"), WithK8sServiceName),
 			// MakeCertificates will create a certificate with DNS name "*.test-ns.example.com" which is not the host name
 			// needed by the input Route.
 			&netv1alpha1.Certificate{
@@ -2603,7 +2608,7 @@ func TestReconcileEnableAutoTLSHTTPDisabled(t *testing.T) {
 								RevisionName:      "config-00001",
 								Percent:           ptr.Int64(100),
 							},
-							ServiceName: "mcd",
+							ServiceName: "config-00001",
 						}},
 					},
 				}, nil, nil),

--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -364,7 +364,7 @@ func (cb *configBuilder) addConfigurationTarget(tt *v1.TrafficTarget) error {
 	target := RevisionTarget{
 		TrafficTarget: *ntt,
 		Protocol:      rev.GetProtocol(),
-		ServiceName:   rev.Status.DeprecatedServiceName,
+		ServiceName:   rev.Name,
 	}
 	target.TrafficTarget.RevisionName = rev.Name
 	cb.addFlattenedTarget(target)
@@ -383,7 +383,7 @@ func (cb *configBuilder) addRevisionTarget(tt *v1.TrafficTarget) error {
 	target := RevisionTarget{
 		TrafficTarget: *ntt,
 		Protocol:      rev.GetProtocol(),
-		ServiceName:   rev.Status.DeprecatedServiceName,
+		ServiceName:   rev.Name,
 	}
 	if configName, ok := rev.Labels[serving.ConfigurationLabelKey]; ok {
 		target.TrafficTarget.ConfigurationName = configName

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -151,7 +151,8 @@ func TestBuildTrafficConfigurationVanilla(t *testing.T) {
 					Percent:           ptr.Int64(100),
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolH2C,
+				Protocol:    net.ProtocolH2C,
+				ServiceName: goodNewRev.Name,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -161,7 +162,8 @@ func TestBuildTrafficConfigurationVanilla(t *testing.T) {
 				Percent:           ptr.Int64(100),
 				LatestRevision:    ptr.Bool(true),
 			},
-			Protocol: net.ProtocolH2C,
+			Protocol:    net.ProtocolH2C,
+			ServiceName: goodNewRev.Name,
 		}},
 		Configurations: map[string]*v1.Configuration{
 			goodConfig.Name: goodConfig,
@@ -212,7 +214,8 @@ func TestBuildTrafficConfigurationNoNameRevision(t *testing.T) {
 					Percent:           ptr.Int64(100),
 					LatestRevision:    ptr.Bool(false),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: goodNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -222,7 +225,8 @@ func TestBuildTrafficConfigurationNoNameRevision(t *testing.T) {
 				Percent:           ptr.Int64(100),
 				LatestRevision:    ptr.Bool(false),
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: goodNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1.Configuration{goodConfig.Name: goodConfig},
 		Revisions:      map[string]*v1.Revision{goodNewRev.Name: goodNewRev},
@@ -249,7 +253,8 @@ func TestBuildTrafficConfigurationVanillaScaledToZero(t *testing.T) {
 					Percent:           ptr.Int64(100),
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolHTTP1,
+				ServiceName: inactiveRev.Name,
+				Protocol:    net.ProtocolHTTP1,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -259,7 +264,8 @@ func TestBuildTrafficConfigurationVanillaScaledToZero(t *testing.T) {
 				Percent:           ptr.Int64(100),
 				LatestRevision:    ptr.Bool(true),
 			},
-			Protocol: net.ProtocolHTTP1,
+			ServiceName: inactiveRev.Name,
+			Protocol:    net.ProtocolHTTP1,
 		}},
 		Configurations: map[string]*v1.Configuration{
 			inactiveConfig.Name: inactiveConfig,
@@ -304,7 +310,8 @@ func TestBuildTrafficConfigurationTwoConfigs(t *testing.T) {
 					Percent:           ptr.Int64(90),
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: niceNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}, {
 				TrafficTarget: v1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
@@ -312,7 +319,8 @@ func TestBuildTrafficConfigurationTwoConfigs(t *testing.T) {
 					Percent:           ptr.Int64(10),
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: goodNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -322,7 +330,8 @@ func TestBuildTrafficConfigurationTwoConfigs(t *testing.T) {
 				Percent:           ptr.Int64(90),
 				LatestRevision:    ptr.Bool(true),
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: niceNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}, {
 			TrafficTarget: v1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
@@ -330,7 +339,8 @@ func TestBuildTrafficConfigurationTwoConfigs(t *testing.T) {
 				Percent:           ptr.Int64(10),
 				LatestRevision:    ptr.Bool(true),
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: goodNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1.Configuration{
 			goodConfig.Name: goodConfig,
@@ -364,7 +374,8 @@ func TestBuildTrafficConfigurationTwoEntriesSameConfig(t *testing.T) {
 					Percent:           ptr.Int64(100),
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: niceNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -374,7 +385,8 @@ func TestBuildTrafficConfigurationTwoEntriesSameConfig(t *testing.T) {
 				Percent:           ptr.Int64(100),
 				LatestRevision:    ptr.Bool(true),
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: niceNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1.Configuration{
 			niceConfig.Name: niceConfig,
@@ -449,7 +461,8 @@ func TestBuildTrafficConfigThreeConfigs(t *testing.T) {
 					Percent:           ptr.Int64(30),
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: niceNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}, {
 				TrafficTarget: v1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
@@ -458,7 +471,8 @@ func TestBuildTrafficConfigThreeConfigs(t *testing.T) {
 					LatestRevision:    ptr.Bool(true),
 					Tag:               "robert",
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: goodNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}, {
 				TrafficTarget: v1.TrafficTarget{
 					ConfigurationName: inactiveConfig.Name,
@@ -467,7 +481,8 @@ func TestBuildTrafficConfigThreeConfigs(t *testing.T) {
 					LatestRevision:    ptr.Bool(true),
 					Tag:               "jackson",
 				},
-				Protocol: net.ProtocolHTTP1,
+				ServiceName: inactiveRev.Name,
+				Protocol:    net.ProtocolHTTP1,
 			}},
 			"robert": {{
 				TrafficTarget: v1.TrafficTarget{
@@ -477,7 +492,8 @@ func TestBuildTrafficConfigThreeConfigs(t *testing.T) {
 					Tag:               "robert",
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: goodNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}},
 			"jackson": {{
 				TrafficTarget: v1.TrafficTarget{
@@ -487,7 +503,8 @@ func TestBuildTrafficConfigThreeConfigs(t *testing.T) {
 					Tag:               "jackson",
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolHTTP1,
+				ServiceName: inactiveRev.Name,
+				Protocol:    net.ProtocolHTTP1,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -497,7 +514,8 @@ func TestBuildTrafficConfigThreeConfigs(t *testing.T) {
 				Percent:           ptr.Int64(30),
 				LatestRevision:    ptr.Bool(true),
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: niceNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}, {
 			TrafficTarget: v1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
@@ -506,7 +524,8 @@ func TestBuildTrafficConfigThreeConfigs(t *testing.T) {
 				LatestRevision:    ptr.Bool(true),
 				Tag:               "robert",
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: goodNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}, {
 			TrafficTarget: v1.TrafficTarget{
 				ConfigurationName: inactiveConfig.Name,
@@ -515,7 +534,8 @@ func TestBuildTrafficConfigThreeConfigs(t *testing.T) {
 				LatestRevision:    ptr.Bool(true),
 				Tag:               "jackson",
 			},
-			Protocol: net.ProtocolHTTP1,
+			ServiceName: inactiveRev.Name,
+			Protocol:    net.ProtocolHTTP1,
 		}},
 		Configurations: map[string]*v1.Configuration{
 			niceConfig.Name:     niceConfig,
@@ -605,7 +625,8 @@ func TestBuildTrafficConfigurationTwoEntriesSameConfigDifferentTags(t *testing.T
 					Percent:           ptr.Int64(100),
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: niceNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}},
 			"robert": {{
 				TrafficTarget: v1.TrafficTarget{
@@ -615,7 +636,8 @@ func TestBuildTrafficConfigurationTwoEntriesSameConfigDifferentTags(t *testing.T
 					Tag:               "robert",
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: niceNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -625,7 +647,8 @@ func TestBuildTrafficConfigurationTwoEntriesSameConfigDifferentTags(t *testing.T
 				Percent:           ptr.Int64(90),
 				LatestRevision:    ptr.Bool(true),
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: niceNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}, {
 			TrafficTarget: v1.TrafficTarget{
 				ConfigurationName: niceConfig.Name,
@@ -634,7 +657,8 @@ func TestBuildTrafficConfigurationTwoEntriesSameConfigDifferentTags(t *testing.T
 				LatestRevision:    ptr.Bool(true),
 				Tag:               "robert",
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: niceNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1.Configuration{
 			niceConfig.Name: niceConfig,
@@ -694,7 +718,8 @@ func TestBuildTrafficConfigurationCanary(t *testing.T) {
 					Percent:           ptr.Int64(90),
 					LatestRevision:    ptr.Bool(false),
 				},
-				Protocol: net.ProtocolHTTP1,
+				ServiceName: goodOldRev.Name,
+				Protocol:    net.ProtocolHTTP1,
 			}, {
 				TrafficTarget: v1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
@@ -702,7 +727,8 @@ func TestBuildTrafficConfigurationCanary(t *testing.T) {
 					Percent:           ptr.Int64(10),
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: goodNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -712,7 +738,8 @@ func TestBuildTrafficConfigurationCanary(t *testing.T) {
 				Percent:           ptr.Int64(90),
 				LatestRevision:    ptr.Bool(false),
 			},
-			Protocol: net.ProtocolHTTP1,
+			ServiceName: goodOldRev.Name,
+			Protocol:    net.ProtocolHTTP1,
 		}, {
 			TrafficTarget: v1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
@@ -720,7 +747,8 @@ func TestBuildTrafficConfigurationCanary(t *testing.T) {
 				Percent:           ptr.Int64(10),
 				LatestRevision:    ptr.Bool(true),
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: goodNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1.Configuration{
 			goodConfig.Name: goodConfig,
@@ -772,7 +800,8 @@ func TestBuildTrafficConfigurationConsolidated(t *testing.T) {
 					Percent:           ptr.Int64(49),
 					LatestRevision:    ptr.Bool(false),
 				},
-				Protocol: net.ProtocolHTTP1,
+				ServiceName: goodOldRev.Name,
+				Protocol:    net.ProtocolHTTP1,
 			}, {
 				TrafficTarget: v1.TrafficTarget{
 					Tag:               "two",
@@ -781,7 +810,8 @@ func TestBuildTrafficConfigurationConsolidated(t *testing.T) {
 					Percent:           ptr.Int64(51),
 					LatestRevision:    ptr.Bool(false),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: goodNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}},
 			"one": {{
 				TrafficTarget: v1.TrafficTarget{
@@ -791,7 +821,8 @@ func TestBuildTrafficConfigurationConsolidated(t *testing.T) {
 					Percent:           ptr.Int64(100),
 					LatestRevision:    ptr.Bool(false),
 				},
-				Protocol: net.ProtocolHTTP1,
+				ServiceName: goodOldRev.Name,
+				Protocol:    net.ProtocolHTTP1,
 			}},
 			"two": {{
 				TrafficTarget: v1.TrafficTarget{
@@ -801,7 +832,8 @@ func TestBuildTrafficConfigurationConsolidated(t *testing.T) {
 					Percent:           ptr.Int64(100),
 					LatestRevision:    ptr.Bool(false),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: goodNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}},
 			"also-two": {{
 				TrafficTarget: v1.TrafficTarget{
@@ -811,7 +843,8 @@ func TestBuildTrafficConfigurationConsolidated(t *testing.T) {
 					Percent:           ptr.Int64(100),
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: goodNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -822,7 +855,8 @@ func TestBuildTrafficConfigurationConsolidated(t *testing.T) {
 				Percent:           ptr.Int64(49),
 				LatestRevision:    ptr.Bool(false),
 			},
-			Protocol: net.ProtocolHTTP1,
+			ServiceName: goodOldRev.Name,
+			Protocol:    net.ProtocolHTTP1,
 		}, {
 			TrafficTarget: v1.TrafficTarget{
 				Tag:               "two",
@@ -831,7 +865,8 @@ func TestBuildTrafficConfigurationConsolidated(t *testing.T) {
 				Percent:           ptr.Int64(50),
 				LatestRevision:    ptr.Bool(false),
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: goodNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}, {
 			TrafficTarget: v1.TrafficTarget{
 				Tag:               "also-two",
@@ -840,7 +875,8 @@ func TestBuildTrafficConfigurationConsolidated(t *testing.T) {
 				Percent:           ptr.Int64(1),
 				LatestRevision:    ptr.Bool(true),
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: goodNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1.Configuration{
 			goodConfig.Name: goodConfig,
@@ -880,7 +916,8 @@ func TestBuildTrafficConfigurationTwoFixedRevisions(t *testing.T) {
 					Percent:           ptr.Int64(90),
 					LatestRevision:    ptr.Bool(false),
 				},
-				Protocol: net.ProtocolHTTP1,
+				ServiceName: goodOldRev.Name,
+				Protocol:    net.ProtocolHTTP1,
 			}, {
 				TrafficTarget: v1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
@@ -888,7 +925,8 @@ func TestBuildTrafficConfigurationTwoFixedRevisions(t *testing.T) {
 					Percent:           ptr.Int64(10),
 					LatestRevision:    ptr.Bool(false),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: goodNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -898,7 +936,8 @@ func TestBuildTrafficConfigurationTwoFixedRevisions(t *testing.T) {
 				Percent:           ptr.Int64(90),
 				LatestRevision:    ptr.Bool(false),
 			},
-			Protocol: net.ProtocolHTTP1,
+			ServiceName: goodOldRev.Name,
+			Protocol:    net.ProtocolHTTP1,
 		}, {
 			TrafficTarget: v1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
@@ -906,7 +945,8 @@ func TestBuildTrafficConfigurationTwoFixedRevisions(t *testing.T) {
 				Percent:           ptr.Int64(10),
 				LatestRevision:    ptr.Bool(false),
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: goodNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1.Configuration{
 			goodConfig.Name: goodConfig,
@@ -948,7 +988,8 @@ func TestBuildTrafficConfigurationTwoFixedRevisionsFromTwoConfigurations(t *test
 					Percent:           ptr.Int64(40),
 					LatestRevision:    ptr.Bool(false),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: goodNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}, {
 				TrafficTarget: v1.TrafficTarget{
 					ConfigurationName: niceConfig.Name,
@@ -956,7 +997,8 @@ func TestBuildTrafficConfigurationTwoFixedRevisionsFromTwoConfigurations(t *test
 					Percent:           ptr.Int64(60),
 					LatestRevision:    ptr.Bool(false),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: niceNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -966,7 +1008,8 @@ func TestBuildTrafficConfigurationTwoFixedRevisionsFromTwoConfigurations(t *test
 				Percent:           ptr.Int64(40),
 				LatestRevision:    ptr.Bool(false),
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: goodNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}, {
 			TrafficTarget: v1.TrafficTarget{
 				ConfigurationName: niceConfig.Name,
@@ -974,7 +1017,8 @@ func TestBuildTrafficConfigurationTwoFixedRevisionsFromTwoConfigurations(t *test
 				Percent:           ptr.Int64(60),
 				LatestRevision:    ptr.Bool(false),
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: niceNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1.Configuration{
 			goodConfig.Name: goodConfig,
@@ -1009,7 +1053,8 @@ func TestBuildTrafficConfigurationPreliminary(t *testing.T) {
 					Percent:           ptr.Int64(100),
 					LatestRevision:    ptr.Bool(false),
 				},
-				Protocol: net.ProtocolHTTP1,
+				ServiceName: goodOldRev.Name,
+				Protocol:    net.ProtocolHTTP1,
 			}, {
 				TrafficTarget: v1.TrafficTarget{
 					Tag:               "beta",
@@ -1018,7 +1063,8 @@ func TestBuildTrafficConfigurationPreliminary(t *testing.T) {
 					LatestRevision:    ptr.Bool(false),
 					Percent:           ptr.Int64(0),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: goodNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}, {
 				TrafficTarget: v1.TrafficTarget{
 					Tag:               "alpha",
@@ -1027,7 +1073,8 @@ func TestBuildTrafficConfigurationPreliminary(t *testing.T) {
 					Percent:           ptr.Int64(0),
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: niceNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}},
 			"beta": {{
 				TrafficTarget: v1.TrafficTarget{
@@ -1037,7 +1084,8 @@ func TestBuildTrafficConfigurationPreliminary(t *testing.T) {
 					Percent:           ptr.Int64(100),
 					LatestRevision:    ptr.Bool(false),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: goodNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}},
 			"alpha": {{
 				TrafficTarget: v1.TrafficTarget{
@@ -1047,7 +1095,8 @@ func TestBuildTrafficConfigurationPreliminary(t *testing.T) {
 					Percent:           ptr.Int64(100),
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: niceNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -1057,7 +1106,8 @@ func TestBuildTrafficConfigurationPreliminary(t *testing.T) {
 				Percent:           ptr.Int64(100),
 				LatestRevision:    ptr.Bool(false),
 			},
-			Protocol: net.ProtocolHTTP1,
+			ServiceName: goodOldRev.Name,
+			Protocol:    net.ProtocolHTTP1,
 		}, {
 			TrafficTarget: v1.TrafficTarget{
 				Tag:               "beta",
@@ -1066,7 +1116,8 @@ func TestBuildTrafficConfigurationPreliminary(t *testing.T) {
 				LatestRevision:    ptr.Bool(false),
 				Percent:           ptr.Int64(0),
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: goodNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}, {
 			TrafficTarget: v1.TrafficTarget{
 				Tag:               "alpha",
@@ -1075,7 +1126,8 @@ func TestBuildTrafficConfigurationPreliminary(t *testing.T) {
 				LatestRevision:    ptr.Bool(true),
 				Percent:           ptr.Int64(0),
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: niceNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1.Configuration{
 			goodConfig.Name: goodConfig,
@@ -1167,7 +1219,8 @@ func TestBuildTrafficConfigurationReadyNotReadyConfig(t *testing.T) {
 					LatestRevision:    ptr.Bool(true),
 					Percent:           ptr.Int64(100),
 				},
-				Protocol: net.ProtocolHTTP1,
+				ServiceName: readyRevision.Name,
+				Protocol:    net.ProtocolHTTP1,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -1177,7 +1230,8 @@ func TestBuildTrafficConfigurationReadyNotReadyConfig(t *testing.T) {
 				LatestRevision:    ptr.Bool(true),
 				Percent:           ptr.Int64(100),
 			},
-			Protocol: net.ProtocolHTTP1,
+			ServiceName: readyRevision.Name,
+			Protocol:    net.ProtocolHTTP1,
 		}},
 		Revisions: map[string]*v1.Revision{
 			readyRevision.Name: readyRevision,
@@ -1584,7 +1638,8 @@ func TestBuildTrafficConfigurationTag0Percent(t *testing.T) {
 					Percent:           ptr.Int64(100),
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolH2C,
+				ServiceName: niceNewRev.Name,
+				Protocol:    net.ProtocolH2C,
 			}, {
 				TrafficTarget: v1.TrafficTarget{
 					ConfigurationName: goodConfig.Name,
@@ -1593,7 +1648,8 @@ func TestBuildTrafficConfigurationTag0Percent(t *testing.T) {
 					LatestRevision:    ptr.Bool(true),
 					Tag:               "robert",
 				},
-				Protocol: net.ProtocolH2C,
+				Protocol:    net.ProtocolH2C,
+				ServiceName: goodNewRev.Name,
 			}},
 			"robert": {{
 				TrafficTarget: v1.TrafficTarget{
@@ -1603,7 +1659,8 @@ func TestBuildTrafficConfigurationTag0Percent(t *testing.T) {
 					Tag:               "robert",
 					LatestRevision:    ptr.Bool(true),
 				},
-				Protocol: net.ProtocolH2C,
+				Protocol:    net.ProtocolH2C,
+				ServiceName: goodNewRev.Name,
 			}},
 		},
 		revisionTargets: []RevisionTarget{{
@@ -1613,7 +1670,8 @@ func TestBuildTrafficConfigurationTag0Percent(t *testing.T) {
 				Percent:           ptr.Int64(100),
 				LatestRevision:    ptr.Bool(true),
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: niceNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}, {
 			TrafficTarget: v1.TrafficTarget{
 				ConfigurationName: goodConfig.Name,
@@ -1622,7 +1680,8 @@ func TestBuildTrafficConfigurationTag0Percent(t *testing.T) {
 				LatestRevision:    ptr.Bool(true),
 				Tag:               "robert",
 			},
-			Protocol: net.ProtocolH2C,
+			ServiceName: goodNewRev.Name,
+			Protocol:    net.ProtocolH2C,
 		}},
 		Configurations: map[string]*v1.Configuration{
 			niceConfig.Name: niceConfig,


### PR DESCRIPTION
And use the `Revision.Name` instead.
Also fix a lot of tests on the way that were not very precise with its objects.

Probably we can make another pass to simplify this more and remove the `ServiceName` field altogether.

Part of #10540

/assign @dprotaso @tcnghia 