### PR TITLE
Use UID rather than name in label to avoid hitting character limits

### DIFF
--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -89,9 +89,11 @@ const (
 	// which Service they are created.
 	ServiceLabelKey = GroupName + "/service"
 
-	// DomainMappingLabelKey is the label key attached to Ingress resources to indicate
+	// DomainMappingUIDLabelKey is the label key attached to Ingress resources to indicate
 	// which DomainMapping triggered their creation.
-	DomainMappingLabelKey = GroupName + "/domainMapping"
+	// This uses a uid rather than a name because domain mapping names can exceed
+	// a label's 63 character limit.
+	DomainMappingUIDLabelKey = GroupName + "/domainMappingUID"
 
 	// DomainMappingNamespaceLabelKey is the label key attached to Ingress
 	// resources created by a DomainMapping to indicate which namespace the

--- a/pkg/reconciler/domainmapping/resources/certificate.go
+++ b/pkg/reconciler/domainmapping/resources/certificate.go
@@ -32,5 +32,5 @@ import (
 func MakeCertificate(dm *v1alpha1.DomainMapping, certClass string) *networkingv1alpha1.Certificate {
 	certName := kmeta.ChildName(dm.GetName(), "")
 	return routeresources.MakeCertificate(
-		dm, serving.DomainMappingLabelKey, dm.Name, certName, certClass)
+		dm, serving.DomainMappingUIDLabelKey, dm.Name, certName, certClass)
 }

--- a/pkg/reconciler/domainmapping/resources/certificate_test.go
+++ b/pkg/reconciler/domainmapping/resources/certificate_test.go
@@ -57,7 +57,7 @@ func TestMakeCertificate(t *testing.T) {
 				Namespace:   "the-namespace",
 				Annotations: map[string]string{"networking.knative.dev/certificate.class": certClass},
 				Labels: map[string]string{
-					serving.DomainMappingLabelKey: "mapping.com",
+					serving.DomainMappingUIDLabelKey: "mapping.com",
 				},
 			},
 			Spec: networkingv1alpha1.CertificateSpec{
@@ -94,7 +94,7 @@ func TestMakeCertificate(t *testing.T) {
 					"others": "kept",
 				},
 				Labels: map[string]string{
-					serving.DomainMappingLabelKey: "mapping.com",
+					serving.DomainMappingUIDLabelKey: "mapping.com",
 				},
 			},
 			Spec: networkingv1alpha1.CertificateSpec{

--- a/pkg/reconciler/domainmapping/resources/ingress.go
+++ b/pkg/reconciler/domainmapping/resources/ingress.go
@@ -46,7 +46,7 @@ func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, hostName
 				return key == corev1.LastAppliedConfigAnnotation
 			}),
 			Labels: kmeta.UnionMaps(dm.Labels, map[string]string{
-				serving.DomainMappingLabelKey:          dm.Name,
+				serving.DomainMappingUIDLabelKey:       string(dm.UID),
 				serving.DomainMappingNamespaceLabelKey: dm.Namespace,
 			}),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(dm)},

--- a/pkg/reconciler/domainmapping/resources/ingress_test.go
+++ b/pkg/reconciler/domainmapping/resources/ingress_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	network "knative.dev/networking/pkg"
 	netv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
@@ -45,6 +46,7 @@ func TestMakeIngress(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "mapping.com",
 				Namespace: "the-namespace",
+				UID:       types.UID("the-uid"),
 				Annotations: map[string]string{
 					"some.annotation":                  "some.value",
 					corev1.LastAppliedConfigAnnotation: "blah",
@@ -95,6 +97,7 @@ func TestMakeIngress(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "mapping.com",
 				Namespace: "the-namespace",
+				UID:       types.UID("the-uid"),
 				Annotations: map[string]string{
 					"some.annotation":                  "some.value",
 					corev1.LastAppliedConfigAnnotation: "blah",
@@ -153,6 +156,7 @@ func TestMakeIngress(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "mapping.com",
 				Namespace: "the-namespace",
+				UID:       types.UID("the-uid"),
 				Annotations: map[string]string{
 					"some.annotation":                  "some.value",
 					corev1.LastAppliedConfigAnnotation: "blah",
@@ -220,8 +224,8 @@ func TestMakeIngress(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.want.Labels = kmeta.UnionMaps(tc.dm.Labels, map[string]string{
-				serving.DomainMappingLabelKey:          tc.dm.Name,
-				serving.DomainMappingNamespaceLabelKey: tc.dm.Namespace,
+				serving.DomainMappingUIDLabelKey:       "the-uid",
+				serving.DomainMappingNamespaceLabelKey: "the-namespace",
 			})
 			tc.want.OwnerReferences = []metav1.OwnerReference{*kmeta.NewControllerRef(&tc.dm)}
 			got := *MakeIngress(&tc.dm,

--- a/pkg/reconciler/domainmapping/table_test.go
+++ b/pkg/reconciler/domainmapping/table_test.go
@@ -887,7 +887,7 @@ func TestReconcileTLSEnabled(t *testing.T) {
 						networking.CertificateClassAnnotationKey: "the-cert-class",
 					},
 					Labels: map[string]string{
-						serving.DomainMappingLabelKey: "becomes.ready.run",
+						serving.DomainMappingUIDLabelKey: "becomes.ready.run",
 					},
 				},
 				Spec: netv1alpha1.CertificateSpec{
@@ -1029,7 +1029,7 @@ func TestReconcileTLSEnabled(t *testing.T) {
 						networking.CertificateClassAnnotationKey: "the-cert-class",
 					},
 					Labels: map[string]string{
-						serving.DomainMappingLabelKey: "challenged.com",
+						serving.DomainMappingUIDLabelKey: "challenged.com",
 					},
 				},
 				Spec: netv1alpha1.CertificateSpec{


### PR DESCRIPTION
Fixes #11352.

DomainMappings can validly sometimes have names exceeding 63 characters
(since they represent an entire domain name). Using UID instead avoids
hitting limits imposed on k8s labels. The annotation is only for
information/debugging purposes anyway and is not otherwise used.

/assign @nak3 @markusthoemmes 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Ingresses created by domain mappings now set a domainMappingUID annotation rather than domainMapping (containing the uid of the mapping rather than the name). This allows domain mappings greater than 63 characters to be successfully created.
```
