### PR TITLE
Allow setting spec.template.spec.automountServiceAccountToken in PodSpec

### DIFF
--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -102,6 +102,9 @@ spec:
                       required:
                         - containers
                       properties:
+                        automountServiceAccountToken:
+                          description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                          type: boolean
                         containerConcurrency:
                           description: ContainerConcurrency specifies the maximum allowed in-flight (concurrent) requests per container of the Revision.  Defaults to `0` which means concurrency to the application is not limited, and the system decides the target concurrency for the autoscaler.
                           type: integer

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -81,6 +81,9 @@ spec:
               required:
                 - containers
               properties:
+                automountServiceAccountToken:
+                  description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                  type: boolean
                 containerConcurrency:
                   description: ContainerConcurrency specifies the maximum allowed in-flight (concurrent) requests per container of the Revision.  Defaults to `0` which means concurrency to the application is not limited, and the system decides the target concurrency for the autoscaler.
                   type: integer

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -106,6 +106,9 @@ spec:
                       required:
                         - containers
                       properties:
+                        automountServiceAccountToken:
+                          description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                          type: boolean
                         containerConcurrency:
                           description: ContainerConcurrency specifies the maximum allowed in-flight (concurrent) requests per container of the Revision.  Defaults to `0` which means concurrency to the application is not limited, and the system decides the target concurrency for the autoscaler.
                           type: integer

--- a/hack/schemapatch-config.yaml
+++ b/hack/schemapatch-config.yaml
@@ -43,6 +43,7 @@ k8s.io/api/core/v1.PodSpec:
     - Volumes
     - ImagePullSecrets
     - EnableServiceLinks
+    - AutomountServiceAccountToken
 k8s.io/api/core/v1.Container:
   preserveUnknownFields: true # for backwards compat field defaulting
   allowedFields:

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -184,7 +184,7 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.ImagePullSecrets = in.ImagePullSecrets
 	out.EnableServiceLinks = in.EnableServiceLinks
 	// Only allow setting AutomountServiceAccountToken to false
-	if !*in.AutomountServiceAccountToken {
+	if !*in.AutomountServiceAccountToken && in.AutomountServiceAccountToken != nil {
 		out.AutomountServiceAccountToken = in.AutomountServiceAccountToken
 	}
 
@@ -216,7 +216,7 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.ActiveDeadlineSeconds = nil
 	out.DNSPolicy = ""
 	// Only allow setting AutomountServiceAccountToken to false
-	if *in.AutomountServiceAccountToken {
+	if *in.AutomountServiceAccountToken && in.AutomountServiceAccountToken != nil {
 		out.AutomountServiceAccountToken = nil
 	}
 	out.NodeName = ""

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -184,7 +184,7 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.ImagePullSecrets = in.ImagePullSecrets
 	out.EnableServiceLinks = in.EnableServiceLinks
 	// Only allow setting AutomountServiceAccountToken to false
-	if !*in.AutomountServiceAccountToken && in.AutomountServiceAccountToken != nil {
+	if in.AutomountServiceAccountToken != nil && !*in.AutomountServiceAccountToken {
 		out.AutomountServiceAccountToken = in.AutomountServiceAccountToken
 	}
 
@@ -216,7 +216,7 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.ActiveDeadlineSeconds = nil
 	out.DNSPolicy = ""
 	// Only allow setting AutomountServiceAccountToken to false
-	if *in.AutomountServiceAccountToken && in.AutomountServiceAccountToken != nil {
+	if in.AutomountServiceAccountToken != nil && !*in.AutomountServiceAccountToken {
 		out.AutomountServiceAccountToken = nil
 	}
 	out.NodeName = ""

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -216,10 +216,12 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.ActiveDeadlineSeconds = nil
 	out.DNSPolicy = ""
 	// Only allow setting AutomountServiceAccountToken to false
-	if in.AutomountServiceAccountToken != nil && !*in.AutomountServiceAccountToken {
-		out.AutomountServiceAccountToken = nil
+	if in.AutomountServiceAccountToken != nil {
+	    if *in.AutomountServiceAccountToken {
+			out.AutomountServiceAccountToken = nil
+		}
 	}
-	out.NodeName = ""
+out.NodeName = ""
 	out.HostNetwork = false
 	out.HostPID = false
 	out.HostIPC = false

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -183,6 +183,7 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.Volumes = in.Volumes
 	out.ImagePullSecrets = in.ImagePullSecrets
 	out.EnableServiceLinks = in.EnableServiceLinks
+	out.AutomountServiceAccountToken = in.AutomountServiceAccountToken
 
 	// Feature fields
 	if cfg.Features.PodSpecAffinity != config.Disabled {
@@ -211,7 +212,6 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.TerminationGracePeriodSeconds = nil
 	out.ActiveDeadlineSeconds = nil
 	out.DNSPolicy = ""
-	out.AutomountServiceAccountToken = nil
 	out.NodeName = ""
 	out.HostNetwork = false
 	out.HostPID = false

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -183,7 +183,10 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.Volumes = in.Volumes
 	out.ImagePullSecrets = in.ImagePullSecrets
 	out.EnableServiceLinks = in.EnableServiceLinks
-	out.AutomountServiceAccountToken = in.AutomountServiceAccountToken
+	// Only allow setting AutomountServiceAccountToken to false
+	if !*in.AutomountServiceAccountToken {
+		out.AutomountServiceAccountToken = in.AutomountServiceAccountToken
+	}
 
 	// Feature fields
 	if cfg.Features.PodSpecAffinity != config.Disabled {
@@ -212,6 +215,10 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.TerminationGracePeriodSeconds = nil
 	out.ActiveDeadlineSeconds = nil
 	out.DNSPolicy = ""
+	// Only allow setting AutomountServiceAccountToken to false
+	if *in.AutomountServiceAccountToken {
+		out.AutomountServiceAccountToken = nil
+	}
 	out.NodeName = ""
 	out.HostNetwork = false
 	out.HostPID = false

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -215,12 +215,6 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.TerminationGracePeriodSeconds = nil
 	out.ActiveDeadlineSeconds = nil
 	out.DNSPolicy = ""
-	// Only allow setting AutomountServiceAccountToken to false
-	if in.AutomountServiceAccountToken != nil {
-		if *in.AutomountServiceAccountToken {
-			out.AutomountServiceAccountToken = nil
-		}
-	}
 	out.NodeName = ""
 	out.HostNetwork = false
 	out.HostPID = false

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -217,11 +217,11 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.DNSPolicy = ""
 	// Only allow setting AutomountServiceAccountToken to false
 	if in.AutomountServiceAccountToken != nil {
-	    if *in.AutomountServiceAccountToken {
+		if *in.AutomountServiceAccountToken {
 			out.AutomountServiceAccountToken = nil
 		}
 	}
-out.NodeName = ""
+	out.NodeName = ""
 	out.HostNetwork = false
 	out.HostPID = false
 	out.HostIPC = false

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -104,6 +104,7 @@ func withPodSpecVolumesEmptyDirEnabled() configOption {
 }
 
 func TestPodSpecValidation(t *testing.T) {
+	falseValue := false
 	tests := []struct {
 		name    string
 		ps      corev1.PodSpec
@@ -135,6 +136,15 @@ func TestPodSpecValidation(t *testing.T) {
 						SecretName: "foo",
 					},
 				},
+			}},
+		},
+		want: nil,
+	}, {
+		name: "with automountServiceAccountToken (ok)",
+		ps: corev1.PodSpec{
+			AutomountServiceAccountToken: &falseValue,
+			Containers: []corev1.Container{{
+				Image: "helloworld",
 			}},
 		},
 		want: nil,

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -104,7 +104,6 @@ func withPodSpecVolumesEmptyDirEnabled() configOption {
 }
 
 func TestPodSpecValidation(t *testing.T) {
-	falseValue := false
 	tests := []struct {
 		name    string
 		ps      corev1.PodSpec
@@ -142,7 +141,7 @@ func TestPodSpecValidation(t *testing.T) {
 	}, {
 		name: "with automountServiceAccountToken (ok)",
 		ps: corev1.PodSpec{
-			AutomountServiceAccountToken: &falseValue,
+			AutomountServiceAccountToken: ptr.Bool(false),
 			Containers: []corev1.Container{{
 				Image: "helloworld",
 			}},


### PR DESCRIPTION
Fixes #9127 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Allows users to set `spec.template.spec.automountServiceAccountToken` in the PodSpec for a kservice

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Users can set `spec.template.spec.automountServiceAccountToken` to `false` in a PodSpec in order to opt-out of Kubenetes' default behaviour of mounting a ServiceAccount token in that Pod's containers.
```
