### PR TITLE
Allow to specify build platform for test images

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -144,6 +144,10 @@ To run the script for all end to end test images:
 A docker tag may be passed as an optional parameter. This can be useful on
 Minikube in tandem with the `--tag` [flag](#using-a-docker-tag):
 
+`PLATFORM` environment variable is optional. If it is specified, test images
+will be built for specific hardware architecture, according to its value
+(for instance,`linux/arm64`).
+
 ```bash
 eval $(minikube docker-env)
 ./test/upload-test-images.sh any-old-tag

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -28,10 +28,18 @@ function upload_test_images() {
     tag_option="--tags $docker_tag,latest"
   fi
 
+  # If PLATFORM environment variable is specified, then images will be built for
+  # specific hardware architecture.
+  # Example of the variable values - "linux/arm64", "linux/s390x".
+  local platform=""
+  if [ -n "${PLATFORM}" ]; then
+    platform="--platform ${PLATFORM}"
+  fi
+
   # ko resolve is being used for the side-effect of publishing images,
   # so the resulting yaml produced is ignored.
   # We limit the number of concurrent builds (jobs) to avoid OOMs.
-  ko resolve --jobs=4 ${tag_option} -RBf "${image_dir}" > /dev/null
+  ko resolve --jobs=4 ${platform} ${tag_option} -RBf "${image_dir}" > /dev/null
 }
 
 : ${KO_DOCKER_REPO:?"You must set 'KO_DOCKER_REPO', see DEVELOPMENT.md"}


### PR DESCRIPTION
This is an echo of the https://github.com/knative/eventing/pull/4763 for serving. The test images are built and uploaded without a break on other architectures by specifying a `PLATFORM` env variable.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add a description to test/README.md
* Add a local variable `platform` (empty by default) which can be set by an environment variable `PLATFORM` at test/upload-test-images.sh
