### PR TITLE
Default webhook rule

### DIFF
--- a/config/core/webhooks/defaulting.yaml
+++ b/config/core/webhooks/defaulting.yaml
@@ -28,3 +28,32 @@ webhooks:
   sideEffects: None
   name: webhook.serving.knative.dev
   timeoutSeconds: 10
+  rules:
+  - apiGroups:
+    - "*.knative.dev"
+    apiVersions:
+    - v1alpha1
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    scope: "*"
+    resources:
+    - metrics
+    - metrics/status
+    - podautoscalers
+    - podautoscalers/status
+    - certificates
+    - certificates/status
+    - ingresses
+    - ingresses/status
+    - serverlessservices
+    - serverlessservices/status
+    - configurations
+    - configurations/status
+    - revisions
+    - revisions/status
+    - routes
+    - routes/status
+    - services
+    - services/status


### PR DESCRIPTION
Catches requests even before the defaulting webhook has been reconciled

Fixes #7576

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Have a default rule active so requests fail before the webhook is ready
*  domainmapping excluded from the default rule