### PR TITLE
Add support for emptyDir volume type

### DIFF
--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -519,6 +519,20 @@ spec:
                                   optional:
                                     description: Specify whether the ConfigMap or its keys must be defined
                                     type: boolean
+                              emptyDir:
+                                description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                type: object
+                                properties:
+                                  medium:
+                                    description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    type: string
+                                  sizeLimit:
+                                    description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
                               name:
                                 description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string

--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -519,20 +519,6 @@ spec:
                                   optional:
                                     description: Specify whether the ConfigMap or its keys must be defined
                                     type: boolean
-                              emptyDir:
-                                description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                                type: object
-                                properties:
-                                  medium:
-                                    description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                                    type: string
-                                  sizeLimit:
-                                    description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    x-kubernetes-int-or-string: true
                               name:
                                 description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
@@ -661,6 +647,7 @@ spec:
                                   secretName:
                                     description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
+                            x-kubernetes-preserve-unknown-fields: true
                       x-kubernetes-preserve-unknown-fields: true
             status:
               description: ConfigurationStatus communicates the observed state of the Configuration (from the controller).

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -498,6 +498,20 @@ spec:
                           optional:
                             description: Specify whether the ConfigMap or its keys must be defined
                             type: boolean
+                      emptyDir:
+                        description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: object
+                        properties:
+                          medium:
+                            description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            type: string
+                          sizeLimit:
+                            description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            x-kubernetes-int-or-string: true
                       name:
                         description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -498,20 +498,6 @@ spec:
                           optional:
                             description: Specify whether the ConfigMap or its keys must be defined
                             type: boolean
-                      emptyDir:
-                        description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                        type: object
-                        properties:
-                          medium:
-                            description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                            type: string
-                          sizeLimit:
-                            description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            x-kubernetes-int-or-string: true
                       name:
                         description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
@@ -640,6 +626,7 @@ spec:
                           secretName:
                             description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                             type: string
+                    x-kubernetes-preserve-unknown-fields: true
               x-kubernetes-preserve-unknown-fields: true
             status:
               description: RevisionStatus communicates the observed state of the Revision (from the controller).

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -523,6 +523,20 @@ spec:
                                   optional:
                                     description: Specify whether the ConfigMap or its keys must be defined
                                     type: boolean
+                              emptyDir:
+                                description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                type: object
+                                properties:
+                                  medium:
+                                    description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    type: string
+                                  sizeLimit:
+                                    description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
                               name:
                                 description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -523,20 +523,6 @@ spec:
                                   optional:
                                     description: Specify whether the ConfigMap or its keys must be defined
                                     type: boolean
-                              emptyDir:
-                                description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                                type: object
-                                properties:
-                                  medium:
-                                    description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                                    type: string
-                                  sizeLimit:
-                                    description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    x-kubernetes-int-or-string: true
                               name:
                                 description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
@@ -665,6 +651,7 @@ spec:
                                   secretName:
                                     description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
+                            x-kubernetes-preserve-unknown-fields: true
                       x-kubernetes-preserve-unknown-fields: true
                 traffic:
                   description: Traffic specifies how to distribute traffic over a collection of revisions and configurations.

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "229ea20a"
+    knative.dev/example-checksum: "3bac317a"
 data:
   _example: |-
     ################################
@@ -132,7 +132,7 @@ data:
     # 2. Disabled: http2 connection will only be attempted when port name is set to "h2c".
     autodetect-http2: "disabled"
 
-    # Controls whether volume supporty for EmptyDir is enabled or not.
+    # Controls whether volume support for EmptyDir is enabled or not.
     # 1. Enabled: enabling EmptyDir volume support
     # 2. Disabled: disabling EmptyDir volume support
     kubernetes.podspec-volumes-emptydir: "disabled"

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "8c1f8302"
+    knative.dev/example-checksum: "229ea20a"
 data:
   _example: |-
     ################################
@@ -131,3 +131,8 @@ data:
     # 1. Enabled: http2 connection will be attempted via upgrade.
     # 2. Disabled: http2 connection will only be attempted when port name is set to "h2c".
     autodetect-http2: "disabled"
+
+    # Controls whether volume supporty for EmptyDir is enabled or not.
+    # 1. Enabled: enabling EmptyDir volume support
+    # 2. Disabled: disabling EmptyDir volume support
+    kubernetes.podspec-volumes-emptydir: "disabled"

--- a/hack/schemapatch-config.yaml
+++ b/hack/schemapatch-config.yaml
@@ -5,11 +5,11 @@ k8s.io/api/core/v1.Volume:
     - Name
     - VolumeSource
 k8s.io/api/core/v1.VolumeSource:
+  preserveUnknownFields: true # for feature flagged fields
   allowedFields:
     - Secret
     - ConfigMap
     - Projected
-    - EmptyDir
 k8s.io/api/core/v1.VolumeProjection:
   allowedFields:
     - Secret

--- a/hack/schemapatch-config.yaml
+++ b/hack/schemapatch-config.yaml
@@ -9,6 +9,7 @@ k8s.io/api/core/v1.VolumeSource:
     - Secret
     - ConfigMap
     - Projected
+    - EmptyDir
 k8s.io/api/core/v1.VolumeProjection:
   allowedFields:
     - Secret

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -72,9 +72,9 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 		asFlag("kubernetes.podspec-securitycontext", &nc.PodSpecSecurityContext),
 		asFlag("kubernetes.containerspec-addcapabilities", &nc.ContainerSpecAddCapabilities),
 		asFlag("kubernetes.podspec-tolerations", &nc.PodSpecTolerations),
+		asFlag("kubernetes.podspec-volumes-emptydir", &nc.PodSpecVolumesEmptyDir),
 		asFlag("tag-header-based-routing", &nc.TagHeaderBasedRouting),
-		asFlag("autodetect-http2", &nc.AutoDetectHTTP2),
-		asFlag("kubernetes.podspec-volumes-emptydir", &nc.PodSpecVolumesEmptyDir)); err != nil {
+		asFlag("autodetect-http2", &nc.AutoDetectHTTP2)); err != nil {
 		return nil, err
 	}
 	return nc, nil
@@ -97,9 +97,9 @@ type Features struct {
 	PodSpecSecurityContext       Flag
 	ContainerSpecAddCapabilities Flag
 	PodSpecTolerations           Flag
+	PodSpecVolumesEmptyDir       Flag
 	TagHeaderBasedRouting        Flag
 	AutoDetectHTTP2              Flag
-	PodSpecVolumesEmptyDir       Flag
 }
 
 // asFlag parses the value at key as a Flag into the target, if it exists.

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -53,6 +53,7 @@ func defaultFeaturesConfig() *Features {
 		PodSpecTolerations:           Disabled,
 		TagHeaderBasedRouting:        Disabled,
 		AutoDetectHTTP2:              Disabled,
+		PodSpecVolumesEmptyDir:       Disabled,
 	}
 }
 
@@ -72,7 +73,8 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 		asFlag("kubernetes.containerspec-addcapabilities", &nc.ContainerSpecAddCapabilities),
 		asFlag("kubernetes.podspec-tolerations", &nc.PodSpecTolerations),
 		asFlag("tag-header-based-routing", &nc.TagHeaderBasedRouting),
-		asFlag("autodetect-http2", &nc.AutoDetectHTTP2)); err != nil {
+		asFlag("autodetect-http2", &nc.AutoDetectHTTP2),
+		asFlag("kubernetes.podspec-volumes-emptydir", &nc.PodSpecVolumesEmptyDir)); err != nil {
 		return nil, err
 	}
 	return nc, nil
@@ -97,6 +99,7 @@ type Features struct {
 	PodSpecTolerations           Flag
 	TagHeaderBasedRouting        Flag
 	AutoDetectHTTP2              Flag
+	PodSpecVolumesEmptyDir       Flag
 }
 
 // asFlag parses the value at key as a Flag into the target, if it exists.

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -51,9 +51,9 @@ func defaultFeaturesConfig() *Features {
 		PodSpecSecurityContext:       Disabled,
 		ContainerSpecAddCapabilities: Disabled,
 		PodSpecTolerations:           Disabled,
+		PodSpecVolumesEmptyDir:       Disabled,
 		TagHeaderBasedRouting:        Disabled,
 		AutoDetectHTTP2:              Disabled,
-		PodSpecVolumesEmptyDir:       Disabled,
 	}
 }
 

--- a/pkg/apis/config/features_test.go
+++ b/pkg/apis/config/features_test.go
@@ -305,6 +305,24 @@ func TestFeaturesConfiguration(t *testing.T) {
 		data: map[string]string{
 			"tag-header-based-routing": "Enabled",
 		},
+	}, {
+		name:    "kubernetes.podspec-volumes-emptyDir Disabled",
+		wantErr: false,
+		wantFeatures: defaultWith(&Features{
+			PodSpecVolumesEmptyDir: Disabled,
+		}),
+		data: map[string]string{
+			"kubernetes.podspec-volumes-emptydir": "Disabled",
+		},
+	}, {
+		name:    "kubernetes.podspec-volumes-emptyDir Enabled",
+		wantErr: false,
+		wantFeatures: defaultWith(&Features{
+			PodSpecVolumesEmptyDir: Enabled,
+		}),
+		data: map[string]string{
+			"kubernetes.podspec-volumes-emptydir": "Enabled",
+		},
 	}}
 
 	for _, tt := range configTests {

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -38,6 +38,7 @@ func VolumeMask(in *corev1.Volume) *corev1.Volume {
 
 	// Allowed fields
 	out.Name = in.Name
+	out.EmptyDir = in.EmptyDir
 	out.VolumeSource = in.VolumeSource
 
 	return out
@@ -57,6 +58,7 @@ func VolumeSourceMask(in *corev1.VolumeSource) *corev1.VolumeSource {
 	out.Secret = in.Secret
 	out.ConfigMap = in.ConfigMap
 	out.Projected = in.Projected
+	out.EmptyDir = in.EmptyDir
 
 	// Too many disallowed fields to list
 

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -29,17 +29,21 @@ import (
 // VolumeMask performs a _shallow_ copy of the Kubernetes Volume object to a new
 // Kubernetes Volume object bringing over only the fields allowed in the Knative API. This
 // does not validate the contents or the bounds of the provided fields.
-func VolumeMask(in *corev1.Volume) *corev1.Volume {
+func VolumeMask(ctx context.Context, in *corev1.Volume) *corev1.Volume {
 	if in == nil {
 		return nil
 	}
+	cfg := config.FromContextOrDefaults(ctx)
 
 	out := new(corev1.Volume)
 
 	// Allowed fields
 	out.Name = in.Name
-	out.EmptyDir = in.EmptyDir
 	out.VolumeSource = in.VolumeSource
+
+	if cfg.Features.PodSpecVolumesEmptyDir != config.Disabled {
+		out.EmptyDir = in.EmptyDir
+	}
 
 	return out
 }
@@ -47,18 +51,21 @@ func VolumeMask(in *corev1.Volume) *corev1.Volume {
 // VolumeSourceMask performs a _shallow_ copy of the Kubernetes VolumeSource object to a new
 // Kubernetes VolumeSource object bringing over only the fields allowed in the Knative API. This
 // does not validate the contents or the bounds of the provided fields.
-func VolumeSourceMask(in *corev1.VolumeSource) *corev1.VolumeSource {
+func VolumeSourceMask(ctx context.Context, in *corev1.VolumeSource) *corev1.VolumeSource {
 	if in == nil {
 		return nil
 	}
-
+	cfg := config.FromContextOrDefaults(ctx)
 	out := new(corev1.VolumeSource)
 
 	// Allowed fields
 	out.Secret = in.Secret
 	out.ConfigMap = in.ConfigMap
 	out.Projected = in.Projected
-	out.EmptyDir = in.EmptyDir
+
+	if cfg.Features.PodSpecVolumesEmptyDir != config.Disabled {
+		out.EmptyDir = in.EmptyDir
+	}
 
 	// Too many disallowed fields to list
 

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -34,7 +34,7 @@ func TestVolumeMask(t *testing.T) {
 	}
 	in := want
 
-	got := VolumeMask(in)
+	got := VolumeMask(context.Background(), in)
 
 	if &want == &got {
 		t.Error("Input and output share addresses. Want different addresses")
@@ -46,7 +46,7 @@ func TestVolumeMask(t *testing.T) {
 		t.Error("VolumeMask (-want, +got):", diff)
 	}
 
-	if got = VolumeMask(nil); got != nil {
+	if got = VolumeMask(context.Background(), nil); got != nil {
 		t.Errorf("VolumeMask(nil) = %v, want: nil", got)
 	}
 }
@@ -62,7 +62,7 @@ func TestVolumeSourceMask(t *testing.T) {
 		NFS:       &corev1.NFSVolumeSource{},
 	}
 
-	got := VolumeSourceMask(in)
+	got := VolumeSourceMask(context.Background(), in)
 
 	if &want == &got {
 		t.Error("Input and output share addresses. Want different addresses")
@@ -74,7 +74,7 @@ func TestVolumeSourceMask(t *testing.T) {
 		t.Error("VolumeSourceMask (-want, +got):", diff)
 	}
 
-	if got = VolumeSourceMask(nil); got != nil {
+	if got = VolumeSourceMask(context.Background(), nil); got != nil {
 		t.Errorf("VolumeSourceMask(nil) = %v, want: nil", got)
 	}
 }

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -1520,7 +1520,7 @@ func TestVolumeValidation(t *testing.T) {
 		v: corev1.Volume{
 			Name: "foo",
 		},
-		want: apis.ErrMissingOneOf("secret", "configMap", "projected"),
+		want: apis.ErrMissingOneOf("secret", "configMap", "projected", "emptyDir"),
 	}, {
 		name: "secret volume",
 		v: corev1.Volume{
@@ -1546,17 +1546,30 @@ func TestVolumeValidation(t *testing.T) {
 		v: corev1.Volume{
 			Name: "foo",
 			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium:    "Memory",
+					SizeLimit: resource.NewQuantity(400, "G"),
+				},
 			},
 		},
-		want: apis.ErrMissingOneOf("secret", "configMap", "projected").Also(
-			apis.ErrDisallowedFields("emptyDir")),
+	}, {
+		name: "invalid emptyDir volume",
+		v: corev1.Volume{
+			Name: "foo",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium:    "Memory",
+					SizeLimit: resource.NewQuantity(-1, "G"),
+				},
+			},
+		},
+		want: apis.ErrInvalidValue(-1, "emptyDir.sizeLimit"),
 	}, {
 		name: "no volume source",
 		v: corev1.Volume{
 			Name: "foo",
 		},
-		want: apis.ErrMissingOneOf("secret", "configMap", "projected"),
+		want: apis.ErrMissingOneOf("secret", "configMap", "projected", "emptyDir"),
 	}, {
 		name: "multiple volume source",
 		v: corev1.Volume{

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -370,14 +370,15 @@ func testConfig() *config.Config {
 			TagTemplate:         network.DefaultTagTemplate,
 		},
 		Features: &apiConfig.Features{
-			MultiContainer:        apiConfig.Disabled,
-			PodSpecAffinity:       apiConfig.Disabled,
-			PodSpecFieldRef:       apiConfig.Disabled,
-			PodSpecDryRun:         apiConfig.Enabled,
-			PodSpecHostAliases:    apiConfig.Disabled,
-			PodSpecNodeSelector:   apiConfig.Disabled,
-			PodSpecTolerations:    apiConfig.Disabled,
-			TagHeaderBasedRouting: apiConfig.Disabled,
+			MultiContainer:         apiConfig.Disabled,
+			PodSpecAffinity:        apiConfig.Disabled,
+			PodSpecFieldRef:        apiConfig.Disabled,
+			PodSpecDryRun:          apiConfig.Enabled,
+			PodSpecHostAliases:     apiConfig.Disabled,
+			PodSpecNodeSelector:    apiConfig.Disabled,
+			PodSpecTolerations:     apiConfig.Disabled,
+			PodSpecVolumesEmptyDir: apiConfig.Disabled,
+			TagHeaderBasedRouting:  apiConfig.Disabled,
 		},
 	}
 }


### PR DESCRIPTION
Part of work in #11664 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds the required feature flag `kubernetes.podspec-volumes-emptydir`, updates the related CRD and apis.
* Updates related unit tests
* Validates EmptyDir contents. A bit stricter with the negative values compared to what K8s does [here](https://github.com/kubernetes/kubernetes/blob/4d78db54a58e250b049c4fe17ac484e5c3ec662d/pkg/volume/emptydir/empty_dir.go#L137).

Tested manually, test cases and results [here](https://gist.github.com/skonto/fc374cdd4ffeb914c3f950540ffa5ad8).

/cc @dprotaso @julz @markusthoemmes 