### PR TITLE
Remove the time computation

### DIFF
--- a/test/e2e/rollout_test.go
+++ b/test/e2e/rollout_test.go
@@ -54,10 +54,10 @@ func TestGradualRollout(t *testing.T) {
 		t.Fatal("Create Ready Service:", err)
 	}
 
+	start := time.Now()
 	if _, err := v1test.PatchService(t, clients, robjs.Service, testingv1.WithServiceImage(pkgtest.ImagePath(test.Autoscale))); err != nil {
 		t.Fatalf("Patch update for Service %s with image %s failed: %v", names.Service, test.Autoscale, err)
 	}
-	start := time.Now()
 
 	// This will cover all the status checks:
 	// - Status is in Rollout

--- a/test/e2e/rollout_test.go
+++ b/test/e2e/rollout_test.go
@@ -54,7 +54,6 @@ func TestGradualRollout(t *testing.T) {
 		t.Fatal("Create Ready Service:", err)
 	}
 
-	start := time.Now()
 	if _, err := v1test.PatchService(t, clients, robjs.Service, testingv1.WithServiceImage(pkgtest.ImagePath(test.Autoscale))); err != nil {
 		t.Fatalf("Patch update for Service %s with image %s failed: %v", names.Service, test.Autoscale, err)
 	}
@@ -124,10 +123,4 @@ func TestGradualRollout(t *testing.T) {
 		}, "RolloutFinished"); err != nil {
 		t.Fatalf("Failed waiting for Rollout %q to complete: %+v", names.Service, err)
 	}
-
-	dur := time.Since(start)
-	if dur < time.Minute {
-		t.Errorf("Actual Rollout duration shorter than requested: %v < %v", dur, rolloutDuration)
-	}
-	t.Log("Rollout Duration =", dur)
 }


### PR DESCRIPTION
#10641 reports that in Kourier this check is not conservative enough, since by the time we observe the start time the process might be well underway.
So, remove the check altogether, since it's not very useful anyway

Fixes #10641

/assign @dprotaso @tcnghia 