### PR TITLE
Add Domainmapping AutoTLS e2e test

### DIFF
--- a/test/e2e/autotls/domain_mapping_test.go
+++ b/test/e2e/autotls/domain_mapping_test.go
@@ -47,9 +47,9 @@ type dmConfig struct {
 }
 
 func TestDomainMappingAutoTLS(t *testing.T) {
-        if !test.ServingFlags.EnableAlphaFeatures {
-                t.Skip("Alpha features not enabled")
-        }
+	if !test.ServingFlags.EnableAlphaFeatures {
+		t.Skip("Alpha features not enabled")
+	}
 	t.Parallel()
 
 	var env dmConfig

--- a/test/e2e/autotls/domain_mapping_test.go
+++ b/test/e2e/autotls/domain_mapping_test.go
@@ -1,0 +1,135 @@
+// +build e2e
+
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autotls
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kelseyhightower/envconfig"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/networking/test/conformance/ingress"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/reconciler"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	"knative.dev/serving/test"
+	"knative.dev/serving/test/e2e"
+	v1test "knative.dev/serving/test/v1"
+)
+
+type dmConfig struct {
+	// ServiceName is the name of testing Knative Service.
+	// It is not required for self-signed CA or for the HTTP01 challenge when wildcard domain
+	// is mapped to the Ingress IP.
+	TLSServiceName string `envconfig:"tls_service_name" required:"false"`
+	// CustomDomainSuffix is the custom domain used for the domainMapping
+	CustomDomainSuffix string `envconfig:"custom_domain_suffix" required:"false"`
+}
+
+func TestDomainMappingAutoTLS(t *testing.T) {
+	var env dmConfig
+	if err := envconfig.Process("", &env); err != nil {
+		t.Fatalf("Failed to process environment variable: %v.", err)
+	}
+
+	t.Parallel()
+	ctx := context.Background()
+
+	clients := e2e.SetupWithNamespace(t, test.TLSNamespace)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   "runtime",
+	}
+
+	if len(env.TLSServiceName) != 0 {
+		names.Service = env.TLSServiceName + "-dmtls"
+	}
+
+	// Clean up on test failure or interrupt.
+	test.EnsureTearDown(t, clients, &names)
+
+	// Set up initial Service.
+	svc, err := v1test.CreateServiceReady(t, clients, &names,
+		func(service *v1.Service) {
+			service.Annotations = map[string]string{"networking.knative.dev/disableAutoTLS": "True"}
+		})
+	if err != nil {
+		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
+	}
+
+	// Using fixed hostnames can lead to conflicts when multiple tests run at
+	// once, so include the svc name to avoid collisions.
+	suffix := "example.com"
+
+	if env.CustomDomainSuffix != "" {
+		suffix = env.CustomDomainSuffix
+	}
+
+	host := "dm." + suffix
+
+	// Point DomainMapping at our service.
+	var dm *v1alpha1.DomainMapping
+	if err := reconciler.RetryTestErrors(func(int) error {
+		dm, err = clients.ServingAlphaClient.DomainMappings.Create(ctx, &v1alpha1.DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      host,
+				Namespace: svc.Service.Namespace,
+			},
+			Spec: v1alpha1.DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Namespace:  svc.Service.Namespace,
+					Name:       svc.Service.Name,
+					APIVersion: "serving.knative.dev/v1",
+					Kind:       "Service",
+				},
+			},
+		}, metav1.CreateOptions{})
+		return err
+	}); err != nil {
+		t.Fatalf("Create(DomainMapping) = %v, expected no error", err)
+	}
+
+	t.Cleanup(func() {
+		clients.ServingAlphaClient.DomainMappings.Delete(ctx, dm.Name, metav1.DeleteOptions{})
+	})
+
+	// Wait for DomainMapping to go Ready.
+	if waitErr := wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
+		state, err := clients.ServingAlphaClient.DomainMappings.Get(context.Background(), dm.Name, metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+
+		// DomainMapping can go Ready if only http is available.
+		// Hence the checking for the URL scheme to make sure it is ready for https
+		dmTLSReady := state.IsReady() && state.Status.URL != nil && state.Status.URL.Scheme == "https"
+
+		return dmTLSReady, nil
+	}); waitErr != nil {
+		t.Fatalf("The DomainMapping %s was not marked as Ready: %v", dm.Name, waitErr)
+	}
+
+	certName := dm.Name
+	rootCAs := createRootCAs(t, clients, svc.Route.Namespace, certName)
+	httpsClient := createHTTPSClient(t, clients, svc, rootCAs)
+	ingress.RuntimeRequest(context.Background(), t, httpsClient, "https://"+host)
+}

--- a/test/e2e/autotls/domain_mapping_test.go
+++ b/test/e2e/autotls/domain_mapping_test.go
@@ -47,6 +47,9 @@ type dmConfig struct {
 }
 
 func TestDomainMappingAutoTLS(t *testing.T) {
+        if !test.ServingFlags.EnableAlphaFeatures {
+                t.Skip("Alpha features not enabled")
+        }
 	t.Parallel()
 
 	var env dmConfig

--- a/test/e2e/autotls/domain_mapping_test.go
+++ b/test/e2e/autotls/domain_mapping_test.go
@@ -40,6 +40,8 @@ type dmConfig struct {
 	// It is not required for self-signed CA or for the HTTP01 challenge when wildcard domain
 	// is mapped to the Ingress IP.
 	TLSServiceName string `envconfig:"tls_service_name" required:"false"`
+	// TLSTestNamespace is the namespace of where the tls tests run.
+	TLSTestNamespace string `envconfig:"tls_test_namespace" required:"false"`
 	// CustomDomainSuffix is the custom domain used for the domainMapping.
 	CustomDomainSuffix string `envconfig:"custom_domain_suffix" required:"false"`
 }
@@ -83,6 +85,10 @@ func TestDomainMappingAutoTLS(t *testing.T) {
 
 	if env.CustomDomainSuffix != "" {
 		suffix = env.CustomDomainSuffix
+	}
+
+	if env.TLSTestNamespace != "" {
+		suffix = env.TLSTestNamespace + "." + suffix
 	}
 
 	host := "dm." + suffix


### PR DESCRIPTION


Fixes #10247

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

- Adds an e2e test under test/autotls/ that tests autotls with domainmapping.
- The test is very similar to `test/conformance/api/v1alpha1/domain_mapping_test.go` except for the fact that it tests with https instead of http.
- for the time being I am using functions from conformance but can be moved to a shared place?
- currently having the check for alpha features commented out in until I figure out how to enable these features in prow.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
 "NONE"
```
