### PR TITLE
Fix invalid link for support.rotation

### DIFF
--- a/support/COMMUNITY_CONTACTS.md
+++ b/support/COMMUNITY_CONTACTS.md
@@ -76,7 +76,7 @@ rotation, feel free to send a PR to remove yourself.
 
 # Schedule
 
-See [a machine-readable schedule here](schedule.rotation). The format is:
+See [a machine-readable schedule here](support.rotation). The format is:
 
 ```
 # comment lines are okay


### PR DESCRIPTION
This patch fixes invalid file `schedule.rotation` to [`support.rotation`](https://github.com/knative/serving/blob/main/support/support.rotation).

[Current link in this page](https://github.com/knative/serving/blob/main/support/COMMUNITY_CONTACTS.md#schedule) returns 404 not found error. 

/cc @evankanderson @n3wscott 