### PR TITLE
Use Revision from context in request log

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -34,7 +34,6 @@ import (
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	"knative.dev/pkg/injection"
 	"knative.dev/serving/pkg/activator"
-	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -181,7 +180,7 @@ func main() {
 	ah = tracing.HTTPSpanMiddleware(ah)
 	ah = configStore.HTTPMiddleware(ah)
 	reqLogHandler, err := pkghttp.NewRequestLogHandler(ah, logging.NewSyncFileWriter(os.Stdout), "",
-		requestLogTemplateInputGetter(revisioninformer.Get(ctx).Lister()), false /*enableProbeRequestLog*/)
+		requestLogTemplateInputGetter, false /*enableProbeRequestLog*/)
 	if err != nil {
 		logger.Fatalw("Unable to create request log handler", zap.Error(err))
 	}

--- a/cmd/activator/request_log.go
+++ b/cmd/activator/request_log.go
@@ -49,7 +49,7 @@ func updateRequestLogFromConfigMap(logger *zap.SugaredLogger, h *pkghttp.Request
 
 // requestLogTemplateInputGetter gets the template input from the request.
 // It assumes the Revision has been set on the context such that
-// WithRevision() returns a non-nil revision.
+// handler.FromRevision() returns a non-nil revision.
 func requestLogTemplateInputGetter(req *http.Request, resp *pkghttp.RequestLogResponse) *pkghttp.RequestLogTemplateInput {
 	revision := handler.RevisionFrom(req.Context())
 

--- a/cmd/activator/request_log_test.go
+++ b/cmd/activator/request_log_test.go
@@ -25,18 +25,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	ltesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/metrics"
-	rtesting "knative.dev/pkg/reconciler/testing"
 	"knative.dev/serving/pkg/activator"
 	activatorhandler "knative.dev/serving/pkg/activator/handler"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
-	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
-	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
-	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
 	pkghttp "knative.dev/serving/pkg/http"
 )
 
@@ -53,7 +48,7 @@ func TestUpdateRequestLogFromConfigMap(t *testing.T) {
 	})
 	buf := bytes.NewBufferString("")
 	handler, err := pkghttp.NewRequestLogHandler(baseHandler, buf, "",
-		requestLogTemplateInputGetter(revisionLister(t, true)), false /*enableProbeRequestLog*/)
+		requestLogTemplateInputGetter, false /*enableProbeRequestLog*/)
 	if err != nil {
 		t.Fatal("want: no error, got:", err)
 	}
@@ -131,11 +126,7 @@ func TestUpdateRequestLogFromConfigMap(t *testing.T) {
 			resp := httptest.NewRecorder()
 			rs := string(uuid.NewUUID())
 			req := httptest.NewRequest(http.MethodPost, test.url, bytes.NewBufferString(rs))
-			ctx := activatorhandler.WithRevID(req.Context(),
-				types.NamespacedName{
-					Namespace: testNamespaceName,
-					Name:      testRevisionName,
-				})
+			ctx := activatorhandler.WithRevision(req.Context(), revision(true))
 			handler.ServeHTTP(resp, req.WithContext(ctx))
 
 			if got := buf.String(); got != test.want {
@@ -148,13 +139,13 @@ func TestUpdateRequestLogFromConfigMap(t *testing.T) {
 func TestRequestLogTemplateInputGetter(t *testing.T) {
 	tests := []struct {
 		name     string
-		getter   pkghttp.RequestLogTemplateInputGetter
+		revision *v1.Revision
 		request  *http.Request
 		response *pkghttp.RequestLogResponse
 		want     pkghttp.RequestLogRevision
 	}{{
-		name:   "success",
-		getter: requestLogTemplateInputGetter(revisionLister(t, true)),
+		name:     "success",
+		revision: revision(true),
 		request: &http.Request{Header: map[string][]string{
 			activator.RevisionHeaderName:      {testRevisionName},
 			activator.RevisionHeaderNamespace: {testNamespaceName},
@@ -167,20 +158,8 @@ func TestRequestLogTemplateInputGetter(t *testing.T) {
 			Service:       testServiceName,
 		},
 	}, {
-		name:   "revision not found",
-		getter: requestLogTemplateInputGetter(revisionLister(t, true)),
-		request: &http.Request{Header: map[string][]string{
-			activator.RevisionHeaderName:      {"foo"},
-			activator.RevisionHeaderNamespace: {"bar"},
-		}},
-		response: &pkghttp.RequestLogResponse{Code: http.StatusAlreadyReported},
-		want: pkghttp.RequestLogRevision{
-			Name:      "foo",
-			Namespace: "bar",
-		},
-	}, {
-		name:   "labels not found",
-		getter: requestLogTemplateInputGetter(revisionLister(t, false)),
+		name:     "labels not found",
+		revision: revision(false),
 		request: &http.Request{Header: map[string][]string{
 			activator.RevisionHeaderName:      {testRevisionName},
 			activator.RevisionHeaderNamespace: {testNamespaceName},
@@ -194,14 +173,10 @@ func TestRequestLogTemplateInputGetter(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := activatorhandler.WithRevID(test.request.Context(),
-				types.NamespacedName{
-					Namespace: test.request.Header.Get(activator.RevisionHeaderNamespace),
-					Name:      test.request.Header.Get(activator.RevisionHeaderName),
-				})
+			ctx := activatorhandler.WithRevision(test.request.Context(), test.revision)
 			request := test.request.WithContext(ctx)
 
-			got := test.getter(request, test.response)
+			got := requestLogTemplateInputGetter(request, test.response)
 			if !cmp.Equal(*got.Revision, test.want) {
 				t.Errorf("Got = %v, want: %v, diff:\n%s", got.Revision, test.want, cmp.Diff(got.Revision, test.want))
 			}
@@ -215,13 +190,14 @@ func TestRequestLogTemplateInputGetter(t *testing.T) {
 	}
 }
 
-func revisionLister(t *testing.T, addLabels bool) servinglisters.RevisionLister {
+func revision(addLabels bool) *v1.Revision {
 	rev := &v1.Revision{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testRevisionName,
 			Namespace: testNamespaceName,
 		},
 	}
+
 	if addLabels {
 		rev.Labels = map[string]string{
 			serving.ConfigurationLabelKey: testConfigName,
@@ -229,9 +205,5 @@ func revisionLister(t *testing.T, addLabels bool) servinglisters.RevisionLister 
 		}
 	}
 
-	ctx, _ := rtesting.SetupFakeContext(t)
-	fakeservingclient.Get(ctx).ServingV1().Revisions(testNamespaceName).Create(ctx, rev, metav1.CreateOptions{})
-	ri := fakerevisioninformer.Get(ctx)
-	ri.Informer().GetIndexer().Add(rev)
-	return ri.Lister()
+	return rev
 }

--- a/pkg/activator/handler/context.go
+++ b/pkg/activator/handler/context.go
@@ -33,13 +33,13 @@ type (
 	revIDKey    struct{}
 )
 
-// withRevision attaches the Revision object to the context.
-func withRevision(ctx context.Context, rev *v1.Revision) context.Context {
+// WithRevision attaches the Revision object to the context.
+func WithRevision(ctx context.Context, rev *v1.Revision) context.Context {
 	return context.WithValue(ctx, revisionKey{}, rev)
 }
 
-// revisionFrom retrieves the Revision object from the context.
-func revisionFrom(ctx context.Context) *v1.Revision {
+// RevisionFrom retrieves the Revision object from the context.
+func RevisionFrom(ctx context.Context) *v1.Revision {
 	return ctx.Value(revisionKey{}).(*v1.Revision)
 }
 

--- a/pkg/activator/handler/context_handler.go
+++ b/pkg/activator/handler/context_handler.go
@@ -76,7 +76,7 @@ func (h *contextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	ctx = logging.WithLogger(ctx, logger)
-	ctx = withRevision(ctx, revision)
+	ctx = WithRevision(ctx, revision)
 	ctx = WithRevID(ctx, revID)
 
 	h.nextHandler.ServeHTTP(w, r.WithContext(ctx))

--- a/pkg/activator/handler/context_handler_test.go
+++ b/pkg/activator/handler/context_handler_test.go
@@ -38,7 +38,7 @@ func TestContextHandler(t *testing.T) {
 	revisionInformer(ctx, revision)
 
 	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := revisionFrom(r.Context()); got != revision {
+		if got := RevisionFrom(r.Context()); got != revision {
 			t.Errorf("revisionFrom() = %v, want %v", got, revision)
 		}
 

--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -42,7 +42,7 @@ type MetricHandler struct {
 }
 
 func (h *MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	rev := revisionFrom(r.Context())
+	rev := RevisionFrom(r.Context())
 	reporterCtx, _ := metrics.PodRevisionContext(h.podName, activator.Name,
 		rev.Namespace, rev.Labels[serving.ServiceLabelKey], rev.Labels[serving.ConfigurationLabelKey], rev.Name)
 

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -114,7 +114,7 @@ func TestRequestMetricHandler(t *testing.T) {
 				metricstest.AssertMetricExists(t, responseTimeInMsecM.Name())
 			}()
 
-			reqCtx := withRevision(context.Background(), rev)
+			reqCtx := WithRevision(context.Background(), rev)
 			reqCtx = WithRevID(reqCtx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
 			handler.ServeHTTP(resp, req.WithContext(reqCtx))
 		})
@@ -128,7 +128,7 @@ func reset() {
 
 func BenchmarkMetricHandler(b *testing.B) {
 	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	reqCtx := withRevision(context.Background(), revision(testNamespace, testRevName))
+	reqCtx := WithRevision(context.Background(), revision(testNamespace, testRevName))
 
 	handler := NewMetricHandler("benchPod", baseHandler)
 


### PR DESCRIPTION
Avoids having to look the revision up again from the lister, and simplifies the tests / method signature a bit.

Note: this removes the test for the revision not existing: this can't actually happen in reality since [contextHandler would've errored in this case](https://github.com/knative/serving/blob/master/pkg/activator/handler/context_handler.go#L71) before the request log handler was invoked (the test was an artifact of the revision lookup being duplicated).

/assign @vagababov 
