### PR TITLE
Add debugging information for autoscaling test

### DIFF
--- a/test/e2e/autoscale.go
+++ b/test/e2e/autoscale.go
@@ -299,7 +299,12 @@ func numberOfReadyPods(ctx *TestContext) (float64, *corev1.Endpoints, error) {
 	if sks.Status.PrivateServiceName == "" {
 		ctx.logf("SKS %s has not yet reconciled", n)
 		// Not an error, but no pods either.
-		return 0, &corev1.Endpoints{}, nil
+		emptyEndpoints := &corev1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "NOT RECONCILED YET",
+			},
+		}
+		return 0, emptyEndpoints, nil
 	}
 	eps, err := ctx.clients.KubeClient.CoreV1().Endpoints(test.ServingNamespace).Get(
 		context.Background(), sks.Status.PrivateServiceName, metav1.GetOptions{})

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -160,7 +160,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 	// Wait for two stable pods.
 	obsScale := 0.0
 	if err := wait.Poll(250*time.Millisecond, 2*cfg.StableWindow, func() (bool, error) {
-		obsScale, err = numberOfReadyPods(ctx)
+		obsScale, _, err = numberOfReadyPods(ctx)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add current endpoints and pod status when failing (returning error) from the continuous autoscaling test, to clarify the cause of the errors.

I haven't been able to get these tests to run locally sucessfully -- the closest I got was one run (non-reproducible) where the downgrade failed trying to reinstall Istio into my contour-based cluster. :frown:

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
