### PR TITLE
Drop explicit namespaces and system imports

### DIFF
--- a/pkg/activator/config/store_test.go
+++ b/pkg/activator/config/store_test.go
@@ -28,8 +28,7 @@ import (
 
 var tracingConfig = &corev1.ConfigMap{
 	ObjectMeta: metav1.ObjectMeta{
-		Namespace: "knative-serving",
-		Name:      tracingconfig.ConfigName,
+		Name: tracingconfig.ConfigName,
 	},
 	Data: map[string]string{
 		"backend": "none",
@@ -50,8 +49,7 @@ func TestStore(t *testing.T) {
 
 	newConfig := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "knative-serving",
-			Name:      tracingconfig.ConfigName,
+			Name: tracingconfig.ConfigName,
 		},
 		Data: map[string]string{
 			"backend":         "zipkin",

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -49,7 +49,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/pkg/logging"
-	_ "knative.dev/pkg/system/testing"
 )
 
 const (

--- a/pkg/activator/handler/tracing_handler_test.go
+++ b/pkg/activator/handler/tracing_handler_test.go
@@ -100,8 +100,7 @@ func TestTracingHandler(t *testing.T) {
 func tracingConfig(enabled bool) *corev1.ConfigMap {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "knative-serving",
-			Name:      config.ConfigName,
+			Name: config.ConfigName,
 		},
 		Data: map[string]string{
 			"backend": "none",

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -39,7 +39,6 @@ import (
 	fakeendpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints/fake"
 	. "knative.dev/pkg/logging/testing"
 	rtesting "knative.dev/pkg/reconciler/testing"
-	_ "knative.dev/pkg/system/testing"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

I accidentally added some explicit namespaces, which are the only usages of those in our codebase, so cleaning those up. Also removed the system namespace imports in the activator since nothing should need those to be set here explicitly.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @julz 
