### PR TITLE
[WIP] Wait for cache sync quickie

### DIFF
--- a/pkg/autoscaler/metrics/stats_scraper_test.go
+++ b/pkg/autoscaler/metrics/stats_scraper_test.go
@@ -134,7 +134,7 @@ func TestPodDirectScrapeSuccess(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatal("StartInformers() =", err)
+		t.Fatal("RunInformers() =", err)
 	}
 	t.Cleanup(func() {
 		cancel()
@@ -167,7 +167,7 @@ func TestPodDirectScrapeSomeFailButSuccess(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatal("StartInformers() =", err)
+		t.Fatal("RunInformers() =", err)
 	}
 	t.Cleanup(func() {
 		cancel()
@@ -207,7 +207,7 @@ func TestPodDirectScrapeNoneSucceed(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatal("StartInformers() =", err)
+		t.Fatal("RunInformers() =", err)
 	}
 	t.Cleanup(func() {
 		cancel()
@@ -237,7 +237,7 @@ func TestPodDirectScrapePodsExhausted(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatal("StartInformers() =", err)
+		t.Fatal("RunInformers() =", err)
 	}
 	t.Cleanup(func() {
 		cancel()
@@ -262,7 +262,7 @@ func TestScrapeReportStatWhenAllCallsSucceed(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatal("StartInformers() =", err)
+		t.Fatal("RunInformers() =", err)
 	}
 	t.Cleanup(func() {
 		cancel()
@@ -299,7 +299,7 @@ func TestScrapeAllPodsYoungPods(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatal("StartInformers() =", err)
+		t.Fatal("RunInformers() =", err)
 	}
 	t.Cleanup(func() {
 		cancel()
@@ -331,7 +331,7 @@ func TestScrapeAllPodsOldPods(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatal("StartInformers() =", err)
+		t.Fatal("RunInformers() =", err)
 	}
 	t.Cleanup(func() {
 		cancel()
@@ -365,7 +365,7 @@ func TestScrapeSomePodsOldPods(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatal("StartInformers() =", err)
+		t.Fatal("RunInformers() =", err)
 	}
 	t.Cleanup(func() {
 		cancel()
@@ -397,7 +397,7 @@ func TestScrapeReportErrorCannotFindEnoughPods(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatal("StartInformers() =", err)
+		t.Fatal("RunInformers() =", err)
 	}
 	t.Cleanup(func() {
 		cancel()
@@ -421,7 +421,7 @@ func TestScrapeReportErrorIfAnyFails(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatal("StartInformers() =", err)
+		t.Fatal("RunInformers() =", err)
 	}
 	t.Cleanup(func() {
 		cancel()
@@ -460,7 +460,7 @@ func TestMixedPodShuffle(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatal("StartInformers() =", err)
+		t.Fatal("RunInformers() =", err)
 	}
 	t.Cleanup(func() {
 		cancel()
@@ -506,7 +506,7 @@ func TestOldPodShuffle(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatal("StartInformers() =", err)
+		t.Fatal("RunInformers() =", err)
 	}
 	t.Cleanup(func() {
 		cancel()
@@ -566,7 +566,7 @@ func TestOldPodsFallback(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatal("StartInformers() =", err)
+		t.Fatal("RunInformers() =", err)
 	}
 	t.Cleanup(func() {
 		cancel()

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1299,7 +1299,7 @@ func TestReconcileDeciderCreatesAndDeletes(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatal("StartInformers() =", err)
+		t.Fatal("RunInformers() =", err)
 	}
 
 	var eg errgroup.Group

--- a/pkg/reconciler/metric/metric_test.go
+++ b/pkg/reconciler/metric/metric_test.go
@@ -192,7 +192,7 @@ func TestReconcileWithCollector(t *testing.T) {
 	wf, err := controller.RunInformers(ctx.Done(), informers...)
 	if err != nil {
 		cancel()
-		t.Fatal("StartInformers() =", err)
+		t.Fatal("RunInformers() =", err)
 	}
 
 	var eg errgroup.Group


### PR DESCRIPTION
This is a PoC, the actual change needs to be discussed and done in pkg.

This speeds up overall test-runtime considerably as the default interval is 100ms and that adds up over all the usages of `RunInformers` that we have in tests.