### PR TITLE
Bump kind and k8s version in kind-e2e.yaml 

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -33,18 +33,18 @@ jobs:
           # This is attempting to make it a bit clearer what's being tested.
           # See: https://github.com/kubernetes-sigs/kind/releases
         - k8s-version: v1.19.11
-          kind-version: v0.11.0
-          kind-image-sha: sha256:7664f21f9cb6ba2264437de0eb3fe99f201db7a3ac72329547ec4373ba5f5911
+          kind-version: v0.11.1
+          kind-image-sha: sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
           kingress: istio
           cluster-suffix: c${{ github.run_id }}.local
         - k8s-version: v1.20.7
-          kind-version: v0.11.0
-          kind-image-sha: sha256:e645428988191fc824529fd0bb5c94244c12401cf5f5ea3bd875eb0a787f0fe9
+          kind-version: v0.11.1
+          kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
           kingress: contour
           cluster-suffix: c${{ github.run_id }}.local
         - k8s-version: v1.21.1
-          kind-version: v0.11.0
-          kind-image-sha: sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
+          kind-version: v0.11.1
+          kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
           kingress: kourier
           cluster-suffix: c${{ github.run_id }}.local
 

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.18.15
-        - v1.19.7
-        - v1.20.2
+        - v1.19.11
+        - v1.20.7
+        - v1.21.1
 
         test-suite:
         - ./test/conformance/runtime
@@ -31,21 +31,21 @@ jobs:
         include:
           # Map between K8s and KinD versions.
           # This is attempting to make it a bit clearer what's being tested.
-          # See: https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0
-        - k8s-version: v1.18.15
-          kind-version: v0.10.0
-          kind-image-sha: sha256:5c1b980c4d0e0e8e7eb9f36f7df525d079a96169c8a8f20d8bd108c0d0889cc4
-          kingress: kourier
-          cluster-suffix: c${{ github.run_id }}.local
-        - k8s-version: v1.19.7
-          kind-version: v0.10.0
-          kind-image-sha: sha256:a70639454e97a4b733f9d9b67e12c01f6b0297449d5b9cbbef87473458e26dca
+          # See: https://github.com/kubernetes-sigs/kind/releases
+        - k8s-version: v1.19.11
+          kind-version: v0.11.0
+          kind-image-sha: sha256:7664f21f9cb6ba2264437de0eb3fe99f201db7a3ac72329547ec4373ba5f5911
           kingress: istio
           cluster-suffix: c${{ github.run_id }}.local
-        - k8s-version: v1.20.2
-          kind-version: v0.10.0
-          kind-image-sha: sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab
+        - k8s-version: v1.20.7
+          kind-version: v0.11.0
+          kind-image-sha: sha256:e645428988191fc824529fd0bb5c94244c12401cf5f5ea3bd875eb0a787f0fe9
           kingress: contour
+          cluster-suffix: c${{ github.run_id }}.local
+        - k8s-version: v1.21.1
+          kind-version: v0.11.0
+          kind-image-sha: sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
+          kingress: kourier
           cluster-suffix: c${{ github.run_id }}.local
 
           # The tests in api/v1alpha1 require the --enable-alpha flag to be set,


### PR DESCRIPTION
Fix https://github.com/knative/serving/issues/11413

**Release Note**

```release-note
NONE
```
