### PR TITLE
Temporarily disable auto TLS test with HTTP01 challenge 

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -210,7 +210,7 @@ add_trap "cleanup_per_selfsigned_namespace_auto_tls" SIGKILL SIGTERM SIGQUIT
 go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
 cleanup_per_selfsigned_namespace_auto_tls
 
-# TODO(ZhiminXiang): resume the HTTP01 E2E tests after figuring out the DNS setup failure.
+# TODO(#10486): resume the HTTP01 E2E tests after figuring out the DNS setup failure.
 
 # subheader "Auto TLS test for per-ksvc certificate provision using HTTP01 challenge"
 # setup_http01_auto_tls

--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -210,7 +210,7 @@ add_trap "cleanup_per_selfsigned_namespace_auto_tls" SIGKILL SIGTERM SIGQUIT
 go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
 cleanup_per_selfsigned_namespace_auto_tls
 
-# TODO(ZhiminXiang): resume the HTTP01 E2E tests after figuring out the DNS setup failure. 
+# TODO(ZhiminXiang): resume the HTTP01 E2E tests after figuring out the DNS setup failure.
 
 # subheader "Auto TLS test for per-ksvc certificate provision using HTTP01 challenge"
 # setup_http01_auto_tls

--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -210,12 +210,14 @@ add_trap "cleanup_per_selfsigned_namespace_auto_tls" SIGKILL SIGTERM SIGQUIT
 go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
 cleanup_per_selfsigned_namespace_auto_tls
 
-subheader "Auto TLS test for per-ksvc certificate provision using HTTP01 challenge"
-setup_http01_auto_tls
-add_trap "delete_dns_record" SIGKILL SIGTERM SIGQUIT
-go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
-kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
-delete_dns_record
+# TODO(ZhiminXiang): resume the HTTP01 E2E tests after figuring out the DNS setup failure. 
+
+# subheader "Auto TLS test for per-ksvc certificate provision using HTTP01 challenge"
+# setup_http01_auto_tls
+# add_trap "delete_dns_record" SIGKILL SIGTERM SIGQUIT
+# go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
+# kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
+# delete_dns_record
 
 (( failed )) && fail_test
 


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*  Temporarily disable auto TLS test with HTTP01 challenge  in order to unblock presubmit.

The issue is still under investigation.

