### PR TITLE
Validate default max scale is set if max scale limit is enabled

### DIFF
--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -176,13 +176,20 @@ func validate(lc *autoscalerconfig.Config) (*autoscalerconfig.Config, error) {
 		return nil, fmt.Errorf("initial-scale = %v, must be at least 0 (or at least 1 when allow-zero-initial-scale is false)", lc.InitialScale)
 	}
 
-	if lc.MaxScale < 0 || (lc.MaxScaleLimit > 0 && lc.MaxScale > lc.MaxScaleLimit) {
-		return nil, fmt.Errorf("max-scale = %v, must be in [0, max-scale-limit] range", lc.MaxScale)
+	var minMaxScale int32 = 0
+	if lc.MaxScaleLimit > 0 {
+		// Default maxScale must be positive if maxScaleLimit is set.
+		minMaxScale = 1
+	}
+
+	if lc.MaxScale < minMaxScale || (lc.MaxScaleLimit > 0 && lc.MaxScale > lc.MaxScaleLimit) {
+		return nil, fmt.Errorf("max-scale = %d, must be in [%d, max-scale-limit] range", minMaxScale, lc.MaxScale)
 	}
 
 	if lc.MaxScaleLimit < 0 {
 		return nil, fmt.Errorf("max-scale-limit = %v, must be at least 0", lc.MaxScaleLimit)
 	}
+
 	return lc, nil
 }
 

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -178,12 +178,12 @@ func validate(lc *autoscalerconfig.Config) (*autoscalerconfig.Config, error) {
 
 	var minMaxScale int32 = 0
 	if lc.MaxScaleLimit > 0 {
-		// Default maxScale must be positive if maxScaleLimit is set.
+		// Default maxScale must be set if maxScaleLimit is set.
 		minMaxScale = 1
 	}
 
 	if lc.MaxScale < minMaxScale || (lc.MaxScaleLimit > 0 && lc.MaxScale > lc.MaxScaleLimit) {
-		return nil, fmt.Errorf("max-scale = %d, must be in [%d, max-scale-limit] range", minMaxScale, lc.MaxScale)
+		return nil, fmt.Errorf("max-scale = %d, must be in [%d, max-scale-limit] range", lc.MaxScale, minMaxScale)
 	}
 
 	if lc.MaxScaleLimit < 0 {

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -344,6 +344,13 @@ func TestNewConfig(t *testing.T) {
 		},
 		wantErr: true,
 	}, {
+		name: "with max scale limit and zero default max scale",
+		input: map[string]string{
+			"max-scale":       "0",
+			"max-scale-limit": "11",
+		},
+		wantErr: true,
+	}, {
 		name: "with valid default max scale and max scale limit",
 		input: map[string]string{
 			"max-scale":       "10",


### PR DESCRIPTION
If a non zero max scale limit is set and no default max scale is provided the "out of the box" situation for ksvcs is invalid (a default ksvc without annotations will fail validation). The operator should provide a reasonable - non-infinite - default for users if a limit is set.

See #10825, #10847.

```release-note
Adds validation that a default max-scale is set if a max-scale-limit is specified in the autoscaler configmap (since otherwise the default max-scale, i.e. 0 = no max, would fail validation as it is above the max-scale-limit).
```

/assign @dprotaso @markusthoemmes 

