### PR TITLE
e2e - wait for deployments to be available

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -204,10 +204,10 @@ jobs:
       run: |
         ko apply --platform=all -PRf config/domain-mapping
 
-    - name: Wait for Webhook to be up
+    - name: Wait for components to be up
       run: |
         # We need the webhook to be up
-        kubectl wait pod --for=condition=Ready -n knative-serving  -l app=webhook
+        ktl wait --for=condition=Available deployment -n knative-serving --all
 
     - name: Install kingress provider (Contour)
       if: matrix.kingress == 'contour'

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -207,7 +207,7 @@ jobs:
     - name: Wait for components to be up
       run: |
         # We need the webhook to be up
-        ktl wait --for=condition=Available deployment -n knative-serving --all
+        kubectl wait --for=condition=Available deployment -n knative-serving --all
 
     - name: Install kingress provider (Contour)
       if: matrix.kingress == 'contour'


### PR DESCRIPTION
# Proposed Changes

* I was noticing the waiting for Pods was failing with 'resource not found' I'm guessing the resource hasn't been created yet (kind being slow/under-provisioned) so we should actually wait for the deployments we created to be 'available'

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
