### PR TITLE
Remove YAML anchors from deployments

### DIFF
--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -97,7 +97,7 @@ spec:
         - name: https-webhook
           containerPort: 8443
 
-        readinessProbe: &probe
+        readinessProbe:
           periodSeconds: 1
           httpGet:
             scheme: HTTPS
@@ -106,7 +106,13 @@ spec:
             - name: k-kubelet-probe
               value: "webhook"
         livenessProbe:
-          <<: *probe
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "webhook"
           failureThreshold: 6
           initialDelaySeconds: 20
 

--- a/config/domain-mapping/webhook.yaml
+++ b/config/domain-mapping/webhook.yaml
@@ -95,7 +95,7 @@ spec:
         - name: https-webhook
           containerPort: 8443
 
-        readinessProbe: &probe
+        readinessProbe:
           periodSeconds: 1
           httpGet:
             scheme: HTTPS
@@ -104,7 +104,13 @@ spec:
             - name: k-kubelet-probe
               value: "webhook"
         livenessProbe:
-          <<: *probe
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "webhook"
           failureThreshold: 6
           initialDelaySeconds: 20
 


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/11468

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This PR removes two YAML anchors from used in two of the deployment YAML files. This is necessary for the `serving-core.yaml` file to be compatible with Kustomize. The relevant Kustomize issue regarding YAML anchor support is https://github.com/kubernetes-sigs/kustomize/issues/3675.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Remove remaining YAML anchors for comparability with Kustomize.
```
