### PR TITLE
Perform some test helper cleanup

### DIFF
--- a/pkg/testing/v1/revision.go
+++ b/pkg/testing/v1/revision.go
@@ -49,13 +49,6 @@ func WithRevName(name string) RevisionOption {
 	}
 }
 
-// WithServiceName propagates the given service name to the revision status.
-func WithServiceName(sn string) RevisionOption {
-	return func(rev *v1.Revision) {
-		rev.Status.ServiceName = sn
-	}
-}
-
 // MarkResourceNotOwned calls the function of the same name on the Revision's status.
 func MarkResourceNotOwned(kind, name string) RevisionOption {
 	return func(rev *v1.Revision) {

--- a/test/conformance/api/v1/route_test.go
+++ b/test/conformance/api/v1/route_test.go
@@ -143,7 +143,7 @@ func TestRouteCreation(t *testing.T) {
 	defer test.AssertProberDefault(t, prober)
 
 	t.Log("Updating the Configuration to use a different image")
-	objects.Config, err = v1test.PatchConfig(t, clients, objects.Config, WithConfigImage(pkgTest.ImagePath(test.PizzaPlanet2)))
+	objects.Config, err = v1test.PatchConfig(t, clients, objects.Config, withConfigImage(pkgTest.ImagePath(test.PizzaPlanet2)))
 	if err != nil {
 		t.Fatalf("Patch update for Configuration %s with new image %s failed: %v", names.Config, test.PizzaPlanet2, err)
 	}

--- a/test/conformance/api/v1/route_test.go
+++ b/test/conformance/api/v1/route_test.go
@@ -26,6 +26,7 @@ import (
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 	v1test "knative.dev/serving/test/v1"
 )
@@ -157,7 +158,7 @@ func TestRouteCreation(t *testing.T) {
 }
 
 // withConfigImage sets the container image to be the provided string.
-func withConfigImage(img string) ConfigOption {
+func withConfigImage(img string) rtesting.ConfigOption {
 	return func(cfg *v1.Configuration) {
 		cfg.Spec.Template.Spec.Containers[0].Image = img
 	}

--- a/test/conformance/api/v1/route_test.go
+++ b/test/conformance/api/v1/route_test.go
@@ -28,8 +28,6 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/test"
 	v1test "knative.dev/serving/test/v1"
-
-	rtesting "knative.dev/serving/pkg/testing/v1"
 )
 
 func assertResourcesUpdatedWhenRevisionIsReady(t *testing.T, clients *test.Clients, names test.ResourceNames, url *url.URL, expectedGeneration, expectedText string) {
@@ -144,7 +142,7 @@ func TestRouteCreation(t *testing.T) {
 	defer test.AssertProberDefault(t, prober)
 
 	t.Log("Updating the Configuration to use a different image")
-	objects.Config, err = v1test.PatchConfig(t, clients, objects.Config, rtesting.WithConfigImage(pkgTest.ImagePath(test.PizzaPlanet2)))
+	objects.Config, err = v1test.PatchConfig(t, clients, objects.Config, WithConfigImage(pkgTest.ImagePath(test.PizzaPlanet2)))
 	if err != nil {
 		t.Fatalf("Patch update for Configuration %s with new image %s failed: %v", names.Config, test.PizzaPlanet2, err)
 	}
@@ -156,4 +154,11 @@ func TestRouteCreation(t *testing.T) {
 	}
 
 	assertResourcesUpdatedWhenRevisionIsReady(t, clients, names, url, "2", test.PizzaPlanetText2)
+}
+
+// withConfigImage sets the container image to be the provided string.
+func withConfigImage(img string) ConfigOption {
+	return func(cfg *v1.Configuration) {
+		cfg.Spec.Template.Spec.Containers[0].Image = img
+	}
 }

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -192,17 +192,14 @@ func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 			revisionName = s.Status.LatestCreatedRevisionName
 			// Without this it might happen that the latest created revision is later overridden by a newer one
 			// and the following check for LatestReadyRevisionName would fail.
-			if revErr := CheckRevisionState(clients.ServingClient, revisionName, IsRevisionRoutingActive); revErr != nil {
-				return false, nil
-			}
-			return true, nil
+			return CheckRevisionState(clients.ServingClient, revisionName, IsRevisionRoutingActive) == nil, nil
 		}
 		return false, nil
 	}, "ServiceUpdatedWithRevision"); err != nil {
 		return "", fmt.Errorf("LatestCreatedRevisionName not updated: %w", err)
 	}
 	if err := WaitForServiceState(clients.ServingClient, names.Service, func(s *v1.Service) (bool, error) {
-		return (s.Status.LatestReadyRevisionName == revisionName), nil
+		return s.Status.LatestReadyRevisionName == revisionName, nil
 	}, "ServiceReadyWithRevision"); err != nil {
 		return "", fmt.Errorf("LatestReadyRevisionName not updated with %s: %w", revisionName, err)
 	}


### PR DESCRIPTION
Remove unused or move single used items closer to invocation, reduces our public method footprint.

Improve the code flow in the e2e tests.

/assign @dprotaso @tcnghia 