### PR TITLE
Fix the analyzer config for load-testing benchmark since it must have a value

### DIFF
--- a/test/performance/benchmarks/load-test/continuous/sla.go
+++ b/test/performance/benchmarks/load-test/continuous/sla.go
@@ -69,8 +69,8 @@ func newLoadTestMaximumErrorRate(tags ...string) *tpb.ThresholdAnalyzerInput {
 	return &tpb.ThresholdAnalyzerInput{
 		Name: ptr.String("Mean error rate"),
 		Configs: []*tpb.ThresholdConfig{{
-			// TODO(chizhg): reenable the error rate check after https://github.com/knative/serving/issues/10074 is fixed.
-			// Max: ptr.Float64(0),
+			// TODO(chizhg): set the error rate check back to 0 after https://github.com/knative/serving/issues/10074 is fixed.
+			Max: ptr.Float64(1),
 			DataFilter: &mpb.DataFilter{
 				DataType: mpb.DataFilter_METRIC_AGGREGATE_MEAN.Enum(),
 				ValueKey: ptr.String("es"),


### PR DESCRIPTION

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
* To get rid of the spams sent on Slack like https://knative.slack.com/archives/C94SPR60H/p1612543661144600

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/cc @vagababov 
