### PR TITLE
Remove deprecated label `networking.internal.knative.dev/disableWildcardCert`

### DIFF
--- a/pkg/reconciler/nscert/nscert.go
+++ b/pkg/reconciler/nscert/nscert.go
@@ -82,15 +82,9 @@ func (c *reconciler) ReconcileKind(ctx context.Context, ns *corev1.Namespace) pk
 		return fmt.Errorf("failed to list certificates: %w", err)
 	}
 
-	disabledWildcardCertValue, hasDisabledWildcardCertValue := ns.Labels[networking.DisableWildcardCertLabelKey]
-	deprecatedDisabledWildcardCertValue, hasDeprecatedDisabledWildcardCertValue := ns.Labels[networking.DeprecatedDisableWildcardCertLabelKey]
+	disabledWildcardCertValue, _ := ns.Labels[networking.DisableWildcardCertLabelKey]
 
-	if hasDisabledWildcardCertValue && hasDeprecatedDisabledWildcardCertValue && !strings.EqualFold(disabledWildcardCertValue, deprecatedDisabledWildcardCertValue) {
-		return fmt.Errorf("both %s and %s are specified but values do not match", networking.DisableWildcardCertLabelKey, networking.DeprecatedDisableWildcardCertLabelKey)
-	}
-
-	if strings.EqualFold(disabledWildcardCertValue, "true") ||
-		strings.EqualFold(deprecatedDisabledWildcardCertValue, "true") {
+	if strings.EqualFold(disabledWildcardCertValue, "true") {
 		return c.deleteNamespaceCerts(ctx, ns, existingCerts)
 	}
 

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -215,32 +215,12 @@ func TestReconcile(t *testing.T) {
 			kubeNamespaceWithLabelValue("foo", map[string]string{networking.DisableWildcardCertLabelKey: "true"}),
 		},
 	}, {
-		Name: "certificate not created for excluded namespace with external label",
-		Key:  "foo",
-		Objects: []runtime.Object{
-			kubeNamespaceWithLabelValue("foo", map[string]string{networking.DeprecatedDisableWildcardCertLabelKey: "true"}),
-		},
-	}, {
 		Name: "certificate not created for excluded namespace when both internal and external labels are present",
 		Key:  "foo",
 		Objects: []runtime.Object{
 			kubeNamespaceWithLabelValue("foo", map[string]string{
-				networking.DeprecatedDisableWildcardCertLabelKey: "true",
-				networking.DisableWildcardCertLabelKey:           "true",
+				networking.DisableWildcardCertLabelKey: "true",
 			}),
-		},
-	}, {
-		Name: "certificate not created for different wildcard cert label",
-		Key:  "foo",
-		Objects: []runtime.Object{
-			kubeNamespaceWithLabelValue("foo", map[string]string{
-				networking.DeprecatedDisableWildcardCertLabelKey: "true",
-				networking.DisableWildcardCertLabelKey:           "false",
-			}),
-		},
-		WantErr: true,
-		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "InternalError", "both networking.knative.dev/disableWildcardCert and networking.internal.knative.dev/disableWildcardCert are specified but values do not match"),
 		},
 	}, {
 		Name:                    "certificate creation failed",

--- a/test/e2e/autotls/config/disablenscert/main.go
+++ b/test/e2e/autotls/config/disablenscert/main.go
@@ -67,7 +67,6 @@ func disableNamespaceCertWithExclusions(clients *test.Clients, keepCerts sets.St
 	for _, ns := range namespaces.Items {
 		if keepCerts.Has(ns.Name) {
 			delete(ns.Labels, networking.DisableWildcardCertLabelKey)
-			delete(ns.Labels, networking.DeprecatedDisableWildcardCertLabelKey)
 		} else {
 			if ns.Labels == nil {
 				ns.Labels = make(map[string]string, 1)


### PR DESCRIPTION
As https://github.com/knative/serving/pull/7530 deprecated
`networking.internal.knative.dev/disableWildcardCert` more than 12
months ago, this patch cleans up the deprecated label.

**Release Note**

```release-note
The deprecated label `networking.internal.knative.dev/disableWildcardCert` since v0.15.0 release is completely cleaned up. Use the label `networking.knative.dev/disableWildcardCert` onto namespace to disable namespace certificate provision. 
```
