### PR TITLE
Don't hardcode replica count in the Activator HA test

### DIFF
--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -44,7 +44,6 @@ import (
 
 const (
 	activatorDeploymentName = "activator"
-	activatorLabel          = "app=activator"
 	minProbes               = 400 // We want to send at least 400 requests.
 )
 

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -195,6 +195,7 @@ func waitForActivatorScale(ctx context.Context, client kubernetes.Interface) (in
 		if *d.Spec.Replicas < 2 {
 			return false, errors.New("spec.replicaCount should be > 1")
 		}
+		desiredScale = int(*d.Spec.Replicas)
 		for _, c := range d.Status.Conditions {
 			if c.Type == appsv1.DeploymentAvailable {
 				return c.Status == v1.ConditionTrue, nil


### PR DESCRIPTION
Prior these counts would need to match our HA replica count
which is determined by a flag

Instead we now:
- query for the activator's desired replica count
- roll only the activators that are handling requests for
  the two test revisions

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @markusthoemmes @vagababov @julz 