### PR TITLE
Remove v2 gc folder. There can be only one.

### DIFF
--- a/pkg/reconciler/gc/gc.go
+++ b/pkg/reconciler/gc/gc.go
@@ -35,8 +35,8 @@ import (
 	configns "knative.dev/serving/pkg/reconciler/gc/config"
 )
 
-// Collect deletes stale revisions if they are sufficiently old
-func Collect(
+// collect deletes stale revisions if they are sufficiently old
+func collect(
 	ctx context.Context,
 	client clientset.Interface,
 	revisionLister listers.RevisionLister,

--- a/pkg/reconciler/gc/gc.go
+++ b/pkg/reconciler/gc/gc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v2
+package gc
 
 import (
 	"context"

--- a/pkg/reconciler/gc/gc_test.go
+++ b/pkg/reconciler/gc/gc_test.go
@@ -14,10 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v2
+package gc
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -27,12 +26,10 @@ import (
 	clientgotesting "k8s.io/client-go/testing"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/ptr"
-	pkgrec "knative.dev/pkg/reconciler"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
 	"knative.dev/serving/pkg/gc"
-	"knative.dev/serving/pkg/reconciler/configuration/resources"
 	"knative.dev/serving/pkg/reconciler/gc/config"
 
 	_ "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration/fake"
@@ -534,44 +531,3 @@ func TestIsRevisionStale(t *testing.T) {
 		})
 	}
 }
-
-func cfg(name, namespace string, generation int64, co ...ConfigOption) *v1.Configuration {
-	c := &v1.Configuration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       name,
-			Namespace:  namespace,
-			Generation: generation,
-		},
-		Spec: v1.ConfigurationSpec{
-			Template: v1.RevisionTemplateSpec{
-				Spec: *revisionSpec.DeepCopy(),
-			},
-		},
-	}
-	for _, opt := range co {
-		opt(c)
-	}
-	c.SetDefaults(context.Background())
-	return c
-}
-
-func rev(configName, namespace string, generation int64, ro ...RevisionOption) *v1.Revision {
-	config := cfg(configName, namespace, generation)
-	rev := resources.MakeRevision(context.Background(), config, time.Now())
-	rev.SetDefaults(context.Background())
-
-	for _, opt := range ro {
-		opt(rev)
-	}
-	return rev
-}
-
-type testConfigStore struct {
-	config *config.Config
-}
-
-func (t *testConfigStore) ToContext(ctx context.Context) context.Context {
-	return config.ToContext(ctx, t.config)
-}
-
-var _ pkgrec.ConfigStore = (*testConfigStore)(nil)

--- a/pkg/reconciler/gc/gc_test.go
+++ b/pkg/reconciler/gc/gc_test.go
@@ -422,7 +422,7 @@ func runTest(
 
 	recorderList := ActionRecorderList{client}
 
-	Collect(ctx, client, ri.Lister(), cfg)
+	collect(ctx, client, ri.Lister(), cfg)
 
 	actions, err := recorderList.ActionsByVerb()
 	if err != nil {

--- a/pkg/reconciler/gc/reconciler.go
+++ b/pkg/reconciler/gc/reconciler.go
@@ -39,5 +39,5 @@ var _ configreconciler.Interface = (*reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
 func (c *reconciler) ReconcileKind(ctx context.Context, config *v1.Configuration) pkgreconciler.Event {
-	return Collect(ctx, c.client, c.revisionLister, config)
+	return collect(ctx, c.client, c.revisionLister, config)
 }

--- a/pkg/reconciler/gc/reconciler.go
+++ b/pkg/reconciler/gc/reconciler.go
@@ -24,7 +24,6 @@ import (
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
 	configreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/configuration"
 	listers "knative.dev/serving/pkg/client/listers/serving/v1"
-	gcv2 "knative.dev/serving/pkg/reconciler/gc/v2"
 )
 
 // reconciler implements controller.Reconciler for garbage collected resources.
@@ -40,5 +39,5 @@ var _ configreconciler.Interface = (*reconciler)(nil)
 
 // ReconcileKind implements Interface.ReconcileKind.
 func (c *reconciler) ReconcileKind(ctx context.Context, config *v1.Configuration) pkgreconciler.Event {
-	return gcv2.Collect(ctx, c.client, c.revisionLister, config)
+	return Collect(ctx, c.client, c.revisionLister, config)
 }

--- a/pkg/reconciler/gc/reconciler_test.go
+++ b/pkg/reconciler/gc/reconciler_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/clock"
@@ -30,7 +29,6 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/ptr"
 	pkgrec "knative.dev/pkg/reconciler"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingclient "knative.dev/serving/pkg/client/injection/client/fake"
@@ -46,15 +44,6 @@ import (
 	. "knative.dev/serving/pkg/reconciler/testing/v1"
 	. "knative.dev/serving/pkg/testing/v1"
 )
-
-var revisionSpec = v1.RevisionSpec{
-	PodSpec: corev1.PodSpec{
-		Containers: []corev1.Container{{
-			Image: "busybox",
-		}},
-	},
-	TimeoutSeconds: ptr.Int64(60),
-}
 
 func TestGCReconcile(t *testing.T) {
 	now := time.Now()


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Remove the v2 GC folder - v1 is gone for good
    * This should be simpler for future code maintainers
