### PR TITLE
Add permission to update namespaces/finalizers

### DIFF
--- a/config/core/200-roles/clusterrole.yaml
+++ b/config/core/200-roles/clusterrole.yaml
@@ -26,6 +26,9 @@ rules:
   - apiGroups: [""]
     resources: ["endpoints/restricted"] # Permission for RestrictedEndpointsAdmission
     verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["namespaces/finalizers"] # finalizers are needed for the owner reference of the webhook
+    verbs: ["update"]
   - apiGroups: ["apps"]
     resources: ["deployments", "deployments/finalizers"] # finalizers are needed for the owner reference of the webhook
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]

--- a/test/config/ytt/core/kapp-config.yaml
+++ b/test/config/ytt/core/kapp-config.yaml
@@ -1,0 +1,13 @@
+# use emptyFieldMatcher to avoid aggregation rule conflict.
+# see: https://github.com/vmware-tanzu/carvel-kapp/issues/227
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+rebaseRules:
+- path: [rules]
+  type: copy
+  sources: [existing, new]
+  resourceMatchers:
+  - notMatcher:
+      matcher:
+        emptyFieldMatcher:
+          path: [aggregationRule]

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -288,6 +288,20 @@ function install() {
     > "${ytt_result}" \
     || fail_test "failed to create deployment configuration"
 
+  cat <<EOF >> ${ytt_result}
+---
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+rebaseRules:
+- path: [rules]
+  type: copy
+  sources: [existing, new]
+  resourceMatchers:
+  - notMatcher:
+      matcher:
+        emptyFieldMatcher:
+          path: [aggregationRule]
+EOF
 
   # Post install jobs configuration
   run_ytt \

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -288,23 +288,6 @@ function install() {
     > "${ytt_result}" \
     || fail_test "failed to create deployment configuration"
 
-  # use emptyFieldMatcher to avoid aggregation rule conflict.
-  # see: https://github.com/vmware-tanzu/carvel-kapp/issues/227
-  cat <<EOF >> ${ytt_result}
----
-apiVersion: kapp.k14s.io/v1alpha1
-kind: Config
-rebaseRules:
-- path: [rules]
-  type: copy
-  sources: [existing, new]
-  resourceMatchers:
-  - notMatcher:
-      matcher:
-        emptyFieldMatcher:
-          path: [aggregationRule]
-EOF
-
   # Post install jobs configuration
   run_ytt \
     -f "${REPO_ROOT_DIR}/test/config/ytt/lib" \

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -288,6 +288,8 @@ function install() {
     > "${ytt_result}" \
     || fail_test "failed to create deployment configuration"
 
+  # use emptyFieldMatcher to avoid aggregation rule conflict.
+  # see: https://github.com/vmware-tanzu/carvel-kapp/issues/227 
   cat <<EOF >> ${ytt_result}
 ---
 apiVersion: kapp.k14s.io/v1alpha1

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -289,7 +289,7 @@ function install() {
     || fail_test "failed to create deployment configuration"
 
   # use emptyFieldMatcher to avoid aggregation rule conflict.
-  # see: https://github.com/vmware-tanzu/carvel-kapp/issues/227 
+  # see: https://github.com/vmware-tanzu/carvel-kapp/issues/227
   cat <<EOF >> ${ytt_result}
 ---
 apiVersion: kapp.k14s.io/v1alpha1

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -288,6 +288,7 @@ function install() {
     > "${ytt_result}" \
     || fail_test "failed to create deployment configuration"
 
+
   # Post install jobs configuration
   run_ytt \
     -f "${REPO_ROOT_DIR}/test/config/ytt/lib" \


### PR DESCRIPTION
This patch adds the permission to update `namespaces/finalizers`.

Since knative/pkg#2098 added ownerRef refers to namespace for webhook,
we need this permission. Without it, cluster which has a stricter RBAC
rules gets the following error:

```
cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on:
```

/cc @markusthoemmes @julz @dprotaso 

**Release Note**

```release-note
knative-serving-core cluster role has update permission for namespaces/finalizers.
```
