### PR TITLE
Disable webhook for net-certmanager-webhook

### DIFF
--- a/test/config/chaosduck.yaml
+++ b/test/config/chaosduck.yaml
@@ -87,6 +87,7 @@ spec:
         # sorted out.
         - "-disable=webhook"
         - "-disable=domainmapping-webhook"
+        - "-disable=net-certmanager-webhook"
         # Currently the new owner of Autoscaler needs time to build the
         # metrics status so some e2e tests are expected to fail if the
         # owner pod crashes.


### PR DESCRIPTION
This patch disables chaos duck for net-certmanager-webhook.

Although chaos duck for `webhook` and `domainmapping-webhook` is disabled,
`net-certmanager-webhook` is not disabled.

It seems `TestRevisionGC` is failing because setting config-gc failed by
webhook issue.

```
Setting config-gc to immediate garbage collectionError from server (InternalError): Internal error occurred: failed calling webhook "config.webhook.net-certmanager.networking.internal.knative.dev": Post https://net-certmanager-webhook.fa21803d-a9d6-4a0d-8740-2149102cce16.svc:443/config-validation?timeout=30s: no endpoints available for service "net-certmanager-webhook"
```

Related to https://github.com/knative/serving/issues/11307 https://github.com/knative/serving/issues/11313