### PR TITLE
Make sure to reinitialise loop var in parallel tests

### DIFF
--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -101,6 +101,7 @@ func TestRevisionTimeout(t *testing.T) {
 	}}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -262,6 +262,7 @@ func TestSvcToSvcViaActivator(t *testing.T) {
 	clients := Setup(t)
 
 	for _, tc := range testInjection {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -310,6 +311,7 @@ func TestCallToPublicService(t *testing.T) {
 	}
 
 	for _, tc := range gatewayTestCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/test/e2e/tagheader/tag_header_based_routing_test.go
+++ b/test/e2e/tagheader/tag_header_based_routing_test.go
@@ -111,6 +111,7 @@ func TestTagHeaderBasedRouting(t *testing.T) {
 	}}
 
 	for _, tt := range testCases {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
`t.Parallel()` causes the `t.Run()` to execute in parallel, which means it's not safe to access the loop variable in table tests without reassigning if t.Parallel is used.

/assign @vagababov @markusthoemmes 