### PR TITLE
Add support for emptydir rw access and e2e testing

### DIFF
--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -1509,7 +1509,7 @@ func TestContainerValidation(t *testing.T) {
 				ctx = config.ToContext(ctx, cfg)
 			}
 
-			got := ValidateContainer(ctx, test.c, test.volumes)
+			got := ValidateContainer(ctx, test.c, test.volumes, make(sets.String))
 			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
 				t.Errorf("ValidateContainer (-want, +got): \n%s", diff)
 			}

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -1086,9 +1086,11 @@ func TestContainerValidation(t *testing.T) {
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-cm",
-						}},
+						},
+					},
 				},
-			}},
+			},
+		},
 	}, {
 		name: "has known volumeMounts, but at reserved path",
 		c: corev1.Container{
@@ -1106,9 +1108,11 @@ func TestContainerValidation(t *testing.T) {
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-cm",
-						}},
+						},
+					},
 				},
-			}},
+			},
+		},
 		want: (&apis.FieldError{
 			Message: `mountPath "/var/log" is a reserved path`,
 			Paths:   []string{"mountPath"},
@@ -1130,9 +1134,11 @@ func TestContainerValidation(t *testing.T) {
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-cm",
-						}},
+						},
+					},
 				},
-			}},
+			},
+		},
 		want: apis.ErrInvalidValue("not/absolute", "volumeMounts[0].mountPath"),
 	}, {
 		name: "Empty dir has rw access",
@@ -1151,7 +1157,8 @@ func TestContainerValidation(t *testing.T) {
 						Medium: "Memory",
 					},
 				},
-			}},
+			},
+		},
 	}, {
 		name: "has lifecycle",
 		c: corev1.Container{
@@ -1180,9 +1187,11 @@ func TestContainerValidation(t *testing.T) {
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-cm",
-						}},
+						},
+					},
 				},
-			}},
+			},
+		},
 	}, {
 		name: "valid with probes (no port)",
 		c: corev1.Container{

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -1080,7 +1080,7 @@ func TestContainerValidation(t *testing.T) {
 			}},
 		},
 		volumes: map[string]corev1.Volume{
-			"the-name": corev1.Volume{
+			"the-name": {
 				Name: "the-name",
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -1100,7 +1100,7 @@ func TestContainerValidation(t *testing.T) {
 			}},
 		},
 		volumes: map[string]corev1.Volume{
-			"the-name": corev1.Volume{
+			"the-name": {
 				Name: "the-name",
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -1124,7 +1124,7 @@ func TestContainerValidation(t *testing.T) {
 			}},
 		},
 		volumes: map[string]corev1.Volume{
-			"the-name": corev1.Volume{
+			"the-name": {
 				Name: "the-name",
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -1144,7 +1144,7 @@ func TestContainerValidation(t *testing.T) {
 			}},
 		},
 		volumes: map[string]corev1.Volume{
-			"the-name": corev1.Volume{
+			"the-name": {
 				Name: "the-name",
 				VolumeSource: corev1.VolumeSource{
 					EmptyDir: &corev1.EmptyDirVolumeSource{
@@ -1174,7 +1174,7 @@ func TestContainerValidation(t *testing.T) {
 			}},
 		},
 		volumes: map[string]corev1.Volume{
-			"the-name": corev1.Volume{
+			"the-name": {
 				Name: "the-name",
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{

--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -135,9 +135,17 @@ func (rs *RevisionSpec) applyDefault(ctx context.Context, container *corev1.Cont
 		rs.PodSpec.EnableServiceLinks = cfg.Defaults.EnableServiceLinks
 	}
 
+	vNames := make(sets.String)
+	for _, v := range rs.PodSpec.Volumes {
+		if v.EmptyDir != nil {
+			vNames.Insert(v.Name)
+		}
+	}
 	vms := container.VolumeMounts
 	for i := range vms {
-		vms[i].ReadOnly = true
+		if !vNames.Has(vms[i].Name) {
+			vms[i].ReadOnly = true
+		}
 	}
 }
 

--- a/test/conformance.go
+++ b/test/conformance.go
@@ -36,6 +36,7 @@ import (
 const (
 	// Test image names
 	Autoscale           = "autoscale"
+	EmptyDir            = "emptydir"
 	Failing             = "failing"
 	HelloVolume         = "hellovolume"
 	HelloWorld          = "helloworld"
@@ -57,6 +58,7 @@ const (
 	PizzaPlanetText2 = "Re-energize yourself with a slice of pepperoni!"
 	HelloWorldText   = "Hello World! How about some tasty noodles?"
 	HelloHTTP2Text   = "Hello, New World! How about donuts and coffee?"
+	EmptyDirText     = "From file in empty dir!"
 
 	MultiContainerResponse = "Yay!! multi-container works"
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -106,7 +106,9 @@ go_test_e2e -timeout=20m -parallel=300 ./test/scale ${TEST_OPTIONS} || failed=1
 go_test_e2e -timeout=15m -tags=hpa ./test/e2e ${TEST_OPTIONS} || failed=1
 
 # Run emptyDir tests with alpha enabled avoiding any issues with the testing options guard above
+toggle_feature kubernetes.podspec-volumes-emptydir Enabled
 go_test_e2e -tags=emptydir ./test/e2e --enable-alpha ${TEST_OPTIONS} || failed=1
+toggle_feature kubernetes.podspec-volumes-emptydir Disabled
 
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -105,6 +105,9 @@ go_test_e2e -timeout=20m -parallel=300 ./test/scale ${TEST_OPTIONS} || failed=1
 # Run HPA tests
 go_test_e2e -timeout=15m -tags=hpa ./test/e2e ${TEST_OPTIONS} || failed=1
 
+# Run emptyDir tests with alpha enabled avoiding any issues with the testing options guard above
+go_test_e2e -tags=emptydir ./test/e2e --enable-alpha ${TEST_OPTIONS} || failed=1
+
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.
 toggle_feature autocreateClusterDomainClaims true config-network || fail_test

--- a/test/e2e/emptydir_test.go
+++ b/test/e2e/emptydir_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package e2e
 
 import (

--- a/test/e2e/emptydir_test.go
+++ b/test/e2e/emptydir_test.go
@@ -1,4 +1,4 @@
-// +build e2e
+// +build emptydir
 
 /*
 Copyright 2021 The Knative Authors
@@ -34,6 +34,9 @@ import (
 
 // TestEmptyDirVolume tests empty dir volume support.
 func TestEmptyDirVolume(t *testing.T) {
+	if !test.ServingFlags.EnableAlphaFeatures {
+		t.Skip()
+	}
 
 	t.Parallel()
 	clients := test.Setup(t)

--- a/test/e2e/emptydir_test.go
+++ b/test/e2e/emptydir_test.go
@@ -47,7 +47,7 @@ func TestEmptyDirVolume(t *testing.T) {
 
 	t.Log("Creating a new Service")
 
-	quantity := resource.MustParse("100Mb")
+	quantity := resource.MustParse("100M")
 	withVolume1 := WithVolume("data", "/data", corev1.VolumeSource{
 		EmptyDir: &corev1.EmptyDirVolumeSource{
 			Medium:    "Memory",

--- a/test/e2e/emptydir_test.go
+++ b/test/e2e/emptydir_test.go
@@ -1,0 +1,79 @@
+// +build e2e
+
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/spoof"
+	"knative.dev/serving/test"
+	v1test "knative.dev/serving/test/v1"
+
+	. "knative.dev/serving/pkg/testing/v1"
+)
+
+// TestEmptyDirVolume tests empty dir volume support.
+func TestEmptyDirVolume(t *testing.T) {
+
+	t.Parallel()
+	clients := test.Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.EmptyDir,
+	}
+
+	test.EnsureTearDown(t, clients, &names)
+
+	t.Log("Creating a new Service")
+
+	quantity := resource.MustParse("100Mb")
+	withVolume1 := WithVolume("data", "/data", corev1.VolumeSource{
+		EmptyDir: &corev1.EmptyDirVolumeSource{
+			Medium:    "Memory",
+			SizeLimit: &quantity,
+		},
+	})
+
+	withVolume2 := WithVolume("cache", "/cache", corev1.VolumeSource{
+		EmptyDir: &corev1.EmptyDirVolumeSource{},
+	})
+
+	resources, err := v1test.CreateServiceReady(t, clients, &names, withVolume1, withVolume2)
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	url := resources.Route.Status.URL.URL()
+	if _, err := pkgTest.WaitForEndpointState(
+		context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		url,
+		v1test.RetryingRouteInconsistency(spoof.MatchesAllOf(spoof.IsStatusOK, spoof.MatchesBody(test.EmptyDirText))),
+		"EmptyDirText",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("The endpoint %s for Route %s didn't serve the expected text %q: %v", url, names.Route, test.EmptyDirText, err)
+	}
+}

--- a/test/test_images/emptydir/emptydir.go
+++ b/test/test_images/emptydir/emptydir.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2021 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+
+	"knative.dev/serving/test"
+)
+
+var path string
+
+// Add content to a file in the emptyDir volume
+func init() {
+	path = os.Getenv("DATA_PATH")
+	if path == "" {
+		path = "/data"
+	}
+	f, _ := os.OpenFile(path+"/testfile", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	_, _ = f.WriteString("From file in empty dir!")
+	defer f.Close()
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	content, err := ioutil.ReadFile(path + "/testfile")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_, _ = fmt.Fprintln(w, string(content))
+}
+
+func main() {
+	flag.Parse()
+	log.Print("Empty dir volume app started.")
+	test.ListenAndServeGracefully(":8080", handler)
+}

--- a/test/test_images/emptydir/emptydir.go
+++ b/test/test_images/emptydir/emptydir.go
@@ -35,7 +35,10 @@ func init() {
 	if path == "" {
 		path = "/data"
 	}
-	f, _ := os.OpenFile(path+"/testfile", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	f, err := os.OpenFile(path+"/testfile", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		log.Print("Failed to open file", err)
+	}
 	_, _ = f.WriteString("From file in empty dir!")
 	defer f.Close()
 }

--- a/test/test_images/emptydir/service.yaml
+++ b/test/test_images/emptydir/service.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: emptydir
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+        - imagePullPolicy: Always
+          image: ko://knative.dev/serving/test/test_images/emptydir
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          env:
+            - name: DATA_PATH
+              value: /data
+      volumes:
+        - name: data
+          emptyDir: {}


### PR DESCRIPTION
Part of the work in #11664.

- adds an e2e test that serves data in an emptyDir volume. Test run [here](https://gist.github.com/skonto/2fef5fff664f6478f5d7d782892cb2cf). It will be run along with the rest when the feature is on by default.
- allows rw access to emptyDir volumes only (extends logic to allow more types of volumes eg. pvc in the future).

/cc @julz @dprotaso @markusthoemmes @nak3 