### PR TITLE
Improve readiness tests for exec case

### DIFF
--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -62,6 +62,10 @@ func TestProbeRuntime(t *testing.T) {
 		},
 	}, {
 		name: "exec",
+		env: []corev1.EnvVar{{
+			Name:  "STARTUP_DELAY",
+			Value: "10s",
+		}},
 		handler: corev1.Handler{
 			Exec: &corev1.ExecAction{
 				Command: []string{"/ko-app/readiness", "probe"},

--- a/test/test_images/readiness/readiness.go
+++ b/test/test_images/readiness/readiness.go
@@ -33,10 +33,14 @@ func main() {
 	flag.Parse()
 	args := flag.Args()
 	if len(args) > 0 && args[0] == "probe" {
-		if _, err := http.Get(os.ExpandEnv("http://localhost:$PORT/")); err != nil {
+		resp, err := http.Get(os.ExpandEnv("http://localhost:$PORT/healthz"))
+		if err != nil {
 			log.Fatal("Failed to probe ", err)
 		}
-		return
+		if resp.StatusCode > 299 {
+			os.Exit(1)
+		}
+		os.Exit(0)
 	}
 
 	// HTTP Probe.


### PR DESCRIPTION
Adds a startup delay to the exec branch of the readiness probe tests to validate that the probe is actually being used to delay reporting readiness.

/assign @markusthoemmes @dprotaso 
