### PR TITLE
Revert Parallelise tests in activator/net

### DIFF
--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -115,8 +115,6 @@ func waitForRevisionBackendManager(t *testing.T, rbm *revisionBackendsManager) {
 }
 
 func TestRevisionWatcher(t *testing.T) {
-	t.Parallel()
-
 	logger := TestLogger(t)
 	for _, tc := range []struct {
 		name                  string
@@ -378,9 +376,7 @@ func TestRevisionWatcher(t *testing.T) {
 			}},
 		},
 	}} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			fakeRT := activatortest.FakeRoundTripper{
 				ExpectHost:         testRevision,
 				ProbeHostResponses: tc.probeHostResponses,
@@ -520,7 +516,6 @@ func epNotReady(revL string, port int32, portName string, readyIps, notReadyIps 
 }
 
 func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
-	t.Parallel()
 	// Make sure we wait out all the jitter in the system.
 	for _, tc := range []struct {
 		name               string
@@ -687,9 +682,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 		},
 		updateCnt: 1,
 	}} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			fakeRT := activatortest.FakeRoundTripper{
 				ExpectHost:         testRevision,
 				ProbeHostResponses: tc.probeHostResponses,
@@ -762,7 +755,6 @@ func emptyDests() dests {
 }
 
 func TestCheckDestsReadyToNotReady(t *testing.T) {
-	t.Parallel()
 	// This test verifies the edge behaviour when a pod
 	// previously in the ready sed moved to non ready set
 	// and now must be re-probed.
@@ -904,7 +896,6 @@ func TestCheckDestsReadyToNotReady(t *testing.T) {
 }
 
 func TestCheckDests(t *testing.T) {
-	t.Parallel()
 	// This test covers some edge cases in `checkDests` which are next to impossible to
 	// test via tests above.
 
@@ -965,7 +956,6 @@ func TestCheckDests(t *testing.T) {
 }
 
 func TestCheckDestsSwinging(t *testing.T) {
-	t.Parallel()
 	// This test permits us to test the case when endpoints actually change
 	// underneath (e.g. pod crash/restart).
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
@@ -1154,7 +1144,6 @@ func TestCheckDestsSwinging(t *testing.T) {
 }
 
 func TestRevisionDeleted(t *testing.T) {
-	t.Parallel()
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 
 	svc := privateSKSService(
@@ -1205,7 +1194,6 @@ func TestRevisionDeleted(t *testing.T) {
 }
 
 func TestServiceDoesNotExist(t *testing.T) {
-	t.Parallel()
 	// Tests when the service is not available.
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 
@@ -1257,7 +1245,6 @@ func TestServiceDoesNotExist(t *testing.T) {
 }
 
 func TestServiceMoreThanOne(t *testing.T) {
-	t.Parallel()
 	// Tests when the service is not available.
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -66,8 +66,6 @@ func newTestThrottler(ctx context.Context) *Throttler {
 }
 
 func TestThrottlerUpdateCapacity(t *testing.T) {
-	t.Parallel()
-
 	logger := TestLogger(t)
 	rt := &revisionThrottler{
 		logger:               logger,
@@ -212,7 +210,6 @@ func makeTrackers(num, cc int) []*podTracker {
 }
 
 func TestThrottlerErrorNoRevision(t *testing.T) {
-	t.Parallel()
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 	servfake := fakeservingclient.Get(ctx)
 	revisions := fakerevisioninformer.Get(ctx)
@@ -263,7 +260,6 @@ func TestThrottlerErrorNoRevision(t *testing.T) {
 }
 
 func TestThrottlerErrorOneTimesOut(t *testing.T) {
-	t.Parallel()
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 	servfake := fakeservingclient.Get(ctx)
 	revisions := fakerevisioninformer.Get(ctx)
@@ -322,7 +318,6 @@ func sortedTrackers(trk []*podTracker) bool {
 }
 
 func TestThrottlerSuccesses(t *testing.T) {
-	t.Parallel()
 	for _, tc := range []struct {
 		name        string
 		revision    *v1.Revision
@@ -411,10 +406,7 @@ func TestThrottlerSuccesses(t *testing.T) {
 		requests:  2,
 		wantDests: sets.NewString("129.0.0.1:1234"),
 	}} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 			servfake := fakeservingclient.Get(ctx)
 			fake := fakekubeclient.Get(ctx)
@@ -537,7 +529,6 @@ func trackerDestSet(ts []*podTracker) sets.String {
 }
 
 func TestPodAssignmentFinite(t *testing.T) {
-	t.Parallel()
 	// An e2e verification test of pod assignment and capacity
 	// computations.
 	logger := TestLogger(t)
@@ -594,7 +585,6 @@ func TestPodAssignmentFinite(t *testing.T) {
 }
 
 func TestPodAssignmentInfinite(t *testing.T) {
-	t.Parallel()
 	logger := TestLogger(t)
 	revName := types.NamespacedName{Namespace: testNamespace, Name: testRevision}
 
@@ -641,7 +631,6 @@ func TestPodAssignmentInfinite(t *testing.T) {
 }
 
 func TestActivatorsIndexUpdate(t *testing.T) {
-	t.Parallel()
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 
 	fake := fakekubeclient.Get(ctx)
@@ -738,7 +727,6 @@ func TestActivatorsIndexUpdate(t *testing.T) {
 }
 
 func TestMultipleActivators(t *testing.T) {
-	t.Parallel()
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 
 	fake := fakekubeclient.Get(ctx)
@@ -833,7 +821,6 @@ func TestMultipleActivators(t *testing.T) {
 }
 
 func TestInfiniteBreakerCreation(t *testing.T) {
-	t.Parallel()
 	// This test verifies that we use infiniteBreaker when CC==0.
 	tttl := newRevisionThrottler(types.NamespacedName{Namespace: "a", Name: "b"}, 0, /*cc*/
 		pkgnet.ServicePortNameHTTP1, queue.BreakerParams{}, TestLogger(t))
@@ -863,7 +850,6 @@ func (t *Throttler) try(ctx context.Context, requests int, try func(string) erro
 }
 
 func TestInfiniteBreaker(t *testing.T) {
-	t.Parallel()
 	b := &infiniteBreaker{
 		broadcast: make(chan struct{}),
 		logger:    TestLogger(t),
@@ -934,7 +920,6 @@ func TestInfiniteBreaker(t *testing.T) {
 }
 
 func TestInferIndex(t *testing.T) {
-	t.Parallel()
 	const myIP = "10.10.10.3"
 	tests := []struct {
 		label string
@@ -962,9 +947,7 @@ func TestInferIndex(t *testing.T) {
 		2,
 	}}
 	for _, test := range tests {
-		test := test
 		t.Run(test.label, func(t *testing.T) {
-			t.Parallel()
 			if got, want := inferIndex(test.ips, myIP), test.want; got != want {
 				t.Errorf("Index = %d, want: %d", got, want)
 			}
@@ -973,7 +956,6 @@ func TestInferIndex(t *testing.T) {
 }
 
 func TestPickIndices(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		l                   string
 		pods                int
@@ -1069,9 +1051,7 @@ func TestPickIndices(t *testing.T) {
 		wantE: 150,
 	}}
 	for _, test := range tests {
-		test := test
-		t.Run(test.l, func(t *testing.T) {
-			t.Parallel()
+		t.Run(test.l, func(tt *testing.T) {
 			bi, ei, rem := pickIndices(test.pods, test.idx, test.acts)
 			if got, want := bi, test.wantB; got != want {
 				t.Errorf("BeginIndex = %d, want: %d", got, want)
@@ -1087,7 +1067,6 @@ func TestPickIndices(t *testing.T) {
 }
 
 func TestAssignSlice(t *testing.T) {
-	t.Parallel()
 	opt := cmp.Comparer(func(a, b *podTracker) bool {
 		return a.dest == b.dest
 	})
@@ -1100,7 +1079,6 @@ func TestAssignSlice(t *testing.T) {
 		dest: "3",
 	}}
 	t.Run("notrackers", func(t *testing.T) {
-		t.Parallel()
 		got := assignSlice([]*podTracker{}, 0 /*selfIdx*/, 1 /*numAct*/, 42 /*cc*/)
 		if !cmp.Equal(got, []*podTracker{}, opt) {
 			t.Errorf("Got=%v, want: %v, diff: %s", got, trackers,
@@ -1108,7 +1086,6 @@ func TestAssignSlice(t *testing.T) {
 		}
 	})
 	t.Run("idx=1, na=1", func(t *testing.T) {
-		t.Parallel()
 		got := assignSlice(trackers, 1, 1, 1982)
 		if !cmp.Equal(got, trackers, opt) {
 			t.Errorf("Got=%v, want: %v, diff: %s", got, trackers,
@@ -1116,7 +1093,6 @@ func TestAssignSlice(t *testing.T) {
 		}
 	})
 	t.Run("idx=-1", func(t *testing.T) {
-		t.Parallel()
 		got := assignSlice(trackers, -1, 1, 1982)
 		if !cmp.Equal(got, trackers, opt) {
 			t.Errorf("Got=%v, want: %v, diff: %s", got, trackers,
@@ -1124,7 +1100,6 @@ func TestAssignSlice(t *testing.T) {
 		}
 	})
 	t.Run("idx=1", func(t *testing.T) {
-		t.Parallel()
 		cp := append(trackers[:0:0], trackers...)
 		got := assignSlice(cp, 1, 3, 1984)
 		if !cmp.Equal(got, trackers[1:2], opt) {
@@ -1133,15 +1108,14 @@ func TestAssignSlice(t *testing.T) {
 		}
 	})
 	t.Run("len=1", func(t *testing.T) {
-		t.Parallel()
 		got := assignSlice(trackers[0:1], 1, 3, 1988)
 		if !cmp.Equal(got, trackers[0:1], opt) {
 			t.Errorf("Got=%v, want: %v; diff: %s", got, trackers[0:1],
 				cmp.Diff(trackers[0:1], got, opt))
 		}
 	})
+
 	t.Run("idx=1, cc=5", func(t *testing.T) {
-		t.Parallel()
 		trackers := []*podTracker{{
 			dest: "1",
 			b:    queue.NewBreaker(testBreakerParams),
@@ -1164,7 +1138,6 @@ func TestAssignSlice(t *testing.T) {
 		}
 	})
 	t.Run("idx=1, cc=6", func(t *testing.T) {
-		t.Parallel()
 		trackers := []*podTracker{{
 			dest: "1",
 			b:    queue.NewBreaker(testBreakerParams),


### PR DESCRIPTION
This seems to have introduced some flakiness. Ideally we'd fix those flakes and keep the parallelisation but I think it's going to be easier to fix the flakes after some tidying of this package (it's pretty overdue anyway 🤷), and in the meantime I don't want everyone to have to deal with flaky tests.

Fixes #10890.

/assign @markusthoemmes @vagababov 