### PR TITLE
Bypass tracing handler if tracing is disabled

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -177,7 +177,7 @@ func main() {
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first
 	ah := activatorhandler.New(ctx, throttler, transport, logger)
 	ah = concurrencyReporter.Handler(ah)
-	ah = tracing.HTTPSpanMiddleware(ah)
+	ah = activatorhandler.NewTracingHandler(ah)
 	reqLogHandler, err := pkghttp.NewRequestLogHandler(ah, logging.NewSyncFileWriter(os.Stdout), "",
 		requestLogTemplateInputGetter, false /*enableProbeRequestLog*/)
 	if err != nil {

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -296,7 +296,9 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	if metricsSupported {
 		composedHandler = requestMetricsHandler(logger, composedHandler, env)
 	}
-	composedHandler = tracing.HTTPSpanMiddleware(composedHandler)
+	if tracingEnabled {
+		composedHandler = tracing.HTTPSpanMiddleware(composedHandler)
+	}
 
 	composedHandler = health.ProbeHandler(healthState, rp.ProbeContainer, rp.IsAggressive(), tracingEnabled, composedHandler)
 	composedHandler = network.NewProbeHandler(composedHandler)

--- a/pkg/activator/handler/main_test.go
+++ b/pkg/activator/handler/main_test.go
@@ -27,7 +27,6 @@ import (
 	"knative.dev/pkg/logging"
 	pkgnet "knative.dev/pkg/network"
 	rtesting "knative.dev/pkg/reconciler/testing"
-	"knative.dev/pkg/tracing"
 	"knative.dev/serving/pkg/activator"
 	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
 	pkghttp "knative.dev/serving/pkg/http"
@@ -72,7 +71,7 @@ func BenchmarkHandlerChain(b *testing.B) {
 	// Make sure to update this if the activator's main file changes.
 	ah := New(ctx, fakeThrottler{}, rt, logger)
 	ah = concurrencyReporter.Handler(ah)
-	ah = tracing.HTTPSpanMiddleware(ah)
+	ah = NewTracingHandler(ah)
 	ah, _ = pkghttp.NewRequestLogHandler(ah, ioutil.Discard, "", nil, false)
 	ah = NewMetricHandler(activatorPodName, ah)
 	ah = NewContextHandler(ctx, ah, configStore)

--- a/pkg/activator/handler/tracing_handler.go
+++ b/pkg/activator/handler/tracing_handler.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"net/http"
+
+	"knative.dev/pkg/tracing"
+	tracingconfig "knative.dev/pkg/tracing/config"
+	activatorconfig "knative.dev/serving/pkg/activator/config"
+)
+
+// NewTracingHandler creates a wrapper around tracing.HTTPSpanMiddleware that completely
+// bypasses said handler when tracing is disabled via the Activator's configuration.
+func NewTracingHandler(next http.Handler) http.HandlerFunc {
+	tracingHandler := tracing.HTTPSpanMiddleware(next)
+	return func(w http.ResponseWriter, r *http.Request) {
+		tracingEnabled := activatorconfig.FromContext(r.Context()).Tracing.Backend != tracingconfig.None
+		if !tracingEnabled {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		tracingHandler.ServeHTTP(w, r)
+	}
+}

--- a/pkg/activator/handler/tracing_handler_test.go
+++ b/pkg/activator/handler/tracing_handler_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/logging"
+	rtesting "knative.dev/pkg/reconciler/testing"
+	"knative.dev/pkg/tracing"
+	"knative.dev/pkg/tracing/config"
+	tracetesting "knative.dev/pkg/tracing/testing"
+	activatorconfig "knative.dev/serving/pkg/activator/config"
+)
+
+func TestTracingHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		tracingEnabled bool
+	}{{
+		name:           "enabled",
+		tracingEnabled: true,
+	}, {
+		name:           "disabled",
+		tracingEnabled: false,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
+			defer cancel()
+
+			baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+			handler := NewTracingHandler(baseHandler)
+
+			resp := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+			const traceID = "821e0d50d931235a5ba3fa42eddddd8f"
+			req.Header["X-B3-Traceid"] = []string{traceID}
+			req.Header["X-B3-Spanid"] = []string{"b3bd5e1c4318c78a"}
+
+			cm := tracingConfig(test.tracingEnabled)
+			cfg, err := config.NewTracingConfigFromConfigMap(cm)
+			if err != nil {
+				t.Fatal("Failed to parse tracing config", err)
+			}
+
+			configStore := activatorconfig.NewStore(logging.FromContext(ctx))
+			configStore.OnConfigChanged(cm)
+			ctx = configStore.ToContext(ctx)
+
+			// Create tracer with reporter recorder
+			reporter, co := tracetesting.FakeZipkinExporter()
+			oct := tracing.NewOpenCensusTracer(co)
+			t.Cleanup(func() {
+				reporter.Close()
+				oct.Finish()
+			})
+
+			if err := oct.ApplyConfig(cfg); err != nil {
+				t.Error("Failed to apply tracer config:", err)
+			}
+
+			handler.ServeHTTP(resp, req.WithContext(ctx))
+
+			spans := reporter.Flush()
+
+			if test.tracingEnabled {
+				if len(spans) != 1 {
+					t.Errorf("Got %d spans, expected 1: spans = %v", len(spans), spans)
+				}
+				if got := spans[0].TraceID.String(); got != traceID {
+					t.Errorf("spans[0].TraceID = %s, want %s", got, traceID)
+				}
+			} else {
+				if len(spans) != 0 {
+					t.Errorf("Got %d spans, expected 0: spans = %v", len(spans), spans)
+				}
+			}
+		})
+	}
+}
+
+func tracingConfig(enabled bool) *corev1.ConfigMap {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "knative-serving",
+			Name:      "config-tracing",
+		},
+		Data: map[string]string{
+			"backend": "none",
+		},
+	}
+	if enabled {
+		cm.Data["backend"] = "zipkin"
+		cm.Data["zipkin-endpoint"] = "foo.bar"
+		cm.Data["debug"] = "true"
+	}
+	return cm
+}

--- a/pkg/activator/handler/tracing_handler_test.go
+++ b/pkg/activator/handler/tracing_handler_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -66,7 +66,6 @@ func TestTracingHandler(t *testing.T) {
 			configStore.OnConfigChanged(cm)
 			ctx = configStore.ToContext(ctx)
 
-			// Create tracer with reporter recorder
 			reporter, co := tracetesting.FakeZipkinExporter()
 			oct := tracing.NewOpenCensusTracer(co)
 			t.Cleanup(func() {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This drops a whopping 55 allocations **per request** from both the activator and the queue-proxy if tracing is disabled. We'd love to reduce the tracing overhead in general of course, but this at least relieves the situation for people that are not running tracing at all.

Benchmark results

```
benchmark                               old ns/op     new ns/op     delta
BenchmarkHandlerChain/sequential-16     21598         13875         -35.76%
BenchmarkHandlerChain/parallel-16       20688         14301         -30.87%

benchmark                               old allocs     new allocs     delta
BenchmarkHandlerChain/sequential-16     125            70             -44.00%
BenchmarkHandlerChain/parallel-16       125            70             -44.00%

benchmark                               old bytes     new bytes     delta
BenchmarkHandlerChain/sequential-16     7701          4686          -39.15%
BenchmarkHandlerChain/parallel-16       7849          4793          -38.93%
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
