### PR TITLE
Use cert-manager API version to v1 for test resources

### DIFF
--- a/test/config/autotls/certmanager/caissuer/issuer.yaml
+++ b/test/config/autotls/certmanager/caissuer/issuer.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: ca-issuer

--- a/test/config/autotls/certmanager/http01/issuer.yaml
+++ b/test/config/autotls/certmanager/http01/issuer.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: http01-issuer

--- a/test/config/autotls/certmanager/http01/mesh-issuer.yaml
+++ b/test/config/autotls/certmanager/http01/mesh-issuer.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: http01-issuer

--- a/test/config/autotls/certmanager/selfsigned/issuer.yaml
+++ b/test/config/autotls/certmanager/selfsigned/issuer.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: self-signed-issuer


### PR DESCRIPTION
This patch updates cert resource in test/config directory to v1.
Doc already updated it by https://github.com/knative/docs/pull/3670.

**Release Note**

```release-note
NONE
```
