### PR TITLE
rename namespace certificate controller & service

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -175,13 +175,13 @@ You can see things running with:
 
 ```console
 kubectl -n knative-serving get pods
-NAME                                  READY   STATUS    RESTARTS   AGE
-activator-7454cd659f-rrz86            1/1     Running   0          105s
-autoscaler-58cbfd4985-fl5h7           1/1     Running   0          105s
-autoscaler-hpa-77964b9b8c-9sbgq       1/1     Running   0          105s
-controller-847b7cc977-5mvvq           1/1     Running   0          105s
-networking-ns-cert-56c58544db-sgstd   1/1     Running   0          105s
-webhook-6b6c77567f-flr59              1/1     Running   0          105s
+NAME                                     READY   STATUS    RESTARTS   AGE
+activator-7454cd659f-rrz86               1/1     Running   0          105s
+autoscaler-58cbfd4985-fl5h7              1/1     Running   0          105s
+autoscaler-hpa-77964b9b8c-9sbgq          1/1     Running   0          105s
+controller-847b7cc977-5mvvq              1/1     Running   0          105s
+net-nscert-controller-56c58544db-sgstd   1/1     Running   0          105s
+webhook-6b6c77567f-flr59                 1/1     Running   0          105s
 ```
 
 You can access the Knative Serving Controller's logs with:

--- a/cmd/networking/nscert/main.go
+++ b/cmd/networking/nscert/main.go
@@ -24,5 +24,5 @@ import (
 )
 
 func main() {
-	sharedmain.Main("nscontroller", nscert.NewController)
+	sharedmain.Main("net-nscert-controller", nscert.NewController)
 }

--- a/config/core/configmaps/logging.yaml
+++ b/config/core/configmaps/logging.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "d9570453"
+    knative.dev/example-checksum: "79e56eb4"
 data:
   _example: |
     ################################
@@ -73,4 +73,4 @@ data:
     loglevel.hpaautoscaler: "info"
     loglevel.certcontroller: "info"
     loglevel.istiocontroller: "info"
-    loglevel.nscontroller: "info"
+    loglevel.net-nscert-controller: "info"

--- a/config/namespace-wildcard-certs/controller.yaml
+++ b/config/namespace-wildcard-certs/controller.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: networking-ns-cert
+  name: net-nscert-controller
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
@@ -23,13 +23,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: networking-ns-cert
+      app: net-nscert-controller
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
-        app: networking-ns-cert
+        app: net-nscert-controller
         serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
@@ -39,13 +39,13 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  app: networking-ns-cert
+                  app: net-nscert-controller
               topologyKey: kubernetes.io/hostname
             weight: 100
 
       serviceAccountName: controller
       containers:
-      - name: networking-nscert
+      - name: controller
         # This is the Go import path for the binary that is containerized
         # and substituted here.
         image: ko://knative.dev/serving/cmd/networking/nscert
@@ -91,10 +91,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: networking-ns-cert
+    app: net-nscert-controller
     serving.knative.dev/release: devel
     networking.knative.dev/wildcard-certificate-provider: nscert
-  name: networking-ns-cert
+  name: net-nscert-controller
   namespace: knative-serving
 spec:
   ports:
@@ -106,4 +106,4 @@ spec:
     port: 8008
     targetPort: 8008
   selector:
-    app: networking-ns-cert
+    app: net-nscert-controller

--- a/test/config/ytt/core/overlay-config-logging.yaml
+++ b/test/config/ytt/core/overlay-config-logging.yaml
@@ -35,4 +35,4 @@ data:
   loglevel.domainmapping: "debug"
   loglevel.certcontroller: "debug"
   loglevel.istiocontroller: "debug"
-  loglevel.nscontroller: "debug"
+  loglevel.net-nscert-controller: "debug"


### PR DESCRIPTION
we're going to be consistent with the naming of our net-* components

Part of https://github.com/knative/networking/issues/448