### PR TITLE
Replace golint with revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,10 +21,10 @@ linters:
     - asciicheck
     - depguard
     - errorlint
-    - golint
     - gosec
     - importas
     - prealloc
+    - revive
     - stylecheck
     - tparallel
     - unconvert
@@ -58,7 +58,7 @@ issues:
     - path: test
       text: "context.Context should be the first"
       linters:
-        - golint
+        - revive
 
     # Allow source and sink receivers in conversion code for clarity.
     - path: _conversion\.go
@@ -68,7 +68,7 @@ issues:
     - path: _conversion\.go
       text: "receiver name"
       linters:
-        - golint
+        - revive
 
     # This check has quite a few false positives where there isn't much value in the package comment.
     - text: "ST1000: at least one file in a package should have a package comment"

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -176,7 +176,7 @@ func validate(lc *autoscalerconfig.Config) (*autoscalerconfig.Config, error) {
 		return nil, fmt.Errorf("initial-scale = %v, must be at least 0 (or at least 1 when allow-zero-initial-scale is false)", lc.InitialScale)
 	}
 
-	var minMaxScale int32 = 0
+	var minMaxScale int32
 	if lc.MaxScaleLimit > 0 {
 		// Default maxScale must be set if maxScaleLimit is set.
 		minMaxScale = 1

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -223,7 +223,7 @@ func (ks *scaler) handleScaleToZero(ctx context.Context, pa *autoscalingv1alpha1
 	default: // Active=False
 		var (
 			err error
-			r   bool = true
+			r   = true
 		)
 
 		if resolveTBC(ctx, pa) != -1 {

--- a/pkg/reconciler/labeler/labeler.go
+++ b/pkg/reconciler/labeler/labeler.go
@@ -37,18 +37,11 @@ var _ routereconciler.Finalizer = (*Reconciler)(nil)
 // FinalizeKind removes all Route reference metadata from its traffic targets.
 // This does not modify or observe spec for the Route itself.
 func (rec *Reconciler) FinalizeKind(ctx context.Context, r *v1.Route) pkgreconciler.Event {
-	if err := clearRoutingMeta(ctx, r, rec.caccV2, rec.raccV2); err != nil {
-		return err
-	}
-	return nil
+	return clearRoutingMeta(ctx, r, rec.caccV2, rec.raccV2)
 }
 
 // ReconcileKind syncs the Route reference metadata to its traffic targets.
 // This does not modify or observe spec for the Route itself.
 func (rec *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconciler.Event {
-	if err := syncRoutingMeta(ctx, r, rec.caccV2, rec.raccV2); err != nil {
-		return err
-	}
-
-	return nil
+	return syncRoutingMeta(ctx, r, rec.caccV2, rec.raccV2)
 }

--- a/pkg/reconciler/nscert/nscert.go
+++ b/pkg/reconciler/nscert/nscert.go
@@ -53,7 +53,7 @@ type reconciler struct {
 
 // Check that our Reconciler implements namespacereconciler.Interface
 var _ namespacereconciler.Interface = (*reconciler)(nil)
-var domainTemplateRegex *regexp.Regexp = regexp.MustCompile(`^\*\..+$`)
+var domainTemplateRegex = regexp.MustCompile(`^\*\..+$`)
 
 func certClass(ctx context.Context, r *corev1.Namespace) string {
 	if class := r.Annotations[networking.CertificateClassAnnotationKey]; class != "" {

--- a/pkg/webhook/podspec_dryrun.go
+++ b/pkg/webhook/podspec_dryrun.go
@@ -47,7 +47,7 @@ func decodeTemplate(val interface{}) (*v1.RevisionTemplateSpec, error) {
 	return templ, nil
 }
 
-func validatePodSpec(ctx context.Context, ps v1.RevisionSpec, namespace string, mode DryRunMode) *apis.FieldError {
+func validatePodSpec(ctx context.Context, ps v1.RevisionSpec, namespace string, mode DryRunMode) error {
 	om := metav1.ObjectMeta{
 		GenerateName: "dry-run-validation",
 		Namespace:    namespace,
@@ -71,7 +71,7 @@ func validatePodSpec(ctx context.Context, ps v1.RevisionSpec, namespace string, 
 }
 
 // dryRunPodSpec makes a dry-run call to k8s to validate the podspec
-func dryRunPodSpec(ctx context.Context, pod *corev1.Pod, mode DryRunMode) *apis.FieldError {
+func dryRunPodSpec(ctx context.Context, pod *corev1.Pod, mode DryRunMode) error {
 	logger := logging.FromContext(ctx)
 	client := kubeclient.Get(ctx)
 

--- a/pkg/webhook/validate_unstructured.go
+++ b/pkg/webhook/validate_unstructured.go
@@ -110,8 +110,5 @@ func validateRevisionTemplate(ctx context.Context, uns *unstructured.Unstructure
 		}
 	}
 
-	if err := validatePodSpec(ctx, templ.Spec, namespace, mode); err != nil {
-		return err
-	}
-	return nil
+	return validatePodSpec(ctx, templ.Spec, namespace, mode)
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

See https://groups.google.com/g/golang-nuts/c/rCP70Aq_tBc/m/8QHp6_cqBgAJ
as towards golint's deprecation. revive is supposed to be a drop-in
replacement.

/assign @julz 
