### PR TITLE
Do not toggle configuration in e2e when unnecessary

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -113,8 +113,6 @@ toggle_feature tag-header-based-routing Enabled
 go_test_e2e -timeout=2m ./test/e2e/tagheader || failed=1
 toggle_feature tag-header-based-routing Disabled
 
-go_test_e2e -timeout=2m ./test/e2e/multicontainer || failed=1
-
 # Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go).
 toggle_feature allow-zero-initial-scale true config-autoscaler || fail_test
 go_test_e2e -timeout=2m ./test/e2e/initscale || failed=1

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -113,22 +113,18 @@ toggle_feature tag-header-based-routing Enabled
 go_test_e2e -timeout=2m ./test/e2e/tagheader || failed=1
 toggle_feature tag-header-based-routing Disabled
 
-toggle_feature multi-container Enabled
 go_test_e2e -timeout=2m ./test/e2e/multicontainer || failed=1
-toggle_feature multi-container Disabled
 
 # Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go).
 toggle_feature allow-zero-initial-scale true config-autoscaler || fail_test
 go_test_e2e -timeout=2m ./test/e2e/initscale || failed=1
 toggle_feature allow-zero-initial-scale false config-autoscaler || fail_test
 
-toggle_feature responsive-revision-gc Enabled
 kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml > ${TMP_DIR}/config-gc.yaml
 add_trap "kubectl replace cm 'config-gc' -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml" SIGKILL SIGTERM SIGQUIT
 immediate_gc
 go_test_e2e -timeout=2m ./test/e2e/gc || failed=1
 kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml
-toggle_feature responsive-revision-gc Disabled
 
 # Run scale tests.
 # Note that we use a very high -parallel because each ksvc is run as its own

--- a/test/e2e/multicontainer_test.go
+++ b/test/e2e/multicontainer_test.go
@@ -28,14 +28,13 @@ import (
 	"knative.dev/pkg/test/spoof"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/test"
-	"knative.dev/serving/test/e2e"
 	v1test "knative.dev/serving/test/v1"
 )
 
 func TestMultiContainer(t *testing.T) {
 	t.Parallel()
 
-	clients := e2e.Setup(t)
+	clients := Setup(t)
 
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),

--- a/test/e2e/multicontainer_test.go
+++ b/test/e2e/multicontainer_test.go
@@ -32,6 +32,9 @@ import (
 )
 
 func TestMultiContainer(t *testing.T) {
+	if !test.ServingFlags.EnableBetaFeatures {
+		t.Skip()
+	}
 	t.Parallel()
 
 	clients := Setup(t)

--- a/test/e2e/multicontainer_test.go
+++ b/test/e2e/multicontainer_test.go
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package multicontainer
+package e2e
 
 import (
 	"context"


### PR DESCRIPTION
`multi-container` and  `responsive-revision-gc`  are enabled by default
so we don't need to toggle the configurations during the e2e.
Also this can confirm that the configurations are surely enabled by
default.

**Release Note**

```release-note
NONE
```
