### PR TITLE
Use OnDeletionInterface to drop potentially racy direct usages of DeleteFunc

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -19,7 +19,6 @@ package kpa
 import (
 	"context"
 
-	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
 
 	networkingclient "knative.dev/networking/pkg/client/injection/client"
@@ -33,7 +32,6 @@ import (
 
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	"knative.dev/serving/pkg/apis/autoscaling"
@@ -93,18 +91,6 @@ func NewController(
 	paInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: onlyKPAClass,
 		Handler:    controller.HandleAll(impl.Enqueue),
-	})
-
-	// When we see PodAutoscalers deleted, clean up the decider.
-	paInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		DeleteFunc: func(obj interface{}) {
-			accessor, err := kmeta.DeletionHandlingAccessor(obj)
-			if err != nil {
-				logger.Errorw("Error accessing object", zap.Error(err))
-				return
-			}
-			deciders.Delete(ctx, accessor.GetNamespace(), accessor.GetName())
-		},
 	})
 
 	onlyPAControlled := controller.FilterController(&autoscalingv1alpha1.PodAutoscaler{})

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1305,7 +1305,6 @@ func TestReconcileDeciderCreatesAndDeletes(t *testing.T) {
 	}
 
 	var eg errgroup.Group
-	eg.Go(func() error { return ctl.Run(1, ctx.Done()) })
 	defer func() {
 		cancel()
 		wf()
@@ -1328,6 +1327,10 @@ func TestReconcileDeciderCreatesAndDeletes(t *testing.T) {
 	fakesksinformer.Get(ctx).Informer().GetIndexer().Add(sks)
 
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(ctx, kpa, metav1.CreateOptions{})
+	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
+
+	// Start controller after creating initial resources so it observes a steady state.
+	eg.Go(func() error { return ctl.Run(1, ctx.Done()) })
 
 	select {
 	case <-time.After(5 * time.Second):

--- a/pkg/reconciler/metric/controller.go
+++ b/pkg/reconciler/metric/controller.go
@@ -19,15 +19,12 @@ package metric
 import (
 	"context"
 
-	"go.uber.org/zap"
-	"k8s.io/client-go/tools/cache"
 	"knative.dev/serving/pkg/autoscaler/metrics"
 	metricinformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/metric"
 	metricreconciler "knative.dev/serving/pkg/client/injection/reconciler/autoscaling/v1alpha1/metric"
 
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 )
 
@@ -50,17 +47,6 @@ func NewController(
 
 	// Watch all the Metric objects.
 	metricInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
-
-	metricInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		DeleteFunc: func(obj interface{}) {
-			accessor, err := kmeta.DeletionHandlingAccessor(obj)
-			if err != nil {
-				logger.Errorw("Error accessing object", zap.Error(err))
-				return
-			}
-			c.collector.Delete(accessor.GetNamespace(), accessor.GetName())
-		},
-	})
 
 	collector.Watch(impl.EnqueueKey)
 

--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -32,8 +32,6 @@ import (
 	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 	revisionreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/revision"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/configmap"
@@ -123,13 +121,6 @@ func newControllerWithOptions(
 	// Set up an event handler for when the resource types of interest change
 	logger.Info("Setting up event handlers")
 	revisionInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
-	revisionInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		DeleteFunc: func(obj interface{}) {
-			if om, ok := obj.(metav1.Object); ok {
-				resolver.Clear(types.NamespacedName{Namespace: om.GetNamespace(), Name: om.GetName()})
-			}
-		},
-	})
 
 	handleMatchingControllers := cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterController(&v1.Revision{}),


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Using `DeleteFunc` on the informers does not send the respective keys via the work queues of the reconciler. In theory, a resource can still be in `ReconcileKind` and then be deleted, resulting in the call to `DeleteFunc` racing with `ReconcileKind` and thus potentially leaving inconsistent state.

`ObserveDeletion` solves that by allowing the implementer to handle deletion events consistently with the underlying queue, eliminating that race.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @n3wscott @dprotaso 
