### PR TITLE
Update support info with machine-readable rotation

### DIFF
--- a/support/COMMUNITY_CONTACTS.md
+++ b/support/COMMUNITY_CONTACTS.md
@@ -67,21 +67,12 @@ rotation, feel free to send a PR to remove yourself.
 
 # Schedule
 
-| week       | contact                                             |
-| ---------- | --------------------------------------------------- |
-| 2020-12-14 | [tcnghia](https://github.com/tcnghia)               |
-| 2020-12-21 | [nak3](https://github.com/nak3)                     |
-| 2020-12-28 | [vagababov](https://github.com/vagababov)           |
-| 2021-01-04 | [mattmoor](https://github.com/mattmoor)             |
-| 2021-01-11 | [vagababov](https://github.com/vagababov)           |
-| 2021-01-18 | [markusthoemmes](https://github.com/markusthoemmes) |
-| 2021-01-25 | [julz](https://github.com/julz)                     |
-| 2021-02-01 | [ZhiminXiang](https://github.com/ZhiminXiang)       |
-| 2021-02-08 | [JRBANCEL](https://github.com/JRBANCEL)             |
-| 2021-02-15 | [nak3](https://github.com/nak3)                     |
-| 2021-02-22 | [yanweiguo](https://github.com/yanweiguo)           |
-| 2021-03-01 | [dprotaso](https://github.com/dprotaso)             |
-| 2021-03-08 | [tcnghia](https://github.com/tcnghia)               |
-| 2021-03-15 | [evankanderson](https://github.com/evankanderson)   |
-| 2021-03-22 | [ZhiminXiang](https://github.com/ZhiminXiang)       |
-| 2021-03-29 | [yanweiguo](https://github.com/yanweiguo)           |
+See [a machine-readable schedule here](schedule.rotation). The format is:
+```
+# comment lines are okay
+#@ metadata: value of the metadata
+RFC3339-date  |  username
+```
+
+You can see the current oncall at https://knative.party/ (which reads the
+machine-readable file).

--- a/support/support.rotation
+++ b/support/support.rotation
@@ -1,0 +1,23 @@
+# Serving community contacts
+#
+# Begin metadata
+#@ title: Serving
+#@ slack: #serving-questions
+#@ slacklink: https://knative.slack.com/archives/C0186KU7STW
+
+2020-12-14T17:00:00Z | tcnghia
+2020-12-21T17:00:00Z | nak3
+2020-12-28T17:00:00Z | vagababov
+2021-01-04T17:00:00Z | mattmoor
+2021-01-11T17:00:00Z | vagababov
+2021-01-18T17:00:00Z | markusthoemmes
+2021-01-25T17:00:00Z | julz
+2021-02-01T17:00:00Z | ZhiminXiang
+2021-02-08T17:00:00Z | JRBANCEL
+2021-02-15T17:00:00Z | nak3
+2021-02-22T17:00:00Z | yanweiguo
+2021-03-01T17:00:00Z | dprotaso
+2021-03-08T17:00:00Z | tcnghia
+2021-03-15T17:00:00Z | evankanderson
+2021-03-22T17:00:00Z | ZhiminXiang
+2021-03-29T17:00:00Z | yanweiguo


### PR DESCRIPTION
## Proposed Changes

Split oncall instructions (for humans) and rotation (humans + machines) into
separate files. This will allow automation to read (and eventuall update?)
the rotation.
