### PR TITLE
add memory metrics for hpa

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -158,11 +158,9 @@ func validateLastPodRetention(annotations map[string]string) *apis.FieldError {
 
 func validateWindow(annotations map[string]string) *apis.FieldError {
 	if w, ok := annotations[WindowAnnotationKey]; ok {
-		if annotations[ClassAnnotationKey] == HPA && annotations[MetricAnnotationKey] == CPU {
-			return apis.ErrInvalidKeyName(WindowAnnotationKey, apis.CurrentField, fmt.Sprintf("%s for %s %s", HPA, MetricAnnotationKey, CPU))
-		}
-		if annotations[ClassAnnotationKey] == HPA && annotations[MetricAnnotationKey] == Memory {
-			return apis.ErrInvalidKeyName(WindowAnnotationKey, apis.CurrentField, fmt.Sprintf("%s for %s %s", HPA, MetricAnnotationKey, Memory))
+		if annotations[ClassAnnotationKey] == HPA && (annotations[MetricAnnotationKey] == CPU || annotations[MetricAnnotationKey] == Memory) {
+			return apis.ErrInvalidKeyName(WindowAnnotationKey, apis.CurrentField, fmt.Sprintf("%s for %s %s", HPA,
+				MetricAnnotationKey, annotations[MetricAnnotationKey]))
 		}
 		switch d, err := time.ParseDuration(w); {
 		case err != nil:
@@ -228,9 +226,7 @@ func validateMetric(annotations map[string]string) *apis.FieldError {
 			}
 		case HPA:
 			switch metric {
-			case CPU:
-				return nil
-			case Memory:
+			case CPU, Memory:
 				return nil
 			}
 		default:

--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -161,6 +161,9 @@ func validateWindow(annotations map[string]string) *apis.FieldError {
 		if annotations[ClassAnnotationKey] == HPA && annotations[MetricAnnotationKey] == CPU {
 			return apis.ErrInvalidKeyName(WindowAnnotationKey, apis.CurrentField, fmt.Sprintf("%s for %s %s", HPA, MetricAnnotationKey, CPU))
 		}
+		if annotations[ClassAnnotationKey] == HPA && annotations[MetricAnnotationKey] == Memory {
+			return apis.ErrInvalidKeyName(WindowAnnotationKey, apis.CurrentField, fmt.Sprintf("%s for %s %s", HPA, MetricAnnotationKey, Memory))
+		}
 		switch d, err := time.ParseDuration(w); {
 		case err != nil:
 			return apis.ErrInvalidValue(w, WindowAnnotationKey)
@@ -226,6 +229,8 @@ func validateMetric(annotations map[string]string) *apis.FieldError {
 		case HPA:
 			switch metric {
 			case CPU:
+				return nil
+			case Memory:
 				return nil
 			}
 		default:

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -62,6 +62,8 @@ const (
 	Concurrency = "concurrency"
 	// CPU is the amount of the requested cpu actually being consumed by the Pod.
 	CPU = "cpu"
+	// Memory is the amount of the requested memory actually being consumed by the Pod.
+	Memory = "memory"
 	// RPS is the requests per second reaching the Pod.
 	RPS = "rps"
 
@@ -69,6 +71,9 @@ const (
 	// PodAutoscaler should attempt to maintain. For example,
 	//   autoscaling.knative.dev/metric: cpu
 	//   autoscaling.knative.dev/target: "75"   # target 75% cpu utilization
+	// Or
+	//   autoscaling.knative.dev/metric: memory
+	//   autoscaling.knative.dev/target: "100"   # target 100MiB utilization
 	TargetAnnotationKey = GroupName + "/target"
 	// TargetMin is the minimum allowable target.
 	// This can be less than 1 due to the fact that with small container

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -73,7 +73,7 @@ const (
 	//   autoscaling.knative.dev/target: "75"   # target 75% cpu utilization
 	// Or
 	//   autoscaling.knative.dev/metric: memory
-	//   autoscaling.knative.dev/target: "100"   # target 100MiB utilization
+	//   autoscaling.knative.dev/target: "100"   # target 100MiB memory usage
 	TargetAnnotationKey = GroupName + "/target"
 	// TargetMin is the minimum allowable target.
 	// This can be less than 1 due to the fact that with small container

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	"math"
-	"strconv"
 
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -74,12 +73,12 @@ func MakeHPA(pa *v1alpha1.PodAutoscaler, config *autoscalerconfig.Config) *autos
 
 	case autoscaling.Memory:
 		if target, ok := pa.Target(); ok {
-			memory := resource.MustParse(strconv.Itoa(int(math.Ceil(target))) + "Mi")
+			memory := resource.NewQuantity(int64(target)*1024*1024, resource.BinarySI)
 			hpa.Spec.Metrics = []autoscalingv2beta1.MetricSpec{{
 				Type: autoscalingv2beta1.ResourceMetricSourceType,
 				Resource: &autoscalingv2beta1.ResourceMetricSource{
 					Name:               corev1.ResourceMemory,
-					TargetAverageValue: &memory,
+					TargetAverageValue: memory,
 				},
 			}}
 		}

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -60,7 +60,8 @@ func MakeHPA(pa *v1alpha1.PodAutoscaler, config *autoscalerconfig.Config) *autos
 		hpa.Spec.MinReplicas = &min
 	}
 
-	if pa.Metric() == autoscaling.CPU {
+	switch pa.Metric() {
+	case autoscaling.CPU:
 		if target, ok := pa.Target(); ok {
 			hpa.Spec.Metrics = []autoscalingv2beta1.MetricSpec{{
 				Type: autoscalingv2beta1.ResourceMetricSourceType,
@@ -70,9 +71,8 @@ func MakeHPA(pa *v1alpha1.PodAutoscaler, config *autoscalerconfig.Config) *autos
 				},
 			}}
 		}
-	}
 
-	if pa.Metric() == autoscaling.Memory {
+	case autoscaling.Memory:
 		if target, ok := pa.Target(); ok {
 			memory := resource.MustParse(strconv.Itoa(int(math.Ceil(target))) + "Mi")
 			hpa.Spec.Metrics = []autoscalingv2beta1.MetricSpec{{
@@ -84,5 +84,6 @@ func MakeHPA(pa *v1alpha1.PodAutoscaler, config *autoscalerconfig.Config) *autos
 			}}
 		}
 	}
+
 	return hpa
 }

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
@@ -80,11 +80,8 @@ func TestMakeHPA(t *testing.T) {
 			withMetric(autoscalingv2beta1.MetricSpec{
 				Type: autoscalingv2beta1.ResourceMetricSourceType,
 				Resource: &autoscalingv2beta1.ResourceMetricSource{
-					Name: corev1.ResourceMemory,
-					TargetAverageValue: func() *resource.Quantity {
-						res := resource.MustParse("50Mi")
-						return &res
-					}(),
+					Name:               corev1.ResourceMemory,
+					TargetAverageValue: resource.NewQuantity(50*1024*1024, resource.BinarySI),
 				},
 			})),
 	}, {

--- a/test/e2e/autoscale_hpa_test.go
+++ b/test/e2e/autoscale_hpa_test.go
@@ -44,7 +44,6 @@ import (
 
 const (
 	cpuTarget             = 75
-	memoryTarget          = 20
 	targetPods            = 5
 	concurrency           = 10
 	scaleUpTimeout        = 3 * time.Minute
@@ -54,16 +53,8 @@ const (
 	primeNum              = 1000000
 )
 
-func TestHPAAutoscaleUpDownUpWithCPUTarget(t *testing.T) {
+func TestHPAAutoscaleUpDownUp(t *testing.T) {
 	ctx := setupHPASvc(t, autoscaling.CPU, cpuTarget)
-	test.EnsureTearDown(t, ctx.Clients(), ctx.Names())
-	assertHPAAutoscaleUpToNumPods(ctx, targetPods, time.After(scaleUpTimeout), true /* quick */)
-	assertScaleDownToOne(ctx)
-	assertHPAAutoscaleUpToNumPods(ctx, targetPods, time.After(scaleUpTimeout), true /* quick */)
-}
-
-func TestHPAAutoscaleUpDownUpWithMemoryTarget(t *testing.T) {
-	ctx := setupHPASvc(t, autoscaling.Memory, memoryTarget)
 	test.EnsureTearDown(t, ctx.Clients(), ctx.Names())
 	assertHPAAutoscaleUpToNumPods(ctx, targetPods, time.After(scaleUpTimeout), true /* quick */)
 	assertScaleDownToOne(ctx)

--- a/test/e2e/autoscale_hpa_test.go
+++ b/test/e2e/autoscale_hpa_test.go
@@ -44,6 +44,7 @@ import (
 
 const (
 	cpuTarget             = 75
+	memoryTarget          = 20
 	targetPods            = 5
 	concurrency           = 10
 	scaleUpTimeout        = 3 * time.Minute
@@ -53,8 +54,16 @@ const (
 	primeNum              = 1000000
 )
 
-func TestHPAAutoscaleUpDownUp(t *testing.T) {
+func TestHPAAutoscaleUpDownUpWithCPUTarget(t *testing.T) {
 	ctx := setupHPASvc(t, autoscaling.CPU, cpuTarget)
+	test.EnsureTearDown(t, ctx.Clients(), ctx.Names())
+	assertHPAAutoscaleUpToNumPods(ctx, targetPods, time.After(scaleUpTimeout), true /* quick */)
+	assertScaleDownToOne(ctx)
+	assertHPAAutoscaleUpToNumPods(ctx, targetPods, time.After(scaleUpTimeout), true /* quick */)
+}
+
+func TestHPAAutoscaleUpDownUpWithMemoryTarget(t *testing.T) {
+	ctx := setupHPASvc(t, autoscaling.Memory, memoryTarget)
 	test.EnsureTearDown(t, ctx.Clients(), ctx.Names())
 	assertHPAAutoscaleUpToNumPods(ctx, targetPods, time.After(scaleUpTimeout), true /* quick */)
 	assertScaleDownToOne(ctx)


### PR DESCRIPTION
Fixes #11635

<!-- Please include the 'why' behind your changes if no issue exists -->


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
add memory metrics for HPA: "hpa.autoscaling.knative.dev"
```
