### PR TITLE
Connect the networking config with stats scraping

### DIFF
--- a/pkg/autoscaler/metrics/collector.go
+++ b/pkg/autoscaler/metrics/collector.go
@@ -46,7 +46,7 @@ var (
 )
 
 // StatsScraperFactory creates a StatsScraper for a given Metric.
-type StatsScraperFactory func(*autoscalingv1alpha1.Metric, bool, *zap.SugaredLogger) (StatsScraper, error)
+type StatsScraperFactory func(*autoscalingv1alpha1.Metric, *zap.SugaredLogger) (StatsScraper, error)
 
 var emptyStat = Stat{}
 
@@ -61,7 +61,7 @@ type StatMessage struct {
 type Collector interface {
 	// CreateOrUpdate either creates a collection for the given metric or update it, should
 	// it already exist.
-	CreateOrUpdate(*autoscalingv1alpha1.Metric) error
+	CreateOrUpdate(metric *autoscalingv1alpha1.Metric) error
 	// Record allows stats to be captured that came from outside the Collector.
 	Record(key types.NamespacedName, now time.Time, stat Stat)
 	// Delete deletes a Metric and halts collection.
@@ -117,7 +117,7 @@ func (c *MetricCollector) CreateOrUpdate(metric *autoscalingv1alpha1.Metric) err
 		Name:      metric.Name,
 	}.String()))
 	// TODO(#10751): Thread the config in from the reconciler and set usePassthroughLb.
-	scraper, err := c.statsScraperFactory(metric, false /*usePassthroughLb*/, logger)
+	scraper, err := c.statsScraperFactory(metric, logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/autoscaler/metrics/collector_test.go
+++ b/pkg/autoscaler/metrics/collector_test.go
@@ -593,7 +593,7 @@ func TestMetricCollectorError(t *testing.T) {
 }
 
 func scraperFactory(scraper StatsScraper, err error) StatsScraperFactory {
-	return func(*autoscalingv1alpha1.Metric, bool, *zap.SugaredLogger) (StatsScraper, error) {
+	return func(*autoscalingv1alpha1.Metric, *zap.SugaredLogger) (StatsScraper, error) {
 		return scraper, err
 	}
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Ref https://github.com/knative/serving/issues/10751

This connects the metrics reconciler with the networking configmap and makes it sensitive to the `EnableMeshPodAddressability` setting. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The stats scraping in the autoscaler is now sensitive to the EnableMeshPodAddressability setting. A restart of the autoscaler is required for the setting to take effect if changed.
```

/assign @vagababov @julz 
