### PR TITLE
Don't validate autoscaling annotations where they're not allowed

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/metric_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/metric_validation.go
@@ -26,7 +26,7 @@ import (
 
 // Validate validates the entire Metric.
 func (m *Metric) Validate(ctx context.Context) *apis.FieldError {
-	return serving.ValidateObjectMetadata(ctx, m.GetObjectMeta()).ViaField("metadata").
+	return serving.ValidateObjectMetadata(ctx, m.GetObjectMeta(), true).ViaField("metadata").
 		Also(m.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 

--- a/pkg/apis/autoscaling/v1alpha1/pa_validation.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_validation.go
@@ -26,7 +26,7 @@ import (
 
 // Validate implements apis.Validatable interface.
 func (pa *PodAutoscaler) Validate(ctx context.Context) *apis.FieldError {
-	return serving.ValidateObjectMetadata(ctx, pa.GetObjectMeta()).ViaField("metadata").
+	return serving.ValidateObjectMetadata(ctx, pa.GetObjectMeta(), true).ViaField("metadata").
 		Also(pa.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 

--- a/pkg/apis/serving/v1/configuration_validation.go
+++ b/pkg/apis/serving/v1/configuration_validation.go
@@ -31,9 +31,8 @@ func (c *Configuration) Validate(ctx context.Context) (errs *apis.FieldError) {
 	// have changed (i.e. due to config-defaults changes), we elide the metadata and
 	// spec validation.
 	if !apis.IsInStatusUpdate(ctx) {
-		errs = errs.Also(serving.ValidateObjectMetadata(ctx, c.GetObjectMeta()))
+		errs = errs.Also(serving.ValidateObjectMetadata(ctx, c.GetObjectMeta(), false))
 		errs = errs.Also(c.validateLabels().ViaField("labels"))
-		errs = errs.Also(serving.ValidateHasNoAutoscalingAnnotation(c.GetAnnotations()).ViaField("annotations"))
 		errs = errs.ViaField("metadata")
 
 		ctx = apis.WithinParent(ctx, c.ObjectMeta)

--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -32,7 +32,7 @@ import (
 
 // Validate ensures Revision is properly configured.
 func (r *Revision) Validate(ctx context.Context) *apis.FieldError {
-	errs := serving.ValidateObjectMetadata(ctx, r.GetObjectMeta()).Also(
+	errs := serving.ValidateObjectMetadata(ctx, r.GetObjectMeta(), true).Also(
 		r.ValidateLabels().ViaField("labels")).ViaField("metadata")
 	errs = errs.Also(r.Status.Validate(apis.WithinStatus(ctx)).ViaField("status"))
 

--- a/pkg/apis/serving/v1/route_validation.go
+++ b/pkg/apis/serving/v1/route_validation.go
@@ -28,7 +28,7 @@ import (
 
 // Validate makes sure that Route is properly configured.
 func (r *Route) Validate(ctx context.Context) *apis.FieldError {
-	errs := serving.ValidateObjectMetadata(ctx, r.GetObjectMeta()).Also(
+	errs := serving.ValidateObjectMetadata(ctx, r.GetObjectMeta(), false).Also(
 		r.validateLabels().ViaField("labels"))
 	errs = errs.Also(serving.ValidateRolloutDurationAnnotation(
 		r.GetAnnotations()).ViaField("annotations"))

--- a/pkg/apis/serving/v1/service_validation.go
+++ b/pkg/apis/serving/v1/service_validation.go
@@ -31,11 +31,9 @@ func (s *Service) Validate(ctx context.Context) (errs *apis.FieldError) {
 	// have changed (i.e. due to config-defaults changes), we elide the metadata and
 	// spec validation.
 	if !apis.IsInStatusUpdate(ctx) {
-		errs = errs.Also(serving.ValidateObjectMetadata(ctx, s.GetObjectMeta()))
+		errs = errs.Also(serving.ValidateObjectMetadata(ctx, s.GetObjectMeta(), false))
 		errs = errs.Also(s.validateLabels().ViaField("labels"))
 		errs = errs.Also(serving.ValidateRolloutDurationAnnotation(
-			s.GetAnnotations()).ViaField("annotations"))
-		errs = errs.Also(serving.ValidateHasNoAutoscalingAnnotation(
 			s.GetAnnotations()).ViaField("annotations"))
 		errs = errs.ViaField("metadata")
 


### PR DESCRIPTION
Fixes #10825.

Some resources, such as Service and Configuration, don't permit autoscaling annotations at all, and even validate that those annotations are not present. But, before this commit, we nevertheless validated autoscaling annotations on those objects. In most cases this is fine, because all the autoscaling annotations are optional by default so the validation passes, but the MaxScaleLimit can be set to deny '0' (unlimited) without changing the default MaxScale to be non-zero (whether we should allow that case is a different question that I'll raise separately :)). 

When this happens the errors are uber-confusing -- I spent ages spinning trying to figure out what was going on -- because the validated values, and corresponding errors, are 0 rather than the value actually passed in the annotation. In general I think we shouldn't have allowed a case where an autoscaling annotation can become essentially required, but it still makes sense to avoid validating annotations on objects that don't support them in the first place.

/assign @vagababov @dprotaso 