### PR TITLE
Hide the things that are private now in effect

### DIFF
--- a/pkg/reconciler/labeler/accessors.go
+++ b/pkg/reconciler/labeler/accessors.go
@@ -35,16 +35,16 @@ import (
 	listers "knative.dev/serving/pkg/client/listers/serving/v1"
 )
 
-// Accessor defines an abstraction for manipulating labeled entity
+// accessor defines an abstraction for manipulating labeled entity
 // (Configuration, Revision) with shared logic.
-type Accessor interface {
-	list(ctx context.Context, ns, routeName string, state v1.RoutingState) ([]kmeta.Accessor, error)
+type accessor interface {
+	list(ns, routeName string, state v1.RoutingState) ([]kmeta.Accessor, error)
 	patch(ctx context.Context, ns, name string, pt types.PatchType, p []byte) error
 	makeMetadataPatch(route *v1.Route, name string, remove bool) (map[string]interface{}, error)
 }
 
-// RevisionAccessor is an implementation of Accessor for Revisions.
-type RevisionAccessor struct {
+// revisionAccessor is an implementation of Accessor for Revisions.
+type revisionAccessor struct {
 	client  clientset.Interface
 	tracker tracker.Interface
 	lister  listers.RevisionLister
@@ -53,7 +53,7 @@ type RevisionAccessor struct {
 }
 
 // RevisionAccessor implements Accessor
-var _ Accessor = (*RevisionAccessor)(nil)
+var _ accessor = (*revisionAccessor)(nil)
 
 // newRevisionAccessor is a factory function to make a new revision accessor.
 func newRevisionAccessor(
@@ -61,8 +61,8 @@ func newRevisionAccessor(
 	tracker tracker.Interface,
 	lister listers.RevisionLister,
 	indexer cache.Indexer,
-	clock clock.PassiveClock) *RevisionAccessor {
-	return &RevisionAccessor{
+	clock clock.PassiveClock) *revisionAccessor {
+	return &revisionAccessor{
 		client:  client,
 		tracker: tracker,
 		lister:  lister,
@@ -141,7 +141,7 @@ func updateRouteAnnotation(acc kmeta.Accessor, routeName string, diffAnn map[str
 }
 
 // list implements Accessor
-func (r *RevisionAccessor) list(_ context.Context, ns, routeName string, state v1.RoutingState) ([]kmeta.Accessor, error) {
+func (r *revisionAccessor) list(ns, routeName string, state v1.RoutingState) ([]kmeta.Accessor, error) {
 	kl := make([]kmeta.Accessor, 0, 1)
 	filter := func(m interface{}) {
 		r := m.(*v1.Revision)
@@ -160,12 +160,12 @@ func (r *RevisionAccessor) list(_ context.Context, ns, routeName string, state v
 }
 
 // patch implements Accessor
-func (r *RevisionAccessor) patch(ctx context.Context, ns, name string, pt types.PatchType, p []byte) error {
+func (r *revisionAccessor) patch(ctx context.Context, ns, name string, pt types.PatchType, p []byte) error {
 	_, err := r.client.ServingV1().Revisions(ns).Patch(ctx, name, pt, p, metav1.PatchOptions{})
 	return err
 }
 
-func (r *RevisionAccessor) makeMetadataPatch(route *v1.Route, name string, remove bool) (map[string]interface{}, error) {
+func (r *revisionAccessor) makeMetadataPatch(route *v1.Route, name string, remove bool) (map[string]interface{}, error) {
 	rev, err := r.lister.Revisions(route.Namespace).Get(name)
 	if err != nil {
 		return nil, err
@@ -173,8 +173,8 @@ func (r *RevisionAccessor) makeMetadataPatch(route *v1.Route, name string, remov
 	return makeMetadataPatch(rev, route.Name, true /*addRoutingState*/, remove, r.clock)
 }
 
-// ConfigurationAccessor is an implementation of Accessor for Configurations.
-type ConfigurationAccessor struct {
+// configurationAccessor is an implementation of Accessor for Configurations.
+type configurationAccessor struct {
 	client  clientset.Interface
 	tracker tracker.Interface
 	lister  listers.ConfigurationLister
@@ -183,7 +183,7 @@ type ConfigurationAccessor struct {
 }
 
 // ConfigurationAccessor implements Accessor
-var _ Accessor = (*ConfigurationAccessor)(nil)
+var _ accessor = (*configurationAccessor)(nil)
 
 // NewConfigurationAccessor is a factory function to make a new configuration Accessor.
 func newConfigurationAccessor(
@@ -191,8 +191,8 @@ func newConfigurationAccessor(
 	tracker tracker.Interface,
 	lister listers.ConfigurationLister,
 	indexer cache.Indexer,
-	clock clock.PassiveClock) *ConfigurationAccessor {
-	return &ConfigurationAccessor{
+	clock clock.PassiveClock) *configurationAccessor {
+	return &configurationAccessor{
 		client:  client,
 		tracker: tracker,
 		lister:  lister,
@@ -202,7 +202,7 @@ func newConfigurationAccessor(
 }
 
 // list implements Accessor
-func (c *ConfigurationAccessor) list(_ context.Context, ns, routeName string, state v1.RoutingState) ([]kmeta.Accessor, error) {
+func (c *configurationAccessor) list(ns, routeName string, state v1.RoutingState) ([]kmeta.Accessor, error) {
 	kl := make([]kmeta.Accessor, 0, 1)
 	filter := func(m interface{}) {
 		c := m.(*v1.Configuration)
@@ -228,12 +228,12 @@ func GetListAnnValue(annotations map[string]string, key string) sets.String {
 }
 
 // patch implements Accessor
-func (c *ConfigurationAccessor) patch(ctx context.Context, ns, name string, pt types.PatchType, p []byte) error {
+func (c *configurationAccessor) patch(ctx context.Context, ns, name string, pt types.PatchType, p []byte) error {
 	_, err := c.client.ServingV1().Configurations(ns).Patch(ctx, name, pt, p, metav1.PatchOptions{})
 	return err
 }
 
-func (c *ConfigurationAccessor) makeMetadataPatch(r *v1.Route, name string, remove bool) (map[string]interface{}, error) {
+func (c *configurationAccessor) makeMetadataPatch(r *v1.Route, name string, remove bool) (map[string]interface{}, error) {
 	config, err := c.lister.Configurations(r.Namespace).Get(name)
 	if err != nil {
 		return nil, err

--- a/pkg/reconciler/labeler/labeler.go
+++ b/pkg/reconciler/labeler/labeler.go
@@ -26,8 +26,8 @@ import (
 
 // Reconciler implements controller.Reconciler for Route resources.
 type Reconciler struct {
-	caccV2 *ConfigurationAccessor
-	raccV2 *RevisionAccessor
+	caccV2 *configurationAccessor
+	raccV2 *revisionAccessor
 }
 
 // Check that our Reconciler implements routereconciler.Interface

--- a/pkg/reconciler/labeler/metasync.go
+++ b/pkg/reconciler/labeler/metasync.go
@@ -123,7 +123,7 @@ func setMetaForListed(ctx context.Context, route *v1.Route, acc accessor, names 
 // not named within our list.  Unlike setMetaForListed, this function takes ns/name instead of a
 // Route so that it can clean things up when a Route ceases to exist.
 func clearMetaForNotListed(ctx context.Context, r *v1.Route, acc accessor, names sets.String) error {
-	oldList, err := acc.list(ctx, r.Namespace, r.Name, v1.RoutingStateActive)
+	oldList, err := acc.list(r.Namespace, r.Name, v1.RoutingStateActive)
 	if err != nil {
 		return err
 	}

--- a/pkg/reconciler/labeler/metasync.go
+++ b/pkg/reconciler/labeler/metasync.go
@@ -32,7 +32,7 @@ import (
 
 // syncRoutingMeta makes sure that the revisions and configurations referenced from
 // a Route are labeled with the routingState label and routes annotation.
-func syncRoutingMeta(ctx context.Context, r *v1.Route, cacc *ConfigurationAccessor, racc *RevisionAccessor) error {
+func syncRoutingMeta(ctx context.Context, r *v1.Route, cacc *configurationAccessor, racc *revisionAccessor) error {
 	revisions := sets.NewString()
 	configs := sets.NewString()
 
@@ -99,7 +99,7 @@ func syncRoutingMeta(ctx context.Context, r *v1.Route, cacc *ConfigurationAccess
 }
 
 // clearRoutingMeta removes any labels for a named route from given accessors.
-func clearRoutingMeta(ctx context.Context, r *v1.Route, accs ...Accessor) error {
+func clearRoutingMeta(ctx context.Context, r *v1.Route, accs ...accessor) error {
 	for _, acc := range accs {
 		if err := clearMetaForNotListed(ctx, r, acc, nil /*none listed*/); err != nil {
 			return err
@@ -110,7 +110,7 @@ func clearRoutingMeta(ctx context.Context, r *v1.Route, accs ...Accessor) error 
 
 // setMetaForListed uses the accessor to attach the label for this route to every element
 // listed within "names" in the same namespace.
-func setMetaForListed(ctx context.Context, route *v1.Route, acc Accessor, names sets.String) error {
+func setMetaForListed(ctx context.Context, route *v1.Route, acc accessor, names sets.String) error {
 	for name := range names {
 		if err := setRoutingMeta(ctx, acc, route, name, false); err != nil {
 			return fmt.Errorf("failed to add route annotation to Namespace=%s Name=%q: %w", route.Namespace, name, err)
@@ -122,7 +122,7 @@ func setMetaForListed(ctx context.Context, route *v1.Route, acc Accessor, names 
 // clearMetaForNotListed uses the accessor to delete the label from any listable entity that is
 // not named within our list.  Unlike setMetaForListed, this function takes ns/name instead of a
 // Route so that it can clean things up when a Route ceases to exist.
-func clearMetaForNotListed(ctx context.Context, r *v1.Route, acc Accessor, names sets.String) error {
+func clearMetaForNotListed(ctx context.Context, r *v1.Route, acc accessor, names sets.String) error {
 	oldList, err := acc.list(ctx, r.Namespace, r.Name, v1.RoutingStateActive)
 	if err != nil {
 		return err
@@ -148,7 +148,7 @@ func clearMetaForNotListed(ctx context.Context, r *v1.Route, acc Accessor, names
 // element through the provided accessor.
 // A nil route name will cause the route to be de-referenced, and a non-nil route will cause
 // that route name to be attached to the element.
-func setRoutingMeta(ctx context.Context, acc Accessor, r *v1.Route, name string, remove bool) error {
+func setRoutingMeta(ctx context.Context, acc accessor, r *v1.Route, name string, remove bool) error {
 	if mergePatch, err := acc.makeMetadataPatch(r, name, remove); err != nil {
 		return err
 	} else if mergePatch != nil {


### PR DESCRIPTION
Upon closer inspection, it seems that When we removed the v1 & v2 or labeler there's no reason for those to continue to be public types.

Also `list` does not seem to use `ctx` at all, so remove that parameter
too from the interface.

/assign @whaught @dprotaso 