### PR TITLE
Excluse domainmapping-webhook from chaos

### DIFF
--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -86,6 +86,7 @@ spec:
         # Disable chaos on webhooks until https://github.com/knative/pkg/issues/1509 is
         # sorted out.
         - "-disable=webhook"
+        - "-disable=domainmapping-webhook"
         # Currently the new owner of Autoscaler needs time to build the
         # metrics status so some e2e tests are expected to fail if the
         # owner pod crashes.


### PR DESCRIPTION
.. for same reasons as excluding regular webhook (see https://github.com/knative/pkg/issues/1509).

/assign @markusthoemmes 