### PR TITLE
allow dropping securityContext capabilities

### DIFF
--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -594,6 +594,7 @@ func SecurityContextMask(ctx context.Context, in *corev1.SecurityContext) *corev
 	// Allowed fields
 	out.RunAsUser = in.RunAsUser
 	out.ReadOnlyRootFilesystem = in.ReadOnlyRootFilesystem
+	out.Capabilities = in.Capabilities
 
 	if config.FromContextOrDefaults(ctx).Features.PodSpecSecurityContext != config.Disabled {
 		out.RunAsGroup = in.RunAsGroup
@@ -601,11 +602,30 @@ func SecurityContextMask(ctx context.Context, in *corev1.SecurityContext) *corev
 	}
 	// Disallowed
 	// This list is unnecessary, but added here for clarity
-	out.Capabilities = nil
 	out.Privileged = nil
 	out.SELinuxOptions = nil
 	out.AllowPrivilegeEscalation = nil
 	out.ProcMount = nil
+
+	return out
+}
+
+// CapabilitiesMask performs a _shallow_ copy of the Kubernetes Capabilities object to a new
+// Kubernetes Capabilities object bringing over only the fields allowed in the Knative API. This
+// does not validate the contents or the bounds of the provided fields.
+func CapabilitiesMask(in *corev1.Capabilities) *corev1.Capabilities {
+	if in == nil {
+		return nil
+	}
+
+	out := new(corev1.Capabilities)
+
+	// Allowed fields
+	out.Drop = in.Drop
+
+	// Disallowed
+	// This list is unnecessary, but added here for clarity
+	out.Add = nil
 
 	return out
 }

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -720,6 +720,7 @@ func TestPodSecurityContextMask_FeatureEnabled(t *testing.T) {
 func TestSecurityContextMask(t *testing.T) {
 	mtype := corev1.UnmaskedProcMount
 	want := &corev1.SecurityContext{
+		Capabilities:           &corev1.Capabilities{},
 		RunAsUser:              ptr.Int64(1),
 		ReadOnlyRootFilesystem: ptr.Bool(true),
 	}
@@ -755,6 +756,7 @@ func TestSecurityContextMask(t *testing.T) {
 func TestSecurityContextMask_FeatureEnabled(t *testing.T) {
 	mtype := corev1.UnmaskedProcMount
 	want := &corev1.SecurityContext{
+		Capabilities:           &corev1.Capabilities{},
 		RunAsGroup:             ptr.Int64(2),
 		RunAsNonRoot:           ptr.Bool(true),
 		RunAsUser:              ptr.Int64(1),

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -447,11 +447,20 @@ func validateResources(resources *corev1.ResourceRequirements) *apis.FieldError 
 	return apis.CheckDisallowedFields(*resources, *ResourceRequirementsMask(resources))
 }
 
+func validateCapabilities(cap *corev1.Capabilities) *apis.FieldError {
+	if cap == nil {
+		return nil
+	}
+	return apis.CheckDisallowedFields(*cap, *CapabilitiesMask(cap))
+}
+
 func validateSecurityContext(ctx context.Context, sc *corev1.SecurityContext) *apis.FieldError {
 	if sc == nil {
 		return nil
 	}
 	errs := apis.CheckDisallowedFields(*sc, *SecurityContextMask(ctx, sc))
+
+	errs = errs.Also(validateCapabilities(sc.Capabilities).ViaField("capabilities"))
 
 	if sc.RunAsUser != nil {
 		uid := *sc.RunAsUser

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -1286,6 +1286,17 @@ func TestContainerValidation(t *testing.T) {
 		},
 		want: apis.ErrDisallowedFields("securityContext.runAsGroup"),
 	}, {
+		name: "not allowed to add a security context capability",
+		c: corev1.Container{
+			Image: "foo",
+			SecurityContext: &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{"all"},
+				},
+			},
+		},
+		want: apis.ErrDisallowedFields("securityContext.capabilities.add"),
+	}, {
 		name: "too large uid",
 		c: corev1.Container{
 			Image: "foo",


### PR DESCRIPTION
Fixes #10812 (part 1)

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This fix allows dropping security context capabilities from a container via `containers[].securityContext.capabilities.drop` 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow dropping capabilities from a container's security context
```
