### PR TITLE
Use kubectl replace instead of patch to restore config-gc

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -122,11 +122,11 @@ go_test_e2e -timeout=2m ./test/e2e/initscale || failed=1
 toggle_feature allow-zero-initial-scale false config-autoscaler || fail_test
 
 toggle_feature responsive-revision-gc Enabled
-GC_CONFIG=$(kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml)
-add_trap "kubectl patch cm 'config-gc' -n ${SYSTEM_NAMESPACE} -p ${GC_CONFIG}" SIGKILL SIGTERM SIGQUIT
+kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml > ${TMP_DIR}/config-gc.yaml
+add_trap "kubectl replace cm 'config-gc' -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml" SIGKILL SIGTERM SIGQUIT
 immediate_gc
 go_test_e2e -timeout=2m ./test/e2e/gc || failed=1
-kubectl patch cm "config-gc" -n ${SYSTEM_NAMESPACE} -p ${GC_CONFIG}
+kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml
 toggle_feature responsive-revision-gc Disabled
 
 # Run scale tests.


### PR DESCRIPTION
The following commands in test/e2e-tests.sh:

```
GC_CONFIG=$(kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml)
kubectl patch cm "config-gc" -n ${SYSTEM_NAMESPACE} -p ${GC_CONFIG}
```

It always failing with the following error. This is replicable in the local env - [example log](https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_serving/11037/pull-knative-serving-kourier-stable/1376356755298062336).

```
2021/03/29 02:42:48 Getting artifacts dir from prow
Error: bad flag syntax: ---------------------------------------
```

Hence this patch fixes it by using `kubectl replace` instead of `patch`.

**Release Note**

```release-note
NONE
```

/cc @whaught @chizhg 