### PR TITLE
Add feature gate to allow adding capabilities to securityContext

### DIFF
--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -415,6 +415,7 @@ spec:
                                         items:
                                           description: Capability represent POSIX capabilities type
                                           type: string
+                                    x-kubernetes-preserve-unknown-fields: true
                                   readOnlyRootFilesystem:
                                     description: Whether this container has a read-only root filesystem. Default is false.
                                     type: boolean
@@ -662,7 +663,7 @@ spec:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array
                   items:
-                    description: 'Conditions defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                     type: object
                     required:
                       - status

--- a/config/core/300-resources/metric.yaml
+++ b/config/core/300-resources/metric.yaml
@@ -89,7 +89,7 @@ spec:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array
                   items:
-                    description: 'Conditions defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                     type: object
                     required:
                       - status

--- a/config/core/300-resources/podautoscaler.yaml
+++ b/config/core/300-resources/podautoscaler.yaml
@@ -116,7 +116,7 @@ spec:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array
                   items:
-                    description: 'Conditions defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                     type: object
                     required:
                       - status

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -394,6 +394,7 @@ spec:
                                 items:
                                   description: Capability represent POSIX capabilities type
                                   type: string
+                            x-kubernetes-preserve-unknown-fields: true
                           readOnlyRootFilesystem:
                             description: Whether this container has a read-only root filesystem. Default is false.
                             type: boolean
@@ -645,7 +646,7 @@ spec:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array
                   items:
-                    description: 'Conditions defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                     type: object
                     required:
                       - status

--- a/config/core/300-resources/route.yaml
+++ b/config/core/300-resources/route.yaml
@@ -113,7 +113,7 @@ spec:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array
                   items:
-                    description: 'Conditions defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                     type: object
                     required:
                       - status

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -419,6 +419,7 @@ spec:
                                         items:
                                           description: Capability represent POSIX capabilities type
                                           type: string
+                                    x-kubernetes-preserve-unknown-fields: true
                                   readOnlyRootFilesystem:
                                     description: Whether this container has a read-only root filesystem. Default is false.
                                     type: boolean
@@ -698,7 +699,7 @@ spec:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array
                   items:
-                    description: 'Conditions defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
                     type: object
                     required:
                       - status

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "1bbf8144"
+    knative.dev/example-checksum: "8c1f8302"
 data:
   _example: |-
     ################################
@@ -104,6 +104,12 @@ data:
     # WARNING: Cannot safely be disabled once enabled.
     # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-security-context
     kubernetes.podspec-securitycontext: "disabled"
+
+    # This feature flag allows end-users to add a subset of capabilities on the Pod's SecurityContext.
+    #
+    # When set to "enabled" or "allowed" it allows capabilities to be added to the container.
+    # For a list of possible capabilities, see https://man7.org/linux/man-pages/man7/capabilities.7.html
+    kubernetes.containerspec-addcapabilities: "disabled"
 
     # This feature validates PodSpecs from the validating webhook
     # against the K8s API Server.

--- a/hack/schemapatch-config.yaml
+++ b/hack/schemapatch-config.yaml
@@ -164,6 +164,7 @@ k8s.io/api/core/v1.SecurityContext:
 k8s.io/api/core/v1.Capabilities:
   allowedFields:
     - Drop
+  preserveUnknownFields: true # for feature flagged fields
 k8s.io/api/core/v1.ObjectReference:
   allowedFields:
     - APIVersion

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -41,17 +41,18 @@ const (
 
 func defaultFeaturesConfig() *Features {
 	return &Features{
-		MultiContainer:          Enabled,
-		PodSpecAffinity:         Disabled,
-		PodSpecDryRun:           Allowed,
-		PodSpecHostAliases:      Disabled,
-		PodSpecFieldRef:         Disabled,
-		PodSpecNodeSelector:     Disabled,
-		PodSpecRuntimeClassName: Disabled,
-		PodSpecSecurityContext:  Disabled,
-		PodSpecTolerations:      Disabled,
-		TagHeaderBasedRouting:   Disabled,
-		AutoDetectHTTP2:         Disabled,
+		MultiContainer:               Enabled,
+		PodSpecAffinity:              Disabled,
+		PodSpecDryRun:                Allowed,
+		PodSpecHostAliases:           Disabled,
+		PodSpecFieldRef:              Disabled,
+		PodSpecNodeSelector:          Disabled,
+		PodSpecRuntimeClassName:      Disabled,
+		PodSpecSecurityContext:       Disabled,
+		ContainerSpecAddCapabilities: Disabled,
+		PodSpecTolerations:           Disabled,
+		TagHeaderBasedRouting:        Disabled,
+		AutoDetectHTTP2:              Disabled,
 	}
 }
 
@@ -68,6 +69,7 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 		asFlag("kubernetes.podspec-nodeselector", &nc.PodSpecNodeSelector),
 		asFlag("kubernetes.podspec-runtimeclassname", &nc.PodSpecRuntimeClassName),
 		asFlag("kubernetes.podspec-securitycontext", &nc.PodSpecSecurityContext),
+		asFlag("kubernetes.containerspec-addcapabilities", &nc.ContainerSpecAddCapabilities),
 		asFlag("kubernetes.podspec-tolerations", &nc.PodSpecTolerations),
 		asFlag("tag-header-based-routing", &nc.TagHeaderBasedRouting),
 		asFlag("autodetect-http2", &nc.AutoDetectHTTP2)); err != nil {
@@ -83,17 +85,18 @@ func NewFeaturesConfigFromConfigMap(config *corev1.ConfigMap) (*Features, error)
 
 // Features specifies which features are allowed by the webhook.
 type Features struct {
-	MultiContainer          Flag
-	PodSpecAffinity         Flag
-	PodSpecDryRun           Flag
-	PodSpecFieldRef         Flag
-	PodSpecHostAliases      Flag
-	PodSpecNodeSelector     Flag
-	PodSpecRuntimeClassName Flag
-	PodSpecSecurityContext  Flag
-	PodSpecTolerations      Flag
-	TagHeaderBasedRouting   Flag
-	AutoDetectHTTP2         Flag
+	MultiContainer               Flag
+	PodSpecAffinity              Flag
+	PodSpecDryRun                Flag
+	PodSpecFieldRef              Flag
+	PodSpecHostAliases           Flag
+	PodSpecNodeSelector          Flag
+	PodSpecRuntimeClassName      Flag
+	PodSpecSecurityContext       Flag
+	ContainerSpecAddCapabilities Flag
+	PodSpecTolerations           Flag
+	TagHeaderBasedRouting        Flag
+	AutoDetectHTTP2              Flag
 }
 
 // asFlag parses the value at key as a Flag into the target, if it exists.

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -616,7 +616,7 @@ func SecurityContextMask(ctx context.Context, in *corev1.SecurityContext) *corev
 // CapabilitiesMask performs a _shallow_ copy of the Kubernetes Capabilities object to a new
 // Kubernetes Capabilities object bringing over only the fields allowed in the Knative API. This
 // does not validate the contents or the bounds of the provided fields.
-func CapabilitiesMask(in *corev1.Capabilities) *corev1.Capabilities {
+func CapabilitiesMask(ctx context.Context, in *corev1.Capabilities) *corev1.Capabilities {
 	if in == nil {
 		return nil
 	}
@@ -626,9 +626,9 @@ func CapabilitiesMask(in *corev1.Capabilities) *corev1.Capabilities {
 	// Allowed fields
 	out.Drop = in.Drop
 
-	// Disallowed
-	// This list is unnecessary, but added here for clarity
-	out.Add = nil
+	if config.FromContextOrDefaults(ctx).Features.ContainerSpecAddCapabilities != config.Disabled {
+		out.Add = in.Add
+	}
 
 	return out
 }

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -447,11 +447,11 @@ func validateResources(resources *corev1.ResourceRequirements) *apis.FieldError 
 	return apis.CheckDisallowedFields(*resources, *ResourceRequirementsMask(resources))
 }
 
-func validateCapabilities(cap *corev1.Capabilities) *apis.FieldError {
+func validateCapabilities(ctx context.Context, cap *corev1.Capabilities) *apis.FieldError {
 	if cap == nil {
 		return nil
 	}
-	return apis.CheckDisallowedFields(*cap, *CapabilitiesMask(cap))
+	return apis.CheckDisallowedFields(*cap, *CapabilitiesMask(ctx, cap))
 }
 
 func validateSecurityContext(ctx context.Context, sc *corev1.SecurityContext) *apis.FieldError {
@@ -460,7 +460,7 @@ func validateSecurityContext(ctx context.Context, sc *corev1.SecurityContext) *a
 	}
 	errs := apis.CheckDisallowedFields(*sc, *SecurityContextMask(ctx, sc))
 
-	errs = errs.Also(validateCapabilities(sc.Capabilities).ViaField("capabilities"))
+	errs = errs.Also(validateCapabilities(ctx, sc.Capabilities).ViaField("capabilities"))
 
 	if sc.RunAsUser != nil {
 		uid := *sc.RunAsUser

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -90,6 +90,13 @@ func withPodSpecSecurityContextEnabled() configOption {
 	}
 }
 
+func withContainerSpecAddCapabilitiesEnabled() configOption {
+	return func(cfg *config.Config) *config.Config {
+		cfg.Features.ContainerSpecAddCapabilities = config.Enabled
+		return cfg
+	}
+}
+
 func TestPodSpecValidation(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1296,6 +1303,18 @@ func TestContainerValidation(t *testing.T) {
 			},
 		},
 		want: apis.ErrDisallowedFields("securityContext.capabilities.add"),
+	}, {
+		name: "allowed to add a security context capability when gate is enabled",
+		c: corev1.Container{
+			Image: "foo",
+			SecurityContext: &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{"all"},
+				},
+			},
+		},
+		cfgOpts: []configOption{withContainerSpecAddCapabilitiesEnabled()},
+		want:    nil,
 	}, {
 		name: "too large uid",
 		c: corev1.Container{


### PR DESCRIPTION
Fixes #10812 (part 2)

For part 1, see #11344 

This fix allows adding security context capabilities from a container via `containers[].securityContext.capabilities.add`. It must be explicitly enabled via the `kubernetes.podspec-addcapabilities` key.

Will raise a corresponding PR to update docs/feature-flags.md in the Docs repo.

```release-note
Provides a feature gate that, when enabled, allows adding capabilities from a container's security context
```
