### PR TITLE
Force ci gke cluster to be 1.18 until we figure out 1.19 failures

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -174,7 +174,8 @@ function delete_dns_record() {
 # Skip installing istio as an add-on
 # Temporarily increasing the cluster size for serving tests to rule out
 # resource/eviction as causes of flakiness.
-initialize "$@" --skip-istio-addon --min-nodes=4 --max-nodes=4
+# Pin to 1.18 since scale test is super flakey on 1.19
+initialize "$@" --skip-istio-addon --min-nodes=4 --max-nodes=4 --cluster-version=1.18.16-gke.502
 
 header "Enabling high-availability"
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -38,7 +38,8 @@ function knative_setup() {
 # Skip installing istio as an add-on.
 # Temporarily increasing the cluster size for serving tests to rule out
 # resource/eviction as causes of flakiness.
-initialize "$@" --skip-istio-addon --min-nodes=4 --max-nodes=4
+# Pin to 1.18 since scale test is super flakey on 1.19
+initialize "$@" --skip-istio-addon --min-nodes=4 --max-nodes=4 --cluster-version=1.18.16-gke.502
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -36,7 +36,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/e2e-common.sh"
 # Skip installing istio as an add-on.
 # Temporarily increasing the cluster size for serving tests to rule out
 # resource/eviction as causes of flakiness.
-initialize "$@" --skip-istio-addon --min-nodes=4 --max-nodes=4
+# Pin to 1.18 since scale test is super flakey on 1.19
+initialize "$@" --skip-istio-addon --min-nodes=4 --max-nodes=4 --cluster-version=1.18.16-gke.502
 
 # We haven't configured these deployments for high-availability,
 # so disable the chaos duck.


### PR DESCRIPTION
Scale tests seem to fail consistently with 1.19. This pins our CI e2e to use 1.18 until we sort out those issues