### PR TITLE
Collapse revision context into specialized context to avoid allocations

### DIFF
--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -437,7 +437,7 @@ func TestConcurrencyReporterHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
-	rCtx := WithRevID(context.Background(), rev1)
+	rCtx := WithRevisionAndID(context.Background(), nil, rev1)
 
 	// Send a few requests.
 	handler.ServeHTTP(resp, req.WithContext(rCtx))
@@ -644,7 +644,7 @@ func BenchmarkConcurrencyReporterHandler(b *testing.B) {
 			Name:      testRevName + strconv.Itoa(i),
 		}
 		req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
-		reqs = append(reqs, req.WithContext(WithRevID(context.Background(), key)))
+		reqs = append(reqs, req.WithContext(WithRevisionAndID(context.Background(), nil, key)))
 
 		// Create revisions in the fake clients to trigger report logic.
 		rev := revision(key.Namespace, key.Name)

--- a/pkg/activator/handler/context.go
+++ b/pkg/activator/handler/context.go
@@ -37,7 +37,7 @@ type (
 type revCtx struct {
 	context.Context
 	revision *v1.Revision
-	revID    types.NamespacedName
+	revID    *types.NamespacedName
 }
 
 func (c *revCtx) String() string {
@@ -59,7 +59,7 @@ func WithRevisionAndID(ctx context.Context, rev *v1.Revision, revID types.Namesp
 	return &revCtx{
 		Context:  ctx,
 		revision: rev,
-		revID:    revID,
+		revID:    &revID,
 	}
 }
 
@@ -70,5 +70,5 @@ func RevisionFrom(ctx context.Context) *v1.Revision {
 
 // RevIDFrom retrieves the the revisionID from the context.
 func RevIDFrom(ctx context.Context) types.NamespacedName {
-	return ctx.Value(revIDKey{}).(types.NamespacedName)
+	return *ctx.Value(revIDKey{}).(*types.NamespacedName)
 }

--- a/pkg/activator/handler/context_handler.go
+++ b/pkg/activator/handler/context_handler.go
@@ -74,8 +74,7 @@ func (h *contextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	ctx = WithRevision(ctx, revision)
-	ctx = WithRevID(ctx, revID)
+	ctx = WithRevisionAndID(ctx, revision, revID)
 
 	h.nextHandler.ServeHTTP(w, r.WithContext(ctx))
 }

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -134,7 +134,7 @@ func TestActivationHandler(t *testing.T) {
 			// Set up config store to populate context.
 			configStore := setupConfigStore(t, logging.FromContext(ctx))
 			ctx = configStore.ToContext(ctx)
-			ctx = WithRevID(ctx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
+			ctx = WithRevisionAndID(ctx, nil, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
 
 			handler.ServeHTTP(resp, req.WithContext(ctx))
 
@@ -172,7 +172,7 @@ func TestActivationHandlerProxyHeader(t *testing.T) {
 	// Set up config store to populate context.
 	configStore := setupConfigStore(t, logging.FromContext(ctx))
 	ctx = configStore.ToContext(req.Context())
-	ctx = WithRevID(ctx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
+	ctx = WithRevisionAndID(ctx, nil, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
 
 	handler.ServeHTTP(writer, req.WithContext(ctx))
 
@@ -267,7 +267,7 @@ func sendRequest(namespace, revName string, handler http.Handler, store *activat
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/", nil)
 	ctx := store.ToContext(req.Context())
-	ctx = WithRevID(ctx, types.NamespacedName{Namespace: namespace, Name: revName})
+	ctx = WithRevisionAndID(ctx, nil, types.NamespacedName{Namespace: namespace, Name: revName})
 	handler.ServeHTTP(resp, req.WithContext(ctx))
 	return resp
 }
@@ -318,7 +318,7 @@ func BenchmarkHandler(b *testing.B) {
 			req.Host = "test-host"
 
 			reqCtx := configStore.ToContext(context.Background())
-			reqCtx = WithRevID(reqCtx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
+			reqCtx = WithRevisionAndID(reqCtx, nil, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
 			return req.WithContext(reqCtx)
 		}
 

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -114,8 +114,7 @@ func TestRequestMetricHandler(t *testing.T) {
 				metricstest.AssertMetricExists(t, responseTimeInMsecM.Name())
 			}()
 
-			reqCtx := WithRevision(context.Background(), rev)
-			reqCtx = WithRevID(reqCtx, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
+			reqCtx := WithRevisionAndID(context.Background(), rev, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
 			handler.ServeHTTP(resp, req.WithContext(reqCtx))
 		})
 	}
@@ -128,7 +127,7 @@ func reset() {
 
 func BenchmarkMetricHandler(b *testing.B) {
 	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	reqCtx := WithRevision(context.Background(), revision(testNamespace, testRevName))
+	reqCtx := WithRevisionAndID(context.Background(), revision(testNamespace, testRevName), types.NamespacedName{Namespace: testNamespace, Name: testRevName})
 
 	handler := NewMetricHandler("benchPod", baseHandler)
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Always wanted to play with custom value contexts, so here we are! This spares us a bit of linked list lookup and context allocation, so yay!

```
benchmark                                                         old ns/op     new ns/op     delta
BenchmarkContextHandler/context_handler_success-sequential-16     923           841           -8.88%
BenchmarkContextHandler/context_handler_success-parallel-16       176           166           -5.68%
BenchmarkContextHandler/context_handler_failure-sequential-16     15401         11938         -22.49%
BenchmarkContextHandler/context_handler_failure-parallel-16       11216         11829         +5.47%

benchmark                                                         old allocs     new allocs     delta
BenchmarkContextHandler/context_handler_success-sequential-16     7              6              -14.29%
BenchmarkContextHandler/context_handler_success-parallel-16       7              6              -14.29%
BenchmarkContextHandler/context_handler_failure-sequential-16     38             38             +0.00%
BenchmarkContextHandler/context_handler_failure-parallel-16       38             38             +0.00%

benchmark                                                         old bytes     new bytes     delta
BenchmarkContextHandler/context_handler_success-sequential-16     592           560           -5.41%
BenchmarkContextHandler/context_handler_success-parallel-16       592           560           -5.41%
BenchmarkContextHandler/context_handler_failure-sequential-16     3944          4111          +4.23%
BenchmarkContextHandler/context_handler_failure-parallel-16       3663          3942          +7.62%
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
