### PR TITLE
Change interface to accept time rather than clock

### DIFF
--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -101,13 +101,13 @@ func (r *Revision) SetRoutingState(state RoutingState, clock clock.Clock) {
 
 	r.Annotations = kmeta.UnionMaps(r.Annotations,
 		map[string]string{
-			serving.RoutingStateModifiedAnnotationKey: RoutingStateModifiedString(clock),
+			serving.RoutingStateModifiedAnnotationKey: RoutingStateModifiedString(clock.Now()),
 		})
 }
 
 // RoutingStateModifiedString gives a formatted now timestamp.
-func RoutingStateModifiedString(clock clock.Clock) string {
-	return clock.Now().UTC().Format(time.RFC3339)
+func RoutingStateModifiedString(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
 }
 
 // GetRoutingState retrieves the RoutingState label.

--- a/pkg/reconciler/configuration/resources/revision_test.go
+++ b/pkg/reconciler/configuration/resources/revision_test.go
@@ -80,7 +80,7 @@ func TestMakeRevisions(t *testing.T) {
 					serving.ServiceLabelKey:                 "",
 				},
 				Annotations: map[string]string{
-					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(clock),
+					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(fakeCurTime),
 				},
 			},
 			Spec: v1.RevisionSpec{
@@ -122,7 +122,7 @@ func TestMakeRevisions(t *testing.T) {
 				Namespace: "with",
 				Name:      "labels-00100",
 				Annotations: map[string]string{
-					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(clock),
+					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(fakeCurTime),
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1.SchemeGroupVersion.String(),
@@ -194,7 +194,7 @@ func TestMakeRevisions(t *testing.T) {
 				Annotations: map[string]string{
 					"foo": "bar",
 					"baz": "blah",
-					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(clock),
+					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(fakeCurTime),
 				},
 			},
 			Spec: v1.RevisionSpec{
@@ -238,7 +238,7 @@ func TestMakeRevisions(t *testing.T) {
 				Annotations: map[string]string{
 					"serving.knative.dev/creator":             "someone",
 					serving.RoutesAnnotationKey:               "route",
-					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(clock),
+					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(fakeCurTime),
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1.SchemeGroupVersion.String(),
@@ -300,7 +300,7 @@ func TestMakeRevisions(t *testing.T) {
 					"serving.knative.dev/creator": "someone",
 					"foo":                         "bar",
 					"baz":                         "blah",
-					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(clock),
+					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(fakeCurTime),
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1.SchemeGroupVersion.String(),

--- a/pkg/reconciler/labeler/accessors.go
+++ b/pkg/reconciler/labeler/accessors.go
@@ -111,7 +111,7 @@ func markRoutingState(acc kmeta.Accessor, clock clock.Clock, diffLabels, diffAnn
 
 	if acc.GetLabels()[serving.RoutingStateLabelKey] != wantState {
 		diffLabels[serving.RoutingStateLabelKey] = wantState
-		diffAnn[serving.RoutingStateModifiedAnnotationKey] = v1.RoutingStateModifiedString(clock)
+		diffAnn[serving.RoutingStateModifiedAnnotationKey] = v1.RoutingStateModifiedString(clock.Now())
 	}
 }
 


### PR DESCRIPTION
No reason to pass the whole clock to the formatter.
Thus this simplifies the tests too.

/assign @whaught @dprotaso @tcnghia 