### PR TITLE
Optimize the execution path around logging

### DIFF
--- a/pkg/reconciler/route/traffic/rollout_test.go
+++ b/pkg/reconciler/route/traffic/rollout_test.go
@@ -990,9 +990,9 @@ func TestStep(t *testing.T) {
 		},
 	}}
 
-	ctx := TestContextWithLogger(t)
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := TestContextWithLogger(t)
 			got, gotNS := tc.cur.Step(ctx, tc.prev, now)
 			if want := tc.want; !cmp.Equal(got, want, cmpopts.EquateEmpty()) {
 				t.Errorf("Wrong rolled rollout, diff(-want,+got):\n%s", cmp.Diff(want, got))
@@ -1249,7 +1249,8 @@ func TestAdjustPercentage(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			adjustPercentage(tc.goal, tc.prev)
+			logger := TestLogger(t)
+			adjustPercentage(tc.goal, tc.prev, logger)
 			if got, want := tc.prev.Revisions, tc.want; !cmp.Equal(got, want, cmpopts.EquateEmpty()) {
 				t.Errorf("Rollout Mistmatch(-want,+got):\n%s", cmp.Diff(want, got))
 			}


### PR DESCRIPTION
- pass the logger to the functions, no need to traverse the context and
  it's not used for anything else anyway.
- instrument the `adjustPercentage` function, since those are rare
  occasions, but they have a chance of being disruptive of cause bugs.

/assign @tcnghia 