### PR TITLE
Use TLS for websocket and gRPC tests

### DIFF
--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -317,7 +317,9 @@ func streamTest(tc *TestContext, host, domain string) {
 
 func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 	t.Helper()
-	t.Parallel()
+	if !test.ServingFlags.HTTPS {
+		t.Parallel()
+	}
 
 	// Setup
 	clients := Setup(t)

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -334,9 +334,11 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 	t.Log("Creating service for grpc-ping")
 
 	svcName := test.ObjectNameForTest(t)
-	// Long name hits this issue https://github.com/knative-sandbox/net-certmanager/issues/214
-	if t.Name() == "TestGRPCStreamingPingViaActivator" {
-		svcName = test.AppendRandomString("grpc-streaming-pig-act")
+	// TODO: 64+ bytes domain name hits the cert-manager issue
+	// https://github.com/knative-sandbox/net-certmanager/issues/214
+	suffixLen := len(test.ServingNamespace) + len("example.com")
+	if test.ServingFlags.HTTPS && len(svcName)+suffixLen > 63 {
+		svcName = test.AppendRandomString(svcName[:63-suffixLen])
 	}
 
 	names := &test.ResourceNames{

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -317,6 +317,8 @@ func streamTest(tc *TestContext, host, domain string) {
 
 func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 	t.Helper()
+	// TODO: https option with parallel leads to flakes.
+	// https://github.com/knative/serving/issues/11387
 	if !test.ServingFlags.HTTPS {
 		t.Parallel()
 	}

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -33,6 +33,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -64,12 +65,18 @@ func hasPort(u string) bool {
 	return err == nil
 }
 
-func dial(host, domain string) (*grpc.ClientConn, error) {
+func dial(ctx *TestContext, host, domain string) (*grpc.ClientConn, error) {
 	if !hasPort(host) {
 		host = net.JoinHostPort(host, defaultPort)
 	}
 	if !hasPort(domain) {
 		domain = net.JoinHostPort(domain, defaultPort)
+	}
+
+	secureOpt := grpc.WithInsecure()
+	if test.ServingFlags.HTTPS {
+		cred := credentials.NewTLS(test.TLSClientConfig(context.Background(), ctx.t.Logf, ctx.clients))
+		secureOpt = grpc.WithTransportCredentials(cred)
 	}
 
 	if host != domain {
@@ -78,7 +85,7 @@ func dial(host, domain string) (*grpc.ClientConn, error) {
 		return grpc.Dial(
 			host,
 			grpc.WithAuthority(domain),
-			grpc.WithInsecure(),
+			secureOpt,
 			// Retrying DNS errors to avoid .xip.io issues.
 			grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 		)
@@ -86,7 +93,7 @@ func dial(host, domain string) (*grpc.ClientConn, error) {
 	// This is a more preferred usage of the go-grpc client.
 	return grpc.Dial(
 		host,
-		grpc.WithInsecure(),
+		secureOpt,
 		// Retrying DNS errors to avoid .xip.io issues.
 		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)
@@ -96,7 +103,7 @@ func unaryTest(ctx *TestContext, host, domain string) {
 	ctx.t.Helper()
 	ctx.t.Logf("Connecting to grpc-ping using host %q and authority %q", host, domain)
 	const want = "Hello!"
-	got, err := pingGRPC(host, domain, want)
+	got, err := pingGRPC(ctx, host, domain, want)
 	if err != nil {
 		ctx.t.Fatal("gRPC ping =", err)
 	}
@@ -150,7 +157,7 @@ func loadBalancingTest(ctx *TestContext, host, domain string) {
 				case <-stopChan:
 					return nil
 				default:
-					got, err := pingGRPC(host, domain, wantPrefix)
+					got, err := pingGRPC(ctx, host, domain, wantPrefix)
 					if err != nil {
 						return fmt.Errorf("ping gRPC error: %w", err)
 					}
@@ -190,7 +197,7 @@ func loadBalancingTest(ctx *TestContext, host, domain string) {
 	}
 }
 
-func generateGRPCTraffic(concurrentRequests int, host, domain string, stopChan chan struct{}) error {
+func generateGRPCTraffic(ctx *TestContext, concurrentRequests int, host, domain string, stopChan chan struct{}) error {
 	var grp errgroup.Group
 
 	for i := 0; i < concurrentRequests; i++ {
@@ -202,7 +209,7 @@ func generateGRPCTraffic(concurrentRequests int, host, domain string, stopChan c
 					return nil
 				default:
 					want := fmt.Sprintf("Hello! stream:%d request: %d", i, j)
-					got, err := pingGRPC(host, domain, want)
+					got, err := pingGRPC(ctx, host, domain, want)
 
 					if err != nil {
 						return fmt.Errorf("ping gRPC error: %w", err)
@@ -220,8 +227,8 @@ func generateGRPCTraffic(concurrentRequests int, host, domain string, stopChan c
 	return nil
 }
 
-func pingGRPC(host, domain, message string) (string, error) {
-	conn, err := dial(host, domain)
+func pingGRPC(ctx *TestContext, host, domain, message string) (string, error) {
+	conn, err := dial(ctx, host, domain)
 	if err != nil {
 		return "", err
 	}
@@ -251,7 +258,7 @@ func assertGRPCAutoscaleUpToNumPods(ctx *TestContext, curPods, targetPods float6
 	var grp errgroup.Group
 
 	grp.Go(func() error {
-		return generateGRPCTraffic(int(targetPods*grpcContainerConcurrency), host, domain, stopChan)
+		return generateGRPCTraffic(ctx, int(targetPods*grpcContainerConcurrency), host, domain, stopChan)
 	})
 
 	grp.Go(func() error {
@@ -267,7 +274,7 @@ func assertGRPCAutoscaleUpToNumPods(ctx *TestContext, curPods, targetPods float6
 func streamTest(tc *TestContext, host, domain string) {
 	tc.t.Helper()
 	tc.t.Logf("Connecting to grpc-ping using host %q and authority %q", host, domain)
-	conn, err := dial(host, domain)
+	conn, err := dial(tc, host, domain)
 	if err != nil {
 		tc.t.Fatal("Fail to dial:", err)
 	}
@@ -357,7 +364,11 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 		if err != nil {
 			t.Fatal("Could not get service endpoint:", err)
 		}
-		host = net.JoinHostPort(addr, mapper("80"))
+		if test.ServingFlags.HTTPS {
+			host = net.JoinHostPort(addr, mapper("443"))
+		} else {
+			host = net.JoinHostPort(addr, mapper("80"))
+		}
 	}
 
 	f(&TestContext{

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -324,8 +324,14 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 
 	t.Log("Creating service for grpc-ping")
 
+	svcName := test.ObjectNameForTest(t)
+	// Long name hits this issue https://github.com/knative-sandbox/net-certmanager/issues/214
+	if t.Name() == "TestGRPCStreamingPingViaActivator" {
+		svcName = test.AppendRandomString("grpc-streaming-pig-act")
+	}
+
 	names := &test.ResourceNames{
-		Service: test.ObjectNameForTest(t),
+		Service: svcName,
 		Image:   "grpc-ping",
 	}
 
@@ -396,9 +402,6 @@ func TestGRPCUnaryPingViaActivator(t *testing.T) {
 }
 
 func TestGRPCStreamingPingViaActivator(t *testing.T) {
-	if test.ServingFlags.HTTPS {
-		t.Skip("TestGRPCStreamingPingViaActivator does not pass with --https option.")
-	}
 	testGRPC(t,
 		func(ctx *TestContext, host, domain string) {
 			if err := waitForActivatorEndpoints(ctx); err != nil {

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -83,21 +83,9 @@ func dial(ctx *TestContext, host, domain string) (*grpc.ClientConn, error) {
 		secureOpt = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 	}
 
-	if host != domain && !test.ServingFlags.HTTPS {
-		// The host to connect and the domain accepted differ.
-		// We need to do grpc.WithAuthority(...) here.
-		return grpc.Dial(
-			host,
-			grpc.WithAuthority(domain),
-			grpc.WithInsecure(),
-			// Retrying DNS errors to avoid .sslip.io issues.
-			grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
-		)
-	}
-
-	// This is a more preferred usage of the go-grpc client.
 	return grpc.Dial(
 		host,
+		grpc.WithAuthority(domain),
 		secureOpt,
 		// Retrying DNS errors to avoid .sslip.io issues.
 		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -79,7 +79,12 @@ func dial(ctx *TestContext, host, domain string) (*grpc.ClientConn, error) {
 	secureOpt := grpc.WithInsecure()
 	if test.ServingFlags.HTTPS {
 		tlsConfig := test.TLSClientConfig(context.Background(), ctx.t.Logf, ctx.clients)
-		tlsConfig.ServerName = strings.Split(domain, ":")[0] // Set ServerName for pseudo hostname with TLS.
+		// Set ServerName for pseudo hostname with TLS.
+		var err error
+		tlsConfig.ServerName, _, err = net.SplitHostPort(domain)
+		if err != nil {
+			return nil, err
+		}
 		secureOpt = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 	}
 

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -408,6 +408,9 @@ func TestGRPCUnaryPingViaActivator(t *testing.T) {
 }
 
 func TestGRPCStreamingPingViaActivator(t *testing.T) {
+	if test.ServingFlags.HTTPS {
+		t.Skip("TestGRPCStreamingPingViaActivator does not pass with --https option.")
+	}
 	testGRPC(t,
 		func(ctx *TestContext, host, domain string) {
 			if err := waitForActivatorEndpoints(ctx); err != nil {

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -334,11 +334,9 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 	t.Log("Creating service for grpc-ping")
 
 	svcName := test.ObjectNameForTest(t)
-	// TODO: 64+ bytes domain name hits the cert-manager issue
-	// https://github.com/knative-sandbox/net-certmanager/issues/214
-	suffixLen := len(test.ServingNamespace) + len("example.com")
-	if test.ServingFlags.HTTPS && len(svcName)+suffixLen > 63 {
-		svcName = test.AppendRandomString(svcName[:63-suffixLen])
+	// Long name hits this issue https://github.com/knative-sandbox/net-certmanager/issues/214
+	if t.Name() == "TestGRPCStreamingPingViaActivator" {
+		svcName = test.AppendRandomString("grpc-streaming-pig-act")
 	}
 
 	names := &test.ResourceNames{

--- a/test/e2e/websocket.go
+++ b/test/e2e/websocket.go
@@ -66,6 +66,7 @@ func connect(t *testing.T, clients *test.Clients, domain string) (*websocket.Con
 		dialer := websocket.DefaultDialer
 		if test.ServingFlags.HTTPS {
 			dialer.TLSClientConfig = test.TLSClientConfig(context.Background(), t.Logf, clients)
+			dialer.TLSClientConfig.ServerName = domain // Set ServerName for pseudo hostname with TLS.
 		}
 
 		c, resp, err := dialer.Dial(u.String(), http.Header{"Host": {domain}})

--- a/test/e2e/websocket.go
+++ b/test/e2e/websocket.go
@@ -63,7 +63,10 @@ func connect(t *testing.T, clients *test.Clients, domain string) (*websocket.Con
 	var conn *websocket.Conn
 	waitErr := wait.PollImmediate(connectRetryInterval, connectTimeout, func() (bool, error) {
 		t.Logf("Connecting using websocket: url=%s, host=%s", u.String(), domain)
-		dialer := &websocket.Dialer{}
+		dialer := &websocket.Dialer{
+			Proxy:            http.ProxyFromEnvironment,
+			HandshakeTimeout: 45 * time.Second,
+		}
 		if test.ServingFlags.HTTPS {
 			dialer.TLSClientConfig = test.TLSClientConfig(context.Background(), t.Logf, clients)
 			dialer.TLSClientConfig.ServerName = domain // Set ServerName for pseudo hostname with TLS.

--- a/test/e2e/websocket.go
+++ b/test/e2e/websocket.go
@@ -63,7 +63,7 @@ func connect(t *testing.T, clients *test.Clients, domain string) (*websocket.Con
 	var conn *websocket.Conn
 	waitErr := wait.PollImmediate(connectRetryInterval, connectTimeout, func() (bool, error) {
 		t.Logf("Connecting using websocket: url=%s, host=%s", u.String(), domain)
-		dialer := websocket.DefaultDialer
+		dialer := &websocket.Dialer{}
 		if test.ServingFlags.HTTPS {
 			dialer.TLSClientConfig = test.TLSClientConfig(context.Background(), t.Logf, clients)
 			dialer.TLSClientConfig.ServerName = domain // Set ServerName for pseudo hostname with TLS.

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -122,9 +122,7 @@ func webSocketResponseFreqs(t *testing.T, clients *test.Clients, url string, num
 // (3) sends a message, and
 // (4) verifies that we receive back the same message.
 func TestWebSocket(t *testing.T) {
-	if !test.ServingFlags.HTTPS {
-		t.Parallel()
-	}
+	t.Parallel()
 
 	clients := Setup(t)
 
@@ -148,9 +146,7 @@ func TestWebSocket(t *testing.T) {
 
 // and with -1 as target burst capacity and then validates that we can still serve.
 func TestWebSocketViaActivator(t *testing.T) {
-	if !test.ServingFlags.HTTPS {
-		t.Parallel()
-	}
+	t.Parallel()
 
 	clients := Setup(t)
 
@@ -186,9 +182,7 @@ func TestWebSocketViaActivator(t *testing.T) {
 }
 
 func TestWebSocketBlueGreenRoute(t *testing.T) {
-	if !test.ServingFlags.HTTPS {
-		t.Parallel()
-	}
+	t.Parallel()
 	clients := test.Setup(t)
 
 	svcName := test.ObjectNameForTest(t)

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -122,7 +122,9 @@ func webSocketResponseFreqs(t *testing.T, clients *test.Clients, url string, num
 // (3) sends a message, and
 // (4) verifies that we receive back the same message.
 func TestWebSocket(t *testing.T) {
-	t.Parallel()
+	if !test.ServingFlags.HTTPS {
+		t.Parallel()
+	}
 
 	clients := Setup(t)
 
@@ -146,7 +148,9 @@ func TestWebSocket(t *testing.T) {
 
 // and with -1 as target burst capacity and then validates that we can still serve.
 func TestWebSocketViaActivator(t *testing.T) {
-	t.Parallel()
+	if !test.ServingFlags.HTTPS {
+		t.Parallel()
+	}
 
 	clients := Setup(t)
 
@@ -182,7 +186,9 @@ func TestWebSocketViaActivator(t *testing.T) {
 }
 
 func TestWebSocketBlueGreenRoute(t *testing.T) {
-	t.Parallel()
+	if !test.ServingFlags.HTTPS {
+		t.Parallel()
+	}
 	clients := test.Setup(t)
 
 	svcName := test.ObjectNameForTest(t)

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -198,11 +198,9 @@ func TestWebSocketBlueGreenRoute(t *testing.T) {
 	clients := test.Setup(t)
 
 	svcName := test.ObjectNameForTest(t)
-	// TODO: 64+ bytes domain name hits the cert-manager issue
-	// https://github.com/knative-sandbox/net-certmanager/issues/214
-	suffixLen := len(test.ServingNamespace) + len("example.com")
-	if test.ServingFlags.HTTPS && len(svcName)+suffixLen > 63 {
-		svcName = test.AppendRandomString(svcName[:63-suffixLen])
+	// Long name hits this issue https://github.com/knative-sandbox/net-certmanager/issues/214
+	if test.ServingFlags.HTTPS {
+		svcName = test.AppendRandomString("web-socket-blue-green")
 	}
 
 	names := test.ResourceNames{

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -122,6 +122,8 @@ func webSocketResponseFreqs(t *testing.T, clients *test.Clients, url string, num
 // (3) sends a message, and
 // (4) verifies that we receive back the same message.
 func TestWebSocket(t *testing.T) {
+	// TODO: https option with parallel leads to flakes.
+	// https://github.com/knative/serving/issues/11387
 	if !test.ServingFlags.HTTPS {
 		t.Parallel()
 	}
@@ -148,6 +150,8 @@ func TestWebSocket(t *testing.T) {
 
 // and with -1 as target burst capacity and then validates that we can still serve.
 func TestWebSocketViaActivator(t *testing.T) {
+	// TODO: https option with parallel leads to flakes.
+	// https://github.com/knative/serving/issues/11387
 	if !test.ServingFlags.HTTPS {
 		t.Parallel()
 	}
@@ -186,6 +190,8 @@ func TestWebSocketViaActivator(t *testing.T) {
 }
 
 func TestWebSocketBlueGreenRoute(t *testing.T) {
+	// TODO: https option with parallel leads to flakes.
+	// https://github.com/knative/serving/issues/11387
 	if !test.ServingFlags.HTTPS {
 		t.Parallel()
 	}

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -198,9 +198,11 @@ func TestWebSocketBlueGreenRoute(t *testing.T) {
 	clients := test.Setup(t)
 
 	svcName := test.ObjectNameForTest(t)
-	// Long name hits this issue https://github.com/knative-sandbox/net-certmanager/issues/214
-	if test.ServingFlags.HTTPS {
-		svcName = test.AppendRandomString("web-socket-blue-green")
+	// TODO: 64+ bytes domain name hits the cert-manager issue
+	// https://github.com/knative-sandbox/net-certmanager/issues/214
+	suffixLen := len(test.ServingNamespace) + len("example.com")
+	if test.ServingFlags.HTTPS && len(svcName)+suffixLen > 63 {
+		svcName = test.AppendRandomString(svcName[:63-suffixLen])
 	}
 
 	names := test.ResourceNames{

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -181,7 +181,7 @@ func TestWebSocketViaActivator(t *testing.T) {
 	}
 }
 
-func TestWebSocketBlueGreenRoute(t *testing.T) {
+func TestWebSocketBlueGreen(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -181,13 +181,19 @@ func TestWebSocketViaActivator(t *testing.T) {
 	}
 }
 
-func TestWebSocketBlueGreen(t *testing.T) {
+func TestWebSocketBlueGreenRoute(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 
+	svcName := test.ObjectNameForTest(t)
+	// Long name hits this issue https://github.com/knative-sandbox/net-certmanager/issues/214
+	if test.ServingFlags.HTTPS {
+		svcName = test.AppendRandomString("web-socket-blue-green")
+	}
+
 	names := test.ResourceNames{
 		// Set Service and Image for names to create the initial service
-		Service: test.ObjectNameForTest(t),
+		Service: svcName,
 		Image:   wsServerTestImageName,
 	}
 


### PR DESCRIPTION
Use TLS for websocket and gRPC tests

Current gRPC and Websocket does not use TLS, but still uses HTTP even
when it runs with HTTPS mode.

This patch fixes it.

FIx https://github.com/knative/serving/issues/11386