### PR TITLE
[POC] Override the scheme using httpProtocol regardless of AutoTLS

### DIFF
--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -361,9 +361,13 @@ func (c *Reconciler) updateRouteStatusURL(ctx context.Context, route *v1.Route, 
 	if err != nil {
 		return err
 	}
+	scheme := "http"
+	if useHTTPS(config.FromContext(ctx).Network.HTTPProtocol) {
+		scheme = "https"
+	}
 
 	route.Status.URL = &apis.URL{
-		Scheme: "http",
+		Scheme: scheme,
 		Host:   host,
 	}
 
@@ -474,4 +478,13 @@ func wildcardCertMatches(ctx context.Context, domains []string, cert *netv1alpha
 	}
 
 	return true
+}
+
+func useHTTPS(httpProtocol network.HTTPProtocol) bool {
+	switch httpProtocol {
+	case network.HTTPDisabled, network.HTTPRedirected:
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
I wanted to know how hard it'd be to do such an override, and it looks fairly straightforward.

It has the wrinkle of it's entanglement with AutoTLS though, so maybe we should create a new setting `overrideExternalScheme` and make clear in its comment, that it's to be used to override the scheme for all external URLs and that it should only be used if you're fronting the ingressgateway with something actually terminating TLS. For all other cases, AutoTLS should be used.

/cc @nak3 @ZhiminXiang 

Ref #7708 