### PR TITLE
Add support for decoding Revision from Host.

### DIFF
--- a/pkg/activator/handler/context_handler.go
+++ b/pkg/activator/handler/context_handler.go
@@ -58,8 +58,8 @@ func (h *contextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// If the headers aren't explicitly specified, then decode the revision
 	// name and namespace from the Host header.
 	if name == "" || namespace == "" {
-		parts := strings.SplitN(r.Host, ".", 3)
-		if len(parts) == 3 && parts[2] == "svc."+network.GetClusterDomainName() {
+		parts := strings.SplitN(r.Host, ".", 4)
+		if len(parts) == 4 && parts[2] == "svc" && parts[3] == network.GetClusterDomainName() {
 			name, namespace = parts[0], parts[1]
 		}
 	}

--- a/pkg/activator/handler/context_handler.go
+++ b/pkg/activator/handler/context_handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,6 +28,7 @@ import (
 
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
+	network "knative.dev/pkg/network"
 	"knative.dev/serving/pkg/activator"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
@@ -52,6 +54,16 @@ type contextHandler struct {
 func (h *contextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	namespace := r.Header.Get(activator.RevisionHeaderNamespace)
 	name := r.Header.Get(activator.RevisionHeaderName)
+
+	// If the headers aren't explicitly specified, then decode the revision
+	// name and namespace from the Host header.
+	if name == "" || namespace == "" {
+		parts := strings.SplitN(r.Host, ".", 3)
+		if len(parts) == 3 && parts[2] == "svc."+network.GetClusterDomainName() {
+			name, namespace = parts[0], parts[1]
+		}
+	}
+
 	revID := types.NamespacedName{Namespace: namespace, Name: name}
 	logger := h.logger.With(zap.String(logkey.Key, revID.String()))
 


### PR DESCRIPTION
This adds logic to the activator that falls back on decoding the Host header when `Knative-Serving-Revision` etc is unspecified.  With this, Revisions can simply be curled using their K8s service name and properly activate.

Part of the goal of this is to support a more standard datapath for Revisions, simplifying the contract that headers must be specified.  The current path remains the default, but in the future we might consider leveraging the RewriteHost functionality to use this for the main path as well.

One interesting observation is that with this we could conceivably make Configuration and Revision "Addressable" (modulo GC concerns), which feels like the datapath contract is headed in the right direction.

Related slack thread: https://knative.slack.com/archives/CA4DNJ9A4/p1611855261031300