### PR TITLE
Allow for more overscale in tests if the deployment is being rolled

### DIFF
--- a/test/e2e/autoscale.go
+++ b/test/e2e/autoscale.go
@@ -301,6 +301,7 @@ func numberOfReadyPods(ctx *TestContext) (float64, *appsv1.Deployment, error) {
 		// Ref: #11092
 		// The deployment was updated and the update is being rolled out so we defensively
 		// pick the desired replicas to assert the autoscaling decisions.
+		// TODO: Drop this once we solved the underscale issue.
 		ctx.t.Logf("Deployment is being rolled, picking spec.replicas=%d", *deploy.Spec.Replicas)
 		return float64(*deploy.Spec.Replicas), deploy, nil
 	}
@@ -347,6 +348,14 @@ func checkPodScale(ctx *TestContext, targetPods, minPods, maxPods float64, done 
 			if err != nil {
 				return fmt.Errorf("failed to fetch number of ready pods: %w", err)
 			}
+
+			if isInRollout(d) {
+				// Ref: #11092
+				// Allow for a higher scale if the deployment is being rolled as that
+				// might be skewing metrics in the autoscaler.
+				maxPods = math.Ceil(maxPods * 1.2)
+			}
+
 			mes := fmt.Sprintf("got %v replicas, expected between [%v, %v] replicas for revision %s\ndeployment state: %s",
 				got, targetPods-1, maxPods, ctx.resources.Revision.Name, spew.Sdump(d))
 			ctx.logf(mes)


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Ref: #11092

As described in that issue, when a deployment is being rolled (as it happens in the upgrade test), the autoscaler might intermittently scale higher than expected as its metrics will be influenced by the rollover. As that's intermittent and not harmful to workloads, we can accept an overscale in those situations.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
