### PR TITLE
Add addressable-resolver role for serving controller

### DIFF
--- a/config/core/200-roles/addressable-resolvers-clusterrole.yaml
+++ b/config/core/200-roles/addressable-resolvers-clusterrole.yaml
@@ -12,6 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Use this aggregated ClusterRole when you need readonly access to "Addressables"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: addressable-resolver
+  labels:
+    serving.knative.dev/release: devel
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      duck.knative.dev/addressable: "true"
+rules: [] # Rules are automatically filled in by the controller manager.
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/config/core/200-roles/addressable-resolvers-clusterrole.yaml
+++ b/config/core/200-roles/addressable-resolvers-clusterrole.yaml
@@ -16,7 +16,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: addressable-resolver
+  # Named like this to avoid clashing with eventing's existing `addressable-resolver` role
+  # (which should be identical, but isn't guaranteed to be installed alongside serving).
+  name: knative-serving-aggregated-addressable-resolver
   labels:
     serving.knative.dev/release: devel
 aggregationRule:

--- a/config/core/200-serviceaccount.yaml
+++ b/config/core/200-serviceaccount.yaml
@@ -46,3 +46,18 @@ roleRef:
   kind: ClusterRole
   name: knative-serving-admin
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-serving-controller-addressable-resolver
+  labels:
+    serving.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: controller
+    namespace: knative-serving
+roleRef:
+  kind: ClusterRole
+  name: addressable-resolver
+  apiGroup: rbac.authorization.k8s.io

--- a/config/core/200-serviceaccount.yaml
+++ b/config/core/200-serviceaccount.yaml
@@ -59,5 +59,5 @@ subjects:
     namespace: knative-serving
 roleRef:
   kind: ClusterRole
-  name: addressable-resolver
+  name: knative-serving-aggregated-addressable-resolver
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Adds the addressable-resolver role to the serving controller's service account. This allows the DomainMapping reconciler to resolve arbitrary addressables like Channel.

I think I'm holding this right, but I don't 100% understand the addressable rbac generation stuff yet tbh :). Appears to work, though 🤷.

Fixes #10662.

/assign @mattmoor @n3wscott 