### PR TITLE
Remove hardcoded config names throughout

### DIFF
--- a/pkg/activator/config/store_test.go
+++ b/pkg/activator/config/store_test.go
@@ -29,7 +29,7 @@ import (
 var tracingConfig = &corev1.ConfigMap{
 	ObjectMeta: metav1.ObjectMeta{
 		Namespace: "knative-serving",
-		Name:      "config-tracing",
+		Name:      tracingconfig.ConfigName,
 	},
 	Data: map[string]string{
 		"backend": "none",
@@ -51,7 +51,7 @@ func TestStore(t *testing.T) {
 	newConfig := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "knative-serving",
-			Name:      "config-tracing",
+			Name:      tracingconfig.ConfigName,
 		},
 		Data: map[string]string{
 			"backend":         "zipkin",

--- a/pkg/activator/handler/tracing_handler_test.go
+++ b/pkg/activator/handler/tracing_handler_test.go
@@ -101,7 +101,7 @@ func tracingConfig(enabled bool) *corev1.ConfigMap {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "knative-serving",
-			Name:      "config-tracing",
+			Name:      config.ConfigName,
 		},
 		Data: map[string]string{
 			"backend": "none",

--- a/pkg/gc/config_test.go
+++ b/pkg/gc/config_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestOurConfig(t *testing.T) {
-	actual, example := ConfigMapsFromTestFile(t, "config-gc")
+	actual, example := ConfigMapsFromTestFile(t, ConfigName)
 	for _, tt := range []struct {
 		name string
 		fail bool

--- a/pkg/leaderelection/config_test.go
+++ b/pkg/leaderelection/config_test.go
@@ -90,7 +90,7 @@ func TestValidateConfig(t *testing.T) {
 }
 
 func TestServingConfig(t *testing.T) {
-	actual, example := ConfigMapsFromTestFile(t, "config-leader-election")
+	actual, example := ConfigMapsFromTestFile(t, kle.ConfigMapName())
 	for _, test := range []struct {
 		name string
 		data *corev1.ConfigMap

--- a/pkg/reconciler/gc/config/store_test.go
+++ b/pkg/reconciler/gc/config/store_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	logtesting "knative.dev/pkg/logging/testing"
+	apicfg "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/gc"
 
 	. "knative.dev/pkg/configmap/testing"
@@ -32,8 +33,8 @@ func TestStoreLoadWithContext(t *testing.T) {
 	ctx := logtesting.TestContextWithLogger(t)
 	store := NewStore(ctx)
 
-	gcConfig := ConfigMapFromTestFile(t, "config-gc")
-	featuresConfig := ConfigMapFromTestFile(t, "config-features")
+	gcConfig := ConfigMapFromTestFile(t, gc.ConfigName)
+	featuresConfig := ConfigMapFromTestFile(t, apicfg.FeaturesConfigName)
 
 	store.OnConfigChanged(gcConfig)
 	store.OnConfigChanged(featuresConfig)

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -87,7 +87,7 @@ func newTestSetup(t *testing.T, configs ...*corev1.ConfigMap) (
 
 	cms := []*corev1.ConfigMap{{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "config-network",
+			Name:      network.ConfigName,
 			Namespace: system.Namespace(),
 		},
 		Data: map[string]string{


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Drive-by cleanup. Replaced various "hardcoded" occurrences of config map names with their respective constants.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
