### PR TITLE
wip: Enable sidecar injection for net-istio controller

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -65,6 +65,9 @@ if [[ -z "${INGRESS_CLASS}" \
   alpha="--enable-alpha"
 fi
 
+# Remove "local-gateway.mesh: mesh" to verify
+kubectl patch configmap/config-istio -n ${SYSTEM_NAMESPACE} --type='json' --patch='[{"op": "remove", "path": "/data/local-gateway.mesh"}]' 
+
 go_test_e2e -timeout=30m \
  ./test/conformance/api/... \
  ./test/conformance/runtime/... \

--- a/third_party/istio-latest/net-istio.yaml
+++ b/third_party/istio-latest/net-istio.yaml
@@ -371,6 +371,10 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        # This must be outside of the mesh to probe the gateways.
+        # NOTE: this is allowed here and not elsewhere because
+        # this is the Istio controller, and so it may be Istio-aware.
+        sidecar.istio.io/inject: "false"
       labels:
         app: networking-istio
         serving.knative.dev/release: "v20210507-3d937cfe"

--- a/third_party/istio-latest/net-istio.yaml
+++ b/third_party/istio-latest/net-istio.yaml
@@ -371,10 +371,6 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
-        # This must be outside of the mesh to probe the gateways.
-        # NOTE: this is allowed here and not elsewhere because
-        # this is the Istio controller, and so it may be Istio-aware.
-        sidecar.istio.io/inject: "false"
       labels:
         app: networking-istio
         serving.knative.dev/release: "v20210507-3d937cfe"


### PR DESCRIPTION
This patch removes `sidecar.istio.io/inject: false` from net-istio controller. 
