### PR TITLE
Validate features configmap

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -43,6 +43,7 @@ import (
 	// config validation constructors
 	network "knative.dev/networking/pkg"
 	tracingconfig "knative.dev/pkg/tracing/config"
+	"knative.dev/serving/pkg/apis/config"
 	defaultconfig "knative.dev/serving/pkg/apis/config"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
@@ -142,6 +143,7 @@ func newConfigValidationController(ctx context.Context, cmw configmap.Watcher) *
 			gc.ConfigName:                    gc.NewConfigFromConfigMapFunc(ctx),
 			network.ConfigName:               network.NewConfigFromConfigMap,
 			deployment.ConfigName:            deployment.NewConfigFromConfigMap,
+			config.FeaturesConfigName:        config.NewFeaturesConfigFromConfigMap,
 			metrics.ConfigMapName():          metrics.NewObservabilityConfigFromConfigMap,
 			logging.ConfigMapName():          logging.NewConfigFromConfigMap,
 			leaderelection.ConfigMapName():   leaderelection.NewConfigFromConfigMap,

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -43,8 +43,7 @@ import (
 	// config validation constructors
 	network "knative.dev/networking/pkg"
 	tracingconfig "knative.dev/pkg/tracing/config"
-	"knative.dev/serving/pkg/apis/config"
-	defaultconfig "knative.dev/serving/pkg/apis/config"
+	apisconfig "knative.dev/serving/pkg/apis/config"
 	autoscalerconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/gc"
@@ -78,7 +77,7 @@ var callbacks = map[schema.GroupVersionKind]validation.Callback{
 
 func newDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 	// Decorate contexts with the current state of the config.
-	store := defaultconfig.NewStore(logging.FromContext(ctx).Named("config-store"))
+	store := apisconfig.NewStore(logging.FromContext(ctx).Named("config-store"))
 	store.WatchConfigs(cmw)
 
 	return defaulting.NewAdmissionController(ctx,
@@ -102,7 +101,7 @@ func newDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher
 
 func newValidationAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 	// Decorate contexts with the current state of the config.
-	store := defaultconfig.NewStore(logging.FromContext(ctx).Named("config-store"))
+	store := apisconfig.NewStore(logging.FromContext(ctx).Named("config-store"))
 	store.WatchConfigs(cmw)
 
 	return validation.NewAdmissionController(ctx,
@@ -138,17 +137,17 @@ func newConfigValidationController(ctx context.Context, cmw configmap.Watcher) *
 
 		// The configmaps to validate.
 		configmap.Constructors{
-			tracingconfig.ConfigName:         tracingconfig.NewTracingConfigFromConfigMap,
-			autoscalerconfig.ConfigName:      autoscalerconfig.NewConfigFromConfigMap,
-			gc.ConfigName:                    gc.NewConfigFromConfigMapFunc(ctx),
-			network.ConfigName:               network.NewConfigFromConfigMap,
-			deployment.ConfigName:            deployment.NewConfigFromConfigMap,
-			config.FeaturesConfigName:        config.NewFeaturesConfigFromConfigMap,
-			metrics.ConfigMapName():          metrics.NewObservabilityConfigFromConfigMap,
-			logging.ConfigMapName():          logging.NewConfigFromConfigMap,
-			leaderelection.ConfigMapName():   leaderelection.NewConfigFromConfigMap,
-			domainconfig.DomainConfigName:    domainconfig.NewDomainFromConfigMap,
-			defaultconfig.DefaultsConfigName: defaultconfig.NewDefaultsConfigFromConfigMap,
+			tracingconfig.ConfigName:       tracingconfig.NewTracingConfigFromConfigMap,
+			autoscalerconfig.ConfigName:    autoscalerconfig.NewConfigFromConfigMap,
+			gc.ConfigName:                  gc.NewConfigFromConfigMapFunc(ctx),
+			network.ConfigName:             network.NewConfigFromConfigMap,
+			deployment.ConfigName:          deployment.NewConfigFromConfigMap,
+			apisconfig.FeaturesConfigName:  apisconfig.NewFeaturesConfigFromConfigMap,
+			metrics.ConfigMapName():        metrics.NewObservabilityConfigFromConfigMap,
+			logging.ConfigMapName():        logging.NewConfigFromConfigMap,
+			leaderelection.ConfigMapName(): leaderelection.NewConfigFromConfigMap,
+			domainconfig.DomainConfigName:  domainconfig.NewDomainFromConfigMap,
+			apisconfig.DefaultsConfigName:  apisconfig.NewDefaultsConfigFromConfigMap,
 		},
 	)
 }


### PR DESCRIPTION
Fixes #11390.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Validates, consistently with other configmaps, that the _example section of the features configmap is not accidentally modified.
```

/assign @markusthoemmes @dprotaso 