### PR TITLE
Drop some stray occurrences of preallocated slices

### DIFF
--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -114,7 +114,7 @@ func validateVolume(volume corev1.Volume) *apis.FieldError {
 
 	vs := volume.VolumeSource
 	errs = errs.Also(apis.CheckDisallowedFields(vs, *VolumeSourceMask(&vs)))
-	specified := []string{}
+	var specified []string
 	if vs.Secret != nil {
 		specified = append(specified, "secret")
 		for i, item := range vs.Secret.Items {

--- a/pkg/reconciler/route/resources/ingress.go
+++ b/pkg/reconciler/route/resources/ingress.go
@@ -225,7 +225,7 @@ func getChallengeHosts(challenges []netv1alpha1.HTTP01Challenge) map[string]netv
 func routeDomain(ctx context.Context, targetName string, r *servingv1.Route, visibility netv1alpha1.IngressVisibility) ([]string, error) {
 	hostname, err := domains.HostnameFromTemplate(ctx, r.Name, targetName)
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
 
 	meta := r.ObjectMeta.DeepCopy()
@@ -234,7 +234,7 @@ func routeDomain(ctx context.Context, targetName string, r *servingv1.Route, vis
 
 	domain, err := domains.DomainNameFromTemplate(ctx, *meta, hostname)
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
 	domains := []string{domain}
 	if isClusterLocal {

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -405,7 +405,7 @@ func objectRef(a accessor) tracker.Reference {
 }
 
 func getTrafficNames(targets map[string]traffic.RevisionTargets) []string {
-	names := []string{}
+	names := make([]string, 0, len(targets))
 	for name := range targets {
 		names = append(names, name)
 	}

--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -436,7 +436,7 @@ func consolidateAll(targets map[string]RevisionTargets) map[string]RevisionTarge
 
 func consolidate(targets RevisionTargets) RevisionTargets {
 	byName := make(map[string]RevisionTarget)
-	names := []string{}
+	var names []string
 	for _, tt := range targets {
 		name := tt.TrafficTarget.RevisionName
 		cur, ok := byName[name]

--- a/test/conformance/api/shared/util.go
+++ b/test/conformance/api/shared/util.go
@@ -155,7 +155,7 @@ func checkResponses(t testing.TB, num, min int, domain string, expectedResponses
 	// Verify that we saw each entry in "expectedResponses" at least "min" times.
 	// check(SELECT body FROM $counts WHERE total < $min)
 	totalMatches := 0
-	errMsg := []string{}
+	var errMsg []string
 	for _, er := range expectedResponses {
 		count := counts[er]
 		if count < min {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Kind of as per title. We don't usually have to allocate a slice with length 0 if we don't know the target capacity anyway. Starting with a `nil` leaves the possibility of not allocating at all.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz 