### PR TITLE
Use NetworkingFlags to enable alpha feature in autotls

### DIFF
--- a/test/e2e/autotls/domain_mapping_test.go
+++ b/test/e2e/autotls/domain_mapping_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	ntest "knative.dev/networking/test"
 	"knative.dev/networking/test/conformance/ingress"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/reconciler"
@@ -47,7 +48,7 @@ type dmConfig struct {
 }
 
 func TestDomainMappingAutoTLS(t *testing.T) {
-	if !test.ServingFlags.EnableAlphaFeatures {
+	if !ntest.NetworkingFlags.EnableAlphaFeatures {
 		t.Skip("Alpha features not enabled")
 	}
 	t.Parallel()


### PR DESCRIPTION
This patch changes to use networking flags instead of serving flags
for TestDomainMappingAutoTLS.

It causes an issue described in https://github.com/knative/serving/issues/11376.

Fix https://github.com/knative/serving/issues/11376

/cc @dprotaso 