### PR TITLE
Fix race condition with Prober logger in upgrade tests

### DIFF
--- a/test/upgrade/probe.go
+++ b/test/upgrade/probe.go
@@ -51,7 +51,7 @@ func ProbeTest() pkgupgrade.BackgroundOperation {
 			// This polls until we get a 200 with the right body.
 			assertServiceResourcesUpdated(c.T, clients, *names, url, test.PizzaPlanetText1)
 
-			prober = test.RunRouteProber(c.T.Logf, clients, url, test.AddRootCAtoTransport(context.Background(), c.T.Logf, clients, test.ServingFlags.HTTPS))
+			prober = test.RunRouteProber(c.Log.Infof, clients, url, test.AddRootCAtoTransport(context.Background(), c.T.Logf, clients, test.ServingFlags.HTTPS))
 		},
 		func(c pkgupgrade.Context) {
 			// Verify


### PR DESCRIPTION
The actual issue is that the test context expires between individual
stages run by the upgrade framework. This fix passes an external logger
that survives the stages.

Fixes https://github.com/knative/pkg/issues/2026

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
