### PR TITLE
Actually use the rate limited queue

### DIFF
--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -33,6 +33,7 @@ import (
 	revisionreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/revision"
 
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
@@ -42,7 +43,6 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/reconciler/revision/config"
-	"k8s.io/client-go/util/workqueue"
 )
 
 // digestResolutionWorkers is the number of image digest resolutions that can


### PR DESCRIPTION
[Previously](https://github.com/knative/serving/pull/10237) we introduced a rate limited queue, but we still called its Add method rather than AddRateLimited, so the rate limit didn't do anything 😊 (the added test fails before this change).

I'm not wild about the time.Sleep in the test here, but given the bug that crept in I really wanted to test the actual behaviour rather than faking the queue out and I didn't find a much better way of doing that.

Note: we still don't properly use the queue for per-item retries (and we call Forget after failures) so this won't work with per-item back-off yet, but at least this rate limits properly.

Helps: #11251 (Ill add fixes when we fix per-item back-off too)

/assign @markusthoemmes @vagababov 