### PR TITLE
Move comment above referenced code

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -167,6 +167,7 @@ func (rw *revisionWatcher) probe(ctx context.Context, dest string) (bool, error)
 		Path:   network.ProbePath,
 	}
 
+	// NOTE: changes below may require changes to testing/roundtripper.go to make unit tests pass.
 	options := []interface{}{
 		prober.WithHeader(network.ProbeHeaderName, queue.Name),
 		prober.WithHeader(network.UserAgentKey, network.ActivatorUserAgent),
@@ -185,7 +186,6 @@ func (rw *revisionWatcher) probe(ctx context.Context, dest string) (bool, error)
 			prober.WithHeader(network.PassthroughLoadbalancingHeaderName, "true"))
 	}
 
-	// NOTE: changes below may require changes to testing/roundtripper.go to make unit tests pass.
 	return prober.Do(ctx, rw.transport, httpDest.String(), options...)
 }
 


### PR DESCRIPTION
Realised immediately after lgtm-ing #11172 😃: the things that may require changes if modified are in the options array
now, so the comment should be above that.

/assign @markusthoemmes 