### PR TITLE
Lower the drain sleep in queue-proxy to previous value

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -57,6 +57,11 @@ import (
 const (
 	// reportingPeriod is the interval of time between reporting stats by queue proxy.
 	reportingPeriod = 1 * time.Second
+
+	// Duration the /wait-for-drain handler should wait before returning.
+	// This is to give networking a little bit more time to remove the pod
+	// from its configuration and propagate that to all loadbalancers and nodes.
+	drainSleepDuration = 30 * time.Second
 )
 
 var (
@@ -232,8 +237,8 @@ func main() {
 	case <-ctx.Done():
 		logger.Info("Received TERM signal, attempting to gracefully shutdown servers.")
 		healthState.Shutdown(func() {
-			logger.Infof("Sleeping %v to allow K8s propagation of non-ready state", pkgnet.DefaultDrainTimeout)
-			time.Sleep(pkgnet.DefaultDrainTimeout)
+			logger.Infof("Sleeping %v to allow K8s propagation of non-ready state", drainSleepDuration)
+			time.Sleep(drainSleepDuration)
 
 			// Calling server.Shutdown() allows pending requests to
 			// complete, while no new work is accepted.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

The global constant is subject to experimentation to get a lot of other components to behave correctly. It currently sits at 45s. We know however, that the queue-proxy timeout is stable at 30s (and probably even at 20s), so this separates the constants to allow for less impact to customer apps taking long to shut down.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Revision replicas shut down 15s quicker.
```

/assign @vagababov @julz 
