### PR TITLE
Do not pass context to the scale, but logger instead

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -27,7 +27,6 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
-	"knative.dev/pkg/logging"
 	pkgmetrics "knative.dev/pkg/metrics"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/autoscaler/aggregation/max"
@@ -141,8 +140,7 @@ func (a *autoscaler) Update(deciderSpec *DeciderSpec) {
 // validScale signifies whether the desiredPodCount should be applied or not.
 // Scale is not thread safe in regards to panic state, but it's thread safe in
 // regards to acquiring the decider spec.
-func (a *autoscaler) Scale(ctx context.Context, now time.Time) ScaleResult {
-	logger := logging.FromContext(ctx)
+func (a *autoscaler) Scale(logger *zap.SugaredLogger, now time.Time) ScaleResult {
 	desugared := logger.Desugar()
 	debugEnabled := desugared.Core().Enabled(zapcore.DebugLevel)
 

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -31,6 +31,7 @@ import (
 	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/pkg/metrics/metricstest"
 
+	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/serving/pkg/autoscaler/metrics"
 	smetrics "knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/resources"
@@ -560,7 +561,7 @@ func TestCantCountPods(t *testing.T) {
 	metrics := &metricClient{StableConcurrency: 1000, PanicConcurrency: 888}
 	a, pc := newTestAutoscaler(10, 81, metrics)
 	pc.err = errors.New("peaches-in-regalia")
-	if got, want := a.Scale(context.Background(), time.Now()), invalidSR; !cmp.Equal(got, want) {
+	if got, want := a.Scale(logtesting.TestLogger(t), time.Now()), invalidSR; !cmp.Equal(got, want) {
 		t.Errorf("Scale = %v, want: %v", got, want)
 	}
 }
@@ -646,7 +647,7 @@ func approxEquateInt32(field string) cmp.Option {
 
 func expectScale(t *testing.T, a UniScaler, now time.Time, want ScaleResult) {
 	t.Helper()
-	got := a.Scale(TestContextWithLogger(t), now)
+	got := a.Scale(logtesting.TestLogger(t), now)
 	if !cmp.Equal(got, want, approxEquateInt32("ExcessBurstCapacity")) {
 		t.Error("ScaleResult mismatch(-want,+got):\n", cmp.Diff(want, got))
 	}
@@ -764,6 +765,6 @@ func BenchmarkAutoscaler(b *testing.B) {
 	now := time.Now()
 
 	for i := 0; i < b.N; i++ {
-		a.Scale(context.Background(), now)
+		a.Scale(logtesting.TestLogger(b), now)
 	}
 }

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -36,7 +36,6 @@ import (
 	smetrics "knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/resources"
 
-	. "knative.dev/pkg/logging/testing"
 	_ "knative.dev/pkg/metrics/testing"
 )
 
@@ -79,7 +78,7 @@ func TestAutoscalerScaleDownDelay(t *testing.T) {
 		PanicThreshold:   100,
 		ScaleDownDelay:   5 * time.Minute,
 	}
-	as := New(TestContextWithLogger(t), testNamespace, testRevision, metrics, pc, spec)
+	as := New(context.Background(), testNamespace, testRevision, metrics, pc, spec)
 
 	now := time.Time{}
 
@@ -148,7 +147,7 @@ func TestAutoscalerScaleDownDelayZero(t *testing.T) {
 		PanicThreshold:   100,
 		ScaleDownDelay:   0,
 	}
-	as := New(TestContextWithLogger(t), testNamespace, testRevision, metrics, pc, spec)
+	as := New(context.Background(), testNamespace, testRevision, metrics, pc, spec)
 
 	now := time.Time{}
 

--- a/pkg/autoscaler/scaling/multiscaler_test.go
+++ b/pkg/autoscaler/scaling/multiscaler_test.go
@@ -413,7 +413,7 @@ func (u *fakeUniScaler) fakeUniScalerFactory(*Decider) (UniScaler, error) {
 	return u, nil
 }
 
-func (u *fakeUniScaler) Scale(context.Context, time.Time) ScaleResult {
+func (u *fakeUniScaler) Scale(*zap.SugaredLogger, time.Time) ScaleResult {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 	u.scaleCount++


### PR DESCRIPTION
Right now Scale accepts context, but it is only used to acquire logger.
While not an issue in itself (besides random performance losses going
through the linkedlist that is context values), the way context is
passed _is_ a problem though.

While trying to sort out #10642 the obvious thing to look is that we use
reconcile context in a some long running process. _This_ is one of
places. And while this probably *is not* the problem, it is not good to
use the context beyond its lifetime.

There are a few ways to solve it. I went with a hammer and just stored
the logger in the runner and passed it to the `Scale`.

I might go over this more a few times to try to make this prettier.

/assign @julz @markusthoemmes 