### PR TITLE
Do not call GetIngressEndpoint() when --resolvabledomain is enabled

### DIFF
--- a/test/e2e/websocket.go
+++ b/test/e2e/websocket.go
@@ -46,13 +46,13 @@ func connect(t *testing.T, clients *test.Clients, domain string) (*websocket.Con
 		address string
 	)
 
-	address, mapper, err := ingress.GetIngressEndpoint(context.Background(), clients.KubeClient, pkgTest.Flags.IngressEndpoint)
-	if err != nil {
-		return nil, err
-	}
-	if test.ServingFlags.ResolvableDomain {
-		address = domain
-		mapper = func(in string) string { return in }
+	address = domain
+	mapper := func(in string) string { return in }
+	if !test.ServingFlags.ResolvableDomain {
+		address, mapper, err = ingress.GetIngressEndpoint(context.Background(), clients.KubeClient, pkgTest.Flags.IngressEndpoint)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	u := url.URL{Scheme: "ws", Host: net.JoinHostPort(address, mapper("80")), Path: "/"}


### PR DESCRIPTION
`GetIngressEndpoint()` is a function to get ingress endpoint for the
spoof client. So we don't need to call it when `--resolvabledomain` is
enabled. Especially when Ingresss service uses `ClusterIP`, it alwasy
fails to get endpoint and test fails.

This patch changes to call GetIngressEndpoint() only when
resolvabledomain is false in websocket test.
