### PR TITLE
[WIP] Add https option to upgrade test

### DIFF
--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -41,6 +41,9 @@ initialize --skip-istio-addon  --min-nodes=4 --max-nodes=4 --install-latest-rele
 # TODO(#2656): Reduce the timeout after we get this test to consistently passing.
 TIMEOUT=30m
 
+# Currently no option to add https.
+HTTPS=1
+
 if (( HTTPS )); then
   use_https="--https"
   toggle_feature autoTLS Enabled config-network

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -57,7 +57,8 @@ func assertServiceResourcesUpdated(t testing.TB, clients *test.Clients, names te
 		url,
 		v1test.RetryingRouteInconsistency(spoof.MatchesAllOf(spoof.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
-		test.ServingFlags.ResolvableDomain); err != nil {
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS)); err != nil {
 		t.Fatal(fmt.Sprintf("The endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, url, expectedText, err))
 	}
 }


### PR DESCRIPTION
Current upgrade test does not use HTTPS.
This patch supports `--https` option for upgrade test.

