### PR TITLE
Use new API for test helpers

### DIFF
--- a/pkg/activator/handler/context_handler_test.go
+++ b/pkg/activator/handler/context_handler_test.go
@@ -111,7 +111,7 @@ func BenchmarkContextHandler(b *testing.B) {
 		label:        "context handler failure",
 		revisionName: "fake",
 	}}
-	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(&testing.T{})
+	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(b)
 	defer cancel()
 	revision := revision(testNamespace, testRevName)
 	revisionInformer(ctx, revision)

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -288,7 +288,7 @@ func revision(namespace, name string) *v1.Revision {
 	}
 }
 
-func setupConfigStore(t *testing.T, logger *zap.SugaredLogger) *activatorconfig.Store {
+func setupConfigStore(t testing.TB, logger *zap.SugaredLogger) *activatorconfig.Store {
 	configStore := activatorconfig.NewStore(logger)
 	tracingConfig := ConfigMapFromTestFile(t, tracingconfig.ConfigName)
 	configStore.OnConfigChanged(tracingConfig)
@@ -296,11 +296,11 @@ func setupConfigStore(t *testing.T, logger *zap.SugaredLogger) *activatorconfig.
 }
 
 func BenchmarkHandler(b *testing.B) {
-	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(&testing.T{})
+	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(b)
 	b.Cleanup(cancel)
-	configStore := setupConfigStore(&testing.T{}, logging.FromContext(ctx))
+	configStore := setupConfigStore(b, logging.FromContext(ctx))
 
-	// bodyLength is in kilobytes.
+	// bodyLength is in Kilobytes.
 	for _, bodyLength := range [5]int{2, 16, 32, 64, 128} {
 		body := []byte(randomString(1024 * bodyLength))
 

--- a/pkg/activator/handler/main_test.go
+++ b/pkg/activator/handler/main_test.go
@@ -37,11 +37,11 @@ import (
 // activator to enable us to see improvements that span handlers and to judge some of
 // the handlers that are not developed here.
 func BenchmarkHandlerChain(b *testing.B) {
-	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(&testing.T{})
+	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(b)
 	b.Cleanup(cancel)
 
 	logger := logging.FromContext(ctx)
-	configStore := setupConfigStore(&testing.T{}, logger)
+	configStore := setupConfigStore(b, logger)
 	revision := revision(testNamespace, testRevName)
 	revisionInformer(ctx, revision)
 


### PR DESCRIPTION
Avoid constructing of the `testing.T` objects and just use `testing.B` in the benchmarks.

/assign @markusthoemmes @julz 