### PR TITLE
e2e tests wait for test resource deletion

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -277,6 +277,6 @@ jobs:
         IPS=( $(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}') )
 
         # Run the tests tagged as e2e on the KinD cluster.
-        go test -race -parallel 4 -count=1 -timeout=40m -tags=e2e ${{ matrix.test-suite }} \
+        go test -race -count=1 -timeout=40m -tags=e2e ${{ matrix.test-suite }} \
            --ingressendpoint="${IPS[0]}" \
            ${{ matrix.test-flags }}

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -277,6 +277,6 @@ jobs:
         IPS=( $(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}') )
 
         # Run the tests tagged as e2e on the KinD cluster.
-        go test -race -count=1 -timeout=20m -tags=e2e ${{ matrix.test-suite }} \
+        go test -race -parallel 4 -count=1 -timeout=20m -tags=e2e ${{ matrix.test-suite }} \
            --ingressendpoint="${IPS[0]}" \
            ${{ matrix.test-flags }}

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -277,6 +277,6 @@ jobs:
         IPS=( $(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}') )
 
         # Run the tests tagged as e2e on the KinD cluster.
-        go test -race -parallel 4 -count=1 -timeout=20m -tags=e2e ${{ matrix.test-suite }} \
+        go test -race -parallel 4 -count=1 -timeout=40m -tags=e2e ${{ matrix.test-suite }} \
            --ingressendpoint="${IPS[0]}" \
            ${{ matrix.test-flags }}

--- a/test/cleanup.go
+++ b/test/cleanup.go
@@ -67,6 +67,12 @@ func TearDown(clients *Clients, names *ResourceNames) {
 			[]string{names.Config},
 			[]string{names.Service},
 		)
+		clients.ServingClient.WaitForDeletion(
+			[]string{names.Route},
+			[]string{names.Config},
+			[]string{names.Service},
+			PollTimeout,
+		)
 	}
 }
 


### PR DESCRIPTION
Fixes #11064

## Proposed Changes
* the test `TearDown` function now will wait for the deletion of all the test resources to complete

This does slow down the tests, though I think it should reduce flakiness due to the "accidental parallelism" of these resources sticking around during subsequent tests.