### PR TITLE
Use test options for feature tests and ha tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -65,7 +65,7 @@ if [[ -z "${INGRESS_CLASS}" \
   alpha="--enable-alpha"
 fi
 
-TEST_OPTIONS="${alpha} --enable-beta --resolvabledomain=$(use_resolvable_domain) ${use_https}"
+TEST_OPTIONS="${TEST_OPTIONS:-${alpha} --enable-beta --resolvabledomain=$(use_resolvable_domain) ${use_https}}"
 
 go_test_e2e -timeout=30m \
  ./test/conformance/api/... \

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -65,33 +65,28 @@ if [[ -z "${INGRESS_CLASS}" \
   alpha="--enable-alpha"
 fi
 
+TEST_OPTIONS="${alpha} --enable-beta --resolvabledomain=$(use_resolvable_domain) ${use_https}"
+
 go_test_e2e -timeout=30m \
  ./test/conformance/api/... \
  ./test/conformance/runtime/... \
  ./test/e2e \
   ${parallelism} \
-  ${alpha} \
-  --enable-beta \
-  "--resolvabledomain=$(use_resolvable_domain)" "${use_https}" || failed=1
-
-if (( HTTPS )); then
-  kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found
-  toggle_feature autoTLS Disabled config-network
-fi
+  ${TEST_OPTIONS} || failed=1
 
 toggle_feature tag-header-based-routing Enabled
-go_test_e2e -timeout=2m ./test/e2e/tagheader || failed=1
+go_test_e2e -timeout=2m ./test/e2e/tagheader ${TEST_OPTIONS} || failed=1
 toggle_feature tag-header-based-routing Disabled
 
 # Enable allow-zero-initial-scale before running e2e tests (for test/e2e/initial_scale_test.go).
 toggle_feature allow-zero-initial-scale true config-autoscaler || fail_test
-go_test_e2e -timeout=2m ./test/e2e/initscale || failed=1
+go_test_e2e -timeout=2m ./test/e2e/initscale ${TEST_OPTIONS} || failed=1
 toggle_feature allow-zero-initial-scale false config-autoscaler || fail_test
 
 kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml > ${TMP_DIR}/config-gc.yaml
 add_trap "kubectl replace cm 'config-gc' -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml" SIGKILL SIGTERM SIGQUIT
 immediate_gc
-go_test_e2e -timeout=2m ./test/e2e/gc || failed=1
+go_test_e2e -timeout=2m ./test/e2e/gc ${TEST_OPTIONS} || failed=1
 kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml
 
 
@@ -99,16 +94,20 @@ kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.ya
 # Note that we use a very high -parallel because each ksvc is run as its own
 # sub-test. If this is not larger than the maximum scale tested then the test
 # simply cannot pass.
-go_test_e2e -timeout=20m -parallel=300 ./test/scale || failed=1
+go_test_e2e -timeout=20m -parallel=300 ./test/scale ${TEST_OPTIONS} || failed=1
 
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.
 go_test_e2e -timeout=25m -failfast -parallel=1 ./test/ha \
-  ${alpha} \
-  --enable-beta \
+  ${TEST_OPTIONS} \
   -replicas="${REPLICAS:-1}" \
   -buckets="${BUCKETS:-1}" \
   -spoofinterval="10ms" || failed=1
+
+if (( HTTPS )); then
+  kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found
+  toggle_feature autoTLS Disabled config-network
+fi
 
 (( failed )) && fail_test
 

--- a/test/ha/activator_test.go
+++ b/test/ha/activator_test.go
@@ -96,7 +96,8 @@ func testActivatorHA(t *testing.T, gracePeriod *int64, slo float64) {
 	test.EnsureTearDown(t, clients, &namesScaleToZero)
 
 	t.Log("Starting prober")
-	prober := test.NewProberManager(t.Logf, clients, minProbes)
+	prober := test.NewProberManager(t.Logf, clients, minProbes, test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
+
 	prober.Spawn(resources.Service.Status.URL.URL())
 	defer assertSLO(t, prober, slo)
 

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -69,7 +69,9 @@ func assertServiceEventuallyWorks(t *testing.T, clients *test.Clients, names tes
 		url,
 		v1test.RetryingRouteInconsistency(spoof.MatchesAllOf(spoof.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
-		resolvabledomain); err != nil {
+		resolvabledomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+	); err != nil {
 		t.Fatalf("The endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, url, expectedText, err)
 	}
 }


### PR DESCRIPTION
Currently feature tests and ha tests do not test with
`resolvabledomain` and `https` options.

They should test when these options were enabled.
