### PR TITLE
fix broken link

### DIFF
--- a/docs/spec/errors.md
+++ b/docs/spec/errors.md
@@ -1,4 +1,6 @@
 # Error Conditions and Reporting
 
-This file has been moved to the
-[Knative Specs Repository](https://github.com/knative/specs/blob/main/specs/serving/errors.md)
+This document has been replaced by the
+[Error Signalling](https://github.com/knative/specs/blob/main/specs/serving/knative-api-specification-1.0.md#error-signalling)
+section of the
+[Knative API Specification](https://github.com/knative/specs/blob/main/specs/serving/knative-api-specification-1.0.md).


### PR DESCRIPTION
Recent updates associated with spec moved to the new repo, the file got replace with a generic link.

I restore the content with a correct link from what was there before.

