### PR TITLE
Update the setup of HTTP01 challenge tests

### DIFF
--- a/test/config/autotls/certmanager/http01/issuer.yaml
+++ b/test/config/autotls/certmanager/http01/issuer.yaml
@@ -18,7 +18,7 @@ metadata:
   name: http01-issuer
 spec:
   acme:
-    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       name: "http01-key"
     solvers:

--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -210,7 +210,7 @@ add_trap "cleanup_per_selfsigned_namespace_auto_tls" SIGKILL SIGTERM SIGQUIT
 go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
 cleanup_per_selfsigned_namespace_auto_tls
 
-if [[ ${RUN_HTTP01_AUTO_TLS_TESTS} -eq 1]]; then
+if [[ ${RUN_HTTP01_AUTO_TLS_TESTS} -eq 1 ]]; then
   subheader "Auto TLS test for per-ksvc certificate provision using HTTP01 challenge"
   setup_http01_auto_tls
   add_trap "delete_dns_record" SIGKILL SIGTERM SIGQUIT

--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -210,14 +210,14 @@ add_trap "cleanup_per_selfsigned_namespace_auto_tls" SIGKILL SIGTERM SIGQUIT
 go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
 cleanup_per_selfsigned_namespace_auto_tls
 
-# TODO(#10486): resume the HTTP01 E2E tests after figuring out the DNS setup failure.
-
-# subheader "Auto TLS test for per-ksvc certificate provision using HTTP01 challenge"
-# setup_http01_auto_tls
-# add_trap "delete_dns_record" SIGKILL SIGTERM SIGQUIT
-# go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
-# kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
-# delete_dns_record
+if [[ ${RUN_HTTP01_AUTO_TLS_TESTS} -eq 1]]; then
+  subheader "Auto TLS test for per-ksvc certificate provision using HTTP01 challenge"
+  setup_http01_auto_tls
+  add_trap "delete_dns_record" SIGKILL SIGTERM SIGQUIT
+  go_test_e2e -timeout=10m ./test/e2e/autotls/ || failed=1
+  kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/http01/
+  delete_dns_record
+fi
 
 (( failed )) && fail_test
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -28,6 +28,7 @@ KOURIER_VERSION=""
 AMBASSADOR_VERSION=""
 CONTOUR_VERSION=""
 CERTIFICATE_CLASS=""
+export RUN_HTTP01_AUTO_TLS_TESTS=0
 # Only build linux/amd64 bit images
 KO_FLAGS="--platform=linux/amd64"
 
@@ -79,6 +80,10 @@ function parse_flags() {
       readonly CERT_MANAGER_VERSION=$2
       readonly CERTIFICATE_CLASS="cert-manager.certificate.networking.knative.dev"
       return 2
+      ;;
+    --run-http01-auto-tls-tests)
+      readonly RUN_HTTP01_AUTO_TLS_TESTS=1
+      return 1
       ;;
     --mesh)
       readonly MESH=1


### PR DESCRIPTION

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Use LetsEncrypt prod endpoint for testing as we have obtained 15,000 cert/week quota for our testing domain which should be sufficient. By using prod endpoint, we can get more stable testing environment.
* Use a flag to control running HTTP01 tests or not so that I can gradually enable the HTTP01 tests.



