### PR TITLE
rename queueproxy flag probe-period to probe-timeout

### DIFF
--- a/cmd/queue/execprobe.go
+++ b/cmd/queue/execprobe.go
@@ -45,7 +45,7 @@ const (
 )
 
 // As well as running as a long-running proxy server, the Queue Proxy can be
-// run as an exec probe if the `--probe-period` flag is passed.
+// run as an exec probe if the `--probe-timeout` flag is passed.
 //
 // In this mode, the exec probe (repeatedly) sends an HTTP request to the Queue
 // Proxy server with a Probe header. The handler for this probe request

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -60,7 +60,7 @@ const (
 )
 
 var (
-	startupProbeTimeout = flag.Duration("probe-period", -1, "run startup probe with given timeout")
+	startupProbeTimeout = flag.Duration("probe-timeout", -1, "run startup probe with given timeout")
 
 	// This creates an abstract socket instead of an actual file.
 	unixSocketPath = "@/knative.dev/serving/queue.sock"

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -80,7 +80,7 @@ var (
 		StartupProbe: &corev1.Probe{
 			Handler: corev1.Handler{
 				Exec: &corev1.ExecAction{
-					Command: []string{"/ko-app/queue", "-probe-period", "1h34m38s"},
+					Command: []string{"/ko-app/queue", "-probe-timeout", "1h34m38s"},
 				},
 			},
 			PeriodSeconds:    1,

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -185,7 +185,7 @@ func makeStartupExecProbe(in *corev1.Probe, progressDeadline time.Duration) *cor
 				// and restarted if it fails. We use the ProgressDeadline as the timeout
 				// to match the time we'll wait before killing the revision if it
 				// fails to go ready on initial deployment.
-				Command: []string{"/ko-app/queue", "-probe-period", progressDeadline.String()},
+				Command: []string{"/ko-app/queue", "-probe-timeout", progressDeadline.String()},
 			},
 		},
 		// The exec probe itself retries aggressively so there's no point retrying via Kubernetes too.

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -713,7 +713,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 			c.StartupProbe = &corev1.Probe{
 				Handler: corev1.Handler{
 					Exec: &corev1.ExecAction{
-						Command: []string{"/ko-app/queue", "-probe-period", "1h34m38s"},
+						Command: []string{"/ko-app/queue", "-probe-timeout", "1h34m38s"},
 					},
 				},
 				// StartupProbe overrides the user's parameters because the


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
