### PR TITLE
Remove private service listing

### DIFF
--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -44,6 +44,7 @@ import (
 	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
 	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/queue"
+	"knative.dev/serving/pkg/reconciler/serverlessservice/resources/names"
 
 	. "knative.dev/pkg/logging/testing"
 )
@@ -84,11 +85,7 @@ func privateSKSService(revID types.NamespacedName, clusterIP string, ports []cor
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: revID.Namespace,
-			Name:      revID.Name,
-			Labels: map[string]string{
-				serving.RevisionLabelKey:  revID.Name,
-				networking.ServiceTypeKey: string(networking.ServiceTypePrivate),
-			},
+			Name:      names.PrivateService(revID.Name),
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: clusterIP,

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -20,7 +20,6 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -30,8 +29,8 @@ import (
 
 	"knative.dev/pkg/system"
 	"knative.dev/serving/pkg/apis/autoscaling"
-	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/networking"
+	"knative.dev/serving/pkg/reconciler/serverlessservice/resources/names"
 	"knative.dev/serving/pkg/resources"
 	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
@@ -228,17 +227,7 @@ func TestFastScaleToZero(t *testing.T) {
 		t.Fatal("Error retrieving autoscaler configmap:", err)
 	}
 
-	epsL, err := ctx.clients.KubeClient.CoreV1().Endpoints(test.ServingNamespace).List(context.Background(), metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s,%s=%s",
-			serving.RevisionLabelKey, ctx.resources.Revision.Name,
-			networking.ServiceTypeKey, networking.ServiceTypePrivate,
-		),
-	})
-	if err != nil || len(epsL.Items) == 0 {
-		t.Fatal("No endpoints or error:", err)
-	}
-
-	epsN := epsL.Items[0].Name
+	epsN := names.PrivateService(ctx.resources.Revision.Name)
 	t.Logf("Waiting for emptying of %q ", epsN)
 
 	// The first thing that happens when pods are starting to terminate


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

We've had deterministic private service names since ages so it feels quite unnecessary to do listing shenanigans to find the private service and we can instead use the constructed name directly. Less code is better code.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
