### PR TITLE
Redisable chaos duck for autoscaler

### DIFF
--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -86,6 +86,10 @@ spec:
         # Disable chaos on webhooks until https://github.com/knative/pkg/issues/1509 is
         # sorted out.
         - "-disable=webhook"
+        # Currently the new owner of Autoscaler needs time to build the
+        # metrics status so some e2e tests are expected to fail if the
+        # owner pod crashes.
+        - "-disable=autoscaler"
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:


### PR DESCRIPTION
Partial revert of https://github.com/knative/serving/pull/9884.

Unfortunately it looks like it still isn't safe to run some autoscaler tests under chaos for the reason in the comment, and this has been causing some flakiness.

It would still be nice to enable chaos for the parts of autoscaler where we can (see #9711), and eventually have full HA work so they all run safely under chaos, but that doesn't seem to be the case yet.. will open separate issue to track being able to unrevert this.

/assign @markusthoemmes @yanweiguo 