### PR TITLE
Add a proxy-builder to make use of passthrough loadbalancing

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -276,7 +276,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 
 	target := net.JoinHostPort("127.0.0.1", env.UserPort)
 
-	httpProxy := pkghttp.NewHeaderPruningReverseProxy(target, "", activator.RevisionHeaders)
+	httpProxy := pkghttp.NewHeaderPruningReverseProxy(target, pkghttp.NoHostOverride, activator.RevisionHeaders)
 	httpProxy.Transport = buildTransport(env, logger, maxIdleConns)
 	httpProxy.ErrorHandler = pkgnet.ErrorHandler(logger)
 	httpProxy.BufferPool = network.NewBufferPool()

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -276,7 +276,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 
 	target := net.JoinHostPort("127.0.0.1", env.UserPort)
 
-	httpProxy := pkghttp.NewHeaderPruningReverseProxy(target, activator.RevisionHeaders)
+	httpProxy := pkghttp.NewHeaderPruningReverseProxy(target, "", activator.RevisionHeaders)
 	httpProxy.Transport = buildTransport(env, logger, maxIdleConns)
 	httpProxy.ErrorHandler = pkgnet.ErrorHandler(logger)
 	httpProxy.BufferPool = network.NewBufferPool()

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -107,7 +107,7 @@ func (a *activationHandler) proxyRequest(revID types.NamespacedName, w http.Resp
 	r.Header.Set(network.ProxyHeaderName, activator.Name)
 
 	// Set up the reverse proxy.
-	proxy := pkghttp.NewHeaderPruningReverseProxy(target, "", activator.RevisionHeaders)
+	proxy := pkghttp.NewHeaderPruningReverseProxy(target, pkghttp.NoHostOverride, activator.RevisionHeaders)
 	proxy.BufferPool = a.bufferPool
 	proxy.Transport = a.transport
 	if tracingEnabled {

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -107,7 +107,7 @@ func (a *activationHandler) proxyRequest(revID types.NamespacedName, w http.Resp
 	r.Header.Set(network.ProxyHeaderName, activator.Name)
 
 	// Set up the reverse proxy.
-	proxy := pkghttp.NewHeaderPruningReverseProxy(target, activator.RevisionHeaders)
+	proxy := pkghttp.NewHeaderPruningReverseProxy(target, "", activator.RevisionHeaders)
 	proxy.BufferPool = a.bufferPool
 	proxy.Transport = a.transport
 	if tracingEnabled {

--- a/pkg/http/proxy.go
+++ b/pkg/http/proxy.go
@@ -24,6 +24,10 @@ import (
 	"knative.dev/pkg/network"
 )
 
+// NoHostOverride signifies that no host overriding should be done and that the host
+// should be inferred from the target of the reverse-proxy.
+const NoHostOverride = ""
+
 // NewHeaderPruningReverseProxy returns a httputil.ReverseProxy that proxies
 // requests to the given targetHost after removing the headersToRemove.
 // If hostOverride is not an empty string, the outgoing request's Host header will be
@@ -35,7 +39,7 @@ func NewHeaderPruningReverseProxy(target, hostOverride string, headersToRemove [
 			req.URL.Scheme = "http"
 			req.URL.Host = target
 
-			if hostOverride != "" {
+			if hostOverride != NoHostOverride {
 				req.Host = hostOverride
 				req.Header.Add(networking.PassthroughLoadbalancingHeaderName, "true")
 			}

--- a/pkg/http/proxy_test.go
+++ b/pkg/http/proxy_test.go
@@ -31,75 +31,6 @@ import (
 
 func TestNewHeaderPruningProxy(t *testing.T) {
 	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewEncoder(w).Encode(r.Header); err != nil {
-			panic(err)
-		}
-	}
-
-	server := httptest.NewServer(handler)
-	serverURL, _ := url.Parse(server.URL)
-
-	defer server.Close()
-
-	tests := []struct {
-		name          string
-		url           string
-		header        http.Header
-		expectHeaders http.Header
-	}{{
-		name: "prunes activator headers, does not add user agent header",
-		url:  "http://example.com/",
-		header: http.Header{
-			"Header-Not-To-Remove": []string{"value"},
-			"Header-To-Remove-1":   []string{"some-value"},
-			"Header-To-Remove-2":   []string{"some-value"},
-		},
-		expectHeaders: http.Header{
-			"Header-Not-To-Remove": []string{"value"},
-		},
-	}, {
-		name: "explicit user agent header not removed",
-		url:  "http://example.com/",
-		header: http.Header{
-			network.UserAgentKey: []string{"gold"},
-		},
-		expectHeaders: http.Header{
-			network.UserAgentKey: []string{"gold"},
-		},
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			proxy := NewHeaderPruningReverseProxy(serverURL.Host, []string{
-				"header-to-remove-1",
-				"header-to-remove-2",
-			})
-
-			resp := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodPost, test.url, nil)
-			req.Header = test.header
-
-			proxy.ServeHTTP(resp, req)
-
-			var proxiedHeaders http.Header
-			if err := json.NewDecoder(resp.Body).Decode(&proxiedHeaders); err != nil {
-				t.Fatalf("Decode = %v", err)
-			}
-
-			// Remove headers golang adds from consideration.
-			for _, k := range []string{"Accept-Encoding", "Content-Length", "X-Forwarded-For"} {
-				proxiedHeaders.Del(k)
-			}
-
-			if got, want := proxiedHeaders, test.expectHeaders; !cmp.Equal(want, got) {
-				t.Errorf("Got Headers=%v, want: %v; diff: %s", got, want, cmp.Diff(want, got))
-			}
-		})
-	}
-}
-
-func TestNewPassthroughLbHeaderPruningReverseProxy(t *testing.T) {
-	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
 		r.Header.Add("Host", r.Host) // Explicitly add the host header so we can assert.
 		if err := json.NewEncoder(w).Encode(r.Header); err != nil {
 			panic(err)
@@ -120,34 +51,42 @@ func TestNewPassthroughLbHeaderPruningReverseProxy(t *testing.T) {
 	}{{
 		name: "prunes activator headers, does not add user agent header",
 		url:  "http://example.com/",
-		host: "foo.bar",
 		header: http.Header{
 			"Header-Not-To-Remove": []string{"value"},
 			"Header-To-Remove-1":   []string{"some-value"},
 			"Header-To-Remove-2":   []string{"some-value"},
 		},
 		expectHeaders: http.Header{
-			"Host":                 []string{"foo.bar"},
+			"Host":                 []string{"example.com"},
 			"Header-Not-To-Remove": []string{"value"},
-			networking.PassthroughLoadbalancingHeaderName: []string{"true"},
 		},
 	}, {
 		name: "explicit user agent header not removed",
 		url:  "http://example.com/",
-		host: "bar.baz",
 		header: http.Header{
 			network.UserAgentKey: []string{"gold"},
 		},
 		expectHeaders: http.Header{
-			"Host":               []string{"bar.baz"},
+			"Host":               []string{"example.com"},
 			network.UserAgentKey: []string{"gold"},
+		},
+	}, {
+		name: "overrides host header",
+		url:  "http://example.com/",
+		host: "foo.bar",
+		header: http.Header{
+			network.UserAgentKey: []string{"gold"},
+		},
+		expectHeaders: http.Header{
+			"Host": []string{"foo.bar"},
 			networking.PassthroughLoadbalancingHeaderName: []string{"true"},
+			network.UserAgentKey:                          []string{"gold"},
 		},
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			proxy := NewPassthroughLbHeaderPruningReverseProxy(serverURL.Host, test.host, []string{
+			proxy := NewHeaderPruningReverseProxy(serverURL.Host, test.host, []string{
 				"header-to-remove-1",
 				"header-to-remove-2",
 			})

--- a/pkg/http/proxy_test.go
+++ b/pkg/http/proxy_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	networking "knative.dev/networking/pkg"
 	"knative.dev/pkg/network"
 )
 
@@ -70,6 +71,83 @@ func TestNewHeaderPruningProxy(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			proxy := NewHeaderPruningReverseProxy(serverURL.Host, []string{
+				"header-to-remove-1",
+				"header-to-remove-2",
+			})
+
+			resp := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, test.url, nil)
+			req.Header = test.header
+
+			proxy.ServeHTTP(resp, req)
+
+			var proxiedHeaders http.Header
+			if err := json.NewDecoder(resp.Body).Decode(&proxiedHeaders); err != nil {
+				t.Fatalf("Decode = %v", err)
+			}
+
+			// Remove headers golang adds from consideration.
+			for _, k := range []string{"Accept-Encoding", "Content-Length", "X-Forwarded-For"} {
+				proxiedHeaders.Del(k)
+			}
+
+			if got, want := proxiedHeaders, test.expectHeaders; !cmp.Equal(want, got) {
+				t.Errorf("Got Headers=%v, want: %v; diff: %s", got, want, cmp.Diff(want, got))
+			}
+		})
+	}
+}
+
+func TestNewPassthroughLbHeaderPruningReverseProxy(t *testing.T) {
+	var handler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+		r.Header.Add("Host", r.Host) // Explicitly add the host header so we can assert.
+		if err := json.NewEncoder(w).Encode(r.Header); err != nil {
+			panic(err)
+		}
+	}
+
+	server := httptest.NewServer(handler)
+	serverURL, _ := url.Parse(server.URL)
+
+	defer server.Close()
+
+	tests := []struct {
+		name          string
+		url           string
+		host          string
+		header        http.Header
+		expectHeaders http.Header
+	}{{
+		name: "prunes activator headers, does not add user agent header",
+		url:  "http://example.com/",
+		host: "foo.bar",
+		header: http.Header{
+			"Header-Not-To-Remove": []string{"value"},
+			"Header-To-Remove-1":   []string{"some-value"},
+			"Header-To-Remove-2":   []string{"some-value"},
+		},
+		expectHeaders: http.Header{
+			"Host":                 []string{"foo.bar"},
+			"Header-Not-To-Remove": []string{"value"},
+			networking.PassthroughLoadbalancingHeaderName: []string{"true"},
+		},
+	}, {
+		name: "explicit user agent header not removed",
+		url:  "http://example.com/",
+		host: "bar.baz",
+		header: http.Header{
+			network.UserAgentKey: []string{"gold"},
+		},
+		expectHeaders: http.Header{
+			"Host":               []string{"bar.baz"},
+			network.UserAgentKey: []string{"gold"},
+			networking.PassthroughLoadbalancingHeaderName: []string{"true"},
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			proxy := NewPassthroughLbHeaderPruningReverseProxy(serverURL.Host, test.host, []string{
 				"header-to-remove-1",
 				"header-to-remove-2",
 			})


### PR DESCRIPTION
Ref #10751

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

In order to utilize Passthrough Loadbalancing in mesh cases, we need to set the correct header and make sure the header is spoofed in correctly. This adds a ReverseProxy implementation that does exactly that to eventually be used in the activator.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
