### PR TITLE
issues/11122 EnableLogStream test flag

### DIFF
--- a/test/conformance.go
+++ b/test/conformance.go
@@ -75,8 +75,10 @@ func Setup(t testing.TB, namespace ...string) *Clients {
 	t.Helper()
 	logging.InitializeLogger()
 
-	cancel := logstream.Start(t)
-	t.Cleanup(cancel)
+	if ServingFlags.EnableLogStream {
+		cancel := logstream.Start(t)
+		t.Cleanup(cancel)
+	}
 
 	cfg, err := pkgTest.Flags.GetRESTConfig()
 	if err != nil {

--- a/test/conformance.go
+++ b/test/conformance.go
@@ -75,7 +75,7 @@ func Setup(t testing.TB, namespace ...string) *Clients {
 	t.Helper()
 	logging.InitializeLogger()
 
-	if ServingFlags.EnableLogStream {
+	if !ServingFlags.DisableLogStream {
 		cancel := logstream.Start(t)
 		t.Cleanup(cancel)
 	}

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -211,8 +211,10 @@ func TestServiceToServiceCall(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			cancel := logstream.Start(t)
-			defer cancel()
+			if test.ServingFlags.EnableLogStream {
+				cancel := logstream.Start(t)
+				defer cancel()
+			}
 			testProxyToHelloworld(t, clients, helloworldURL, true /*inject*/, false /*accessible externally*/)
 		})
 	}
@@ -265,9 +267,10 @@ func TestSvcToSvcViaActivator(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			cancel := logstream.Start(t)
-			defer cancel()
+			if test.ServingFlags.EnableLogStream {
+				cancel := logstream.Start(t)
+				defer cancel()
+			}
 			testSvcToSvcCallViaActivator(t, clients, tc.injectA, tc.injectB)
 		})
 	}
@@ -314,9 +317,10 @@ func TestCallToPublicService(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			cancel := logstream.Start(t)
-			defer cancel()
+			if test.ServingFlags.EnableLogStream {
+				cancel := logstream.Start(t)
+				defer cancel()
+			}
 			testProxyToHelloworld(t, clients, tc.url, false /*inject*/, tc.accessibleExternally)
 		})
 	}

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -211,7 +211,7 @@ func TestServiceToServiceCall(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			if test.ServingFlags.EnableLogStream {
+			if !test.ServingFlags.DisableLogStream {
 				cancel := logstream.Start(t)
 				defer cancel()
 			}
@@ -267,7 +267,7 @@ func TestSvcToSvcViaActivator(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if test.ServingFlags.EnableLogStream {
+			if !test.ServingFlags.DisableLogStream {
 				cancel := logstream.Start(t)
 				defer cancel()
 			}
@@ -317,7 +317,7 @@ func TestCallToPublicService(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if test.ServingFlags.EnableLogStream {
+			if !test.ServingFlags.DisableLogStream {
 				cancel := logstream.Start(t)
 				defer cancel()
 			}

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -38,7 +38,7 @@ type ServingEnvironmentFlags struct {
 	Replicas            int    // The number of controlplane replicas being run.
 	EnableAlphaFeatures bool   // Indicates whether we run tests for alpha features
 	EnableBetaFeatures  bool   // Indicates whether we run tests for beta features
-	EnableLogStream     bool   // Indicates whether log streaming is enabled
+	DisableLogStream    bool   // Indicates whether log streaming is disabled
 }
 
 func initializeServingFlags() *ServingEnvironmentFlags {
@@ -65,8 +65,8 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 	flag.BoolVar(&f.EnableBetaFeatures, "enable-beta", false,
 		"Set this flag to run tests against beta features")
 
-	flag.BoolVar(&f.EnableLogStream, "enable-logstream", true,
-		"Set this flag to stream logs from system components")
+	flag.BoolVar(&f.DisableLogStream, "disable-logstream", false,
+		"Set this flag to disable streaming logs from system components")
 
 	return &f
 }

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -38,6 +38,7 @@ type ServingEnvironmentFlags struct {
 	Replicas            int    // The number of controlplane replicas being run.
 	EnableAlphaFeatures bool   // Indicates whether we run tests for alpha features
 	EnableBetaFeatures  bool   // Indicates whether we run tests for beta features
+	EnableLogStream     bool   // Indicates whether log streaming is enabled
 }
 
 func initializeServingFlags() *ServingEnvironmentFlags {
@@ -63,6 +64,9 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 
 	flag.BoolVar(&f.EnableBetaFeatures, "enable-beta", false,
 		"Set this flag to run tests against beta features")
+
+	flag.BoolVar(&f.EnableLogStream, "enable-logstream", true,
+		"Set this flag to stream logs from system components")
 
 	return &f
 }


### PR DESCRIPTION
Fixes #11122

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Introduce EnableLogStream flag that is "true" by default but allows for disabling the log streaming from system compontents

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
