### PR TITLE
Propagate invalid traffic error to Route status

### DIFF
--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -130,6 +130,9 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconcil
 	// Configure traffic based on the RouteSpec.
 	traffic, err := c.configureTraffic(ctx, r)
 	if traffic == nil || err != nil {
+		if err != nil {
+			r.Status.MarkUnknownTrafficError(err.Error())
+		}
 		// Traffic targets aren't ready, no need to configure child resources.
 		return err
 	}
@@ -330,7 +333,6 @@ func (c *Reconciler) configureTraffic(ctx context.Context, r *v1.Route) (*traffi
 	if trafficErr != nil && !isTargetError {
 		// An error that's not due to missing traffic target should
 		// make us fail fast.
-		r.Status.MarkUnknownTrafficError(trafficErr.Error())
 		return nil, trafficErr
 	}
 	if badTarget != nil && isTargetError {

--- a/pkg/testing/v1/route.go
+++ b/pkg/testing/v1/route.go
@@ -122,7 +122,7 @@ func WithURL(r *v1.Route) {
 	}
 }
 
-// WithURL sets the .Status.Domain field with custom domain.
+// WithHost sets the .Status.Domain field with domain from arg.
 func WithHost(host string) RouteOption {
 	return func(r *v1.Route) {
 		r.Status.Address = &duckv1.Addressable{

--- a/pkg/testing/v1/route.go
+++ b/pkg/testing/v1/route.go
@@ -122,6 +122,18 @@ func WithURL(r *v1.Route) {
 	}
 }
 
+// WithURL sets the .Status.Domain field with custom domain.
+func WithHost(host string) RouteOption {
+	return func(r *v1.Route) {
+		r.Status.Address = &duckv1.Addressable{
+			URL: &apis.URL{
+				Scheme: "http",
+				Host:   host,
+			},
+		}
+	}
+}
+
 // WithHTTPSDomain sets the .Status.URL field to a https-domain based on the name and namespace.
 func WithHTTPSDomain(r *v1.Route) {
 	r.Status.URL = &apis.URL{
@@ -185,6 +197,13 @@ func WithRouteConditionsHTTPDowngrade(rt *v1.Route) {
 // MarkTrafficAssigned calls the method of the same name on .Status
 func MarkTrafficAssigned(r *v1.Route) {
 	r.Status.MarkTrafficAssigned()
+}
+
+// MarkUnknownTrafficError calls the method of the same name on .Status
+func MarkUnknownTrafficError(msg string) RouteOption {
+	return func(r *v1.Route) {
+		r.Status.MarkUnknownTrafficError(msg)
+	}
 }
 
 // MarkCertificateNotReady calls the method of the same name on .Status


### PR DESCRIPTION
Currently error from `configureTraffic()` does not mark traffic error
status.
This patch changes it to mark traffic whenever bad traffic
configuration happens.

Fixes https://github.com/knative/serving/issues/11476

**Release Note**

```release-note
Traffic status in Route is updated whenever traffic configuration was wrong.
```

/cc @ZhiminXiang @markusthoemmes 