### PR TITLE
WIP - Add debug log for TestDomainMappingHA

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -95,45 +95,45 @@ if [[ -z "${INGRESS_CLASS}" \
   alpha="--enable-alpha"
 fi
 
-go_test_e2e -timeout=30m \
- ./test/conformance/api/... ./test/conformance/runtime/... \
- ./test/e2e \
-  ${parallelism} \
-  ${alpha} \
-  --enable-beta \
-  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
-
-if (( HTTPS )); then
-  kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found
-  toggle_feature autoTLS Disabled config-network
-fi
-
-toggle_feature tag-header-based-routing Enabled
-go_test_e2e -timeout=2m ./test/e2e/tagheader || failed=1
-toggle_feature tag-header-based-routing Disabled
-
-toggle_feature multi-container Enabled
-go_test_e2e -timeout=2m ./test/e2e/multicontainer || failed=1
-toggle_feature multi-container Disabled
-
-# Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go).
-toggle_feature allow-zero-initial-scale true config-autoscaler || fail_test
-go_test_e2e -timeout=2m ./test/e2e/initscale || failed=1
-toggle_feature allow-zero-initial-scale false config-autoscaler || fail_test
-
-toggle_feature responsive-revision-gc Enabled
-kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml > ${TMP_DIR}/config-gc.yaml
-add_trap "kubectl replace cm 'config-gc' -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml" SIGKILL SIGTERM SIGQUIT
-immediate_gc
-go_test_e2e -timeout=2m ./test/e2e/gc || failed=1
-kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml
-toggle_feature responsive-revision-gc Disabled
-
-# Run scale tests.
-# Note that we use a very high -parallel because each ksvc is run as its own
-# sub-test. If this is not larger than the maximum scale tested then the test
-# simply cannot pass.
-go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
+#go_test_e2e -timeout=30m \
+# ./test/conformance/api/... ./test/conformance/runtime/... \
+# ./test/e2e \
+#  ${parallelism} \
+#  ${alpha} \
+#  --enable-beta \
+#  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
+#
+#if (( HTTPS )); then
+#  kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found
+#  toggle_feature autoTLS Disabled config-network
+#fi
+#
+#toggle_feature tag-header-based-routing Enabled
+#go_test_e2e -timeout=2m ./test/e2e/tagheader || failed=1
+#toggle_feature tag-header-based-routing Disabled
+#
+#toggle_feature multi-container Enabled
+#go_test_e2e -timeout=2m ./test/e2e/multicontainer || failed=1
+#toggle_feature multi-container Disabled
+#
+## Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go).
+#toggle_feature allow-zero-initial-scale true config-autoscaler || fail_test
+#go_test_e2e -timeout=2m ./test/e2e/initscale || failed=1
+#toggle_feature allow-zero-initial-scale false config-autoscaler || fail_test
+#
+#toggle_feature responsive-revision-gc Enabled
+#kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml > ${TMP_DIR}/config-gc.yaml
+#add_trap "kubectl replace cm 'config-gc' -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml" SIGKILL SIGTERM SIGQUIT
+#immediate_gc
+#go_test_e2e -timeout=2m ./test/e2e/gc || failed=1
+#kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml
+#toggle_feature responsive-revision-gc Disabled
+#
+## Run scale tests.
+## Note that we use a very high -parallel because each ksvc is run as its own
+## sub-test. If this is not larger than the maximum scale tested then the test
+## simply cannot pass.
+#go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
 
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -133,7 +133,7 @@ fi
 ## Note that we use a very high -parallel because each ksvc is run as its own
 ## sub-test. If this is not larger than the maximum scale tested then the test
 ## simply cannot pass.
-#go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
+go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
 
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -95,13 +95,13 @@ if [[ -z "${INGRESS_CLASS}" \
   alpha="--enable-alpha"
 fi
 
-go_test_e2e -timeout=30m \
- ./test/conformance/api/... ./test/conformance/runtime/... \
- ./test/e2e \
-  ${parallelism} \
-  ${alpha} \
-  --enable-beta \
-  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
+#go_test_e2e -timeout=30m \
+# ./test/conformance/api/... ./test/conformance/runtime/... \
+# ./test/e2e \
+#  ${parallelism} \
+#  ${alpha} \
+#  --enable-beta \
+#  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 
 if (( HTTPS )); then
   kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found
@@ -140,7 +140,7 @@ go_test_e2e -timeout=25m -failfast -parallel=1 ./test/ha \
 # Note that we use a very high -parallel because each ksvc is run as its own
 # sub-test. If this is not larger than the maximum scale tested then the test
 # simply cannot pass.
-go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
+#go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
 
 (( failed )) && fail_test
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -131,7 +131,7 @@ fi
 
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.
-go_test_e2e -timeout=25m -failfast -parallel=1 ./test/ha \
+go_test_e2e -timeout=25m -failfast -parallel=1 ./test/ha -run TestDomainMappingHA \
             ${alpha} \
             --enable-beta \
 	    -replicas="${REPLICAS:-1}" -buckets="${BUCKETS:-1}" -spoofinterval="10ms" || failed=1

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -108,26 +108,26 @@ if (( HTTPS )); then
   toggle_feature autoTLS Disabled config-network
 fi
 
-toggle_feature tag-header-based-routing Enabled
-go_test_e2e -timeout=2m ./test/e2e/tagheader || failed=1
-toggle_feature tag-header-based-routing Disabled
-
-toggle_feature multi-container Enabled
-go_test_e2e -timeout=2m ./test/e2e/multicontainer || failed=1
-toggle_feature multi-container Disabled
-
-# Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go).
-toggle_feature allow-zero-initial-scale true config-autoscaler || fail_test
-go_test_e2e -timeout=2m ./test/e2e/initscale || failed=1
-toggle_feature allow-zero-initial-scale false config-autoscaler || fail_test
-
-toggle_feature responsive-revision-gc Enabled
-kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml > ${TMP_DIR}/config-gc.yaml
-add_trap "kubectl replace cm 'config-gc' -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml" SIGKILL SIGTERM SIGQUIT
-immediate_gc
-go_test_e2e -timeout=2m ./test/e2e/gc || failed=1
-kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml
-toggle_feature responsive-revision-gc Disabled
+#toggle_feature tag-header-based-routing Enabled
+#go_test_e2e -timeout=2m ./test/e2e/tagheader || failed=1
+#toggle_feature tag-header-based-routing Disabled
+#
+#toggle_feature multi-container Enabled
+#go_test_e2e -timeout=2m ./test/e2e/multicontainer || failed=1
+#toggle_feature multi-container Disabled
+#
+## Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go).
+#toggle_feature allow-zero-initial-scale true config-autoscaler || fail_test
+#go_test_e2e -timeout=2m ./test/e2e/initscale || failed=1
+#toggle_feature allow-zero-initial-scale false config-autoscaler || fail_test
+#
+#toggle_feature responsive-revision-gc Enabled
+#kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml > ${TMP_DIR}/config-gc.yaml
+#add_trap "kubectl replace cm 'config-gc' -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml" SIGKILL SIGTERM SIGQUIT
+#immediate_gc
+#go_test_e2e -timeout=2m ./test/e2e/gc || failed=1
+#kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml
+#toggle_feature responsive-revision-gc Disabled
 
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -95,45 +95,39 @@ if [[ -z "${INGRESS_CLASS}" \
   alpha="--enable-alpha"
 fi
 
-#go_test_e2e -timeout=30m \
-# ./test/conformance/api/... ./test/conformance/runtime/... \
-# ./test/e2e \
-#  ${parallelism} \
-#  ${alpha} \
-#  --enable-beta \
-#  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
+go_test_e2e -timeout=30m \
+ ./test/conformance/api/... ./test/conformance/runtime/... \
+ ./test/e2e \
+  ${parallelism} \
+  ${alpha} \
+  --enable-beta \
+  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 
 if (( HTTPS )); then
   kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found
   toggle_feature autoTLS Disabled config-network
 fi
 
-#toggle_feature tag-header-based-routing Enabled
-#go_test_e2e -timeout=2m ./test/e2e/tagheader || failed=1
-#toggle_feature tag-header-based-routing Disabled
-#
-#toggle_feature multi-container Enabled
-#go_test_e2e -timeout=2m ./test/e2e/multicontainer || failed=1
-#toggle_feature multi-container Disabled
-#
-## Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go).
-#toggle_feature allow-zero-initial-scale true config-autoscaler || fail_test
-#go_test_e2e -timeout=2m ./test/e2e/initscale || failed=1
-#toggle_feature allow-zero-initial-scale false config-autoscaler || fail_test
-#
-#toggle_feature responsive-revision-gc Enabled
-#kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml > ${TMP_DIR}/config-gc.yaml
-#add_trap "kubectl replace cm 'config-gc' -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml" SIGKILL SIGTERM SIGQUIT
-#immediate_gc
-#go_test_e2e -timeout=2m ./test/e2e/gc || failed=1
-#kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml
-#toggle_feature responsive-revision-gc Disabled
-#
-## Run scale tests.
-## Note that we use a very high -parallel because each ksvc is run as its own
-## sub-test. If this is not larger than the maximum scale tested then the test
-## simply cannot pass.
-#go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
+toggle_feature tag-header-based-routing Enabled
+go_test_e2e -timeout=2m ./test/e2e/tagheader || failed=1
+toggle_feature tag-header-based-routing Disabled
+
+toggle_feature multi-container Enabled
+go_test_e2e -timeout=2m ./test/e2e/multicontainer || failed=1
+toggle_feature multi-container Disabled
+
+# Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go).
+toggle_feature allow-zero-initial-scale true config-autoscaler || fail_test
+go_test_e2e -timeout=2m ./test/e2e/initscale || failed=1
+toggle_feature allow-zero-initial-scale false config-autoscaler || fail_test
+
+toggle_feature responsive-revision-gc Enabled
+kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml > ${TMP_DIR}/config-gc.yaml
+add_trap "kubectl replace cm 'config-gc' -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml" SIGKILL SIGTERM SIGQUIT
+immediate_gc
+go_test_e2e -timeout=2m ./test/e2e/gc || failed=1
+kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml
+toggle_feature responsive-revision-gc Disabled
 
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.
@@ -141,6 +135,12 @@ go_test_e2e -timeout=25m -failfast -parallel=1 ./test/ha \
             ${alpha} \
             --enable-beta \
 	    -replicas="${REPLICAS:-1}" -buckets="${BUCKETS:-1}" -spoofinterval="10ms" || failed=1
+
+# Run scale tests.
+# Note that we use a very high -parallel because each ksvc is run as its own
+# sub-test. If this is not larger than the maximum scale tested then the test
+# simply cannot pass.
+go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
 
 (( failed )) && fail_test
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -133,7 +133,7 @@ fi
 ## Note that we use a very high -parallel because each ksvc is run as its own
 ## sub-test. If this is not larger than the maximum scale tested then the test
 ## simply cannot pass.
-go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
+#go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
 
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -95,13 +95,13 @@ if [[ -z "${INGRESS_CLASS}" \
   alpha="--enable-alpha"
 fi
 
-go_test_e2e -timeout=30m \
- ./test/conformance/api/... ./test/conformance/runtime/... \
- ./test/e2e \
-  ${parallelism} \
-  ${alpha} \
-  --enable-beta \
-  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
+#go_test_e2e -timeout=30m \
+# ./test/conformance/api/... ./test/conformance/runtime/... \
+# ./test/e2e \
+#  ${parallelism} \
+#  ${alpha} \
+#  --enable-beta \
+#  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
 
 if (( HTTPS )); then
   kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -95,19 +95,19 @@ if [[ -z "${INGRESS_CLASS}" \
   alpha="--enable-alpha"
 fi
 
-#go_test_e2e -timeout=30m \
-# ./test/conformance/api/... ./test/conformance/runtime/... \
-# ./test/e2e \
-#  ${parallelism} \
-#  ${alpha} \
-#  --enable-beta \
-#  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
-#
-#if (( HTTPS )); then
-#  kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found
-#  toggle_feature autoTLS Disabled config-network
-#fi
-#
+go_test_e2e -timeout=30m \
+ ./test/conformance/api/... ./test/conformance/runtime/... \
+ ./test/e2e \
+  ${parallelism} \
+  ${alpha} \
+  --enable-beta \
+  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
+
+if (( HTTPS )); then
+  kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found
+  toggle_feature autoTLS Disabled config-network
+fi
+
 #toggle_feature tag-header-based-routing Enabled
 #go_test_e2e -timeout=2m ./test/e2e/tagheader || failed=1
 #toggle_feature tag-header-based-routing Disabled

--- a/test/ha/domainmapping_test.go
+++ b/test/ha/domainmapping_test.go
@@ -19,8 +19,6 @@ limitations under the License.
 package ha
 
 import (
-	"fmt"
-
 	"context"
 	"net/url"
 	"testing"
@@ -181,7 +179,6 @@ func TestDomainMappingHA(t *testing.T) {
 	// The second DomainMapping should now be able to claim the domain.
 	waitErr = wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
 		state, err := altClients.ServingAlphaClient.DomainMappings.Get(ctx, altDm.Name, metav1.GetOptions{})
-		fmt.Printf("The second DomainMapping %s was state \n%+v\n: %v", dm.Name, state, err)
 		return state.IsReady(), err
 	})
 	if waitErr != nil {

--- a/test/ha/domainmapping_test.go
+++ b/test/ha/domainmapping_test.go
@@ -19,6 +19,8 @@ limitations under the License.
 package ha
 
 import (
+	"fmt"
+
 	"context"
 	"net/url"
 	"testing"
@@ -179,6 +181,7 @@ func TestDomainMappingHA(t *testing.T) {
 	// The second DomainMapping should now be able to claim the domain.
 	waitErr = wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
 		state, err := altClients.ServingAlphaClient.DomainMappings.Get(ctx, altDm.Name, metav1.GetOptions{})
+		fmt.Printf("The second DomainMapping %s was state \n%+v\n: %v", dm.Name, state, err)
 		return state.IsReady(), err
 	})
 	if waitErr != nil {

--- a/test/ha/domainmapping_test.go
+++ b/test/ha/domainmapping_test.go
@@ -1,7 +1,7 @@
 // +build e2e
 
 /*
-Copyright 2020 The Knative Authors
+Copyright 2021 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,28 +19,47 @@ limitations under the License.
 package ha
 
 import (
+	"fmt"
+
 	"context"
 	"net/url"
 	"testing"
 
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/reconciler"
+	"knative.dev/pkg/system"
+	pkgTest "knative.dev/pkg/test"
+	pkgHa "knative.dev/pkg/test/ha"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
+	v1alpha1test "knative.dev/serving/pkg/testing/v1alpha1"
 	"knative.dev/serving/test"
-	"knative.dev/serving/test/conformance/api/shared"
 	"knative.dev/serving/test/e2e"
 	v1test "knative.dev/serving/test/v1"
 )
 
-func TestDomainMapping(t *testing.T) {
+const (
+	domainmappingDeploymentName = "domain-mapping"
+)
+
+func TestDomainMappingHA(t *testing.T) {
 	if !test.ServingFlags.EnableAlphaFeatures {
 		t.Skip("Alpha features not enabled")
 	}
 
-	t.Parallel()
 	ctx, clients := context.Background(), test.Setup(t)
+
+	if err := pkgTest.WaitForDeploymentScale(ctx, clients.KubeClient, domainmappingDeploymentName, system.Namespace(), test.ServingFlags.Replicas); err != nil {
+		t.Fatalf("Deployment %s not scaled to %d: %v", domainmappingDeploymentName, test.ServingFlags.Replicas, err)
+	}
+
+	leaders, err := pkgHa.WaitForNewLeaders(ctx, t, clients.KubeClient, domainmappingDeploymentName, system.Namespace(), sets.NewString(), test.ServingFlags.Buckets)
+	if err != nil {
+		t.Fatal("Failed to get leader:", err)
+	}
+	t.Log("Got initial leader set:", leaders)
 
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),
@@ -69,20 +88,9 @@ func TestDomainMapping(t *testing.T) {
 	// Point DomainMapping at our service.
 	var dm *v1alpha1.DomainMapping
 	if err := reconciler.RetryTestErrors(func(int) error {
-		dm, err = clients.ServingAlphaClient.DomainMappings.Create(ctx, &v1alpha1.DomainMapping{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: svc.Service.Namespace,
-			},
-			Spec: v1alpha1.DomainMappingSpec{
-				Ref: duckv1.KReference{
-					Namespace:  svc.Service.Namespace,
-					Name:       svc.Service.Name,
-					APIVersion: "serving.knative.dev/v1",
-					Kind:       "Service",
-				},
-			},
-		}, metav1.CreateOptions{})
+		dm, err = clients.ServingAlphaClient.DomainMappings.Create(ctx,
+			v1alpha1test.DomainMapping(svc.Service.Namespace, host, v1alpha1test.KReference(svc.Service.Namespace, svc.Service.Name)),
+			metav1.CreateOptions{})
 		return err
 	}); err != nil {
 		t.Fatalf("Create(DomainMapping) = %v, expected no error", err)
@@ -94,21 +102,31 @@ func TestDomainMapping(t *testing.T) {
 
 	// Wait for DomainMapping to go Ready.
 	waitErr := wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
-		state, err := clients.ServingAlphaClient.DomainMappings.Get(context.Background(), dm.Name, metav1.GetOptions{})
-		if err != nil {
-			return true, err
-		}
-
-		return state.IsReady(), nil
+		state, err := clients.ServingAlphaClient.DomainMappings.Get(ctx, dm.Name, metav1.GetOptions{})
+		return state.IsReady(), err
 	})
 	if waitErr != nil {
 		t.Fatalf("The DomainMapping %s was not marked as Ready: %v", dm.Name, waitErr)
 	}
 
-	// Should be able to access the test image text via the mapped domain.
-	if err := shared.CheckDistribution(ctx, t, clients, &url.URL{Host: host, Scheme: "http"}, test.ConcurrentRequests, test.ConcurrentRequests, []string{test.PizzaPlanetText1}, resolvableCustomDomain); err != nil {
-		t.Errorf("CheckDistribution=%v, expected no error", err)
+	assertServiceEventuallyWorks(t, clients, names, &url.URL{Scheme: "http", Host: host}, test.PizzaPlanetText1, resolvableCustomDomain)
+
+	for _, leader := range leaders.List() {
+		if err := clients.KubeClient.CoreV1().Pods(system.Namespace()).Delete(ctx, leader,
+			metav1.DeleteOptions{}); err != nil && !apierrs.IsNotFound(err) {
+			t.Fatalf("Failed to delete pod %s: %v", leader, err)
+		}
+		if err := pkgTest.WaitForPodDeleted(ctx, clients.KubeClient, leader, system.Namespace()); err != nil {
+			t.Fatalf("Did not observe %s to actually be deleted: %v", leader, err)
+		}
 	}
+
+	// Wait for all of the old leaders to go away, and then for the right number to be back.
+	if _, err := pkgHa.WaitForNewLeaders(ctx, t, clients.KubeClient, domainmappingDeploymentName, system.Namespace(), leaders, test.ServingFlags.Buckets); err != nil {
+		t.Fatal("Failed to find new leader:", err)
+	}
+
+	// Verify that after changing the leader we can still create a new domainmapping and the second DomainMapping collided with the first.
 
 	altClients := e2e.SetupAlternativeNamespace(t)
 	altNames := test.ResourceNames{
@@ -126,20 +144,9 @@ func TestDomainMapping(t *testing.T) {
 	// Create second domain mapping with same name in alt namespace - this will collide with the existing mapping.
 	var altDm *v1alpha1.DomainMapping
 	if err := reconciler.RetryTestErrors(func(int) error {
-		altDm, err = altClients.ServingAlphaClient.DomainMappings.Create(ctx, &v1alpha1.DomainMapping{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host,
-				Namespace: altSvc.Service.Namespace,
-			},
-			Spec: v1alpha1.DomainMappingSpec{
-				Ref: duckv1.KReference{
-					Namespace:  altSvc.Service.Namespace,
-					Name:       altSvc.Service.Name,
-					APIVersion: "serving.knative.dev/v1",
-					Kind:       "Service",
-				},
-			},
-		}, metav1.CreateOptions{})
+		altDm, err = altClients.ServingAlphaClient.DomainMappings.Create(ctx,
+			v1alpha1test.DomainMapping(altSvc.Service.Namespace, host, v1alpha1test.KReference(altSvc.Service.Namespace, altSvc.Service.Name)),
+			metav1.CreateOptions{})
 		return err
 	}); err != nil {
 		t.Fatalf("Create(DomainMapping) = %v, expected no error", err)
@@ -151,9 +158,9 @@ func TestDomainMapping(t *testing.T) {
 
 	// Second domain mapping should go to DomainMappingConditionDomainClaimed=false state.
 	waitErr = wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
-		state, err := altClients.ServingAlphaClient.DomainMappings.Get(context.Background(), dm.Name, metav1.GetOptions{})
+		state, err := altClients.ServingAlphaClient.DomainMappings.Get(ctx, dm.Name, metav1.GetOptions{})
 		if err != nil {
-			return true, err
+			return false, err
 		}
 
 		return state.Generation == state.Status.ObservedGeneration &&
@@ -164,9 +171,7 @@ func TestDomainMapping(t *testing.T) {
 	}
 
 	// Because the second DomainMapping collided with the first, it should not have taken effect.
-	if err := shared.CheckDistribution(ctx, t, clients, &url.URL{Host: host, Scheme: "http"}, test.ConcurrentRequests, test.ConcurrentRequests, []string{test.PizzaPlanetText1}, resolvableCustomDomain); err != nil {
-		t.Errorf("CheckDistribution=%v, expected no error", err)
-	}
+	assertServiceEventuallyWorks(t, clients, names, &url.URL{Scheme: "http", Host: host}, test.PizzaPlanetText1, resolvableCustomDomain)
 
 	// Delete the first DomainMapping.
 	if err := clients.ServingAlphaClient.DomainMappings.Delete(ctx, dm.Name, metav1.DeleteOptions{}); err != nil {
@@ -175,19 +180,14 @@ func TestDomainMapping(t *testing.T) {
 
 	// The second DomainMapping should now be able to claim the domain.
 	waitErr = wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
-		state, err := altClients.ServingAlphaClient.DomainMappings.Get(context.Background(), altDm.Name, metav1.GetOptions{})
-		if err != nil {
-			return true, err
-		}
-
-		return state.IsReady(), nil
+		state, err := altClients.ServingAlphaClient.DomainMappings.Get(ctx, altDm.Name, metav1.GetOptions{})
+		fmt.Printf("The second DomainMapping %s was state \n%+v\n: %v", dm.Name, state, err)
+		return state.IsReady(), err
 	})
 	if waitErr != nil {
 		t.Fatalf("The second DomainMapping %s was not marked as Ready: %v", dm.Name, waitErr)
 	}
 
 	// The domain name should now point to the second service.
-	if err := shared.CheckDistribution(ctx, t, clients, &url.URL{Host: host, Scheme: "http"}, test.ConcurrentRequests, test.ConcurrentRequests, []string{test.PizzaPlanetText2}, resolvableCustomDomain); err != nil {
-		t.Errorf("CheckDistribution=%v, expected no error", err)
-	}
+	assertServiceEventuallyWorks(t, clients, names, &url.URL{Scheme: "http", Host: host}, test.PizzaPlanetText2, resolvableCustomDomain)
 }

--- a/third_party/kourier-latest/kourier.yaml
+++ b/third_party/kourier-latest/kourier.yaml
@@ -193,7 +193,7 @@ spec:
         app: 3scale-kourier-control
     spec:
       containers:
-        - image: gcr.io/knative-nightly/knative.dev/net-kourier/cmd/kourier@sha256:9179151b77ea735c569ab3fce38ff3ac09e872f528837467f1a3e7bd1c208e5f
+        - image: gcr.io/gcp-compute-engine-223401/kourier-b74c3918b7eee585f87df62ccd297dc8@sha256:83e86f715df828a0902118349f59dffda9604b5caa4c84c15b617607348212eb
           name: kourier-control
           env:
             - name: CERTS_SECRET_NAMESPACE


### PR DESCRIPTION
/cc

This patch debugs TestDomainMappingHA as https://testgrid.knative.dev/serving#kourier-stable&sort-by-failures=.

Only kourier always fails TestDomainMappingHA due to:
```
    domainmapping_test.go:185: The second DomainMapping domain-mapping-h-a-wggssbue.example.org was not marked as Ready: timed out waiting for the condition
```
