### PR TITLE
Fix references to xip.io in comments/DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -157,7 +157,8 @@ ko apply -Rf config/core/
 
 # Optional steps
 
-# Run post-install job to set up nice XIP.IO domain name.  This only works
+
+# Run post-install job to set up a nice sslip.io domain name.  This only works
 # if your Kubernetes LoadBalancer has an IPv4 address.
 ko delete -f config/post-install/default-domain.yaml --ignore-not-found
 ko apply -f config/post-install/default-domain.yaml

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -157,7 +157,6 @@ ko apply -Rf config/core/
 
 # Optional steps
 
-
 # Run post-install job to set up a nice sslip.io domain name.  This only works
 # if your Kubernetes LoadBalancer has an IPv4 address.
 ko delete -f config/post-install/default-domain.yaml --ignore-not-found

--- a/cmd/default-domain/main.go
+++ b/cmd/default-domain/main.go
@@ -48,7 +48,7 @@ import (
 var (
 	serverURL  = flag.String("server", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	kubeconfig = flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-	magicDNS   = flag.String("magic-dns", "", "The hostname for the magic DNS service, e.g. xip.io or nip.io")
+	magicDNS   = flag.String("magic-dns", "", "The hostname for the magic DNS service, e.g. sslip.io or nip.io")
 )
 
 const (
@@ -212,8 +212,8 @@ func main() {
 	}
 
 	// Use the IP (assumes IPv4) to set up a magic DNS name under a top-level Magic
-	// DNS service like xip.io or nip.io, where:
-	//     1.2.3.4.xip.io  ===(magically resolves to)===> 1.2.3.4
+	// DNS service like sslip.io or nip.io, where:
+	//     1.2.3.4.sslip.io  ===(magically resolves to)===> 1.2.3.4
 	// Add this magic DNS name without a label selector to the ConfigMap,
 	// and send it back to the API server.
 	domain := fmt.Sprintf("%s.%s", ip, *magicDNS)

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -327,7 +327,7 @@ function install() {
 # Check if we should use --resolvabledomain.  In case the ingress only has
 # hostname, we doesn't yet have a way to support resolvable domain in tests.
 function use_resolvable_domain() {
-  # Temporarily turning off xip.io tests, as DNS errors aren't always retried.
+  # Temporarily turning off sslip.io tests, as DNS errors aren't always retried.
   echo "false"
 }
 

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -95,7 +95,7 @@ func testProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 		Value: helloworldURL.Hostname(),
 	}}
 
-	// When resolvable domain is not set for external access test, use gateway for the endpoint as xip.io is flaky.
+	// When resolvable domain is not set for external access test, use gateway for the endpoint as services like sslip.io may be flaky.
 	// ref: https://github.com/knative/serving/issues/5389
 	if !test.ServingFlags.ResolvableDomain && accessibleExternal {
 		gatewayTarget, mapper, err := ingress.GetIngressEndpoint(context.Background(), clients.KubeClient, pkgTest.Flags.IngressEndpoint)

--- a/test/test_images/httpproxy/httpproxy.go
+++ b/test/test_images/httpproxy/httpproxy.go
@@ -87,7 +87,7 @@ func main() {
 	port := getPort()
 
 	// Gateway is an optional value. It is used only when resolvable domain is not set
-	// for external access test, as xip.io is flaky.
+	// for external access test, as services like sslip.io may be flaky.
 	// ref: https://github.com/knative/serving/issues/5389
 	gateway := os.Getenv(gatewayHostEnv)
 	if gateway != "" {

--- a/vendor/knative.dev/pkg/test/spoof/spoof.go
+++ b/vendor/knative.dev/pkg/test/spoof/spoof.go
@@ -208,7 +208,7 @@ func DefaultErrorRetryChecker(err error) (bool, error) {
 	if isTCPTimeout(err) {
 		return true, fmt.Errorf("retrying for TCP timeout: %w", err)
 	}
-	// Retrying on DNS error, since we may be using sslip.io or nip.io in tests.
+	// Retrying on DNS error, since we may be using xip.io or nip.io in tests.
 	if isDNSError(err) {
 		return true, fmt.Errorf("retrying for DNS error: %w", err)
 	}

--- a/vendor/knative.dev/pkg/test/spoof/spoof.go
+++ b/vendor/knative.dev/pkg/test/spoof/spoof.go
@@ -208,7 +208,7 @@ func DefaultErrorRetryChecker(err error) (bool, error) {
 	if isTCPTimeout(err) {
 		return true, fmt.Errorf("retrying for TCP timeout: %w", err)
 	}
-	// Retrying on DNS error, since we may be using xip.io or nip.io in tests.
+	// Retrying on DNS error, since we may be using sslip.io or nip.io in tests.
 	if isDNSError(err) {
 		return true, fmt.Errorf("retrying for DNS error: %w", err)
 	}


### PR DESCRIPTION
Since xip.io is no more and we [already changed the default-domain job](http://github.com/knative/serving/pull/11298) to use sslip instead, updates comments and dev instructions to match.

/assign @dprotaso @markusthoemmes 