### PR TITLE
Statically configure passthrough lb in the activator

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -187,7 +187,7 @@ func main() {
 
 	// Create activation handler chain
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first
-	ah := activatorhandler.New(ctx, throttler, transport, logger)
+	ah := activatorhandler.New(ctx, throttler, transport, networkConfig.EnableMeshPodAddressability, logger)
 	ah = concurrencyReporter.Handler(ah)
 	ah = activatorhandler.NewTracingHandler(ah)
 	reqLogHandler, err := pkghttp.NewRequestLogHandler(ah, logging.NewSyncFileWriter(os.Stdout), "",

--- a/pkg/activator/config/store_test.go
+++ b/pkg/activator/config/store_test.go
@@ -22,36 +22,23 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	network "knative.dev/networking/pkg"
 	ltesting "knative.dev/pkg/logging/testing"
 	tracingconfig "knative.dev/pkg/tracing/config"
 )
 
-var (
-	tracingConfig = &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: tracingconfig.ConfigName,
-		},
-		Data: map[string]string{
-			"backend": "none",
-		},
-	}
-	networkConfig = &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: network.ConfigName,
-		},
-		Data: map[string]string{
-			network.EnableMeshPodAddressabilityKey: "true",
-		},
-	}
-)
+var tracingConfig = &corev1.ConfigMap{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: tracingconfig.ConfigName,
+	},
+	Data: map[string]string{
+		"backend": "none",
+	},
+}
 
 func TestStore(t *testing.T) {
 	logger := ltesting.TestLogger(t)
-
 	store := NewStore(logger)
 	store.OnConfigChanged(tracingConfig)
-	store.OnConfigChanged(networkConfig)
 
 	ctx := store.ToContext(context.Background())
 	cfg := FromContext(ctx)
@@ -83,7 +70,6 @@ func BenchmarkStoreToContext(b *testing.B) {
 	logger := ltesting.TestLogger(b)
 	store := NewStore(logger)
 	store.OnConfigChanged(tracingConfig)
-	store.OnConfigChanged(networkConfig)
 
 	b.Run("sequential", func(b *testing.B) {
 		for j := 0; j < b.N; j++ {

--- a/pkg/activator/handler/main_test.go
+++ b/pkg/activator/handler/main_test.go
@@ -69,7 +69,7 @@ func BenchmarkHandlerChain(b *testing.B) {
 	})
 
 	// Make sure to update this if the activator's main file changes.
-	ah := New(ctx, fakeThrottler{}, rt, logger)
+	ah := New(ctx, fakeThrottler{}, rt, false, logger)
 	ah = concurrencyReporter.Handler(ah)
 	ah = NewTracingHandler(ah)
 	ah, _ = pkghttp.NewRequestLogHandler(ah, ioutil.Discard, "", nil, false)

--- a/pkg/activator/handler/tracing_handler_test.go
+++ b/pkg/activator/handler/tracing_handler_test.go
@@ -64,7 +64,6 @@ func TestTracingHandler(t *testing.T) {
 
 			configStore := activatorconfig.NewStore(logging.FromContext(ctx))
 			configStore.OnConfigChanged(cm)
-			configStore.OnConfigChanged(networkConfig(false))
 			ctx = configStore.ToContext(ctx)
 
 			reporter, co := tracetesting.FakeZipkinExporter()


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Ref https://github.com/knative/serving/issues/10751

This rolls back config threading in the activator's handler in favor of statically configuring the respective config to be consistent with the setting used in Throttler. This makes it so that both of these equally require a restart to avoid the handler from picking up a change in the mesh pod addressability setting on the live-instances and thus making a safe rollout impossible.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
