### PR TITLE
Drop the use of serving specific metric keys declared in knative.dev/pkg

### DIFF
--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -31,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	network "knative.dev/networking/pkg"
-	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/pkg/metrics/metricstest"
 	_ "knative.dev/pkg/metrics/testing"
 	rtesting "knative.dev/pkg/reconciler/testing"
@@ -39,6 +38,7 @@ import (
 	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
+	"knative.dev/serving/pkg/metrics"
 )
 
 const (
@@ -562,15 +562,15 @@ func TestMetricsReported(t *testing.T) {
 	wantResource := &resource.Resource{
 		Type: "knative_revision",
 		Labels: map[string]string{
-			metricskey.LabelRevisionName:      rev1.Name,
-			metricskey.LabelNamespaceName:     rev1.Namespace,
-			metricskey.LabelServiceName:       "service-" + rev1.Name,
-			metricskey.LabelConfigurationName: "config-" + rev1.Name,
+			metrics.LabelRevisionName:      rev1.Name,
+			metrics.LabelNamespaceName:     rev1.Namespace,
+			metrics.LabelServiceName:       "service-" + rev1.Name,
+			metrics.LabelConfigurationName: "config-" + rev1.Name,
 		},
 	}
 	wantTags := map[string]string{
-		metricskey.PodName:       "the-best-activator",
-		metricskey.ContainerName: "activator",
+		metrics.LabelPodName:       "the-best-activator",
+		metrics.LabelContainerName: "activator",
 	}
 
 	// Should report a concurrency of 3 because the first event was a scale-from-0 (gets discounted)

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -27,11 +27,11 @@ import (
 
 	"go.opencensus.io/resource"
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/pkg/metrics/metricstest"
 	_ "knative.dev/pkg/metrics/testing"
 	"knative.dev/serving/pkg/activator"
 	"knative.dev/serving/pkg/apis/serving"
+	"knative.dev/serving/pkg/metrics"
 )
 
 func TestRequestMetricHandler(t *testing.T) {
@@ -97,17 +97,17 @@ func TestRequestMetricHandler(t *testing.T) {
 				wantResource := &resource.Resource{
 					Type: "knative_revision",
 					Labels: map[string]string{
-						metricskey.LabelNamespaceName:     rev.Namespace,
-						metricskey.LabelServiceName:       rev.Labels[serving.ServiceLabelKey],
-						metricskey.LabelConfigurationName: rev.Labels[serving.ConfigurationLabelKey],
-						metricskey.LabelRevisionName:      rev.Name,
+						metrics.LabelNamespaceName:     rev.Namespace,
+						metrics.LabelServiceName:       rev.Labels[serving.ServiceLabelKey],
+						metrics.LabelConfigurationName: rev.Labels[serving.ConfigurationLabelKey],
+						metrics.LabelRevisionName:      rev.Name,
 					},
 				}
 				wantTags := map[string]string{
-					metricskey.PodName:                testPod,
-					metricskey.ContainerName:          activator.Name,
-					metricskey.LabelResponseCode:      strconv.Itoa(labelCode),
-					metricskey.LabelResponseCodeClass: strconv.Itoa(labelCode/100) + "xx",
+					metrics.LabelPodName:           testPod,
+					metrics.LabelContainerName:     activator.Name,
+					metrics.LabelResponseCode:      strconv.Itoa(labelCode),
+					metrics.LabelResponseCodeClass: strconv.Itoa(labelCode/100) + "xx",
 				}
 
 				metricstest.AssertMetric(t, metricstest.IntMetric(requestCountM.Name(), 1, wantTags).WithResource(wantResource))

--- a/pkg/activator/handler/metrics.go
+++ b/pkg/activator/handler/metrics.go
@@ -57,19 +57,19 @@ func register() {
 			Description: "Concurrent requests that are routed to Activator",
 			Measure:     requestConcurrencyM,
 			Aggregation: view.LastValue(),
-			TagKeys:     []tag.Key{metrics.PodTagKey, metrics.ContainerTagKey},
+			TagKeys:     []tag.Key{metrics.PodKey, metrics.ContainerKey},
 		},
 		&view.View{
 			Description: "The number of requests that are routed to Activator",
 			Measure:     requestCountM,
 			Aggregation: view.Count(),
-			TagKeys:     []tag.Key{metrics.PodTagKey, metrics.ContainerTagKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey},
+			TagKeys:     []tag.Key{metrics.PodKey, metrics.ContainerKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey},
 		},
 		&view.View{
 			Description: "The response time in millisecond",
 			Measure:     responseTimeInMsecM,
 			Aggregation: defaultLatencyDistribution,
-			TagKeys:     []tag.Key{metrics.PodTagKey, metrics.ContainerTagKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey},
+			TagKeys:     []tag.Key{metrics.PodKey, metrics.ContainerKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey},
 		},
 	); err != nil {
 		panic(err)

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -33,7 +33,6 @@ import (
 
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/serving/pkg/autoscaler/metrics"
-	smetrics "knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/resources"
 
 	_ "knative.dev/pkg/metrics/testing"
@@ -587,7 +586,7 @@ func newTestAutoscalerWithScalingMetric(targetValue, targetBurstCapacity float64
 	if startInPanic {
 		pc.readyCount = 2
 	}
-	ctx := smetrics.RevisionContext(testNamespace, "testSvc", "testConfig", testRevision)
+	ctx := servingmetrics.RevisionContext(testNamespace, "testSvc", "testConfig", testRevision)
 	return newAutoscaler(ctx, testNamespace, testRevision, metrics, pc, deciderSpec, nil), pc
 }
 

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -28,8 +28,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/pkg/metrics/metricstest"
+	servingmetrics "knative.dev/serving/pkg/metrics"
 
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/serving/pkg/autoscaler/metrics"
@@ -51,10 +51,10 @@ const (
 var wantResource = &resource.Resource{
 	Type: "knative_revision",
 	Labels: map[string]string{
-		metricskey.LabelConfigurationName: "testConfig",
-		metricskey.LabelNamespaceName:     testNamespace,
-		metricskey.LabelRevisionName:      testRevision,
-		metricskey.LabelServiceName:       "testSvc",
+		servingmetrics.LabelConfigurationName: "testConfig",
+		servingmetrics.LabelNamespaceName:     testNamespace,
+		servingmetrics.LabelRevisionName:      testRevision,
+		servingmetrics.LabelServiceName:       "testSvc",
 	},
 }
 

--- a/pkg/metrics/key.go
+++ b/pkg/metrics/key.go
@@ -21,15 +21,55 @@ import (
 	"knative.dev/pkg/metrics/metricskey"
 )
 
+const (
+	ResourceTypeKnativeRevision = "knative_revision"
+
+	// LabelServiceName is the label for the deployed service name
+	LabelServiceName = "service_name"
+
+	// LabelRouteName is the label for immutable name of the route that receives the request
+	LabelRouteName = "route_name"
+
+	// LabelRouteTag is the label for immutable name of the route tag that receives the request
+	LabelRouteTag = "route_tag"
+
+	// LabelConfigurationName is the label for the configuration which created the monitored revision
+	LabelConfigurationName = "configuration_name"
+
+	// LabelRevisionName is the label for the monitored revision
+	LabelRevisionName = "revision_name"
+
+	// LabelNamespaceName is the label for immutable name of the namespace that the service is deployed
+	LabelNamespaceName = metricskey.LabelNamespaceName
+
+	// ContainerName is the container for which the metric is reported.
+	LabelContainerName = metricskey.ContainerName
+
+	// PodName is the name of the pod for which the metric is reported.
+	LabelPodName = metricskey.PodName
+
+	// LabelResponseCode is the label for the HTTP response status code.
+	LabelResponseCode = metricskey.LabelResponseCode
+
+	// LabelResponseCodeClass is the label for the HTTP response status code class. For example, "2xx", "3xx", etc.
+	LabelResponseCodeClass = metricskey.LabelResponseCodeClass
+
+	// LabelResponseError is the label for client error. For HTTP, A non-2xx status code doesn't cause an error.
+	LabelResponseError = metricskey.LabelResponseError
+
+	// LabelResponseTimeout is the label timeout.
+	LabelResponseTimeout = metricskey.LabelResponseTimeout
+)
+
 // Create the tag keys that will be used to add tags to our measurements.
 // Tag keys must conform to the restrictions described in
 // go.opencensus.io/tag/validate.go. Currently those restrictions are:
 // - length between 1 and 255 inclusive
 // - characters are printable US-ASCII
 var (
-	PodTagKey            = tag.MustNewKey(metricskey.PodName)
-	ContainerTagKey      = tag.MustNewKey(metricskey.ContainerName)
-	ResponseCodeKey      = tag.MustNewKey(metricskey.LabelResponseCode)
-	ResponseCodeClassKey = tag.MustNewKey(metricskey.LabelResponseCodeClass)
-	RouteTagKey          = tag.MustNewKey("route_tag")
+	PodKey               = tag.MustNewKey(LabelPodName)
+	ContainerKey         = tag.MustNewKey(LabelContainerName)
+	ResponseCodeKey      = tag.MustNewKey(LabelResponseCode)
+	ResponseCodeClassKey = tag.MustNewKey(LabelResponseCodeClass)
+	RouteTagKey          = tag.MustNewKey(LabelRouteTag)
 )

--- a/pkg/metrics/key.go
+++ b/pkg/metrics/key.go
@@ -22,6 +22,7 @@ import (
 )
 
 const (
+	// ResourceTypeKnativeRevision is the resource type for Knative revision
 	ResourceTypeKnativeRevision = "knative_revision"
 
 	// LabelServiceName is the label for the deployed service name
@@ -42,10 +43,10 @@ const (
 	// LabelNamespaceName is the label for immutable name of the namespace that the service is deployed
 	LabelNamespaceName = metricskey.LabelNamespaceName
 
-	// ContainerName is the container for which the metric is reported.
+	// LabelContainerName is the container for which the metric is reported.
 	LabelContainerName = metricskey.ContainerName
 
-	// PodName is the name of the pod for which the metric is reported.
+	// LabelPodName is the name of the pod for which the metric is reported.
 	LabelPodName = metricskey.PodName
 
 	// LabelResponseCode is the label for the HTTP response status code.

--- a/pkg/metrics/tags.go
+++ b/pkg/metrics/tags.go
@@ -79,8 +79,8 @@ func PodContext(pod, container string) (context.Context, error) {
 	if !ok {
 		rctx, err := tag.New(
 			context.Background(),
-			tag.Upsert(PodTagKey, pod),
-			tag.Upsert(ContainerTagKey, container))
+			tag.Upsert(PodKey, pod),
+			tag.Upsert(ContainerKey, container))
 		if err != nil {
 			return rctx, err
 		}
@@ -118,12 +118,12 @@ func PodRevisionContext(pod, container, ns, svc, cfg, rev string) (context.Conte
 // AugmentWithRevision augments the given context with a knative_revision resource.
 func AugmentWithRevision(baseCtx context.Context, ns, svc, cfg, rev string) context.Context {
 	r := resource.Resource{
-		Type: metricskey.ResourceTypeKnativeRevision,
+		Type: ResourceTypeKnativeRevision,
 		Labels: map[string]string{
-			metricskey.LabelNamespaceName:     ns,
-			metricskey.LabelServiceName:       valueOrUnknown(svc),
-			metricskey.LabelConfigurationName: cfg,
-			metricskey.LabelRevisionName:      rev,
+			LabelNamespaceName:     ns,
+			LabelServiceName:       valueOrUnknown(svc),
+			LabelConfigurationName: cfg,
+			LabelRevisionName:      rev,
 		},
 	}
 	return metricskey.WithResource(baseCtx, r)

--- a/pkg/metrics/tags_test.go
+++ b/pkg/metrics/tags_test.go
@@ -46,7 +46,7 @@ func register(t *testing.T) func() {
 			Description: "Number of pods autoscaler wants to allocate",
 			Measure:     testM,
 			Aggregation: view.LastValue(),
-			TagKeys:     []tag.Key{ResponseCodeKey, ResponseCodeClassKey, PodTagKey, ContainerTagKey},
+			TagKeys:     []tag.Key{ResponseCodeKey, ResponseCodeClassKey, PodKey, ContainerKey},
 		}); err != nil {
 		t.Fatal("Failed to register view:", err)
 	}

--- a/pkg/queue/request_metric.go
+++ b/pkg/queue/request_metric.go
@@ -75,7 +75,7 @@ type appRequestMetricsHandler struct {
 // NewRequestMetricsHandler creates an http.Handler that emits request metrics.
 func NewRequestMetricsHandler(next http.Handler,
 	ns, service, config, rev, pod string) (http.Handler, error) {
-	keys := []tag.Key{metrics.PodTagKey, metrics.ContainerTagKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey, metrics.RouteTagKey}
+	keys := []tag.Key{metrics.PodKey, metrics.ContainerKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey, metrics.RouteTagKey}
 	if err := pkgmetrics.RegisterResourceView(
 		&view.View{
 			Description: "The number of requests that are routed to queue-proxy",
@@ -137,7 +137,7 @@ func (h *requestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 // NewAppRequestMetricsHandler creates an http.Handler that emits request metrics.
 func NewAppRequestMetricsHandler(next http.Handler, b *Breaker,
 	ns, service, config, rev, pod string) (http.Handler, error) {
-	keys := []tag.Key{metrics.PodTagKey, metrics.ContainerTagKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey}
+	keys := []tag.Key{metrics.PodKey, metrics.ContainerKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey}
 	if err := pkgmetrics.RegisterResourceView(&view.View{
 		Description: "The number of requests that are routed to user-container",
 		Measure:     appRequestCountM,

--- a/pkg/queue/request_metric_test.go
+++ b/pkg/queue/request_metric_test.go
@@ -24,9 +24,9 @@ import (
 
 	"go.opencensus.io/resource"
 	network "knative.dev/networking/pkg"
-	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/pkg/metrics/metricstest"
 	_ "knative.dev/pkg/metrics/testing"
+	"knative.dev/serving/pkg/metrics"
 )
 
 const targetURI = "http://example.com"
@@ -51,19 +51,19 @@ func TestRequestMetricsHandler(t *testing.T) {
 	handler.ServeHTTP(resp, req)
 
 	wantTags := map[string]string{
-		metricskey.PodName:                "pod",
-		metricskey.ContainerName:          "queue-proxy",
-		metricskey.LabelResponseCode:      "200",
-		metricskey.LabelResponseCodeClass: "2xx",
-		"route_tag":                       disabledTagName,
+		metrics.LabelPodName:           "pod",
+		metrics.LabelContainerName:     "queue-proxy",
+		metrics.LabelResponseCode:      "200",
+		metrics.LabelResponseCodeClass: "2xx",
+		"route_tag":                    disabledTagName,
 	}
 	wantResource := &resource.Resource{
 		Type: "knative_revision",
 		Labels: map[string]string{
-			metricskey.LabelNamespaceName:     "ns",
-			metricskey.LabelRevisionName:      "rev",
-			metricskey.LabelServiceName:       "svc",
-			metricskey.LabelConfigurationName: "cfg",
+			metrics.LabelNamespaceName:     "ns",
+			metrics.LabelRevisionName:      "rev",
+			metrics.LabelServiceName:       "svc",
+			metrics.LabelConfigurationName: "cfg",
 		},
 	}
 
@@ -92,19 +92,19 @@ func TestRequestMetricsHandlerWithEnablingTagOnRequestMetrics(t *testing.T) {
 	handler.ServeHTTP(resp, req)
 
 	wantTags := map[string]string{
-		metricskey.PodName:                "pod",
-		metricskey.ContainerName:          "queue-proxy",
-		metricskey.LabelResponseCode:      "200",
-		metricskey.LabelResponseCodeClass: "2xx",
-		"route_tag":                       "test-tag",
+		metrics.LabelPodName:           "pod",
+		metrics.LabelContainerName:     "queue-proxy",
+		metrics.LabelResponseCode:      "200",
+		metrics.LabelResponseCodeClass: "2xx",
+		metrics.LabelRouteTag:          "test-tag",
 	}
 	wantResource := &resource.Resource{
 		Type: "knative_revision",
 		Labels: map[string]string{
-			metricskey.LabelNamespaceName:     "ns",
-			metricskey.LabelRevisionName:      "rev",
-			metricskey.LabelServiceName:       "svc",
-			metricskey.LabelConfigurationName: "cfg",
+			metrics.LabelNamespaceName:     "ns",
+			metrics.LabelRevisionName:      "rev",
+			metrics.LabelServiceName:       "svc",
+			metrics.LabelConfigurationName: "cfg",
 		},
 	}
 
@@ -160,19 +160,19 @@ func TestRequestMetricsHandlerPanickingHandler(t *testing.T) {
 			t.Error("Want ServeHTTP to panic, got nothing.")
 		}
 		wantTags := map[string]string{
-			metricskey.PodName:                "pod",
-			metricskey.ContainerName:          "queue-proxy",
-			metricskey.LabelResponseCode:      "500",
-			metricskey.LabelResponseCodeClass: "5xx",
-			"route_tag":                       disabledTagName,
+			metrics.LabelPodName:           "pod",
+			metrics.LabelContainerName:     "queue-proxy",
+			metrics.LabelResponseCode:      "500",
+			metrics.LabelResponseCodeClass: "5xx",
+			"route_tag":                    disabledTagName,
 		}
 		wantResource := &resource.Resource{
 			Type: "knative_revision",
 			Labels: map[string]string{
-				metricskey.LabelNamespaceName:     "ns",
-				metricskey.LabelRevisionName:      "rev",
-				metricskey.LabelServiceName:       "svc",
-				metricskey.LabelConfigurationName: "cfg",
+				metrics.LabelNamespaceName:     "ns",
+				metrics.LabelRevisionName:      "rev",
+				metrics.LabelServiceName:       "svc",
+				metrics.LabelConfigurationName: "cfg",
 			},
 		}
 		metricstest.AssertMetric(t, metricstest.IntMetric("request_count", 1, wantTags).WithResource(wantResource))
@@ -228,18 +228,18 @@ func TestAppRequestMetricsHandlerPanickingHandler(t *testing.T) {
 			t.Error("Want ServeHTTP to panic, got nothing.")
 		}
 		wantTags := map[string]string{
-			metricskey.PodName:                "pod",
-			metricskey.ContainerName:          "queue-proxy",
-			metricskey.LabelResponseCode:      "500",
-			metricskey.LabelResponseCodeClass: "5xx",
+			metrics.LabelPodName:           "pod",
+			metrics.LabelContainerName:     "queue-proxy",
+			metrics.LabelResponseCode:      "500",
+			metrics.LabelResponseCodeClass: "5xx",
 		}
 		wantResource := &resource.Resource{
 			Type: "knative_revision",
 			Labels: map[string]string{
-				metricskey.LabelNamespaceName:     "ns",
-				metricskey.LabelRevisionName:      "rev",
-				metricskey.LabelServiceName:       "svc",
-				metricskey.LabelConfigurationName: "cfg",
+				metrics.LabelNamespaceName:     "ns",
+				metrics.LabelRevisionName:      "rev",
+				metrics.LabelServiceName:       "svc",
+				metrics.LabelConfigurationName: "cfg",
 			},
 		}
 
@@ -264,18 +264,18 @@ func TestAppRequestMetricsHandler(t *testing.T) {
 	handler.ServeHTTP(resp, req)
 
 	wantTags := map[string]string{
-		metricskey.PodName:                "pod",
-		metricskey.ContainerName:          "queue-proxy",
-		metricskey.LabelResponseCode:      "200",
-		metricskey.LabelResponseCodeClass: "2xx",
+		metrics.LabelPodName:           "pod",
+		metrics.LabelContainerName:     "queue-proxy",
+		metrics.LabelResponseCode:      "200",
+		metrics.LabelResponseCodeClass: "2xx",
 	}
 	wantResource := &resource.Resource{
 		Type: "knative_revision",
 		Labels: map[string]string{
-			metricskey.LabelNamespaceName:     "ns",
-			metricskey.LabelRevisionName:      "rev",
-			metricskey.LabelServiceName:       "svc",
-			metricskey.LabelConfigurationName: "cfg",
+			metrics.LabelNamespaceName:     "ns",
+			metrics.LabelRevisionName:      "rev",
+			metrics.LabelServiceName:       "svc",
+			metrics.LabelConfigurationName: "cfg",
 		},
 	}
 

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -39,6 +39,7 @@ import (
 	fakemetricinformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/metric/fake"
 	fakepainformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler/fake"
 	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
+	"knative.dev/serving/pkg/metrics"
 
 	networkingclient "knative.dev/networking/pkg/client/injection/client"
 	filteredinformerfactory "knative.dev/pkg/client/injection/kube/informers/factory/filtered"
@@ -66,7 +67,6 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/metrics/metricskey"
 	"knative.dev/pkg/metrics/metricstest"
 	_ "knative.dev/pkg/metrics/testing"
 	"knative.dev/pkg/ptr"
@@ -1785,10 +1785,10 @@ func TestMetricsReporter(t *testing.T) {
 	wantResource := &resource.Resource{
 		Type: "knative_revision",
 		Labels: map[string]string{
-			metricskey.LabelRevisionName:      testRevision,
-			metricskey.LabelNamespaceName:     testNamespace,
-			metricskey.LabelServiceName:       pa.Labels[serving.ServiceLabelKey],
-			metricskey.LabelConfigurationName: pa.Labels[serving.ConfigurationLabelKey],
+			metrics.LabelRevisionName:      testRevision,
+			metrics.LabelNamespaceName:     testNamespace,
+			metrics.LabelServiceName:       pa.Labels[serving.ServiceLabelKey],
+			metrics.LabelConfigurationName: pa.Labels[serving.ConfigurationLabelKey],
 		},
 	}
 	pc := podCounts{


### PR DESCRIPTION
Part of: https://github.com/knative/pkg/issues/608

- 🧹 moves serving metric constants in knative.dev/pkg to here