### PR TITLE
change type of revision status replicas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,8 +49,8 @@ require (
 	k8s.io/code-generator v0.19.7
 	k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 // indirect
 	k8s.io/kube-openapi v0.0.0-20210113233702-8566a335510f
-	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009
-	knative.dev/caching v0.0.0-20210506040209-3d48f8dc4abc
+	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009 // indirect
+	knative.dev/caching v0.0.0-20210428140754-1fab472d2faf
 	knative.dev/hack v0.0.0-20210428122153-93ad9129c268
 	knative.dev/networking v0.0.0-20210506040209-a3028d57082a
 	knative.dev/pkg v0.0.0-20210510123559-37b289bab1db

--- a/go.sum
+++ b/go.sum
@@ -1260,8 +1260,8 @@ k8s.io/legacy-cloud-providers v0.19.7/go.mod h1:dsZk4gH9QIwAtHQ8CK0Ps257xlfgoXE3
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210111153108-fddb29f9d009 h1:0T5IaWHO3sJTEmCP6mUlBvMukxPKUQWqiI/YuiBNMiQ=
 k8s.io/utils v0.0.0-20210111153108-fddb29f9d009/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-knative.dev/caching v0.0.0-20210506040209-3d48f8dc4abc h1:JGlT3XNfcQdTPY65uTwDtVRKW3Lo2GOkJ4YosR2tmxM=
-knative.dev/caching v0.0.0-20210506040209-3d48f8dc4abc/go.mod h1:CLQDWuBhkGnC3Pq/3G56qMP14dPt+Y4QmBEe3it44HM=
+knative.dev/caching v0.0.0-20210428140754-1fab472d2faf h1:rFELGpFuUEd5uCulBcmqBYfx6i1kaUWiw9mF81d2sbg=
+knative.dev/caching v0.0.0-20210428140754-1fab472d2faf/go.mod h1:CLQDWuBhkGnC3Pq/3G56qMP14dPt+Y4QmBEe3it44HM=
 knative.dev/hack v0.0.0-20210427190353-86f9adc0c8e2/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
 knative.dev/hack v0.0.0-20210428122153-93ad9129c268 h1:lBIj9Epd9UQ55NEaHzAdY/UZbuaegCdGPKVC2+Z68Q0=
 knative.dev/hack v0.0.0-20210428122153-93ad9129c268/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=

--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -172,8 +172,15 @@ func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *autoscalingv1alpha1.PodA
 	// Reflect the PA status in our own.
 	cond := ps.GetCondition(autoscalingv1alpha1.PodAutoscalerConditionReady)
 
-	rs.ActualReplicas = ps.ActualScale
-	rs.DesiredReplicas = ps.DesiredScale
+	rs.ActualReplicas = nil
+	if ps.ActualScale != nil && *ps.ActualScale >= 0 {
+		rs.ActualReplicas = ps.ActualScale
+	}
+
+	rs.DesiredReplicas = nil
+	if ps.DesiredScale != nil && *ps.DesiredScale >= 0 {
+		rs.DesiredReplicas = ps.DesiredScale
+	}
 
 	if cond == nil {
 		rs.MarkActiveUnknown("Deploying", "")

--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -22,7 +22,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/integer"
 
 	"knative.dev/pkg/apis"
 	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
@@ -173,8 +172,8 @@ func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *autoscalingv1alpha1.PodA
 	// Reflect the PA status in our own.
 	cond := ps.GetCondition(autoscalingv1alpha1.PodAutoscalerConditionReady)
 
-	rs.ActualReplicas = integer.Int32Max(ps.GetActualScale(), 0)
-	rs.DesiredReplicas = integer.Int32Max(ps.GetDesiredScale(), 0)
+	rs.ActualReplicas = ps.ActualScale
+	rs.DesiredReplicas = ps.DesiredScale
 
 	if cond == nil {
 		rs.MarkActiveUnknown("Deploying", "")

--- a/pkg/apis/serving/v1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1/revision_lifecycle_test.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -690,33 +691,50 @@ func TestPropagateAutoscalerStatusReplicas(t *testing.T) {
 	testCases := []struct {
 		name                string
 		ps                  autoscalingv1alpha1.PodAutoscalerStatus
-		wantActualReplicas  int32
-		wantDesiredReplicas int32
+		wantActualReplicas  *int32
+		wantDesiredReplicas *int32
 	}{{
 		name: "active PodAutoScaler",
 		ps: autoscalingv1alpha1.PodAutoscalerStatus{
 			ActualScale:  ptr.Int32(1),
 			DesiredScale: ptr.Int32(2),
 		},
-		wantActualReplicas:  1,
-		wantDesiredReplicas: 2,
+		wantActualReplicas:  ptr.Int32(1),
+		wantDesiredReplicas: ptr.Int32(2),
 	}, {
 		name: "inactive PodAutoScaler",
 		ps: autoscalingv1alpha1.PodAutoscalerStatus{
 			DesiredScale: ptr.Int32(-1),
 		},
-		wantActualReplicas:  0,
-		wantDesiredReplicas: 0,
+		wantActualReplicas:  nil,
+		wantDesiredReplicas: ptr.Int32(-1),
 	}}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			r.PropagateAutoscalerStatus(&tc.ps)
-			if r.ActualReplicas != tc.wantActualReplicas {
-				t.Errorf("Expected r.ActualReplicas to be %d but got %d", tc.wantActualReplicas, r.ActualReplicas)
+
+			wantActual, gotActual := "nil", "nil"
+			if tc.wantActualReplicas != nil {
+				wantActual = strconv.Itoa(int(*tc.wantActualReplicas))
 			}
-			if r.DesiredReplicas != tc.wantDesiredReplicas {
-				t.Errorf("Expected r.DesiredReplicas to be %d but got %d", tc.wantDesiredReplicas, r.DesiredReplicas)
+			if r.ActualReplicas != nil {
+				gotActual = strconv.Itoa(int(*r.ActualReplicas))
+			}
+			if wantActual != gotActual {
+				t.Errorf("Expected r.ActualReplicas to be %s but got %s", wantActual, gotActual)
+			}
+
+			wantDesired, gotDesired := "nil", "nil"
+			if tc.wantDesiredReplicas != nil {
+				wantDesired = strconv.Itoa(int(*tc.wantDesiredReplicas))
+			}
+			if r.DesiredReplicas != nil {
+				gotDesired = strconv.Itoa(int(*r.DesiredReplicas))
+			}
+
+			if wantDesired != gotDesired {
+				t.Errorf("Expected r.DesiredReplicas to be %s but got %s", wantDesired, gotDesired)
 			}
 		})
 	}

--- a/pkg/apis/serving/v1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1/revision_lifecycle_test.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	"sort"
-	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -714,27 +713,12 @@ func TestPropagateAutoscalerStatusReplicas(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r.PropagateAutoscalerStatus(&tc.ps)
 
-			wantActual, gotActual := "nil", "nil"
-			if tc.wantActualReplicas != nil {
-				wantActual = strconv.Itoa(int(*tc.wantActualReplicas))
-			}
-			if r.ActualReplicas != nil {
-				gotActual = strconv.Itoa(int(*r.ActualReplicas))
-			}
-			if wantActual != gotActual {
-				t.Errorf("Expected r.ActualReplicas to be %s but got %s", wantActual, gotActual)
+			if !cmp.Equal(tc.wantActualReplicas, r.ActualReplicas) {
+				t.Errorf("r.ActualReplicas replicas wasn't as expected, (-want, +got):\n%s", cmp.Diff(tc.wantActualReplicas, r.ActualReplicas))
 			}
 
-			wantDesired, gotDesired := "nil", "nil"
-			if tc.wantDesiredReplicas != nil {
-				wantDesired = strconv.Itoa(int(*tc.wantDesiredReplicas))
-			}
-			if r.DesiredReplicas != nil {
-				gotDesired = strconv.Itoa(int(*r.DesiredReplicas))
-			}
-
-			if wantDesired != gotDesired {
-				t.Errorf("Expected r.DesiredReplicas to be %s but got %s", wantDesired, gotDesired)
+			if !cmp.Equal(tc.wantDesiredReplicas, r.DesiredReplicas) {
+				t.Errorf("r.DesiredReplicas replicas wasn't as expected, (-want, +got):\n%s", cmp.Diff(tc.wantDesiredReplicas, r.DesiredReplicas))
 			}
 		})
 	}

--- a/pkg/apis/serving/v1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1/revision_lifecycle_test.go
@@ -707,7 +707,7 @@ func TestPropagateAutoscalerStatusReplicas(t *testing.T) {
 			DesiredScale: ptr.Int32(-1),
 		},
 		wantActualReplicas:  nil,
-		wantDesiredReplicas: ptr.Int32(-1),
+		wantDesiredReplicas: nil,
 	}}
 
 	for _, tc := range testCases {

--- a/pkg/apis/serving/v1/revision_types.go
+++ b/pkg/apis/serving/v1/revision_types.go
@@ -161,10 +161,10 @@ type RevisionStatus struct {
 
 	// ActualReplicas reflects the amount of ready pods running this revision.
 	// +optional
-	ActualReplicas int32 `json:"actualReplicas,omitempty"`
+	ActualReplicas *int32 `json:"actualReplicas,omitempty"`
 	// DesiredReplicas reflects the desired amount of pods running this revision.
 	// +optional
-	DesiredReplicas int32 `json:"desiredReplicas,omitempty"`
+	DesiredReplicas *int32 `json:"desiredReplicas,omitempty"`
 }
 
 // ContainerStatus holds the information of container name and image digest value

--- a/pkg/apis/serving/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/serving/v1/zz_generated.deepcopy.go
@@ -251,6 +251,16 @@ func (in *RevisionStatus) DeepCopyInto(out *RevisionStatus) {
 		*out = make([]ContainerStatus, len(*in))
 		copy(*out, *in)
 	}
+	if in.ActualReplicas != nil {
+		in, out := &in.ActualReplicas, &out.ActualReplicas
+		*out = new(int32)
+		**out = **in
+	}
+	if in.DesiredReplicas != nil {
+		in, out := &in.DesiredReplicas, &out.DesiredReplicas
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -105,7 +105,7 @@ func TestMinScale(t *testing.T) {
 	if err != nil {
 		t.Fatalf("An error occurred getting revision %v, %v", revName, err)
 	}
-	if replicas := revision.Status.ActualReplicas; replicas != minScale {
+	if replicas := *revision.Status.ActualReplicas; replicas != minScale {
 		t.Fatalf("Expected actual replicas for revision %v to be %v but got %v", revision.Name, minScale, replicas)
 	}
 
@@ -138,7 +138,7 @@ func TestMinScale(t *testing.T) {
 	if err != nil {
 		t.Fatalf("An error occurred getting revision %v, %v", newRevName, err)
 	}
-	if replicas := revision.Status.ActualReplicas; replicas != minScale {
+	if replicas := *revision.Status.ActualReplicas; replicas != minScale {
 		t.Fatalf("Expected actual replicas for revision %v to be %v but got %v", revision.Name, minScale, replicas)
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1002,7 +1002,7 @@ k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# knative.dev/caching v0.0.0-20210506040209-3d48f8dc4abc
+# knative.dev/caching v0.0.0-20210428140754-1fab472d2faf
 ## explicit
 knative.dev/caching/config
 knative.dev/caching/pkg/apis/caching


### PR DESCRIPTION

Fixes #11170 by changing the revision status actual and desired replicas from `int` to `*int`