### PR TITLE
Run scale-200 test at last

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -96,12 +96,6 @@ immediate_gc
 go_test_e2e -timeout=2m ./test/e2e/gc ${TEST_OPTIONS} || failed=1
 kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml
 
-# Run scale tests.
-# Note that we use a very high -parallel because each ksvc is run as its own
-# sub-test. If this is not larger than the maximum scale tested then the test
-# simply cannot pass.
-go_test_e2e -timeout=20m -parallel=300 ./test/scale ${TEST_OPTIONS} || failed=1
-
 # Run HPA tests
 go_test_e2e -timeout=15m -tags=hpa ./test/e2e ${TEST_OPTIONS} || failed=1
 
@@ -114,6 +108,12 @@ go_test_e2e -timeout=25m -failfast -parallel=1 ./test/ha \
   -buckets="${BUCKETS:-1}" \
   -spoofinterval="10ms" || failed=1
 toggle_feature autocreateClusterDomainClaims false config-network || fail_test
+
+# Run scale tests.
+# Note that we use a very high -parallel because each ksvc is run as its own
+# sub-test. If this is not larger than the maximum scale tested then the test
+# simply cannot pass.
+go_test_e2e -timeout=20m -parallel=300 ./test/scale ${TEST_OPTIONS} || failed=1
 
 if (( HTTPS )); then
   kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found


### PR DESCRIPTION
Current mesh test often blank with HA test and `TestHPAAutoscaleUpDownUp`
and sometimes no output for `scale-200` test.
Please see - https://testgrid.k8s.io/r/knative-own-testgrid/serving#istio-stable-mesh

It seems the test process was killed(?) during scale test and did not finish correctly.

```
    stream.go:254: I 04:51:23.183 controller-655845f67-jznwf [knative.dev.serving.pkg.reconciler.route.Reconciler] [serving-tests/scale-to-n-scale-200-034-of-200-mcsoyglj] All referred targets are routable, marking AllTrafficAssigned with traffic information.
    stream.go:254: I 04:51:23.183 controller-655845f67-jznwf [knative.dev.serving.pkg.reconc./test/../vendor/knative.dev/hack/library.sh: line 629:   334 Killed                  kntest "$@"
```

So this patch changes to run scale-200 test.