### PR TITLE
Use similar rollout check to kubectl in autoscale test

### DIFF
--- a/test/e2e/autoscale.go
+++ b/test/e2e/autoscale.go
@@ -297,17 +297,7 @@ func numberOfReadyPods(ctx *TestContext) (float64, *appsv1.Deployment, error) {
 		return 0, nil, fmt.Errorf("failed to get deployment %s: %w", n, err)
 	}
 
-	var minAvailable, updated bool
-	for _, cond := range deploy.Status.Conditions {
-		switch cond.Type {
-		case appsv1.DeploymentAvailable:
-			minAvailable = cond.Status == corev1.ConditionTrue
-		case appsv1.DeploymentProgressing:
-			updated = cond.Reason == "ReplicaSetUpdated"
-		}
-	}
-
-	if minAvailable && updated {
+	if isInRollout(deploy) {
 		// Ref: #11092
 		// The deployment was updated and the update is being rolled out so we defensively
 		// pick the desired replicas to assert the autoscaling decisions.
@@ -409,4 +399,26 @@ func AutoscaleUpToNumPods(ctx *TestContext, curPods, targetPods float64, done <-
 	})
 
 	return grp.Wait
+}
+
+// isInRollout is a loose copy of the kubectl function handling rollouts.
+// See: https://github.com/kubernetes/kubectl/blob/0149779a03735a5d483115ca4220a7b6c861430c/pkg/polymorphichelpers/rollout_status.go#L75-L91
+func isInRollout(deploy *appsv1.Deployment) bool {
+	if deploy.Generation > deploy.Status.ObservedGeneration {
+		// Waiting for update to be observed.
+		return true
+	}
+	if deploy.Spec.Replicas != nil && deploy.Status.UpdatedReplicas < *deploy.Spec.Replicas {
+		// Not enough replicas updated yet.
+		return true
+	}
+	if deploy.Status.Replicas > deploy.Status.UpdatedReplicas {
+		// Old replicas are being terminated.
+		return true
+	}
+	if deploy.Status.AvailableReplicas < deploy.Status.UpdatedReplicas {
+		// Not enough available yet.
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

We're still seeing issues with this test and my poor-man's rollout detection was just horribly wrong. So I went checking how `kubectl rollout status` works and replicated the logic for detecting something being in-rollout here.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
