### PR TITLE
Refactor: remove labeler v2 package

### DIFF
--- a/pkg/reconciler/labeler/accessors.go
+++ b/pkg/reconciler/labeler/accessors.go
@@ -43,8 +43,8 @@ type Accessor interface {
 	makeMetadataPatch(route *v1.Route, name string, remove bool) (map[string]interface{}, error)
 }
 
-// RevisionAcc is an implementation of Accessor for Revisions.
-type RevisionAcc struct {
+// RevisionAccessor is an implementation of Accessor for Revisions.
+type RevisionAccessor struct {
 	client  clientset.Interface
 	tracker tracker.Interface
 	lister  listers.RevisionLister
@@ -52,8 +52,8 @@ type RevisionAcc struct {
 	clock   clock.Clock
 }
 
-// RevisionAcc implements Accessor
-var _ Accessor = (*RevisionAcc)(nil)
+// RevisionAccessor implements Accessor
+var _ Accessor = (*RevisionAccessor)(nil)
 
 // newRevisionAccessor is a factory function to make a new revision accessor.
 func newRevisionAccessor(
@@ -61,8 +61,8 @@ func newRevisionAccessor(
 	tracker tracker.Interface,
 	lister listers.RevisionLister,
 	indexer cache.Indexer,
-	clock clock.Clock) *RevisionAcc {
-	return &RevisionAcc{
+	clock clock.Clock) *RevisionAccessor {
+	return &RevisionAccessor{
 		client:  client,
 		tracker: tracker,
 		lister:  lister,
@@ -141,7 +141,7 @@ func updateRouteAnnotation(acc kmeta.Accessor, routeName string, diffAnn map[str
 }
 
 // list implements Accessor
-func (r *RevisionAcc) list(_ context.Context, ns, routeName string, state v1.RoutingState) ([]kmeta.Accessor, error) {
+func (r *RevisionAccessor) list(_ context.Context, ns, routeName string, state v1.RoutingState) ([]kmeta.Accessor, error) {
 	kl := make([]kmeta.Accessor, 0, 1)
 	filter := func(m interface{}) {
 		r := m.(*v1.Revision)
@@ -160,12 +160,12 @@ func (r *RevisionAcc) list(_ context.Context, ns, routeName string, state v1.Rou
 }
 
 // patch implements Accessor
-func (r *RevisionAcc) patch(ctx context.Context, ns, name string, pt types.PatchType, p []byte) error {
+func (r *RevisionAccessor) patch(ctx context.Context, ns, name string, pt types.PatchType, p []byte) error {
 	_, err := r.client.ServingV1().Revisions(ns).Patch(ctx, name, pt, p, metav1.PatchOptions{})
 	return err
 }
 
-func (r *RevisionAcc) makeMetadataPatch(route *v1.Route, name string, remove bool) (map[string]interface{}, error) {
+func (r *RevisionAccessor) makeMetadataPatch(route *v1.Route, name string, remove bool) (map[string]interface{}, error) {
 	rev, err := r.lister.Revisions(route.Namespace).Get(name)
 	if err != nil {
 		return nil, err
@@ -173,8 +173,8 @@ func (r *RevisionAcc) makeMetadataPatch(route *v1.Route, name string, remove boo
 	return makeMetadataPatch(rev, route.Name, true /*addRoutingState*/, remove, r.clock)
 }
 
-// ConfigurationAcc is an implementation of Accessor for Configurations.
-type ConfigurationAcc struct {
+// ConfigurationAccessor is an implementation of Accessor for Configurations.
+type ConfigurationAccessor struct {
 	client  clientset.Interface
 	tracker tracker.Interface
 	lister  listers.ConfigurationLister
@@ -182,8 +182,8 @@ type ConfigurationAcc struct {
 	clock   clock.Clock
 }
 
-// ConfigurationAcc implements Accessor
-var _ Accessor = (*ConfigurationAcc)(nil)
+// ConfigurationAccessor implements Accessor
+var _ Accessor = (*ConfigurationAccessor)(nil)
 
 // NewConfigurationAccessor is a factory function to make a new configuration Accessor.
 func newConfigurationAccessor(
@@ -191,8 +191,8 @@ func newConfigurationAccessor(
 	tracker tracker.Interface,
 	lister listers.ConfigurationLister,
 	indexer cache.Indexer,
-	clock clock.Clock) *ConfigurationAcc {
-	return &ConfigurationAcc{
+	clock clock.Clock) *ConfigurationAccessor {
+	return &ConfigurationAccessor{
 		client:  client,
 		tracker: tracker,
 		lister:  lister,
@@ -202,7 +202,7 @@ func newConfigurationAccessor(
 }
 
 // list implements Accessor
-func (c *ConfigurationAcc) list(_ context.Context, ns, routeName string, state v1.RoutingState) ([]kmeta.Accessor, error) {
+func (c *ConfigurationAccessor) list(_ context.Context, ns, routeName string, state v1.RoutingState) ([]kmeta.Accessor, error) {
 	kl := make([]kmeta.Accessor, 0, 1)
 	filter := func(m interface{}) {
 		c := m.(*v1.Configuration)
@@ -228,12 +228,12 @@ func GetListAnnValue(annotations map[string]string, key string) sets.String {
 }
 
 // patch implements Accessor
-func (c *ConfigurationAcc) patch(ctx context.Context, ns, name string, pt types.PatchType, p []byte) error {
+func (c *ConfigurationAccessor) patch(ctx context.Context, ns, name string, pt types.PatchType, p []byte) error {
 	_, err := c.client.ServingV1().Configurations(ns).Patch(ctx, name, pt, p, metav1.PatchOptions{})
 	return err
 }
 
-func (c *ConfigurationAcc) makeMetadataPatch(r *v1.Route, name string, remove bool) (map[string]interface{}, error) {
+func (c *ConfigurationAccessor) makeMetadataPatch(r *v1.Route, name string, remove bool) (map[string]interface{}, error) {
 	config, err := c.lister.Configurations(r.Namespace).Get(name)
 	if err != nil {
 		return nil, err

--- a/pkg/reconciler/labeler/accessors.go
+++ b/pkg/reconciler/labeler/accessors.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v2
+package labeler
 
 import (
 	"context"
@@ -43,8 +43,8 @@ type Accessor interface {
 	makeMetadataPatch(route *v1.Route, name string, remove bool) (map[string]interface{}, error)
 }
 
-// Revision is an implementation of Accessor for Revisions.
-type Revision struct {
+// RevisionAcc is an implementation of Accessor for Revisions.
+type RevisionAcc struct {
 	client  clientset.Interface
 	tracker tracker.Interface
 	lister  listers.RevisionLister
@@ -52,17 +52,17 @@ type Revision struct {
 	clock   clock.Clock
 }
 
-// Revision implements Accessor
-var _ Accessor = (*Revision)(nil)
+// RevisionAcc implements Accessor
+var _ Accessor = (*RevisionAcc)(nil)
 
-// NewRevisionAccessor is a factory function to make a new revision accessor.
-func NewRevisionAccessor(
+// newRevisionAccessor is a factory function to make a new revision accessor.
+func newRevisionAccessor(
 	client clientset.Interface,
 	tracker tracker.Interface,
 	lister listers.RevisionLister,
 	indexer cache.Indexer,
-	clock clock.Clock) *Revision {
-	return &Revision{
+	clock clock.Clock) *RevisionAcc {
+	return &RevisionAcc{
 		client:  client,
 		tracker: tracker,
 		lister:  lister,
@@ -141,7 +141,7 @@ func updateRouteAnnotation(acc kmeta.Accessor, routeName string, diffAnn map[str
 }
 
 // list implements Accessor
-func (r *Revision) list(_ context.Context, ns, routeName string, state v1.RoutingState) ([]kmeta.Accessor, error) {
+func (r *RevisionAcc) list(_ context.Context, ns, routeName string, state v1.RoutingState) ([]kmeta.Accessor, error) {
 	kl := make([]kmeta.Accessor, 0, 1)
 	filter := func(m interface{}) {
 		r := m.(*v1.Revision)
@@ -160,12 +160,12 @@ func (r *Revision) list(_ context.Context, ns, routeName string, state v1.Routin
 }
 
 // patch implements Accessor
-func (r *Revision) patch(ctx context.Context, ns, name string, pt types.PatchType, p []byte) error {
+func (r *RevisionAcc) patch(ctx context.Context, ns, name string, pt types.PatchType, p []byte) error {
 	_, err := r.client.ServingV1().Revisions(ns).Patch(ctx, name, pt, p, metav1.PatchOptions{})
 	return err
 }
 
-func (r *Revision) makeMetadataPatch(route *v1.Route, name string, remove bool) (map[string]interface{}, error) {
+func (r *RevisionAcc) makeMetadataPatch(route *v1.Route, name string, remove bool) (map[string]interface{}, error) {
 	rev, err := r.lister.Revisions(route.Namespace).Get(name)
 	if err != nil {
 		return nil, err
@@ -173,8 +173,8 @@ func (r *Revision) makeMetadataPatch(route *v1.Route, name string, remove bool) 
 	return makeMetadataPatch(rev, route.Name, true /*addRoutingState*/, remove, r.clock)
 }
 
-// Configuration is an implementation of Accessor for Configurations.
-type Configuration struct {
+// ConfigurationAcc is an implementation of Accessor for Configurations.
+type ConfigurationAcc struct {
 	client  clientset.Interface
 	tracker tracker.Interface
 	lister  listers.ConfigurationLister
@@ -182,17 +182,17 @@ type Configuration struct {
 	clock   clock.Clock
 }
 
-// Configuration implements Accessor
-var _ Accessor = (*Configuration)(nil)
+// ConfigurationAcc implements Accessor
+var _ Accessor = (*ConfigurationAcc)(nil)
 
 // NewConfigurationAccessor is a factory function to make a new configuration Accessor.
-func NewConfigurationAccessor(
+func newConfigurationAccessor(
 	client clientset.Interface,
 	tracker tracker.Interface,
 	lister listers.ConfigurationLister,
 	indexer cache.Indexer,
-	clock clock.Clock) *Configuration {
-	return &Configuration{
+	clock clock.Clock) *ConfigurationAcc {
+	return &ConfigurationAcc{
 		client:  client,
 		tracker: tracker,
 		lister:  lister,
@@ -202,7 +202,7 @@ func NewConfigurationAccessor(
 }
 
 // list implements Accessor
-func (c *Configuration) list(_ context.Context, ns, routeName string, state v1.RoutingState) ([]kmeta.Accessor, error) {
+func (c *ConfigurationAcc) list(_ context.Context, ns, routeName string, state v1.RoutingState) ([]kmeta.Accessor, error) {
 	kl := make([]kmeta.Accessor, 0, 1)
 	filter := func(m interface{}) {
 		c := m.(*v1.Configuration)
@@ -228,12 +228,12 @@ func GetListAnnValue(annotations map[string]string, key string) sets.String {
 }
 
 // patch implements Accessor
-func (c *Configuration) patch(ctx context.Context, ns, name string, pt types.PatchType, p []byte) error {
+func (c *ConfigurationAcc) patch(ctx context.Context, ns, name string, pt types.PatchType, p []byte) error {
 	_, err := c.client.ServingV1().Configurations(ns).Patch(ctx, name, pt, p, metav1.PatchOptions{})
 	return err
 }
 
-func (c *Configuration) makeMetadataPatch(r *v1.Route, name string, remove bool) (map[string]interface{}, error) {
+func (c *ConfigurationAcc) makeMetadataPatch(r *v1.Route, name string, remove bool) (map[string]interface{}, error) {
 	config, err := c.lister.Configurations(r.Namespace).Get(name)
 	if err != nil {
 		return nil, err

--- a/pkg/reconciler/labeler/controller.go
+++ b/pkg/reconciler/labeler/controller.go
@@ -29,7 +29,6 @@ import (
 	routeinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/route"
 	routereconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/route"
 	"knative.dev/serving/pkg/reconciler/configuration/config"
-	labelerv2 "knative.dev/serving/pkg/reconciler/labeler/v2"
 
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -94,8 +93,8 @@ func newControllerWithClock(
 	))
 
 	client := servingclient.Get(ctx)
-	c.caccV2 = labelerv2.NewConfigurationAccessor(client, tracker, configInformer.Lister(), configInformer.Informer().GetIndexer(), clock)
-	c.raccV2 = labelerv2.NewRevisionAccessor(client, tracker, revisionInformer.Lister(), revisionInformer.Informer().GetIndexer(), clock)
+	c.caccV2 = newConfigurationAccessor(client, tracker, configInformer.Lister(), configInformer.Informer().GetIndexer(), clock)
+	c.raccV2 = newRevisionAccessor(client, tracker, revisionInformer.Lister(), revisionInformer.Informer().GetIndexer(), clock)
 
 	return impl
 }

--- a/pkg/reconciler/labeler/labeler.go
+++ b/pkg/reconciler/labeler/labeler.go
@@ -22,13 +22,12 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	routereconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/route"
-	labelerv2 "knative.dev/serving/pkg/reconciler/labeler/v2"
 )
 
 // Reconciler implements controller.Reconciler for Route resources.
 type Reconciler struct {
-	caccV2 *labelerv2.Configuration
-	raccV2 *labelerv2.Revision
+	caccV2 *ConfigurationAcc
+	raccV2 *RevisionAcc
 }
 
 // Check that our Reconciler implements routereconciler.Interface
@@ -38,7 +37,7 @@ var _ routereconciler.Finalizer = (*Reconciler)(nil)
 // FinalizeKind removes all Route reference metadata from its traffic targets.
 // This does not modify or observe spec for the Route itself.
 func (rec *Reconciler) FinalizeKind(ctx context.Context, r *v1.Route) pkgreconciler.Event {
-	if err := labelerv2.ClearRoutingMeta(ctx, r, rec.caccV2, rec.raccV2); err != nil {
+	if err := clearRoutingMeta(ctx, r, rec.caccV2, rec.raccV2); err != nil {
 		return err
 	}
 	return nil
@@ -47,7 +46,7 @@ func (rec *Reconciler) FinalizeKind(ctx context.Context, r *v1.Route) pkgreconci
 // ReconcileKind syncs the Route reference metadata to its traffic targets.
 // This does not modify or observe spec for the Route itself.
 func (rec *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconciler.Event {
-	if err := labelerv2.SyncRoutingMeta(ctx, r, rec.caccV2, rec.raccV2); err != nil {
+	if err := syncRoutingMeta(ctx, r, rec.caccV2, rec.raccV2); err != nil {
 		return err
 	}
 

--- a/pkg/reconciler/labeler/labeler.go
+++ b/pkg/reconciler/labeler/labeler.go
@@ -26,8 +26,8 @@ import (
 
 // Reconciler implements controller.Reconciler for Route resources.
 type Reconciler struct {
-	caccV2 *ConfigurationAcc
-	raccV2 *RevisionAcc
+	caccV2 *ConfigurationAccessor
+	raccV2 *RevisionAccessor
 }
 
 // Check that our Reconciler implements routereconciler.Interface

--- a/pkg/reconciler/labeler/labeler_test.go
+++ b/pkg/reconciler/labeler/labeler_test.go
@@ -46,7 +46,6 @@ import (
 	autoscalercfg "knative.dev/serving/pkg/autoscaler/config"
 
 	. "knative.dev/pkg/reconciler/testing"
-	labelerv2 "knative.dev/serving/pkg/reconciler/labeler/v2"
 	. "knative.dev/serving/pkg/reconciler/testing/v1"
 	. "knative.dev/serving/pkg/testing/v1"
 )
@@ -344,8 +343,8 @@ func TestV2Reconcile(t *testing.T) {
 		rLister := listers.GetRevisionLister()
 		rIndexer := listers.IndexerFor(&v1.Revision{})
 		r := &Reconciler{
-			caccV2: labelerv2.NewConfigurationAccessor(client, &NullTracker{}, cLister, cIndexer, clock),
-			raccV2: labelerv2.NewRevisionAccessor(client, &NullTracker{}, rLister, rIndexer, clock),
+			caccV2: newConfigurationAccessor(client, &NullTracker{}, cLister, cIndexer, clock),
+			raccV2: newRevisionAccessor(client, &NullTracker{}, rLister, rIndexer, clock),
 		}
 
 		return routereconciler.NewReconciler(ctx, logging.FromContext(ctx), servingclient.Get(ctx),

--- a/pkg/reconciler/labeler/metasync.go
+++ b/pkg/reconciler/labeler/metasync.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v2
+package labeler
 
 import (
 	"context"
@@ -30,9 +30,9 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
-// SyncRoutingMeta makes sure that the revisions and configurations referenced from
+// syncRoutingMeta makes sure that the revisions and configurations referenced from
 // a Route are labeled with the routingState label and routes annotation.
-func SyncRoutingMeta(ctx context.Context, r *v1.Route, cacc *Configuration, racc *Revision) error {
+func syncRoutingMeta(ctx context.Context, r *v1.Route, cacc *ConfigurationAcc, racc *RevisionAcc) error {
 	revisions := sets.NewString()
 	configs := sets.NewString()
 
@@ -98,8 +98,8 @@ func SyncRoutingMeta(ctx context.Context, r *v1.Route, cacc *Configuration, racc
 	return setMetaForListed(ctx, r, cacc, configs)
 }
 
-// ClearRoutingMeta removes any labels for a named route from given accessors.
-func ClearRoutingMeta(ctx context.Context, r *v1.Route, accs ...Accessor) error {
+// clearRoutingMeta removes any labels for a named route from given accessors.
+func clearRoutingMeta(ctx context.Context, r *v1.Route, accs ...Accessor) error {
 	for _, acc := range accs {
 		if err := clearMetaForNotListed(ctx, r, acc, nil /*none listed*/); err != nil {
 			return err

--- a/pkg/reconciler/labeler/metasync.go
+++ b/pkg/reconciler/labeler/metasync.go
@@ -32,7 +32,7 @@ import (
 
 // syncRoutingMeta makes sure that the revisions and configurations referenced from
 // a Route are labeled with the routingState label and routes annotation.
-func syncRoutingMeta(ctx context.Context, r *v1.Route, cacc *ConfigurationAcc, racc *RevisionAcc) error {
+func syncRoutingMeta(ctx context.Context, r *v1.Route, cacc *ConfigurationAccessor, racc *RevisionAccessor) error {
 	revisions := sets.NewString()
 	configs := sets.NewString()
 

--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -25,7 +25,7 @@ import (
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	labelerv2 "knative.dev/serving/pkg/reconciler/labeler/v2"
+	"knative.dev/serving/pkg/reconciler/labeler"
 	"knative.dev/serving/pkg/reconciler/service/resources/names"
 )
 
@@ -47,7 +47,7 @@ func MakeConfigurationFromExisting(service *v1.Service, existing *v1.Configurati
 	})
 
 	routeName := names.Route(service)
-	set := labelerv2.GetListAnnValue(existing.Annotations, serving.RoutesAnnotationKey)
+	set := labeler.GetListAnnValue(existing.Annotations, serving.RoutesAnnotationKey)
 	set.Insert(routeName)
 	anns[serving.RoutesAnnotationKey] = strings.Join(set.UnsortedList(), ",")
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Collapses the `v2` folder back down to `labeler`
    * While we were in dual mode there was a `v1` which is gone. 
* Give private scope to appropriate functions
* Rename the accessors to not conflict or confuse with v1.Revision/Configuration