### PR TITLE
Update docs for revision timeoutSeconds field

### DIFF
--- a/pkg/apis/serving/v1/revision_types.go
+++ b/pkg/apis/serving/v1/revision_types.go
@@ -82,9 +82,9 @@ type RevisionSpec struct {
 	// +optional
 	ContainerConcurrency *int64 `json:"containerConcurrency,omitempty"`
 
-	// TimeoutSeconds holds the max duration the instance is allowed for
-	// responding to a request.  If unspecified, a system default will
-	// be provided.
+	// TimeoutSeconds is the maximum duration in seconds that the request routing
+	// layer will wait for a request delivered to a container to begin replying
+	// (send network traffic). If unspecified, a system default will be provided.
 	// +optional
 	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty"`
 }


### PR DESCRIPTION
Updated the doc comment for timeoutSeconds to better align with what's in the [API spec](https://knative.dev/docs/serving/spec/knative-api-specification-1.0/#metadata-3) (but clarified "to progress" to "to begin replying").

I think we may also at some point want to introduce a MaxDurationSeconds (and maybe even an IdleTimeoutSeconds) to do what TimeoutSeconds sounds like it might do, and at one point did, but I'll add an issue for those separately.

/assign @dprotaso @mattmoor 