### PR TITLE
Cache the generic listers when they are returned.

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -603,7 +603,8 @@ func TestDisableScaleToZero(t *testing.T) {
 			conf := defaultConfig()
 			conf.Autoscaler.EnableScaleToZero = false
 			ctx = config.ToContext(ctx, conf)
-			desiredScale, err := revisionScaler.scale(ctx, pa, nil /*sks doesn't matter in this test*/, test.scaleTo)
+			desiredScale, err := revisionScaler.scale(
+				ctx, pa, nil /*sks doesn't matter in this test*/, test.scaleTo)
 
 			if err != nil {
 				t.Error("Scale got an unexpected error:", err)

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -231,7 +231,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantErr: true,
 		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", `error retrieving deployment selector spec: error fetching Pod Scalable on/blah: deployments.apps "blah" not found`),
+			Eventf(corev1.EventTypeWarning, "InternalError", `error retrieving deployment selector spec: error fetching pod scalable on/blah: deployments.apps "blah" not found`),
 		},
 	}, {
 		Name: "OnCreate-deployment-exists",

--- a/pkg/resources/scale.go
+++ b/pkg/resources/scale.go
@@ -51,7 +51,7 @@ func GetScaleResource(namespace string, ref corev1.ObjectReference, listerFactor
 
 	psObj, err := lister.ByNamespace(namespace).Get(name)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching Pod Scalable %s/%s: %w", namespace, name, err)
+		return nil, fmt.Errorf("error fetching pod scalable %s/%s: %w", namespace, name, err)
 	}
 	return psObj.(*autoscalingv1alpha1.PodScalable), nil
 }


### PR DESCRIPTION
For all intents and purposes there is going to be just a single element
and there is no reason to iterate the linked list of context values to
get the same value each time.

/assign @julz @markusthoemmes 