### PR TITLE
Add test for existing queue probe behaviour

### DIFF
--- a/pkg/queue/health/health_state_test.go
+++ b/pkg/queue/health/health_state_test.go
@@ -131,6 +131,15 @@ func TestHealthStateHealthHandler(t *testing.T) {
 		prober:       func() bool { return false },
 		isAggressive: true,
 		wantStatus:   http.StatusServiceUnavailable,
+	}, {
+		name:         "aggressive: false, alive: true, prober: false, shuttingDown: false",
+		alive:        true,
+		prober:       func() bool { return false },
+		isAggressive: false,
+		// The current behaviour is that if aggressive is false (ie probePeriod > 0),
+		// we actually don't probe once the first probe succeeds.
+		wantStatus: http.StatusOK,
+		wantBody:   queue.Name,
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
While starting to look at fixing #10764 I noticed we don't actually have a test for the existing behaviour (i.e. removing [health_state.go#L110-L111](https://github.com/julz/serving/blob/64cb01fd4b01bed365f3bc8d55e345ada4694f44/pkg/queue/health/health_state.go#L110-L111) doesn't cause any tests to fail). 

This backfills one so current behaviour (that we cache success forever if periodSeconds > 0) is covered before I go changing it.

/assign @markusthoemmes 