### PR TITLE
Don't fall back to cluster IP when error is not mesh-related

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -150,9 +150,8 @@ func (rw *revisionWatcher) probe(ctx context.Context, dest string) (pass bool, n
 		Path:   network.ProbePath,
 	}
 
-	// We want to differentiate between 503 errors, which are compatible with
-	// failures being caused by the mesh being enabled, and generic probe
-	// failures. We don't want to fall back to ClusterIP for generic probe fails.
+	// We don't want to unnecessarily fall back to ClusterIP if we see a failure
+	// that could not have been caused by the mesh being enabled.
 	var checkMesh prober.Verifier = func(resp *http.Response, b []byte) (bool, error) {
 		notMesh = !network.IsPotentialMeshErrorResponse(resp)
 		return true, nil

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
@@ -139,17 +140,30 @@ func newRevisionWatcher(ctx context.Context, rev types.NamespacedName, protocol 
 	}
 }
 
-func (rw *revisionWatcher) probe(ctx context.Context, dest string) (bool, error) {
+// probe probes the destination and returns whether it is ready according to
+// the probe. If the failure is not compatible with having been caused by mesh
+// being enabled, notMesh will be true.
+func (rw *revisionWatcher) probe(ctx context.Context, dest string) (pass bool, notMesh bool, err error) {
 	httpDest := url.URL{
 		Scheme: "http",
 		Host:   dest,
 		Path:   network.ProbePath,
 	}
 
+	// We want to differentiate between 503 errors, which are compatible with
+	// failures being caused by the mesh being enabled, and generic probe
+	// failures. We don't want to fall back to ClusterIP for generic probe fails.
+	var checkMesh prober.Verifier = func(resp *http.Response, b []byte) (bool, error) {
+		notMesh = !network.IsPotentialMeshErrorResponse(resp)
+		return true, nil
+	}
+
 	// NOTE: changes below may require changes to testing/roundtripper.go to make unit tests pass.
 	options := []interface{}{
 		prober.WithHeader(network.ProbeHeaderName, queue.Name),
 		prober.WithHeader(network.UserAgentKey, network.ActivatorUserAgent),
+		// Order is important since first failing verification short-circuits the rest: checkMesh must be first.
+		checkMesh,
 		prober.ExpectsBody(queue.Name),
 		prober.ExpectsStatusCodes([]int{http.StatusOK})}
 
@@ -165,7 +179,8 @@ func (rw *revisionWatcher) probe(ctx context.Context, dest string) (bool, error)
 			prober.WithHeader(network.PassthroughLoadbalancingHeaderName, "true"))
 	}
 
-	return prober.Do(ctx, rw.transport, httpDest.String(), options...)
+	match, err := prober.Do(ctx, rw.transport, httpDest.String(), options...)
+	return match, notMesh, err
 }
 
 func (rw *revisionWatcher) getDest() (string, error) {
@@ -187,15 +202,18 @@ func (rw *revisionWatcher) getDest() (string, error) {
 func (rw *revisionWatcher) probeClusterIP(dest string) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
 	defer cancel()
-	return rw.probe(ctx, dest)
+	match, _, err := rw.probe(ctx, dest)
+	return match, err
 }
 
 // probePodIPs will probe the given target Pod IPs and will return
 // the ones that are successfully probed, whether the update was a no-op, or an error.
-func (rw *revisionWatcher) probePodIPs(dests sets.String) (sets.String, bool, error) {
+// If probing fails but not all errors were compatible with being caused by
+// mesh being enabled, being enabled, notMesh will be true.
+func (rw *revisionWatcher) probePodIPs(dests sets.String) (succeeded sets.String, noop bool, notMesh bool, err error) {
 	// Short circuit case where dests == healthyPods
 	if rw.healthyPods.Equal(dests) {
-		return rw.healthyPods, true /*no-op*/, nil
+		return rw.healthyPods, true /*no-op*/, false /* notMesh */, nil
 	}
 
 	toProbe := sets.NewString()
@@ -210,7 +228,7 @@ func (rw *revisionWatcher) probePodIPs(dests sets.String) (sets.String, bool, er
 
 	// Short circuit case where the healthy list got effectively smaller.
 	if toProbe.Len() == 0 {
-		return healthy, false, nil
+		return healthy, false, false, nil
 	}
 
 	// Context used for our probe requests.
@@ -220,25 +238,31 @@ func (rw *revisionWatcher) probePodIPs(dests sets.String) (sets.String, bool, er
 	probeGroup, egCtx := errgroup.WithContext(ctx)
 	healthyDests := make(chan string, toProbe.Len())
 
+	var sawNotMesh atomic.Bool
 	for dest := range toProbe {
 		dest := dest // Standard Go concurrency pattern.
 		probeGroup.Go(func() error {
-			ok, err := rw.probe(egCtx, dest)
+			ok, notMesh, err := rw.probe(egCtx, dest)
 			if ok {
 				healthyDests <- dest
+			}
+			if notMesh {
+				// If *any* of the errors are not mesh related, assume the mesh is not
+				// enabled and stay with direct scraping.
+				sawNotMesh.Store(true)
 			}
 			return err
 		})
 	}
 
-	err := probeGroup.Wait()
+	err = probeGroup.Wait()
 	close(healthyDests)
 	unchanged := len(healthyDests) == 0
 
 	for d := range healthyDests {
 		healthy.Insert(d)
 	}
-	return healthy, unchanged, err
+	return healthy, unchanged, sawNotMesh.Load(), err
 }
 
 func (rw *revisionWatcher) sendUpdate(clusterIP string, dests sets.String) {
@@ -282,7 +306,7 @@ func (rw *revisionWatcher) checkDests(curDests, prevDests dests) {
 		// First check the pod IPs. If we can individually address
 		// the Pods we should go that route, since it permits us to do
 		// precise load balancing in the throttler.
-		hs, noop, err := rw.probePodIPs(curDests.ready.Union(curDests.notReady))
+		hs, noop, notMesh, err := rw.probePodIPs(curDests.ready.Union(curDests.notReady))
 		if err != nil {
 			rw.logger.Warnw("Failed probing pods", zap.Object("curDests", curDests), zap.Error(err))
 			// We dont want to return here as an error still affects health states.
@@ -298,6 +322,11 @@ func (rw *revisionWatcher) checkDests(curDests, prevDests dests) {
 		}
 		// no-op, and we have successfully probed at least one pod.
 		if len(hs) > 0 {
+			return
+		}
+		// We didn't get any pods, but we know the mesh is not enabled since we got
+		// a non-mesh status code while probing, so we don't want to fall back.
+		if notMesh {
 			return
 		}
 	}


### PR DESCRIPTION
Corresponding PR to #11174 for activator. Avoids falling back to clusterIP when we know - due to seeing a non-mesh-related-error - that we did not fail due to the mesh. This avoids (or at least minimises) races where we fail in direct podIP mode just due to things starting up, then pass with clusterIP and stay with clusterIP forever when direct would have worked.