### PR TITLE
Drop extra revision check from MinScale test

### DIFF
--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -102,7 +102,6 @@ func TestMinScale(t *testing.T) {
 	}
 
 	revision, err := clients.ServingClient.Revisions.Get(context.Background(), revName, metav1.GetOptions{})
-
 	if err != nil {
 		t.Fatalf("An error occurred getting revision %v, %v", revName, err)
 	}
@@ -136,7 +135,6 @@ func TestMinScale(t *testing.T) {
 	}
 
 	revision, err = clients.ServingClient.Revisions.Get(context.Background(), newRevName, metav1.GetOptions{})
-
 	if err != nil {
 		t.Fatalf("An error occurred getting revision %v, %v", newRevName, err)
 	}
@@ -147,15 +145,6 @@ func TestMinScale(t *testing.T) {
 	t.Log("Waiting for old revision to scale below minScale after being replaced")
 	if lr, err := waitForDesiredScale(clients, serviceName, lt(minScale)); err != nil {
 		t.Fatalf("The revision %q scaled to %d > %d after not being routable anymore: %v", revName, lr, minScale, err)
-	}
-
-	revision, err = clients.ServingClient.Revisions.Get(context.Background(), revName, metav1.GetOptions{})
-
-	if err != nil {
-		t.Fatalf("An error occurred getting revision %v, %v", revName, err)
-	}
-	if replicas := revision.Status.ActualReplicas; err != nil || replicas >= minScale {
-		t.Fatalf("Expected actual replicas for revision %v to be less than %v but got %v", revision.Name, minScale, replicas)
 	}
 
 	t.Log("Deleting route", names.Route)


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This check causes flakes like https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-serving-contour-latest/1380003328133435392.

The check is not guaranteed to be consistent since the ready pods might have been propagated to the endpoint but not to the revision's status yet. We'd have to poll for the revision status to be consistent as well, but that doesn't seem to buy us a lot, so I opted for a drop.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
