### PR TITLE
Make sure deployments never underscale on rollouts

### DIFF
--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -190,6 +190,7 @@ var (
 		EnableServiceLinks:            ptr.Bool(false),
 	}
 
+	maxUnavailable    = intstr.FromInt(0)
 	defaultDeployment = &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
@@ -217,6 +218,12 @@ var (
 				},
 			},
 			ProgressDeadlineSeconds: ptr.Int32(0),
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: &maxUnavailable,
+				},
+			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Ref https://github.com/knative/serving/issues/11092

Sometimes we DO update the revision deployment, for example for config
changes and for updates to the queue-proxy. We want those updates to
have as little interruption as possible, so this requires the pods to be
rolled in a way that there is never less pods than requested.

Context on the rollout speed: This does not significantly impact the speed at which a rollout is done. As soon as the pods are Terminating, the next batch will be rolled, so this just makes sure we never dip below the `replicas` setting of the Deployment. Since our pods take ~40s to shut down anyway, this likely isn't even impacting the amount of resources used by the rollout significantly.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Changed the rollout behavior of application deployment changes (due to Knative upgrade for example) to never have less ready posd than required.
```
