### PR TITLE
Update comment line for config store

### DIFF
--- a/pkg/reconciler/nscert/config/store.go
+++ b/pkg/reconciler/nscert/config/store.go
@@ -42,8 +42,7 @@ func ToContext(ctx context.Context, c *Config) context.Context {
 	return context.WithValue(ctx, cfgKey{}, c)
 }
 
-// Store is based on configmap.UntypedStore and is used to store and watch for
-// updates to configuration related to routes (currently only config-domain).
+// Store is a typed wrapper around configmap.Untyped store to handle our configmaps.
 type Store struct {
 	*configmap.UntypedStore
 }

--- a/pkg/reconciler/route/config/store.go
+++ b/pkg/reconciler/route/config/store.go
@@ -62,8 +62,7 @@ func ToContext(ctx context.Context, c *Config) context.Context {
 	return context.WithValue(ctx, cfgKey{}, c)
 }
 
-// Store is based on configmap.UntypedStore and is used to store and watch for
-// updates to configuration related to routes (currently only config-domain).
+// Store is a typed wrapper around configmap.Untyped store to handle our configmaps.
 //
 // +k8s:deepcopy-gen=false
 type Store struct {


### PR DESCRIPTION
This patch updates outdated comment line.

It mentions `currently only config-domain` but watches other
configmaps.

**Release Note**

```release-note
NONE
```
