### PR TITLE
Temporarily disable HTTP01 E2E tests 

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -210,12 +210,14 @@ add_trap "cleanup_per_selfsigned_namespace_auto_tls" SIGKILL SIGTERM SIGQUIT
 go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
 cleanup_per_selfsigned_namespace_auto_tls
 
-subheader "Auto TLS test for per-ksvc certificate provision using HTTP01 challenge"
-setup_http01_auto_tls
-add_trap "delete_dns_record" SIGKILL SIGTERM SIGQUIT
-go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
-kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
-delete_dns_record
+# TODO(#10486): resume the HTTP01 E2E tests after figuring out the DNS setup failure.
+
+# subheader "Auto TLS test for per-ksvc certificate provision using HTTP01 challenge"
+# setup_http01_auto_tls
+# add_trap "delete_dns_record" SIGKILL SIGTERM SIGQUIT
+# go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
+# kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
+# delete_dns_record
 
 (( failed )) && fail_test
 


### PR DESCRIPTION
The test grid seems still not happy: https://testgrid.knative.dev/serving#istio-latest-no-mesh&include-filter-by-regex=http01


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
