### PR TITLE
Add specific port to instruct istio to open correct listener

### DIFF
--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -155,6 +155,14 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 				Protocol:   corev1.ProtocolTCP,
 				Port:       networking.QueueAdminPort,
 				TargetPort: intstr.FromInt(networking.QueueAdminPort),
+			}, {
+				// When run with the Istio mesh and with the pod-addressability feature
+				// enabled, this mirrors the target port to the "outer" service port to
+				// instruct Istio to open the respective listener on the pod.
+				Name:       pkgnet.ServicePortName(sks.Spec.ProtocolType) + "-istio",
+				Protocol:   corev1.ProtocolTCP,
+				Port:       targetPort(sks).IntVal,
+				TargetPort: targetPort(sks),
 			}},
 			Selector: selector,
 		},

--- a/pkg/reconciler/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/serverlessservice/resources/services_test.go
@@ -144,6 +144,11 @@ func privateSvcMod(s *corev1.Service) {
 			Protocol:   corev1.ProtocolTCP,
 			Port:       networking.QueueAdminPort,
 			TargetPort: intstr.FromInt(networking.QueueAdminPort),
+		}, {
+			Name:       pkgnet.ServicePortNameHTTP1 + "-istio",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       networking.BackendHTTPPort,
+			TargetPort: intstr.FromInt(networking.BackendHTTPPort),
 		}}...)
 }
 
@@ -412,6 +417,12 @@ func TestMakePrivateService(t *testing.T) {
 				Name:       pkgnet.ServicePortNameH2C,
 				Protocol:   corev1.ProtocolTCP,
 				Port:       pkgnet.ServiceHTTPPort,
+				TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
+			}
+			s.Spec.Ports[4] = corev1.ServicePort{
+				Name:       pkgnet.ServicePortNameH2C + "-istio",
+				Protocol:   corev1.ProtocolTCP,
+				Port:       networking.BackendHTTP2Port,
 				TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
 			}
 		}),

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -768,6 +768,10 @@ func deploy(namespace, name string, opts ...deploymentOption) *appsv1.Deployment
 func withHTTP2Priv(svc *corev1.Service) {
 	svc.Spec.Ports[0].Name = "http2"
 	svc.Spec.Ports[0].TargetPort = intstr.FromInt(networking.BackendHTTP2Port)
+
+	svc.Spec.Ports[4].Name = "http2-istio"
+	svc.Spec.Ports[4].Port = networking.BackendHTTP2Port
+	svc.Spec.Ports[4].TargetPort = intstr.FromInt(networking.BackendHTTP2Port)
 }
 
 func withHTTP2(svc *corev1.Service) {


### PR DESCRIPTION
Ref https://github.com/knative/serving/issues/10751

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As per the comment in code, this extra port makes sure that Istio opens the correct listener on its envoys. I've debated hiding this behind the respective "mesh-pod-addressability" flag but was thinking this might be cheap enough to thread it through without it and thus avoid threading the config in. Open to feedback in that regard though obviously.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov @dprotaso 
