### PR TITLE
Automate schema creation via update-codegen.sh.

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -94,6 +94,10 @@ group "Generating API reference docs"
 
 ${REPO_ROOT_DIR}/hack/update-reference-docs.sh
 
+group "Generating schemas"
+
+${REPO_ROOT_DIR}/hack/update-schemas.sh
+
 group "Update deps post-codegen"
 
 # Make sure our dependencies are up-to-date


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

It's really not pretty... but it should work for everybody as far as I can tell. This automates installing the customized `controller-gen` binary and thus generating the schemas. Also hooks things up with `update-codegen` so schema updates will be forced in the future.

All ears for suggestions on how to make installing the binary better. I really don't like this either, but I'd like to unblock contributors having to manually do these steps too. So here we are, incrementing away :joy:. Happy to back out the codegen change if people feel strongly about that.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
