### PR TITLE
Bump timeout to (hopefully) avoid flake

### DIFF
--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -54,7 +54,7 @@ const (
 	testRevision  = "test-revision"
 
 	probeFreq     = 50 * time.Millisecond
-	updateTimeout = 8 * probeFreq
+	updateTimeout = 16 * probeFreq
 )
 
 // revisionCC1 - creates a revision with concurrency == 1.


### PR DESCRIPTION
Not totally sure that this is what happened in #10890, but it's easy to bump this and see if the problem goes away before looking at anything more difficult.

We're now running these tests in parallel and `probeFreq` is relatively small (50ms), so it's possible under parallel load on a CI box we take longer than (8*50ms=)400ms to see an update. Looks like we [did this before](https://github.com/knative/serving/pull/8239) and afaict that did fix things last time, and now we [added more parallel load](#10880) so 🤷 worth a shot before worrying :).

Fixes #10890.

/assign @markusthoemmes @vagababov 