### PR TITLE
Allow the autoscale upgrade test traffic to settle before upgrading

### DIFF
--- a/test/upgrade/autoscaler.go
+++ b/test/upgrade/autoscaler.go
@@ -31,6 +31,7 @@ const (
 	targetUtilization    = 0.7
 	curPods              = 1
 	targetPods           = 10
+	trafficSettleTime    = 10 * time.Second
 )
 
 // AutoscaleSustainingTest checks that when traffic increases a knative app
@@ -49,6 +50,9 @@ func AutoscaleSustainingTest() pkgupgrade.BackgroundOperation {
 				}))
 			ctx.SetLogger(c.Log.Infof)
 			wait = e2e.AutoscaleUpToNumPods(ctx, curPods, targetPods, stopCh, false /* quick */)
+
+			// Allow the traffic and scale to settle before starting the upgrade.
+			time.Sleep(trafficSettleTime)
 		},
 		func(c pkgupgrade.Context) {
 			test.EnsureTearDown(c.T, ctx.Clients(), ctx.Names())
@@ -77,6 +81,9 @@ func AutoscaleSustainingWithTBCTest() pkgupgrade.BackgroundOperation {
 				}))
 			ctx.SetLogger(c.Log.Infof)
 			wait = e2e.AutoscaleUpToNumPods(ctx, curPods, targetPods, stopCh, false /* quick */)
+
+			// Allow the traffic and scale to settle before starting the upgrade.
+			time.Sleep(trafficSettleTime)
 		},
 		func(c pkgupgrade.Context) {
 			test.EnsureTearDown(c.T, ctx.Clients(), ctx.Names())


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Currently, after the initial setup is done, the Knative Serving rollout is started almost immediately after the sample traffic is started. That creates a worst case scenario where the autoscaler (and the underlying deployment) is almost immediately rolled, which adds a lot of (unintentional) moving parts to this test. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @vagababov 
