### PR TITLE
Fix activator index update log

### DIFF
--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -637,7 +637,7 @@ func (rt *revisionThrottler) handlePubEpsUpdate(eps *corev1.Endpoints, selfIP st
 	rt.numActivators.Store(newNA)
 	rt.activatorIndex.Store(newAI)
 	rt.logger.Infof("This activator index is %d/%d was %d/%d",
-		rt.activatorIndex, rt.numActivators, newAI, newNA)
+		newAI, newNA, ai, na)
 	rt.updateCapacity(rt.backendCount)
 }
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This currently prints things the wrong way in two ways:
1. Tries to print atomics directly (yields in `{[] 2}` for example)
2. It prints the same values twice.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @vagababov @julz 
