### PR TITLE
Drop outdated HPA code regarding concurrency and RPS

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -21,15 +21,12 @@ import (
 
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
-	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
-	aresources "knative.dev/serving/pkg/reconciler/autoscaling/resources"
 )
 
 // MakeHPA creates an HPA resource from a PA resource.
@@ -70,22 +67,6 @@ func MakeHPA(pa *v1alpha1.PodAutoscaler, config *autoscalerconfig.Config) *autos
 				},
 			}}
 		}
-	case autoscaling.Concurrency, autoscaling.RPS:
-		t, _ := aresources.ResolveMetricTarget(pa, config)
-		target := int64(math.Ceil(t))
-		hpa.Spec.Metrics = []autoscalingv2beta1.MetricSpec{{
-			Type: autoscalingv2beta1.ObjectMetricSourceType,
-			Object: &autoscalingv2beta1.ObjectMetricSource{
-				Target: autoscalingv2beta1.CrossVersionObjectReference{
-					APIVersion: servingv1.SchemeGroupVersion.String(),
-					Kind:       "revision",
-					Name:       pa.Name,
-				},
-				MetricName:   pa.Metric(),
-				AverageValue: resource.NewQuantity(target, resource.DecimalSI),
-				TargetValue:  *resource.NewQuantity(target, resource.DecimalSI),
-			},
-		}}
 	}
 	return hpa
 }

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
@@ -26,12 +26,10 @@ import (
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
-	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
 
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "knative.dev/serving/pkg/testing"
@@ -83,80 +81,6 @@ func TestMakeHPA(t *testing.T) {
 				Resource: &autoscalingv2beta1.ResourceMetricSource{
 					Name:                     corev1.ResourceCPU,
 					TargetAverageUtilization: ptr.Int32(1983),
-				},
-			})),
-	}, {
-		name: "with metric=concurrency",
-		pa:   pa(WithMetricAnnotation(autoscaling.Concurrency)),
-		want: hpa(
-			withAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.Concurrency),
-			withMetric(autoscalingv2beta1.MetricSpec{
-				Type: autoscalingv2beta1.ObjectMetricSourceType,
-				Object: &autoscalingv2beta1.ObjectMetricSource{
-					Target: autoscalingv2beta1.CrossVersionObjectReference{
-						APIVersion: servingv1.SchemeGroupVersion.String(),
-						Kind:       "revision",
-						Name:       testName,
-					},
-					MetricName:   autoscaling.Concurrency,
-					AverageValue: resource.NewQuantity(100, resource.DecimalSI),
-					TargetValue:  *resource.NewQuantity(100, resource.DecimalSI),
-				},
-			})),
-	}, {
-		name: "with metric=concurrency and target=50",
-		pa:   pa(WithTargetAnnotation("50"), WithMetricAnnotation(autoscaling.Concurrency)),
-		want: hpa(
-			withAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.Concurrency),
-			withAnnotationValue(autoscaling.TargetAnnotationKey, "50"),
-			withMetric(autoscalingv2beta1.MetricSpec{
-				Type: autoscalingv2beta1.ObjectMetricSourceType,
-				Object: &autoscalingv2beta1.ObjectMetricSource{
-					Target: autoscalingv2beta1.CrossVersionObjectReference{
-						APIVersion: servingv1.SchemeGroupVersion.String(),
-						Kind:       "revision",
-						Name:       testName,
-					},
-					MetricName:   autoscaling.Concurrency,
-					AverageValue: resource.NewQuantity(50, resource.DecimalSI),
-					TargetValue:  *resource.NewQuantity(50, resource.DecimalSI),
-				},
-			})),
-	}, {
-		name: "with metric=RPS",
-		pa:   pa(WithMetricAnnotation(autoscaling.RPS)),
-		want: hpa(
-			withAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.RPS),
-			withMetric(autoscalingv2beta1.MetricSpec{
-				Type: autoscalingv2beta1.ObjectMetricSourceType,
-				Object: &autoscalingv2beta1.ObjectMetricSource{
-					Target: autoscalingv2beta1.CrossVersionObjectReference{
-						APIVersion: servingv1.SchemeGroupVersion.String(),
-						Kind:       "revision",
-						Name:       testName,
-					},
-					MetricName:   autoscaling.RPS,
-					AverageValue: resource.NewQuantity(200, resource.DecimalSI),
-					TargetValue:  *resource.NewQuantity(200, resource.DecimalSI),
-				},
-			})),
-	}, {
-		name: "with metric=RPS and target=50",
-		pa:   pa(WithTargetAnnotation("50"), WithMetricAnnotation(autoscaling.RPS)),
-		want: hpa(
-			withAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.RPS),
-			withAnnotationValue(autoscaling.TargetAnnotationKey, "50"),
-			withMetric(autoscalingv2beta1.MetricSpec{
-				Type: autoscalingv2beta1.ObjectMetricSourceType,
-				Object: &autoscalingv2beta1.ObjectMetricSource{
-					Target: autoscalingv2beta1.CrossVersionObjectReference{
-						APIVersion: servingv1.SchemeGroupVersion.String(),
-						Kind:       "revision",
-						Name:       testName,
-					},
-					MetricName:   autoscaling.RPS,
-					AverageValue: resource.NewQuantity(50, resource.DecimalSI),
-					TargetValue:  *resource.NewQuantity(50, resource.DecimalSI),
 				},
 			})),
 	}}


### PR DESCRIPTION
As per title.

We used to support concurrency/RPS based scaling via the HPA but have dropped the necessary custom-metrics-API ages ago, so this is completely defunct now.

/assign @julz @vagababov 