### PR TITLE
Validate domain mapping is not a cluster local name

### DIFF
--- a/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/domainmapping_validation_test.go
@@ -120,6 +120,23 @@ func TestDomainMappingValidation(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "cluster local domain name",
+		want: apis.ErrGeneric("invalid name \"notallowed.svc.cluster.local\": must not be a subdomain of cluster local domain \"cluster.local\"", "metadata.name"),
+		dm: &DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "notallowed.svc.cluster.local",
+				Namespace: "ns",
+			},
+			Spec: DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Name:       "some-name",
+					Namespace:  "ns",
+					Kind:       "Service",
+					APIVersion: "serving.knative.dev/v1",
+				},
+			},
+		},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Cluster local domain mapping names can easily clash with existing routes in the cluster (e.g. ksvc names) and might allow recursive domain mappings etc 😬. I can't quickly think of a good use case for them, so better to disable the foot-gun for now.

If we ever want to allow cluster local source names, it might be nice to specifically whitelist a specific subdomain which they "own" e.g. "mymapping.domainmappings.cluster.local", but seems better to do that explicitly in a separate PR if we want it. Anyway, better to keep initial supported surface area small for beta and then expand.

```release-note
Domain mappings disallow mapping from cluster local domain names (generally domains under "cluster.local") 
```

/assign @tcnghia @mattmoor 