### PR TITLE
Deep cleaning of the time manipulation in config and revision and other fixes to the codebase

### DIFF
--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/clock"
 	net "knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving"
@@ -89,7 +88,7 @@ func (rs *RevisionSpec) GetContainer() *corev1.Container {
 
 // SetRoutingState sets the routingState label on this Revision and updates the
 // routingStateModified annotation.
-func (r *Revision) SetRoutingState(state RoutingState, clock clock.PassiveClock) {
+func (r *Revision) SetRoutingState(state RoutingState, tm time.Time) {
 	stateStr := string(state)
 	if t := r.Annotations[serving.RoutingStateModifiedAnnotationKey]; t != "" &&
 		r.Labels[serving.RoutingStateLabelKey] == stateStr {
@@ -101,8 +100,9 @@ func (r *Revision) SetRoutingState(state RoutingState, clock clock.PassiveClock)
 
 	r.Annotations = kmeta.UnionMaps(r.Annotations,
 		map[string]string{
-			serving.RoutingStateModifiedAnnotationKey: RoutingStateModifiedString(clock.Now()),
-		})
+			serving.RoutingStateModifiedAnnotationKey: RoutingStateModifiedString(tm),
+		},
+	)
 }
 
 // RoutingStateModifiedString gives a formatted now timestamp.

--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -101,13 +101,13 @@ func (r *Revision) SetRoutingState(state RoutingState, clock clock.PassiveClock)
 
 	r.Annotations = kmeta.UnionMaps(r.Annotations,
 		map[string]string{
-			serving.RoutingStateModifiedAnnotationKey: RoutingStateModifiedString(clock),
+			serving.RoutingStateModifiedAnnotationKey: RoutingStateModifiedString(clock.Now()),
 		})
 }
 
 // RoutingStateModifiedString gives a formatted now timestamp.
-func RoutingStateModifiedString(clock clock.PassiveClock) string {
-	return clock.Now().UTC().Format(time.RFC3339)
+func RoutingStateModifiedString(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
 }
 
 // GetRoutingState retrieves the RoutingState label.

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -279,7 +279,7 @@ func (c *Reconciler) latestCreatedRevision(ctx context.Context, config *v1.Confi
 func (c *Reconciler) createRevision(ctx context.Context, config *v1.Configuration) (*v1.Revision, error) {
 	logger := logging.FromContext(ctx)
 
-	rev := resources.MakeRevision(ctx, config, c.clock)
+	rev := resources.MakeRevision(ctx, config, c.clock.Now())
 	created, err := c.client.ServingV1().Revisions(config.Namespace).Create(ctx, rev, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -57,8 +57,10 @@ var revisionSpec = v1.RevisionSpec{
 	TimeoutSeconds: ptr.Int64(60),
 }
 
-var testCtx context.Context
-var testClock clock.PassiveClock
+var (
+	testCtx   context.Context
+	testClock clock.PassiveClock
+)
 
 // This is heavily based on the way the OpenShift Ingress controller tests its reconciliation method.
 func TestReconcile(t *testing.T) {
@@ -562,8 +564,8 @@ func cfg(name, namespace string, generation int64, co ...ConfigOption) *v1.Confi
 }
 
 func rev(name, namespace string, generation int64, ro ...RevisionOption) *v1.Revision {
-	r := resources.MakeRevision(testCtx, cfg(name, namespace, generation), testClock)
-	r.SetDefaults(context.Background())
+	r := resources.MakeRevision(testCtx, cfg(name, namespace, generation), testClock.Now())
+	r.SetDefaults(testCtx)
 	for _, opt := range ro {
 		opt(r)
 	}

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -64,12 +64,8 @@ var testClock clock.PassiveClock
 func TestReconcile(t *testing.T) {
 	testClock = clock.NewFakePassiveClock(time.Now())
 	testCtx = context.Background()
-
-	test(t)
-}
-
-func test(t *testing.T) {
 	retryAttempted := false
+
 	now := testClock.Now()
 
 	table := TableTest{{

--- a/pkg/reconciler/configuration/resources/revision_test.go
+++ b/pkg/reconciler/configuration/resources/revision_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/clock"
 
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving"
@@ -34,7 +33,7 @@ import (
 var fakeCurTime = time.Unix(1e9, 20102021)
 
 func TestMakeRevisions(t *testing.T) {
-	clock := clock.NewFakePassiveClock(fakeCurTime)
+	tm := fakeCurTime
 
 	tests := []struct {
 		name          string
@@ -328,7 +327,7 @@ func TestMakeRevisions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := MakeRevision(context.Background(), test.configuration, clock)
+			got := MakeRevision(context.Background(), test.configuration, tm)
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Error("MakeRevision (-want, +got) =", diff)
 			}

--- a/pkg/reconciler/configuration/resources/revision_test.go
+++ b/pkg/reconciler/configuration/resources/revision_test.go
@@ -80,7 +80,7 @@ func TestMakeRevisions(t *testing.T) {
 					serving.ServiceLabelKey:                 "",
 				},
 				Annotations: map[string]string{
-					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(clock),
+					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(fakeCurTime),
 				},
 			},
 			Spec: v1.RevisionSpec{
@@ -122,7 +122,7 @@ func TestMakeRevisions(t *testing.T) {
 				Namespace: "with",
 				Name:      "labels-00100",
 				Annotations: map[string]string{
-					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(clock),
+					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(fakeCurTime),
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1.SchemeGroupVersion.String(),
@@ -194,7 +194,7 @@ func TestMakeRevisions(t *testing.T) {
 				Annotations: map[string]string{
 					"foo": "bar",
 					"baz": "blah",
-					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(clock),
+					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(fakeCurTime),
 				},
 			},
 			Spec: v1.RevisionSpec{
@@ -238,7 +238,7 @@ func TestMakeRevisions(t *testing.T) {
 				Annotations: map[string]string{
 					"serving.knative.dev/creator":             "someone",
 					serving.RoutesAnnotationKey:               "route",
-					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(clock),
+					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(fakeCurTime),
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1.SchemeGroupVersion.String(),
@@ -300,7 +300,7 @@ func TestMakeRevisions(t *testing.T) {
 					"serving.knative.dev/creator": "someone",
 					"foo":                         "bar",
 					"baz":                         "blah",
-					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(clock),
+					serving.RoutingStateModifiedAnnotationKey: v1.RoutingStateModifiedString(fakeCurTime),
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1.SchemeGroupVersion.String(),

--- a/pkg/reconciler/gc/reconciler_test.go
+++ b/pkg/reconciler/gc/reconciler_test.go
@@ -140,7 +140,7 @@ func cfg(name, namespace string, generation int64, co ...ConfigOption) *v1.Confi
 
 func rev(name, namespace string, generation int64, ro ...RevisionOption) *v1.Revision {
 	config := cfg(name, namespace, generation)
-	rev := resources.MakeRevision(context.Background(), config, clock.RealClock{})
+	rev := resources.MakeRevision(context.Background(), config, time.Now())
 	rev.SetDefaults(context.Background())
 
 	for _, opt := range ro {

--- a/pkg/reconciler/gc/v2/gc_test.go
+++ b/pkg/reconciler/gc/v2/gc_test.go
@@ -557,7 +557,7 @@ func cfg(name, namespace string, generation int64, co ...ConfigOption) *v1.Confi
 
 func rev(configName, namespace string, generation int64, ro ...RevisionOption) *v1.Revision {
 	config := cfg(configName, namespace, generation)
-	rev := resources.MakeRevision(context.Background(), config, clock.RealClock{})
+	rev := resources.MakeRevision(context.Background(), config, time.Now())
 	rev.SetDefaults(context.Background())
 
 	for _, opt := range ro {

--- a/pkg/reconciler/labeler/accessors.go
+++ b/pkg/reconciler/labeler/accessors.go
@@ -111,7 +111,7 @@ func markRoutingState(acc kmeta.Accessor, clock clock.PassiveClock, diffLabels, 
 
 	if acc.GetLabels()[serving.RoutingStateLabelKey] != wantState {
 		diffLabels[serving.RoutingStateLabelKey] = wantState
-		diffAnn[serving.RoutingStateModifiedAnnotationKey] = v1.RoutingStateModifiedString(clock)
+		diffAnn[serving.RoutingStateModifiedAnnotationKey] = v1.RoutingStateModifiedString(clock.Now())
 	}
 }
 

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	// Install our fake informers
 	_ "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration/fake"
@@ -47,7 +48,6 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/clock"
 	clientgotesting "k8s.io/client-go/testing"
 
 	. "knative.dev/pkg/reconciler/testing"
@@ -870,5 +870,5 @@ func RouteFailed(reason, message string) RouteOption {
 
 func rev(name, namespace string, so ServiceOption, co ...ConfigOption) *v1.Revision {
 	cfg := config(name, namespace, so, co...)
-	return configresources.MakeRevision(context.Background(), cfg, clock.RealClock{})
+	return configresources.MakeRevision(context.Background(), cfg, time.Now())
 }

--- a/pkg/testing/v1/revision.go
+++ b/pkg/testing/v1/revision.go
@@ -103,7 +103,7 @@ func WithRoutingStateModified(t time.Time) RevisionOption {
 // WithRoutingState updates the annotation to the provided timestamp.
 func WithRoutingState(s v1.RoutingState, c clock.PassiveClock) RevisionOption {
 	return func(rev *v1.Revision) {
-		rev.SetRoutingState(s, c)
+		rev.SetRoutingState(s, c.Now())
 	}
 }
 


### PR DESCRIPTION

- Stop passing the clock around when we mean `now`
- This yielded quite a few places to clean up
- Various other nits and bits that I picked to fix on the way.

(Should be the last in this series of fixes, I hope)

/assign @tcnghia @whaught 