### PR TITLE
Avoid deleting a stat if a request raced the reporter

### DIFF
--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -47,7 +47,7 @@ const reportInterval = time.Second
 type revisionStats struct {
 	stats        *network.RequestStats
 	firstRequest float64
-	refs         *atomic.Int64
+	refs         atomic.Int64
 }
 
 // ConcurrencyReporter reports stats based on incoming requests and ticks.
@@ -118,8 +118,8 @@ func (cr *ConcurrencyReporter) getOrCreateStat(event network.ReqEvent) (*revisio
 	stat = &revisionStats{
 		stats:        network.NewRequestStats(event.Time),
 		firstRequest: 1,
-		refs:         atomic.NewInt64(1),
 	}
+	stat.refs.Inc()
 	cr.stats[event.Key] = stat
 
 	return stat, &asmetrics.StatMessage{

--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/types"
 	network "knative.dev/networking/pkg"
@@ -46,6 +47,7 @@ const reportInterval = time.Second
 type revisionStats struct {
 	stats        *network.RequestStats
 	firstRequest float64
+	refs         *atomic.Int64
 }
 
 // ConcurrencyReporter reports stats based on incoming requests and ticks.
@@ -79,6 +81,7 @@ func NewConcurrencyReporter(ctx context.Context, podName string, statCh chan []a
 // handleEvent handles request events (in, out) and updates the respective stats.
 func (cr *ConcurrencyReporter) handleEvent(event network.ReqEvent) {
 	stat, msg := cr.getOrCreateStat(event)
+	defer stat.refs.Dec()
 	if msg != nil {
 		cr.statCh <- []asmetrics.StatMessage{*msg}
 	}
@@ -89,14 +92,16 @@ func (cr *ConcurrencyReporter) handleEvent(event network.ReqEvent) {
 // If absent it creates a new one and returns it, potentially returning a StatMessage too
 // to trigger an immediate scale-from-0.
 func (cr *ConcurrencyReporter) getOrCreateStat(event network.ReqEvent) (*revisionStats, *asmetrics.StatMessage) {
-	stat := func() *revisionStats {
-		cr.mux.RLock()
-		defer cr.mux.RUnlock()
-		return cr.stats[event.Key]
-	}()
+	cr.mux.RLock()
+	stat := cr.stats[event.Key]
 	if stat != nil {
+		// Since this is incremented under the lock, it's guaranteed to be observed by
+		// the deletion routine.
+		stat.refs.Inc()
+		cr.mux.RUnlock()
 		return stat, nil
 	}
+	cr.mux.RUnlock()
 
 	// Doubly checked locking.
 	cr.mux.Lock()
@@ -104,12 +109,16 @@ func (cr *ConcurrencyReporter) getOrCreateStat(event network.ReqEvent) (*revisio
 
 	stat = cr.stats[event.Key]
 	if stat != nil {
+		// Since this is incremented under the lock, it's guaranteed to be observed by
+		// the deletion routine.
+		stat.refs.Inc()
 		return stat, nil
 	}
 
 	stat = &revisionStats{
 		stats:        network.NewRequestStats(event.Time),
 		firstRequest: 1,
+		refs:         atomic.NewInt64(1),
 	}
 	cr.stats[event.Key] = stat
 
@@ -136,7 +145,11 @@ func (cr *ConcurrencyReporter) report(now time.Time) []asmetrics.StatMessage {
 		cr.mux.Lock()
 		defer cr.mux.Unlock()
 		for _, key := range toDelete {
-			delete(cr.stats, key)
+			// Avoid deleting the stat if a request raced fetching it while we've been
+			// busy reporting.
+			if cr.stats[key].refs.Load() == 0 {
+				delete(cr.stats, key)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This prevents a race between the report routine and requests flowing in and out. Since we're trying to minimize contention of the request path, the locking routines try to grab as little write-locks as possible, to allow things to progress in parallel.

That breaks though if a report would report AverageConcurrency == 0 and hence marking the stat for deletion. If between this being done and the entry actually being deleted (two separate locks as we only grab a read lock for determining the deletion) comes a nwe request, it'll grab the stat that is now going to be deleted and hence not seen by the next report routine.

The In event is lost and the stats concurrency becomes negative, unrecoverably.

## Benchmark

```
benchmark                                             old ns/op     new ns/op     delta
BenchmarkConcurrencyReporterHandler/sequential-16     263           263           +0.00%
BenchmarkConcurrencyReporterHandler/parallel-16       76.9          82.6          +7.41%

benchmark                                             old allocs     new allocs     delta
BenchmarkConcurrencyReporterHandler/sequential-16     0              0              +0.00%
BenchmarkConcurrencyReporterHandler/parallel-16       0              0              +0.00%

benchmark                                             old bytes     new bytes     delta
BenchmarkConcurrencyReporterHandler/sequential-16     0             0             +0.00%
BenchmarkConcurrencyReporterHandler/parallel-16       0             0             +0.00%
```

Slightly worse as expected, but no biggy imo.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixed a bug where the activator's metrics could get stuck and thus scale to and from zero didn't work as expected.
```
