### PR TITLE
Implement per-item rate limits for digest resolution

### DIFF
--- a/pkg/reconciler/revision/background.go
+++ b/pkg/reconciler/revision/background.go
@@ -177,12 +177,12 @@ func (r *backgroundResolver) addWorkItems(rev *v1.Revision, name types.Namespace
 		},
 	}
 
-	for i := range rev.Spec.Containers {
+	for i, container := range rev.Spec.Containers {
 		item := workItem{
 			revision: name,
 			timeout:  timeout,
-			name:     rev.Spec.Containers[i].Name,
-			image:    rev.Spec.Containers[i].Image,
+			name:     container.Name,
+			image:    container.Image,
 			index:    i,
 		}
 

--- a/pkg/reconciler/revision/background.go
+++ b/pkg/reconciler/revision/background.go
@@ -55,6 +55,7 @@ type resolveResult struct {
 	opt                k8schain.Options
 	registriesToSkip   sets.String
 	completionCallback func()
+	workItems          []workItem
 
 	// these fields can be written concurrently, so should only be accessed while
 	// holding the backgroundResolver mutex.
@@ -170,21 +171,23 @@ func (r *backgroundResolver) addWorkItems(rev *v1.Revision, name types.Namespace
 		registriesToSkip: registriesToSkip,
 		statuses:         make([]v1.ContainerStatus, len(rev.Spec.Containers)),
 		remaining:        len(rev.Spec.Containers),
+		workItems:        make([]workItem, len(rev.Spec.Containers)),
 		completionCallback: func() {
 			r.enqueue(name)
 		},
 	}
 
 	for i := range rev.Spec.Containers {
-		image := rev.Spec.Containers[i].Image
-
-		r.queue.AddRateLimited(workItem{
+		item := workItem{
 			revision: name,
 			timeout:  timeout,
 			name:     rev.Spec.Containers[i].Name,
-			image:    image,
+			image:    rev.Spec.Containers[i].Image,
 			index:    i,
-		})
+		}
+
+		r.results[name].workItems[i] = item
+		r.queue.AddRateLimited(item)
 	}
 }
 
@@ -192,13 +195,7 @@ func (r *backgroundResolver) addWorkItems(rev *v1.Revision, name types.Namespace
 // in the resolveResult. If this completes the work for the revision, the
 // completionCallback is called.
 func (r *backgroundResolver) processWorkItem(item workItem) {
-	defer func() {
-		// NOTE: right now we do not retry failing items, but if we were
-		// `Forget` should be called only in case of a success
-		// (or if we abandon the item).
-		r.queue.Forget(item)
-		r.queue.Done(item)
-	}()
+	defer r.queue.Done(item)
 
 	// We need to acquire the result under lock since it's theoretically possible
 	// for a Clear to race with this and try to delete the result from the map.
@@ -219,6 +216,11 @@ func (r *backgroundResolver) processWorkItem(item workItem) {
 	// just storing the result.
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	// If we succeeded we can stop remembering the item for back-off purposes.
+	if resolveErr == nil {
+		r.queue.Forget(item)
+	}
 
 	// If we're already ready we don't want to callback twice.
 	// This can happen if an image resolve completes but we've already reported
@@ -246,11 +248,29 @@ func (r *backgroundResolver) processWorkItem(item workItem) {
 }
 
 // Clear removes any cached results for the revision. This should be called
-// when the revision is deleted or once the revision's ContainerStatus has been
-// set.
+// once the revision's ContainerStatus has been set.
 func (r *backgroundResolver) Clear(name types.NamespacedName) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	delete(r.results, name)
+}
+
+// Forget removes the revision from the rate limiter and removes any cached
+// results for the revision. It should be called when the revision is deleted
+// or marked permanently failed.
+func (r *backgroundResolver) Forget(name types.NamespacedName) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	result := r.results[name]
+	if result == nil {
+		return
+	}
+
+	for _, item := range result.workItems {
+		r.queue.Forget(item)
+	}
 
 	delete(r.results, name)
 }

--- a/pkg/reconciler/revision/background_test.go
+++ b/pkg/reconciler/revision/background_test.go
@@ -254,7 +254,7 @@ func TestRateLimitPerItem(t *testing.T) {
 	if took := time.Since(start); took < 500*time.Millisecond {
 		// Per-item time is 50ms, so after 4 cycles of back-off should take at least 500ms.
 		// (Otherwise will take only ~200ms)
-		t.Fatal("Expected second resolve to take longer than 500ms, but took", took)
+		t.Fatal("Expected resolves to take longer than 500ms, but took", took)
 	}
 
 	subject.Forget(types.NamespacedName{Name: "rev", Namespace: "ns"})

--- a/pkg/reconciler/revision/background_test.go
+++ b/pkg/reconciler/revision/background_test.go
@@ -239,7 +239,7 @@ func TestRateLimitPerItem(t *testing.T) {
 	start := time.Now()
 	revision := rev("rev", "img1", "img2")
 	for i := 0; i < 4; i++ {
-		subject.Clear(types.NamespacedName{Name: "rev", Namespace: "ns"})
+		subject.Clear(types.NamespacedName{Name: revision.Name, Namespace: revision.Namespace})
 		resolution, err := subject.Resolve(revision, k8schain.Options{ServiceAccountName: "san"}, sets.NewString("skip"), 0)
 		if err != nil || resolution != nil {
 			t.Fatalf("Expected Resolve to be nil, nil but got %v, %v", resolution, err)
@@ -273,10 +273,10 @@ func TestRateLimitPerItem(t *testing.T) {
 	})
 
 	t.Run("Forget clears per-item rate limit", func(t *testing.T) {
-		subject.Forget(types.NamespacedName{Name: "rev", Namespace: "ns"})
+		subject.Forget(types.NamespacedName{Name: revision.Name, Namespace: revision.Namespace})
 
 		start = time.Now()
-		resolution, err := subject.Resolve(rev("rev", "img1", "img2"), k8schain.Options{ServiceAccountName: "san"}, sets.NewString("skip"), 0)
+		resolution, err := subject.Resolve(revision, k8schain.Options{ServiceAccountName: "san"}, sets.NewString("skip"), 0)
 		if err != nil || resolution != nil {
 			t.Fatalf("Expected Resolve to be nil, nil but got %v, %v", resolution, err)
 		}

--- a/pkg/reconciler/revision/background_test.go
+++ b/pkg/reconciler/revision/background_test.go
@@ -245,7 +245,7 @@ func TestRateLimitPerItem(t *testing.T) {
 		}
 
 		<-enqueue
-		resolution, err = subject.Resolve(rev("rev", "img1", "img2"), k8schain.Options{ServiceAccountName: "san"}, sets.NewString("skip"), 0)
+		_, err = subject.Resolve(rev("rev", "img1", "img2"), k8schain.Options{ServiceAccountName: "san"}, sets.NewString("skip"), 0)
 		if err == nil {
 			t.Fatalf("Expected Resolve to fail")
 		}

--- a/pkg/reconciler/revision/background_test.go
+++ b/pkg/reconciler/revision/background_test.go
@@ -251,10 +251,10 @@ func TestRateLimitPerItem(t *testing.T) {
 		}
 	}
 
-	if took := time.Since(start); took < 600*time.Millisecond {
-		// Per-item time is 50ms, so after 4 cycles of back-off should take at least 600ms.
+	if took := time.Since(start); took < 500*time.Millisecond {
+		// Per-item time is 50ms, so after 4 cycles of back-off should take at least 500ms.
 		// (Otherwise will take only ~200ms)
-		t.Fatal("Expected second resolve to take longer than 600ms, but took", took)
+		t.Fatal("Expected second resolve to take longer than 500ms, but took", took)
 	}
 
 	subject.Forget(types.NamespacedName{Name: "rev", Namespace: "ns"})

--- a/pkg/reconciler/revision/background_test.go
+++ b/pkg/reconciler/revision/background_test.go
@@ -251,7 +251,7 @@ func TestRateLimitPerItem(t *testing.T) {
 		}
 	}
 
-	if took := time.Now().Sub(start); took < 600*time.Millisecond {
+	if took := time.Since(start); took < 600*time.Millisecond {
 		// Per-item time is 50ms, so after 4 cycles of back-off should take at least 600ms.
 		// (Otherwise will take only ~200ms)
 		t.Fatal("Expected second resolve to take longer than 600ms, but took", took)
@@ -266,7 +266,7 @@ func TestRateLimitPerItem(t *testing.T) {
 	}
 
 	<-enqueue
-	if took := time.Now().Sub(start); took > 500*time.Millisecond {
+	if took := time.Since(start); took > 500*time.Millisecond {
 		t.Fatal("Expected Forget to remove revision from rate limiter, but took", took)
 	}
 }

--- a/pkg/reconciler/revision/background_test.go
+++ b/pkg/reconciler/revision/background_test.go
@@ -215,9 +215,7 @@ func TestRateLimitGlobal(t *testing.T) {
 func TestRateLimitPerItem(t *testing.T) {
 	logger := logtesting.TestLogger(t)
 
-	var resolves atomic.Int32
 	var resolver resolveFunc = func(ctx context.Context, img string, _ k8schain.Options, _ sets.String) (string, error) {
-		resolves.Inc()
 		return "", errors.New("failed")
 	}
 

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -46,6 +46,7 @@ import (
 type resolver interface {
 	Resolve(*v1.Revision, k8schain.Options, sets.String, time.Duration) ([]v1.ContainerStatus, error)
 	Clear(types.NamespacedName)
+	Forget(types.NamespacedName)
 }
 
 // Reconciler implements controller.Reconciler for Revision resources.
@@ -186,6 +187,6 @@ func (c *Reconciler) updateRevisionLoggingURL(ctx context.Context, rev *v1.Revis
 
 // ObserveDeletion implements OnDeletionInterface.ObserveDeletion.
 func (c *Reconciler) ObserveDeletion(ctx context.Context, key types.NamespacedName) error {
-	c.resolver.Clear(key)
+	c.resolver.Forget(key)
 	return nil
 }

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -234,7 +234,8 @@ func (r *nopResolver) Resolve(rev *v1.Revision, _ k8schain.Options, _ sets.Strin
 	}}, nil
 }
 
-func (r *nopResolver) Clear(types.NamespacedName) {}
+func (r *nopResolver) Clear(types.NamespacedName)  {}
+func (r *nopResolver) Forget(types.NamespacedName) {}
 
 func testPodSpec() corev1.PodSpec {
 	return corev1.PodSpec{
@@ -328,7 +329,8 @@ func (r *notResolvedYetResolver) Resolve(_ *v1.Revision, _ k8schain.Options, _ s
 	return nil, nil
 }
 
-func (r *notResolvedYetResolver) Clear(types.NamespacedName) {}
+func (r *notResolvedYetResolver) Clear(types.NamespacedName)  {}
+func (r *notResolvedYetResolver) Forget(types.NamespacedName) {}
 
 type errorResolver struct {
 	err     error
@@ -342,6 +344,8 @@ func (r *errorResolver) Resolve(_ *v1.Revision, _ k8schain.Options, _ sets.Strin
 func (r *errorResolver) Clear(types.NamespacedName) {
 	r.cleared = true
 }
+
+func (r *errorResolver) Forget(types.NamespacedName) {}
 
 func TestResolutionFailed(t *testing.T) {
 	// Unconditionally return this error during resolution.


### PR DESCRIPTION
Fixes #11251.

Implements per-item back-off in digest resolution. We now only `Forget` the revision when we succeed, or when the revision is deleted.

/assign @markusthoemmes @vagababov 