### PR TITLE
Adding config to enable setting concurrencyStateEndpoint

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -102,6 +102,9 @@ type config struct {
 	TracingConfigBackend        tracingconfig.BackendType `split_words:"true"` // optional
 	TracingConfigSampleRate     float64                   `split_words:"true"` // optional
 	TracingConfigZipkinEndpoint string                    `split_words:"true"` // optional
+
+	// OnNoTraffic configuration
+	QueueOnNoMoreTrafficEndpoint string `split_words:"true"` // optional
 }
 
 func init() {

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -104,7 +104,7 @@ type config struct {
 	TracingConfigZipkinEndpoint string                    `split_words:"true"` // optional
 
 	// OnNoTraffic configuration
-	QueueOnNoMoreTrafficEndpoint string `split_words:"true"` // optional
+	ConcurrencyStateEndpoint string `split_words:"true"` // optional
 }
 
 func init() {

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -103,7 +103,7 @@ type config struct {
 	TracingConfigSampleRate     float64                   `split_words:"true"` // optional
 	TracingConfigZipkinEndpoint string                    `split_words:"true"` // optional
 
-	// OnNoTraffic configuration
+	// Concurrency State Endpoint configuration
 	ConcurrencyStateEndpoint string `split_words:"true"` // optional
 }
 

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "2b1881b6"
+    knative.dev/example-checksum: "3395209c"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -78,7 +78,8 @@ data:
     # If omitted, no value is specified and the system default is used.
     queueSidecarEphemeralStorageLimit: "1024Mi"
 
-    # queueOnNoMoreTrafficEndpoint is the service endpoint that queue-proxy calls when its traffic
+    # concurrencyStateEndpoint is the service endpoint that queue-proxy calls when its traffic
     # drops to zero or scales up from zero.
     # If omitted, queue proxy takes no action (this is the default behavior).
-    queueOnNoMoreTrafficEndpoint: ""
+    # NOTE THAT THIS IS AN EXPERIMENTAL / ALPHA FEATURE
+    concurrencyStateEndpoint: ""

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -77,3 +77,8 @@ data:
     # for the queue proxy sidecar container.
     # If omitted, no value is specified and the system default is used.
     queueSidecarEphemeralStorageLimit: "1024Mi"
+
+    # queueOnNoMoreTrafficEndpoint is the service endpoint that queue-proxy calls when its traffic
+    # drops to zero or scales up from zero.
+    # If omitted, queue proxy takes no action (this is the default behavior).
+    queueOnNoMoreTrafficEndpoint: ""

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -25,7 +25,7 @@ data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
   queueSidecarImage: ko://knative.dev/serving/cmd/queue
-  _example: |
+  _example: |-
     ################################
     #                              #
     #    EXAMPLE CONFIGURATION     #

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "fa67b403"
+    knative.dev/example-checksum: "2b1881b6"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "3395209c"
+    knative.dev/example-checksum: "d42e2c33"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -78,7 +78,7 @@ data:
     # If omitted, no value is specified and the system default is used.
     queueSidecarEphemeralStorageLimit: "1024Mi"
 
-    # concurrencyStateEndpoint is the service endpoint that queue-proxy calls when its traffic
+    # concurrencyStateEndpoint is the endpoint that queue-proxy calls when its traffic
     # drops to zero or scales up from zero.
     # If omitted, queue proxy takes no action (this is the default behavior).
     # NOTE THAT THIS IS AN EXPERIMENTAL / ALPHA FEATURE

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -66,7 +66,7 @@ const (
 	concurrencyStateEndpointKey = "concurrencyStateEndpoint"
 
 	// ConcurrencyStateEndpointDefault is the default endpoint for acting when traffic drops to / increases from zero.
-	ConcurrencyStateEndpointDefault = ""
+	concurrencyStateEndpointDefault = ""
 )
 
 var (
@@ -82,7 +82,7 @@ func defaultConfig() *Config {
 		DigestResolutionTimeout:        digestResolutionTimeoutDefault,
 		RegistriesSkippingTagResolving: sets.NewString("kind.local", "ko.local", "dev.local"),
 		QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
-		ConcurrencyStateEndpoint:       ConcurrencyStateEndpointDefault,
+		ConcurrencyStateEndpoint:       concurrencyStateEndpointDefault,
 	}
 }
 

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -61,6 +61,12 @@ const (
 	queueSidecarCPULimitKey              = "queueSidecarCPULimit"
 	queueSidecarMemoryLimitKey           = "queueSidecarMemoryLimit"
 	queueSidecarEphemeralStorageLimitKey = "queueSidecarEphemeralStorageLimit"
+
+	// queueOnNoMoreTrafficEndpointKey is the key to configure the endpoint for acting when traffic drops to / increases from zero.
+	queueOnNoMoreTrafficEndpointKey = "queueOnNoMoreTrafficEndpoint"
+
+	// queueOnNoMoreTrafficEndpointDefault is the default endpoint for acting when traffic drops to / increases from zero.
+	queueOnNoMoreTrafficEndpointDefault = ""
 )
 
 var (
@@ -95,6 +101,8 @@ func NewConfigFromMap(configMap map[string]string) (*Config, error) {
 		cm.AsQuantity(queueSidecarCPULimitKey, &nc.QueueSidecarCPULimit),
 		cm.AsQuantity(queueSidecarMemoryLimitKey, &nc.QueueSidecarMemoryLimit),
 		cm.AsQuantity(queueSidecarEphemeralStorageLimitKey, &nc.QueueSidecarEphemeralStorageLimit),
+
+		cm.AsString(queueOnNoMoreTrafficEndpointKey, &nc.QueueNoMoreTrafficEndpoint),
 	); err != nil {
 		return nil, err
 	}
@@ -158,4 +166,7 @@ type Config struct {
 	// QueueSidecarEphemeralStorageLimit is the Ephemeral Storage Limit to set
 	// for the queue proxy sidecar container.
 	QueueSidecarEphemeralStorageLimit *resource.Quantity
+
+	// QueueNoMoreTrafficEndpoint is the endpoint for acting when traffic drops to / increases from zero.
+	QueueNoMoreTrafficEndpoint string
 }

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -82,6 +82,7 @@ func defaultConfig() *Config {
 		DigestResolutionTimeout:        digestResolutionTimeoutDefault,
 		RegistriesSkippingTagResolving: sets.NewString("kind.local", "ko.local", "dev.local"),
 		QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
+		QueueOnNoMoreTrafficEndpoint:   queueOnNoMoreTrafficEndpointDefault,
 	}
 }
 
@@ -102,7 +103,7 @@ func NewConfigFromMap(configMap map[string]string) (*Config, error) {
 		cm.AsQuantity(queueSidecarMemoryLimitKey, &nc.QueueSidecarMemoryLimit),
 		cm.AsQuantity(queueSidecarEphemeralStorageLimitKey, &nc.QueueSidecarEphemeralStorageLimit),
 
-		cm.AsString(queueOnNoMoreTrafficEndpointKey, &nc.QueueNoMoreTrafficEndpoint),
+		cm.AsString(queueOnNoMoreTrafficEndpointKey, &nc.QueueOnNoMoreTrafficEndpoint),
 	); err != nil {
 		return nil, err
 	}
@@ -168,5 +169,5 @@ type Config struct {
 	QueueSidecarEphemeralStorageLimit *resource.Quantity
 
 	// QueueNoMoreTrafficEndpoint is the endpoint for acting when traffic drops to / increases from zero.
-	QueueNoMoreTrafficEndpoint string
+	QueueOnNoMoreTrafficEndpoint string
 }

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -63,10 +63,10 @@ const (
 	queueSidecarEphemeralStorageLimitKey = "queueSidecarEphemeralStorageLimit"
 
 	// concurrencyStateEndpointKey is the key to configure the endpoint for acting when traffic drops to / increases from zero.
-	concurrencyStateEndpointKey = "queueOnNoMoreTrafficEndpoint"
+	concurrencyStateEndpointKey = "concurrencyStateEndpoint"
 
-	// concurrencyStateEndpointDefault is the default endpoint for acting when traffic drops to / increases from zero.
-	concurrencyStateEndpointDefault = ""
+	// ConcurrencyStateEndpointDefault is the default endpoint for acting when traffic drops to / increases from zero.
+	ConcurrencyStateEndpointDefault = ""
 )
 
 var (
@@ -82,7 +82,7 @@ func defaultConfig() *Config {
 		DigestResolutionTimeout:        digestResolutionTimeoutDefault,
 		RegistriesSkippingTagResolving: sets.NewString("kind.local", "ko.local", "dev.local"),
 		QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
-		ConcurrencyStateEndpoint:       concurrencyStateEndpointDefault,
+		ConcurrencyStateEndpoint:       ConcurrencyStateEndpointDefault,
 	}
 }
 

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -62,11 +62,11 @@ const (
 	queueSidecarMemoryLimitKey           = "queueSidecarMemoryLimit"
 	queueSidecarEphemeralStorageLimitKey = "queueSidecarEphemeralStorageLimit"
 
-	// queueOnNoMoreTrafficEndpointKey is the key to configure the endpoint for acting when traffic drops to / increases from zero.
-	queueOnNoMoreTrafficEndpointKey = "queueOnNoMoreTrafficEndpoint"
+	// concurrencyStateEndpointKey is the key to configure the endpoint for acting when traffic drops to / increases from zero.
+	concurrencyStateEndpointKey = "queueOnNoMoreTrafficEndpoint"
 
-	// queueOnNoMoreTrafficEndpointDefault is the default endpoint for acting when traffic drops to / increases from zero.
-	queueOnNoMoreTrafficEndpointDefault = ""
+	// concurrencyStateEndpointDefault is the default endpoint for acting when traffic drops to / increases from zero.
+	concurrencyStateEndpointDefault = ""
 )
 
 var (
@@ -82,7 +82,7 @@ func defaultConfig() *Config {
 		DigestResolutionTimeout:        digestResolutionTimeoutDefault,
 		RegistriesSkippingTagResolving: sets.NewString("kind.local", "ko.local", "dev.local"),
 		QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
-		QueueOnNoMoreTrafficEndpoint:   queueOnNoMoreTrafficEndpointDefault,
+		ConcurrencyStateEndpoint:       concurrencyStateEndpointDefault,
 	}
 }
 
@@ -103,7 +103,7 @@ func NewConfigFromMap(configMap map[string]string) (*Config, error) {
 		cm.AsQuantity(queueSidecarMemoryLimitKey, &nc.QueueSidecarMemoryLimit),
 		cm.AsQuantity(queueSidecarEphemeralStorageLimitKey, &nc.QueueSidecarEphemeralStorageLimit),
 
-		cm.AsString(queueOnNoMoreTrafficEndpointKey, &nc.QueueOnNoMoreTrafficEndpoint),
+		cm.AsString(concurrencyStateEndpointKey, &nc.ConcurrencyStateEndpoint),
 	); err != nil {
 		return nil, err
 	}
@@ -168,6 +168,6 @@ type Config struct {
 	// for the queue proxy sidecar container.
 	QueueSidecarEphemeralStorageLimit *resource.Quantity
 
-	// QueueNoMoreTrafficEndpoint is the endpoint for acting when traffic drops to / increases from zero.
-	QueueOnNoMoreTrafficEndpoint string
+	// ConcurrencyStateEndpoint is the endpoint for acting when traffic drops to / increases from zero.
+	ConcurrencyStateEndpoint string
 }

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -165,6 +165,6 @@ type Config struct {
 	// for the queue proxy sidecar container.
 	QueueSidecarEphemeralStorageLimit *resource.Quantity
 
-	// ConcurrencyStateEndpoint is the endpoint for acting when traffic drops to / increases from zero.
+	// ConcurrencyStateEndpoint is the endpoint Queue Proxy will call when traffic drops to / increases from zero.
 	ConcurrencyStateEndpoint string
 }

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -62,11 +62,8 @@ const (
 	queueSidecarMemoryLimitKey           = "queueSidecarMemoryLimit"
 	queueSidecarEphemeralStorageLimitKey = "queueSidecarEphemeralStorageLimit"
 
-	// concurrencyStateEndpointKey is the key to configure the endpoint for acting when traffic drops to / increases from zero.
+	// concurrencyStateEndpointKey is the key to configure the endpoint Queue Proxy will call when traffic drops to / increases from zero.
 	concurrencyStateEndpointKey = "concurrencyStateEndpoint"
-
-	// ConcurrencyStateEndpointDefault is the default endpoint for acting when traffic drops to / increases from zero.
-	concurrencyStateEndpointDefault = ""
 )
 
 var (
@@ -82,7 +79,7 @@ func defaultConfig() *Config {
 		DigestResolutionTimeout:        digestResolutionTimeoutDefault,
 		RegistriesSkippingTagResolving: sets.NewString("kind.local", "ko.local", "dev.local"),
 		QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
-		ConcurrencyStateEndpoint:       concurrencyStateEndpointDefault,
+		ConcurrencyStateEndpoint:       "",
 	}
 }
 

--- a/pkg/deployment/config_test.go
+++ b/pkg/deployment/config_test.go
@@ -194,6 +194,20 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarImageKey: defaultSidecarImage,
 			ProgressDeadlineKey:  "1982ms",
 		},
+	}, {
+		name: "controller configuration with concurrency state endpoint",
+		wantConfig: &Config{
+			RegistriesSkippingTagResolving: sets.NewString("kind.local", "ko.local", "dev.local"),
+			DigestResolutionTimeout:        digestResolutionTimeoutDefault,
+			QueueSidecarImage:              defaultSidecarImage,
+			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
+			ProgressDeadline:               ProgressDeadlineDefault,
+			ConcurrencyStateEndpoint:       "freeze-proxy",
+		},
+		data: map[string]string{
+			QueueSidecarImageKey:        defaultSidecarImage,
+			concurrencyStateEndpointKey: "freeze-proxy",
+		},
 	}}
 
 	for _, tt := range configTests {

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -179,6 +179,9 @@ var (
 		}, {
 			Name:  "METRICS_COLLECTOR_ADDRESS",
 			Value: "",
+		}, {
+			Name:  "CONCURRENCY_STATE_ENDPOINT",
+			Value: "",
 		}},
 	}
 

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -361,6 +361,9 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		}, {
 			Name:  "METRICS_COLLECTOR_ADDRESS",
 			Value: cfg.Observability.MetricsCollectorAddress,
+		}, {
+			Name:  "QUEUE_ON_NO_MORE_TRAFFIC_ENDPOINT",
+			Value: cfg.Deployment.QueueOnNoMoreTrafficEndpoint,
 		}},
 	}
 

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -361,9 +361,6 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		}, {
 			Name:  "METRICS_COLLECTOR_ADDRESS",
 			Value: cfg.Observability.MetricsCollectorAddress,
-		}, {
-			Name:  "CONCURRENCY_STATE_ENDPOINT",
-			Value: cfg.Deployment.ConcurrencyStateEndpoint,
 		}},
 	}
 
@@ -372,6 +369,14 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		c.Env = append(c.Env, corev1.EnvVar{
 			Name:  "ENABLE_HTTP2_AUTO_DETECTION",
 			Value: "true",
+		})
+	}
+
+	// Only add this if the value is actually set
+	if cfg.Deployment.ConcurrencyStateEndpoint != deployment.ConcurrencyStateEndpointDefault {
+		c.Env = append(c.Env, corev1.EnvVar{
+			Name:  "CONCURRENCY_STATE_ENDPOINT",
+			Value: cfg.Deployment.ConcurrencyStateEndpoint,
 		})
 	}
 

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -362,8 +362,8 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 			Name:  "METRICS_COLLECTOR_ADDRESS",
 			Value: cfg.Observability.MetricsCollectorAddress,
 		}, {
-			Name:  "QUEUE_ON_NO_MORE_TRAFFIC_ENDPOINT",
-			Value: cfg.Deployment.QueueOnNoMoreTrafficEndpoint,
+			Name:  "CONCURRENCY_STATE_ENDPOINT",
+			Value: cfg.Deployment.ConcurrencyStateEndpoint,
 		}},
 	}
 

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -373,7 +373,7 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 	}
 
 	// Only add this if the value is actually set
-	if cfg.Deployment.ConcurrencyStateEndpoint != deployment.ConcurrencyStateEndpointDefault {
+	if cfg.Deployment.ConcurrencyStateEndpoint != "" {
 		c.Env = append(c.Env, corev1.EnvVar{
 			Name:  "CONCURRENCY_STATE_ENDPOINT",
 			Value: cfg.Deployment.ConcurrencyStateEndpoint,

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -361,6 +361,9 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		}, {
 			Name:  "METRICS_COLLECTOR_ADDRESS",
 			Value: cfg.Observability.MetricsCollectorAddress,
+		}, {
+			Name:  "CONCURRENCY_STATE_ENDPOINT",
+			Value: cfg.Deployment.ConcurrencyStateEndpoint,
 		}},
 	}
 
@@ -369,14 +372,6 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		c.Env = append(c.Env, corev1.EnvVar{
 			Name:  "ENABLE_HTTP2_AUTO_DETECTION",
 			Value: "true",
-		})
-	}
-
-	// Only add this if the value is actually set
-	if cfg.Deployment.ConcurrencyStateEndpoint != "" {
-		c.Env = append(c.Env, corev1.EnvVar{
-			Name:  "CONCURRENCY_STATE_ENDPOINT",
-			Value: cfg.Deployment.ConcurrencyStateEndpoint,
 		})
 	}
 

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -354,6 +354,19 @@ func TestMakeQueueContainer(t *testing.T) {
 				"ENABLE_HTTP2_AUTO_DETECTION": "true",
 			})
 		}),
+	}, {
+		name: "set concurrency state endpoint",
+		rev: revision("bar", "foo",
+			withContainers(containers)),
+		dc: deployment.Config{
+			ProgressDeadline:         5678 * time.Second,
+			ConcurrencyStateEndpoint: "freeze-proxy",
+		},
+		want: queueContainer(func(c *corev1.Container) {
+			c.Env = env(map[string]string{
+				"CONCURRENCY_STATE_ENDPOINT": "freeze-proxy",
+			})
+		}),
 	}}
 
 	for _, test := range tests {

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -879,6 +879,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 }
 
 var defaultEnv = map[string]string{
+	"CONCURRENCY_STATE_ENDPOINT":       "",
 	"CONTAINER_CONCURRENCY":            "0",
 	"ENABLE_PROFILING":                 "false",
 	"METRICS_DOMAIN":                   metrics.Domain(),


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Adds a feature gate for the pod freezer capability (see #11694), disabled by default. Additional functionality will be added in subsequent PRs, but to keep the size small thought it was best to start with the feature gate.

Edit: renamed this as we're no longer using a feature gate and we've changed the name (see comments below)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @markusthoemmes 
/assign @dprotaso 
FYI @julz 