### PR TITLE
Use consistent alias for autoscaler v1alpha1 everywhere

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -46,7 +46,7 @@ import (
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/version"
-	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/autoscaler/bucket"
 	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
@@ -230,7 +230,7 @@ func uniScalerFactoryFunc(podLister corev1listers.PodLister,
 }
 
 func statsScraperFactoryFunc(podLister corev1listers.PodLister) asmetrics.StatsScraperFactory {
-	return func(metric *av1alpha1.Metric, logger *zap.SugaredLogger) (asmetrics.StatsScraper, error) {
+	return func(metric *autoscalingv1alpha1.Metric, logger *zap.SugaredLogger) (asmetrics.StatsScraper, error) {
 		if metric.Spec.ScrapeTarget == "" {
 			return nil, nil
 		}

--- a/pkg/autoscaler/metrics/collector.go
+++ b/pkg/autoscaler/metrics/collector.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/clock"
 	"knative.dev/pkg/logging/logkey"
-	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler/aggregation"
 	"knative.dev/serving/pkg/autoscaler/config"
 )
@@ -45,7 +45,7 @@ var (
 )
 
 // StatsScraperFactory creates a StatsScraper for a given Metric.
-type StatsScraperFactory func(*av1alpha1.Metric, *zap.SugaredLogger) (StatsScraper, error)
+type StatsScraperFactory func(*autoscalingv1alpha1.Metric, *zap.SugaredLogger) (StatsScraper, error)
 
 var emptyStat = Stat{}
 
@@ -60,7 +60,7 @@ type StatMessage struct {
 type Collector interface {
 	// CreateOrUpdate either creates a collection for the given metric or update it, should
 	// it already exist.
-	CreateOrUpdate(*av1alpha1.Metric) error
+	CreateOrUpdate(*autoscalingv1alpha1.Metric) error
 	// Record allows stats to be captured that came from outside the Collector.
 	Record(key types.NamespacedName, now time.Time, stat Stat)
 	// Delete deletes a Metric and halts collection.
@@ -110,7 +110,7 @@ func NewMetricCollector(statsScraperFactory StatsScraperFactory, logger *zap.Sug
 
 // CreateOrUpdate either creates a collection for the given metric or update it, should
 // it already exist.
-func (c *MetricCollector) CreateOrUpdate(metric *av1alpha1.Metric) error {
+func (c *MetricCollector) CreateOrUpdate(metric *autoscalingv1alpha1.Metric) error {
 	logger := c.logger.With(zap.String(logkey.Key, types.NamespacedName{
 		Namespace: metric.Namespace,
 		Name:      metric.Name,
@@ -221,7 +221,7 @@ type collection struct {
 	// mux guards access to all of the collection's state.
 	mux sync.RWMutex
 
-	metric *av1alpha1.Metric
+	metric *autoscalingv1alpha1.Metric
 
 	// Fields relevant to metric collection in general.
 	concurrencyBuckets      *aggregation.TimedFloat64Buckets
@@ -250,7 +250,7 @@ func (c *collection) getScraper() StatsScraper {
 
 // newCollection creates a new collection, which uses the given scraper to
 // collect stats every scrapeTickInterval.
-func newCollection(metric *av1alpha1.Metric, scraper StatsScraper, clock clock.Clock,
+func newCollection(metric *autoscalingv1alpha1.Metric, scraper StatsScraper, clock clock.Clock,
 	callback func(types.NamespacedName), logger *zap.SugaredLogger) *collection {
 	c := &collection{
 		metric: metric,
@@ -314,7 +314,7 @@ func (c *collection) close() {
 }
 
 // updateMetric safely updates the metric stored in the collection.
-func (c *collection) updateMetric(metric *av1alpha1.Metric) {
+func (c *collection) updateMetric(metric *autoscalingv1alpha1.Metric) {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
@@ -326,7 +326,7 @@ func (c *collection) updateMetric(metric *av1alpha1.Metric) {
 }
 
 // currentMetric safely returns the current metric stored in the collection.
-func (c *collection) currentMetric() *av1alpha1.Metric {
+func (c *collection) currentMetric() *autoscalingv1alpha1.Metric {
 	c.mux.RLock()
 	defer c.mux.RUnlock()
 

--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	. "knative.dev/pkg/logging/testing"
-	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/autoscaler/aggregation"
 	"knative.dev/serving/pkg/autoscaler/config"
@@ -41,12 +41,12 @@ import (
 var (
 	defaultNamespace = "test-namespace"
 	defaultName      = "test-name"
-	defaultMetric    = av1alpha1.Metric{
+	defaultMetric    = autoscalingv1alpha1.Metric{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: defaultNamespace,
 			Name:      defaultName,
 		},
-		Spec: av1alpha1.MetricSpec{
+		Spec: autoscalingv1alpha1.MetricSpec{
 			StableWindow: 60 * time.Second,
 			PanicWindow:  6 * time.Second,
 			ScrapeTarget: "original-target",
@@ -483,7 +483,7 @@ func TestDoubleWatch(t *testing.T) {
 }
 
 func TestMetricCollectorError(t *testing.T) {
-	testMetric := &av1alpha1.Metric{
+	testMetric := &autoscalingv1alpha1.Metric{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testRevision,
@@ -491,7 +491,7 @@ func TestMetricCollectorError(t *testing.T) {
 				serving.RevisionLabelKey: testRevision,
 			},
 		},
-		Spec: av1alpha1.MetricSpec{
+		Spec: autoscalingv1alpha1.MetricSpec{
 			ScrapeTarget: testRevision + "-zhudex",
 		},
 	}
@@ -570,7 +570,7 @@ func TestMetricCollectorError(t *testing.T) {
 }
 
 func scraperFactory(scraper StatsScraper, err error) StatsScraperFactory {
-	return func(*av1alpha1.Metric, *zap.SugaredLogger) (StatsScraper, error) {
+	return func(*autoscalingv1alpha1.Metric, *zap.SugaredLogger) (StatsScraper, error) {
 		return scraper, err
 	}
 }

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -33,7 +33,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	pkgmetrics "knative.dev/pkg/metrics"
-	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/networking"
@@ -155,7 +155,7 @@ type serviceScraper struct {
 
 // NewStatsScraper creates a new StatsScraper for the Revision which
 // the given Metric is responsible for.
-func NewStatsScraper(metric *av1alpha1.Metric, revisionName string, podAccessor resources.PodAccessor,
+func NewStatsScraper(metric *autoscalingv1alpha1.Metric, revisionName string, podAccessor resources.PodAccessor,
 	logger *zap.SugaredLogger) StatsScraper {
 	directClient := newHTTPScrapeClient(client)
 	meshClient := newHTTPScrapeClient(noKeepaliveClient)
@@ -163,7 +163,7 @@ func NewStatsScraper(metric *av1alpha1.Metric, revisionName string, podAccessor 
 }
 
 func newServiceScraperWithClient(
-	metric *av1alpha1.Metric,
+	metric *autoscalingv1alpha1.Metric,
 	revisionName string,
 	podAccessor resources.PodAccessor,
 	directClient, meshClient scrapeClient,

--- a/pkg/autoscaler/metrics/stats_scraper_test.go
+++ b/pkg/autoscaler/metrics/stats_scraper_test.go
@@ -31,7 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
-	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 
 	fakepodsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 
@@ -632,8 +632,8 @@ func serviceScraperForTest(ctx context.Context, t *testing.T, directClient, mesh
 	return ss
 }
 
-func testMetric() *av1alpha1.Metric {
-	return &av1alpha1.Metric{
+func testMetric() *autoscalingv1alpha1.Metric {
+	return &autoscalingv1alpha1.Metric{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
 			Name:      testRevision,
@@ -641,7 +641,7 @@ func testMetric() *av1alpha1.Metric {
 				serving.RevisionLabelKey: testRevision,
 			},
 		},
-		Spec: av1alpha1.MetricSpec{
+		Spec: autoscalingv1alpha1.MetricSpec{
 			StableWindow: time.Minute,
 			ScrapeTarget: testRevision + "-zhudex",
 		},

--- a/pkg/autoscaler/scaling/multiscaler.go
+++ b/pkg/autoscaler/scaling/multiscaler.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/logging/logkey"
-	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler/metrics"
 )
 
@@ -216,7 +216,7 @@ func (m *MultiScaler) Get(_ context.Context, namespace, name string) (*Decider, 
 	scaler, exists := m.scalers[key]
 	if !exists {
 		// This GroupResource is a lie, but unfortunately this interface requires one.
-		return nil, errors.NewNotFound(av1alpha1.Resource("Deciders"), key.String())
+		return nil, errors.NewNotFound(autoscalingv1alpha1.Resource("Deciders"), key.String())
 	}
 	return scaler.safeDecider(), nil
 }
@@ -252,7 +252,7 @@ func (m *MultiScaler) Update(_ context.Context, decider *Decider) (*Decider, err
 		return decider, nil
 	}
 	// This GroupResource is a lie, but unfortunately this interface requires one.
-	return nil, errors.NewNotFound(av1alpha1.Resource("Deciders"), key.String())
+	return nil, errors.NewNotFound(autoscalingv1alpha1.Resource("Deciders"), key.String())
 }
 
 // Delete stops and removes a Decider.

--- a/pkg/reconciler/autoscaling/hpa/controller.go
+++ b/pkg/reconciler/autoscaling/hpa/controller.go
@@ -35,7 +35,7 @@ import (
 	"knative.dev/pkg/controller"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/serving/pkg/apis/autoscaling"
-	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
@@ -86,7 +86,7 @@ func NewController(
 		Handler:    controller.HandleAll(impl.Enqueue),
 	})
 
-	onlyPAControlled := controller.FilterControllerGVK(av1alpha1.SchemeGroupVersion.WithKind("PodAutoscaler"))
+	onlyPAControlled := controller.FilterControllerGVK(autoscalingv1alpha1.SchemeGroupVersion.WithKind("PodAutoscaler"))
 	handleMatchingControllers := cache.FilteringResourceEventHandler{
 		FilterFunc: pkgreconciler.ChainFilterFuncs(onlyHPAClass, onlyPAControlled),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),

--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -29,7 +29,7 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
 	pkgreconciler "knative.dev/pkg/reconciler"
-	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	pareconciler "knative.dev/serving/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler"
 	areconciler "knative.dev/serving/pkg/reconciler/autoscaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
@@ -48,7 +48,7 @@ type Reconciler struct {
 var _ pareconciler.Interface = (*Reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
-func (c *Reconciler) ReconcileKind(ctx context.Context, pa *pav1alpha1.PodAutoscaler) pkgreconciler.Event {
+func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscaler) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 	logger.Debug("PA exists")
 

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -54,7 +54,7 @@ import (
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/apis/autoscaling"
-	asv1a1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
@@ -434,13 +434,13 @@ func key(namespace, name string) string {
 	return namespace + "/" + name
 }
 
-func pa(namespace, name string, options ...PodAutoscalerOption) *asv1a1.PodAutoscaler {
-	pa := &asv1a1.PodAutoscaler{
+func pa(namespace, name string, options ...PodAutoscalerOption) *autoscalingv1alpha1.PodAutoscaler {
+	pa := &autoscalingv1alpha1.PodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Spec: asv1a1.PodAutoscalerSpec{
+		Spec: autoscalingv1alpha1.PodAutoscalerSpec{
 			ScaleTargetRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
@@ -463,7 +463,7 @@ func withHPAOwnersRemoved(hpa *autoscalingv2beta1.HorizontalPodAutoscaler) {
 }
 
 func withScales(d, a int32) PodAutoscalerOption {
-	return func(pa *asv1a1.PodAutoscaler) {
+	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
 		pa.Status.DesiredScale, pa.Status.ActualScale = ptr.Int32(d), ptr.Int32(a)
 	}
 }
@@ -473,7 +473,7 @@ func withHPAScaleStatus(d, a int32) hpaOption {
 	}
 }
 
-func hpa(pa *asv1a1.PodAutoscaler, options ...hpaOption) *autoscalingv2beta1.HorizontalPodAutoscaler {
+func hpa(pa *autoscalingv1alpha1.PodAutoscaler, options ...hpaOption) *autoscalingv2beta1.HorizontalPodAutoscaler {
 	h := resources.MakeHPA(pa, defaultConfig().Autoscaler)
 	for _, o := range options {
 		o(h)

--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -37,7 +37,7 @@ import (
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/serving/pkg/apis/autoscaling"
-	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
 	"knative.dev/serving/pkg/deployment"
@@ -107,7 +107,7 @@ func NewController(
 		},
 	})
 
-	onlyPAControlled := controller.FilterControllerGVK(av1alpha1.SchemeGroupVersion.WithKind("PodAutoscaler"))
+	onlyPAControlled := controller.FilterControllerGVK(autoscalingv1alpha1.SchemeGroupVersion.WithKind("PodAutoscaler"))
 	handleMatchingControllers := cache.FilteringResourceEventHandler{
 		FilterFunc: pkgreconciler.ChainFilterFuncs(onlyKPAClass, onlyPAControlled),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -20,7 +20,7 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/types"
-	asv1a1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
 	"knative.dev/serving/pkg/autoscaler/scaling"
 	"knative.dev/serving/pkg/reconciler/autoscaling/resources"
@@ -47,7 +47,7 @@ type Deciders interface {
 // MakeDecider constructs a Decider resource from a PodAutoscaler taking
 // into account the PA's ContainerConcurrency and the relevant
 // autoscaling annotation.
-func MakeDecider(pa *asv1a1.PodAutoscaler, config *autoscalerconfig.Config) *scaling.Decider {
+func MakeDecider(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig.Config) *scaling.Decider {
 	panicThresholdPercentage := config.PanicThresholdPercentage
 	if x, ok := pa.PanicThresholdPercentage(); ok {
 		panicThresholdPercentage = x
@@ -80,14 +80,14 @@ func MakeDecider(pa *asv1a1.PodAutoscaler, config *autoscalerconfig.Config) *sca
 			StableWindow:        resources.StableWindow(pa, config),
 			ScaleDownDelay:      scaleDownDelay,
 			InitialScale:        GetInitialScale(config, pa),
-			Reachable:           pa.Spec.Reachability != asv1a1.ReachabilityUnreachable,
+			Reachable:           pa.Spec.Reachability != autoscalingv1alpha1.ReachabilityUnreachable,
 		},
 	}
 }
 
 // GetInitialScale returns the calculated initial scale based on the autoscaler
 // ConfigMap and PA initial scale annotation value.
-func GetInitialScale(asConfig *autoscalerconfig.Config, pa *asv1a1.PodAutoscaler) int32 {
+func GetInitialScale(asConfig *autoscalerconfig.Config, pa *autoscalingv1alpha1.PodAutoscaler) int32 {
 	initialScale := asConfig.InitialScale
 	revisionInitialScale, ok := pa.InitialScale()
 	if !ok || (revisionInitialScale == 0 && !asConfig.AllowZeroInitialScale) {

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -24,7 +24,7 @@ import (
 	netclientset "knative.dev/networking/pkg/client/clientset/versioned"
 	nlisters "knative.dev/networking/pkg/client/listers/networking/v1alpha1"
 	"knative.dev/pkg/logging"
-	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
 	listers "knative.dev/serving/pkg/client/listers/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
@@ -45,7 +45,7 @@ type Base struct {
 }
 
 // ReconcileSKS reconciles a ServerlessService based on the given PodAutoscaler.
-func (c *Base) ReconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler,
+func (c *Base) ReconcileSKS(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscaler,
 	mode nv1alpha1.ServerlessServiceOperationMode, numActivators int32) (*nv1alpha1.ServerlessService, error) {
 	logger := logging.FromContext(ctx)
 
@@ -79,7 +79,7 @@ func (c *Base) ReconcileSKS(ctx context.Context, pa *pav1alpha1.PodAutoscaler,
 }
 
 // ReconcileMetric reconciles a metric instance out of the given PodAutoscaler to control metric collection.
-func (c *Base) ReconcileMetric(ctx context.Context, pa *pav1alpha1.PodAutoscaler, metricSN string) error {
+func (c *Base) ReconcileMetric(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscaler, metricSN string) error {
 	desiredMetric := resources.MakeMetric(pa, metricSN, config.FromContext(ctx).Autoscaler)
 	metric, err := c.MetricLister.Metrics(desiredMetric.Namespace).Get(desiredMetric.Name)
 	if errors.IsNotFound(err) {

--- a/pkg/reconciler/autoscaling/resources/sks.go
+++ b/pkg/reconciler/autoscaling/resources/sks.go
@@ -21,12 +21,12 @@ import (
 	nv1a1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/autoscaling"
-	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/reconciler/autoscaling/resources/names"
 )
 
 // MakeSKS makes an SKS resource from the PA and operation mode.
-func MakeSKS(pa *pav1alpha1.PodAutoscaler, mode nv1a1.ServerlessServiceOperationMode, numActivators int32) *nv1a1.ServerlessService {
+func MakeSKS(pa *autoscalingv1alpha1.PodAutoscaler, mode nv1a1.ServerlessServiceOperationMode, numActivators int32) *nv1a1.ServerlessService {
 	return &nv1a1.ServerlessService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      names.SKS(pa.Name),

--- a/pkg/reconciler/autoscaling/resources/sks_test.go
+++ b/pkg/reconciler/autoscaling/resources/sks_test.go
@@ -25,13 +25,13 @@ import (
 	"knative.dev/networking/pkg/apis/networking"
 	nv1a1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/ptr"
-	pav1a1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 )
 
 // MakeSKS makes an SKS resource from the PA, selector and operation mode.
 func TestMakeSKS(t *testing.T) {
-	pa := &pav1a1.PodAutoscaler{
+	pa := &autoscalingv1alpha1.PodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "here",
 			Name:      "with-you",
@@ -45,7 +45,7 @@ func TestMakeSKS(t *testing.T) {
 				"a": "b",
 			},
 		},
-		Spec: pav1a1.PodAutoscalerSpec{
+		Spec: autoscalingv1alpha1.PodAutoscalerSpec{
 			ProtocolType: networking.ProtocolHTTP1,
 			ScaleTargetRef: corev1.ObjectReference{
 				APIVersion: "apps/v1",
@@ -71,7 +71,7 @@ func TestMakeSKS(t *testing.T) {
 				"a": "b",
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         pav1a1.SchemeGroupVersion.String(),
+				APIVersion:         autoscalingv1alpha1.SchemeGroupVersion.String(),
 				Kind:               "PodAutoscaler",
 				Name:               "with-you",
 				UID:                "2006",

--- a/pkg/reconciler/metric/metric_test.go
+++ b/pkg/reconciler/metric/metric_test.go
@@ -36,7 +36,7 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
-	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/autoscaler/metrics"
 	servingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	metricreconciler "knative.dev/serving/pkg/client/injection/reconciler/autoscaling/v1alpha1/metric"
@@ -225,31 +225,31 @@ func TestReconcileWithCollector(t *testing.T) {
 	}
 }
 
-type metricOption func(*av1alpha1.Metric)
+type metricOption func(*autoscalingv1alpha1.Metric)
 
 func failed(r, m string) metricOption {
-	return func(metric *av1alpha1.Metric) {
+	return func(metric *autoscalingv1alpha1.Metric) {
 		metric.Status.MarkMetricFailed(r, m)
 	}
 }
 
 func unknown(r, m string) metricOption {
-	return func(metric *av1alpha1.Metric) {
+	return func(metric *autoscalingv1alpha1.Metric) {
 		metric.Status.MarkMetricNotReady(r, m)
 	}
 }
 
-func ready(m *av1alpha1.Metric) {
+func ready(m *autoscalingv1alpha1.Metric) {
 	m.Status.MarkMetricReady()
 }
 
-func metric(namespace, name string, opts ...metricOption) *av1alpha1.Metric {
-	m := &av1alpha1.Metric{
+func metric(namespace, name string, opts ...metricOption) *autoscalingv1alpha1.Metric {
+	m := &autoscalingv1alpha1.Metric{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
 		},
-		Spec: av1alpha1.MetricSpec{
+		Spec: autoscalingv1alpha1.MetricSpec{
 			// Doesn't really matter what is by default, but we need something, so that
 			// Spec is not empty.
 			StableWindow: time.Minute,
@@ -269,7 +269,7 @@ type testCollector struct {
 	deleteCalls atomic.Int32
 }
 
-func (c *testCollector) CreateOrUpdate(metric *av1alpha1.Metric) error {
+func (c *testCollector) CreateOrUpdate(metric *autoscalingv1alpha1.Metric) error {
 	c.createOrUpdateCalls.Inc()
 	return c.createOrUpdateError
 }

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -28,7 +28,7 @@ import (
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
-	autoscaling "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler/revision/config"
 	"knative.dev/serving/pkg/reconciler/revision/resources"
@@ -99,7 +99,7 @@ func (c *Reconciler) createImageCache(ctx context.Context, rev *v1.Revision, con
 	return c.cachingclient.CachingV1alpha1().Images(image.Namespace).Create(ctx, image, metav1.CreateOptions{})
 }
 
-func (c *Reconciler) createPA(ctx context.Context, rev *v1.Revision) (*autoscaling.PodAutoscaler, error) {
+func (c *Reconciler) createPA(ctx context.Context, rev *v1.Revision) (*autoscalingv1alpha1.PodAutoscaler, error) {
 	pa := resources.MakePA(rev)
 	return c.client.AutoscalingV1alpha1().PodAutoscalers(pa.Namespace).Create(ctx, pa, metav1.CreateOptions{})
 }

--- a/pkg/reconciler/revision/resources/pa_test.go
+++ b/pkg/reconciler/revision/resources/pa_test.go
@@ -25,7 +25,7 @@ import (
 
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/ptr"
-	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
@@ -34,7 +34,7 @@ func TestMakePA(t *testing.T) {
 	tests := []struct {
 		name string
 		rev  *v1.Revision
-		want *av1alpha1.PodAutoscaler
+		want *autoscalingv1alpha1.PodAutoscaler
 	}{{
 		name: "name is bar (Concurrency=1, Reachable=true)",
 		rev: func() *v1.Revision {
@@ -57,7 +57,7 @@ func TestMakePA(t *testing.T) {
 			rev.Status.MarkActiveTrue()
 			return &rev
 		}(),
-		want: &av1alpha1.PodAutoscaler{
+		want: &autoscalingv1alpha1.PodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
 				Name:      "bar",
@@ -78,7 +78,7 @@ func TestMakePA(t *testing.T) {
 					BlockOwnerDeletion: ptr.Bool(true),
 				}},
 			},
-			Spec: av1alpha1.PodAutoscalerSpec{
+			Spec: autoscalingv1alpha1.PodAutoscalerSpec{
 				ContainerConcurrency: 1,
 				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
@@ -86,7 +86,7 @@ func TestMakePA(t *testing.T) {
 					Name:       "bar-deployment",
 				},
 				ProtocolType: networking.ProtocolHTTP1,
-				Reachability: av1alpha1.ReachabilityReachable,
+				Reachability: autoscalingv1alpha1.ReachabilityReachable,
 			},
 		},
 	}, {
@@ -113,7 +113,7 @@ func TestMakePA(t *testing.T) {
 			rev.Status.MarkActiveTrue()
 			return &rev
 		}(),
-		want: &av1alpha1.PodAutoscaler{
+		want: &autoscalingv1alpha1.PodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "blah",
 				Name:      "baz",
@@ -132,7 +132,7 @@ func TestMakePA(t *testing.T) {
 					BlockOwnerDeletion: ptr.Bool(true),
 				}},
 			},
-			Spec: av1alpha1.PodAutoscalerSpec{
+			Spec: autoscalingv1alpha1.PodAutoscalerSpec{
 				ContainerConcurrency: 0,
 				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
@@ -140,7 +140,7 @@ func TestMakePA(t *testing.T) {
 					Name:       "baz-deployment",
 				},
 				ProtocolType: networking.ProtocolH2C,
-				Reachability: av1alpha1.ReachabilityUnreachable,
+				Reachability: autoscalingv1alpha1.ReachabilityUnreachable,
 			}},
 	}, {
 		name: "name is baz (Concurrency=0, Reachable=false, Activating)",
@@ -166,7 +166,7 @@ func TestMakePA(t *testing.T) {
 			rev.Status.MarkActiveUnknown("reasons", "because")
 			return &rev
 		}(),
-		want: &av1alpha1.PodAutoscaler{
+		want: &autoscalingv1alpha1.PodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "blah",
 				Name:      "baz",
@@ -185,7 +185,7 @@ func TestMakePA(t *testing.T) {
 					BlockOwnerDeletion: ptr.Bool(true),
 				}},
 			},
-			Spec: av1alpha1.PodAutoscalerSpec{
+			Spec: autoscalingv1alpha1.PodAutoscalerSpec{
 				ContainerConcurrency: 0,
 				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
@@ -193,7 +193,7 @@ func TestMakePA(t *testing.T) {
 					Name:       "baz-deployment",
 				},
 				ProtocolType: networking.ProtocolH2C,
-				Reachability: av1alpha1.ReachabilityUnknown,
+				Reachability: autoscalingv1alpha1.ReachabilityUnknown,
 			}},
 	}, {
 		name: "name is batman (Activating, Revision failed)",
@@ -220,7 +220,7 @@ func TestMakePA(t *testing.T) {
 			rev.Status.MarkResourcesAvailableFalse("foo", "bar")
 			return &rev
 		}(),
-		want: &av1alpha1.PodAutoscaler{
+		want: &autoscalingv1alpha1.PodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "blah",
 				Name:      "batman",
@@ -239,7 +239,7 @@ func TestMakePA(t *testing.T) {
 					BlockOwnerDeletion: ptr.Bool(true),
 				}},
 			},
-			Spec: av1alpha1.PodAutoscalerSpec{
+			Spec: autoscalingv1alpha1.PodAutoscalerSpec{
 				ContainerConcurrency: 0,
 				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
@@ -248,7 +248,7 @@ func TestMakePA(t *testing.T) {
 				},
 				ProtocolType: networking.ProtocolH2C,
 				// When the Revision has failed, we mark the PA as unreachable.
-				Reachability: av1alpha1.ReachabilityUnreachable,
+				Reachability: autoscalingv1alpha1.ReachabilityUnreachable,
 			}},
 	}, {
 		name: "name is robin (Activating, Revision routable but failed)",
@@ -278,7 +278,7 @@ func TestMakePA(t *testing.T) {
 			rev.Status.MarkResourcesAvailableFalse("foo", "bar")
 			return &rev
 		}(),
-		want: &av1alpha1.PodAutoscaler{
+		want: &autoscalingv1alpha1.PodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "blah",
 				Name:      "robin",
@@ -297,7 +297,7 @@ func TestMakePA(t *testing.T) {
 					BlockOwnerDeletion: ptr.Bool(true),
 				}},
 			},
-			Spec: av1alpha1.PodAutoscalerSpec{
+			Spec: autoscalingv1alpha1.PodAutoscalerSpec{
 				ContainerConcurrency: 0,
 				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
@@ -306,7 +306,7 @@ func TestMakePA(t *testing.T) {
 				},
 				ProtocolType: networking.ProtocolH2C,
 				// Reachability trumps failure of Revisions.
-				Reachability: av1alpha1.ReachabilityUnknown,
+				Reachability: autoscalingv1alpha1.ReachabilityUnknown,
 			}},
 	}}
 

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -58,7 +58,7 @@ import (
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	tracingconfig "knative.dev/pkg/tracing/config"
-	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -190,7 +190,7 @@ func updateRevision(
 	}
 }
 
-func addResourcesToInformers(t *testing.T, ctx context.Context, rev *v1.Revision) (*v1.Revision, *appsv1.Deployment, *av1alpha1.PodAutoscaler) {
+func addResourcesToInformers(t *testing.T, ctx context.Context, rev *v1.Revision) (*v1.Revision, *appsv1.Deployment, *autoscalingv1alpha1.PodAutoscaler) {
 	t.Helper()
 
 	rev, err := fakeservingclient.Get(ctx).ServingV1().Revisions(rev.Namespace).Get(ctx, rev.Name, metav1.GetOptions{})

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -38,7 +38,7 @@ import (
 	"knative.dev/pkg/metrics"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	tracingconfig "knative.dev/pkg/tracing/config"
-	asv1a1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	defaultconfig "knative.dev/serving/pkg/apis/config"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
@@ -767,7 +767,7 @@ func image(namespace, name string, co ...configOption) *caching.Image {
 	return resources.MakeImageCache(Revision(namespace, name), name, "")
 }
 
-func pa(namespace, name string, ko ...PodAutoscalerOption) *asv1a1.PodAutoscaler {
+func pa(namespace, name string, ko ...PodAutoscalerOption) *autoscalingv1alpha1.PodAutoscaler {
 	rev := Revision(namespace, name)
 	k := resources.MakePA(rev)
 

--- a/pkg/reconciler/testing/v1/listers.go
+++ b/pkg/reconciler/testing/v1/listers.go
@@ -33,7 +33,7 @@ import (
 	fakenetworkingclientset "knative.dev/networking/pkg/client/clientset/versioned/fake"
 	networkinglisters "knative.dev/networking/pkg/client/listers/networking/v1alpha1"
 	"knative.dev/pkg/reconciler/testing"
-	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	fakeservingclientset "knative.dev/serving/pkg/client/clientset/versioned/fake"
@@ -140,12 +140,12 @@ func (l *Listers) GetRevisionLister() servinglisters.RevisionLister {
 
 // GetPodAutoscalerLister gets the PodAutoscaler lister.
 func (l *Listers) GetPodAutoscalerLister() palisters.PodAutoscalerLister {
-	return palisters.NewPodAutoscalerLister(l.IndexerFor(&av1alpha1.PodAutoscaler{}))
+	return palisters.NewPodAutoscalerLister(l.IndexerFor(&autoscalingv1alpha1.PodAutoscaler{}))
 }
 
 // GetMetricLister returns a lister for the Metric objects.
 func (l *Listers) GetMetricLister() palisters.MetricLister {
-	return palisters.NewMetricLister(l.IndexerFor(&av1alpha1.Metric{}))
+	return palisters.NewMetricLister(l.IndexerFor(&autoscalingv1alpha1.Metric{}))
 }
 
 // GetHorizontalPodAutoscalerLister gets lister for HorizontalPodAutoscaler resources.

--- a/pkg/resources/scale.go
+++ b/pkg/resources/scale.go
@@ -22,7 +22,7 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
-	pav1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,7 +40,7 @@ func ScaleResourceArguments(ref corev1.ObjectReference) (gvr *schema.GroupVersio
 
 // GetScaleResource returns the current scale resource for the PA.
 // TODO(markusthoemmes): We shouldn't need to pass namespace here.
-func GetScaleResource(ctx context.Context, namespace string, ref corev1.ObjectReference, psInformerFactory duck.InformerFactory) (*pav1alpha1.PodScalable, error) {
+func GetScaleResource(ctx context.Context, namespace string, ref corev1.ObjectReference, psInformerFactory duck.InformerFactory) (*autoscalingv1alpha1.PodScalable, error) {
 	gvr, name, err := ScaleResourceArguments(ref)
 	if err != nil {
 		return nil, fmt.Errorf("error getting the scale arguments: %w", err)
@@ -54,5 +54,5 @@ func GetScaleResource(ctx context.Context, namespace string, ref corev1.ObjectRe
 	if err != nil {
 		return nil, fmt.Errorf("error fetching Pod Scalable %s/%s: %w", namespace, name, err)
 	}
-	return psObj.(*pav1alpha1.PodScalable), nil
+	return psObj.(*autoscalingv1alpha1.PodScalable), nil
 }

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -28,98 +28,98 @@ import (
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/autoscaling"
-	asv1a1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 )
 
 // PodAutoscalerOption is an option that can be applied to a PA.
-type PodAutoscalerOption func(*asv1a1.PodAutoscaler)
+type PodAutoscalerOption func(*autoscalingv1alpha1.PodAutoscaler)
 
 // WithProtocolType sets the protocol type on the PodAutoscaler.
 func WithProtocolType(pt networking.ProtocolType) PodAutoscalerOption {
-	return func(pa *asv1a1.PodAutoscaler) {
+	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
 		pa.Spec.ProtocolType = pt
 	}
 }
 
 // WithReachability sets the reachability of the PodAutoscaler to the given value.
-func WithReachability(r asv1a1.ReachabilityType) PodAutoscalerOption {
-	return func(pa *asv1a1.PodAutoscaler) {
+func WithReachability(r autoscalingv1alpha1.ReachabilityType) PodAutoscalerOption {
+	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
 		pa.Spec.Reachability = r
 	}
 }
 
 // WithReachabilityUnknown sets the reachability of the PodAutoscaler to unknown.
-func WithReachabilityUnknown(pa *asv1a1.PodAutoscaler) {
-	WithReachability(asv1a1.ReachabilityUnknown)(pa)
+func WithReachabilityUnknown(pa *autoscalingv1alpha1.PodAutoscaler) {
+	WithReachability(autoscalingv1alpha1.ReachabilityUnknown)(pa)
 }
 
 // WithReachabilityReachable sets the reachability of the PodAutoscaler to reachable.
-func WithReachabilityReachable(pa *asv1a1.PodAutoscaler) {
-	WithReachability(asv1a1.ReachabilityReachable)(pa)
+func WithReachabilityReachable(pa *autoscalingv1alpha1.PodAutoscaler) {
+	WithReachability(autoscalingv1alpha1.ReachabilityReachable)(pa)
 }
 
 // WithReachabilityUnreachable sets the reachability of the PodAutoscaler to unreachable.
-func WithReachabilityUnreachable(pa *asv1a1.PodAutoscaler) {
-	WithReachability(asv1a1.ReachabilityUnreachable)(pa)
+func WithReachabilityUnreachable(pa *autoscalingv1alpha1.PodAutoscaler) {
+	WithReachability(autoscalingv1alpha1.ReachabilityUnreachable)(pa)
 }
 
 // WithPAOwnersRemoved clears the owner references of this PA resource.
-func WithPAOwnersRemoved(pa *asv1a1.PodAutoscaler) {
+func WithPAOwnersRemoved(pa *autoscalingv1alpha1.PodAutoscaler) {
 	pa.OwnerReferences = nil
 }
 
 // MarkResourceNotOwnedByPA marks PA as not owning a resource it is supposed to own.
 func MarkResourceNotOwnedByPA(rType, name string) PodAutoscalerOption {
-	return func(pa *asv1a1.PodAutoscaler) {
+	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
 		pa.Status.MarkResourceNotOwned(rType, name)
 	}
 }
 
 // WithPodAutoscalerOwnersRemoved clears the owner references of this PodAutoscaler.
-func WithPodAutoscalerOwnersRemoved(r *asv1a1.PodAutoscaler) {
+func WithPodAutoscalerOwnersRemoved(r *autoscalingv1alpha1.PodAutoscaler) {
 	r.OwnerReferences = nil
 }
 
 // WithTraffic updates the PA to reflect it receiving traffic.
-func WithTraffic(pa *asv1a1.PodAutoscaler) {
+func WithTraffic(pa *autoscalingv1alpha1.PodAutoscaler) {
 	pa.Status.MarkActive()
 }
 
 // WithPASKSReady marks PA status that SKS is ready.
-func WithPASKSReady(pa *asv1a1.PodAutoscaler) {
+func WithPASKSReady(pa *autoscalingv1alpha1.PodAutoscaler) {
 	pa.Status.MarkSKSReady()
 }
 
 // WithPASKSNotReady marks PA status that SKS is not ready.
 func WithPASKSNotReady(m string) PodAutoscalerOption {
-	return func(pa *asv1a1.PodAutoscaler) {
+	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
 		pa.Status.MarkSKSNotReady(m)
 	}
 }
 
 // WithScaleTargetInitialized updates the PA to reflect it having initialized its
 // ScaleTarget.
-func WithScaleTargetInitialized(pa *asv1a1.PodAutoscaler) {
+func WithScaleTargetInitialized(pa *autoscalingv1alpha1.PodAutoscaler) {
 	pa.Status.MarkScaleTargetInitialized()
 }
 
 // WithPAStatusService annotates PA Status with the provided service name.
 func WithPAStatusService(svc string) PodAutoscalerOption {
-	return func(pa *asv1a1.PodAutoscaler) {
+	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
 		pa.Status.ServiceName = svc
 	}
 }
 
 // WithPAMetricsService annotates PA Status with the provided service name.
 func WithPAMetricsService(svc string) PodAutoscalerOption {
-	return func(pa *asv1a1.PodAutoscaler) {
+	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
 		pa.Status.MetricsServiceName = svc
 	}
 }
 
 // WithBufferedTraffic updates the PA to reflect that it has received
 // and buffered traffic while it is being activated.
-func WithBufferedTraffic(pa *asv1a1.PodAutoscaler) {
+func WithBufferedTraffic(pa *autoscalingv1alpha1.PodAutoscaler) {
 	pa.Status.MarkActivating("Queued",
 		"Requests to the target are being buffered as resources are provisioned.")
 }
@@ -127,19 +127,19 @@ func WithBufferedTraffic(pa *asv1a1.PodAutoscaler) {
 // WithNoTraffic updates the PA to reflect the fact that it is not
 // receiving traffic.
 func WithNoTraffic(reason, message string) PodAutoscalerOption {
-	return func(pa *asv1a1.PodAutoscaler) {
+	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
 		pa.Status.MarkInactive(reason, message)
 	}
 }
 
 // WithPADeletionTimestamp will set the DeletionTimestamp on the PodAutoscaler.
-func WithPADeletionTimestamp(r *asv1a1.PodAutoscaler) {
+func WithPADeletionTimestamp(r *autoscalingv1alpha1.PodAutoscaler) {
 	t := metav1.NewTime(time.Unix(1e9, 0))
 	r.ObjectMeta.SetDeletionTimestamp(&t)
 }
 
 // WithHPAClass updates the PA to add the hpa class annotation.
-func WithHPAClass(pa *asv1a1.PodAutoscaler) {
+func WithHPAClass(pa *autoscalingv1alpha1.PodAutoscaler) {
 	if pa.Annotations == nil {
 		pa.Annotations = make(map[string]string, 1)
 	}
@@ -149,13 +149,13 @@ func WithHPAClass(pa *asv1a1.PodAutoscaler) {
 // WithPAContainerConcurrency returns a PodAutoscalerOption which sets
 // the PodAutoscaler containerConcurrency to the provided value.
 func WithPAContainerConcurrency(cc int64) PodAutoscalerOption {
-	return func(pa *asv1a1.PodAutoscaler) {
+	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
 		pa.Spec.ContainerConcurrency = cc
 	}
 }
 
 func withAnnotationValue(key, value string) PodAutoscalerOption {
-	return func(pa *asv1a1.PodAutoscaler) {
+	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
 		if pa.Annotations == nil {
 			pa.Annotations = make(map[string]string, 1)
 		}
@@ -208,13 +208,13 @@ func WithMetricAnnotation(metric string) PodAutoscalerOption {
 // WithObservedGeneration returns a PodAutoScalerOption which sets
 // the Status.ObservedGeneration field to the given generation.
 func WithObservedGeneration(gen int64) PodAutoscalerOption {
-	return func(pa *asv1a1.PodAutoscaler) {
+	return func(pa *autoscalingv1alpha1.PodAutoscaler) {
 		pa.Status.ObservedGeneration = gen
 	}
 }
 
 // WithMetricOwnersRemoved clears the owner references of this PodAutoscaler.
-func WithMetricOwnersRemoved(m *asv1a1.Metric) {
+func WithMetricOwnersRemoved(m *autoscalingv1alpha1.Metric) {
 	m.OwnerReferences = nil
 }
 

--- a/test/performance/benchmarks/deployment-probe/continuous/main.go
+++ b/test/performance/benchmarks/deployment-probe/continuous/main.go
@@ -43,7 +43,7 @@ import (
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	networkingclient "knative.dev/networking/pkg/client/injection/client"
 	"knative.dev/pkg/test/mako"
-	asv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 )
@@ -284,7 +284,7 @@ func main() {
 					// Skip events other than modifications
 					break
 				}
-				pa := event.Object.(*asv1alpha1.PodAutoscaler)
+				pa := event.Object.(*autoscalingv1alpha1.PodAutoscaler)
 				handle(q, pa, pa.Status.Status, paSeen, "pal")
 			}
 		}


### PR DESCRIPTION
Monday pedantry/cleanup!

Currently we have the same package aliased as: `av1alpha1`, `asv1a1`,
`pav1alpha1`, `pav1a1`, `asv1alpha1`, `autoscaling`, and
`autoscalingv1alpha1`. I picked `autoscalingv1alpha1` to be consistent.
It's a bit long, but it's the concatenation of the last two packages in
the path so at least there's some logic to it.

(I made a [little linter/fixer to do this](http://github.com/julz/importas) for a bit of fun last week, so if anyone
wants to bike-shed on the name it's super easy to regenerate this).

/assign @markusthoemmes @vagababov 