### PR TITLE
Add readiness test image

### DIFF
--- a/test/test_images/readiness/README.md
+++ b/test/test_images/readiness/README.md
@@ -1,0 +1,21 @@
+# Ready test image
+
+This directory contains the test image used to simulate an image that responds
+to various types of readiness probe.
+
+The image provides a /healthz endpoint which will reply with a 200 status code
+and the Hello World text only after the delay requested by the STARTUP_DELAY
+environment variable has elapsed.
+
+The image also contains an exec probe when run with "probe" as its only argument.
+
+## Trying out
+
+To run the image as a Service outside of the test suite:
+
+`ko apply -f service.yaml`
+
+## Building
+
+For details about building and adding new images, see the
+[section about test images](/test/README.md#test-images).

--- a/test/test_images/readiness/readiness.go
+++ b/test/test_images/readiness/readiness.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"knative.dev/serving/test"
+)
+
+func main() {
+	// Exec probe.
+	flag.Parse()
+	args := flag.Args()
+	if len(args) > 0 && args[0] == "probe" {
+		if _, err := http.Get(os.ExpandEnv("http://localhost:$PORT/")); err != nil {
+			log.Fatal("Failed to probe ", err)
+		}
+		return
+	}
+
+	// HTTP Probe.
+	healthy := true
+	var mu sync.Mutex
+	if env := os.Getenv("STARTUP_DELAY"); env != "" {
+		delay, err := time.ParseDuration(env)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		healthy = false
+		go func() {
+			<-time.After(delay)
+			mu.Lock()
+			healthy = true
+			mu.Unlock()
+		}()
+	}
+
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if !healthy {
+			http.Error(w, "not healthy", http.StatusInternalServerError)
+			return
+		}
+
+		fmt.Fprint(w, test.HelloWorldText)
+	})
+
+	http.ListenAndServe(":8080", nil)
+}

--- a/test/test_images/readiness/service.yaml
+++ b/test/test_images/readiness/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: readiness-test-image
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - image: ko://knative.dev/serving/test/test_images/readiness


### PR DESCRIPTION
Adds test image which sleeps for a configurable period of time before responding 200 on the /healthz endpoint. This will allow the readiness tests (in a follow-up, just to split the PR up a bit) to actually assert that the image doesn't go ready too early (the current tests [don't try curling the created service](https://github.com/knative/serving/blob/main/test/conformance/runtime/readiness_probe_test.go#L85-L93), so they don't really check that readiness is only reported once the probe passes).

/assign @dprotaso @markusthoemmes 