### PR TITLE
Correct typo in a few places and include error in log

### DIFF
--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -264,7 +264,7 @@ func flush(logger *zap.SugaredLogger) {
 func componentConfigAndIP(ctx context.Context) leaderelection.ComponentConfig {
 	id, err := bucket.Identity()
 	if err != nil {
-		logging.FromContext(ctx).Fatalw("Failed to generate Lease holder identify", zap.Error(err))
+		logging.FromContext(ctx).Fatalw("Failed to generate Lease holder identity", zap.Error(err))
 	}
 
 	// Set up leader election config

--- a/pkg/autoscaler/bucket/bucket.go
+++ b/pkg/autoscaler/bucket/bucket.go
@@ -65,7 +65,7 @@ func PodIP() (string, error) {
 	return selfIP, nil
 }
 
-// Identity returns a identify for this Autoscaler pod used as the Lease holder
+// Identity returns an identity for this Autoscaler pod used as the Lease holder
 // identity. It's in the format of <POD-NAME>_<POD-IP> whose information is ready from
 // environment variables.
 func Identity() (string, error) {


### PR DESCRIPTION
Remove never-used return parameter from extractIP, include returned error from extractIP in log message, and correct typo `identify -> identity` in a few places.

/assign @psschwei @markusthoemmes 
