### PR TITLE
Allow setting runAsNotRoot without the feature flag

### DIFF
--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -596,12 +596,12 @@ func SecurityContextMask(ctx context.Context, in *corev1.SecurityContext) *corev
 
 	// Allowed fields
 	out.RunAsUser = in.RunAsUser
+	out.RunAsNonRoot = in.RunAsNonRoot
 	out.ReadOnlyRootFilesystem = in.ReadOnlyRootFilesystem
 	out.Capabilities = in.Capabilities
 
 	if config.FromContextOrDefaults(ctx).Features.PodSpecSecurityContext != config.Disabled {
 		out.RunAsGroup = in.RunAsGroup
-		out.RunAsNonRoot = in.RunAsNonRoot
 	}
 	// Disallowed
 	// This list is unnecessary, but added here for clarity

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -596,12 +596,15 @@ func SecurityContextMask(ctx context.Context, in *corev1.SecurityContext) *corev
 
 	// Allowed fields
 	out.RunAsUser = in.RunAsUser
-	out.RunAsNonRoot = in.RunAsNonRoot
+	if in.RunAsNonRoot != nil && *in.RunAsNonRoot == true {
+		out.RunAsNonRoot = in.RunAsNonRoot
+	}
 	out.ReadOnlyRootFilesystem = in.ReadOnlyRootFilesystem
 	out.Capabilities = in.Capabilities
 
 	if config.FromContextOrDefaults(ctx).Features.PodSpecSecurityContext != config.Disabled {
 		out.RunAsGroup = in.RunAsGroup
+		out.RunAsNonRoot = in.RunAsNonRoot
 	}
 	// Disallowed
 	// This list is unnecessary, but added here for clarity

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -596,7 +596,7 @@ func SecurityContextMask(ctx context.Context, in *corev1.SecurityContext) *corev
 
 	// Allowed fields
 	out.RunAsUser = in.RunAsUser
-	if in.RunAsNonRoot != nil && *in.RunAsNonRoot == true {
+	if in.RunAsNonRoot != nil && *in.RunAsNonRoot {
 		out.RunAsNonRoot = in.RunAsNonRoot
 	}
 	out.ReadOnlyRootFilesystem = in.ReadOnlyRootFilesystem

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -722,6 +722,7 @@ func TestSecurityContextMask(t *testing.T) {
 	want := &corev1.SecurityContext{
 		Capabilities:           &corev1.Capabilities{},
 		RunAsUser:              ptr.Int64(1),
+		RunAsNonRoot:           ptr.Bool(true),
 		ReadOnlyRootFilesystem: ptr.Bool(true),
 	}
 	in := &corev1.SecurityContext{


### PR DESCRIPTION
Fixes #10814

### Release Note

```release-note
containers[*].securityContext.runAsNonRoot can be set to true without a feature flag
```