### PR TITLE
Add DomainMapping namespace label annotation

### DIFF
--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -93,6 +93,11 @@ const (
 	// which DomainMapping triggered their creation.
 	DomainMappingLabelKey = GroupName + "/domainMapping"
 
+	// DomainMappingNamespaceLabelKey is the label key attached to Ingress
+	// resources created by a DomainMapping to indicate which namespace the
+	// DomainMapping was created in.
+	DomainMappingNamespaceLabelKey = GroupName + "/domainMappingNamespace"
+
 	// ConfigurationGenerationLabelKey is the label key attached to a Revision indicating the
 	// metadata generation of the Configuration that created this revision
 	ConfigurationGenerationLabelKey = GroupName + "/configurationGeneration"

--- a/pkg/reconciler/domainmapping/resources/ingress.go
+++ b/pkg/reconciler/domainmapping/resources/ingress.go
@@ -46,7 +46,8 @@ func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, hostName
 				return key == corev1.LastAppliedConfigAnnotation
 			}),
 			Labels: kmeta.UnionMaps(dm.Labels, map[string]string{
-				serving.DomainMappingLabelKey: dm.Name,
+				serving.DomainMappingLabelKey:          dm.Name,
+				serving.DomainMappingNamespaceLabelKey: dm.Namespace,
 			}),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(dm)},
 		},

--- a/pkg/reconciler/domainmapping/resources/ingress_test.go
+++ b/pkg/reconciler/domainmapping/resources/ingress_test.go
@@ -221,6 +221,7 @@ func TestMakeIngress(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.want.Labels = kmeta.UnionMaps(tc.dm.Labels, map[string]string{
 				serving.DomainMappingLabelKey: tc.dm.Name,
+				serving.DomainMappingNamespaceLabelKey: tc.dm.Namespace,
 			})
 			tc.want.OwnerReferences = []metav1.OwnerReference{*kmeta.NewControllerRef(&tc.dm)}
 			got := *MakeIngress(&tc.dm,

--- a/pkg/reconciler/domainmapping/resources/ingress_test.go
+++ b/pkg/reconciler/domainmapping/resources/ingress_test.go
@@ -220,7 +220,7 @@ func TestMakeIngress(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.want.Labels = kmeta.UnionMaps(tc.dm.Labels, map[string]string{
-				serving.DomainMappingLabelKey: tc.dm.Name,
+				serving.DomainMappingLabelKey:          tc.dm.Name,
 				serving.DomainMappingNamespaceLabelKey: tc.dm.Namespace,
 			})
 			tc.want.OwnerReferences = []metav1.OwnerReference{*kmeta.NewControllerRef(&tc.dm)}


### PR DESCRIPTION
I don't honestly know how useful this is since the DM/route namespace and the Ingress
NS are always the same, but seems nice to add this to be consistent with Route
which [adds a similar `RouteNamespaceLabelKey` label when it applies `RouteLabelKey`](https://github.com/knative/serving/blob/master/pkg/reconciler/route/resources/ingress.go#L94), since we added an equivalent `DomainMappingLabelKey` in https://github.com/knative/serving/pull/10370.

/assign @markusthoemmes @nak3 