### PR TITLE
Resume HTTP01 challenge E2E tests

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -210,14 +210,12 @@ add_trap "cleanup_per_selfsigned_namespace_auto_tls" SIGKILL SIGTERM SIGQUIT
 go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
 cleanup_per_selfsigned_namespace_auto_tls
 
-# TODO(#10486): resume the HTTP01 E2E tests after figuring out the DNS setup failure.
-
-# subheader "Auto TLS test for per-ksvc certificate provision using HTTP01 challenge"
-# setup_http01_auto_tls
-# add_trap "delete_dns_record" SIGKILL SIGTERM SIGQUIT
-# go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
-# kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
-# delete_dns_record
+subheader "Auto TLS test for per-ksvc certificate provision using HTTP01 challenge"
+setup_http01_auto_tls
+add_trap "delete_dns_record" SIGKILL SIGTERM SIGQUIT
+go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
+kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
+delete_dns_record
 
 (( failed )) && fail_test
 

--- a/test/e2e/autotls/config/dnssetup/main.go
+++ b/test/e2e/autotls/config/dnssetup/main.go
@@ -53,8 +53,7 @@ func setupDNSRecord() error {
 		return err
 	}
 	if err := waitForDNSRecordVisible(dnsRecord); err != nil {
-		config.DeleteDNSRecord(dnsRecord, env.CloudDNSServiceAccountKeyFile, env.CloudDNSProject, env.DNSZone)
-		return err
+		log.Printf("DNS record is not visible yet %v", err)
 	}
 	return nil
 }

--- a/test/e2e/autotls/config/dnssetup/main.go
+++ b/test/e2e/autotls/config/dnssetup/main.go
@@ -83,12 +83,13 @@ func waitForDNSRecordVisible(record *config.DNSRecord) error {
 	if err != nil {
 		return err
 	}
-
-	return wait.PollImmediate(10*time.Second, 300*time.Second, func() (bool, error) {
+	var lastErr error
+	if err := wait.PollImmediate(10*time.Second, 300*time.Second, func() (bool, error) {
 		for _, ns := range nameservers {
 			nsIP, err := net.LookupHost(ns.Host)
 			if err != nil {
-				log.Printf("failed to look up host %s: %v", ns.Host, err)
+				log.Printf("Failed to look up host %s: %v", ns.Host, err)
+				lastErr = err
 				return false, nil
 			}
 			// This resolver bypasses the local resolver and instead queries the
@@ -99,22 +100,35 @@ func waitForDNSRecordVisible(record *config.DNSRecord) error {
 					return d.DialContext(ctx, "udp", nsIP[0]+":53")
 				},
 			}
-			if !validateRecord(r, record) {
+			valid, err := validateRecord(r, record)
+			if err != nil {
+				log.Printf("Failed to validate DNS record %v", err)
+				lastErr = err
 				return false, nil
 			}
+			if !valid {
+				return false, nil
+			}
+
 		}
 		return true, nil
-	})
+	}); err != nil {
+		return lastErr
+	}
+	return nil
 }
 
-func validateRecord(resolver *net.Resolver, record *config.DNSRecord) bool {
-	ips, _ := resolver.LookupHost(context.Background(), replaceWildcard(record.Domain))
+func validateRecord(resolver *net.Resolver, record *config.DNSRecord) (bool, error) {
+	ips, err := resolver.LookupHost(context.Background(), replaceWildcard(record.Domain))
+	if err != nil {
+		return false, err
+	}
 	for _, ip := range ips {
 		if ip == record.IP {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func replaceWildcard(domain string) string {


### PR DESCRIPTION
Fixes #10486

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Resume HTTP01 challenge E2E tests
* Do not enforce DNS record to be valid before testing. The certificate controller should handle the case that DNS record is not visible yet properly. And cert-manager has already handled this case.



