### PR TITLE
Only allocate named logger if necessary in activator

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -175,7 +175,7 @@ func main() {
 
 	// Create activation handler chain
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first
-	var ah http.Handler = activatorhandler.New(ctx, throttler, transport)
+	var ah http.Handler = activatorhandler.New(ctx, throttler, transport, logger)
 	ah = concurrencyReporter.Handler(ah)
 	ah = tracing.HTTPSpanMiddleware(ah)
 	ah = configStore.HTTPMiddleware(ah)

--- a/pkg/activator/handler/context_handler.go
+++ b/pkg/activator/handler/context_handler.go
@@ -65,17 +65,15 @@ func (h *contextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	revID := types.NamespacedName{Namespace: namespace, Name: name}
-	logger := h.logger.With(zap.String(logkey.Key, revID.String()))
 
 	revision, err := h.revisionLister.Revisions(namespace).Get(name)
 	if err != nil {
-		logger.Errorw("Error while getting revision", zap.Error(err))
+		h.logger.Errorw("Error while getting revision", zap.String(logkey.Key, revID.String()), zap.Error(err))
 		sendError(err, w)
 		return
 	}
 
 	ctx := r.Context()
-	ctx = logging.WithLogger(ctx, logger)
 	ctx = WithRevision(ctx, revision)
 	ctx = WithRevID(ctx, revID)
 

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -125,7 +125,7 @@ func TestActivationHandler(t *testing.T) {
 
 			ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 			defer cancel()
-			handler := New(ctx, test.throttler, rt)
+			handler := New(ctx, test.throttler, rt, logging.FromContext(ctx))
 
 			resp := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
@@ -164,7 +164,7 @@ func TestActivationHandlerProxyHeader(t *testing.T) {
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 	defer cancel()
 
-	handler := New(ctx, fakeThrottler{}, rt)
+	handler := New(ctx, fakeThrottler{}, rt, logging.FromContext(ctx))
 
 	writer := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
@@ -241,7 +241,7 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 				oct.Finish()
 			}()
 
-			handler := New(ctx, fakeThrottler{}, rt)
+			handler := New(ctx, fakeThrottler{}, rt, logging.FromContext(ctx))
 
 			// Set up config store to populate context.
 			configStore := setupConfigStore(t, logging.FromContext(ctx))
@@ -311,7 +311,7 @@ func BenchmarkHandler(b *testing.B) {
 			}, nil
 		})
 
-		handler := New(ctx, fakeThrottler{}, rt)
+		handler := New(ctx, fakeThrottler{}, rt, logging.FromContext(ctx))
 
 		request := func() *http.Request {
 			req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Allocating a named logger is somewhat expensive (~ 10 allocs) so it's worth avoiding it, especially in high-speed components like the activator.

This defers allocation of the respective named logger to error cases.

## Context handler benchmark

```
benchmark                                                         old ns/op     new ns/op     delta
BenchmarkContextHandler/context_handler_success-sequential-16     3258          924           -71.64%
BenchmarkContextHandler/context_handler_success-parallel-16       569           175           -69.24%
BenchmarkContextHandler/context_handler_failure-sequential-16     14659         14838         +1.22%
BenchmarkContextHandler/context_handler_failure-parallel-16       10980         11384         +3.68%

benchmark                                                         old allocs     new allocs     delta
BenchmarkContextHandler/context_handler_success-sequential-16     19             7              -63.16%
BenchmarkContextHandler/context_handler_success-parallel-16       19             7              -63.16%
BenchmarkContextHandler/context_handler_failure-sequential-16     45             38             -15.56%
BenchmarkContextHandler/context_handler_failure-parallel-16       45             38             -15.56%

benchmark                                                         old bytes     new bytes     delta
BenchmarkContextHandler/context_handler_success-sequential-16     2091          592           -71.69%
BenchmarkContextHandler/context_handler_success-parallel-16       2090          592           -71.67%
BenchmarkContextHandler/context_handler_failure-sequential-16     5086          4119          -19.01%
BenchmarkContextHandler/context_handler_failure-parallel-16       4882          3715          -23.90%
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
