### PR TITLE
Add passthrough LB functionality to the stats scraper

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -230,7 +230,7 @@ func uniScalerFactoryFunc(podLister corev1listers.PodLister,
 }
 
 func statsScraperFactoryFunc(podLister corev1listers.PodLister) asmetrics.StatsScraperFactory {
-	return func(metric *autoscalingv1alpha1.Metric, logger *zap.SugaredLogger) (asmetrics.StatsScraper, error) {
+	return func(metric *autoscalingv1alpha1.Metric, usePassthroughLb bool, logger *zap.SugaredLogger) (asmetrics.StatsScraper, error) {
 		if metric.Spec.ScrapeTarget == "" {
 			return nil, nil
 		}
@@ -241,7 +241,7 @@ func statsScraperFactoryFunc(podLister corev1listers.PodLister) asmetrics.StatsS
 		}
 
 		podAccessor := resources.NewPodAccessor(podLister, metric.Namespace, revisionName)
-		return asmetrics.NewStatsScraper(metric, revisionName, podAccessor, logger), nil
+		return asmetrics.NewStatsScraper(metric, revisionName, podAccessor, usePassthroughLb, logger), nil
 	}
 }
 

--- a/pkg/autoscaler/metrics/collector.go
+++ b/pkg/autoscaler/metrics/collector.go
@@ -46,7 +46,7 @@ var (
 )
 
 // StatsScraperFactory creates a StatsScraper for a given Metric.
-type StatsScraperFactory func(*autoscalingv1alpha1.Metric, *zap.SugaredLogger) (StatsScraper, error)
+type StatsScraperFactory func(*autoscalingv1alpha1.Metric, bool, *zap.SugaredLogger) (StatsScraper, error)
 
 var emptyStat = Stat{}
 
@@ -116,7 +116,8 @@ func (c *MetricCollector) CreateOrUpdate(metric *autoscalingv1alpha1.Metric) err
 		Namespace: metric.Namespace,
 		Name:      metric.Name,
 	}.String()))
-	scraper, err := c.statsScraperFactory(metric, logger)
+	// TODO(#10751): Thread the config in from the reconciler and set usePassthroughLb.
+	scraper, err := c.statsScraperFactory(metric, false /*usePassthroughLb*/, logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -593,7 +593,7 @@ func TestMetricCollectorError(t *testing.T) {
 }
 
 func scraperFactory(scraper StatsScraper, err error) StatsScraperFactory {
-	return func(*autoscalingv1alpha1.Metric, *zap.SugaredLogger) (StatsScraper, error) {
+	return func(*autoscalingv1alpha1.Metric, bool, *zap.SugaredLogger) (StatsScraper, error) {
 		return scraper, err
 	}
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Ref https://github.com/knative/serving/issues/10751

As per title, this adds an option to the stats scraper to enable it to use the passthrough loadbalancer, if enabled. Actually enabling it is not hooked up yet as that's going to require threading the respective config into the metrics reconciler and I figured separating that would make sense. So the flag is always `false` in production for now.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
