### PR TITLE
Remove unused TimeoutFunc stuff and revert to simple duration

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -220,7 +220,7 @@ func main() {
 	}()
 
 	// Blocks until we actually receive a TERM signal or one of the servers
-	// exit unexpectedly. We fold both signals together because we only want
+	// exits unexpectedly. We fold both signals together because we only want
 	// to act on the first of those to reach here.
 	select {
 	case err := <-errCh:
@@ -291,7 +291,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	}
 	composedHandler = queue.ProxyHandler(breaker, stats, tracingEnabled, composedHandler)
 	composedHandler = queue.ForwardedShimHandler(composedHandler)
-	composedHandler = handler.NewTimeToFirstByteTimeoutHandler(composedHandler, "request timeout", handler.StaticTimeoutFunc(timeout))
+	composedHandler = handler.NewTimeToFirstByteTimeoutHandler(composedHandler, "request timeout", timeout)
 
 	if metricsSupported {
 		composedHandler = requestMetricsHandler(logger, composedHandler, env)


### PR DESCRIPTION
This was introduced when we wanted to use the timeout handler in the activator, but we [reverted this several months ago](https://github.com/knative/serving/pull/8534) and haven't resurrected the behaviour. Seems best to just simplify the code at this point and re-introduce this if we ever decide to take another run at this feature.

/assign @markusthoemmes @vagababov 