### PR TITLE
Add an e2e hpa test

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -136,7 +136,7 @@ toggle_feature responsive-revision-gc Disabled
 go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
 
 # Run HPA tests
-go test -v -timeout=15m -tags=hpa ./test/e2e
+go test -timeout=15m -tags=hpa ./test/e2e
 
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -136,7 +136,7 @@ toggle_feature responsive-revision-gc Disabled
 go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
 
 # Run HPA tests
-go_test_e2e -v -tags=hpa -timeout=15m ./test/e2e || failed=1
+go test -v -timeout=15m -tags=hpa ./test/e2e
 
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -136,7 +136,7 @@ toggle_feature responsive-revision-gc Disabled
 go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
 
 # Run HPA tests
-go_test_e2e -tags=hpa -timeout=15m ./test/e2e || failed=1
+go_test_e2e -v -tags=hpa -timeout=15m ./test/e2e || failed=1
 
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -136,7 +136,7 @@ toggle_feature responsive-revision-gc Disabled
 go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
 
 # Run HPA tests
-go test -timeout=15m -tags=hpa ./test/e2e
+go_test_e2e -timeout=15m -tags=hpa ./test/e2e || failed=1
 
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -135,6 +135,9 @@ toggle_feature responsive-revision-gc Disabled
 # simply cannot pass.
 go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
 
+# Run HPA tests
+go_test_e2e -tags=hpa -timeout=15m ./test/e2e || failed=1
+
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.
 go_test_e2e -timeout=25m -failfast -parallel=1 ./test/ha \

--- a/test/e2e/autoscale.go
+++ b/test/e2e/autoscale.go
@@ -102,11 +102,11 @@ func (ctx *TestContext) SetLogger(logf logging.FormatLogger) {
 	ctx.logf = logf
 }
 
-func getVegetaTarget(kubeClientset kubernetes.Interface, domain, endpointOverride string, resolvable bool) (vegeta.Target, error) {
+func getVegetaTarget(kubeClientset kubernetes.Interface, domain, endpointOverride string, resolvable bool, paramName string, paramValue int) (vegeta.Target, error) {
 	if resolvable {
 		return vegeta.Target{
 			Method: http.MethodGet,
-			URL:    fmt.Sprintf("http://%s?sleep=%d", domain, autoscaleSleep),
+			URL:    fmt.Sprintf("http://%s?%s=%d", domain, paramName, paramValue),
 		}, nil
 	}
 
@@ -120,7 +120,7 @@ func getVegetaTarget(kubeClientset kubernetes.Interface, domain, endpointOverrid
 
 	return vegeta.Target{
 		Method: http.MethodGet,
-		URL:    fmt.Sprintf("http://%s:%s?sleep=%d", endpoint, mapper("80"), autoscaleSleep),
+		URL:    fmt.Sprintf("http://%s:%s?%s=%d", endpoint, mapper("80"), paramName, paramValue),
 		Header: http.Header{"Host": []string{domain}},
 	}, nil
 }
@@ -129,13 +129,8 @@ func generateTraffic(
 	ctx *TestContext,
 	attacker *vegeta.Attacker,
 	pacer vegeta.Pacer,
-	stopChan chan struct{}) error {
-
-	target, err := getVegetaTarget(
-		ctx.clients.KubeClient, ctx.resources.Route.Status.URL.URL().Hostname(), pkgTest.Flags.IngressEndpoint, test.ServingFlags.ResolvableDomain)
-	if err != nil {
-		return fmt.Errorf("error creating vegeta target: %w", err)
-	}
+	stopChan chan struct{},
+	target vegeta.Target) error {
 
 	// The 0 duration means that the attack will only be controlled by the `Stop` function.
 	results := attacker.Attack(vegeta.NewStaticTargeter(target), pacer, 0, "load-test")
@@ -177,17 +172,27 @@ func generateTrafficAtFixedConcurrency(ctx *TestContext, concurrency int, stopCh
 		vegeta.Timeout(0), // No timeout is enforced at all.
 		vegeta.Workers(uint64(concurrency)),
 		vegeta.MaxWorkers(uint64(concurrency)))
+	target, err := getVegetaTarget(
+		ctx.clients.KubeClient, ctx.resources.Route.Status.URL.URL().Hostname(), pkgTest.Flags.IngressEndpoint, test.ServingFlags.ResolvableDomain, "sleep", autoscaleSleep)
+	if err != nil {
+		return fmt.Errorf("error creating vegeta target: %w", err)
+	}
 
 	ctx.logf("Maintaining %d concurrent requests.", concurrency)
-	return generateTraffic(ctx, attacker, pacer, stopChan)
+	return generateTraffic(ctx, attacker, pacer, stopChan, target)
 }
 
 func generateTrafficAtFixedRPS(ctx *TestContext, rps int, stopChan chan struct{}) error {
 	pacer := vegeta.ConstantPacer{Freq: rps, Per: time.Second}
 	attacker := vegeta.NewAttacker(vegeta.Timeout(0)) // No timeout is enforced at all.
+	target, err := getVegetaTarget(
+		ctx.clients.KubeClient, ctx.resources.Route.Status.URL.URL().Hostname(), pkgTest.Flags.IngressEndpoint, test.ServingFlags.ResolvableDomain, "sleep", autoscaleSleep)
+	if err != nil {
+		return fmt.Errorf("error creating vegeta target: %w", err)
+	}
 
 	ctx.logf("Maintaining %v RPS.", rps)
-	return generateTraffic(ctx, attacker, pacer, stopChan)
+	return generateTraffic(ctx, attacker, pacer, stopChan, target)
 }
 
 func toPercentageString(f float64) string {

--- a/test/e2e/autoscale_hpa_test.go
+++ b/test/e2e/autoscale_hpa_test.go
@@ -1,4 +1,5 @@
 // +build e2e,hpa
+
 /*
 Copyright 2021 The Knative Authors
 

--- a/test/e2e/autoscale_hpa_test.go
+++ b/test/e2e/autoscale_hpa_test.go
@@ -1,4 +1,4 @@
-// +build e2ehpa
+// +build e2e,hpa
 /*
 Copyright 2021 The Knative Authors
 
@@ -20,7 +20,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"knative.dev/pkg/test/spoof"
 	"strconv"
 	"strings"
 	"testing"
@@ -32,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	resourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
 	rtesting "knative.dev/serving/pkg/testing/v1"

--- a/test/e2e/autoscale_hpa_test.go
+++ b/test/e2e/autoscale_hpa_test.go
@@ -1,0 +1,203 @@
+// +build e2ehpa
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"knative.dev/pkg/test/spoof"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	vegeta "github.com/tsenart/vegeta/v12/lib"
+	"golang.org/x/sync/errgroup"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/serving/pkg/apis/autoscaling"
+	resourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
+	rtesting "knative.dev/serving/pkg/testing/v1"
+	"knative.dev/serving/test"
+	v1test "knative.dev/serving/test/v1"
+)
+
+const (
+	cpuTarget             = 75
+	targetPods            = 5
+	scaleUpTimeout        = 3 * time.Minute
+	scaleToMinimumTimeout = 10 * time.Minute // 5 minutes is the default window for hpa to calculate if should scale down
+	minimumReplicas       = 1
+	minPods               = 1.0
+	maxPods               = 10.0
+	primeNum              = 500000
+)
+
+func TestHPAAutoscaleUpDownUp(t *testing.T) {
+	ctx := setupHPASvc(t, autoscaling.HPA, autoscaling.CPU, cpuTarget)
+	test.EnsureTearDown(t, ctx.Clients(), ctx.Names())
+	assertHPAAutoscaleUpToNumPods(ctx, minimumReplicas, targetPods, time.After(scaleUpTimeout), true /* quick */)
+	assertScaleDownToOne(ctx)
+	assertHPAAutoscaleUpToNumPods(ctx, minimumReplicas, targetPods, time.After(scaleUpTimeout), true /* quick */)
+}
+
+func setupHPASvc(t *testing.T, class, metric string, target int) *TestContext {
+	t.Helper()
+	clients := Setup(t)
+
+	t.Log("Creating a new Route and Configuration")
+	names := &test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   autoscaleTestImageName,
+	}
+	resources, err := v1test.CreateServiceReady(t, clients, names,
+		[]rtesting.ServiceOption{
+			rtesting.WithConfigAnnotations(map[string]string{
+				autoscaling.ClassAnnotationKey:    class,
+				autoscaling.MetricAnnotationKey:   metric,
+				autoscaling.TargetAnnotationKey:   strconv.Itoa(target),
+				autoscaling.MinScaleAnnotationKey: fmt.Sprintf("%d", minimumReplicas),
+				autoscaling.MaxScaleAnnotationKey: fmt.Sprintf("%d", int(maxPods)),
+			}), rtesting.WithResourceRequirements(corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("30m"),
+					corev1.ResourceMemory: resource.MustParse("20Mi"),
+				},
+			}),
+		}...)
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	if _, err := pkgTest.WaitForEndpointState(
+		context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		names.URL,
+		v1test.RetryingRouteInconsistency(spoof.MatchesAllOf(spoof.IsStatusOK)),
+		"CheckingEndpointAfterCreate",
+		false,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("Error probing %s: %v", names.URL.Hostname(), err)
+	}
+
+	return &TestContext{
+		t:           t,
+		logf:        t.Logf,
+		clients:     clients,
+		names:       names,
+		resources:   resources,
+		targetValue: target,
+		metric:      metric,
+	}
+}
+func assertHPAAutoscaleUpToNumPods(ctx *TestContext, curPods, targetPods float64, done <-chan time.Time, quick bool) {
+	ctx.t.Helper()
+	wait := autoscaleHPAUpToNumPods(ctx, curPods, targetPods, done, quick)
+	if err := wait(); err != nil {
+		ctx.t.Fatal(err)
+	}
+}
+
+func autoscaleHPAUpToNumPods(ctx *TestContext, curPods, targetPods float64, done <-chan time.Time, quick bool) func() error {
+	ctx.t.Helper()
+
+	stopChan := make(chan struct{})
+	var grp errgroup.Group
+	grp.Go(func() error {
+		return generateTrafficAtFixedRPSWithCPULoad(ctx, int(targetPods*5), stopChan)
+	})
+
+	grp.Go(func() error {
+		defer close(stopChan)
+		return checkPodScale(ctx, targetPods, minPods, maxPods, done, quick)
+	})
+
+	return grp.Wait
+}
+
+func generateTrafficAtFixedRPSWithCPULoad(ctx *TestContext, rps int, stopChan chan struct{}) error {
+	pacer := vegeta.ConstantPacer{Freq: rps, Per: time.Second}
+	attacker := vegeta.NewAttacker(vegeta.Timeout(0)) // No timeout is enforced at all.
+	target, err := getVegetaTarget(
+		ctx.clients.KubeClient, ctx.resources.Route.Status.URL.URL().Hostname(), pkgTest.Flags.IngressEndpoint, test.ServingFlags.ResolvableDomain, "prime", primeNum)
+	if err != nil {
+		return fmt.Errorf("error creating vegeta target: %w", err)
+	}
+	ctx.logf("Maintaining %v RPS.", rps)
+	return generateTraffic(ctx, attacker, pacer, stopChan, target)
+}
+
+func assertScaleDownToOne(ctx *TestContext) {
+	deploymentName := resourcenames.Deployment(ctx.resources.Revision)
+	if err := waitForScaleToOne(ctx.t, deploymentName, ctx.clients); err != nil {
+		ctx.t.Fatalf("Unable to observe the Deployment named %s scaling down: %v", deploymentName, err)
+	}
+	// Account for the case where scaling up uses all available pods.
+	ctx.logf("Wait for all pods to terminate.")
+
+	if err := pkgTest.WaitForPodListState(
+		context.Background(),
+		ctx.clients.KubeClient,
+		func(p *corev1.PodList) (bool, error) {
+			if !(len(getDepPods(p.Items, deploymentName)) == 1) {
+				return false, nil
+			}
+			return true, nil
+		},
+		"WaitForAvailablePods", test.ServingNamespace); err != nil {
+		ctx.t.Fatalf("Waiting for Pod.List to have no non-Evicted pods of %q: %v", deploymentName, err)
+	}
+
+	ctx.logf("The Revision should remain ready after scaling to one.")
+	if err := v1test.CheckRevisionState(ctx.clients.ServingClient, ctx.names.Revision, v1test.IsRevisionReady); err != nil {
+		ctx.t.Fatalf("The Revision %s did not stay Ready after scaling down to one: %v", ctx.names.Revision, err)
+	}
+
+	ctx.logf("Scaled down.")
+}
+
+func getDepPods(nsPods []corev1.Pod, deploymentName string) []corev1.Pod {
+	var pods []corev1.Pod
+	for _, p := range nsPods {
+		if strings.Contains(p.Name, deploymentName) && !strings.Contains(p.Status.Reason, "Evicted") {
+			pods = append(pods, p)
+		}
+	}
+	return pods
+}
+
+func waitForScaleToOne(t *testing.T, deploymentName string, clients *test.Clients) error {
+	t.Helper()
+	t.Logf("Waiting for %q to scale to one", deploymentName)
+
+	return pkgTest.WaitForDeploymentState(
+		context.Background(),
+		clients.KubeClient,
+		deploymentName,
+		func(d *appsv1.Deployment) (bool, error) {
+			return d.Status.ReadyReplicas == 1, nil
+		},
+		"DeploymentIsScaledDown",
+		test.ServingNamespace,
+		scaleToMinimumTimeout,
+	)
+}

--- a/test/e2e/autoscale_hpa_test.go
+++ b/test/e2e/autoscale_hpa_test.go
@@ -1,4 +1,5 @@
-// +build e2e,hpa
+// +build e2e
+// +build hpa
 
 /*
 Copyright 2021 The Knative Authors


### PR DESCRIPTION
Fixes #9553 

This has been tested on minikube + istio since kind does not support heapster. Has a special tag `hpa` so it is not run with the other e2e tests.  Test run with `-timeout=30m`.
The screenshots bellow show the different steps:
1) no traffic yet, hpa has no metrics
![image](https://user-images.githubusercontent.com/7945591/114761194-d7f13180-9d68-11eb-8f90-584628c1b62f.png)

2) After a while traffic hits the service and cpu usage increases dramatically,
![image](https://user-images.githubusercontent.com/7945591/114761365-08d16680-9d69-11eb-902a-37b5bb07e63b.png)

3) At some point there are enough replicas created:
![image](https://user-images.githubusercontent.com/7945591/114761448-24d50800-9d69-11eb-905d-07d1a7acb24c.png)

4) Traffic terminates and cpu usage goes down as expected:
![image](https://user-images.githubusercontent.com/7945591/114761520-40401300-9d69-11eb-9dca-b7e6316ab0fc.png)

5) Wait for the revision to scale to 1:
![image](https://user-images.githubusercontent.com/7945591/114761587-5ea60e80-9d69-11eb-98ce-48a517315be7.png)

6) Then we create traffic and wait to reach the target number of pods and exit:
![image](https://user-images.githubusercontent.com/7945591/114761682-7f6e6400-9d69-11eb-8efb-dd49a5a8e229.png)
