### PR TITLE
Relax annotation constraints & some cleanup

### DIFF
--- a/pkg/apis/serving/metadata_validation_test.go
+++ b/pkg/apis/serving/metadata_validation_test.go
@@ -102,14 +102,6 @@ func TestValidateObjectMetadata(t *testing.T) {
 			Paths:   []string{"name"},
 		},
 	}, {
-		name: "valid forceUpgrade annotation label",
-		objectMeta: &metav1.ObjectMeta{
-			GenerateName: "some-name",
-			Annotations: map[string]string{
-				"serving.knative.dev/forceUpgrade": "true",
-			},
-		},
-	}, {
 		name: "valid creator annotation label",
 		objectMeta: &metav1.ObjectMeta{
 			GenerateName: "some-name",
@@ -142,14 +134,13 @@ func TestValidateObjectMetadata(t *testing.T) {
 			},
 		},
 	}, {
-		name: "invalid knative prefix annotation",
+		name: "valid knative prefix annotation",
 		objectMeta: &metav1.ObjectMeta{
 			GenerateName: "some-name",
 			Annotations: map[string]string{
 				"serving.knative.dev/testAnnotation": "value",
 			},
 		},
-		expectErr: apis.ErrInvalidKeyName("serving.knative.dev/testAnnotation", "annotations"),
 	}, {
 		name: "valid non-knative prefix annotation label",
 		objectMeta: &metav1.ObjectMeta{

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -91,17 +91,11 @@ const (
 
 	// DomainMappingLabelKey is the label key attached to Ingress resources to indicate
 	// which DomainMapping triggered their creation.
-	DomainMappingLabelKey = GroupName + "/domainmapping"
+	DomainMappingLabelKey = GroupName + "/domainMapping"
 
 	// ConfigurationGenerationLabelKey is the label key attached to a Revision indicating the
 	// metadata generation of the Configuration that created this revision
 	ConfigurationGenerationLabelKey = GroupName + "/configurationGeneration"
-
-	// ForceUpgradeAnnotationKey is the annotation which was added to resources
-	// upgraded from v1alpha1.
-	// This annotation is no longer used since v1alpha1 was removed, but
-	// must continue to be allowed since it may be present on existing resources.
-	ForceUpgradeAnnotationKey = GroupName + "/forceUpgrade"
 
 	// CreatorAnnotation is the annotation key to describe the user that
 	// created the resource.

--- a/pkg/apis/serving/v1/service_validation_test.go
+++ b/pkg/apis/serving/v1/service_validation_test.go
@@ -262,7 +262,9 @@ func TestServiceValidation(t *testing.T) {
 		},
 		wantErr: nil,
 	}, {
-		name: "invalid serving.knative.dev annotation",
+		// We want to be able to introduce new annotations with the serving prefix in the future
+		// and not break downgrading.
+		name: "allow unknown uses of serving.knative.dev prefix for annotations",
 		r: &Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "serving-annotation",
@@ -272,7 +274,7 @@ func TestServiceValidation(t *testing.T) {
 			},
 			Spec: getServiceSpec("helloworld:foo"),
 		},
-		wantErr: apis.ErrInvalidKeyName("serving.knative.dev/foo", "metadata.annotations"),
+		wantErr: nil,
 	}, {
 		name: "invalid name",
 		r: &Service{


### PR DESCRIPTION
Fixes: https://github.com/knative/serving/issues/10622 but for annotations

- unknown annotations with serving.knative.dev/prefix are allowed
  but not recommended to allow us to introduce new annotations
  in a single release
- drop old v1alpha1 force upgrade annotation
- fix domainMapping casing to be consistent

/hold wait for https://github.com/knative/serving/pull/10834 to merge first