### PR TITLE
Bump autoscaler resources to be equal to controller resources

### DIFF
--- a/config/core/deployments/autoscaler.yaml
+++ b/config/core/deployments/autoscaler.yaml
@@ -52,11 +52,11 @@ spec:
 
         resources:
           requests:
-            cpu: 30m
-            memory: 40Mi
+            cpu: 100m
+            memory: 100Mi
           limits:
-            cpu: 300m
-            memory: 400Mi
+            cpu: 1000m
+            memory: 1000Mi
 
         env:
         - name: POD_NAME


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

The autoscaler is a controller of a few resources after all and it's doing a lot more work asynchronously too. We've (Red Hat Openshift Serverless) been seeing quite a lot of CPU throttling in the autoscaler and the limits and requests seem indeed to be fairly low given the work the autoscaler is doing. This aligns the resources with the controller but we surely need a better way to set these values and/or communicate what the expected amount of handled resources can be.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Bumped the resource request and limits of the autoscaler to 100m/100Mi, 1000m/1000Mi respectively. 
```

/assign @julz @vagababov 
