### PR TITLE
Only use exec probe at startup time

### DIFF
--- a/cmd/queue/execprobe.go
+++ b/cmd/queue/execprobe.go
@@ -31,7 +31,6 @@ import (
 	network "knative.dev/networking/pkg"
 	"knative.dev/serving/pkg/queue"
 	"knative.dev/serving/pkg/queue/health"
-	"knative.dev/serving/pkg/queue/readiness"
 )
 
 const (
@@ -74,10 +73,6 @@ func standaloneProbeMain(timeout time.Duration, transport http.RoundTripper) (ex
 	if queueServingPort == 0 {
 		fmt.Fprintln(os.Stderr, "port must be a positive value, got 0")
 		return 1
-	}
-
-	if timeout == 0 {
-		timeout = readiness.PollTimeout
 	}
 
 	if err := probeQueueHealthPath(timeout, int(queueServingPort), transport); err != nil {

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -60,7 +60,7 @@ const (
 )
 
 var (
-	readinessProbeTimeout = flag.Duration("probe-period", -1, "run readiness probe with given timeout")
+	startupProbeTimeout = flag.Duration("probe-timeout", -1, "run startup probe with given timeout")
 
 	// This creates an abstract socket instead of an actual file.
 	unixSocketPath = "@/knative.dev/serving/queue.sock"
@@ -107,7 +107,7 @@ func main() {
 	flag.Parse()
 
 	// If this is set, we run as a standalone binary to probe the queue-proxy.
-	if *readinessProbeTimeout >= 0 {
+	if *startupProbeTimeout >= 0 {
 		// Use a unix socket rather than TCP to avoid going via entire TCP stack
 		// when we're actually in the same container.
 		transport := http.DefaultTransport.(*http.Transport).Clone()
@@ -115,7 +115,7 @@ func main() {
 			return net.Dial("unix", unixSocketPath)
 		}
 
-		os.Exit(standaloneProbeMain(*readinessProbeTimeout, transport))
+		os.Exit(standaloneProbeMain(*startupProbeTimeout, transport))
 	}
 
 	// Otherwise, we run as the queue-proxy service.

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -60,7 +60,7 @@ const (
 )
 
 var (
-	startupProbeTimeout = flag.Duration("probe-timeout", -1, "run startup probe with given timeout")
+	startupProbeTimeout = flag.Duration("probe-period", -1, "run startup probe with given timeout")
 
 	// This creates an abstract socket instead of an actual file.
 	unixSocketPath = "@/knative.dev/serving/queue.sock"

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -80,11 +80,13 @@ var (
 		StartupProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{
-					Command: []string{"/ko-app/queue", "-probe-period", "0"},
+					Command: []string{"/ko-app/queue", "-probe-timeout", "1h34m38s"},
 				},
 			},
-			PeriodSeconds:  10,
-			TimeoutSeconds: 10,
+			PeriodSeconds:    1,
+			FailureThreshold: 1,
+			SuccessThreshold: 1,
+			TimeoutSeconds:   5678,
 		},
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -80,7 +80,7 @@ var (
 		StartupProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{
-					Command: []string{"/ko-app/queue", "-probe-timeout", "1h34m38s"},
+					Command: []string{"/ko-app/queue", "-probe-period", "1h34m38s"},
 				},
 			},
 			PeriodSeconds:    1,

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -77,7 +77,7 @@ var (
 		Name:      QueueContainerName,
 		Resources: createQueueResources(&deploymentConfig, make(map[string]string), &corev1.Container{}),
 		Ports:     append(queueNonServingPorts, queueHTTPPort),
-		ReadinessProbe: &corev1.Probe{
+		StartupProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{
 					Command: []string{"/ko-app/queue", "-probe-period", "0"},
@@ -85,6 +85,17 @@ var (
 			},
 			PeriodSeconds:  10,
 			TimeoutSeconds: 10,
+		},
+		ReadinessProbe: &corev1.Probe{
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(int(queueHTTPPort.ContainerPort)),
+					HTTPHeaders: []corev1.HTTPHeader{{
+						Name:  network.ProbeHeaderName,
+						Value: queue.Name,
+					}},
+				},
+			},
 		},
 		SecurityContext: queueSecurityContext,
 		Env: []corev1.EnvVar{{

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -181,7 +181,7 @@ func makeStartupExecProbe(in *corev1.Probe, progressDeadline time.Duration) *cor
 	out := &corev1.Probe{
 		Handler: corev1.Handler{
 			Exec: &corev1.ExecAction{
-				Command: []string{"/ko-app/queue", "-probe-timeout", progressDeadline.String()},
+				Command: []string{"/ko-app/queue", "-probe-period", progressDeadline.String()},
 			},
 		},
 		// We keep the connection open for a while because we're actively probing

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -713,7 +713,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 			c.StartupProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					Exec: &corev1.ExecAction{
-						Command: []string{"/ko-app/queue", "-probe-timeout", "1h34m38s"},
+						Command: []string{"/ko-app/queue", "-probe-period", "1h34m38s"},
 					},
 				},
 				// StartupProbe overrides the user's parameters because the


### PR DESCRIPTION
Fixes #10703.

Now that StartupProbe is available, we can avoid spawning an exec probe in to the user pod every 10 seconds \o/. This maintains the same probe as now at startup-time, then after that uses a HTTP readiness probe that hits the same QP endpoint the exec probe hits. This minimises the changes from today and is a nice, backwards-compatible start. 

Following on from this I think we may want to rework quite a bit of how our readiness probe stuff works (e.g. it'd be nice to keep the probes on the user container so failures are on the right object, and we currently [ignore probes ~entirely after startup if periodSeconds>0](https://github.com/knative/serving/issues/10764)), but this is a minimal change that should be entirely backwards-compatible and save quite a few cpu cycles.