### PR TITLE
Lint use of type-safe atomics

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,7 +33,6 @@ linters:
 
 linters-settings:
   depguard:
-    list-type: blacklist
     include-go-root: true
     packages:
       - sync/atomic

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,6 +19,7 @@ run:
 linters:
   enable:
     - asciicheck
+    - depguard
     - errorlint
     - golint
     - gosec
@@ -29,6 +30,15 @@ linters:
     - unparam
   disable:
     - errcheck
+
+linters-settings:
+  depguard:
+    list-type: blacklist
+    include-go-root: true
+    packages:
+      - sync/atomic
+    packages-with-error-message:
+      - sync/atomic: "please use type-safe atomics from go.uber.org/atomic"
 
 issues:
   include:
@@ -62,3 +72,8 @@ issues:
     - text: "ST1000: at least one file in a package should have a package comment"
       linters:
         - stylecheck
+
+    # Uses atomic.StorePointer in request_log, for now.
+    - path: pkg/http
+      linters:
+        - depguard

--- a/pkg/queue/protobuf_stats_reporter.go
+++ b/pkg/queue/protobuf_stats_reporter.go
@@ -18,8 +18,9 @@ package queue
 
 import (
 	"net/http"
-	"sync/atomic"
 	"time"
+
+	"go.uber.org/atomic"
 
 	"github.com/gogo/protobuf/proto"
 

--- a/test/prober.go
+++ b/test/prober.go
@@ -24,8 +24,9 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
-	"sync/atomic"
 	"testing"
+
+	"go.uber.org/atomic"
 
 	"golang.org/x/sync/errgroup"
 	pkgTest "knative.dev/pkg/test"
@@ -52,8 +53,8 @@ type prober struct {
 	url           *url.URL
 	minimumProbes int64
 
-	requests int64
-	failures int64
+	requests atomic.Int64
+	failures atomic.Int64
 
 	// This channel is simply closed when minimumProbes has been satisfied.
 	minDoneCh chan struct{}
@@ -68,7 +69,7 @@ var _ Prober = (*prober)(nil)
 
 // SLI implements Prober
 func (p *prober) SLI() (int64, int64) {
-	return atomic.LoadInt64(&p.requests), atomic.LoadInt64(&p.failures)
+	return p.requests.Load(), p.failures.Load()
 }
 
 // Stop implements Prober
@@ -157,16 +158,16 @@ func (m *manager) Spawn(url *url.URL) Prober {
 				return nil
 			default:
 				res, err := client.Do(req)
-				if atomic.AddInt64(&p.requests, 1) == p.minimumProbes {
+				if p.requests.Inc() == p.minimumProbes {
 					close(p.minDoneCh)
 				}
 				if err != nil {
 					p.logf("%q error: %v", p.url, err)
-					atomic.AddInt64(&p.failures, 1)
+					p.failures.Inc()
 				} else if res.StatusCode != http.StatusOK {
 					p.logf("%q status = %d, want: %d", p.url, res.StatusCode, http.StatusOK)
 					p.logf("response: %s", res)
-					atomic.AddInt64(&p.failures, 1)
+					p.failures.Inc()
 				}
 			}
 		}


### PR DESCRIPTION
Adds a linter to ensure we won't regress on using type-safe atomics in preference to raw sync/atomic again.

For now I just disabled the linter in `pkg/http` since [we use atomic.StorePointer there](https://github.com/knative/serving/blob/master/pkg/http/request_log.go#L121) which doesn't have a type-safe equivalent. Will see if it changes the benchmarks at all to replace that with an atomic.Value in a follow-on.

/hold for https://github.com/knative/serving/pull/10881 to land first

/assign @markusthoemmes @vagababov 