### PR TITLE
Use passthrough loadbalancing in activator state keeping

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -286,7 +286,7 @@ func (rw *revisionWatcher) checkDests(curDests, prevDests dests) {
 
 	// If we have discovered that this revision cannot be probed directly
 	// do not spend time trying.
-	if rw.podsAddressable || rw.usePassthroughLb {
+	if rw.podsAddressable {
 		// reprobe set contains the targets that moved from ready to non-ready set.
 		// so they have to be re-probed.
 		reprobe := curDests.becameNonReady(prevDests)

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -176,10 +176,10 @@ func (rw *revisionWatcher) probe(ctx context.Context, dest string) (bool, error)
 	if rw.usePassthroughLb {
 		options = append(options,
 			prober.WithHost(kmeta.ChildName(rw.rev.Name, "-private")+"."+rw.rev.Namespace),
-			prober.WithHeader("Knative-Direct-Lb", "true"))
+			prober.WithHeader(network.PassthroughLoadbalancingHeaderName, "true"))
 	}
 
-	// NOTE: changes below may require changes to testing/roundtripper.go to make unit tests passing.
+	// NOTE: changes below may require changes to testing/roundtripper.go to make unit tests pass.
 	return prober.Do(ctx, rw.transport, httpDest.String(), options...)
 }
 

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -44,7 +44,6 @@ import (
 	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
 	"knative.dev/pkg/reconciler"
@@ -53,6 +52,7 @@ import (
 	servinglisters "knative.dev/serving/pkg/client/listers/serving/v1"
 	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/queue"
+	"knative.dev/serving/pkg/reconciler/serverlessservice/resources/names"
 )
 
 // revisionDestsUpdate contains the state of healthy l4 dests for talking to a revision and is the
@@ -181,7 +181,7 @@ func (rw *revisionWatcher) probe(ctx context.Context, dest string) (bool, error)
 		// configured, which will cause the request to "pass" but doesn't guarantee it
 		// actually lands on the correct pod, which breaks our state keeping.
 		options = append(options,
-			prober.WithHost(kmeta.ChildName(rw.rev.Name, "-private")+"."+rw.rev.Namespace),
+			prober.WithHost(names.PrivateService(rw.rev.Name)+"."+rw.rev.Namespace),
 			prober.WithHeader(network.PassthroughLoadbalancingHeaderName, "true"))
 	}
 

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -491,8 +491,8 @@ func NewThrottler(ctx context.Context, ipAddr string) *Throttler {
 }
 
 // Run starts the throttler and blocks until the context is done.
-func (t *Throttler) Run(ctx context.Context, probeTransport http.RoundTripper) {
-	rbm := newRevisionBackendsManager(ctx, probeTransport)
+func (t *Throttler) Run(ctx context.Context, probeTransport http.RoundTripper, usePassthroughLb bool) {
+	rbm := newRevisionBackendsManager(ctx, probeTransport, usePassthroughLb)
 	// Update channel is closed when ctx is done.
 	t.run(rbm.updates())
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Ref https://github.com/knative/serving/issues/10751

This connects the revision watchers in the activator with the networking configmap and makes it sensitive to the EnableMeshPodAddressability setting.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The state keeping in the activator is now sensitive to the EnableMeshPodAddressability setting. A restart of the activator is required for the setting to take effect if changed.
```

/assign @vagababov @julz 
