### PR TITLE
Add limits and proper security context to jobs

### DIFF
--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -51,6 +51,17 @@ spec:
           httpGet:
             port: 8080
           failureThreshold: 6
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         env:
         - name: POD_NAME
           valueFrom:

--- a/config/post-install/storage-version-migration.yaml
+++ b/config/post-install/storage-version-migration.yaml
@@ -47,3 +47,14 @@ spec:
           - "configurations.serving.knative.dev"
           - "revisions.serving.knative.dev"
           - "routes.serving.knative.dev"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true


### PR DESCRIPTION
Mostly to make [kube-linter tool](https://github.com/stackrox/kube-linter) happy (might look at setting this up in CI next), apart from this the config in serving looks good. 

Adds limits/requests (copied from controller), and enforces allowPrivilegeEscalation=false, readOnlyRootFilesystem and runAsNonRoot.

Similar changes for eventing in https://github.com/knative/eventing/pull/5611 and https://github.com/knative/eventing/pull/5612.

/assign @markusthoemmes @dprotaso 