### PR TITLE
Use atomic.Value rather than unsafe.Pointer

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -71,8 +71,3 @@ issues:
     - text: "ST1000: at least one file in a package should have a package comment"
       linters:
         - stylecheck
-
-    # Uses atomic.StorePointer in request_log, for now.
-    - path: pkg/http
-      linters:
-        - depguard


### PR DESCRIPTION
Doesn't seem to make any real difference (actually over 10ish runs, according to benchstat, atomic.Value seems better, but I'd pretty much bet that's just noise -- and we're talking fractions of a microsecond difference anyway 🤷) so: it's nicer and safer (lets us drop direct use of unsafe.Pointer) and ~same performance, and it means we can lint everything in #10882 rather than excepting `pkg/http`.

~~~~
name                                            old time/op    new time/op    delta
RequestLogHandlerDefaultTemplate/sequential-16    13.0µs ± 5%    12.6µs ± 2%   -2.98%  (p=0.039 n=12+12)
RequestLogHandlerDefaultTemplate/parallel-16      2.71µs ±12%    2.67µs ± 6%     ~     (p=0.211 n=12+11)

name                                            old alloc/op   new alloc/op   delta
RequestLogHandlerDefaultTemplate/sequential-16    1.81kB ± 0%    1.81kB ± 0%     ~     (all equal)
RequestLogHandlerDefaultTemplate/parallel-16      1.81kB ± 0%    1.81kB ± 0%     ~     (all equal)

name                                            old allocs/op  new allocs/op  delta
RequestLogHandlerDefaultTemplate/sequential-16      82.0 ± 0%      82.0 ± 0%     ~     (all equal)
RequestLogHandlerDefaultTemplate/parallel-16        82.0 ± 0%      82.0 ± 0%     ~     (all equal)
~~~~

/assign @markusthoemmes @vagababov 