### PR TITLE
Remove responsive-revision-gc config from config-features

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "2cf73688"
+    knative.dev/example-checksum: "1bbf8144"
 data:
   _example: |-
     ################################
@@ -114,13 +114,6 @@ data:
     #   attaching the following metadata annotation: "features.knative.dev/podspec-dryrun":"enabled".
     # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-dry-run
     kubernetes.podspec-dryrun: "allowed"
-
-    # Indicates whether new responsive garbage collection is enabled. This
-    # feature labels revisions in real-time as they become referenced and
-    # dereferenced by Routes. This allows us to reap revisions shortly after
-    # they are no longer active.
-    # See: https://knative.dev/docs/serving/feature-flags/#responsive-revision-garbage-collector
-    responsive-revision-gc: "enabled"
 
     # Controls whether tag header based routing feature are enabled or not.
     # 1. Enabled: enabling tag header based routing

--- a/pkg/apis/config/features_test.go
+++ b/pkg/apis/config/features_test.go
@@ -78,7 +78,6 @@ func TestFeaturesConfiguration(t *testing.T) {
 			"kubernetes.podspec-runtimeclassname": "Enabled",
 			"kubernetes.podspec-securitycontext":  "Enabled",
 			"kubernetes.podspec-tolerations":      "Enabled",
-			"responsive-revision-gc":              "Enabled",
 			"tag-header-based-routing":            "Enabled",
 		},
 	}, {


### PR DESCRIPTION
Since https://github.com/knative/serving/pull/10084 deleted old GC and started using responsive GC,
`responsive-revision-gc` in `config-feature` is not used at all.

This patch removes the config from the config-feature configmap.

/kind cleanup
/cc @whaught  @julz @dprotaso 