### PR TITLE
Make sure the decider state is settled in test

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1347,7 +1347,7 @@ func TestReconcileDeciderCreatesAndDeletes(t *testing.T) {
 		if err != nil {
 			return true, err
 		}
-		return newKPA.IsReady() && *newKPA.Status.DesiredScale == 1, nil
+		return newKPA.IsReady() && newKPA.Status.GetDesiredScale() == 1, nil
 	}); err != nil {
 		t.Fatal("PA failed to become ready:", err)
 	}

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1347,7 +1347,7 @@ func TestReconcileDeciderCreatesAndDeletes(t *testing.T) {
 		if err != nil {
 			return true, err
 		}
-		return newKPA.IsReady(), nil
+		return newKPA.IsReady() && *newKPA.Status.DesiredScale == 1, nil
 	}); err != nil {
 		t.Fatal("PA failed to become ready:", err)
 	}


### PR DESCRIPTION
Fixes #11258

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

When the KPA first reconciles, it creates all the necessary objects (including the Decider) all while not being `Ready` itself. That causes it to return a `scaleUnknown` (because it's still activating) and then becoming ready. Only in the next reconcile will it move to the actually correct scaling behavior, as it's now Ready itself and the scaling subsystem considers it stable.

This seemed like the least invasive fix. I've also went through to see if I could cut out the extra reconcile but its... involved :joy: and not likely to matter a lot in real systems.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
