### PR TITLE
Unexport some methods

### DIFF
--- a/pkg/queue/health/health_state.go
+++ b/pkg/queue/health/health_state.go
@@ -41,18 +41,18 @@ func NewState() *State {
 	}
 }
 
-// IsAlive returns whether or not the health server is in a known
+// isAlive returns whether or not the health server is in a known
 // working state currently.
-func (h *State) IsAlive() bool {
+func (h *State) isAlive() bool {
 	h.mutex.RLock()
 	defer h.mutex.RUnlock()
 
 	return h.alive
 }
 
-// IsShuttingDown returns whether or not the health server is currently
+// isShuttingDown returns whether or not the health server is currently
 // shutting down.
-func (h *State) IsShuttingDown() bool {
+func (h *State) isShuttingDown() bool {
 	h.mutex.RLock()
 	defer h.mutex.RUnlock()
 
@@ -107,9 +107,9 @@ func (h *State) HandleHealthProbe(prober func() bool, isAggressive bool, w http.
 	}
 
 	switch {
-	case !isAggressive && h.IsAlive():
+	case !isAggressive && h.isAlive():
 		sendAlive()
-	case h.IsShuttingDown():
+	case h.isShuttingDown():
 		sendShuttingDown()
 	case prober != nil && !prober():
 		sendNotAlive()
@@ -126,7 +126,7 @@ func (h *State) DrainHandlerFunc() func(_ http.ResponseWriter, _ *http.Request) 
 	}
 }
 
-// Shutdown marks the proxy server as no ready and begins its shutdown process. This
+// Shutdown marks the proxy server as not ready and begins its shutdown process. This
 // results in unblocking any connections waiting for drain.
 func (h *State) Shutdown(drain func()) {
 	h.shutdown()

--- a/pkg/queue/health/health_state_test.go
+++ b/pkg/queue/health/health_state_test.go
@@ -29,22 +29,22 @@ func TestHealthStateSetsState(t *testing.T) {
 	s := NewState()
 
 	wantAlive := func() {
-		if !s.IsAlive() {
+		if !s.isAlive() {
 			t.Error("State was not alive but it should have been alive")
 		}
 	}
 	wantNotAlive := func() {
-		if s.IsAlive() {
+		if s.isAlive() {
 			t.Error("State was alive but it shouldn't have been")
 		}
 	}
 	wantShuttingDown := func() {
-		if !s.IsShuttingDown() {
+		if !s.isShuttingDown() {
 			t.Error("State was not shutting down but it should have been")
 		}
 	}
 	wantNotShuttingDown := func() {
-		if s.IsShuttingDown() {
+		if s.isShuttingDown() {
 			t.Error("State was shutting down but it shouldn't have been")
 		}
 	}


### PR DESCRIPTION
These are unused outside of the health package, so might as well unexport them.

Also spun out https://github.com/knative/serving/issues/10783 to look at replacing some of this with `pkg/drain`, but I already had this ready and it doesn't hurt in the meantime.

/assign @vagababov 