### PR TITLE
Change magic DNS to sslip.io

### DIFF
--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -34,7 +34,7 @@ spec:
         # This is the Go import path for the binary that is containerized
         # and substituted here.
         image: ko://knative.dev/serving/cmd/default-domain
-        args: ["-magic-dns=xip.io"]
+        args: ["-magic-dns=sslip.io"]
         ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
Fixes #11297.

As the issue says, looks like xip.io has been shut down for several days (possibly related to https://twitter.com/sstephenson/status/1388146131377528832) so the docs are currently broken.

(We could alternatively use nip.io, I don't feel strongly about the alternative we use, I just picked one).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Change the default post-install job to use sslip.io rather than xip.io.
```

/assign @dprotaso @evankanderson 