### PR TITLE
Bump request timeout in TestProbeQueueNotReady to fix flake

### DIFF
--- a/cmd/queue/execprobe_test.go
+++ b/cmd/queue/execprobe_test.go
@@ -54,7 +54,7 @@ func TestProbeQueueNotReady(t *testing.T) {
 		w.WriteHeader(http.StatusBadRequest)
 	})
 
-	err := probeQueueHealthPath(100*time.Millisecond, port, http.DefaultTransport)
+	err := probeQueueHealthPath(300*time.Millisecond, port, http.DefaultTransport)
 
 	if err == nil || err.Error() != "probe returned not ready" {
 		t.Error("Unexpected not ready error:", err)


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/11048

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As per title, we went a little bit too aggressive with the timeouts on this endpoint so let's give it a little bit more leeway.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz  @vagababov 
