### PR TITLE
Thread network config into the autoscaler

### DIFF
--- a/pkg/reconciler/autoscaling/config/store.go
+++ b/pkg/reconciler/autoscaling/config/store.go
@@ -19,6 +19,7 @@ package config
 import (
 	"context"
 
+	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/configmap"
 	asconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
@@ -32,6 +33,7 @@ type cfgKey struct{}
 type Config struct {
 	Autoscaler *autoscalerconfig.Config
 	Deployment *deployment.Config
+	Network    *network.Config
 }
 
 // FromContext fetch config from context.
@@ -67,6 +69,7 @@ func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value i
 			configmap.Constructors{
 				asconfig.ConfigName:   asconfig.NewConfigFromConfigMap,
 				deployment.ConfigName: deployment.NewConfigFromConfigMap,
+				network.ConfigName:    network.NewConfigFromConfigMap,
 			},
 			onAfterStore...,
 		),
@@ -84,5 +87,6 @@ func (s *Store) Load() *Config {
 	return &Config{
 		Autoscaler: s.UntypedLoad(asconfig.ConfigName).(*autoscalerconfig.Config).DeepCopy(),
 		Deployment: s.UntypedLoad(deployment.ConfigName).(*deployment.Config).DeepCopy(),
+		Network:    s.UntypedLoad(network.ConfigName).(*network.Config).DeepCopy(),
 	}
 }

--- a/pkg/reconciler/autoscaling/config/store_test.go
+++ b/pkg/reconciler/autoscaling/config/store_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	logtesting "knative.dev/pkg/logging/testing"
 
+	network "knative.dev/networking/pkg"
 	. "knative.dev/pkg/configmap/testing"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
@@ -34,8 +35,10 @@ func TestStoreLoadWithContext(t *testing.T) {
 
 	autoscalerConfig := ConfigMapFromTestFile(t, autoscalerconfig.ConfigName)
 	depConfig := ConfigMapFromTestFile(t, deployment.ConfigName, deployment.QueueSidecarImageKey)
+	networkConfig := ConfigMapFromTestFile(t, network.ConfigName)
 	store.OnConfigChanged(autoscalerConfig)
 	store.OnConfigChanged(depConfig)
+	store.OnConfigChanged(networkConfig)
 	config := FromContext(store.ToContext(context.Background()))
 
 	wantAS, _ := autoscalerconfig.NewConfigFromConfigMap(autoscalerConfig)
@@ -46,6 +49,11 @@ func TestStoreLoadWithContext(t *testing.T) {
 	if !cmp.Equal(wantD, config.Deployment) {
 		t.Error("Deployment ConfigMap mismatch (-want, +got):", cmp.Diff(wantD, config.Deployment))
 	}
+
+	wantN, _ := network.NewConfigFromConfigMap(networkConfig)
+	if !cmp.Equal(wantN, config.Network) {
+		t.Error("Network ConfigMap mismatch (-want, +got):", cmp.Diff(wantN, config.Network))
+	}
 }
 
 func TestStoreImmutableConfig(t *testing.T) {
@@ -54,6 +62,7 @@ func TestStoreImmutableConfig(t *testing.T) {
 	store.OnConfigChanged(ConfigMapFromTestFile(t, autoscalerconfig.ConfigName))
 	store.OnConfigChanged(ConfigMapFromTestFile(t, deployment.ConfigName,
 		deployment.QueueSidecarImageKey))
+	store.OnConfigChanged(ConfigMapFromTestFile(t, network.ConfigName))
 
 	config := store.Load()
 	config.Autoscaler.MaxScaleUpRate = 100.0

--- a/pkg/reconciler/autoscaling/config/testdata/config-network.yaml
+++ b/pkg/reconciler/autoscaling/config/testdata/config-network.yaml
@@ -1,0 +1,1 @@
+../../../../../config/core/configmaps/network.yaml

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ktesting "k8s.io/client-go/testing"
 
+	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking"
 	nv1a1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/configmap"
@@ -92,6 +93,13 @@ func TestControllerCanReconcile(t *testing.T) {
 			Data: map[string]string{
 				deployment.QueueSidecarImageKey: "motorbike-sidecar",
 			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      network.ConfigName,
+			},
+			Data: map[string]string{},
 		}))
 
 	waitInformers, err := RunAndSyncInformers(ctx, infs...)

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -58,6 +58,7 @@ import (
 	"go.uber.org/atomic"
 	"golang.org/x/sync/errgroup"
 
+	network "knative.dev/networking/pkg"
 	nv1a1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/configmap"
@@ -145,6 +146,11 @@ func newConfigWatcher() configmap.Watcher {
 		},
 		Data: map[string]string{
 			deployment.QueueSidecarImageKey: "covid is here",
+		},
+	}, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: system.Namespace(),
+			Name:      network.ConfigName,
 		},
 	})
 }
@@ -1225,6 +1231,12 @@ func TestGlobalResyncOnUpdateAutoscalerConfigMap(t *testing.T) {
 		},
 		Data: map[string]string{
 			deployment.QueueSidecarImageKey: "i'm on a bike",
+		},
+	})
+	watcher.OnChange(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      network.ConfigName,
+			Namespace: system.Namespace(),
 		},
 	})
 


### PR DESCRIPTION
Ref https://github.com/knative/serving/issues/10751

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This threads the networking config into the autoscalers's config and adjusts the mechanisms necessary to make everything still work. I'm defensively sending these in as separate PRs to avoid us not catching some weird edge case.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
