### PR TITLE
Unflake per-item test again

### DIFF
--- a/pkg/reconciler/revision/background_test.go
+++ b/pkg/reconciler/revision/background_test.go
@@ -215,7 +215,11 @@ func TestRateLimitGlobal(t *testing.T) {
 func TestRateLimitPerItem(t *testing.T) {
 	logger := logtesting.TestLogger(t)
 
-	var resolver resolveFunc = func(ctx context.Context, img string, _ k8schain.Options, _ sets.String) (string, error) {
+	var resolver resolveFunc = func(_ context.Context, img string, _ k8schain.Options, _ sets.String) (string, error) {
+		if img == "img1" {
+			return "", nil
+		}
+
 		return "", errors.New("failed")
 	}
 


### PR DESCRIPTION
The rate limit applies to each image (the revision contains two), and we fail as soon as either image fails. In rare cases this could mean that a _different_ image fails on each iteration of the loop, meaning we don't back off as much as we expect. To simplify this, this commit changes the test so the same image fails each time.

/assign @markusthoemmes @psschwei 