### PR TITLE
Refactor scrape client to actually take an HTTP request

### DIFF
--- a/pkg/autoscaler/metrics/http_scrape_client_test.go
+++ b/pkg/autoscaler/metrics/http_scrape_client_test.go
@@ -18,7 +18,6 @@ package metrics
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -55,7 +54,11 @@ var (
 func TestHTTPScrapeClientScrapeHappyCaseWithOptionals(t *testing.T) {
 	hClient := newTestHTTPClient(makeProtoResponse(http.StatusOK, stat, network.ProtoAcceptContent), nil)
 	sClient := newHTTPScrapeClient(hClient)
-	got, err := sClient.Scrape(context.Background(), testURL)
+	req, err := http.NewRequest(http.MethodGet, testURL, nil)
+	if err != nil {
+		t.Fatalf("Failed to create a request: %v", err)
+	}
+	got, err := sClient.Do(req)
 	if err != nil {
 		t.Fatalf("Scrape = %v, want no error", err)
 	}
@@ -92,7 +95,11 @@ func TestHTTPScrapeClientScrapeProtoErrorCases(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			hClient := newTestHTTPClient(makeProtoResponse(test.responseCode, test.stat, test.responseType), test.responseErr)
 			sClient := newHTTPScrapeClient(hClient)
-			_, err := sClient.Scrape(context.Background(), testURL)
+			req, err := http.NewRequest(http.MethodGet, testURL, nil)
+			if err != nil {
+				t.Fatalf("Failed to create a request: %v", err)
+			}
+			_, err = sClient.Do(req)
 			if err == nil {
 				t.Fatal("Got no error")
 			}

--- a/pkg/autoscaler/metrics/stats_scraper_test.go
+++ b/pkg/autoscaler/metrics/stats_scraper_test.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strconv"
 	"strings"
 	"sync"
@@ -665,13 +666,13 @@ type fakeScrapeClient struct {
 }
 
 // Scrape return the next item in the stats and error array of fakeScrapeClient.
-func (c *fakeScrapeClient) Scrape(_ context.Context, url string) (Stat, error) {
+func (c *fakeScrapeClient) Do(req *http.Request) (Stat, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	ans := c.stats[c.curIdx%len(c.stats)]
 	err := c.errs[c.curIdx%len(c.errs)]
 	c.curIdx++
-	c.urls.Insert(url)
+	c.urls.Insert(req.URL.String())
 	return ans, err
 }
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

I pondered ditching the entire interface, seeing as it is not really helping to be honest. We've already passed in a URL with a path and all, so we might as well pass an entire HTTP request.

This makes it easier to muck with said HTTP request in special cases (like adding a header just for direct-pod-scraping).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
