### PR TITLE
Make schema generation idempotent

### DIFF
--- a/hack/update-schemas.sh
+++ b/hack/update-schemas.sh
@@ -39,5 +39,6 @@ SCHEMAPATCH_CONFIG_FILE="$(dirname $0)/schemapatch-config.yaml" controller-gen \
 
 # Restore linked CRDs.
 for link in $links; do
-  mv "$link.bkp" "$(readlink -f "$link")"
+  cat "$link.bkp" > "$link"
+  rm "$link.bkp"
 done

--- a/hack/update-schemas.sh
+++ b/hack/update-schemas.sh
@@ -18,6 +18,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Create a backup for every linked CRD.
+links=$(find "$(dirname "$0")/../config/core/300-resources" -type l)
+for link in $links; do
+  cp "$link" "$link.bkp"
+done
+
 # Make sure you install the patched version of controller-gen from
 # https://github.com/markusthoemmes/controller-tools/tree/knative-specific
 #
@@ -30,3 +36,8 @@ SCHEMAPATCH_CONFIG_FILE="$(dirname $0)/schemapatch-config.yaml" controller-gen \
   schemapatch:manifests=config/core/300-resources,generateEmbeddedObjectMeta=true \
   output:dir=config/core/300-resources \
   paths=./pkg/apis/...
+
+# Restore linked CRDs.
+for link in $links; do
+  mv "$link.bkp" "$(readlink -f "$link")"
+done


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Without this change, the schemas linked in the config directories would be touched by the generator as well, leaving us with a dirty git stage. This makes a backup of all linked CRDs and reverts them to their before state to allow us to easily run the `update-schemas.sh` script in CI eventually.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz @dprotaso 
