### PR TITLE
Drop master references to knative repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/github.com/knative/serving)
 [![Go Report Card](https://goreportcard.com/badge/knative/serving)](https://goreportcard.com/report/knative/serving)
 [![Releases](https://img.shields.io/github/release-pre/knative/serving.svg?sort=semver)](https://github.com/knative/serving/releases)
-[![LICENSE](https://img.shields.io/github/license/knative/serving.svg)](https://github.com/knative/serving/blob/master/LICENSE)
+[![LICENSE](https://img.shields.io/github/license/knative/serving.svg)](https://github.com/knative/serving/blob/main/LICENSE)
 [![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://knative.slack.com)
-[![codecov](https://codecov.io/gh/knative/serving/branch/master/graph/badge.svg)](https://codecov.io/gh/knative/serving)
+[![codecov](https://codecov.io/gh/knative/serving/branch/main/graph/badge.svg)](https://codecov.io/gh/knative/serving)
 
 Knative Serving builds on Kubernetes to support deploying and serving of
 applications and functions as serverless containers. Serving is easy to get
@@ -23,7 +23,7 @@ For documentation on using Knative Serving, see the
 [Knative documentation site](https://www.knative.dev/docs).
 
 For documentation on the Knative Serving specification, see the
-[docs](https://github.com/knative/serving/tree/master/docs) folder of this
+[docs](https://github.com/knative/serving/tree/main/docs) folder of this
 repository.
 
 If you are interested in contributing, see [CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/docs/client-conventions.md
+++ b/docs/client-conventions.md
@@ -1,4 +1,4 @@
 # Client Conventions
 
 This document has been moved to the
-[Knative Client Repository](https://github.com/knative/client/tree/master/conventions).
+[Knative Client Repository](https://github.com/knative/client/tree/main/conventions).

--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -145,7 +145,7 @@ to provide signalling to the container.
 ### Hooks
 
 Operation hooks
-[SHOULD NOT](https://github.com/knative/serving/blob/master/test/conformance/runtime/container_test.go)
+[SHOULD NOT](https://github.com/knative/serving/blob/main/test/conformance/runtime/container_test.go)
 be configurable by the Knative developer. Operators or platform providers MAY
 use hooks to implement their own lifecycle controls.
 
@@ -154,7 +154,7 @@ use hooks to implement their own lifecycle controls.
 #### File descriptors
 
 A read from the `stdin` file descriptor on the container
-[SHOULD](https://github.com/knative/serving/blob/master/test/conformance/runtime/file_descriptor_test.go)
+[SHOULD](https://github.com/knative/serving/blob/main/test/conformance/runtime/file_descriptor_test.go)
 always result in `EOF`. The `stdout` and `stderr` file descriptors on the
 container SHOULD be collected and retained in a developer-accessible logging
 repository. (TODO:[docs#902](https://github.com/knative/docs/issues/902)).
@@ -185,11 +185,11 @@ environment SHOULD
 same port as HTTP/1.1. The developer MAY specify this port at deployment; if the
 developer does not specify a port, the platform provider MUST provide a default.
 Only one inbound `containerPort`
-[SHALL](https://github.com/knative/serving/blob/master/test/conformance/runtime/container_test.go)
+[SHALL](https://github.com/knative/serving/blob/main/test/conformance/runtime/container_test.go)
 be specified in the
 [`core.v1.Container`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#containerport-v1-core)
 specification. The `hostPort` parameter
-[SHOULD NOT](https://github.com/knative/serving/blob/master/test/conformance/runtime/container_test.go)
+[SHOULD NOT](https://github.com/knative/serving/blob/main/test/conformance/runtime/container_test.go)
 be set by the developer or the platform provider, as it can interfere with
 ingress autoscaling. Regardless of its source, the selected port will be made
 available in the `PORT` environment variable.
@@ -219,7 +219,7 @@ server process and client processes.
 
 As requests to the container will be proxied by the platform, all inbound
 request headers
-[SHOULD](https://github.com/knative/serving/blob/master/test/conformance/runtime/header_test.go)
+[SHOULD](https://github.com/knative/serving/blob/main/test/conformance/runtime/header_test.go)
 be set to the same values as the incoming request. Some implementations MAY
 strip certain HTTP headers for security or other reasons; such implementations
 SHOULD document the set of stripped headers. Because the full set of HTTP
@@ -227,27 +227,27 @@ headers is constantly evolving, it is RECOMMENDED that platforms which strip
 headers define a common prefix which covers all headers removed by the platform.
 
 In addition, the following base set of HTTP/1.1 headers
-[MUST](https://github.com/knative/serving/blob/master/test/conformance/runtime/header_test.go)
+[MUST](https://github.com/knative/serving/blob/main/test/conformance/runtime/header_test.go)
 be set on the request:
 
 - `Host` - As specified by
   [RFC 7230 Section 5.4](https://tools.ietf.org/html/rfc7230#section-5.4)
 
 Also, the following proxy-specific request headers
-[MUST](https://github.com/knative/serving/blob/master/test/conformance/runtime/header_test.go)
+[MUST](https://github.com/knative/serving/blob/main/test/conformance/runtime/header_test.go)
 be set:
 
 - `Forwarded` - As specified by [RFC 7239](https://tools.ietf.org/html/rfc7239).
 
 Additionally, the following legacy headers
-[SHOULD](https://github.com/knative/serving/blob/master/test/conformance/runtime/header_test.go)
+[SHOULD](https://github.com/knative/serving/blob/main/test/conformance/runtime/header_test.go)
 be set for compatibility with client software:
 
 - `X-Forwarded-For`
 - `X-Forwarded-Proto`
 
 In addition, the following headers
-[SHOULD](https://github.com/knative/serving/blob/master/test/conformance/runtime/header_test.go)
+[SHOULD](https://github.com/knative/serving/blob/main/test/conformance/runtime/header_test.go)
 be set to enable tracing and observability features:
 
 - Trace headers - Platform providers SHOULD provide and document headers needed
@@ -269,7 +269,7 @@ If not provided, container startup and listening on the declared HTTP socket is
 considered sufficient to declare the container "ready" and "live" (see the probe
 definition below). If specified, liveness and readiness probes are REQUIRED to
 be of the `httpGet` or `tcpSocket` types, and
-[MUST](https://github.com/knative/serving/blob/master/test/conformance/runtime/container_test.go)
+[MUST](https://github.com/knative/serving/blob/main/test/conformance/runtime/container_test.go)
 target the inbound container port; platform providers SHOULD disallow other
 probe methods.
 
@@ -292,13 +292,13 @@ the probe succeeds.
 ##### Deployment probe
 
 On the initial deployment, platform providers
-[SHOULD](https://github.com/knative/serving/blob/master/test/conformance/runtime/readiness_probe_test.go)
+[SHOULD](https://github.com/knative/serving/blob/main/test/conformance/runtime/readiness_probe_test.go)
 start an instance of the container to validate that the container is valid and
 will become ready. This startup
-[SHOULD](https://github.com/knative/serving/blob/master/test/conformance/runtime/readiness_probe_test.go)
+[SHOULD](https://github.com/knative/serving/blob/main/test/conformance/runtime/readiness_probe_test.go)
 occur even if the container would not serve any user requests. If a container
 cannot satisfy the `readinessProbe` during deployment startup, the Revision
-[SHOULD](https://github.com/knative/serving/blob/master/test/conformance/runtime/readiness_probe_test.go)
+[SHOULD](https://github.com/knative/serving/blob/main/test/conformance/runtime/readiness_probe_test.go)
 be marked as failed.
 
 Initial readiness probes allow the platform to avoid attempting to later
@@ -371,13 +371,13 @@ declarative fashion, and individual instances SHOULD NOT be interacted with or
 connected directly.
 
 - The `terminal` property
-  [SHOULD NOT](https://github.com/knative/serving/blob/master/test/conformance/runtime/filesystem_test.go)
+  [SHOULD NOT](https://github.com/knative/serving/blob/main/test/conformance/runtime/filesystem_test.go)
   be set to `true`.
 - The linux process specific properties MUST NOT be configurable by the
   developer, and MAY set by the operator or platform provider.
 
 The following environment variables
-[MUST](https://github.com/knative/serving/blob/master/test/conformance/runtime/envvars_test.go)
+[MUST](https://github.com/knative/serving/blob/main/test/conformance/runtime/envvars_test.go)
 be set:
 
 | Name   | Meaning                                                                                                                                             |
@@ -385,7 +385,7 @@ be set:
 | `PORT` | Ingress `containerPort` for ingress requests and health checks. See [Inbound network connectivity](#inbound-network-connectivity) for more details. |
 
 The following environment variables
-[SHOULD](https://github.com/knative/serving/blob/master/test/conformance/runtime/envvars_test.go)
+[SHOULD](https://github.com/knative/serving/blob/main/test/conformance/runtime/envvars_test.go)
 be set:
 
 | Name              | Meaning                                                                                                          |
@@ -401,7 +401,7 @@ such variables will follow demonstrated usage and utility.
 
 Developers MAY specify that containers be run as a specific user or group ID
 using the `runAsUser` container property. If specified, the runtime
-[MUST](https://github.com/knative/serving/blob/master/test/conformance/runtime/user_test.go)
+[MUST](https://github.com/knative/serving/blob/main/test/conformance/runtime/user_test.go)
 run the container as the specified user ID if allowed by the platform (see
 below). If no `runAsUser` is specified, a platform-specific default SHALL be
 used. Platform Providers SHOULD document this default behavior.
@@ -409,7 +409,7 @@ used. Platform Providers SHOULD document this default behavior.
 Operators and Platform Providers MAY prohibit certain user IDs, such as `root`,
 from executing code. In this case, if the identity selected by the developer is
 invalid, the container execution
-[MUST](https://github.com/knative/serving/blob/master/test/conformance/runtime/container_test.go)
+[MUST](https://github.com/knative/serving/blob/main/test/conformance/runtime/container_test.go)
 be failed.
 
 ### Default Filesystems
@@ -423,7 +423,7 @@ developers might not have access to the container's filesystems (or the
 containers might be rapidly recycled), so log aggregation SHOULD be provided.
 
 In addition to the filesystems recommended in the OCI, the following filesystems
-[MUST](https://github.com/knative/serving/blob/master/test/conformance/runtime/filesystem_test.go)
+[MUST](https://github.com/knative/serving/blob/main/test/conformance/runtime/filesystem_test.go)
 be provided:
 
 | Mount      | Description                                                                                                                                                     |
@@ -458,17 +458,17 @@ Developers MUST NOT use OCI `devices` to request additional devices beyond the
 ### Control Groups
 
 Control group (cgroups) controllers
-[MUST](https://github.com/knative/serving/blob/master/test/conformance/runtime/cgroup_test.go)
+[MUST](https://github.com/knative/serving/blob/main/test/conformance/runtime/cgroup_test.go)
 be selected and configured by the operator or platform provider. The cgroup
 devices
-[SHOULD](https://github.com/knative/serving/blob/master/test/conformance/runtime/cgroup_test.go)
+[SHOULD](https://github.com/knative/serving/blob/main/test/conformance/runtime/cgroup_test.go)
 be mounted as read-only.
 
 #### Memory and CPU limits
 
 The serverless platform MAY automatically adjust the resource limits (e.g. CPU)
 based on observed resource usage. The limits enforced to a container
-[SHOULD](https://github.com/knative/serving/blob/master/test/conformance/runtime/cgroup_test.go)
+[SHOULD](https://github.com/knative/serving/blob/main/test/conformance/runtime/cgroup_test.go)
 be exposed in
 
 - `/sys/fs/cgroup/memory/memory.limit_in_bytes`
@@ -486,7 +486,7 @@ for this feature with the Kubernetes SIG-Node team.
 The sysctl parameter applies system-wide kernel parameter tuning, which could
 interfere with other workloads on the host system. This is not appropriate for a
 shared environment, and
-[SHOULD NOT](https://github.com/knative/serving/blob/master/test/conformance/runtime/sysctl_test.go)
+[SHOULD NOT](https://github.com/knative/serving/blob/main/test/conformance/runtime/sysctl_test.go)
 be exposed for developer tuning.
 
 ### Seccomp
@@ -530,7 +530,7 @@ be configurable by the developer.
 ### Posix-platform Hooks
 
 Operation hooks
-[SHOULD NOT](https://github.com/knative/serving/blob/master/test/conformance/runtime/container_test.go)
+[SHOULD NOT](https://github.com/knative/serving/blob/main/test/conformance/runtime/container_test.go)
 be configurable by the developer. Operators or platform providers MAY use hooks
 to implement their own lifecycle controls.
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -3,8 +3,8 @@
 The Knative Serving specifications have been moved. See the links below for
 document locations:
 
-- [Knative Serving API Specification](https://github.com/knative/docs/blob/master/docs/serving/spec/).
-- [Knative Serving Runtime Specification](https://github.com/knative/serving/blob/master/docs/runtime-contract.md)
+- [Knative Serving API Specification](https://github.com/knative/docs/blob/main/docs/serving/spec/).
+- [Knative Serving Runtime Specification](https://github.com/knative/serving/blob/main/docs/runtime-contract.md)
 - [Knative Serving Conformance Tests](/test/conformance)
 
 Docs in this directory:

--- a/docs/spec/errors.md
+++ b/docs/spec/errors.md
@@ -1,9 +1,9 @@
 # Error Conditions and Reporting
 
 This document has been replaced by the
-[Error Signalling](https://github.com/knative/docs/blob/master/docs/serving/spec/knative-api-specification-1.0.md#error-signalling)
+[Error Signalling](https://github.com/knative/docs/blob/main/docs/serving/spec/knative-api-specification-1.0.md#error-signalling)
 section of the
-[Knative API Specification](https://github.com/knative/docs/blob/master/docs/serving/spec/knative-api-specification-1.0.md).
+[Knative API Specification](https://github.com/knative/docs/blob/main/docs/serving/spec/knative-api-specification-1.0.md).
 
 Specification documents can be found in the
-[Knative Docs Repository](https://github.com/knative/docs/tree/master/docs/serving/spec).
+[Knative Docs Repository](https://github.com/knative/docs/tree/main/docs/serving/spec).

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -1,4 +1,4 @@
 # Knative Serving API spec
 
 The API Specification has been moved to the
-[Knative Docs Repository](https://github.com/knative/docs/tree/master/docs/serving/spec).
+[Knative Docs Repository](https://github.com/knative/docs/tree/main/docs/serving/spec).

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Documentation about this script and how to use it can be found
-# at https://github.com/knative/test-infra/tree/master/ci
+# at https://github.com/knative/test-infra/tree/main/ci
 
 source $(dirname $0)/../vendor/knative.dev/hack/release.sh
 

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -73,7 +73,7 @@ var (
 	// The port is named "user-port" on the deployment, but a user cannot set an arbitrary name on the port
 	// in Configuration. The name field is reserved for content-negotiation. Currently 'h2c' and 'http1' are
 	// allowed.
-	// https://github.com/knative/serving/blob/master/docs/runtime-contract.md#inbound-network-connectivity
+	// https://github.com/knative/serving/blob/main/docs/runtime-contract.md#inbound-network-connectivity
 	validPortNames = sets.NewString(
 		"h2c",
 		"http1",

--- a/pkg/apis/serving/v1/configuration_types.go
+++ b/pkg/apis/serving/v1/configuration_types.go
@@ -31,7 +31,7 @@ import (
 // Users create new Revisions by updating the Configuration's spec.
 // The "latest created" revision's name is available under status, as is the
 // "latest ready" revision's name.
-// See also: https://github.com/knative/serving/blob/master/docs/spec/overview.md#configuration
+// See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#configuration
 type Configuration struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/pkg/apis/serving/v1/revision_types.go
+++ b/pkg/apis/serving/v1/revision_types.go
@@ -32,7 +32,7 @@ import (
 // references a container image. Revisions are created by updates to a
 // Configuration.
 //
-// See also: https://github.com/knative/serving/blob/master/docs/spec/overview.md#revision
+// See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#revision
 type Revision struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/pkg/apis/serving/v1/route_types.go
+++ b/pkg/apis/serving/v1/route_types.go
@@ -33,7 +33,7 @@ import (
 // referencing the Configuration responsible for creating them; in these cases
 // the Route is additionally responsible for monitoring the Configuration for
 // "latest ready revision" changes, and smoothly rolling out latest revisions.
-// See also: https://github.com/knative/serving/blob/master/docs/spec/overview.md#route
+// See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#route
 type Route struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/pkg/apis/serving/v1/service_types.go
+++ b/pkg/apis/serving/v1/service_types.go
@@ -39,7 +39,7 @@ import (
 // The Service's controller will track the statuses of its owned Configuration
 // and Route, reflecting their statuses and conditions as its own.
 //
-// See also: https://github.com/knative/serving/blob/master/docs/spec/overview.md#service
+// See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#service
 type Service struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/sample/README.md
+++ b/sample/README.md
@@ -1,4 +1,4 @@
 # Serving Samples
 
 Samples for Knative Serving are available in the
-[Knative Docs repo](https://github.com/knative/docs/tree/master/docs/serving/samples).
+[Knative Docs repo](https://github.com/knative/docs/tree/main/docs/serving/samples).

--- a/test/README.md
+++ b/test/README.md
@@ -62,7 +62,7 @@ go test -v -tags=e2e -count=1 ./test/e2e
 
 Each performance test case in Knative serving is a benchmark, to run these
 benchmarks, please follow
-[dev.md](https://github.com/knative/serving/blob/master/test/performance/dev.md).
+[dev.md](https://github.com/knative/serving/blob/main/test/performance/dev.md).
 
 > As of now, only Googlers can run these benchmarks due to one issue of
 > [Mako](https://github.com/google/mako) - the benchmarking tool we use. Details
@@ -165,7 +165,7 @@ your existing [environment setup](../DEVELOPMENT.md#setup-your-environment).
 Tests importing [`knative.dev/serving/test`](#test-library) recognize these
 flags:
 
-- [All flags added by `knative/pkg/test`](https://github.com/knative/pkg/tree/master/test#flags)
+- [All flags added by `knative/pkg/test`](https://github.com/knative/pkg/tree/main/test#flags)
   such as:
   - [`--dockerrepo`](#overriding-docker-repo)
   - [`--tag`](#using-a-docker-tag)

--- a/test/adding_tests.md
+++ b/test/adding_tests.md
@@ -27,7 +27,7 @@ In the [`test`](.) dir you will find several libraries in the `test` package you
 can use in your tests.
 
 This library exists partially in this directory and partially in
-[`knative/pkg/test`](https://github.com/knative/pkg/tree/master/test).
+[`knative/pkg/test`](https://github.com/knative/pkg/tree/main/test).
 
 The libs in this dir can:
 
@@ -37,7 +37,7 @@ The libs in this dir can:
 - [Verify resource state transitions](#verify-resource-state-transitions)
 - [Generate boilerplate CRDs](#generate-boilerplate-crds)
 
-See [`knative/pkg/test`](https://github.com/knative/pkg/tree/master/test) to:
+See [`knative/pkg/test`](https://github.com/knative/pkg/tree/main/test) to:
 
 - [Use common test flags](#use-common-test-flags)
 - Output logs
@@ -58,7 +58,7 @@ imagePath := strings.Join([]string{test.Flags.DockerRepo, image}, "/"))
 ```
 
 _See
-[e2e_flags.go](https://github.com/knative/pkg/blob/master/test/e2e_flags.go)._
+[e2e_flags.go](https://github.com/knative/pkg/blob/main/test/e2e_flags.go)._
 
 ### Get access to client objects
 
@@ -146,7 +146,7 @@ This function makes use of
 to determine if the ingress should be used or the domain should be used
 directly.
 
-_See [request.go](https://github.com/knative/pkg/blob/master/test/request.go)._
+_See [request.go](https://github.com/knative/pkg/blob/main/test/request.go)._
 
 If you need more low-level access to the http request or response against a
 deployed service, you can directly use the `SpoofingClient` that
@@ -165,7 +165,7 @@ resp, err := client.Poll(req, test.BodyMatches(expectedText))
 ```
 
 _See
-[spoof.go](https://github.com/knative/pkg/blob/master/test/spoof/spoof.go)._
+[spoof.go](https://github.com/knative/pkg/blob/main/test/spoof/spoof.go)._
 
 ### Check Knative Serving resources
 
@@ -217,14 +217,14 @@ _v1testing is alias for package `knative.dev/serving/pkg/testing/v1`_
 
 _For knative crd state, for example `Config`. You can see the code in
 [configuration.go](./v1/configuration.go). For kubernetes objects see
-[kube_checks.go](https://github.com/knative/pkg/blob/master/test/kube_checks.go)._
+[kube_checks.go](https://github.com/knative/pkg/blob/main/test/kube_checks.go)._
 
 ### Verify resource state transitions
 
 To use the [check functions](#check-knative-serving-resources) you must provide
 a function to check the state. Some of the expected transition states (as
 defined in
-[the Knative Serving spec](https://github.com/knative/docs/blob/master/docs/serving/spec/knative-api-specification-1.0.md))
+[the Knative Serving spec](https://github.com/knative/docs/blob/main/docs/serving/spec/knative-api-specification-1.0.md))
 , for example `v1/Revision` state, are expressed in function in
 [revision.go](./v1/revision.go).
 

--- a/test/conformance/api/v1/errorcondition_test.go
+++ b/test/conformance/api/v1/errorcondition_test.go
@@ -41,7 +41,7 @@ const (
 )
 
 // TestContainerErrorMsg is to validate the error condition defined at
-// https://github.com/knative/docs/blob/master/docs/serving/spec/knative-api-specification-1.0.md#error-signalling
+// https://github.com/knative/docs/blob/main/docs/serving/spec/knative-api-specification-1.0.md#error-signalling
 // for the container image missing scenario.
 func TestContainerErrorMsg(t *testing.T) {
 	t.Parallel()
@@ -124,7 +124,7 @@ func TestContainerErrorMsg(t *testing.T) {
 }
 
 // TestContainerExitingMsg is to validate the error condition defined at
-// https://github.com/knative/serving/blob/master/docs/spec/errors.md
+// https://github.com/knative/serving/blob/main/docs/spec/errors.md
 // for the container crashing scenario.
 func TestContainerExitingMsg(t *testing.T) {
 	t.Parallel()

--- a/test/conformance/api/v1/util.go
+++ b/test/conformance/api/v1/util.go
@@ -167,7 +167,7 @@ func validateControlPlane(t *testing.T, clients *test.Clients, names test.Resour
 }
 
 // Validates labels on Revision, Configuration, and Route objects when created by a Service
-// see spec here: https://github.com/knative/serving/blob/master/docs/spec/spec.md#revision
+// see spec here: https://github.com/knative/serving/blob/main/docs/spec/spec.md#revision
 func validateLabelsPropagation(t testing.TB, objects v1test.ResourceObjects, names test.ResourceNames) error {
 	t.Log("Validate Labels on Revision Object")
 	revision := objects.Revision

--- a/test/e2e/tagheader/tag_header_based_routing_test.go
+++ b/test/e2e/tagheader/tag_header_based_routing_test.go
@@ -42,7 +42,7 @@ import (
 // 2) request with header "Knative-Serving-Tag: WrongHeader". This request should be routed to revision 2
 // as when header Knative-Serving-Tag does not match any revision tag, the request will fall back to the main Route.
 // In order to run this test, the tag hearder based routing feature needs to be turned on:
-// https://github.com/knative/serving/blob/master/config/core/configmaps/network.yaml#L115
+// https://github.com/knative/serving/blob/main/config/core/configmaps/network.yaml#L115
 func TestTagHeaderBasedRouting(t *testing.T) {
 	t.Parallel()
 

--- a/test/performance/Benchmarks.md
+++ b/test/performance/Benchmarks.md
@@ -16,15 +16,15 @@ For creating new benchmarks, follow the steps:
 4. Write a `Go` program that runs the test and stores the result in
    [mako](##Writing-to-mako)
 5. (Optional)Create a
-   [setup.yaml](https://github.com/knative/serving/blob/master/test/performance/benchmarks/dataplane-probe/continuous/dataplane-probe-setup.yaml)
+   [setup.yaml](https://github.com/knative/serving/blob/main/test/performance/benchmarks/dataplane-probe/continuous/dataplane-probe-setup.yaml)
    that includes all the K8S and Knative objects needed to run the test.
 6. Create a
-   [cron.yaml](https://github.com/knative/serving/blob/master/test/performance/benchmarks/dataplane-probe/continuous/dataplane-probe.yaml)
+   [cron.yaml](https://github.com/knative/serving/blob/main/test/performance/benchmarks/dataplane-probe/continuous/dataplane-probe.yaml)
    that defines how to run and capture metrics as mentioned in
    [benchmark cronjobs](#Benchmark-cronjobs).
 7. Test and confirm the dev config works on your personal cluster.
 8. Add a
-   [cluster.yaml](https://github.com/knative/serving/blob/master/test/performance/benchmarks/dataplane-probe/cluster.yaml)
+   [cluster.yaml](https://github.com/knative/serving/blob/main/test/performance/benchmarks/dataplane-probe/cluster.yaml)
    that includes the configuration information for a GKE cluster, which will be
    created to run this benchmark. If the file is not added, a minimum cluster
    will be created.
@@ -39,10 +39,10 @@ We will be using two
 [mako benchmarks](https://github.com/google/mako/blob/master/docs/GUIDE.md#preparing-your-benchmark)
 with the same config.
 
-1. [dev.config](https://github.com/knative/serving/blob/master/test/performance/benchmarks/dataplane-probe/dev.config)
+1. [dev.config](https://github.com/knative/serving/blob/main/test/performance/benchmarks/dataplane-probe/dev.config)
    This will be only used for development and testing changes and will have less
    restrictions on who can write to the benchmark.
-2. [prod.config](https://github.com/knative/serving/blob/master/test/performance/benchmarks/dataplane-probe/prod.config)
+2. [prod.config](https://github.com/knative/serving/blob/main/test/performance/benchmarks/dataplane-probe/prod.config)
    This will be used for looking at the state of the project and will be
    restricted to prod-only robots(and some admins).
 
@@ -51,28 +51,28 @@ with the same config.
 Every benchmark directory under `/test/performance/benchmarks` has a `kodata`
 directory and it should have four symlinks.
 
-1. [dev.config](https://github.com/knative/serving/blob/master/test/performance/benchmarks/dataplane-probe/continuous/kodata/dev.config)
+1. [dev.config](https://github.com/knative/serving/blob/main/test/performance/benchmarks/dataplane-probe/continuous/kodata/dev.config)
    Points to the dev.config file in the bechmark directory.
 
    ```sh
    ln -r -s ./test/performance/benchmarks/dataplane-probe/dev.config test/performance/benchmarks/dataplane-probe/continuous/kodata/
    ```
 
-2. [prod.config](https://github.com/knative/serving/blob/master/test/performance/benchmarks/dataplane-probe/continuous/kodata/prod.config)
+2. [prod.config](https://github.com/knative/serving/blob/main/test/performance/benchmarks/dataplane-probe/continuous/kodata/prod.config)
    Points to the prod.config file in the benchmark directory.
 
    ```sh
    ln -r -s ./test/performance/benchmarks/dataplane-probe/prod.config test/performance/benchmarks/dataplane-probe/continuous/kodata/
    ```
 
-3. [HEAD](https://github.com/knative/serving/blob/master/test/performance/benchmarks/dataplane-probe/continuous/kodata/HEAD)
+3. [HEAD](https://github.com/knative/serving/blob/main/test/performance/benchmarks/dataplane-probe/continuous/kodata/HEAD)
    Points to `.git/HEAD`.
 
    ```sh
    ln -r -s .git/HEAD test/performance/benchmarks/dataplane-probe/continuous/kodata/
    ```
 
-4. [refs](https://github.com/knative/serving/blob/master/test/performance/benchmarks/dataplane-probe/continuous/kodata/HEAD)
+4. [refs](https://github.com/knative/serving/blob/main/test/performance/benchmarks/dataplane-probe/continuous/kodata/HEAD)
    Points to `.git/refs`.
 
    ```sh
@@ -87,7 +87,7 @@ is running.
 ## Benchmark CronJobs
 
 Every benchmark will have one or more
-[cronjob](https://github.com/knative/serving/blob/master/test/performance/benchmarks/dataplane-probe/continuous/dataplane-probe.yaml)
+[cronjob](https://github.com/knative/serving/blob/main/test/performance/benchmarks/dataplane-probe/continuous/dataplane-probe.yaml)
 that defines how to run the benchmark SUT. In addition to the SUT container, we
 need to add the following:
 
@@ -154,7 +154,7 @@ metrics. To store these metrics in the test, follow these steps:
 ## Testing Existing Benchmarks
 
 For testing existing benchmarks, use
-[dev.md](https://github.com/knative/serving/blob/master/test/performance/dev.md)
+[dev.md](https://github.com/knative/serving/blob/main/test/performance/dev.md)
 
 ## Admins
 

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -13,7 +13,7 @@ supports constant rate and sine rate, but if you want to generate load at a
 different rate, you can write your own pacer by implementing
 [Pacer](https://github.com/tsenart/vegeta/blob/e04d9c0df8177e8633bff4afe7b39c2f3a9e7dea/lib/pacer.go#L10)
 interface. Custom pacer implementations used in Knative tests are under
-[pacers](https://github.com/knative/pkg/tree/master/test/vegeta/pacers).
+[pacers](https://github.com/knative/pkg/tree/main/test/vegeta/pacers).
 
 ## Benchmarking
 
@@ -21,4 +21,4 @@ Knative uses [mako](https://github.com/google/mako) for benchmarking. It
 provides a set of tools for metrics data storage, charting, statistical
 aggregation and performance regression analysis. To use it to create a benchmark
 for Knative and run it continuously, please refer to
-[Benchmarks.md](https://github.com/knative/serving/blob/master/test/performance/Benchmarks.md).
+[Benchmarks.md](https://github.com/knative/serving/blob/main/test/performance/Benchmarks.md).

--- a/test/performance/config/README.md
+++ b/test/performance/config/README.md
@@ -8,7 +8,7 @@ ko apply -f test/performance/config
 ```
 
 By default, it is configured to load test the
-[autoscale-go](https://github.com/knative/docs/tree/master/docs/serving/autoscaling/autoscale-go)
+[autoscale-go](https://github.com/knative/docs/tree/main/docs/serving/autoscaling/autoscale-go)
 sample, which must already be deployed. You can change the target by altering
 the `ConfigMap` to point to a different endpoint.
 

--- a/test/performance/dev.md
+++ b/test/performance/dev.md
@@ -14,7 +14,7 @@ GKE.
 Take `dataplane-probe` benchmark for example:
 
 1. Edit
-   [mako config](https://github.com/knative/serving/blob/master/test/performance/config/config-mako.yaml)
+   [mako config](https://github.com/knative/serving/blob/main/test/performance/config/config-mako.yaml)
    to attach your desired tags, see the `_example` stanza for how. Then apply
    it:
 

--- a/test/upgrade/README.md
+++ b/test/upgrade/README.md
@@ -26,13 +26,13 @@ At a high level, we want to do this:
 1. Test those resources, verify that we didn’t break anything.
 
 To achieve that, we utilize the
-[upgrade test framework](https://github.com/knative/pkg/tree/master/test/upgrade).
+[upgrade test framework](https://github.com/knative/pkg/tree/main/test/upgrade).
 The framework runs tests in the following phases:
 
 1. Install the latest release from GitHub.
 1. Run the `PreUpgrade` tests.
 1. Start the `Continual` tests.
-1. Install from the HEAD of the master branch.
+1. Install from the HEAD of the default branch.
 1. Run the `PostUpgrade` tests.
 1. Install the latest release from GitHub.
 1. Run the `PostDowngrade` tests.

--- a/test/upgrade/installation/shell.go
+++ b/test/upgrade/installation/shell.go
@@ -23,7 +23,7 @@ import (
 	pkgupgrade "knative.dev/pkg/test/upgrade"
 )
 
-// Head installs Knative Serving from the HEAD of the master branch.
+// Head installs Knative Serving from the HEAD of the default branch.
 func Head() pkgupgrade.Operation {
 	return install("ServingHead", "install_head_reuse_ingress")
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As a followup to the recent renaming spree, all of these can now change :partying_face: 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mattmoor 
