### PR TITLE
Default PeriodSeconds of the readiness probe to 1 if unset

### DIFF
--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -98,6 +98,7 @@ var (
 					}},
 				},
 			},
+			PeriodSeconds: 1,
 		},
 		SecurityContext: queueSecurityContext,
 		Env: []corev1.EnvVar{{

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -249,8 +249,8 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 
 	// After startup we'll directly use the same http health check endpoint the
 	// execprobe would have used (which will then check the user container).
-	// Unlike the StartupProbe, we don't need to override any of the
-	// timeouts/periods/thresholds here.
+	// Unlike the StartupProbe, we don't need to override any of the other settings
+	// except period here. See below.
 	httpProbe := container.ReadinessProbe.DeepCopy()
 	httpProbe.Handler = corev1.Handler{
 		HTTPGet: &corev1.HTTPGetAction{
@@ -260,6 +260,13 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 				Value: queue.Name,
 			}},
 		},
+	}
+
+	// Default PeriodSeconds to 1 if not set to make for the quickest possible startup
+	// time.
+	// TODO(#10973): Remove this once we're on K8s 1.21
+	if httpProbe.PeriodSeconds == 0 {
+		httpProbe.PeriodSeconds = 1
 	}
 
 	return &corev1.Container{

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -735,10 +735,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 						}},
 					},
 				},
-				// The ReadinessProbe does not override the user's probe parameters.
-				// (The aggressive probing will have happened on startup, now
-				// we can probe at the user-requested/default interval).
-				PeriodSeconds:    0,
+				PeriodSeconds:    1,
 				TimeoutSeconds:   0,
 				SuccessThreshold: 3,
 			}


### PR DESCRIPTION
Fixes #10973

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

#10973 has a quite extensive of writeup of the whys here.

Tl;dr: We might wait for 10s before we run the readiness probe and thus call the container ready. That's kinda long.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixed a regression where the pod bringup time might have a latency of 10s or more even though the container should be up quickly.
```

/assign @vagababov @julz 