### PR TITLE
Fix race in health state

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -166,7 +166,7 @@ func main() {
 
 	// Setup probe to run for checking user-application healthiness.
 	probe := buildProbe(logger, env.ServingReadinessProbe)
-	healthState := &health.State{}
+	healthState := health.NewState()
 
 	mainServer := buildServer(ctx, env, healthState, probe, stats, logger)
 	servers := map[string]*http.Server{


### PR DESCRIPTION
The `DrainHandlerFunc` creates a channel on-demand when it is called, but this can theoretically occur _after_ a drain has completed, in which case the channel will never be closed (`drainFinished()` just exits if `drainCh` is nil..), and drain will never return. 

(This is super unlikely to occur in practice since drain takes some time to complete by which time we've ~always called `DrainHandlerFunc`, but worth fixing in case we ever make draining quicker!).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixes a race in Queue Proxy drain logic that could, in a very unlikely edge case, lead to the pre-stop hook not exiting even though draining has finished
```

/assign @markusthoemmes @vagababov 
