### PR TITLE
Revert "Temporarily remove routetags for queue metrics (#8969)"

### DIFF
--- a/pkg/metrics/key.go
+++ b/pkg/metrics/key.go
@@ -31,5 +31,5 @@ var (
 	ContainerTagKey      = tag.MustNewKey(metricskey.ContainerName)
 	ResponseCodeKey      = tag.MustNewKey(metricskey.LabelResponseCode)
 	ResponseCodeClassKey = tag.MustNewKey(metricskey.LabelResponseCodeClass)
-	RouteTagKey          = tag.MustNewKey("tag")
+	RouteTagKey          = tag.MustNewKey("route_tag")
 )

--- a/pkg/queue/request_metric.go
+++ b/pkg/queue/request_metric.go
@@ -75,7 +75,7 @@ type appRequestMetricsHandler struct {
 // NewRequestMetricsHandler creates an http.Handler that emits request metrics.
 func NewRequestMetricsHandler(next http.Handler,
 	ns, service, config, rev, pod string) (http.Handler, error) {
-	keys := []tag.Key{metrics.PodTagKey, metrics.ContainerTagKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey /*, metrics.RouteTagKey*/}
+	keys := []tag.Key{metrics.PodTagKey, metrics.ContainerTagKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey, metrics.RouteTagKey}
 	if err := pkgmetrics.RegisterResourceView(
 		&view.View{
 			Description: "The number of requests that are routed to queue-proxy",
@@ -117,22 +117,16 @@ func (h *requestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		// If ServeHTTP panics, recover, record the failure and panic again.
 		err := recover()
 		latency := time.Since(startTime)
-		// routeTag := GetRouteTagNameFromRequest(r)
+		routeTag := GetRouteTagNameFromRequest(r)
 		if err != nil {
-			ctx := metrics.AugmentWithResponse(h.statsCtx, http.StatusInternalServerError)
-			// TODO: add the routeTag back after stackdriver adds support for it.
-			// https://github.com/knative/serving/issues/8970
-			// ctx := metrics.AugmentWithResponseAndRouteTag(h.statsCtx,
-			// http.StatusInternalServerError, routeTag)
+			ctx := metrics.AugmentWithResponseAndRouteTag(h.statsCtx,
+				http.StatusInternalServerError, routeTag)
 			pkgmetrics.RecordBatch(ctx, requestCountM.M(1),
 				responseTimeInMsecM.M(float64(latency.Milliseconds())))
 			panic(err)
 		}
-		ctx := metrics.AugmentWithResponse(h.statsCtx, rr.ResponseCode)
-		// TODO: add the routeTag back after stackdriver adds support for it.
-		// https://github.com/knative/serving/issues/8970
-		// ctx := metrics.AugmentWithResponseAndRouteTag(h.statsCtx,
-		// rr.ResponseCode, routeTag)
+		ctx := metrics.AugmentWithResponseAndRouteTag(h.statsCtx,
+			rr.ResponseCode, routeTag)
 		pkgmetrics.RecordBatch(ctx, requestCountM.M(1),
 			responseTimeInMsecM.M(float64(latency.Milliseconds())))
 	}()
@@ -205,10 +199,6 @@ func (h *appRequestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	h.next.ServeHTTP(rr, r)
 }
 
-/*
-TODO: add the routeTag back after stackdriver adds support for it.
-https://github.com/knative/serving/issues/8970
-
 const (
 	defaultTagName   = "DEFAULT"
 	undefinedTagName = "UNDEFINED"
@@ -235,4 +225,4 @@ func GetRouteTagNameFromRequest(r *http.Request) string {
 	}
 	// Otherwise, returns the value of the tag header.
 	return name
-}*/
+}

--- a/pkg/queue/request_metric_test.go
+++ b/pkg/queue/request_metric_test.go
@@ -55,7 +55,7 @@ func TestRequestMetricsHandler(t *testing.T) {
 		metricskey.ContainerName:          "queue-proxy",
 		metricskey.LabelResponseCode:      "200",
 		metricskey.LabelResponseCodeClass: "2xx",
-		//"tag":                             disabledTagName,
+		"route_tag":                       disabledTagName,
 	}
 	wantResource := &resource.Resource{
 		Type: "knative_revision",
@@ -77,7 +77,7 @@ func TestRequestMetricsHandler(t *testing.T) {
 	metricstest.AssertMetric(t, metricstest.DistributionCountOnlyMetric("request_latencies", 1, wantTags).WithResource(wantResource))
 }
 
-/* func TestRequestMetricsHandlerWithEnablingTagOnRequestMetrics(t *testing.T) {
+func TestRequestMetricsHandlerWithEnablingTagOnRequestMetrics(t *testing.T) {
 	defer reset()
 	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	handler, err := NewRequestMetricsHandler(baseHandler, "ns", "svc", "cfg", "rev", "pod")
@@ -96,7 +96,7 @@ func TestRequestMetricsHandler(t *testing.T) {
 		metricskey.ContainerName:          "queue-proxy",
 		metricskey.LabelResponseCode:      "200",
 		metricskey.LabelResponseCodeClass: "2xx",
-		"tag":                             "test-tag",
+		"route_tag":                       "test-tag",
 	}
 	wantResource := &resource.Resource{
 		Type: "knative_revision",
@@ -116,7 +116,7 @@ func TestRequestMetricsHandler(t *testing.T) {
 	req.Header.Del(network.TagHeaderName)
 	req.Header.Set(network.DefaultRouteHeaderName, "true")
 	handler.ServeHTTP(resp, req)
-	wantTags["tag"] = defaultTagName
+	wantTags["route_tag"] = defaultTagName
 	metricstest.AssertMetric(t, metricstest.IntMetric("request_count", 1, wantTags).WithResource(wantResource))
 
 	reset()
@@ -124,7 +124,7 @@ func TestRequestMetricsHandler(t *testing.T) {
 	req.Header.Set(network.TagHeaderName, "test-tag")
 	req.Header.Set(network.DefaultRouteHeaderName, "true")
 	handler.ServeHTTP(resp, req)
-	wantTags["tag"] = undefinedTagName
+	wantTags["route_tag"] = undefinedTagName
 	metricstest.AssertMetric(t, metricstest.IntMetric("request_count", 1, wantTags).WithResource(wantResource))
 
 	reset()
@@ -132,9 +132,9 @@ func TestRequestMetricsHandler(t *testing.T) {
 	req.Header.Set(network.TagHeaderName, "test-tag")
 	req.Header.Set(network.DefaultRouteHeaderName, "false")
 	handler.ServeHTTP(resp, req)
-	wantTags["tag"] = "test-tag"
+	wantTags["route_tag"] = "test-tag"
 	metricstest.AssertMetric(t, metricstest.IntMetric("request_count", 1, wantTags).WithResource(wantResource))
-} */
+}
 
 func reset() {
 	metricstest.Unregister(
@@ -164,7 +164,7 @@ func TestRequestMetricsHandlerPanickingHandler(t *testing.T) {
 			metricskey.ContainerName:          "queue-proxy",
 			metricskey.LabelResponseCode:      "500",
 			metricskey.LabelResponseCodeClass: "5xx",
-			// "tag":                             disabledTagName,
+			"route_tag":                       disabledTagName,
 		}
 		wantResource := &resource.Resource{
 			Type: "knative_revision",


### PR DESCRIPTION
This reverts commit 77a19fcba960f07c5041bca93d0ae118b0dce18a.

Also renames RouteTagKey for queue metrics from 'tag' to 'route_tag'
as per https://github.com/knative/serving/issues/8970#issuecomment-672127099

Fixes #8970

## Proposed Changes

* Revert removal of route tag from `queue-proxy` metrics.
* Rename route tag name from `tag` to `route_tag`.
