### PR TITLE
Thread the metric aggregation algorithm through collector.

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/metric_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/metric_types.go
@@ -65,8 +65,6 @@ type MetricSpec struct {
 	PanicWindow time.Duration `json:"panicWindow"`
 	// ScrapeTarget is the K8s service that publishes the metric endpoint.
 	ScrapeTarget string `json:"scrapeTarget"`
-	// AggregationAlgorithm is the metric averaging algorithm.
-	AggregationAlgorithm string `json:"algorithm"`
 }
 
 // MetricStatus reflects the status of metric collection for this specific entity.

--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -110,7 +110,7 @@ func NewWeightedFloat64Buckets(window, granularity time.Duration) *WeightedFloat
 	nb := math.Ceil(float64(window) / float64(granularity))
 	return &WeightedFloat64Buckets{
 		TimedFloat64Buckets: NewTimedFloat64Buckets(window, granularity),
-		smoothingCoeff:     computeDecayMultiplier(nb),
+		smoothingCoeff:      computeDecayMultiplier(nb),
 	}
 }
 

--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -25,15 +25,6 @@ import (
 )
 
 type (
-	// TimedBuckets is the generic interface for various implementations
-	// of timed buckets.
-	TimedBuckets interface {
-		WindowAverage(time.Time) float64
-		Record(time.Time, float64)
-		ResizeWindow(w time.Duration)
-		IsEmpty(time.Time) bool
-	}
-
 	// TimedFloat64Buckets keeps buckets that have been collected at a certain time.
 	TimedFloat64Buckets struct {
 		bucketsMutex sync.RWMutex

--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -75,9 +75,9 @@ func (t *TimedFloat64Buckets) String() string {
 	return spew.Sdump(t.buckets)
 }
 
-// computeDecayMultiplier computes the decay given number of buckets.
+// computeSmoothingCoeff computes the decay given number of buckets.
 // The function uses precision and min exponent value constants.
-func computeDecayMultiplier(nb float64) float64 {
+func computeSmoothingCoeff(nb float64) float64 {
 	return math.Max(
 		// Given number of buckets, infer the desired multiplier
 		// so that at least weightPrecision sum of buckets is met.
@@ -110,7 +110,7 @@ func NewWeightedFloat64Buckets(window, granularity time.Duration) *WeightedFloat
 	nb := math.Ceil(float64(window) / float64(granularity))
 	return &WeightedFloat64Buckets{
 		TimedFloat64Buckets: NewTimedFloat64Buckets(window, granularity),
-		smoothingCoeff:      computeDecayMultiplier(nb),
+		smoothingCoeff:      computeSmoothingCoeff(nb),
 	}
 }
 
@@ -306,7 +306,7 @@ func min(a, b int) int {
 // ResizeWindow implements window resizing for the weighted averaging buckets object.
 func (t *WeightedFloat64Buckets) ResizeWindow(w time.Duration) {
 	t.TimedFloat64Buckets.ResizeWindow(w)
-	t.smoothingCoeff = computeDecayMultiplier(math.Ceil(float64(w) / float64(t.granularity)))
+	t.smoothingCoeff = computeSmoothingCoeff(math.Ceil(float64(w) / float64(t.granularity)))
 }
 
 // ResizeWindow resizes the window. This is an O(N) operation,

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -204,19 +204,19 @@ func TestTimedFloat64BucketsWeightedAverage(t *testing.T) {
 	buckets := NewWeightedFloat64Buckets(5*time.Second, granularity)
 
 	buckets.Record(now, 2)
-	want := 2 * buckets.decayMultiplier // 2*dm = dm.
+	want := 2 * buckets.smoothingCoeff // 2*dm = dm.
 	if got, want := buckets.WindowAverage(now), want; got != want {
 		t.Errorf("WeightedAverage = %v, want: %v", got, want)
 	}
 
 	// Let's read one second in future, but no writes.
-	want *= (1 - buckets.decayMultiplier)
+	want *= (1 - buckets.smoothingCoeff)
 	if got, want := buckets.WindowAverage(now.Add(time.Second)), want; got != want {
 		t.Errorf("WeightedAverage = %v, want: %v", got, want)
 	}
 	// Record some more data.
 	buckets.Record(now.Add(time.Second), 2)
-	want += 2 * buckets.decayMultiplier
+	want += 2 * buckets.smoothingCoeff
 	if got, want := buckets.WindowAverage(now.Add(time.Second)), want; got != want {
 		t.Errorf("WeightedAverage = %v, want: %v", got, want)
 	}
@@ -226,7 +226,7 @@ func TestTimedFloat64BucketsWeightedAverage(t *testing.T) {
 		buckets.Record(now.Add(time.Duration(2+i)*time.Second), float64(i+2))
 	}
 	// Manually compute wanted average.
-	m := buckets.decayMultiplier
+	m := buckets.smoothingCoeff
 	want = 6*m +
 		5*m*(1-m) +
 		4*m*(1-m)*(1-m) +
@@ -379,7 +379,7 @@ func TestWeightedFloat64BucketsResizeWindow(t *testing.T) {
 	startTime := time.Now()
 	buckets := NewWeightedFloat64Buckets(5*time.Second, granularity)
 
-	if got, want := buckets.decayMultiplier, computeDecayMultiplier(5); math.Abs(got-want) > weightPrecision {
+	if got, want := buckets.smoothingCoeff, computeDecayMultiplier(5); math.Abs(got-want) > weightPrecision {
 		t.Errorf("DecayMultipler = %v, want: %v", got, want)
 	}
 
@@ -415,7 +415,7 @@ func TestWeightedFloat64BucketsResizeWindow(t *testing.T) {
 	}
 
 	// And this is the main logic that was added in this type.
-	if got, want := buckets.decayMultiplier, computeDecayMultiplier(10); math.Abs(got-want) > weightPrecision {
+	if got, want := buckets.smoothingCoeff, computeDecayMultiplier(10); math.Abs(got-want) > weightPrecision {
 		t.Errorf("DecayMultipler = %v, want: %v", got, want)
 	}
 }

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -48,7 +48,7 @@ func TestComputeDecayMultiplier(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprint("nb=", tc.numBuckets), func(t *testing.T) {
-			if got, want := computeDecayMultiplier(tc.numBuckets), tc.want; math.Abs(got-want) > weightPrecision {
+			if got, want := computeSmoothingCoeff(tc.numBuckets), tc.want; math.Abs(got-want) > weightPrecision {
 				t.Errorf("Decay multiplier = %v, want: %v", got, want)
 			}
 		})
@@ -379,7 +379,7 @@ func TestWeightedFloat64BucketsResizeWindow(t *testing.T) {
 	startTime := time.Now()
 	buckets := NewWeightedFloat64Buckets(5*time.Second, granularity)
 
-	if got, want := buckets.smoothingCoeff, computeDecayMultiplier(5); math.Abs(got-want) > weightPrecision {
+	if got, want := buckets.smoothingCoeff, computeSmoothingCoeff(5); math.Abs(got-want) > weightPrecision {
 		t.Errorf("DecayMultipler = %v, want: %v", got, want)
 	}
 
@@ -415,7 +415,7 @@ func TestWeightedFloat64BucketsResizeWindow(t *testing.T) {
 	}
 
 	// And this is the main logic that was added in this type.
-	if got, want := buckets.smoothingCoeff, computeDecayMultiplier(10); math.Abs(got-want) > weightPrecision {
+	if got, want := buckets.smoothingCoeff, computeSmoothingCoeff(10); math.Abs(got-want) > weightPrecision {
 		t.Errorf("DecayMultipler = %v, want: %v", got, want)
 	}
 }

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -201,23 +201,23 @@ func TestTimedFloat64BucketsManyRepsWithNonMonotonicalOrder(t *testing.T) {
 
 func TestTimedFloat64BucketsWeightedAverage(t *testing.T) {
 	now := time.Now()
-	buckets := NewTimedFloat64Buckets(5*time.Second, granularity)
+	buckets := NewWeightedFloat64Buckets(5*time.Second, granularity)
 
 	buckets.Record(now, 2)
 	want := 2 * buckets.decayMultiplier // 2*dm = dm.
-	if got, want := buckets.WeightedAverage(now), want; got != want {
+	if got, want := buckets.WindowAverage(now), want; got != want {
 		t.Errorf("WeightedAverage = %v, want: %v", got, want)
 	}
 
 	// Let's read one second in future, but no writes.
 	want *= (1 - buckets.decayMultiplier)
-	if got, want := buckets.WeightedAverage(now.Add(time.Second)), want; got != want {
+	if got, want := buckets.WindowAverage(now.Add(time.Second)), want; got != want {
 		t.Errorf("WeightedAverage = %v, want: %v", got, want)
 	}
 	// Record some more data.
 	buckets.Record(now.Add(time.Second), 2)
 	want += 2 * buckets.decayMultiplier
-	if got, want := buckets.WeightedAverage(now.Add(time.Second)), want; got != want {
+	if got, want := buckets.WindowAverage(now.Add(time.Second)), want; got != want {
 		t.Errorf("WeightedAverage = %v, want: %v", got, want)
 	}
 
@@ -232,12 +232,12 @@ func TestTimedFloat64BucketsWeightedAverage(t *testing.T) {
 		4*m*(1-m)*(1-m) +
 		3*m*(1-m)*(1-m)*(1-m) +
 		2*m*(1-m)*(1-m)*(1-m)*(1-m)
-	if got, want := buckets.WeightedAverage(now.Add(6*time.Second)), want; got != want {
+	if got, want := buckets.WindowAverage(now.Add(6*time.Second)), want; got != want {
 		t.Errorf("WeightedAverage = %v, want: %v", got, want)
 	}
 
 	// Read from an empty window.
-	if got, want := buckets.WeightedAverage(now.Add(16*time.Second)), 0.; got != want {
+	if got, want := buckets.WindowAverage(now.Add(16*time.Second)), 0.; got != want {
 		t.Errorf("WeightedAverage = %v, want: %v", got, want)
 	}
 }
@@ -375,13 +375,54 @@ func TestTimedFloat64BucketsHoles(t *testing.T) {
 	}
 }
 
-func TestTimedFloat64BucketsResizeWindow(t *testing.T) {
+func TestWeightedFloat64BucketsResizeWindow(t *testing.T) {
 	startTime := time.Now()
-	buckets := NewTimedFloat64Buckets(5*time.Second, granularity)
+	buckets := NewWeightedFloat64Buckets(5*time.Second, granularity)
 
 	if got, want := buckets.decayMultiplier, computeDecayMultiplier(5); math.Abs(got-want) > weightPrecision {
 		t.Errorf("DecayMultipler = %v, want: %v", got, want)
 	}
+
+	// Fill the whole bucketing list with rollover.
+	buckets.Record(startTime, 1)
+	buckets.Record(startTime.Add(1*time.Second), 2)
+	buckets.Record(startTime.Add(2*time.Second), 3)
+	buckets.Record(startTime.Add(3*time.Second), 4)
+	buckets.Record(startTime.Add(4*time.Second), 5)
+	buckets.Record(startTime.Add(5*time.Second), 6)
+	now := startTime.Add(5 * time.Second)
+
+	sum := 0.
+	buckets.forEachBucket(now, func(t time.Time, b float64) {
+		sum += b
+	})
+	const wantInitial = 2. + 3 + 4 + 5 + 6
+	if got, want := sum, wantInitial; got != want {
+		t.Fatalf("Initial data set Sum = %v, want: %v", got, want)
+	}
+	if got, want := roundToNDigits(3, buckets.WindowAverage(now)), 5.811; /*computed a mano*/ got != want {
+		t.Fatalf("Initial data set Sum = %v, want: %v", got, want)
+	}
+
+	// Increase window. Most of the heavy lifting is delegated to regular buckets
+	// so just do a cursory check.
+	buckets.ResizeWindow(10 * time.Second)
+	if got, want := len(buckets.buckets), 10; got != want {
+		t.Fatalf("Resized bucket count = %d, want: %d", got, want)
+	}
+	if got, want := buckets.window, 10*time.Second; got != want {
+		t.Fatalf("Resized bucket windows = %v, want: %v", got, want)
+	}
+
+	// And this is the main logic that was added in this type.
+	if got, want := buckets.decayMultiplier, computeDecayMultiplier(10); math.Abs(got-want) > weightPrecision {
+		t.Errorf("DecayMultipler = %v, want: %v", got, want)
+	}
+}
+
+func TestTimedFloat64BucketsResizeWindow(t *testing.T) {
+	startTime := time.Now()
+	buckets := NewTimedFloat64Buckets(5*time.Second, granularity)
 
 	// Fill the whole bucketing list with rollover.
 	buckets.Record(startTime, 1)
@@ -411,9 +452,6 @@ func TestTimedFloat64BucketsResizeWindow(t *testing.T) {
 	}
 	if got, want := buckets.window, 10*time.Second; got != want {
 		t.Fatalf("Resized bucket windows = %v, want: %v", got, want)
-	}
-	if got, want := buckets.decayMultiplier, computeDecayMultiplier(10); math.Abs(got-want) > weightPrecision {
-		t.Errorf("DecayMultipler = %v, want: %v", got, want)
 	}
 
 	// Verify values were properly copied.


### PR DESCRIPTION
This required a few changes:

- add a new type in buckets. That simplified things. Should've done when
  @julz asked to. That frugality didn't pay off as I hoped
- Remove the metric field, since metric inherts the annotations from PA,
  and thus will inherit the algorithm type.
- in the end, just select the constructor and that's about it.
  Everything else should magically work.

/assign @julz 