### PR TITLE
Adding securityContext.capabilities.drop to schemas

### DIFF
--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -412,6 +412,16 @@ spec:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: integer
                                     format: int64
+                                  capabilities:
+                                    description: 'Optional: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.'
+                                    type: object
+                                    properties:
+                                      drop:
+                                        description: 'Optional: Removed capabilities'
+                                        type: array
+                                        items:
+                                          description: POSIX capabilities type
+                                          type: string
                                 x-kubernetes-preserve-unknown-fields: true
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -391,6 +391,16 @@ spec:
                             description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: integer
                             format: int64
+                          capabilities:
+                            description: 'Optional: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.'
+                            type: object
+                            properties:
+                              drop:
+                                description: 'Optional: Removed capabilities'
+                                type: array
+                                items:
+                                  description: POSIX capabilities type
+                                  type: string
                         x-kubernetes-preserve-unknown-fields: true
                       terminationMessagePath:
                         description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -416,6 +416,16 @@ spec:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: integer
                                     format: int64
+                                  capabilities:
+                                    description: 'Optional: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.'
+                                    type: object
+                                    properties:
+                                      drop:
+                                        description: 'Optional: Removed capabilities'
+                                        type: array
+                                        items:
+                                          description: POSIX capabilities type
+                                          type: string
                                 x-kubernetes-preserve-unknown-fields: true
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'


### PR DESCRIPTION
Updating schemas for Service / Configuration / Reconciler to include `securityContext.capabilities.drop` (see @dprotaso 's [comment](https://github.com/knative/serving/pull/11344#issuecomment-845585329) on [PR #11344](https://github.com/knative/serving/pull/11344)