### PR TITLE
Be more discerning about which errors cause mesh fall-back

### DIFF
--- a/pkg/autoscaler/metrics/http_scrape_client_test.go
+++ b/pkg/autoscaler/metrics/http_scrape_client_test.go
@@ -69,16 +69,22 @@ func TestHTTPScrapeClientScrapeHappyCaseWithOptionals(t *testing.T) {
 
 func TestHTTPScrapeClientScrapeProtoErrorCases(t *testing.T) {
 	testCases := []struct {
-		name         string
-		responseCode int
-		responseType string
-		responseErr  error
-		stat         Stat
-		expectedErr  string
+		name            string
+		responseCode    int
+		responseType    string
+		responseErr     error
+		stat            Stat
+		expectedErr     string
+		expectedMeshErr bool
 	}{{
 		name:         "Non 200 return code",
 		responseCode: http.StatusForbidden,
 		expectedErr:  fmt.Sprintf("GET request for URL %q returned HTTP status 403", testURL),
+	}, {
+		name:            "503 return code",
+		responseCode:    meshErrorStatusCode,
+		expectedErr:     fmt.Sprintf("GET request for URL %q returned HTTP status 503", testURL),
+		expectedMeshErr: true,
 	}, {
 		name:         "Error got when sending request",
 		responseCode: http.StatusOK,
@@ -105,6 +111,9 @@ func TestHTTPScrapeClientScrapeProtoErrorCases(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), test.expectedErr) {
 				t.Errorf("Error = %q, want to contain: %q", err.Error(), test.expectedErr)
+			}
+			if got := isMeshError(err); got != test.expectedMeshErr {
+				t.Errorf("isMeshError(err) = %v, expected %v", got, test.expectedMeshErr)
 			}
 		})
 	}


### PR DESCRIPTION
Before this PR, we would fall back to service scraping if all pods we tried to scrape errored. In many cases this heuristic is fine, but with a small number (e.g. one) of pods, it can lead to us falling back to service scraping unnecessarily if an unrelated error occurs. Once we've turned off direct scraping, we never turn it back on, so this is unfortunate.

This PR tightens the check to ensure that all of the errors we saw were compatible with having been caused by the mesh being enabled before falling back to service scraping.

/hold for prow to tell me if this actually works with mesh, I might've guessed the wrong status code for mesh errors

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Tightens the heuristic for mesh being abled in the service scraper. We now expect all errors to be related to mesh (i.e. 503 status code). This prevents accidentally falling in to service scrape mode when errors are encountered for other reasons.
```
