### PR TITLE
Test that readiness is not reported early in HTTP probe test

### DIFF
--- a/test/conformance.go
+++ b/test/conformance.go
@@ -43,6 +43,7 @@ const (
 	PizzaPlanet1        = "pizzaplanetv1"
 	PizzaPlanet2        = "pizzaplanetv2"
 	Protocols           = "protocols"
+	Readiness           = "readiness"
 	Runtime             = "runtime"
 	SingleThreadedImage = "singlethreaded"
 	Timeout             = "timeout"

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -19,10 +19,13 @@ limitations under the License.
 package runtime
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	pkgtest "knative.dev/pkg/test"
 	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
 	v1opts "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
@@ -38,26 +41,30 @@ func TestProbeRuntime(t *testing.T) {
 		// name of the test case, which will be inserted in names of routes, configurations, etc.
 		// Use a short name here to avoid hitting the 63-character limit in names
 		// (e.g., "service-to-service-call-svc-cluster-local-uagkdshh-frkml-service" is too long.)
-		name string
-		// handler to be used for readiness probe in user container.
+		name    string
 		handler corev1.Handler
+		env     []corev1.EnvVar
 	}{{
-		"httpGet",
-		corev1.Handler{
+		name: "httpGet",
+		env: []corev1.EnvVar{{
+			Name:  "STARTUP_DELAY",
+			Value: "10s",
+		}},
+		handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path: "/healthz",
 			},
 		},
 	}, {
-		"tcpSocket",
-		corev1.Handler{
+		name: "tcpSocket",
+		handler: corev1.Handler{
 			TCPSocket: &corev1.TCPSocketAction{},
 		},
 	}, {
-		"exec",
-		corev1.Handler{
+		name: "exec",
+		handler: corev1.Handler{
 			Exec: &corev1.ExecAction{
-				Command: []string{"/ko-app/runtime", "probe"},
+				Command: []string{"/ko-app/readiness", "probe"},
 			},
 		},
 	}}
@@ -76,13 +83,14 @@ func TestProbeRuntime(t *testing.T) {
 				t.Parallel()
 				names := test.ResourceNames{
 					Service: test.ObjectNameForTest(t),
-					Image:   test.Runtime,
+					Image:   test.Readiness,
 				}
 
 				test.EnsureTearDown(t, clients, &names)
 
 				t.Log("Creating a new Service")
 				resources, err := v1test.CreateServiceReady(t, clients, &names,
+					v1opts.WithEnv(tc.env...),
 					v1opts.WithReadinessProbe(
 						&corev1.Probe{
 							Handler:       tc.handler,
@@ -91,6 +99,30 @@ func TestProbeRuntime(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 				}
+
+				// Once the service reports ready we should immediately be able to curl it.
+				client, err := pkgtest.NewSpoofingClient(context.Background(), clients.KubeClient, t.Logf, resources.Route.Status.URL.URL().Host,
+					test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
+				if err != nil {
+					t.Fatal("Create spoofing client:", err)
+				}
+
+				url := resources.Route.Status.URL.URL()
+				url.Path = "/healthz"
+				req, err := http.NewRequest(http.MethodGet, url.String(), nil)
+				if err != nil {
+					t.Fatal("NewRequest:", err)
+				}
+
+				resp, err := client.Do(req)
+				if err != nil {
+					t.Fatal("GET ready service:", err)
+				}
+
+				if want, got := test.HelloWorldText, string(resp.Body); want != got {
+					t.Fatalf("Expected body to be %q but was %q:", want, got)
+				}
+
 				// Check if scaling down works even if access from liveness probe exists.
 				if err := shared.WaitForScaleToZero(t, revisionresourcenames.Deployment(resources.Revision), clients); err != nil {
 					t.Fatal("Could not scale to zero:", err)

--- a/test/test_images/runtime/main.go
+++ b/test/test_images/runtime/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"log"
 	"net/http"
 	"os"
@@ -32,17 +31,6 @@ func main() {
 	port, isSet := os.LookupEnv("PORT")
 	if !isSet {
 		log.Fatal("Environment variable PORT is not set.")
-	}
-
-	// This is an option for exec readiness probe test.
-	flag.Parse()
-	args := flag.Args()
-	if len(args) > 0 && args[0] == "probe" {
-		url := "http://localhost:" + port
-		if _, err := http.Get(url); err != nil {
-			log.Fatal("Failed to probe ", err)
-		}
-		return
 	}
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
The previous test passed even if the probe config was ignored, since it didn't actually try curling the service to check readiness wasn't achieved early.

/assign @markusthoemmes @dprotaso 