### PR TITLE
opt out of aggressive probing when the user has specified periodSeconds > 0

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -60,7 +60,8 @@ const (
 )
 
 var (
-	readinessProbeTimeout = flag.Duration("probe-period", -1, "run readiness probe with given timeout")
+	readinessProbeTimeout = flag.Duration("probe-timeout", -1, "run readiness probe with given timeout")
+	readinessProbePeriod  = flag.Duration("probe-period", -1, "run readiness probe with given period")
 
 	// This creates an abstract socket instead of an actual file.
 	unixSocketPath = "@/knative.dev/serving/queue.sock"
@@ -107,7 +108,7 @@ func main() {
 	flag.Parse()
 
 	// If this is set, we run as a standalone binary to probe the queue-proxy.
-	if *readinessProbeTimeout >= 0 {
+	if *readinessProbePeriod >= 0 {
 		// Use a unix socket rather than TCP to avoid going via entire TCP stack
 		// when we're actually in the same container.
 		transport := http.DefaultTransport.(*http.Transport).Clone()
@@ -115,7 +116,7 @@ func main() {
 			return net.Dial("unix", unixSocketPath)
 		}
 
-		os.Exit(standaloneProbeMain(*readinessProbeTimeout, transport))
+		os.Exit(standaloneProbeMain(*readinessProbePeriod, *readinessProbeTimeout, transport))
 	}
 
 	// Otherwise, we run as the queue-proxy service.

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -80,7 +80,10 @@ var (
 		ReadinessProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{
-					Command: []string{"/ko-app/queue", "-probe-period", "0"},
+					Command: []string{"/ko-app/queue",
+						"-probe-period", "0s",
+						"-probe-timeout", "0s",
+					},
 				},
 			},
 			PeriodSeconds:  10,

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -524,7 +524,7 @@ func TestProbeGenerationHTTPDefaults(t *testing.T) {
 		c.ReadinessProbe = &corev1.Probe{
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{
-					Command: []string{"/ko-app/queue", "-probe-period", "10s"},
+					Command: []string{"/ko-app/queue", "-probe-period", "1s", "-probe-timeout", "10s"},
 				},
 			},
 			PeriodSeconds:  1,
@@ -596,7 +596,7 @@ func TestProbeGenerationHTTP(t *testing.T) {
 		c.ReadinessProbe = &corev1.Probe{
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{
-					Command: []string{"/ko-app/queue", "-probe-period", "10s"},
+					Command: []string{"/ko-app/queue", "-probe-period", "2s", "-probe-timeout", "10s"},
 				}},
 			PeriodSeconds:  2,
 			TimeoutSeconds: 10,
@@ -654,7 +654,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 			c.ReadinessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					Exec: &corev1.ExecAction{
-						Command: []string{"/ko-app/queue", "-probe-period", "0"},
+						Command: []string{"/ko-app/queue", "-probe-period", "0s", "-probe-timeout", "0s"},
 					},
 				},
 				PeriodSeconds:  10,
@@ -692,7 +692,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 			c.ReadinessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					Exec: &corev1.ExecAction{
-						Command: []string{"/ko-app/queue", "-probe-period", "1s"},
+						Command: []string{"/ko-app/queue", "-probe-period", "1s", "-probe-timeout", "1s"},
 					},
 				},
 				PeriodSeconds:  1,
@@ -740,7 +740,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 			c.ReadinessProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					Exec: &corev1.ExecAction{
-						Command: []string{"/ko-app/queue", "-probe-period", "15s"},
+						Command: []string{"/ko-app/queue", "-probe-period", "2s", "-probe-timeout", "15s"},
 					},
 				},
 				PeriodSeconds:       2,


### PR DESCRIPTION
Fixes #10838

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Setting the readiness probing periodSeconds >1 will opt-out of aggressive probing

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Setting the readiness probing periodSeconds >1 will opt-out of aggressive probing. Prior the period was fixed at 100ms. 
```

/assign @julz 