### PR TITLE
Avoid adding gzip-encoding to requests implicitly

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -139,7 +139,7 @@ func main() {
 	// (via keep-alive) to send real requests, avoiding needing an extra
 	// reconnect for the first request after the probe succeeds.
 	logger.Debugf("MaxIdleProxyConns: %d, MaxIdleProxyConnsPerHost: %d", env.MaxIdleProxyConns, env.MaxIdleProxyConnsPerHost)
-	transport := pkgnet.NewAutoTransport(env.MaxIdleProxyConns, env.MaxIdleProxyConnsPerHost)
+	transport := pkgnet.NewProxyAutoTransport(env.MaxIdleProxyConns, env.MaxIdleProxyConnsPerHost)
 
 	// Start throttler.
 	throttler := activatornet.NewThrottler(ctx, env.PodIP)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -309,7 +309,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 
 func buildTransport(env config, logger *zap.SugaredLogger, maxConns int) http.RoundTripper {
 	// set max-idle and max-idle-per-host to same value since we're always proxying to the same host.
-	transport := pkgnet.NewAutoTransport(maxConns /* max-idle */, maxConns /* max-idle-per-host */)
+	transport := pkgnet.NewProxyAutoTransport(maxConns /* max-idle */, maxConns /* max-idle-per-host */)
 
 	if env.TracingConfigBackend == tracingconfig.None {
 		return transport

--- a/go.mod
+++ b/go.mod
@@ -53,8 +53,8 @@ require (
 	k8s.io/kube-openapi v0.0.0-20210113233702-8566a335510f
 	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009 // indirect
 	knative.dev/caching v0.0.0-20210201195732-f8bed817dad1
-	knative.dev/hack v0.0.0-20210120165453-8d623a0af457
+	knative.dev/hack v0.0.0-20210203173706-8368e1f6eacf
 	knative.dev/networking v0.0.0-20210202173433-c069ad20a560
-	knative.dev/pkg v0.0.0-20210130001831-ca02ef752ac6
+	knative.dev/pkg v0.0.0-20210203171706-6045ed499615
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1293,10 +1293,14 @@ knative.dev/caching v0.0.0-20210201195732-f8bed817dad1 h1:cgLn/SJdX1/q0RV9qssJtg
 knative.dev/caching v0.0.0-20210201195732-f8bed817dad1/go.mod h1:YTyeMeeMzVkCsGLNuucs0Ui25BcR0iKUGQgef4cj4/o=
 knative.dev/hack v0.0.0-20210120165453-8d623a0af457 h1:jEBITgx/lQydGncM0uetpv/ZqawRzb2aSfEaYoMeDjM=
 knative.dev/hack v0.0.0-20210120165453-8d623a0af457/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
+knative.dev/hack v0.0.0-20210203173706-8368e1f6eacf h1:u4cY4jr2LYvhoz/1HBWEPsMiLkm0HMdDTfmmw1RE8zE=
+knative.dev/hack v0.0.0-20210203173706-8368e1f6eacf/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
 knative.dev/networking v0.0.0-20210202173433-c069ad20a560 h1:7k0pMfVwtCuRUnuzoK2BN8r2SgBki+HG8cjjQPPFz3U=
 knative.dev/networking v0.0.0-20210202173433-c069ad20a560/go.mod h1:LFCHSswO9cLifBJtuipVzw4M+nPdvkR1t82U6YJdhCA=
 knative.dev/pkg v0.0.0-20210130001831-ca02ef752ac6 h1:HIACRvhv/4U7vcFTAakfqYJIlENCSGtTrZOwz/q/A00=
 knative.dev/pkg v0.0.0-20210130001831-ca02ef752ac6/go.mod h1:X4NPrCo8NK3hbDVan9Vm7mf5io3ZoINakAdrpSXVB08=
+knative.dev/pkg v0.0.0-20210203171706-6045ed499615 h1:Ee0n+axzrQXWkJfGl91B5RRmB25R1plTfC7MDw3NxUU=
+knative.dev/pkg v0.0.0-20210203171706-6045ed499615/go.mod h1:X4NPrCo8NK3hbDVan9Vm7mf5io3ZoINakAdrpSXVB08=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/knative.dev/hack/library.sh
+++ b/vendor/knative.dev/hack/library.sh
@@ -539,7 +539,8 @@ function go_update_deps() {
 
   export GO111MODULE=on
   export GOFLAGS=""
-  export GOSUMDB=off   # Do not use the sum.golang.org service.
+  export GONOSUMDB="${GONOSUMDB:-},knative.dev/*"
+  export GONOPROXY="${GONOPROXY:-},knative.dev/*"
 
   echo "=== Update Deps for Golang"
 
@@ -559,16 +560,6 @@ function go_update_deps() {
 
   if [[ $UPGRADE == 1 ]]; then
     group "Upgrading to ${VERSION}"
-    # From shell parameter expansion:
-    # ${parameter:+word}
-    # If parameter is null or unset, nothing is substituted, otherwise the expansion of word is substituted.
-    # -z is if the length of the string, so skip setting GOPROXY if GOPROXY is already set.
-    if [[ -z ${GOPROXY:+skip} ]]; then
-      export GOPROXY=direct
-      echo "Using 'GOPROXY=direct'."
-    else
-      echo "Respecting 'GOPROXY=${GOPROXY}'."
-    fi
     FLOATING_DEPS+=( $(run_go_tool knative.dev/test-infra/buoy buoy float ${REPO_ROOT_DIR}/go.mod --release ${VERSION} --domain ${DOMAIN}) )
     if [[ ${#FLOATING_DEPS[@]} > 0 ]]; then
       echo "Floating deps to ${FLOATING_DEPS[@]}"

--- a/vendor/knative.dev/pkg/network/h2c.go
+++ b/vendor/knative.dev/pkg/network/h2c.go
@@ -41,8 +41,13 @@ func NewServer(addr string, h http.Handler) *http.Server {
 // to explicitly allow h2c (http2 without TLS) transport.
 // See https://github.com/golang/go/issues/14141 for more details.
 func NewH2CTransport() http.RoundTripper {
+	return newH2CTransport(false)
+}
+
+func newH2CTransport(disableCompression bool) http.RoundTripper {
 	return &http2.Transport{
-		AllowHTTP: true,
+		AllowHTTP:          true,
+		DisableCompression: disableCompression,
 		DialTLS: func(netw, addr string, _ *tls.Config) (net.Conn, error) {
 			return DialWithBackOff(context.Background(),
 				netw, addr)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1025,7 +1025,7 @@ knative.dev/caching/pkg/client/injection/informers/caching/v1alpha1/image/fake
 knative.dev/caching/pkg/client/injection/informers/factory
 knative.dev/caching/pkg/client/injection/informers/factory/fake
 knative.dev/caching/pkg/client/listers/caching/v1alpha1
-# knative.dev/hack v0.0.0-20210120165453-8d623a0af457
+# knative.dev/hack v0.0.0-20210203173706-8368e1f6eacf
 ## explicit
 knative.dev/hack
 knative.dev/hack/shell
@@ -1064,7 +1064,7 @@ knative.dev/networking/test/conformance/ingress
 knative.dev/networking/test/defaultsystem
 knative.dev/networking/test/test_images/grpc-ping/proto
 knative.dev/networking/test/types
-# knative.dev/pkg v0.0.0-20210130001831-ca02ef752ac6
+# knative.dev/pkg v0.0.0-20210203171706-6045ed499615
 ## explicit
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate


### PR DESCRIPTION
See https://github.com/knative/pkg/issues/2006.

Go helpfully adds an Accept-Encoding: gzip header to requests by
default, and silently uncompresses the response if it did so and the
server added compression in response. While this is normally a good
thing, in our case this means we silently add an extra "Accept-Encoding"
header to requests before they get to the user container, and if the
user container compresses the request in response we end up pointlessly
uncompressing the just-compressed response inside Queue Proxy. This
commit picks up the new NewProxyAutoTransport method from pkg
to avoid this behaviour.

```release-note
Avoids implicitly adding an "Accept-Encoding: gzip" header to proxied requests if one was not already present.
```

/assign @vagababov @markusthoemmes 
