### PR TITLE
Fix HTTP2 feature-gate threading in queue-proxy

### DIFF
--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -34,10 +34,9 @@ import (
 type HTTPProbeConfigOptions struct {
 	Timeout time.Duration
 	*corev1.HTTPGetAction
-	KubeMajor       string
-	KubeMinor       string
-	MaxProtoMajor   int
-	AutoDetectHTTP2 bool
+	KubeMajor     string
+	KubeMinor     string
+	MaxProtoMajor int
 }
 
 // TCPProbeConfigOptions holds the TCP probe config options
@@ -144,15 +143,12 @@ func http2UpgradeProbe(config HTTPProbeConfigOptions) (int, error) {
 
 // HTTPProbe checks that HTTP connection can be established to the address.
 func HTTPProbe(config HTTPProbeConfigOptions) error {
-	if !config.AutoDetectHTTP2 {
-		config.MaxProtoMajor = 1
-	}
-	// If we don't know if the connection supports HTTP2, we will try it.
-	// Once we get a non-error response, we won't try again.
-	// If maxProto is 0, container is not ready, so we don't know whether http2 is supported.
-	// If maxProto is 1, we know we're ready, but we also can't upgrade, so just return.
-	// If maxProto is 2, we know we can upgrade to http2
-	if config.AutoDetectHTTP2 && config.MaxProtoMajor == 0 {
+	if config.MaxProtoMajor == 0 {
+		// If we don't know if the connection supports HTTP2, we will try it.
+		// Once we get a non-error response, we won't try again.
+		// If maxProto is 0, container is not ready, so we don't know whether http2 is supported.
+		// If maxProto is 1, we know we're ready, but we also can't upgrade, so just return.
+		// If maxProto is 2, we know we can upgrade to http2
 		maxProto, err := http2UpgradeProbe(config)
 		if err != nil {
 			return fmt.Errorf("failed to run HTTP2 upgrade probe with error: %w", err)

--- a/pkg/queue/health/probe_test.go
+++ b/pkg/queue/health/probe_test.go
@@ -82,6 +82,7 @@ func TestHTTPProbeSuccess(t *testing.T) {
 	config := HTTPProbeConfigOptions{
 		Timeout:       time.Second,
 		HTTPGetAction: action,
+		MaxProtoMajor: 1,
 	}
 
 	// Connecting to the server should work
@@ -130,9 +131,9 @@ func TestHTTPProbeNoAutoHTTP2IfDisabled(t *testing.T) {
 	action.Path = expectedPath
 
 	config := HTTPProbeConfigOptions{
-		Timeout:         time.Second,
-		HTTPGetAction:   action,
-		AutoDetectHTTP2: false,
+		Timeout:       time.Second,
+		HTTPGetAction: action,
+		MaxProtoMajor: 1,
 	}
 	if err := HTTPProbe(config); err != nil {
 		t.Error("Expected probe to succeed but it failed with", err)
@@ -177,9 +178,9 @@ func TestHTTPProbeAutoHTTP2(t *testing.T) {
 	action.Path = expectedPath
 
 	config := HTTPProbeConfigOptions{
-		Timeout:         time.Second,
-		HTTPGetAction:   action,
-		AutoDetectHTTP2: true,
+		Timeout:       time.Second,
+		HTTPGetAction: action,
+		MaxProtoMajor: 0,
 	}
 	if err := HTTPProbe(config); err != nil {
 		t.Error("Expected probe to succeed but it failed with", err)
@@ -197,6 +198,7 @@ func TestHTTPSchemeProbeSuccess(t *testing.T) {
 	config := HTTPProbeConfigOptions{
 		Timeout:       time.Second,
 		HTTPGetAction: newHTTPGetAction(t, server.URL),
+		MaxProtoMajor: 1,
 	}
 
 	// Connecting to the server should work
@@ -224,6 +226,7 @@ func TestHTTPProbeTimeoutFailure(t *testing.T) {
 	config := HTTPProbeConfigOptions{
 		Timeout:       1 * time.Millisecond,
 		HTTPGetAction: newHTTPGetAction(t, server.URL),
+		MaxProtoMajor: 1,
 	}
 	if err := HTTPProbe(config); err == nil {
 		t.Error("Expected probe to fail but it succeeded")
@@ -238,6 +241,7 @@ func TestHTTPProbeResponseStatusCodeFailure(t *testing.T) {
 	config := HTTPProbeConfigOptions{
 		Timeout:       time.Second,
 		HTTPGetAction: newHTTPGetAction(t, server.URL),
+		MaxProtoMajor: 1,
 	}
 	if err := HTTPProbe(config); err == nil {
 		t.Error("Expected probe to fail but it succeeded")
@@ -247,6 +251,7 @@ func TestHTTPProbeResponseStatusCodeFailure(t *testing.T) {
 func TestHTTPProbeResponseErrorFailure(t *testing.T) {
 	config := HTTPProbeConfigOptions{
 		HTTPGetAction: newHTTPGetAction(t, "http://localhost:0"),
+		MaxProtoMajor: 1,
 	}
 	if err := HTTPProbe(config); err == nil {
 		t.Error("Expected probe to fail but it succeeded")

--- a/pkg/queue/readiness/probe.go
+++ b/pkg/queue/readiness/probe.go
@@ -206,8 +206,13 @@ func (p *Probe) tcpProbe() error {
 // if the probe count is greater than success threshold and false if HTTP probe fails
 func (p *Probe) httpProbe() error {
 	config := health.HTTPProbeConfigOptions{
-		HTTPGetAction:   p.HTTPGet,
-		AutoDetectHTTP2: p.autoDetectHTTP2,
+		HTTPGetAction: p.HTTPGet,
+		MaxProtoMajor: 1,
+	}
+	if p.autoDetectHTTP2 {
+		// A value of 0 indicates that the prober should find out which version is
+		// supported.
+		config.MaxProtoMajor = 0
 	}
 
 	return p.doProbe(func(to time.Duration) error {

--- a/pkg/queue/readiness/probe_test.go
+++ b/pkg/queue/readiness/probe_test.go
@@ -18,7 +18,6 @@ package readiness
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -51,7 +50,7 @@ func TestNewProbe(t *testing.T) {
 		},
 	}
 
-	p := NewProbe(context.Background(), v1p)
+	p := NewProbe(v1p)
 
 	if diff := cmp.Diff(p.Probe, v1p); diff != "" {
 		t.Error("NewProbe (-want, +got) =", diff)
@@ -63,7 +62,7 @@ func TestNewProbe(t *testing.T) {
 }
 
 func TestTCPFailure(t *testing.T) {
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
 		TimeoutSeconds:   1,
 		SuccessThreshold: 1,
@@ -82,7 +81,7 @@ func TestTCPFailure(t *testing.T) {
 }
 
 func TestAggressiveFailureOnlyLogsOnce(t *testing.T) {
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0, // Aggressive probe.
 		TimeoutSeconds:   1,
 		SuccessThreshold: 1,
@@ -121,7 +120,7 @@ func TestAggressiveFailureNotLoggedOnSuccess(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0, // Aggressive probe.
 		TimeoutSeconds:   1,
 		SuccessThreshold: 1,
@@ -145,7 +144,7 @@ func TestAggressiveFailureNotLoggedOnSuccess(t *testing.T) {
 }
 
 func TestEmptyHandler(t *testing.T) {
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
 		TimeoutSeconds:   1,
 		SuccessThreshold: 1,
@@ -159,7 +158,7 @@ func TestEmptyHandler(t *testing.T) {
 }
 
 func TestExecHandler(t *testing.T) {
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
 		TimeoutSeconds:   1,
 		SuccessThreshold: 1,
@@ -180,7 +179,7 @@ func TestTCPSuccess(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
 		TimeoutSeconds:   2,
 		SuccessThreshold: 1,
@@ -199,7 +198,7 @@ func TestTCPSuccess(t *testing.T) {
 }
 
 func TestHTTPFailureToConnect(t *testing.T) {
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
 		TimeoutSeconds:   2,
 		SuccessThreshold: 1,
@@ -223,7 +222,7 @@ func TestHTTPBadResponse(t *testing.T) {
 		w.WriteHeader(http.StatusBadRequest)
 	})
 
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
 		TimeoutSeconds:   5,
 		SuccessThreshold: 1,
@@ -247,7 +246,7 @@ func TestHTTPSuccess(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
 		TimeoutSeconds:   5,
 		SuccessThreshold: 1,
@@ -275,7 +274,7 @@ func TestHTTPManyParallel(t *testing.T) {
 		}
 	})
 
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
 		TimeoutSeconds:   5,
 		SuccessThreshold: 1,
@@ -321,7 +320,7 @@ func TestHTTPTimeout(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
 		TimeoutSeconds:   1,
 		SuccessThreshold: 1,
@@ -346,7 +345,7 @@ func TestHTTPSuccessWithDelay(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    1,
 		TimeoutSeconds:   2,
 		SuccessThreshold: 1,
@@ -376,7 +375,7 @@ func TestKnHTTPSuccessWithRetry(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,
 		TimeoutSeconds:   0,
 		SuccessThreshold: 1,
@@ -404,7 +403,7 @@ func TestKnHTTPSuccessWithThreshold(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,
 		TimeoutSeconds:   0,
 		SuccessThreshold: threshold,
@@ -441,7 +440,7 @@ func TestKnHTTPSuccessWithThresholdAndFailure(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,
 		TimeoutSeconds:   0,
 		SuccessThreshold: threshold,
@@ -478,7 +477,7 @@ func TestKnHTTPTimeoutFailure(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,
 		TimeoutSeconds:   0,
 		SuccessThreshold: 1,
@@ -508,7 +507,7 @@ func TestKnTCPProbeSuccess(t *testing.T) {
 	defer listener.Close()
 	addr := listener.Addr().(*net.TCPAddr)
 
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,
 		TimeoutSeconds:   0,
 		SuccessThreshold: 1,
@@ -527,7 +526,7 @@ func TestKnTCPProbeSuccess(t *testing.T) {
 }
 
 func TestKnUnimplementedProbe(t *testing.T) {
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,
 		TimeoutSeconds:   0,
 		SuccessThreshold: 1,
@@ -541,7 +540,7 @@ func TestKnUnimplementedProbe(t *testing.T) {
 }
 
 func TestKnTCPProbeFailure(t *testing.T) {
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,
 		TimeoutSeconds:   0,
 		SuccessThreshold: 1,
@@ -570,7 +569,7 @@ func TestKnTCPProbeSuccessWithThreshold(t *testing.T) {
 	defer listener.Close()
 	addr := listener.Addr().(*net.TCPAddr)
 
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,
 		TimeoutSeconds:   0,
 		SuccessThreshold: 3,
@@ -600,7 +599,7 @@ func TestKnTCPProbeSuccessThresholdIncludesFailure(t *testing.T) {
 	addr := listener.Addr().(*net.TCPAddr)
 
 	var successThreshold int32 = 3
-	pb := NewProbe(context.Background(), &corev1.Probe{
+	pb := NewProbe(&corev1.Probe{
 		PeriodSeconds:    0,
 		TimeoutSeconds:   0,
 		SuccessThreshold: successThreshold,

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -812,6 +812,7 @@ func reconcilerTestConfig() *config.Config {
 			Autoscaler: &autoscalerconfig.Config{
 				InitialScale: 1,
 			},
+			Features: &defaultconfig.Features{},
 		},
 		Deployment: testDeploymentConfig(),
 		Observability: &metrics.ObservabilityConfig{


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

We don't actually read configs in the queue-proxy at all, so the config
will not be part of the context ever. Instead, the queue-proxy uses
environment variables to pass selected feature-flags along.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @rafaeltello @julz 
