### PR TITLE
Move TestServiceCreateWithMultipleContainers test to Beta

### DIFF
--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -590,7 +590,7 @@ func TestAnnotationPropagation(t *testing.T) {
 // TestServiceCreateWithMultipleContainers tests both Creation paths for a service.
 // The test performs a series of Validate steps to ensure that the service transitions as expected during each step.
 func TestServiceCreateWithMultipleContainers(t *testing.T) {
-	if !test.ServingFlags.EnableAlphaFeatures {
+	if !test.ServingFlags.EnableBetaFeatures {
 		t.Skip()
 	}
 	t.Parallel()


### PR DESCRIPTION
As per [docs](https://knative.dev/docs/serving/feature-flags/#feature),

> Alpha = Disabled by default.
> Beta = Enabled by default.
> GA = The feature is always enabled; you cannot disable it.

Multi container is enabled by default but the feature can be disabled.
So the test should be covered by Beta flag.

/cc @savitaashture @dprotaso  
