### PR TITLE
Add short option to scale test

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -93,6 +93,9 @@ function parse_flags() {
       ;;
     --mesh)
       readonly MESH=1
+      # DO NOT SUBMIT:
+      # This line is to verify the option. Remove before merge.
+      readonly SHORT=1
       return 1
       ;;
     --no-mesh)

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -32,6 +32,7 @@ export KO_FLAGS="${KO_FLAGS:---platform=linux/amd64}"
 
 export RUN_HTTP01_AUTO_TLS_TESTS=0
 export HTTPS=0
+export SHORT=0
 export ENABLE_HA=0
 export MESH=0
 export KIND=0
@@ -108,6 +109,10 @@ function parse_flags() {
       ;;
     --https)
       readonly HTTPS=1
+      return 1
+      ;;
+    --short)
+      readonly SHORT=1
       return 1
       ;;
     --cluster-domain)

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -93,9 +93,6 @@ function parse_flags() {
       ;;
     --mesh)
       readonly MESH=1
-      # DO NOT SUBMIT:
-      # This line is to verify the option. Remove before merge.
-      readonly SHORT=1
       return 1
       ;;
     --no-mesh)

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -65,6 +65,9 @@ if [[ -z "${INGRESS_CLASS}" \
 fi
 
 TEST_OPTIONS="${TEST_OPTIONS:-${alpha} --enable-beta --resolvabledomain=$(use_resolvable_domain) ${use_https}}"
+if (( SHORT )); then
+  TEST_OPTIONS+=" -short"
+fi
 
 toggle_feature autocreateClusterDomainClaims true config-network || fail_test
 go_test_e2e -timeout=30m \
@@ -97,10 +100,6 @@ kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.ya
 # Note that we use a very high -parallel because each ksvc is run as its own
 # sub-test. If this is not larger than the maximum scale tested then the test
 # simply cannot pass.
-if (( SHORT )); then
-  TEST_OPTIONS+=" -short"
-fi
-
 go_test_e2e -timeout=20m -parallel=300 ./test/scale ${TEST_OPTIONS} || failed=1
 
 # Run HPA tests

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -97,6 +97,10 @@ kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.ya
 # Note that we use a very high -parallel because each ksvc is run as its own
 # sub-test. If this is not larger than the maximum scale tested then the test
 # simply cannot pass.
+if (( SHORT )); then
+  TEST_OPTIONS+=" -short"
+fi
+
 go_test_e2e -timeout=20m -parallel=300 ./test/scale ${TEST_OPTIONS} || failed=1
 
 # Run HPA tests


### PR DESCRIPTION
This patch adds short option to e2e test and support it on scale test.
Please see https://github.com/knative/serving/issues/11286 for the discussion.

I will add a new job trigger in [test-infra](https://github.com/knative/test-infra) later.