### PR TITLE
Add a private service name helper and use throughout

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	network "knative.dev/networking/pkg"
-	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging/logkey"
 	pkgnet "knative.dev/pkg/network"
 	tracingconfig "knative.dev/pkg/tracing/config"
@@ -37,6 +36,7 @@ import (
 	activatorconfig "knative.dev/serving/pkg/activator/config"
 	pkghttp "knative.dev/serving/pkg/http"
 	"knative.dev/serving/pkg/queue"
+	"knative.dev/serving/pkg/reconciler/serverlessservice/resources/names"
 )
 
 // Throttler is the interface that Handler calls to Try to proxy the user request.
@@ -112,7 +112,7 @@ func (a *activationHandler) proxyRequest(revID types.NamespacedName, w http.Resp
 	// Set up the reverse proxy.
 	hostOverride := pkghttp.NoHostOverride
 	if usePassthroughLb {
-		hostOverride = kmeta.ChildName(revID.Name, "-private") + "." + revID.Namespace
+		hostOverride = names.PrivateService(revID.Name) + "." + revID.Namespace
 	}
 	proxy := pkghttp.NewHeaderPruningReverseProxy(target, hostOverride, activator.RevisionHeaders)
 	proxy.BufferPool = a.bufferPool

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -63,6 +63,7 @@ import (
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
 	"knative.dev/serving/pkg/reconciler/autoscaling/hpa/resources"
 	aresources "knative.dev/serving/pkg/reconciler/autoscaling/resources"
+	"knative.dev/serving/pkg/reconciler/serverlessservice/resources/names"
 
 	_ "knative.dev/pkg/metrics/testing"
 	. "knative.dev/pkg/reconciler/testing"
@@ -133,10 +134,8 @@ func TestControllerCanReconcile(t *testing.T) {
 
 func TestReconcile(t *testing.T) {
 	retryAttempted := false
-	const (
-		deployName = testRevision + "-deployment"
-		privateSvc = testRevision + "-private"
-	)
+	deployName := testRevision + "-deployment"
+	privateSvc := names.PrivateService(testRevision)
 
 	table := TableTest{{
 		Name: "no op",

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -85,6 +85,7 @@ import (
 	"knative.dev/serving/pkg/reconciler/autoscaling/kpa/resources"
 	aresources "knative.dev/serving/pkg/reconciler/autoscaling/resources"
 	revisionresources "knative.dev/serving/pkg/reconciler/revision/resources"
+	"knative.dev/serving/pkg/reconciler/serverlessservice/resources/names"
 
 	. "knative.dev/pkg/reconciler/testing"
 	. "knative.dev/serving/pkg/reconciler/testing/v1"
@@ -171,7 +172,7 @@ type metricOption func(*autoscalingv1alpha1.Metric)
 
 func metric(ns, n string, opts ...metricOption) *autoscalingv1alpha1.Metric {
 	pa := kpa(ns, n)
-	m := aresources.MakeMetric(pa, kmeta.ChildName(n, "-private"), defaultConfig().Autoscaler)
+	m := aresources.MakeMetric(pa, names.PrivateService(n), defaultConfig().Autoscaler)
 	for _, o := range opts {
 		o(m)
 	}
@@ -222,12 +223,12 @@ func markResourceNotOwned(rType, name string) PodAutoscalerOption {
 func TestReconcile(t *testing.T) {
 	const (
 		deployName   = testRevision + "-deployment"
-		privateSvc   = testRevision + "-private"
 		defaultScale = 11
 		unknownScale = scaleUnknown
 		underscale   = defaultScale - 1
 		overscale    = defaultScale + 1
 	)
+	privateSvc := names.PrivateService(testRevision)
 
 	// Set up a default deployment with the appropriate scale so that we don't
 	// see patches to correct that scale.

--- a/pkg/reconciler/serverlessservice/resources/names/names.go
+++ b/pkg/reconciler/serverlessservice/resources/names/names.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package names
+
+import "knative.dev/pkg/kmeta"
+
+// PrivateService returns the precomputed name for the SKS' private service.
+func PrivateService(revName string) string {
+	return kmeta.ChildName(revName, "-private")
+}

--- a/pkg/reconciler/serverlessservice/resources/names/names_test.go
+++ b/pkg/reconciler/serverlessservice/resources/names/names_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package names
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNamer(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		f    func(string) string
+		want string
+	}{{
+		name: "Private Service too long",
+		in:   strings.Repeat("f", 63),
+		f:    PrivateService,
+		want: "fffffffffffffffffffffff105d7597f637e83cc711605ac3ea4957-private",
+	}, {
+		name: "Private Service long enough",
+		in:   strings.Repeat("f", 55),
+		f:    PrivateService,
+		want: strings.Repeat("f", 55) + "-private",
+	}, {
+		name: "Private Service",
+		in:   "foo",
+		f:    PrivateService,
+		want: "foo-private",
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.f(test.in)
+			if got != test.want {
+				t.Errorf("%s() = %v, wanted %v", test.name, got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -22,6 +22,7 @@ import (
 	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/networking"
+	"knative.dev/serving/pkg/reconciler/serverlessservice/resources/names"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -115,7 +116,7 @@ func filterSubsetPorts(targetPort int32, subsets []corev1.EndpointSubset) []core
 func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      kmeta.ChildName(sks.Name, "-private"),
+			Name:      names.PrivateService(sks.Name),
 			Namespace: sks.Namespace,
 			Labels: kmeta.UnionMaps(sks.GetLabels(), map[string]string{
 				// Add our own special key.

--- a/pkg/reconciler/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/serverlessservice/resources/services_test.go
@@ -27,11 +27,11 @@ import (
 
 	pkgnet "knative.dev/networking/pkg/apis/networking"
 	"knative.dev/networking/pkg/apis/networking/v1alpha1"
-	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/serving"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/networking"
+	"knative.dev/serving/pkg/reconciler/serverlessservice/resources/names"
 )
 
 func sks(mod func(*v1alpha1.ServerlessService)) *v1alpha1.ServerlessService {
@@ -122,7 +122,7 @@ func svc(t networking.ServiceType, mods ...func(*corev1.Service)) *corev1.Servic
 }
 
 func privateSvcMod(s *corev1.Service) {
-	s.Name = kmeta.ChildName(s.Name, "-private")
+	s.Name = names.PrivateService(s.Name)
 	if s.Spec.Selector == nil {
 		s.Spec.Selector = map[string]string{
 			"app": "sadness",

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -38,12 +38,12 @@ import (
 
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/hash"
-	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/reconciler/serverlessservice/resources"
+	"knative.dev/serving/pkg/reconciler/serverlessservice/resources/names"
 	presources "knative.dev/serving/pkg/resources"
 )
 
@@ -301,7 +301,7 @@ func (r *reconciler) reconcilePrivateService(ctx context.Context, sks *netv1alph
 		return fmt.Errorf("error retrieving deployment selector spec: %w", err)
 	}
 
-	sn := kmeta.ChildName(sks.Name, "-private")
+	sn := names.PrivateService(sks.Name)
 	svc, err := r.serviceLister.Services(sks.Namespace).Get(sn)
 	if apierrs.IsNotFound(err) {
 		logger.Info("SKS has no private service; creating.")

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -26,9 +26,9 @@ import (
 
 	"knative.dev/networking/pkg/apis/networking"
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
-	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	"knative.dev/serving/pkg/reconciler/serverlessservice/resources/names"
 )
 
 // PodAutoscalerOption is an option that can be applied to a PA.
@@ -386,7 +386,7 @@ func WithNumActivators(n int32) SKSOption {
 
 // WithPrivateService annotates SKS status with the private service name.
 func WithPrivateService(sks *netv1alpha1.ServerlessService) {
-	sks.Status.PrivateServiceName = kmeta.ChildName(sks.Name, "-private")
+	sks.Status.PrivateServiceName = names.PrivateService(sks.Name)
 }
 
 // WithSKSOwnersRemoved clears the owner references of this SKS resource.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

By popular demand, this adds a helper function to generate the private service name and makes use of it throughout the codebase.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
