### PR TITLE
Make TestProjectedServiceAccountToken not need to run as root

### DIFF
--- a/test/conformance/api/v1/volumes_test.go
+++ b/test/conformance/api/v1/volumes_test.go
@@ -428,6 +428,7 @@ func TestProjectedServiceAccountToken(t *testing.T) {
 					Path:     tokenPath,
 				},
 			}},
+			DefaultMode: ptr.Int32(0444), // Ensure everybody can read the mounted files.
 		},
 	})
 	withSubpath := func(svc *v1.Service) {
@@ -436,15 +437,7 @@ func TestProjectedServiceAccountToken(t *testing.T) {
 		vm.SubPath = filepath.Base(saPath)
 	}
 
-	withRunAsUser := func(svc *v1.Service) {
-		svc.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
-			// The token will be mounted owned by root, so we need the container to
-			// run as root to be able to read it.
-			RunAsUser: ptr.Int64(0),
-		}
-	}
-
-	serviceOpts := []ServiceOption{withVolume, withSubpath, withRunAsUser}
+	serviceOpts := []ServiceOption{withVolume, withSubpath}
 
 	// Setup initial Service
 	if _, err := v1test.CreateServiceReady(t, clients, &names, serviceOpts...); err != nil {


### PR DESCRIPTION
It seems to be not necessary to run this test as root.

FWIW, for my local `kind` cluster, even the defaults (without providing a `DefaultMode`) were good to be able to actually pass the test, but I included an explicit read-all mode for good measure, should some other cluster intervene in some way.

/assign @julz 