### PR TITLE
Remove the User-Agent inline constant with standard constant from pkg

### DIFF
--- a/pkg/activator/handler/healthz_handler_test.go
+++ b/pkg/activator/handler/healthz_handler_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	ktesting "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/network"
 )
 
 func TestHealthHandler(t *testing.T) {
@@ -36,19 +37,17 @@ func TestHealthHandler(t *testing.T) {
 		check          func() error
 	}{{
 		name:           "forward non-kubelet request",
-		headers:        mapToHeader(map[string]string{"User-Agent": "chromium/734.6.5"}),
+		headers:        http.Header{network.UserAgentKey: []string{"chromium/734.6.5"}},
 		passed:         true,
 		expectedStatus: http.StatusOK,
 	}, {
 		name:           "kubelet probe success",
-		headers:        mapToHeader(map[string]string{"User-Agent": "kube-probe/something"}),
-		passed:         false,
+		headers:        http.Header{network.UserAgentKey: []string{"kube-probe/something"}},
 		expectedStatus: http.StatusOK,
 		check:          func() error { return nil },
 	}, {
 		name:           "kubelet probe failure",
-		headers:        mapToHeader(map[string]string{"User-Agent": "kube-probe/something"}),
-		passed:         false,
+		headers:        http.Header{network.UserAgentKey: []string{"kube-probe/something"}},
 		expectedStatus: http.StatusInternalServerError,
 		check:          func() error { return errors.New("not ready") },
 	}}
@@ -77,7 +76,7 @@ func TestHealthHandler(t *testing.T) {
 			}
 
 			if resp.Code != e.expectedStatus {
-				t.Errorf("Unexpected response status. Want %d, got %d", e.expectedStatus, resp.Code)
+				t.Errorf("HTTP Status = %d, want: %d", resp.Code, e.expectedStatus)
 			}
 		})
 	}
@@ -90,15 +89,15 @@ func BenchmarkHealthHandler(b *testing.B) {
 		check   func() error
 	}{{
 		label:   "forward non-kubelet request",
-		headers: mapToHeader(map[string]string{"User-Agent": "chromium/734.6.5"}),
+		headers: http.Header{network.UserAgentKey: []string{"chromium/734.6.5"}},
 		check:   func() error { return nil },
 	}, {
 		label:   "kubelet probe success",
-		headers: mapToHeader(map[string]string{"User-Agent": "kube-probe/something"}),
+		headers: http.Header{network.UserAgentKey: []string{"kube-probe/something"}},
 		check:   func() error { return nil },
 	}, {
 		label:   "kubelet probe failure",
-		headers: mapToHeader(map[string]string{"User-Agent": "kube-probe/something"}),
+		headers: http.Header{network.UserAgentKey: []string{"kube-probe/something"}},
 		check:   func() error { return errors.New("not ready") },
 	}}
 

--- a/pkg/autoscaler/statserver/server_test.go
+++ b/pkg/autoscaler/statserver/server_test.go
@@ -81,7 +81,7 @@ func TestProbe(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error creating request:", err)
 	}
-	req.Header.Set("User-Agent", "kube-probe/1.15.i.wish")
+	req.Header.Set(network.UserAgentKey, network.KubeProbeUAPrefix+"1.15.i.wish")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg/http/proxy.go
+++ b/pkg/http/proxy.go
@@ -19,6 +19,8 @@ package http
 import (
 	"net/http"
 	"net/http/httputil"
+
+	"knative.dev/pkg/network"
 )
 
 // NewHeaderPruningReverseProxy returns a httputil.ReverseProxy that proxies
@@ -30,9 +32,9 @@ func NewHeaderPruningReverseProxy(targetHost string, headersToRemove []string) *
 			req.URL.Host = targetHost
 
 			// Copied from httputil.NewSingleHostReverseProxy.
-			if _, ok := req.Header["User-Agent"]; !ok {
+			if _, ok := req.Header[network.UserAgentKey]; !ok {
 				// explicitly disable User-Agent so it's not set to default value
-				req.Header.Set("User-Agent", "")
+				req.Header.Set(network.UserAgentKey, "")
 			}
 
 			for _, h := range headersToRemove {

--- a/pkg/http/proxy_test.go
+++ b/pkg/http/proxy_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	"knative.dev/pkg/network"
 )
 
 func TestNewHeaderPruningProxy(t *testing.T) {
@@ -58,10 +60,10 @@ func TestNewHeaderPruningProxy(t *testing.T) {
 		name: "explicit user agent header not removed",
 		url:  "http://example.com/",
 		header: http.Header{
-			"User-Agent": []string{"gold"},
+			network.UserAgentKey: []string{"gold"},
 		},
 		expectHeaders: http.Header{
-			"User-Agent": []string{"gold"},
+			network.UserAgentKey: []string{"gold"},
 		},
 	}}
 

--- a/pkg/queue/health/probe_test.go
+++ b/pkg/queue/health/probe_test.go
@@ -66,7 +66,7 @@ func TestHTTPProbeSuccess(t *testing.T) {
 				gotHeader = corev1.HTTPHeader{Name: headerKey, Value: headerValue[0]}
 			}
 
-			if headerKey == "User-Agent" && strings.HasPrefix(headerValue[0], network.KubeProbeUAPrefix) {
+			if headerKey == network.UserAgentKey && strings.HasPrefix(headerValue[0], network.KubeProbeUAPrefix) {
 				gotKubeletHeader = true
 			}
 		}

--- a/test/test_images/runtime/handlers/handler.go
+++ b/test/test_images/runtime/handlers/handler.go
@@ -21,7 +21,6 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
-	"strings"
 
 	network "knative.dev/networking/pkg"
 )
@@ -50,7 +49,7 @@ func withRequestLog(next http.HandlerFunc) http.HandlerFunc {
 
 // withKubeletProbeHeaderCheck checks each health request has Kubelet probe header
 func withKubeletProbeHeaderCheck(w http.ResponseWriter, r *http.Request) {
-	if !strings.HasPrefix(r.Header.Get("User-Agent"), network.KubeProbeUAPrefix) {
+	if !network.IsKubeletProbe(r) {
 		w.WriteHeader(http.StatusBadRequest)
 	} else {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
- Also other minor changes and improvements to the code
  - remove `mapToHeader` call, since it does not save us much, but
    builds a whole new map and then iterates over it.
  - remove test valu defaults
  - etc

/assign @tcnghia @yanweiguo 