### PR TITLE
Add HA test for DomainMapping controller

### DIFF
--- a/pkg/testing/v1alpha1/domainmapping.go
+++ b/pkg/testing/v1alpha1/domainmapping.go
@@ -18,31 +18,30 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
-type domainMappingOption func(dm *v1alpha1.DomainMapping)
-
-// WithRef fills reference field in domainmapping.
-func WithRef(namespace, name string) domainMappingOption {
-	return func(dm *v1alpha1.DomainMapping) {
-		dm.Spec.Ref.Namespace = namespace
-		dm.Spec.Ref.Name = name
-		dm.Spec.Ref.APIVersion = "serving.knative.dev/v1"
-		dm.Spec.Ref.Kind = "Service"
+// KReference creates a KReference which points to KService.
+func KReference(namespace, name string) *duckv1.KReference {
+	return &duckv1.KReference{
+		Namespace:  namespace,
+		Name:       name,
+		APIVersion: "serving.knative.dev/v1",
+		Kind:       "Service",
 	}
 }
 
-// DomainMapping creates a domainmapping with domainMappingOption.
-func DomainMapping(namespace, name string, opt ...domainMappingOption) *v1alpha1.DomainMapping {
+// DomainMapping creates a domainmapping with KReference.
+func DomainMapping(namespace, name string, kref *duckv1.KReference) *v1alpha1.DomainMapping {
 	dm := &v1alpha1.DomainMapping{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
 		},
-	}
-	for _, o := range opt {
-		o(dm)
+		Spec: v1alpha1.DomainMappingSpec{
+			Ref: *kref,
+		},
 	}
 	return dm
 }

--- a/pkg/testing/v1alpha1/domainmapping.go
+++ b/pkg/testing/v1alpha1/domainmapping.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+)
+
+type domainMappingOption func(dm *v1alpha1.DomainMapping)
+
+type refOption func(*duckv1.KReference)
+
+func WithRef(namespace, name string, opt ...refOption) domainMappingOption {
+	return func(dm *v1alpha1.DomainMapping) {
+		dm.Spec.Ref.Namespace = namespace
+		dm.Spec.Ref.Name = name
+		dm.Spec.Ref.APIVersion = "serving.knative.dev/v1"
+		dm.Spec.Ref.Kind = "Service"
+
+		for _, o := range opt {
+			o(&dm.Spec.Ref)
+		}
+	}
+}
+
+func DomainMapping(namespace, name string, opt ...domainMappingOption) *v1alpha1.DomainMapping {
+	dm := &v1alpha1.DomainMapping{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+	for _, o := range opt {
+		o(dm)
+	}
+	return dm
+}

--- a/pkg/testing/v1alpha1/domainmapping.go
+++ b/pkg/testing/v1alpha1/domainmapping.go
@@ -18,27 +18,22 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 )
 
 type domainMappingOption func(dm *v1alpha1.DomainMapping)
 
-type refOption func(*duckv1.KReference)
-
-func WithRef(namespace, name string, opt ...refOption) domainMappingOption {
+// WithRef fills reference field in domainmapping.
+func WithRef(namespace, name string) domainMappingOption {
 	return func(dm *v1alpha1.DomainMapping) {
 		dm.Spec.Ref.Namespace = namespace
 		dm.Spec.Ref.Name = name
 		dm.Spec.Ref.APIVersion = "serving.knative.dev/v1"
 		dm.Spec.Ref.Kind = "Service"
-
-		for _, o := range opt {
-			o(&dm.Spec.Ref)
-		}
 	}
 }
 
+// DomainMapping creates a domainmapping with domainMappingOption.
 func DomainMapping(namespace, name string, opt ...domainMappingOption) *v1alpha1.DomainMapping {
 	dm := &v1alpha1.DomainMapping{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -284,7 +284,7 @@ function install_knative_serving_standard() {
   UNINSTALL_LIST+=( "${CERT_YAML_NAME}" )
 
   echo ">> Installing Knative serving"
-  HA_COMPONENTS+=( "controller" "webhook" "autoscaler-hpa" "autoscaler" "domainmapping-webhook" )
+  HA_COMPONENTS+=( "controller" "webhook" "autoscaler-hpa" "autoscaler" "domain-mapping" "domainmapping-webhook" )
   if [[ "$1" == "HEAD" ]]; then
     local CORE_YAML_NAME=${TMP_DIR}/${SERVING_CORE_YAML##*/}
     sed "s/namespace: ${KNATIVE_DEFAULT_NAMESPACE}/namespace: ${SYSTEM_NAMESPACE}/g" ${SERVING_CORE_YAML} > ${CORE_YAML_NAME}

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -138,6 +138,8 @@ go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.
 go_test_e2e -timeout=25m -failfast -parallel=1 ./test/ha \
+            ${alpha} \
+            --enable-beta \
 	    -replicas="${REPLICAS:-1}" -buckets="${BUCKETS:-1}" -spoofinterval="10ms" || failed=1
 
 (( failed )) && fail_test

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -116,7 +116,7 @@ func testActivatorHA(t *testing.T, gracePeriod *int64, slo float64) {
 		}
 
 		t.Log("Test if service still works")
-		assertServiceEventuallyWorks(t, clients, namesScaleToZero, resourcesScaleToZero.Service.Status.URL.URL(), test.PizzaPlanetText1)
+		assertServiceEventuallyWorks(t, clients, namesScaleToZero, resourcesScaleToZero.Service.Status.URL.URL(), test.PizzaPlanetText1, test.ServingFlags.ResolvableDomain)
 
 		t.Logf("Wait for activator%d (%s) to vanish", i, activator.Name)
 		if err := pkgTest.WaitForPodDeleted(context.Background(), clients.KubeClient, activator.Name, system.Namespace()); err != nil {

--- a/test/ha/autoscalerhpa_test.go
+++ b/test/ha/autoscalerhpa_test.go
@@ -78,7 +78,7 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 	}
 
 	url := resources.Service.Status.URL.URL()
-	assertServiceEventuallyWorks(t, clients, names, url, test.PizzaPlanetText1)
+	assertServiceEventuallyWorks(t, clients, names, url, test.PizzaPlanetText1, test.ServingFlags.ResolvableDomain)
 
 	t.Log("Updating the Service after selecting new leader controller in order to generate a new revision")
 	names.Image = test.PizzaPlanet2
@@ -93,5 +93,5 @@ func TestAutoscalerHPAHANewRevision(t *testing.T) {
 		t.Fatal("New image not reflected in Service:", err)
 	}
 
-	assertServiceEventuallyWorks(t, clients, names, url, test.PizzaPlanetText2)
+	assertServiceEventuallyWorks(t, clients, names, url, test.PizzaPlanetText2, test.ServingFlags.ResolvableDomain)
 }

--- a/test/ha/domainmapping_test.go
+++ b/test/ha/domainmapping_test.go
@@ -87,7 +87,7 @@ func TestDomainMappingHA(t *testing.T) {
 	var dm *v1alpha1.DomainMapping
 	if err := reconciler.RetryTestErrors(func(int) error {
 		dm, err = clients.ServingAlphaClient.DomainMappings.Create(ctx,
-			v1alpha1test.DomainMapping(svc.Service.Namespace, host, v1alpha1test.WithRef(svc.Service.Namespace, svc.Service.Name)),
+			v1alpha1test.DomainMapping(svc.Service.Namespace, host, v1alpha1test.KReference(svc.Service.Namespace, svc.Service.Name)),
 			metav1.CreateOptions{})
 		return err
 	}); err != nil {
@@ -143,7 +143,7 @@ func TestDomainMappingHA(t *testing.T) {
 	var altDm *v1alpha1.DomainMapping
 	if err := reconciler.RetryTestErrors(func(int) error {
 		altDm, err = altClients.ServingAlphaClient.DomainMappings.Create(ctx,
-			v1alpha1test.DomainMapping(altSvc.Service.Namespace, host, v1alpha1test.WithRef(altSvc.Service.Namespace, altSvc.Service.Name)),
+			v1alpha1test.DomainMapping(altSvc.Service.Namespace, host, v1alpha1test.KReference(altSvc.Service.Namespace, altSvc.Service.Name)),
 			metav1.CreateOptions{})
 		return err
 	}); err != nil {

--- a/test/ha/domainmapping_test.go
+++ b/test/ha/domainmapping_test.go
@@ -1,0 +1,220 @@
+// +build e2e
+
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ha
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/reconciler"
+	"knative.dev/pkg/system"
+	pkgTest "knative.dev/pkg/test"
+	pkgHa "knative.dev/pkg/test/ha"
+	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	"knative.dev/serving/test"
+	"knative.dev/serving/test/e2e"
+	v1test "knative.dev/serving/test/v1"
+)
+
+const (
+	domainmappingDeploymentName = "domain-mapping"
+)
+
+func TestDomainMappingHA(t *testing.T) {
+	if !test.ServingFlags.EnableAlphaFeatures {
+		t.Skip("Alpha features not enabled")
+	}
+
+	ctx, clients := context.Background(), test.Setup(t)
+
+	if err := pkgTest.WaitForDeploymentScale(context.Background(), clients.KubeClient, domainmappingDeploymentName, system.Namespace(), test.ServingFlags.Replicas); err != nil {
+		t.Fatalf("Deployment %s not scaled to %d: %v", domainmappingDeploymentName, test.ServingFlags.Replicas, err)
+	}
+
+	leaders, err := pkgHa.WaitForNewLeaders(context.Background(), t, clients.KubeClient, domainmappingDeploymentName, system.Namespace(), sets.NewString(), test.ServingFlags.Buckets)
+	if err != nil {
+		t.Fatal("Failed to get leader:", err)
+	}
+	t.Log("Got initial leader set:", leaders)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.PizzaPlanet1,
+	}
+
+	// Clean up on test failure or interrupt.
+	test.EnsureTearDown(t, clients, &names)
+
+	// Set up initial Service.
+	svc, err := v1test.CreateServiceReady(t, clients, &names)
+	if err != nil {
+		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
+	}
+
+	// Using fixed hostnames can lead to conflicts when multiple tests run at
+	// once, so include the svc name to avoid collisions.
+	host := svc.Service.Name + ".example.org"
+	// Set resolvabledomain for custom domain to false by default.
+	resolvableCustomDomain := false
+
+	if test.ServingFlags.CustomDomain != "" {
+		host = svc.Service.Name + "." + test.ServingFlags.CustomDomain
+		resolvableCustomDomain = true
+	}
+	// Point DomainMapping at our service.
+	var dm *v1alpha1.DomainMapping
+	if err := reconciler.RetryTestErrors(func(int) error {
+		dm, err = clients.ServingAlphaClient.DomainMappings.Create(ctx, &v1alpha1.DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      host,
+				Namespace: svc.Service.Namespace,
+			},
+			Spec: v1alpha1.DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Namespace:  svc.Service.Namespace,
+					Name:       svc.Service.Name,
+					APIVersion: "serving.knative.dev/v1",
+					Kind:       "Service",
+				},
+			},
+		}, metav1.CreateOptions{})
+		return err
+	}); err != nil {
+		t.Fatalf("Create(DomainMapping) = %v, expected no error", err)
+	}
+
+	t.Cleanup(func() {
+		clients.ServingAlphaClient.DomainMappings.Delete(ctx, dm.Name, metav1.DeleteOptions{})
+	})
+
+	// Wait for DomainMapping to go Ready.
+	waitErr := wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
+		state, err := clients.ServingAlphaClient.DomainMappings.Get(context.Background(), dm.Name, metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+
+		return state.IsReady(), nil
+	})
+	if waitErr != nil {
+		t.Fatalf("The DomainMapping %s was not marked as Ready: %v", dm.Name, waitErr)
+	}
+
+	assertServiceEventuallyWorks(t, clients, names, &url.URL{Scheme: "http", Host: host}, test.PizzaPlanetText1, resolvableCustomDomain)
+
+	for _, leader := range leaders.List() {
+		if err := clients.KubeClient.CoreV1().Pods(system.Namespace()).Delete(context.Background(), leader,
+			metav1.DeleteOptions{}); err != nil && !apierrs.IsNotFound(err) {
+			t.Fatalf("Failed to delete pod %s: %v", leader, err)
+		}
+		if err := pkgTest.WaitForPodDeleted(context.Background(), clients.KubeClient, leader, system.Namespace()); err != nil {
+			t.Fatalf("Did not observe %s to actually be deleted: %v", leader, err)
+		}
+	}
+
+	// Wait for all of the old leaders to go away, and then for the right number to be back.
+	if _, err := pkgHa.WaitForNewLeaders(context.Background(), t, clients.KubeClient, domainmappingDeploymentName, system.Namespace(), leaders, test.ServingFlags.Buckets); err != nil {
+		t.Fatal("Failed to find new leader:", err)
+	}
+
+	// Verify that after changing the leader we can still create a new domainmapping and the second DomainMapping collided with the first.
+
+	altClients := e2e.SetupAlternativeNamespace(t)
+	altNames := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.PizzaPlanet2,
+	}
+	test.EnsureTearDown(t, altClients, &altNames)
+
+	// Set up second Service in alt namespace.
+	altSvc, err := v1test.CreateServiceReady(t, altClients, &altNames)
+	if err != nil {
+		t.Fatalf("Failed to create initial Service %v: %v", altNames.Service, err)
+	}
+
+	// Create second domain mapping with same name in alt namespace - this will collide with the existing mapping.
+	var altDm *v1alpha1.DomainMapping
+	if err := reconciler.RetryTestErrors(func(int) error {
+		altDm, err = altClients.ServingAlphaClient.DomainMappings.Create(ctx, &v1alpha1.DomainMapping{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      host,
+				Namespace: altSvc.Service.Namespace,
+			},
+			Spec: v1alpha1.DomainMappingSpec{
+				Ref: duckv1.KReference{
+					Namespace:  altSvc.Service.Namespace,
+					Name:       altSvc.Service.Name,
+					APIVersion: "serving.knative.dev/v1",
+					Kind:       "Service",
+				},
+			},
+		}, metav1.CreateOptions{})
+		return err
+	}); err != nil {
+		t.Fatalf("Create(DomainMapping) = %v, expected no error", err)
+	}
+
+	t.Cleanup(func() {
+		altClients.ServingAlphaClient.DomainMappings.Delete(ctx, altDm.Name, metav1.DeleteOptions{})
+	})
+
+	// Second domain mapping should go to DomainMappingConditionDomainClaimed=false state.
+	waitErr = wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
+		state, err := altClients.ServingAlphaClient.DomainMappings.Get(context.Background(), dm.Name, metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+
+		return state.Generation == state.Status.ObservedGeneration &&
+			state.Status.GetCondition(v1alpha1.DomainMappingConditionDomainClaimed).IsFalse(), nil
+	})
+	if waitErr != nil {
+		t.Fatalf("The second DomainMapping %s did not enter DomainMappingConditionDomainClaimed=false state: %v", altDm.Name, waitErr)
+	}
+
+	// Because the second DomainMapping collided with the first, it should not have taken effect.
+	assertServiceEventuallyWorks(t, clients, names, &url.URL{Scheme: "http", Host: host}, test.PizzaPlanetText1, resolvableCustomDomain)
+
+	// Delete the first DomainMapping.
+	if err := clients.ServingAlphaClient.DomainMappings.Delete(ctx, dm.Name, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("Delete=%v, expected no error", err)
+	}
+
+	// The second DomainMapping should now be able to claim the domain.
+	waitErr = wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
+		state, err := altClients.ServingAlphaClient.DomainMappings.Get(context.Background(), altDm.Name, metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+
+		return state.IsReady(), nil
+	})
+	if waitErr != nil {
+		t.Fatalf("The second DomainMapping %s was not marked as Ready: %v", dm.Name, waitErr)
+	}
+
+	// The domain name should now point to the second service.
+	assertServiceEventuallyWorks(t, clients, names, &url.URL{Scheme: "http", Host: host}, test.PizzaPlanetText2, resolvableCustomDomain)
+}

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -51,11 +51,11 @@ func createPizzaPlanetService(t *testing.T, fopt ...rtesting.ServiceOption) (tes
 		t.Fatal("Failed to create Service:", err)
 	}
 
-	assertServiceEventuallyWorks(t, clients, names, resources.Service.Status.URL.URL(), test.PizzaPlanetText1)
+	assertServiceEventuallyWorks(t, clients, names, resources.Service.Status.URL.URL(), test.PizzaPlanetText1, test.ServingFlags.ResolvableDomain)
 	return names, resources
 }
 
-func assertServiceEventuallyWorks(t *testing.T, clients *test.Clients, names test.ResourceNames, url *url.URL, expectedText string) {
+func assertServiceEventuallyWorks(t *testing.T, clients *test.Clients, names test.ResourceNames, url *url.URL, expectedText string, resolvabledomain bool) {
 	t.Helper()
 	// Wait for the Service to be ready.
 	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
@@ -69,7 +69,7 @@ func assertServiceEventuallyWorks(t *testing.T, clients *test.Clients, names tes
 		url,
 		v1test.RetryingRouteInconsistency(spoof.MatchesAllOf(spoof.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
-		test.ServingFlags.ResolvableDomain); err != nil {
+		resolvabledomain); err != nil {
 		t.Fatalf("The endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, url, expectedText, err)
 	}
 }


### PR DESCRIPTION
This patch adds HA test for domain-mapping controller.

The test is basically same with conformance test for domain-mapping,
but it verifies after changing the leader.

Fix https://github.com/knative/serving/issues/10805

**Release Note**

```release-note
NONE
```
