### PR TITLE
Add labels and annotations to metrics

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -230,9 +230,11 @@ func uniScalerFactoryFunc(podLister corev1listers.PodLister,
 			return nil, fmt.Errorf("label %q not found or empty in Decider %s", serving.RevisionLabelKey, decider.Name)
 		}
 		serviceName := decider.Labels[serving.ServiceLabelKey] // This can be empty.
+		annotations := decider.Annotations
+		labels := decider.Labels
 
 		// Create a stats reporter which tags statistics by PA namespace, configuration name, and PA name.
-		ctx := smetrics.RevisionContext(decider.Namespace, serviceName, configName, revisionName)
+		ctx := smetrics.RevisionContext(decider.Namespace, serviceName, configName, revisionName, annotations, labels)
 
 		podAccessor := resources.NewPodAccessor(podLister, decider.Namespace, revisionName)
 		return scaling.New(ctx, decider.Namespace, decider.Name, metricClient,

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -417,7 +417,7 @@ func pushRequestLogHandler(logger *zap.SugaredLogger, currentHandler http.Handle
 
 func requestMetricsHandler(logger *zap.SugaredLogger, currentHandler http.Handler, env config) http.Handler {
 	h, err := queue.NewRequestMetricsHandler(currentHandler, env.ServingNamespace,
-		env.ServingService, env.ServingConfiguration, env.ServingRevision, env.ServingPod)
+		env.ServingService, env.ServingConfiguration, env.ServingRevision, env.ServingPod, map[string]string{}, map[string]string{})
 	if err != nil {
 		logger.Errorw("Error setting up request metrics reporter. Request metrics will be unavailable.", zap.Error(err))
 		return currentHandler
@@ -427,7 +427,7 @@ func requestMetricsHandler(logger *zap.SugaredLogger, currentHandler http.Handle
 
 func requestAppMetricsHandler(logger *zap.SugaredLogger, currentHandler http.Handler, breaker *queue.Breaker, env config) http.Handler {
 	h, err := queue.NewAppRequestMetricsHandler(currentHandler, breaker, env.ServingNamespace,
-		env.ServingService, env.ServingConfiguration, env.ServingRevision, env.ServingPod)
+		env.ServingService, env.ServingConfiguration, env.ServingRevision, env.ServingPod, map[string]string{}, map[string]string{})
 	if err != nil {
 		logger.Errorw("Error setting up app request metrics reporter. Request metrics will be unavailable.", zap.Error(err))
 		return currentHandler

--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -211,7 +211,7 @@ func (cr *ConcurrencyReporter) reportToMetricsBackend(key types.NamespacedName, 
 	configurationName := revision.Labels[serving.ConfigurationLabelKey]
 	serviceName := revision.Labels[serving.ServiceLabelKey]
 
-	reporterCtx, _ := metrics.PodRevisionContext(cr.podName, activator.Name, ns, serviceName, configurationName, revName)
+	reporterCtx, _ := metrics.PodRevisionContext(cr.podName, activator.Name, ns, serviceName, configurationName, revName, revision.GetAnnotations(), revision.GetLabels())
 	pkgmetrics.Record(reporterCtx, requestConcurrencyM.M(concurrency))
 }
 

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -575,7 +575,7 @@ func TestMetricsReported(t *testing.T) {
 
 	// Should report a concurrency of 3 because the first event was a scale-from-0 (gets discounted)
 	wantMetric := metricstest.FloatMetric("request_concurrency", 3, wantTags).WithResource(wantResource)
-	metricstest.AssertMetric(t, wantMetric)
+	metricstest.AssertMetricRequiredOnly(t, wantMetric)
 
 	// Report again
 	reportCh <- now.Add(2)
@@ -583,7 +583,7 @@ func TestMetricsReported(t *testing.T) {
 
 	// The next time round we should report the "real" concurrency
 	wantMetric = metricstest.FloatMetric("request_concurrency", 4, wantTags).WithResource(wantResource)
-	metricstest.AssertMetric(t, wantMetric)
+	metricstest.AssertMetricRequiredOnly(t, wantMetric)
 }
 
 func newTestReporter(t *testing.T) (*ConcurrencyReporter, context.Context, context.CancelFunc) {

--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -44,7 +44,7 @@ type MetricHandler struct {
 func (h *MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rev := RevisionFrom(r.Context())
 	reporterCtx, _ := metrics.PodRevisionContext(h.podName, activator.Name,
-		rev.Namespace, rev.Labels[serving.ServiceLabelKey], rev.Labels[serving.ConfigurationLabelKey], rev.Name)
+		rev.Namespace, rev.Labels[serving.ServiceLabelKey], rev.Labels[serving.ConfigurationLabelKey], rev.Name, rev.GetAnnotations(), rev.GetLabels())
 
 	start := time.Now()
 

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -110,8 +110,8 @@ func TestRequestMetricHandler(t *testing.T) {
 					metrics.LabelResponseCodeClass: strconv.Itoa(labelCode/100) + "xx",
 				}
 
-				metricstest.AssertMetric(t, metricstest.IntMetric(requestCountM.Name(), 1, wantTags).WithResource(wantResource))
-				metricstest.AssertMetricExists(t, responseTimeInMsecM.Name())
+				metricstest.AssertMetricRequiredOnly(t, metricstest.IntMetric(requestCountM.Name(), 1, wantTags).WithResource(wantResource))
+				metricstest.AssertMetricExistsRequiredOnly(t, responseTimeInMsecM.Name())
 			}()
 
 			reqCtx := WithRevisionAndID(context.Background(), rev, types.NamespacedName{Namespace: testNamespace, Name: testRevName})

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -173,8 +173,10 @@ func newServiceScraperWithClient(
 	logger *zap.SugaredLogger) *serviceScraper {
 	svcName := metric.Labels[serving.ServiceLabelKey]
 	cfgName := metric.Labels[serving.ConfigurationLabelKey]
+	labels := metric.GetLabels()
+	annotations := metric.GetAnnotations()
 
-	ctx := metrics.RevisionContext(metric.ObjectMeta.Namespace, svcName, cfgName, revisionName)
+	ctx := metrics.RevisionContext(metric.ObjectMeta.Namespace, svcName, cfgName, revisionName, annotations, labels)
 
 	return &serviceScraper{
 		directClient:     directClient,

--- a/pkg/queue/request_metric.go
+++ b/pkg/queue/request_metric.go
@@ -74,7 +74,7 @@ type appRequestMetricsHandler struct {
 
 // NewRequestMetricsHandler creates an http.Handler that emits request metrics.
 func NewRequestMetricsHandler(next http.Handler,
-	ns, service, config, rev, pod string) (http.Handler, error) {
+	ns, service, config, rev, pod string, annotations map[string]string, labels map[string]string) (http.Handler, error) {
 	keys := []tag.Key{metrics.PodKey, metrics.ContainerKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey, metrics.RouteTagKey}
 	if err := pkgmetrics.RegisterResourceView(
 		&view.View{
@@ -93,7 +93,7 @@ func NewRequestMetricsHandler(next http.Handler,
 		return nil, err
 	}
 
-	ctx, err := metrics.PodRevisionContext(pod, "queue-proxy", ns, service, config, rev)
+	ctx, err := metrics.PodRevisionContext(pod, "queue-proxy", ns, service, config, rev, annotations, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (h *requestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 // NewAppRequestMetricsHandler creates an http.Handler that emits request metrics.
 func NewAppRequestMetricsHandler(next http.Handler, b *Breaker,
-	ns, service, config, rev, pod string) (http.Handler, error) {
+	ns, service, config, rev, pod string, annotations map[string]string, labels map[string]string) (http.Handler, error) {
 	keys := []tag.Key{metrics.PodKey, metrics.ContainerKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey}
 	if err := pkgmetrics.RegisterResourceView(&view.View{
 		Description: "The number of requests that are routed to user-container",
@@ -157,7 +157,7 @@ func NewAppRequestMetricsHandler(next http.Handler, b *Breaker,
 		return nil, err
 	}
 
-	ctx, err := metrics.PodRevisionContext(pod, "queue-proxy", ns, service, config, rev)
+	ctx, err := metrics.PodRevisionContext(pod, "queue-proxy", ns, service, config, rev, annotations, labels)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -221,7 +221,7 @@ func reportMetrics(pa *autoscalingv1alpha1.PodAutoscaler, pc podCounts) {
 	serviceLabel := pa.Labels[serving.ServiceLabelKey] // This might be empty.
 	configLabel := pa.Labels[serving.ConfigurationLabelKey]
 
-	ctx := metrics.RevisionContext(pa.Namespace, serviceLabel, configLabel, pa.Name)
+	ctx := metrics.RevisionContext(pa.Namespace, serviceLabel, configLabel, pa.Name, pa.GetAnnotations(), pa.GetLabels())
 
 	stats := []stats.Measurement{
 		actualPodCountM.M(int64(pc.ready)), notReadyPodCountM.M(int64(pc.notReady)),

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1806,7 +1806,7 @@ func TestMetricsReporter(t *testing.T) {
 		metricstest.IntMetric("pending_pods", 1996, nil).WithResource(wantResource),
 		metricstest.IntMetric("terminating_pods", 1983, nil).WithResource(wantResource),
 	}
-	metricstest.AssertMetric(t, wantMetrics...)
+	metricstest.AssertMetricRequiredOnly(t, wantMetrics...)
 
 	// Verify `want` is ignored, when it is equal to -1.
 	pc.want = -1
@@ -1821,7 +1821,7 @@ func TestMetricsReporter(t *testing.T) {
 		metricstest.IntMetric("pending_pods", 1996, nil).WithResource(wantResource),
 		metricstest.IntMetric("terminating_pods", 1955, nil).WithResource(wantResource),
 	}
-	metricstest.AssertMetric(t, wantMetrics...)
+	metricstest.AssertMetricRequiredOnly(t, wantMetrics...)
 }
 
 func TestResolveScrapeTarget(t *testing.T) {


### PR DESCRIPTION
Adds additional Prometheus labels to exposed metrics with "annotation_" and "label_" prefixes.

Fixes #11673
[Related PR](https://github.com/knative/pkg/pull/2188)

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Include annotations and labels in the exposed Prometheus metrics (more details in the [issue](https://github.com/knative/serving/issues/11673))
