### PR TITLE
bump kind e2e to use go1.15

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -65,10 +65,10 @@ jobs:
       KO_DOCKER_REPO: registry.local:5000/knative
 
     steps:
-    - name: Set up Go 1.14.x
+    - name: Set up Go 1.15.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.14.x
+        go-version: 1.15.x
 
     - name: Install Dependencies
       working-directory: ./


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
