### PR TITLE
Update OWNERS_ALIASES to match autogen in community

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- serving-wg-leads
+- technical-oversight-committee
+- api-core-wg-leads
+- autoscaling-wg-leads
+- networking-wg-leads

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,59 +1,39 @@
 aliases:
-  serving-api-approvers:
+  api-core-wg-leads:
+  - dprotaso
+  serving-writers:
   - dprotaso
   - markusthoemmes
   - tcnghia
   - vagababov
-  serving-api-reviewers:
-  - dprotaso
-  - markusthoemmes
-  - tcnghia
-  - vagababov
-  - whaught
+  serving-reviewers:
   - julz
+  - whaught
 
-  toc:
+  technical-oversight-committee:
   - evankanderson
   - grantr
   - markusthoemmes
   - tcnghia
 
-  wg-leads:
-  - dprotaso        # API
-  - markusthoemmes  # Scaling
-  - tcnghia         # Network
-  - vagababov       # Scaling
-
-  # TOC + WG leads
-  serving-wg-leads:
-  - dprotaso        # API
-  - evankanderson   # TOC
-  - grantr          # TOC
-  - markusthoemmes  # Scaling/TOC
-  - nak3            # Network
-  - tcnghia         # Network/TOC
-  - ZhiminXiang     # Network
-  - vagababov       # Scaling
-
-  autoscaling-approvers:
+  autoscaling-wg-leads:
+  - markusthoemmes
+  - vagababov
+  autoscaling-writers:
   - julz
   - markusthoemmes
   - vagababov
   - yanweiguo
   autoscaling-reviewers:
-  - julz
-  - markusthoemmes
   - taragu
-  - vagababov
-  - yanweiguo
 
-  monitoring-approvers:
+  serving-observability-writers:
   - mdemirhan
   - yanweiguo
-  monitoring-reviewers:
+  serving-observability-reviewers:
   - mdemirhan
-  - yanweiguo
   - skonto
+  - yanweiguo
 
   productivity-approvers:
   - chaodaiG
@@ -65,21 +45,27 @@ aliases:
   - steuhs
   - yt3liu
 
-  networking-approvers:
+  networking-writers:
   - JRBANCEL
-  - markusthoemmes
   - nak3
   - tcnghia
   - vagababov
   - ZhiminXiang
   networking-reviewers:
+  - JRBANCEL
+  - ZhiminXiang
   - andrew-su
   - arturenault
-  - JRBANCEL
   - markusthoemmes
   - nak3
   - shashwathi
   - tcnghia
   - vagababov
   - yanweiguo
-  - ZhiminXiang
+
+
+
+
+
+
+

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -35,7 +35,7 @@ aliases:
   - skonto
   - yanweiguo
 
-  productivity-approvers:
+  productivity-writers:
   - chaodaiG
   - chizhg
   productivity-reviewers:
@@ -45,6 +45,10 @@ aliases:
   - steuhs
   - yt3liu
 
+  networking-wg-leads:
+  - ZhiminXiang
+  - nak3
+  - tcnghia
   networking-writers:
   - JRBANCEL
   - nak3

--- a/cmd/activator/OWNERS
+++ b/cmd/activator/OWNERS
@@ -1,8 +1,8 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- autoscaling-approvers
-- networking-approvers
+- autoscaling-writers
+- networking-writers
 
 reviewers:
 - autoscaling-reviewers

--- a/cmd/autoscaler-hpa/OWNERS
+++ b/cmd/autoscaler-hpa/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- autoscaling-approvers
+- autoscaling-writers
 
 reviewers:
 - autoscaling-reviewers

--- a/cmd/autoscaler/OWNERS
+++ b/cmd/autoscaler/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- autoscaling-approvers
+- autoscaling-writers
 
 reviewers:
 - autoscaling-reviewers

--- a/cmd/controller/OWNERS
+++ b/cmd/controller/OWNERS
@@ -1,10 +1,10 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- serving-api-approvers
+- serving-writers
 
 reviewers:
-- serving-api-reviewers
+- serving-reviewers
 
 labels:
 - area/API

--- a/cmd/networking/OWNERS
+++ b/cmd/networking/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- networking-approvers
+- networking-writers
 
 reviewers:
 - networking-reviewers

--- a/cmd/queue/OWNERS
+++ b/cmd/queue/OWNERS
@@ -1,8 +1,8 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- autoscaling-approvers
-- networking-approvers
+- autoscaling-writers
+- networking-writers
 
 reviewers:
 - autoscaling-reviewers

--- a/cmd/webhook/OWNERS
+++ b/cmd/webhook/OWNERS
@@ -1,10 +1,10 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- serving-api-approvers
+- serving-writers
 
 reviewers:
-- serving-api-reviewers
+- serving-reviewers
 
 labels:
 - area/API

--- a/config/OWNERS
+++ b/config/OWNERS
@@ -1,9 +1,13 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- serving-wg-leads
+- api-core-wg-leads
+- autoscaling-wg-leads
+- networking-wg-leads
 
 
 reviewers:
-- serving-wg-leads
+- api-core-wg-leads
+- autoscaling-wg-leads
+- networking-wg-leads
 

--- a/docs/scaling/OWNERS
+++ b/docs/scaling/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- autoscaling-approvers
+- autoscaling-writers
 
 reviewers:
 - autoscaling-reviewers

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- productivity-approvers
+- productivity-writers
 
 reviewers:
 - productivity-reviewers

--- a/pkg/activator/OWNERS
+++ b/pkg/activator/OWNERS
@@ -1,8 +1,8 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- autoscaling-approvers
-- networking-approvers
+- autoscaling-writers
+- networking-writers
 
 reviewers:
 - autoscaling-reviewers

--- a/pkg/apis/OWNERS
+++ b/pkg/apis/OWNERS
@@ -1,12 +1,8 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-# TOC
-- evankanderson
-- mattmoor
-- vaikas
-# Serving WG Leads
-- dprotaso
+- technical-oversight-committee
+- api-core-wg-leads
 
 labels:
 - area/API

--- a/pkg/apis/autoscaling/OWNERS
+++ b/pkg/apis/autoscaling/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- autoscaling-approvers
+- autoscaling-writers
 
 reviewers:
 - autoscaling-reviewers

--- a/pkg/autoscaler/OWNERS
+++ b/pkg/autoscaler/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- autoscaling-approvers
+- autoscaling-writers
 
 reviewers:
 - autoscaling-reviewers

--- a/pkg/deployment/OWNERS
+++ b/pkg/deployment/OWNERS
@@ -1,9 +1,9 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- serving-api-approvers
+- serving-writers
 
 
 reviewers:
-- serving-api-approvers
+- serving-reviewers
 

--- a/pkg/gc/OWNERS
+++ b/pkg/gc/OWNERS
@@ -1,10 +1,10 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- serving-api-approvers
+- serving-writers
 
 reviewers:
-- serving-api-reviewers
+- serving-reviewers
 
 labels:
 - area/API

--- a/pkg/http/OWNERS
+++ b/pkg/http/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- networking-approvers
+- networking-writers
 
 reviewers:
 - networking-reviewers

--- a/pkg/leaderelection/OWNERS
+++ b/pkg/leaderelection/OWNERS
@@ -1,10 +1,10 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- serving-api-approvers
+- serving-writers
 
 reviewers:
-- serving-api-reviewers
+- serving-reviewers
 
 labels:
 - area/API

--- a/pkg/logging/OWNERS
+++ b/pkg/logging/OWNERS
@@ -1,10 +1,10 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- monitoring-approvers
+- serving-observability-writers
 
 reviewers:
-- monitoring-reviewers
+- serving-observability-reviewers
 
 labels:
 - area/monitoring

--- a/pkg/metrics/OWNERS
+++ b/pkg/metrics/OWNERS
@@ -1,11 +1,13 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- monitoring-approvers
-- serving-wg-leads
+- serving-observability-writers
+- api-core-wg-leads
+- autoscaling-wg-leads
+- networking-wg-leads
 
 reviewers:
-- monitoring-reviewers
+- serving-observability-reviewers
 
 labels:
 - area/monitoring

--- a/pkg/queue/OWNERS
+++ b/pkg/queue/OWNERS
@@ -1,8 +1,8 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- autoscaling-approvers
-- networking-approvers
+- autoscaling-writers
+- networking-writers
 
 reviewers:
 - autoscaling-reviewers

--- a/pkg/reconciler/OWNERS
+++ b/pkg/reconciler/OWNERS
@@ -1,10 +1,10 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- serving-api-approvers
+- serving-writers
 
 reviewers:
-- serving-api-reviewers
+- serving-reviewers
 
 labels:
 - area/API

--- a/pkg/reconciler/autoscaling/OWNERS
+++ b/pkg/reconciler/autoscaling/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- autoscaling-approvers
+- autoscaling-writers
 
 reviewers:
 - autoscaling-reviewers

--- a/pkg/reconciler/nscert/OWNERS
+++ b/pkg/reconciler/nscert/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- networking-approvers
+- networking-writers
 
 reviewers:
 - networking-reviewers

--- a/pkg/reconciler/route/OWNERS
+++ b/pkg/reconciler/route/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- networking-approvers
+- networking-writers
 
 reviewers:
 - networking-reviewers

--- a/pkg/resources/OWNERS
+++ b/pkg/resources/OWNERS
@@ -1,10 +1,10 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- serving-api-approvers
+- serving-writers
 
 reviewers:
-- serving-api-reviewers
+- serving-reviewers
 
 labels:
 - area/API

--- a/pkg/testing/OWNERS
+++ b/pkg/testing/OWNERS
@@ -1,16 +1,16 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- productivity-approvers
-- serving-api-approvers
-- networking-approvers
-- autoscaling-approvers
+- productivity-writers
+- serving-writers
+- networking-writers
+- autoscaling-writers
 
 reviewers:
 - productivity-reviewers
-- serving-api-approvers
-- networking-approvers
-- autoscaling-approvers
+- serving-writers
+- networking-writers
+- autoscaling-writers
 
 labels:
 - area/test-and-release

--- a/pkg/webhook/OWNERS
+++ b/pkg/webhook/OWNERS
@@ -1,10 +1,10 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- serving-api-approvers
+- serving-writers
 
 reviewers:
-- serving-api-reviewers
+- serving-reviewers
 
 labels:
 - area/API

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,12 +1,12 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- productivity-approvers
-- serving-api-approvers
+- productivity-writers
+- serving-writers
 
 reviewers:
 - productivity-reviewers
-- serving-api-approvers
+- serving-writers
 
 labels:
 - area/test-and-release

--- a/third_party/OWNERS
+++ b/third_party/OWNERS
@@ -2,13 +2,13 @@
 
 approvers:
 # Istio
-- networking-approvers
+- networking-writers
 # Monitoring Configs
-- monitoring-approvers
+- serving-observability-writers
 
 
 reviewers:
 # Istio
 - networking-reviewers
 # Monitoring Configs
-- monitoring-reviewers
+- serving-observability-writers


### PR DESCRIPTION
See https://github.com/knative/community/pull/552 for the addition of groups/full OWNERS_ALIASES that will be synced.

This is a preparatory PR for landing OWNERS_ALIASES automation across the Knative org (alternative to the CODEOWNERS changes in knative-sandbox).

If this seems to be expanding permissions or otherwise likely to cause a problem, `/hold` this PR and comment here or on https://github.com/knative/community/pull/552.
