### PR TITLE
[WIP] Update to GC / labeler informer event triggers

### DIFF
--- a/pkg/reconciler/gc/controller.go
+++ b/pkg/reconciler/gc/controller.go
@@ -25,7 +25,6 @@ import (
 	"knative.dev/pkg/logging"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
-	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 	configreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/configuration"
 	gcconfig "knative.dev/serving/pkg/gc"
@@ -40,7 +39,6 @@ func NewController(
 	cmw configmap.Watcher,
 ) *controller.Impl {
 	logger := logging.FromContext(ctx)
-	configurationInformer := configurationinformer.Get(ctx)
 	revisionInformer := revisioninformer.Get(ctx)
 
 	c := &reconciler{

--- a/pkg/reconciler/gc/controller.go
+++ b/pkg/reconciler/gc/controller.go
@@ -58,8 +58,8 @@ func NewController(
 					return
 				}
 				// Enqueue on latest created or ready change.
-				if c1.Status.LatestCreatedRevisionName != c1.Status.LatestCreatedRevisionName ||
-					c1.Status.LatestReadyRevisionName != c1.Status.LatestReadyRevisionName {
+				if c1.Status.LatestCreatedRevisionName != c2.Status.LatestCreatedRevisionName ||
+					c1.Status.LatestReadyRevisionName != c2.Status.LatestReadyRevisionName {
 					impl.Enqueue(new)
 				}
 			},

--- a/pkg/reconciler/gc/controller.go
+++ b/pkg/reconciler/gc/controller.go
@@ -19,11 +19,9 @@ package gc
 import (
 	"context"
 
-	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
-	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
@@ -50,16 +48,7 @@ func NewController(
 	return configreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
 		logger.Info("Setting up event handlers")
 
-		// Since the gc controller came from the configuration controller, having event handlers
-		// on both configuration and revision matches the existing behaviors of the configuration
-		// controller. This is to minimize risk heading into v1.
-		// TODO (taragu): probably one or both of these event handlers are not needed
 		configurationInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
-
-		revisionInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-			FilterFunc: controller.FilterControllerGK(v1.Kind("Configuration")),
-			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
-		})
 
 		logger.Info("Setting up ConfigMap receivers with resync func")
 		configsToResync := []interface{}{

--- a/pkg/reconciler/gc/controller.go
+++ b/pkg/reconciler/gc/controller.go
@@ -19,9 +19,11 @@ package gc
 import (
 	"context"
 
+	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
@@ -48,7 +50,12 @@ func NewController(
 	return configreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
 		logger.Info("Setting up event handlers")
 
-		configurationInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+		// Run GC as Revisions are enqueued by Configurations.
+		// This timing means both the Configurations and (new) Revisions have been created as GC is run.
+		revisionInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+			FilterFunc: controller.FilterControllerGK(v1.Kind("Configuration")),
+			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+		})
 
 		logger.Info("Setting up ConfigMap receivers with resync func")
 		configsToResync := []interface{}{

--- a/pkg/reconciler/labeler/accessors.go
+++ b/pkg/reconciler/labeler/accessors.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/kmeta"
 
-	"knative.dev/pkg/tracker"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
@@ -46,7 +45,6 @@ type accessor interface {
 // revisionAccessor is an implementation of Accessor for Revisions.
 type revisionAccessor struct {
 	client  clientset.Interface
-	tracker tracker.Interface
 	lister  listers.RevisionLister
 	indexer cache.Indexer
 	clock   clock.PassiveClock
@@ -58,13 +56,11 @@ var _ accessor = (*revisionAccessor)(nil)
 // newRevisionAccessor is a factory function to make a new revision accessor.
 func newRevisionAccessor(
 	client clientset.Interface,
-	tracker tracker.Interface,
 	lister listers.RevisionLister,
 	indexer cache.Indexer,
 	clock clock.PassiveClock) *revisionAccessor {
 	return &revisionAccessor{
 		client:  client,
-		tracker: tracker,
 		lister:  lister,
 		indexer: indexer,
 		clock:   clock,
@@ -176,7 +172,6 @@ func (r *revisionAccessor) makeMetadataPatch(route *v1.Route, name string, remov
 // configurationAccessor is an implementation of Accessor for Configurations.
 type configurationAccessor struct {
 	client  clientset.Interface
-	tracker tracker.Interface
 	lister  listers.ConfigurationLister
 	indexer cache.Indexer
 	clock   clock.PassiveClock
@@ -188,13 +183,11 @@ var _ accessor = (*configurationAccessor)(nil)
 // NewConfigurationAccessor is a factory function to make a new configuration Accessor.
 func newConfigurationAccessor(
 	client clientset.Interface,
-	tracker tracker.Interface,
 	lister listers.ConfigurationLister,
 	indexer cache.Indexer,
 	clock clock.PassiveClock) *configurationAccessor {
 	return &configurationAccessor{
 		client:  client,
-		tracker: tracker,
 		lister:  lister,
 		indexer: indexer,
 		clock:   clock,

--- a/pkg/reconciler/labeler/controller.go
+++ b/pkg/reconciler/labeler/controller.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/client-go/tools/cache"
 
-	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	configurationinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/configuration"
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
@@ -69,20 +68,6 @@ func NewController(
 	routeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: tracker.OnDeletedObserver,
 	})
-
-	configInformer.Informer().AddEventHandler(controller.HandleAll(
-		controller.EnsureTypeMeta(
-			tracker.OnChanged,
-			v1.SchemeGroupVersion.WithKind("Configuration"),
-		),
-	))
-
-	revisionInformer.Informer().AddEventHandler(controller.HandleAll(
-		controller.EnsureTypeMeta(
-			tracker.OnChanged,
-			v1.SchemeGroupVersion.WithKind("Revision"),
-		),
-	))
 
 	client := servingclient.Get(ctx)
 	clock := &clock.RealClock{}

--- a/pkg/reconciler/labeler/labeler_test.go
+++ b/pkg/reconciler/labeler/labeler_test.go
@@ -343,8 +343,8 @@ func TestV2Reconcile(t *testing.T) {
 		rLister := listers.GetRevisionLister()
 		rIndexer := listers.IndexerFor(&v1.Revision{})
 		r := &Reconciler{
-			caccV2: newConfigurationAccessor(client, &NullTracker{}, cLister, cIndexer, clock),
-			raccV2: newRevisionAccessor(client, &NullTracker{}, rLister, rIndexer, clock),
+			caccV2: newConfigurationAccessor(client, cLister, cIndexer, clock),
+			raccV2: newRevisionAccessor(client, rLister, rIndexer, clock),
 		}
 
 		return routereconciler.NewReconciler(ctx, logging.FromContext(ctx), servingclient.Get(ctx),

--- a/pkg/reconciler/labeler/metasync.go
+++ b/pkg/reconciler/labeler/metasync.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/tracker"
 
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
@@ -154,14 +153,4 @@ func setRoutingMeta(ctx context.Context, acc accessor, r *v1.Route, name string,
 	}
 
 	return nil
-}
-
-func ref(namespace, name, kind string) tracker.Reference {
-	apiVersion, kind := v1.SchemeGroupVersion.WithKind(kind).ToAPIVersionAndKind()
-	return tracker.Reference{
-		APIVersion: apiVersion,
-		Kind:       kind,
-		Name:       name,
-		Namespace:  namespace,
-	}
 }

--- a/pkg/reconciler/labeler/metasync.go
+++ b/pkg/reconciler/labeler/metasync.go
@@ -43,10 +43,6 @@ func syncRoutingMeta(ctx context.Context, r *v1.Route, cacc *configurationAccess
 		configName := tt.ConfigurationName
 
 		if revName != "" {
-			if err := racc.tracker.TrackReference(ref(r.Namespace, revName, "Revision"), r); err != nil {
-				return err
-			}
-
 			rev, err := racc.lister.Revisions(r.Namespace).Get(revName)
 			if err != nil {
 				// The revision might not exist (yet). The informers will notify if it gets created.
@@ -62,10 +58,6 @@ func syncRoutingMeta(ctx context.Context, r *v1.Route, cacc *configurationAccess
 		}
 
 		if configName != "" {
-			if err := cacc.tracker.TrackReference(ref(r.Namespace, configName, "Configuration"), r); err != nil {
-				return err
-			}
-
 			config, err := cacc.lister.Configurations(r.Namespace).Get(configName)
 			if err != nil {
 				// The config might not exist (yet). The informers will notify if it gets created.

--- a/pkg/reconciler/labeler/metasync.go
+++ b/pkg/reconciler/labeler/metasync.go
@@ -44,8 +44,7 @@ func syncRoutingMeta(ctx context.Context, r *v1.Route, cacc *configurationAccess
 		if revName != "" {
 			rev, err := racc.lister.Revisions(r.Namespace).Get(revName)
 			if err != nil {
-				// The revision might not exist (yet). The informers will notify if it gets created.
-				continue
+				continue // The revision might not exist.
 			}
 
 			revisions.Insert(revName)
@@ -57,19 +56,10 @@ func syncRoutingMeta(ctx context.Context, r *v1.Route, cacc *configurationAccess
 		}
 
 		if configName != "" {
-			config, err := cacc.lister.Configurations(r.Namespace).Get(configName)
-			if err != nil {
-				// The config might not exist (yet). The informers will notify if it gets created.
-				continue
+			if _, err := cacc.lister.Configurations(r.Namespace).Get(configName); err != nil {
+				continue // The config might not exist.
 			}
-
 			configs.Insert(configName)
-
-			// If the target is for the latest revision, add the latest created revision to the list
-			// so that there is a smooth transition when the new revision becomes ready.
-			if config.Status.LatestCreatedRevisionName != "" && tt.LatestRevision != nil && *tt.LatestRevision {
-				revisions.Insert(config.Status.LatestCreatedRevisionName)
-			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Only run GC when Configuration changes i.e. produces a new revision
    * Currently we enqueue for any Config change and another when a Revision owned by a Configuration is enqueued. We shouldn't need doubled events.
* Likewise Labeler should only change as Route traffic changes, so we only need those events.

There's no harm in running these on so many changes, but nearly all of them should be no-ops.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Reduce the number of events that enqueue Labeler and GC.
```
