### PR TITLE
Restrict the Clock interface to the passive where possible.

### DIFF
--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -89,7 +89,7 @@ func (rs *RevisionSpec) GetContainer() *corev1.Container {
 
 // SetRoutingState sets the routingState label on this Revision and updates the
 // routingStateModified annotation.
-func (r *Revision) SetRoutingState(state RoutingState, clock clock.Clock) {
+func (r *Revision) SetRoutingState(state RoutingState, clock clock.PassiveClock) {
 	stateStr := string(state)
 	if t := r.Annotations[serving.RoutingStateModifiedAnnotationKey]; t != "" &&
 		r.Labels[serving.RoutingStateLabelKey] == stateStr {
@@ -106,7 +106,7 @@ func (r *Revision) SetRoutingState(state RoutingState, clock clock.Clock) {
 }
 
 // RoutingStateModifiedString gives a formatted now timestamp.
-func RoutingStateModifiedString(clock clock.Clock) string {
+func RoutingStateModifiedString(clock clock.PassiveClock) string {
 	return clock.Now().UTC().Format(time.RFC3339)
 }
 

--- a/pkg/apis/serving/v1/revision_helpers_test.go
+++ b/pkg/apis/serving/v1/revision_helpers_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/clock"
+
 	net "knative.dev/networking/pkg/apis/networking"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/serving/pkg/apis/serving"
@@ -261,7 +262,7 @@ func TestGetContainer(t *testing.T) {
 func TestSetRoutingState(t *testing.T) {
 	rev := &Revision{}
 	empty := time.Time{}
-	clock := clock.RealClock{}
+	clock := &clock.RealClock{}
 
 	// Test unset timestamp
 	if rev.GetRoutingStateModified() != empty {

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -49,7 +49,7 @@ type Reconciler struct {
 	// listers index properties about resources
 	revisionLister listers.RevisionLister
 
-	clock clock.Clock
+	clock clock.PassiveClock
 }
 
 // Check that our Reconciler implements configreconciler.Interface

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -58,11 +58,11 @@ var revisionSpec = v1.RevisionSpec{
 }
 
 var testCtx context.Context
-var testClock clock.Clock
+var testClock clock.PassiveClock
 
 // This is heavily based on the way the OpenShift Ingress controller tests its reconciliation method.
 func TestReconcile(t *testing.T) {
-	testClock = clock.NewFakeClock(time.Now())
+	testClock = clock.NewFakePassiveClock(time.Now())
 	testCtx = context.Background()
 
 	test(t)

--- a/pkg/reconciler/configuration/controller.go
+++ b/pkg/reconciler/configuration/controller.go
@@ -37,15 +37,6 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
-	return NewControllerWithClock(ctx, cmw, clock.RealClock{})
-}
-
-// NewControllerWithClock creates a new Configuration controller with a clock
-func NewControllerWithClock(
-	ctx context.Context,
-	cmw configmap.Watcher,
-	clock clock.Clock,
-) *controller.Impl {
 	logger := logging.FromContext(ctx)
 	configurationInformer := configurationinformer.Get(ctx)
 	revisionInformer := revisioninformer.Get(ctx)
@@ -57,7 +48,7 @@ func NewControllerWithClock(
 	c := &Reconciler{
 		client:         servingclient.Get(ctx),
 		revisionLister: revisionInformer.Lister(),
-		clock:          clock,
+		clock:          &clock.RealClock{},
 	}
 	impl := configreconciler.NewImpl(ctx, c, func(*controller.Impl) controller.Options {
 		return controller.Options{ConfigStore: configStore}

--- a/pkg/reconciler/configuration/resources/revision.go
+++ b/pkg/reconciler/configuration/resources/revision.go
@@ -28,7 +28,7 @@ import (
 )
 
 // MakeRevision creates a revision object from configuration.
-func MakeRevision(ctx context.Context, configuration *v1.Configuration, clock clock.Clock) *v1.Revision {
+func MakeRevision(ctx context.Context, configuration *v1.Configuration, clock clock.PassiveClock) *v1.Revision {
 	// Start from the ObjectMeta/Spec inlined in the Configuration resources.
 	rev := &v1.Revision{
 		ObjectMeta: configuration.Spec.GetTemplate().ObjectMeta,

--- a/pkg/reconciler/configuration/resources/revision_test.go
+++ b/pkg/reconciler/configuration/resources/revision_test.go
@@ -31,10 +31,10 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
-var fakeCurTime = time.Unix(1e9, 0)
+var fakeCurTime = time.Unix(1e9, 20102021)
 
 func TestMakeRevisions(t *testing.T) {
-	clock := clock.NewFakeClock(fakeCurTime)
+	clock := clock.NewFakePassiveClock(fakeCurTime)
 
 	tests := []struct {
 		name          string

--- a/pkg/reconciler/gc/reconciler_test.go
+++ b/pkg/reconciler/gc/reconciler_test.go
@@ -75,7 +75,7 @@ func TestGCReconcile(t *testing.T) {
 			},
 		}}
 
-	fc := clock.NewFakeClock(time.Now())
+	fc := clock.NewFakePassiveClock(time.Now())
 	table := TableTest{{
 		Name: "delete oldest, keep two V2",
 		Objects: []runtime.Object{

--- a/pkg/reconciler/gc/v2/gc_test.go
+++ b/pkg/reconciler/gc/v2/gc_test.go
@@ -65,7 +65,7 @@ func TestCollectMin(t *testing.T) {
 	old := now.Add(-11 * time.Minute)
 	older := now.Add(-12 * time.Minute)
 	oldest := now.Add(-13 * time.Minute)
-	fc := clock.NewFakeClock(now)
+	fc := clock.NewFakePassiveClock(now)
 
 	table := []struct {
 		name        string
@@ -229,7 +229,7 @@ func TestCollectMax(t *testing.T) {
 	old := now.Add(-11 * time.Minute)
 	older := now.Add(-12 * time.Minute)
 	oldest := now.Add(-13 * time.Minute)
-	fc := clock.NewFakeClock(now)
+	fc := clock.NewFakePassiveClock(now)
 
 	table := []struct {
 		name        string
@@ -329,7 +329,7 @@ func TestCollectSettings(t *testing.T) {
 	old := now.Add(-11 * time.Minute)
 	older := now.Add(-12 * time.Minute)
 	oldest := now.Add(-13 * time.Minute)
-	fc := clock.NewFakeClock(now)
+	fc := clock.NewFakePassiveClock(now)
 
 	cfg := cfg("settings-test", "foo", 5556,
 		WithLatestCreated("5556"),

--- a/pkg/reconciler/labeler/accessors.go
+++ b/pkg/reconciler/labeler/accessors.go
@@ -49,7 +49,7 @@ type RevisionAccessor struct {
 	tracker tracker.Interface
 	lister  listers.RevisionLister
 	indexer cache.Indexer
-	clock   clock.Clock
+	clock   clock.PassiveClock
 }
 
 // RevisionAccessor implements Accessor
@@ -61,7 +61,7 @@ func newRevisionAccessor(
 	tracker tracker.Interface,
 	lister listers.RevisionLister,
 	indexer cache.Indexer,
-	clock clock.Clock) *RevisionAccessor {
+	clock clock.PassiveClock) *RevisionAccessor {
 	return &RevisionAccessor{
 		client:  client,
 		tracker: tracker,
@@ -73,7 +73,7 @@ func newRevisionAccessor(
 
 // makeMetadataPatch makes a metadata map to be patched or nil if no changes are needed.
 func makeMetadataPatch(
-	acc kmeta.Accessor, routeName string, addRoutingState, remove bool, clock clock.Clock) (map[string]interface{}, error) {
+	acc kmeta.Accessor, routeName string, addRoutingState, remove bool, clock clock.PassiveClock) (map[string]interface{}, error) {
 	labels := map[string]interface{}{}
 	annotations := map[string]interface{}{}
 
@@ -97,7 +97,7 @@ func makeMetadataPatch(
 }
 
 // markRoutingState updates the RoutingStateLabel and bumps the modified time annotation.
-func markRoutingState(acc kmeta.Accessor, clock clock.Clock, diffLabels, diffAnn map[string]interface{}) {
+func markRoutingState(acc kmeta.Accessor, clock clock.PassiveClock, diffLabels, diffAnn map[string]interface{}) {
 
 	hasRoute := acc.GetAnnotations()[serving.RoutesAnnotationKey] != ""
 	if val, has := diffAnn[serving.RoutesAnnotationKey]; has {
@@ -179,7 +179,7 @@ type ConfigurationAccessor struct {
 	tracker tracker.Interface
 	lister  listers.ConfigurationLister
 	indexer cache.Indexer
-	clock   clock.Clock
+	clock   clock.PassiveClock
 }
 
 // ConfigurationAccessor implements Accessor
@@ -191,7 +191,7 @@ func newConfigurationAccessor(
 	tracker tracker.Interface,
 	lister listers.ConfigurationLister,
 	indexer cache.Indexer,
-	clock clock.Clock) *ConfigurationAccessor {
+	clock clock.PassiveClock) *ConfigurationAccessor {
 	return &ConfigurationAccessor{
 		client:  client,
 		tracker: tracker,

--- a/pkg/reconciler/labeler/controller.go
+++ b/pkg/reconciler/labeler/controller.go
@@ -42,14 +42,6 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
-	return newControllerWithClock(ctx, cmw, clock.RealClock{})
-}
-
-func newControllerWithClock(
-	ctx context.Context,
-	cmw configmap.Watcher,
-	clock clock.Clock,
-) *controller.Impl {
 	logger := logging.FromContext(ctx)
 	routeInformer := routeinformer.Get(ctx)
 	configInformer := configurationinformer.Get(ctx)
@@ -93,6 +85,7 @@ func newControllerWithClock(
 	))
 
 	client := servingclient.Get(ctx)
+	clock := &clock.RealClock{}
 	c.caccV2 = newConfigurationAccessor(client, tracker, configInformer.Lister(), configInformer.Informer().GetIndexer(), clock)
 	c.raccV2 = newRevisionAccessor(client, tracker, revisionInformer.Lister(), revisionInformer.Informer().GetIndexer(), clock)
 

--- a/pkg/reconciler/labeler/labeler_test.go
+++ b/pkg/reconciler/labeler/labeler_test.go
@@ -53,7 +53,7 @@ import (
 func TestV2Reconcile(t *testing.T) {
 	now := metav1.Now()
 	fakeTime := now.Time
-	clock := clock.NewFakeClock(fakeTime)
+	clock := clock.NewFakePassiveClock(fakeTime)
 
 	table := TableTest{{
 		Name: "bad workqueue key",

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -57,7 +57,7 @@ import (
 func TestReconcile(t *testing.T) {
 	// We don't care about the value, but that it does not change,
 	// since it leads to flakes.
-	fc := clock.NewFakeClock(time.Now())
+	fc := clock.NewFakePassiveClock(time.Now())
 
 	table := TableTest{{
 		Name: "bad workqueue key",

--- a/pkg/testing/v1/revision.go
+++ b/pkg/testing/v1/revision.go
@@ -101,7 +101,7 @@ func WithRoutingStateModified(t time.Time) RevisionOption {
 }
 
 // WithRoutingState updates the annotation to the provided timestamp.
-func WithRoutingState(s v1.RoutingState, c clock.Clock) RevisionOption {
+func WithRoutingState(s v1.RoutingState, c clock.PassiveClock) RevisionOption {
 	return func(rev *v1.Revision) {
 		rev.SetRoutingState(s, c)
 	}


### PR DESCRIPTION
Accept wide, require narrow in effect.

Also remove the c'tors that were not even used in the tests.

/assign @dprotaso @whaught mattmoor