### PR TITLE
Relax the grace period minival vaue to be any positive value

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "1d830d9e"
+    knative.dev/example-checksum: "604cb513"
 data:
   _example: |
     ################################
@@ -138,7 +138,8 @@ data:
     enable-scale-to-zero: "true"
 
     # Scale to zero grace period is the time an inactive revision is left
-    # running before it is scaled to zero (min: 6s).
+    # running before it is scaled to zero (must be positive, but recommended
+    # at least a few seconds if running with mesh networking).
     # This is the upper limit and is provided not to enforce timeout after
     # the revision stopped receiving requests for stable window, but to
     # ensure network reprogramming to put activator in the path has completed.

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -37,7 +37,6 @@ const (
 	BucketSize = 1 * time.Second
 
 	defaultTargetUtilization = 0.7
-	minScaleTo0GracePeriod   = 5 * time.Second
 )
 
 func defaultConfig() *autoscalerconfig.Config {

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -37,6 +37,7 @@ const (
 	BucketSize = 1 * time.Second
 
 	defaultTargetUtilization = 0.7
+	minScaleTo0GracePeriod   = 5 * time.Second
 )
 
 func defaultConfig() *autoscalerconfig.Config {
@@ -109,8 +110,8 @@ func NewConfigFromMap(data map[string]string) (*autoscalerconfig.Config, error) 
 }
 
 func validate(lc *autoscalerconfig.Config) (*autoscalerconfig.Config, error) {
-	if lc.ScaleToZeroGracePeriod < autoscaling.WindowMin {
-		return nil, fmt.Errorf("scale-to-zero-grace-period must be at least %v, was: %v", autoscaling.WindowMin, lc.ScaleToZeroGracePeriod)
+	if lc.ScaleToZeroGracePeriod <= 0 {
+		return nil, fmt.Errorf("scale-to-zero-grace-period must be positive, was: %v", lc.ScaleToZeroGracePeriod)
 	}
 
 	if lc.ScaleDownDelay < 0 {

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -272,7 +272,7 @@ func TestNewConfig(t *testing.T) {
 		name: "grace window too small",
 		input: map[string]string{
 			"stable-window":              "12s",
-			"scale-to-zero-grace-period": "4s",
+			"scale-to-zero-grace-period": "0s",
 		},
 		wantErr: true,
 	}, {


### PR DESCRIPTION
/assign @markusthoemmes @dprotaso 

Basically the discussion we had resulted in that there's no real reason why it should be 6s or 1s or 30s.
We know it has to be positive especially in mesh scenarios, but the value is highly dependent on the cluster and knative deployment itself.