### PR TITLE
Drop ingressClass and certificateClass flags from serving test

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -172,7 +172,6 @@ flags:
   - [`--ingressendpoint`](#using-a-custom-ingress-endpoint)
 - [`--resolvabledomain`](#using-a-resolvable-domain)
 - [`--https`](#using-https)
-- [`--ingressClass`](#using-ingress-class)
 
 ### Overriding docker repo
 
@@ -246,8 +245,3 @@ export GATEWAY_NAMESPACE_OVERRIDE=kourier-system
 ### Using https
 
 You can use the `--https` flag to have all tests run with https.
-
-### Using ingress class
-
-The `--ingressClass` argument lets you specify the ingress class. The default
-value is `istio.ingress.networking.knative.dev`.

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -336,24 +336,6 @@ function use_resolvable_domain() {
   echo "false"
 }
 
-# Check if we should specify --ingressClass
-function ingress_class() {
-  if [[ -z "${INGRESS_CLASS}" ]]; then
-    echo ""
-  else
-    echo "--ingressClass=${INGRESS_CLASS}"
-  fi
-}
-
-# Check if we should specify --certificateClass
-function certificate_class() {
-  if [[ -z "${CERTIFICATE_CLASS}" ]]; then
-    echo ""
-  else
-    echo "--certificateClass=${CERTIFICATE_CLASS}"
-  fi
-}
-
 # Uninstalls Knative Serving from the current cluster.
 function knative_teardown() {
   if [[ -z "${INSTALL_CUSTOM_YAMLS}" && -z "${UNINSTALL_LIST[@]}" ]]; then

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -102,7 +102,7 @@ go_test_e2e -timeout=30m \
   ${parallelism} \
   ${alpha} \
   --enable-beta \
-  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" "$(ingress_class)" || failed=1
+  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" || failed=1
 
 if (( HTTPS )); then
   kubectl delete -f ${TMP_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -36,8 +36,6 @@ type ServingEnvironmentFlags struct {
 	ResolvableDomain    bool   // Resolve Route controller's `domainSuffix`
 	CustomDomain        string // Indicaates the `domainSuffix` for custom domain test.
 	HTTPS               bool   // Indicates where the test service will be created with https
-	IngressClass        string // Indicates the class of Ingress provider to test.
-	CertificateClass    string // Indicates the class of Certificate provider to test.
 	Buckets             int    // The number of reconciler buckets configured.
 	Replicas            int    // The number of controlplane replicas being run.
 	EnableAlphaFeatures bool   // Indicates whether we run tests for alpha features
@@ -74,24 +72,6 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 			"Set this flag to true to run all tests with https.")
 	} else {
 		f.HTTPS = fl.Value.(flag.Getter).Get().(bool)
-	}
-
-	if fl := flag.Lookup("ingressClass"); fl == nil {
-		flag.StringVar(&f.IngressClass,
-			"ingressClass",
-			network.IstioIngressClassName,
-			"Set this flag to the ingress class to test against.")
-	} else {
-		f.IngressClass = fl.Value.String()
-	}
-
-	if fl := flag.Lookup("certificateClass"); fl == nil {
-		flag.StringVar(&f.CertificateClass,
-			"certificateClass",
-			network.CertManagerCertificateClassName,
-			"Set this flag to the certificate class to test against.")
-	} else {
-		f.IngressClass = fl.Value.String()
 	}
 
 	if fl := flag.Lookup("buckets"); fl == nil {

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -22,8 +22,6 @@ package test
 import (
 	"flag"
 
-	network "knative.dev/networking/pkg"
-
 	// Load the generic flags of knative.dev/pkg too.
 	_ "knative.dev/pkg/test"
 )


### PR DESCRIPTION
ingressClass and certificateClass flags are moved to networking repo
and they are not used in serving repo.

This patch removes them.

**Release Note**

```release-note
NONE
```
