### PR TITLE
Enable to scale chaosduck down to zero for prow test

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -31,6 +31,8 @@ export RUN_HTTP01_AUTO_TLS_TESTS=0
 # Only build linux/amd64 bit images
 KO_FLAGS="--platform=linux/amd64"
 
+readonly SCALE_CHAOSDUCK_TO_ZERO="${SCALE_CHAOSDUCK_TO_ZERO:-0}"
+
 HTTPS=0
 export MESH=0
 
@@ -396,6 +398,8 @@ function test_setup() {
     kubectl label namespace serving-tests istio-injection=enabled
     kubectl label namespace serving-tests-alt istio-injection=enabled
   fi
+
+  if (( SCALE_CHAOSDUCK_TO_ZERO )); then disable_chaosduck; fi
 
   # Setting deadline progress to a shorter value.
   kubectl patch cm "config-deployment" -n "${SYSTEM_NAMESPACE}" \


### PR DESCRIPTION
It is a coherent PR from the issue in eventing (https://github.com/knative/eventing/issues/5292). 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* If an environment variable (e.g. `SCALE_CHAOSDUCK_TO_ZERO`) is set to 1 when running the `test/e2e-tests.sh`, the `chaosduck` deployment scales the corresponding pod down to 0 by calling the existing function `disable_chaosduck`. 
*  The change is tested via the local `phaino` test. If the env variable is set to 1, the `chaosduck` gets scaled to 0 and the following messages are logged as expected.

```
deployment.apps/chaosduck created
deployment.apps/chaosduck scaled
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
