### PR TITLE
Accept 'head' as a parameter for istio version

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -64,7 +64,7 @@ LATEST_NET_ISTIO_RELEASE_VERSION=$(
 function parse_flags() {
   case "$1" in
     --istio-version)
-      [[ $2 =~ ^(stable|latest)$ ]] || abort "version format must be 'stable' or 'latest'"
+      [[ $2 =~ ^(stable|latest|head)$ ]] || abort "version format must be 'stable', 'latest', or 'head'"
       readonly ISTIO_VERSION=$2
       readonly INGRESS_CLASS="istio.ingress.networking.knative.dev"
       return 2


### PR DESCRIPTION
Makes progress on net-istio#496

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
* Accept "head" as an Istio version as that is now supported in net-istio.

/cc @JRBANCEL @nak3 @ZhiminXiang 