### PR TITLE
Only log about service scraping on first transition.

### DIFF
--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -220,7 +220,7 @@ func (s *serviceScraper) Scrape(window time.Duration) (stat Stat, err error) {
 		return emptyStat, nil
 	}
 	stat, err = s.scrapeService(window, readyPodsCount)
-	if err == nil {
+	if err == nil && s.podsAddressable {
 		s.logger.Info("Direct pod scraping off, service scraping, on")
 		// If err == nil, this means that we failed to scrape all pods, but service worked
 		// thus it is probably a mesh case.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

When running KNative with Istio, the autoscaler runs in service scraping
mode. Once the autoscaler detects that it should be running in this
mode, it properly latches, and remains there, but it still prints out a
log statement for each scrape attempt. This generates a fairly
substantial volume of logs when there are a number of services active in
a cluster. This changes to only printing out the log statement on
transition rather than every time.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
