### PR TITLE
[WIP] Allowing Probes to sidecar containers

### DIFF
--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -360,14 +360,7 @@ func validateContainersPorts(containers []corev1.Container) *apis.FieldError {
 
 // validateSidecarContainer validate fields for non serving containers
 func validateSidecarContainer(ctx context.Context, container corev1.Container, volumes sets.String) (errs *apis.FieldError) {
-	if container.LivenessProbe != nil {
-		errs = errs.Also(apis.CheckDisallowedFields(*container.LivenessProbe,
-			*ProbeMask(&corev1.Probe{})).ViaField("livenessProbe"))
-	}
-	if container.ReadinessProbe != nil {
-		errs = errs.Also(apis.CheckDisallowedFields(*container.ReadinessProbe,
-			*ProbeMask(&corev1.Probe{})).ViaField("readinessProbe"))
-	}
+	// you can add here validations for sidecar container fields
 	return errs.Also(validate(ctx, container, volumes))
 }
 

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -302,7 +302,7 @@ func TestPodSpecMultiContainerValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		name: "flag enabled: probes are not allowed for non serving containers",
+		name: "flag enabled: probes are allowed for non serving containers",
 		ps: corev1.PodSpec{
 			Containers: []corev1.Container{{
 				Image: "busybox",
@@ -319,10 +319,7 @@ func TestPodSpecMultiContainerValidation(t *testing.T) {
 				},
 			}},
 		},
-		want: &apis.FieldError{
-			Message: "must not set the field(s)",
-			Paths:   []string{"containers[1].livenessProbe.timeoutSeconds", "containers[1].readinessProbe.timeoutSeconds"},
-		},
+		want: nil,
 	}, {
 		name: "flag enabled: multiple containers with no port",
 		ps: corev1.PodSpec{

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -832,8 +832,8 @@ func TestMakePodSpec(t *testing.T) {
 		rev: revision("bar", "foo",
 
 			withContainers([]corev1.Container{{
-				Name:           servingContainerName,
-				Image:          "busybox",
+				Name:  servingContainerName,
+				Image: "busybox",
 				Ports: []corev1.ContainerPort{{
 					ContainerPort: v1.DefaultUserPort,
 				}},
@@ -846,10 +846,10 @@ func TestMakePodSpec(t *testing.T) {
 					},
 				},
 			}, {
-				Name: sidecarContainerName2,
-				Image: "busybox",
+				Name:           sidecarContainerName2,
+				Image:          "busybox",
 				ReadinessProbe: withHTTPReadinessProbe(8081),
-				LivenessProbe: withHTTPLivenessProbe(8081),
+				LivenessProbe:  withHTTPLivenessProbe(8081),
 			},
 			}),
 			WithContainerStatuses([]v1.ContainerStatus{{
@@ -894,7 +894,7 @@ func TestMakePodSpec(t *testing.T) {
 				),
 				queueContainer(),
 			}),
-	},  {
+	}, {
 		name: "with tcp liveness probe",
 		rev: revision("bar", "foo",
 			withContainers([]corev1.Container{{


### PR DESCRIPTION
Fixes #8949

This PR is work in progress
I am waiting for my environment to be ready to be able to run e2e tests
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* removing validation for Probes in sidecar containers
* checking that probes are maintained in the sidecar containers when they are set


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
This change in the validation of Knative Revisions allows sidecar containers now to define liveness and readiness probes that will be performed by the kubelet. 
```
