### PR TITLE
hardcode the ambassador namespace

### DIFF
--- a/third_party/ambassador-latest/ambassador-namespace.yaml
+++ b/third_party/ambassador-latest/ambassador-namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ambassador

--- a/third_party/ambassador-latest/ambassador-rbac.yaml
+++ b/third_party/ambassador-latest/ambassador-rbac.yaml
@@ -6,6 +6,7 @@ metadata:
     service: ambassador-admin
     app.kubernetes.io/managed-by: getambassador.io
   name: ambassador-admin
+  namespace: ambassador
 spec:
   type: NodePort
   ports:
@@ -49,6 +50,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ambassador
+  namespace: ambassador
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -67,6 +69,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ambassador
+  namespace: ambassador
 spec:
   replicas: 3
   selector:

--- a/third_party/ambassador-latest/ambassador-service.yaml
+++ b/third_party/ambassador-latest/ambassador-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ambassador
+  namespace: ambassador
   labels:
     app.kubernetes.io/component: ambassador-service
 spec:


### PR DESCRIPTION
it's already hardcoded in the cluster role so changing the namespace wouldn't work

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Should simplify setting up e2e tests

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
