### PR TITLE
More deep cleaning of the Route reconciler it needed for some time.

### DIFF
--- a/pkg/reconciler/route/controller.go
+++ b/pkg/reconciler/route/controller.go
@@ -47,12 +47,12 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
-	return newControllerWithClock(ctx, cmw, clock.RealClock{})
+	return newController(ctx, cmw, clock.RealClock{})
 }
 
 type reconcilerOption func(*Reconciler)
 
-func newControllerWithClock(
+func newController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 	clock clock.Clock,

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -168,7 +168,7 @@ func TestReconcileIngressUpdateReenqueueRollout(t *testing.T) {
 			const drift = 5
 			fakeClock.SetTime(fakeClock.Now().Add(drift * time.Second))
 
-			// 5s of the duration already spent.
+			// Drift seconds of the duration already spent.
 			totalDuration := float64(rd - drift)
 			// Step count is minimum of % points of traffic allocated to the config (1% already shifted).
 			steps := math.Min(totalDuration/drift, allocatedTraffic-1)
@@ -330,7 +330,7 @@ func TestReconcileIngressUpdateReenqueueRolloutAnnotation(t *testing.T) {
 			const drift = 5
 			fakeClock.SetTime(fakeClock.Now().Add(drift * time.Second))
 
-			// 5s of the duration already spent.
+			// Drift seconds of the duration already spent.
 			totalDuration := float64(rd - drift)
 			// Step count is minimum of % points of traffic allocated to the config (1% already shifted).
 			steps := math.Min(totalDuration/drift, allocatedTraffic-1)

--- a/pkg/reconciler/route/reconcile_resources_test.go
+++ b/pkg/reconciler/route/reconcile_resources_test.go
@@ -165,12 +165,13 @@ func TestReconcileIngressUpdateReenqueueRollout(t *testing.T) {
 			ing = updated
 
 			// Advance the time by 5s.
-			fakeClock.SetTime(fakeClock.Now().Add(5 * time.Second))
+			const drift = 5
+			fakeClock.SetTime(fakeClock.Now().Add(drift * time.Second))
 
 			// 5s of the duration already spent.
-			totalDuration := float64(rd - 5)
+			totalDuration := float64(rd - drift)
 			// Step count is minimum of % points of traffic allocated to the config (1% already shifted).
-			steps := math.Min(totalDuration/5, allocatedTraffic-1)
+			steps := math.Min(totalDuration/drift, allocatedTraffic-1)
 			stepSize := math.Max(1, math.Round((allocatedTraffic-1)/steps)) // we round the step size.
 			stepDuration := time.Duration(int(totalDuration * float64(time.Second) / steps))
 
@@ -270,7 +271,7 @@ func TestReconcileIngressUpdateReenqueueRolloutAnnotation(t *testing.T) {
 				wasReenqueued = true
 				duration = d
 			}
-			ctx := updateContext(baseCtx, 311) // This should be ignored, since we set annotation.
+			ctx := updateContext(baseCtx, 311 /*rolloutDuration*/) // This should be ignored, since we set annotation.
 			_, ro, err := reconciler.reconcileIngress(ctx, r, tc, tls, "foo-ingress-class")
 			if err != nil {
 				t.Fatal("Unexpected error:", err)
@@ -326,12 +327,13 @@ func TestReconcileIngressUpdateReenqueueRolloutAnnotation(t *testing.T) {
 			ing = updated
 
 			// Advance the time by 5s.
-			fakeClock.SetTime(fakeClock.Now().Add(5 * time.Second))
+			const drift = 5
+			fakeClock.SetTime(fakeClock.Now().Add(drift * time.Second))
 
 			// 5s of the duration already spent.
-			totalDuration := float64(rd - 5)
+			totalDuration := float64(rd - drift)
 			// Step count is minimum of % points of traffic allocated to the config (1% already shifted).
-			steps := math.Min(totalDuration/5, allocatedTraffic-1)
+			steps := math.Min(totalDuration/drift, allocatedTraffic-1)
 			stepSize := math.Max(1, math.Round((allocatedTraffic-1)/steps)) // we round the step size.
 			stepDuration := time.Duration(int(totalDuration * float64(time.Second) / steps))
 

--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -22,9 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking"
@@ -36,22 +34,6 @@ import (
 )
 
 var errLoadBalancerNotFound = errors.New("failed to fetch loadbalancer domain/IP from ingress status")
-
-// GetNames returns a set of service names.
-func GetNames(services []*corev1.Service) sets.String {
-	names := make(sets.String, len(services))
-
-	for i := range services {
-		names.Insert(services[i].Name)
-	}
-
-	return names
-}
-
-// SelectorFromRoute creates a label selector given a specific route.
-func SelectorFromRoute(route *v1.Route) labels.Selector {
-	return labels.SelectorFromSet(labels.Set{serving.RouteLabelKey: route.Name})
-}
 
 // MakeK8sPlaceholderService creates a placeholder Service to prevent naming collisions. It's owned by the
 // provided v1.Route.

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -24,9 +24,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking"
@@ -356,13 +354,6 @@ func TestMakeK8sPlaceholderService(t *testing.T) {
 	}
 }
 
-func TestSelectorFromRoute(t *testing.T) {
-	selector := SelectorFromRoute(r)
-	if !selector.Matches(labels.Set{serving.RouteLabelKey: r.Name}) {
-		t.Errorf("Unexpected labels in selector")
-	}
-}
-
 func testConfig() *config.Config {
 	return &config.Config{
 		Domain: &config.Domain{
@@ -388,43 +379,5 @@ func testConfig() *config.Config {
 			PodSpecTolerations:    apiConfig.Disabled,
 			TagHeaderBasedRouting: apiConfig.Disabled,
 		},
-	}
-}
-
-func TestGetNames(t *testing.T) {
-	tests := []struct {
-		name     string
-		services []*corev1.Service
-		want     sets.String
-	}{
-		{
-			name: "nil services",
-			want: sets.String{},
-		},
-		{
-			name: "multiple services",
-			services: []*corev1.Service{
-				{ObjectMeta: metav1.ObjectMeta{Name: "svc1"}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "svc2"}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "svc3"}},
-			},
-			want: sets.NewString("svc1", "svc2", "svc3"),
-		},
-		{
-			name: "duplicate services",
-			services: []*corev1.Service{
-				{ObjectMeta: metav1.ObjectMeta{Name: "svc1"}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "svc1"}},
-				{ObjectMeta: metav1.ObjectMeta{Name: "svc1"}},
-			},
-			want: sets.NewString("svc1"),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GetNames(tt.services); !cmp.Equal(got, tt.want) {
-				t.Error("GetNames() (-want, +got) =", cmp.Diff(tt.want, got))
-			}
-		})
 	}
 }


### PR DESCRIPTION
- remove some double O(N) operations, where one was enough
- reflow rollout code so that all `rolloutInProgress` pieces are next to
  each other. I don't recall why I didn't do this in the first place.
- this led to removing some unneeded public functions, and instead we
  have nice inline code now. Test coverage is basically same :D
- remove debug printfs
- improve somec constants

/assign @tcnghia @ZhiminXiang 