### PR TITLE
Use more specific error when Domain Claim does not exist

### DIFF
--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -342,7 +342,7 @@ func (r *Reconciler) reconcileDomainClaim(ctx context.Context, dm *v1alpha1.Doma
 func (r *Reconciler) createDomainClaim(ctx context.Context, dm *v1alpha1.DomainMapping) error {
 	if !config.FromContext(ctx).Network.AutocreateClusterDomainClaims {
 		dm.Status.MarkDomainClaimNotOwned()
-		return fmt.Errorf("namespace %q does not own ClusterDomainClaim for %q", dm.Namespace, dm.Name)
+		return fmt.Errorf("no ClusterDomainClaim found for domain %q", dm.Name)
 	}
 
 	_, err := r.netclient.NetworkingV1alpha1().ClusterDomainClaims().Create(ctx, resources.MakeDomainClaim(dm), metav1.CreateOptions{})

--- a/pkg/reconciler/domainmapping/table_test.go
+++ b/pkg/reconciler/domainmapping/table_test.go
@@ -759,7 +759,7 @@ func TestReconcileAutocreateClaimsDisabled(t *testing.T) {
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", "first-reconcile.com"),
-			Eventf(corev1.EventTypeWarning, "InternalError", `namespace "default" does not own ClusterDomainClaim for "first-reconcile.com"`),
+			Eventf(corev1.EventTypeWarning, "InternalError", `no ClusterDomainClaim found for domain "first-reconcile.com"`),
 		},
 	}, {
 		Name: "first reconcile, claim exists and is owned",


### PR DESCRIPTION
Previously the same error string was used for not found and for found but owned by another namespace. Using a more specific error helps debugging and avoids confusing users (a user in slack was confused by this).

/assign @markusthoemmes @ZhiminXiang 
