### PR TITLE
Drop jwt dependency and match token via regex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/docker/cli v20.10.2+incompatible // indirect
 	github.com/docker/docker v20.10.2+incompatible // indirect
 	github.com/emicklei/go-restful v2.15.0+incompatible // indirect
-	github.com/form3tech-oss/jwt-go v3.2.2+incompatible
 	github.com/go-openapi/spec v0.20.2 // indirect
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-cmp v0.5.4

--- a/test/conformance/api/v1/volumes_test.go
+++ b/test/conformance/api/v1/volumes_test.go
@@ -22,9 +22,9 @@ import (
 	"context"
 	"path"
 	"path/filepath"
+	"regexp"
 	"testing"
 
-	"github.com/form3tech-oss/jwt-go"
 	"knative.dev/pkg/ptr"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
@@ -457,12 +457,7 @@ func TestProjectedServiceAccountToken(t *testing.T) {
 	}
 	names.URL.Path = path.Join(names.URL.Path, tokenPath)
 	var parsesToken = func(resp *spoof.Response) (bool, error) {
-		jwtToken := string(resp.Body)
-		parser := &jwt.Parser{}
-		if _, _, err := parser.ParseUnverified(jwtToken, jwt.MapClaims{}); err != nil {
-			return false, err
-		}
-		return true, nil
+		return regexp.Match(`[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*`, resp.Body)
 	}
 
 	if _, err := pkgTest.WaitForEndpointState(

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -135,7 +135,6 @@ github.com/emicklei/go-restful/log
 # github.com/evanphx/json-patch v4.9.0+incompatible
 github.com/evanphx/json-patch
 # github.com/form3tech-oss/jwt-go v3.2.2+incompatible
-## explicit
 github.com/form3tech-oss/jwt-go
 # github.com/go-logr/logr v0.4.0
 github.com/go-logr/logr


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

The test only really cares about the token actually being there and looking like a JWT token, so we might as well parse it via a quick and dirty regex rather than fully parsing it, I think.

Drops the jwt dep from our explicit deps.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @julz 
