### PR TITLE
Add lint for aliasing autoscaling import correctly

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,7 @@ linters:
     - errorlint
     - golint
     - gosec
+    - importas
     - prealloc
     - stylecheck
     - tparallel
@@ -38,6 +39,8 @@ linters-settings:
       - sync/atomic
     packages-with-error-message:
       - sync/atomic: "please use type-safe atomics from go.uber.org/atomic"
+  importas:
+    autoscalingv1alpha1: knative.dev/serving/pkg/apis/autoscaling/v1alpha1
 
 issues:
   include:

--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"knative.dev/pkg/apis"
-	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
 )
@@ -168,9 +168,9 @@ func (rs *RevisionStatus) PropagateDeploymentStatus(original *appsv1.DeploymentS
 }
 
 // PropagateAutoscalerStatus propagates autoscaler's status to the revision's status.
-func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *av1alpha1.PodAutoscalerStatus) {
+func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *autoscalingv1alpha1.PodAutoscalerStatus) {
 	// Reflect the PA status in our own.
-	cond := ps.GetCondition(av1alpha1.PodAutoscalerConditionReady)
+	cond := ps.GetCondition(autoscalingv1alpha1.PodAutoscalerConditionReady)
 	if cond == nil {
 		rs.MarkActiveUnknown("Deploying", "")
 		return

--- a/pkg/apis/serving/v1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1/revision_lifecycle_test.go
@@ -31,7 +31,7 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	apistest "knative.dev/pkg/apis/testing"
 	"knative.dev/pkg/ptr"
-	av1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/config"
 )
 
@@ -529,19 +529,19 @@ func TestPropagateAutoscalerStatus(t *testing.T) {
 	apistest.CheckConditionOngoing(r, RevisionConditionReady, t)
 
 	// PodAutoscaler has no active condition, so we are just coming up.
-	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
+	r.PropagateAutoscalerStatus(&autoscalingv1alpha1.PodAutoscalerStatus{
 		Status: duckv1.Status{},
 	})
 	apistest.CheckConditionOngoing(r, RevisionConditionActive, t)
 
 	// PodAutoscaler becomes ready, making us active.
-	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
+	r.PropagateAutoscalerStatus(&autoscalingv1alpha1.PodAutoscalerStatus{
 		Status: duckv1.Status{
 			Conditions: duckv1.Conditions{{
-				Type:   av1alpha1.PodAutoscalerConditionReady,
+				Type:   autoscalingv1alpha1.PodAutoscalerConditionReady,
 				Status: corev1.ConditionTrue,
 			}, {
-				Type:   av1alpha1.PodAutoscalerConditionScaleTargetInitialized,
+				Type:   autoscalingv1alpha1.PodAutoscalerConditionScaleTargetInitialized,
 				Status: corev1.ConditionTrue,
 			}},
 		},
@@ -550,13 +550,13 @@ func TestPropagateAutoscalerStatus(t *testing.T) {
 	apistest.CheckConditionSucceeded(r, RevisionConditionReady, t)
 
 	// PodAutoscaler flipping back to Unknown causes Active become ongoing immediately.
-	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
+	r.PropagateAutoscalerStatus(&autoscalingv1alpha1.PodAutoscalerStatus{
 		Status: duckv1.Status{
 			Conditions: duckv1.Conditions{{
-				Type:   av1alpha1.PodAutoscalerConditionReady,
+				Type:   autoscalingv1alpha1.PodAutoscalerConditionReady,
 				Status: corev1.ConditionUnknown,
 			}, {
-				Type:   av1alpha1.PodAutoscalerConditionScaleTargetInitialized,
+				Type:   autoscalingv1alpha1.PodAutoscalerConditionScaleTargetInitialized,
 				Status: corev1.ConditionTrue,
 			}},
 		},
@@ -565,13 +565,13 @@ func TestPropagateAutoscalerStatus(t *testing.T) {
 	apistest.CheckConditionSucceeded(r, RevisionConditionReady, t)
 
 	// PodAutoscaler becoming unready makes Active false, but doesn't affect readiness.
-	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
+	r.PropagateAutoscalerStatus(&autoscalingv1alpha1.PodAutoscalerStatus{
 		Status: duckv1.Status{
 			Conditions: duckv1.Conditions{{
-				Type:   av1alpha1.PodAutoscalerConditionReady,
+				Type:   autoscalingv1alpha1.PodAutoscalerConditionReady,
 				Status: corev1.ConditionFalse,
 			}, {
-				Type:   av1alpha1.PodAutoscalerConditionScaleTargetInitialized,
+				Type:   autoscalingv1alpha1.PodAutoscalerConditionScaleTargetInitialized,
 				Status: corev1.ConditionTrue,
 			}},
 		},
@@ -592,13 +592,13 @@ func TestPAResAvailableNoOverride(t *testing.T) {
 	r.MarkResourcesAvailableFalse("somehow", "somewhere")
 
 	// PodAutoscaler achieved initial scale.
-	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
+	r.PropagateAutoscalerStatus(&autoscalingv1alpha1.PodAutoscalerStatus{
 		Status: duckv1.Status{
 			Conditions: duckv1.Conditions{{
-				Type:   av1alpha1.PodAutoscalerConditionReady,
+				Type:   autoscalingv1alpha1.PodAutoscalerConditionReady,
 				Status: corev1.ConditionUnknown,
 			}, {
-				Type:   av1alpha1.PodAutoscalerConditionScaleTargetInitialized,
+				Type:   autoscalingv1alpha1.PodAutoscalerConditionScaleTargetInitialized,
 				Status: corev1.ConditionTrue,
 			}},
 		},
@@ -617,14 +617,14 @@ func TestPropagateAutoscalerStatusNoProgress(t *testing.T) {
 	apistest.CheckConditionOngoing(r, RevisionConditionReady, t)
 
 	// PodAutoscaler is not ready and initial scale was never attained.
-	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
+	r.PropagateAutoscalerStatus(&autoscalingv1alpha1.PodAutoscalerStatus{
 		ServiceName: "testRevision",
 		Status: duckv1.Status{
 			Conditions: duckv1.Conditions{{
-				Type:   av1alpha1.PodAutoscalerConditionReady,
+				Type:   autoscalingv1alpha1.PodAutoscalerConditionReady,
 				Status: corev1.ConditionFalse,
 			}, {
-				Type:   av1alpha1.PodAutoscalerConditionScaleTargetInitialized,
+				Type:   autoscalingv1alpha1.PodAutoscalerConditionScaleTargetInitialized,
 				Status: corev1.ConditionUnknown,
 			}},
 		},
@@ -640,13 +640,13 @@ func TestPropagateAutoscalerStatusNoProgress(t *testing.T) {
 	r.MarkResourcesAvailableFalse("another-one", "bit-the-dust")
 
 	// And apply the status.
-	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
+	r.PropagateAutoscalerStatus(&autoscalingv1alpha1.PodAutoscalerStatus{
 		Status: duckv1.Status{
 			Conditions: duckv1.Conditions{{
-				Type:   av1alpha1.PodAutoscalerConditionReady,
+				Type:   autoscalingv1alpha1.PodAutoscalerConditionReady,
 				Status: corev1.ConditionFalse,
 			}, {
-				Type:   av1alpha1.PodAutoscalerConditionScaleTargetInitialized,
+				Type:   autoscalingv1alpha1.PodAutoscalerConditionScaleTargetInitialized,
 				Status: corev1.ConditionUnknown,
 			}},
 		},
@@ -664,19 +664,19 @@ func TestPropagateAutoscalerStatusRace(t *testing.T) {
 	apistest.CheckConditionOngoing(r, RevisionConditionReady, t)
 
 	// PodAutoscaler has no active condition, so we are just coming up.
-	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
+	r.PropagateAutoscalerStatus(&autoscalingv1alpha1.PodAutoscalerStatus{
 		Status: duckv1.Status{},
 	})
 	apistest.CheckConditionOngoing(r, RevisionConditionActive, t)
 
 	// The PodAutoscaler might have been ready but it's scaled down already.
-	r.PropagateAutoscalerStatus(&av1alpha1.PodAutoscalerStatus{
+	r.PropagateAutoscalerStatus(&autoscalingv1alpha1.PodAutoscalerStatus{
 		Status: duckv1.Status{
 			Conditions: duckv1.Conditions{{
-				Type:   av1alpha1.PodAutoscalerConditionReady,
+				Type:   autoscalingv1alpha1.PodAutoscalerConditionReady,
 				Status: corev1.ConditionFalse,
 			}, {
-				Type:   av1alpha1.PodAutoscalerConditionScaleTargetInitialized,
+				Type:   autoscalingv1alpha1.PodAutoscalerConditionScaleTargetInitialized,
 				Status: corev1.ConditionTrue,
 			}},
 		},


### PR DESCRIPTION
Someone [very kindly did the work to add](https://github.com/golangci/golangci-lint/pull/1783) the [linter I hacked up for funsies](https://github.com/julz/importas) when [I fixed these before](https://github.com/knative/serving/pull/10666) to golanglint-ci, so we might as well use it!

Also, fix up a package that I apparently forgot to `git add` when I fixed these before, and never spotted because we didn't lint it :).

/hold I think I'll need to bump the golanglint-ci version in knative/.github before this will work

/assign @markusthoemmes 