### PR TITLE
Using latest v1 version for PDB

### DIFF
--- a/config/core/deployments/activator-hpa.yaml
+++ b/config/core/deployments/activator-hpa.yaml
@@ -38,7 +38,7 @@ spec:
 # Activator PDB. Currently we permit unavailability of 20% of tasks at the same time.
 # Given the subsetting and that the activators are partially stateful systems, we want
 # a slow rollout of the new versions and slow migration during node upgrades.
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: activator-pdb

--- a/config/core/deployments/webhook-hpa.yaml
+++ b/config/core/deployments/webhook-hpa.yaml
@@ -36,7 +36,7 @@ spec:
         averageUtilization: 100
 ---
 # Webhook PDB.
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: webhook-pdb


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #11488

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* :broom: Update to V1 version of the PodDisruptionBudget API
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
