### PR TITLE
Set spec.HTTPOption in Ingress created from DomainMapping

### DIFF
--- a/pkg/reconciler/domainmapping/resources/ingress.go
+++ b/pkg/reconciler/domainmapping/resources/ingress.go
@@ -35,7 +35,7 @@ import (
 // backend is always in the same namespace also (as this is required by
 // KIngress).  The created ingress will contain a RewriteHost rule to cause the
 // given hostName to be used as the host.
-func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, hostName, ingressClass string, tls []netv1alpha1.IngressTLS, acmeChallenges ...netv1alpha1.HTTP01Challenge) *netv1alpha1.Ingress {
+func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, hostName, ingressClass string, httpOption netv1alpha1.HTTPOption, tls []netv1alpha1.IngressTLS, acmeChallenges ...netv1alpha1.HTTP01Challenge) *netv1alpha1.Ingress {
 	return &netv1alpha1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kmeta.ChildName(dm.GetName(), ""),
@@ -52,7 +52,8 @@ func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, hostName
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(dm)},
 		},
 		Spec: netv1alpha1.IngressSpec{
-			TLS: tls,
+			HTTPOption: httpOption,
+			TLS:        tls,
 			Rules: []netv1alpha1.IngressRule{{
 				Hosts:      []string{dm.Name},
 				Visibility: netv1alpha1.IngressVisibilityExternalIP,

--- a/pkg/reconciler/domainmapping/resources/ingress_test.go
+++ b/pkg/reconciler/domainmapping/resources/ingress_test.go
@@ -69,6 +69,7 @@ func TestMakeIngress(t *testing.T) {
 				},
 			},
 			Spec: netv1alpha1.IngressSpec{
+				HTTPOption: netv1alpha1.HTTPOptionEnabled,
 				Rules: []netv1alpha1.IngressRule{{
 					Hosts:      []string{"mapping.com"},
 					Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -124,6 +125,7 @@ func TestMakeIngress(t *testing.T) {
 				},
 			},
 			Spec: netv1alpha1.IngressSpec{
+				HTTPOption: netv1alpha1.HTTPOptionEnabled,
 				Rules: []netv1alpha1.IngressRule{{
 					Hosts:      []string{"mapping.com"},
 					Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -189,6 +191,7 @@ func TestMakeIngress(t *testing.T) {
 				},
 			},
 			Spec: netv1alpha1.IngressSpec{
+				HTTPOption: netv1alpha1.HTTPOptionEnabled,
 				Rules: []netv1alpha1.IngressRule{{
 					Hosts:      []string{"mapping.com"},
 					Visibility: netv1alpha1.IngressVisibilityExternalIP,
@@ -230,6 +233,7 @@ func TestMakeIngress(t *testing.T) {
 			tc.want.OwnerReferences = []metav1.OwnerReference{*kmeta.NewControllerRef(&tc.dm)}
 			got := *MakeIngress(&tc.dm,
 				"the-target-svc", "the-rewrite-host", "the-ingress-class",
+				netv1alpha1.HTTPOptionEnabled,
 				tc.tls, tc.acmeChallenges...)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("Unexpected Ingress (-want, +got):\n%s", diff)

--- a/pkg/reconciler/domainmapping/table_test.go
+++ b/pkg/reconciler/domainmapping/table_test.go
@@ -898,7 +898,7 @@ func TestReconcileTLSEnabled(t *testing.T) {
 				},
 				Status: readyCertStatus(),
 			},
-			ingress(domainMapping("default", "becomes.ready.run", withRef("default", "ready")), "the-ingress-class", withIngressReady),
+			ingress(domainMapping("default", "becomes.ready.run", withRef("default", "ready")), "the-ingress-class", withIngressReady, withIngressHTTPOption(netv1alpha1.HTTPOptionRedirected)),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: domainMapping("default", "becomes.ready.run",
@@ -913,11 +913,13 @@ func TestReconcileTLSEnabled(t *testing.T) {
 			),
 		}},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: ingress(domainMapping("default", "becomes.ready.run", withRef("default", "ready")), "the-ingress-class", withIngressReady, withIngressTLS(netv1alpha1.IngressTLS{
-				Hosts:           []string{"becomes.ready.run"},
-				SecretName:      "becomes.ready.run",
-				SecretNamespace: "default",
-			})),
+			Object: ingress(domainMapping("default", "becomes.ready.run", withRef("default", "ready")), "the-ingress-class", withIngressReady,
+				withIngressHTTPOption(netv1alpha1.HTTPOptionRedirected),
+				withIngressTLS(netv1alpha1.IngressTLS{
+					Hosts:           []string{"becomes.ready.run"},
+					SecretName:      "becomes.ready.run",
+					SecretNamespace: "default",
+				})),
 		}},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizerAction("default", "becomes.ready.run"),
@@ -1016,7 +1018,7 @@ func TestReconcileTLSEnabled(t *testing.T) {
 				withAddress("http", "challenged.com"),
 			),
 			resources.MakeDomainClaim(domainMapping("default", "challenged.com", withRef("default", "ready"))),
-			ingress(domainMapping("default", "challenged.com", withRef("default", "ready")), "the-ingress-class", withIngressReady),
+			ingress(domainMapping("default", "challenged.com", withRef("default", "ready")), "the-ingress-class", withIngressReady, withIngressHTTPOption(netv1alpha1.HTTPOptionRedirected)),
 			&netv1alpha1.Certificate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "challenged.com",
@@ -1098,7 +1100,7 @@ func TestReconcileTLSEnabled(t *testing.T) {
 					ServiceName:      "cm-solver",
 					ServicePort:      intstr.FromInt(8090),
 					ServiceNamespace: "default",
-				}}, withIngressReady),
+				}}, withIngressReady, withIngressHTTPOption(netv1alpha1.HTTPOptionRedirected)),
 		}},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizerAction("default", "challenged.com"),

--- a/pkg/reconciler/domainmapping/table_test.go
+++ b/pkg/reconciler/domainmapping/table_test.go
@@ -88,7 +88,7 @@ func TestReconcile(t *testing.T) {
 		SkipNamespaceValidation: true, // allow creation of ClusterDomainClaim.
 		WantCreates: []runtime.Object{
 			resources.MakeDomainClaim(domainMapping("default", "first-reconcile.com", withRef("default", "target"))),
-			resources.MakeIngress(domainMapping("default", "first-reconcile.com", withRef("default", "target")), "the-target-svc", "the-target-svc.default.svc.cluster.local", "the-ingress-class", nil /* tls */),
+			resources.MakeIngress(domainMapping("default", "first-reconcile.com", withRef("default", "target")), "the-target-svc", "the-target-svc.default.svc.cluster.local", "the-ingress-class", netv1alpha1.HTTPOptionEnabled, nil /* tls */),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizerAction("default", "first-reconcile.com"),
@@ -188,7 +188,7 @@ func TestReconcile(t *testing.T) {
 			resources.MakeDomainClaim(domainMapping("default", "first-reconcile.com", withRef("default", "target", withAPIVersionKind("v1", "Service")))),
 			resources.MakeIngress(
 				domainMapping("default", "first-reconcile.com", withRef("default", "target", withAPIVersionKind("v1", "Service"))),
-				"target", "target.default.svc.cluster.local", "the-ingress-class", nil /* tls */),
+				"target", "target.default.svc.cluster.local", "the-ingress-class", netv1alpha1.HTTPOptionEnabled, nil /* tls */),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizerAction("default", "first-reconcile.com"),
@@ -337,7 +337,7 @@ func TestReconcile(t *testing.T) {
 			),
 		}},
 		WantCreates: []runtime.Object{
-			resources.MakeIngress(domainMapping("default", "first-reconcile.com", withRef("default", "target")), "the-target-svc", "the-target-svc.default.svc.cluster.local", "the-ingress-class", nil /* tls */),
+			resources.MakeIngress(domainMapping("default", "first-reconcile.com", withRef("default", "target")), "the-target-svc", "the-target-svc.default.svc.cluster.local", "the-ingress-class", netv1alpha1.HTTPOptionEnabled, nil /* tls */),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizerAction("default", "first-reconcile.com"),
@@ -436,7 +436,7 @@ func TestReconcile(t *testing.T) {
 		WantCreates: []runtime.Object{
 			resources.MakeDomainClaim(domainMapping("default", "ingressclass.first-reconcile.com", withRef("default", "target"))),
 			resources.MakeIngress(domainMapping("default", "ingressclass.first-reconcile.com", withRef("default", "target")),
-				"the-target-svc", "the-target-svc.default.svc.cluster.local", "overridden-ingress-class", nil /* tls */),
+				"the-target-svc", "the-target-svc.default.svc.cluster.local", "overridden-ingress-class", netv1alpha1.HTTPOptionEnabled, nil /* tls */),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizerAction("default", "ingressclass.first-reconcile.com"),
@@ -451,7 +451,7 @@ func TestReconcile(t *testing.T) {
 		Objects: []runtime.Object{
 			ksvc("default", "changed", "changed.default.svc.cluster.local", ""),
 			domainMapping("default", "ingress-exists.org", withRef("default", "changed")),
-			resources.MakeIngress(domainMapping("default", "ingress-exists.org", withRef("default", "changed")), "previous", "previous.default.svc.cluster.local", "the-ingress-class", nil /* tls */),
+			resources.MakeIngress(domainMapping("default", "ingress-exists.org", withRef("default", "changed")), "previous", "previous.default.svc.cluster.local", "the-ingress-class", netv1alpha1.HTTPOptionEnabled, nil /* tls */),
 			resources.MakeDomainClaim(domainMapping("default", "ingress-exists.org", withRef("default", "changed"))),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -687,6 +687,7 @@ func TestReconcile(t *testing.T) {
 					Network: &network.Config{
 						DefaultIngressClass:           "the-ingress-class",
 						AutocreateClusterDomainClaims: true,
+						HTTPProtocol:                  network.HTTPEnabled,
 					},
 				},
 			}},
@@ -745,7 +746,7 @@ func TestReconcileAutocreateClaimsDisabled(t *testing.T) {
 		}},
 		SkipNamespaceValidation: true, // allow creation of ClusterDomainClaim.
 		WantCreates: []runtime.Object{
-			resources.MakeIngress(domainMapping("default", "first-reconcile.com", withRef("default", "target")), "the-target-svc", "the-target-svc.default.svc.cluster.local", "the-ingress-class", nil /* tls */),
+			resources.MakeIngress(domainMapping("default", "first-reconcile.com", withRef("default", "target")), "the-target-svc", "the-target-svc.default.svc.cluster.local", "the-ingress-class", netv1alpha1.HTTPOptionEnabled, nil /* tls */),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchAddFinalizerAction("default", "first-reconcile.com"),
@@ -815,6 +816,7 @@ func TestReconcileAutocreateClaimsDisabled(t *testing.T) {
 					Network: &network.Config{
 						DefaultIngressClass:           "the-ingress-class",
 						AutocreateClusterDomainClaims: false,
+						HTTPProtocol:                  network.HTTPEnabled,
 					},
 				},
 			}},
@@ -841,7 +843,7 @@ func TestReconcileTLSEnabled(t *testing.T) {
 				withURL("http", "first.reconcile.io"),
 				withAddress("http", "first.reconcile.io"),
 			), "the-cert-class"),
-			ingress(domainMapping("default", "first.reconcile.io", withRef("default", "ready")), "the-ingress-class"),
+			ingress(domainMapping("default", "first.reconcile.io", withRef("default", "ready")), "the-ingress-class", withIngressHTTPOption(netv1alpha1.HTTPOptionRedirected)),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: domainMapping("default", "first.reconcile.io",
@@ -1124,6 +1126,7 @@ func TestReconcileTLSEnabled(t *testing.T) {
 						DefaultIngressClass:     "the-ingress-class",
 						DefaultCertificateClass: "the-cert-class",
 						AutoTLS:                 true,
+						HTTPProtocol:            network.HTTPRedirected,
 					},
 				},
 			}},
@@ -1342,7 +1345,7 @@ func ingress(dm *v1alpha1.DomainMapping, ingressClass string, opt ...IngressOpti
 }
 
 func ingressWithChallenges(dm *v1alpha1.DomainMapping, ingressClass string, challenges []netv1alpha1.HTTP01Challenge, opt ...IngressOption) *netv1alpha1.Ingress {
-	ing := resources.MakeIngress(dm, dm.Spec.Ref.Name, dm.Spec.Ref.Name+"."+dm.Spec.Ref.Namespace+".svc.cluster.local", ingressClass, nil /* tls */, challenges...)
+	ing := resources.MakeIngress(dm, dm.Spec.Ref.Name, dm.Spec.Ref.Name+"."+dm.Spec.Ref.Namespace+".svc.cluster.local", ingressClass, netv1alpha1.HTTPOptionEnabled, nil /* tls */, challenges...)
 	for _, o := range opt {
 		o(ing)
 	}
@@ -1364,6 +1367,12 @@ func withIngressReady(ing *netv1alpha1.Ingress) {
 	)
 
 	ing.Status = status
+}
+
+func withIngressHTTPOption(httpOpt netv1alpha1.HTTPOption) IngressOption {
+	return func(ing *netv1alpha1.Ingress) {
+		ing.Spec.HTTPOption = httpOpt
+	}
 }
 
 func ksvc(ns, name, host, path string) *servingv1.Service {


### PR DESCRIPTION
This is a follow up with https://github.com/knative/serving/pull/10412.
Ingress has HTTPOption field now and DomainMapping's Ingress should
set it.

Note, the field does not effect until net-* controller implements
the feature like https://github.com/knative/networking/issues/302.