### PR TITLE
Make KO_FLAGS flexible for e2e-tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -29,7 +29,7 @@ CONTOUR_VERSION=""
 CERTIFICATE_CLASS=""
 export RUN_HTTP01_AUTO_TLS_TESTS=0
 # Only build linux/amd64 bit images
-KO_FLAGS="--platform=linux/amd64"
+KO_FLAGS="${KO_FLAGS:---platform=linux/amd64}"
 
 HTTPS=0
 export MESH=0


### PR DESCRIPTION
ATM, `$KO_FLAGS` in the e2e-tests.sh is [hard-coded](https://github.com/knative/serving/blob/main/test/e2e-common.sh#L32) as `--platform=linux/amd64`, which does not look flexible for the `ko` usage. This PR is to make it flexible while the default behavior is kept without an explicit configuration of the env variable. 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Switch from the direct value assignment to the parameter substitution with the default value `--platform=linux/amd64` for `$KO_FLAGS`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
