### PR TITLE
Move activator count computation into KPA

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -88,20 +88,17 @@ func TestAutoscalerScaleDownDelay(t *testing.T) {
 		expectScale(t, as, now.Add(2*time.Second), ScaleResult{
 			ScaleValid:      true,
 			DesiredPodCount: 4,
-			NumActivators:   2,
 		})
 		// five minutes pass at reduced concurrency - should not scale down (less than delay).
 		metrics.SetStableAndPanicConcurrency(0, 0)
 		expectScale(t, as, now.Add(5*time.Minute), ScaleResult{
 			ScaleValid:      true,
 			DesiredPodCount: 4,
-			NumActivators:   2,
 		})
 		// five minutes and 2 seconds pass at reduced concurrency - now we scale down.
 		expectScale(t, as, now.Add(5*time.Minute+2*time.Second), ScaleResult{
 			ScaleValid:      true,
 			DesiredPodCount: 0,
-			NumActivators:   2,
 		})
 	})
 
@@ -110,29 +107,24 @@ func TestAutoscalerScaleDownDelay(t *testing.T) {
 		expectScale(t, as, now.Add(9*time.Minute), ScaleResult{
 			ScaleValid:      true,
 			DesiredPodCount: 4,
-			NumActivators:   2,
 		})
 		metrics.SetStableAndPanicConcurrency(30, 30)
 		expectScale(t, as, now.Add(10*time.Minute), ScaleResult{
 			ScaleValid:      true,
 			DesiredPodCount: 4, // 4 still dominates
-			NumActivators:   2,
 		})
 		metrics.SetStableAndPanicConcurrency(0, 0)
 		expectScale(t, as, now.Add(11*time.Minute), ScaleResult{
 			ScaleValid:      true,
 			DesiredPodCount: 4, // still at 4
-			NumActivators:   2,
 		})
 		expectScale(t, as, now.Add(14*time.Minute), ScaleResult{
 			ScaleValid:      true,
 			DesiredPodCount: 3, // 4 scrolls out, drop to 3
-			NumActivators:   2,
 		})
 		expectScale(t, as, now.Add(15*time.Minute), ScaleResult{
 			ScaleValid:      true,
 			DesiredPodCount: 0, // everything scrolled out, drop to 0
-			NumActivators:   2,
 		})
 	})
 }
@@ -155,7 +147,6 @@ func TestAutoscalerScaleDownDelayZero(t *testing.T) {
 	expectScale(t, as, now, ScaleResult{
 		ScaleValid:      true,
 		DesiredPodCount: 4,
-		NumActivators:   2,
 	})
 	// With zero delay we should immediately scale down (this is not the case
 	// with a 1-element time window delay).
@@ -163,7 +154,6 @@ func TestAutoscalerScaleDownDelayZero(t *testing.T) {
 	expectScale(t, as, now.Add(500*time.Millisecond), ScaleResult{
 		ScaleValid:      true,
 		DesiredPodCount: 2,
-		NumActivators:   2,
 	})
 }
 
@@ -176,19 +166,13 @@ func TestAutoscalerNoDataNoAutoscale(t *testing.T) {
 	}
 
 	a := newTestAutoscalerNoPC(10, 100, metrics)
-	expectScale(t, a, time.Now(), ScaleResult{0, 0, MinActivators, false})
+	expectScale(t, a, time.Now(), ScaleResult{0, 0, false})
 }
 
 func expectedEBC(totCap, targetBC, recordedConcurrency, numPods float64) int32 {
 	ebcF := totCap/targetUtilization*numPods - targetBC - recordedConcurrency
 	// We need to floor for negative values.
 	return int32(math.Floor(ebcF))
-}
-
-func expectedNA(a *autoscaler, numP float64) int32 {
-	return int32(math.Max(MinActivators,
-		math.Ceil(
-			(a.deciderSpec.TotalValue*numP+a.deciderSpec.TargetBurstCapacity)/a.deciderSpec.ActivatorCapacity)))
 }
 
 func TestAutoscalerStartMetrics(t *testing.T) {
@@ -207,8 +191,7 @@ func TestAutoscalerMetrics(t *testing.T) {
 	// Non-panic created autoscaler.
 	metricstest.AssertMetric(t, metricstest.IntMetric(panicM.Name(), 0, nil).WithResource(wantResource))
 	ebc := expectedEBC(10, 100, 50, 1)
-	na := expectedNA(a, 1)
-	expectScale(t, a, time.Now(), ScaleResult{5, ebc, na, true})
+	expectScale(t, a, time.Now(), ScaleResult{5, ebc, true})
 	spec := a.currentSpec()
 
 	wantMetrics := []metricstest.Metric{
@@ -227,11 +210,10 @@ func TestAutoscalerMetricsWithRPS(t *testing.T) {
 	metrics := &metricClient{PanicRPS: 99.0, StableRPS: 100}
 	a, _ := newTestAutoscalerWithScalingMetric(10, 100, metrics, "rps", false /*startInPanic*/)
 	ebc := expectedEBC(10, 100, 99, 1)
-	na := expectedNA(a, 1)
-	expectScale(t, a, time.Now(), ScaleResult{10, ebc, na, true})
+	expectScale(t, a, time.Now(), ScaleResult{10, ebc, true})
 	spec := a.currentSpec()
 
-	expectScale(t, a, time.Now().Add(61*time.Second), ScaleResult{10, ebc, na, true})
+	expectScale(t, a, time.Now().Add(61*time.Second), ScaleResult{10, ebc, true})
 	wantMetrics := []metricstest.Metric{
 		metricstest.FloatMetric(stableRPSM.Name(), 100, nil).WithResource(wantResource),
 		metricstest.FloatMetric(panicRPSM.Name(), 100, nil).WithResource(wantResource),
@@ -246,22 +228,20 @@ func TestAutoscalerMetricsWithRPS(t *testing.T) {
 func TestAutoscalerStableModeIncreaseWithConcurrencyDefault(t *testing.T) {
 	metrics := &metricClient{StableConcurrency: 50.0, PanicConcurrency: 10}
 	a := newTestAutoscalerNoPC(10, 101, metrics)
-	na := expectedNA(a, 1)
-	expectScale(t, a, time.Now(), ScaleResult{5, expectedEBC(10, 101, 10, 1), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{5, expectedEBC(10, 101, 10, 1), true})
 
 	metrics.StableConcurrency = 100
-	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 101, 10, 1), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 101, 10, 1), true})
 }
 
 func TestAutoscalerStableModeIncreaseWithRPS(t *testing.T) {
 	metrics := &metricClient{StableRPS: 50.0, PanicRPS: 50}
 	a, _ := newTestAutoscalerWithScalingMetric(10, 101, metrics, "rps", false /*startInPanic*/)
-	na := expectedNA(a, 1)
-	expectScale(t, a, time.Now(), ScaleResult{5, expectedEBC(10, 101, 50, 1), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{5, expectedEBC(10, 101, 50, 1), true})
 
 	metrics.StableRPS = 100
 	metrics.PanicRPS = 99
-	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 101, 99, 1), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 101, 99, 1), true})
 }
 
 func TestAutoscalerUnpanicAfterSlowIncrease(t *testing.T) {
@@ -270,10 +250,9 @@ func TestAutoscalerUnpanicAfterSlowIncrease(t *testing.T) {
 	a, pc := newTestAutoscaler(1, 98, metrics)
 	pc.readyCount = 10
 
-	na := expectedNA(a, 10)
 	start := time.Now()
 	tm := start
-	expectScale(t, a, tm, ScaleResult{25, expectedEBC(1, 98, 25, 10), na, true})
+	expectScale(t, a, tm, ScaleResult{25, expectedEBC(1, 98, 25, 10), true})
 	if a.panicTime != tm {
 		t.Errorf("PanicTime = %v, want: %v", a.panicTime, tm)
 	}
@@ -284,8 +263,7 @@ func TestAutoscalerUnpanicAfterSlowIncrease(t *testing.T) {
 	metrics.SetStableAndPanicConcurrency(30, 41)
 	tm = tm.Add(stableWindow / 2)
 
-	na = expectedNA(a, 40)
-	expectScale(t, a, tm, ScaleResult{41, expectedEBC(1, 98, 41, 40), na, true})
+	expectScale(t, a, tm, ScaleResult{41, expectedEBC(1, 98, 41, 40), true})
 	if a.panicTime != start {
 		t.Error("Panic Time should not have moved")
 	}
@@ -295,8 +273,7 @@ func TestAutoscalerUnpanicAfterSlowIncrease(t *testing.T) {
 	metrics.SetStableAndPanicConcurrency(50, 56)
 	tm = tm.Add(stableWindow/2 + tickInterval)
 
-	na = expectedNA(a, 55)
-	expectScale(t, a, tm, ScaleResult{50 /* no longer in panic*/, expectedEBC(1, 98, 56, 55), na, true})
+	expectScale(t, a, tm, ScaleResult{50 /* no longer in panic*/, expectedEBC(1, 98, 56, 55), true})
 	if !a.panicTime.IsZero() {
 		t.Errorf("PanicTime = %v, want: 0", a.panicTime)
 	}
@@ -308,10 +285,9 @@ func TestAutoscalerExtendPanicWindow(t *testing.T) {
 	a, pc := newTestAutoscaler(1, 98, metrics)
 	pc.readyCount = 10
 
-	na := expectedNA(a, 10)
 	start := time.Now()
 	tm := start
-	expectScale(t, a, tm, ScaleResult{25, expectedEBC(1, 98, 25, 10), na, true})
+	expectScale(t, a, tm, ScaleResult{25, expectedEBC(1, 98, 25, 10), true})
 	if a.panicTime != tm {
 		t.Errorf("PanicTime = %v, want: %v", a.panicTime, tm)
 	}
@@ -321,8 +297,7 @@ func TestAutoscalerExtendPanicWindow(t *testing.T) {
 	metrics.SetStableAndPanicConcurrency(30, 80)
 	tm = tm.Add(stableWindow / 2)
 
-	na = expectedNA(a, 40)
-	expectScale(t, a, tm, ScaleResult{80, expectedEBC(1, 98, 80, 40), na, true})
+	expectScale(t, a, tm, ScaleResult{80, expectedEBC(1, 98, 80, 40), true})
 	if a.panicTime != tm {
 		t.Errorf("PanicTime = %v, want: %v", a.panicTime, tm)
 	}
@@ -332,21 +307,19 @@ func TestAutoscalerStableModeDecrease(t *testing.T) {
 	metrics := &metricClient{StableConcurrency: 100.0, PanicConcurrency: 100}
 	a, pc := newTestAutoscaler(10, 98, metrics)
 	pc.readyCount = 8
-	na := expectedNA(a, 8)
-	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 98, 100, 8), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 98, 100, 8), true})
 
 	metrics.SetStableAndPanicConcurrency(50, 50)
-	expectScale(t, a, time.Now(), ScaleResult{5, expectedEBC(10, 98, 50, 8), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{5, expectedEBC(10, 98, 50, 8), true})
 }
 
 func TestAutoscalerStableModeNoTrafficScaleToZero(t *testing.T) {
 	metrics := &metricClient{StableConcurrency: 1, PanicConcurrency: 0}
 	a := newTestAutoscalerNoPC(10, 75, metrics)
-	na := expectedNA(a, 1)
-	expectScale(t, a, time.Now(), ScaleResult{1, expectedEBC(10, 75, 0, 1), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{1, expectedEBC(10, 75, 0, 1), true})
 
 	metrics.StableConcurrency = 0.0
-	expectScale(t, a, time.Now(), ScaleResult{0, expectedEBC(10, 75, 0, 1), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{0, expectedEBC(10, 75, 0, 1), true})
 }
 
 // QPS is increasing exponentially. Each scaling event bring concurrency
@@ -355,39 +328,34 @@ func TestAutoscalerStableModeNoTrafficScaleToZero(t *testing.T) {
 func TestAutoscalerPanicModeExponentialTrackAndStabilize(t *testing.T) {
 	metrics := &metricClient{StableConcurrency: 6, PanicConcurrency: 6}
 	a, pc := newTestAutoscaler(1, 101, metrics)
-	na := expectedNA(a, 1)
-	expectScale(t, a, time.Now(), ScaleResult{6, expectedEBC(1, 101, 6, 1), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{6, expectedEBC(1, 101, 6, 1), true})
 
 	tm := time.Now()
 	pc.readyCount = 6
-	na = expectedNA(a, 6)
 	metrics.SetStableAndPanicConcurrency(36, 36)
-	expectScale(t, a, tm, ScaleResult{36, expectedEBC(1, 101, 36, 6), na, true})
+	expectScale(t, a, tm, ScaleResult{36, expectedEBC(1, 101, 36, 6), true})
 	if got, want := a.panicTime, tm; got != tm {
 		t.Errorf("PanicTime = %v, want: %v", got, want)
 	}
 
 	pc.readyCount = 36
-	na = expectedNA(a, 36)
 	metrics.SetStableAndPanicConcurrency(216, 216)
 	tm = tm.Add(time.Second)
-	expectScale(t, a, tm, ScaleResult{216, expectedEBC(1, 101, 216, 36), na, true})
+	expectScale(t, a, tm, ScaleResult{216, expectedEBC(1, 101, 216, 36), true})
 	if got, want := a.panicTime, tm; got != tm {
 		t.Errorf("PanicTime = %v, want: %v", got, want)
 	}
 
 	pc.readyCount = 216
-	na = expectedNA(a, 216)
 	metrics.SetStableAndPanicConcurrency(1296, 1296)
-	expectScale(t, a, tm, ScaleResult{1296, expectedEBC(1, 101, 1296, 216), na, true})
+	expectScale(t, a, tm, ScaleResult{1296, expectedEBC(1, 101, 1296, 216), true})
 	if got, want := a.panicTime, tm; got != tm {
 		t.Errorf("PanicTime = %v, want: %v", got, want)
 	}
 
 	pc.readyCount = 1296
-	na = expectedNA(a, 1296)
 	tm = tm.Add(time.Second)
-	expectScale(t, a, tm, ScaleResult{1296, expectedEBC(1, 101, 1296, 1296), na, true})
+	expectScale(t, a, tm, ScaleResult{1296, expectedEBC(1, 101, 1296, 1296), true})
 }
 
 func TestAutoscalerScale(t *testing.T) {
@@ -501,8 +469,7 @@ func TestAutoscalerScale(t *testing.T) {
 			if test.prepFunc != nil {
 				test.prepFunc(test.as)
 			}
-			wantNA := expectedNA(test.as, float64(test.baseScale))
-			expectScale(tt, test.as, time.Now(), ScaleResult{test.wantScale, test.wantEBC, wantNA, !test.wantInvalid})
+			expectScale(tt, test.as, time.Now(), ScaleResult{test.wantScale, test.wantEBC, !test.wantInvalid})
 		})
 	}
 }
@@ -510,35 +477,31 @@ func TestAutoscalerScale(t *testing.T) {
 func TestAutoscalerPanicThenUnPanicScaleDown(t *testing.T) {
 	metrics := &metricClient{StableConcurrency: 100, PanicConcurrency: 100}
 	a, pc := newTestAutoscaler(10, 93, metrics)
-	na := expectedNA(a, 1)
-	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 93, 100, 1), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 93, 100, 1), true})
 	pc.readyCount = 10
 
-	na = expectedNA(a, 10)
 	panicTime := time.Now()
 	metrics.PanicConcurrency = 1000
-	expectScale(t, a, panicTime, ScaleResult{100, expectedEBC(10, 93, 1000, 10), na, true})
+	expectScale(t, a, panicTime, ScaleResult{100, expectedEBC(10, 93, 1000, 10), true})
 
 	// Traffic dropped off, scale stays as we're still in panic.
 	metrics.SetStableAndPanicConcurrency(1, 1)
-	expectScale(t, a, panicTime.Add(30*time.Second), ScaleResult{100, expectedEBC(10, 93, 1, 10), na, true})
+	expectScale(t, a, panicTime.Add(30*time.Second), ScaleResult{100, expectedEBC(10, 93, 1, 10), true})
 
 	// Scale down after the StableWindow
-	expectScale(t, a, panicTime.Add(61*time.Second), ScaleResult{1, expectedEBC(10, 93, 1, 10), na, true})
+	expectScale(t, a, panicTime.Add(61*time.Second), ScaleResult{1, expectedEBC(10, 93, 1, 10), true})
 }
 
 func TestAutoscalerRateLimitScaleUp(t *testing.T) {
 	metrics := &metricClient{StableConcurrency: 1000, PanicConcurrency: 1001}
 	a, pc := newTestAutoscaler(10, 61, metrics)
-	na := expectedNA(a, 1)
 
 	// Need 100 pods but only scale x10
-	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 61, 1001, 1), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 61, 1001, 1), true})
 
 	pc.readyCount = 10
-	na = expectedNA(a, 10)
 	// Scale x10 again
-	expectScale(t, a, time.Now(), ScaleResult{100, expectedEBC(10, 61, 1001, 10), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{100, expectedEBC(10, 61, 1001, 10), true})
 }
 
 func TestAutoscalerRateLimitScaleDown(t *testing.T) {
@@ -547,13 +510,11 @@ func TestAutoscalerRateLimitScaleDown(t *testing.T) {
 
 	// Need 1 pods but can only scale down ten times, to 10.
 	pc.readyCount = 100
-	na := expectedNA(a, 100)
-	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 61, 1, 100), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 61, 1, 100), true})
 
-	na = expectedNA(a, 10)
 	pc.readyCount = 10
 	// Scale ÷10 again.
-	expectScale(t, a, time.Now(), ScaleResult{1, expectedEBC(10, 61, 1, 10), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{1, expectedEBC(10, 61, 1, 10), true})
 }
 
 func TestCantCountPods(t *testing.T) {
@@ -572,14 +533,13 @@ func TestAutoscalerUseOnePodAsMinimumIfEndpointsNotFound(t *testing.T) {
 	pc.readyCount = 0
 	// 2*10 as the rate limited if we can get the actual pods number.
 	// 1*10 as the rate limited since no read pods are there from K8S API.
-	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 81, 888, 0), MinActivators, true})
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 81, 888, 0), true})
 }
 
 func TestAutoscalerUpdateTarget(t *testing.T) {
 	metrics := &metricClient{StableConcurrency: 100, PanicConcurrency: 101}
 	a, pc := newTestAutoscaler(10, 77, metrics)
-	na := expectedNA(a, 1)
-	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 77, 101, 1), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{10, expectedEBC(10, 77, 101, 1), true})
 
 	pc.readyCount = 10
 	a.Update(&DeciderSpec{
@@ -592,8 +552,7 @@ func TestAutoscalerUpdateTarget(t *testing.T) {
 		MaxScaleUpRate:      10,
 		StableWindow:        stableWindow,
 	})
-	na = expectedNA(a, 10)
-	expectScale(t, a, time.Now(), ScaleResult{100, expectedEBC(1, 71, 101, 10), na, true})
+	expectScale(t, a, time.Now(), ScaleResult{100, expectedEBC(1, 71, 101, 10), true})
 }
 
 // For table tests and tests that don't care about changing scale.

--- a/pkg/autoscaler/scaling/multiscaler.go
+++ b/pkg/autoscaler/scaling/multiscaler.go
@@ -90,10 +90,6 @@ type DeciderStatus struct {
 	// If this number is negative: Activator will be threaded in
 	// the request path by the PodAutoscaler controller.
 	ExcessBurstCapacity int32
-
-	// NumActivators is the computed number of activators
-	// necessary to back the revision.
-	NumActivators int32
 }
 
 // ScaleResult holds the scale result of the UniScaler evaluation cycle.
@@ -103,16 +99,13 @@ type ScaleResult struct {
 	// ExcessBurstCapacity is computed headroom of the revision taking into
 	// the account target burst capacity.
 	ExcessBurstCapacity int32
-	// NumActivators is the number of activators required to back this revision.
-	NumActivators int32
 	// ScaleValid specifies whether this scale result is valid, i.e. whether
 	// Autoscaler had all the necessary information to compute a suggestion.
 	ScaleValid bool
 }
 
 var invalidSR = ScaleResult{
-	ScaleValid:    false,
-	NumActivators: MinActivators,
+	ScaleValid: false,
 }
 
 // UniScaler records statistics for a particular Decider and proposes the scale for the Decider's target based on those statistics.
@@ -162,10 +155,6 @@ func (sr *scalerRunner) updateLatestScale(sRes ScaleResult) bool {
 	defer sr.mux.Unlock()
 	if sr.decider.Status.DesiredScale != sRes.DesiredPodCount {
 		sr.decider.Status.DesiredScale = sRes.DesiredPodCount
-		ret = true
-	}
-	if sr.decider.Status.NumActivators != sRes.NumActivators {
-		sr.decider.Status.NumActivators = sRes.NumActivators
 		ret = true
 	}
 


### PR DESCRIPTION
Fixes #11373

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

See the above issue for further infromation. Changes the default to 2 rather than all, which should be correct in most cases anyway as the autoscaler would immediately set it to 2 in most cases anyway.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixed a bug where traffic would briefly be routed 'wrong', leading to errors due to exceeded queues in deployments with a large activator count and a low service pod count.
```

/assign @julz @vagababov 
