### PR TITLE
Use update API instead of patch API in conformance tests

### DIFF
--- a/pkg/testing/v1/service.go
+++ b/pkg/testing/v1/service.go
@@ -161,6 +161,13 @@ func WithServiceImage(img string) ServiceOption {
 	}
 }
 
+// WithTraffic sets the traffic to be the provided traffic target.
+func WithTraffic(tt []v1.TrafficTarget) ServiceOption {
+	return func(svc *v1.Service) {
+		svc.Spec.Traffic = tt
+	}
+}
+
 // WithServiceTemplateMeta sets the container image to be the provided string.
 func WithServiceTemplateMeta(m metav1.ObjectMeta) ServiceOption {
 	return func(svc *v1.Service) {

--- a/pkg/testing/v1/service.go
+++ b/pkg/testing/v1/service.go
@@ -161,8 +161,8 @@ func WithServiceImage(img string) ServiceOption {
 	}
 }
 
-// WithTraffic sets the traffic to be the provided traffic target.
-func WithTraffic(tt []v1.TrafficTarget) ServiceOption {
+// WithTrafficTarget sets the traffic to be the provided traffic target.
+func WithTrafficTarget(tt []v1.TrafficTarget) ServiceOption {
 	return func(svc *v1.Service) {
 		svc.Spec.Traffic = tt
 	}

--- a/test/conformance/api/v1/blue_green_test.go
+++ b/test/conformance/api/v1/blue_green_test.go
@@ -64,7 +64,7 @@ func TestBlueGreenRoute(t *testing.T) {
 
 	// Setup Initial Service
 	t.Log("Creating a new Service in runLatest")
-	objects, err := v1test.CreateServiceReady(t, clients, &names)
+	_, err := v1test.CreateServiceReady(t, clients, &names)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}
@@ -76,11 +76,10 @@ func TestBlueGreenRoute(t *testing.T) {
 	green.TrafficTarget = "green"
 
 	t.Log("Updating the Service to use a different image")
-	service, err := v1test.PatchService(t, clients, objects.Service, rtesting.WithServiceImage(greenImagePath))
+	_, err = v1test.UpdateService(t, clients, names, rtesting.WithServiceImage(greenImagePath))
 	if err != nil {
-		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, greenImagePath, err)
+		t.Fatalf("Update for Service %s with new image %s failed: %v", names.Service, greenImagePath, err)
 	}
-	objects.Service = service
 
 	t.Log("Since the Service was updated a new Revision will be created and the Service will be updated")
 	green.Revision, err = v1test.WaitForServiceLatestRevision(clients, names)
@@ -89,8 +88,8 @@ func TestBlueGreenRoute(t *testing.T) {
 	}
 
 	t.Log("Updating RouteSpec")
-	if _, err := v1test.UpdateServiceRouteSpec(t, clients, names, v1.RouteSpec{
-		Traffic: []v1.TrafficTarget{{
+	if _, err := v1test.UpdateService(t, clients, names, rtesting.WithTraffic(
+		[]v1.TrafficTarget{{
 			Tag:          blue.TrafficTarget,
 			RevisionName: blue.Revision,
 			Percent:      ptr.Int64(50),
@@ -99,7 +98,7 @@ func TestBlueGreenRoute(t *testing.T) {
 			RevisionName: green.Revision,
 			Percent:      ptr.Int64(50),
 		}},
-	}); err != nil {
+	)); err != nil {
 		t.Fatal("Failed to update Service:", err)
 	}
 
@@ -108,7 +107,7 @@ func TestBlueGreenRoute(t *testing.T) {
 		t.Fatalf("The Service %s was not marked as Ready to serve traffic: %v", names.Service, err)
 	}
 
-	service, err = clients.ServingClient.Services.Get(context.Background(), names.Service, metav1.GetOptions{})
+	service, err := clients.ServingClient.Services.Get(context.Background(), names.Service, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Error fetching Service %s: %v", names.Service, err)
 	}

--- a/test/conformance/api/v1/blue_green_test.go
+++ b/test/conformance/api/v1/blue_green_test.go
@@ -88,7 +88,7 @@ func TestBlueGreenRoute(t *testing.T) {
 	}
 
 	t.Log("Updating RouteSpec")
-	if _, err := v1test.UpdateService(t, clients, names, rtesting.WithTraffic(
+	if _, err := v1test.UpdateService(t, clients, names, rtesting.WithTrafficTarget(
 		[]v1.TrafficTarget{{
 			Tag:          blue.TrafficTarget,
 			RevisionName: blue.Revision,

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -281,7 +281,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 
 	// 1. One Revision Specified, current == latest.
 	t.Log("1. Updating Service to ReleaseType using lastCreatedRevision")
-	objects.Service, err = v1test.UpdateService(t, clients, names, rtesting.WithTraffic(
+	objects.Service, err = v1test.UpdateService(t, clients, names, rtesting.WithTrafficTarget(
 		[]v1.TrafficTarget{{
 			Tag:          "current",
 			RevisionName: firstRevision,
@@ -368,7 +368,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 
 	// 3. Two Revisions Specified, 50% rollout, candidate == latest.
 	t.Log("3. Updating Service to split traffic between two revisions using Release mode")
-	objects.Service, err = v1test.UpdateService(t, clients, names, rtesting.WithTraffic(
+	objects.Service, err = v1test.UpdateService(t, clients, names, rtesting.WithTrafficTarget(
 		[]v1.TrafficTarget{{
 			Tag:          "current",
 			RevisionName: firstRevision,
@@ -469,7 +469,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 	// Now update the service to use `@latest` as candidate.
 	t.Log("5. Updating Service to split traffic between two `current` and `@latest`")
 
-	objects.Service, err = v1test.UpdateService(t, clients, names, rtesting.WithTraffic(
+	objects.Service, err = v1test.UpdateService(t, clients, names, rtesting.WithTrafficTarget(
 		[]v1.TrafficTarget{{
 			Tag:          "current",
 			RevisionName: firstRevision,

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -88,7 +88,7 @@ func TestServiceCreateAndUpdate(t *testing.T) {
 	names.Image = test.PizzaPlanet2
 	image2 := pkgtest.ImagePath(names.Image)
 	if objects.Service, err = v1test.UpdateService(t, clients, names, rtesting.WithServiceImage(image2)); err != nil {
-		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, image2, err)
+		t.Fatalf("Update for Service %s with new image %s failed: %v", names.Service, image2, err)
 	}
 
 	t.Log("Service should reflect new revision created and ready in status.")
@@ -331,7 +331,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 	// 2. One Revision Specified, current != latest.
 	t.Log("2. Updating the Service Spec with a new image")
 	if objects.Service, err = v1test.UpdateService(t, clients, names, rtesting.WithServiceImage(releaseImagePath2)); err != nil {
-		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, releaseImagePath2, err)
+		t.Fatalf("Update for Service %s with new image %s failed: %v", names.Service, releaseImagePath2, err)
 	}
 
 	t.Log("Since the Service was updated a new Revision will be created")
@@ -430,7 +430,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 	// 4. Two Revisions Specified, 50% rollout, candidate != latest.
 	t.Log("4. Updating the Service Spec with a new image")
 	if objects.Service, err = v1test.UpdateService(t, clients, names, rtesting.WithServiceImage(releaseImagePath3)); err != nil {
-		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, releaseImagePath3, err)
+		t.Fatalf("Update for Service %s with new image %s failed: %v", names.Service, releaseImagePath3, err)
 	}
 	t.Log("Since the Service was updated a new Revision will be created")
 	if names.Revision, err = v1test.WaitForServiceLatestRevision(clients, names); err != nil {
@@ -558,7 +558,7 @@ func TestAnnotationPropagation(t *testing.T) {
 	t.Log("Updating the Service to use a different image.")
 	image2 := pkgtest.ImagePath(test.PizzaPlanet2)
 	if objects.Service, err = v1test.UpdateService(t, clients, names, rtesting.WithServiceImage(image2)); err != nil {
-		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, image2, err)
+		t.Fatalf("Update for Service %s with new image %s failed: %v", names.Service, image2, err)
 	}
 
 	t.Log("Service should reflect new revision created and ready in status.")
@@ -591,7 +591,7 @@ func TestAnnotationPropagation(t *testing.T) {
 	t.Log("Updating the Service to use a different image.")
 	image3 := pkgtest.ImagePath(test.HelloWorld)
 	if objects.Service, err = v1test.UpdateService(t, clients, names, rtesting.WithServiceImage(image3)); err != nil {
-		t.Fatalf("Patch update for Service %s with new image %s failed: %v", names.Service, image3, err)
+		t.Fatalf("Update for Service %s with new image %s failed: %v", names.Service, image3, err)
 	}
 
 	t.Log("Service should reflect new revision created and ready in status.")

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -120,7 +120,7 @@ func testAutoTLS(t *testing.T) {
 			return transport
 		}
 
-		if _, err := v1test.UpdateServiceRouteSpec(t, clients, names, servingv1.RouteSpec{
+		if _, err := v1test.PatchServiceRouteSpec(t, clients, names, servingv1.RouteSpec{
 			Traffic: []servingv1.TrafficTarget{{
 				Tag:            "r",
 				Percent:        ptr.Int64(50),

--- a/test/e2e/subroutes_test.go
+++ b/test/e2e/subroutes_test.go
@@ -153,7 +153,7 @@ func TestSubrouteVisibilityPublicToPrivate(t *testing.T) {
 			LatestRevision: ptr.Bool(true),
 		})
 
-	if _, err = v1test.UpdateServiceRouteSpec(t, clients, names, v1.RouteSpec{Traffic: ksvcCopyRouteTraffic}); err != nil {
+	if _, err = v1test.PatchServiceRouteSpec(t, clients, names, v1.RouteSpec{Traffic: ksvcCopyRouteTraffic}); err != nil {
 		t.Fatal("Failed to patch service:", err)
 	}
 

--- a/test/e2e/tagheader/tag_header_based_routing_test.go
+++ b/test/e2e/tagheader/tag_header_based_routing_test.go
@@ -76,7 +76,7 @@ func TestTagHeaderBasedRouting(t *testing.T) {
 		t.Fatalf("Service %s was not updated with the Revision for image %s: %v", names.Service, test.PizzaPlanet2, err)
 	}
 
-	if _, err := v1test.UpdateServiceRouteSpec(t, clients, names, v1.RouteSpec{
+	if _, err := v1test.PatchServiceRouteSpec(t, clients, names, v1.RouteSpec{
 		Traffic: []v1.TrafficTarget{{
 			Tag:          "rev1",
 			RevisionName: revision1,

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -243,7 +243,7 @@ func TestWebSocketBlueGreenRoute(t *testing.T) {
 	}
 
 	t.Log("Updating RouteSpec")
-	if _, err := v1test.UpdateServiceRouteSpec(t, clients, names, v1.RouteSpec{
+	if _, err := v1test.PatchServiceRouteSpec(t, clients, names, v1.RouteSpec{
 		Traffic: []v1.TrafficTarget{{
 			Tag:          blue.TrafficTarget,
 			RevisionName: blue.Revision,

--- a/test/upgrade/postupgrade.go
+++ b/test/upgrade/postupgrade.go
@@ -108,7 +108,7 @@ func bYORevisionPostUpgrade(t *testing.T) {
 		Service: byoServiceName,
 	}
 
-	if _, err := v1test.UpdateServiceRouteSpec(t, clients, names, v1.RouteSpec{
+	if _, err := v1test.PatchServiceRouteSpec(t, clients, names, v1.RouteSpec{
 		Traffic: []v1.TrafficTarget{{
 			Tag:          "example-tag",
 			RevisionName: byoRevName,

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -184,7 +184,7 @@ func PatchService(t testing.TB, clients *test.Clients, service *v1.Service, fopt
 	})
 }
 
-// PatchServiceRouteSpec updates a service to use the route name in names.
+// PatchServiceRouteSpec patches a service to use the route name in names.
 func PatchServiceRouteSpec(t testing.TB, clients *test.Clients, names test.ResourceNames, rs v1.RouteSpec) (svc *v1.Service, err error) {
 	patch := []map[string]interface{}{{
 		"op":    "replace",

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -155,7 +155,7 @@ func UpdateService(t testing.TB, clients *test.Clients, names test.ResourceNames
 		if err != nil {
 			return err
 		}
-		// newSvc.ObjectMeta.ResourceVersion = ""
+
 		for _, opt := range fopt {
 			opt(newSvc)
 		}

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -147,6 +147,25 @@ func createService(t testing.TB, clients *test.Clients, service *v1.Service) (sv
 	})
 }
 
+// UpdateService updates the existing service with name in names with the applied mutations.
+// Returns the latest service object
+func UpdateService(t testing.TB, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.ServiceOption) (svc *v1.Service, err error) {
+	return svc, reconciler.RetryTestErrors(func(int) (err error) {
+		newSvc, err := clients.ServingClient.Services.Get(context.Background(), names.Service, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		// newSvc.ObjectMeta.ResourceVersion = ""
+		for _, opt := range fopt {
+			opt(newSvc)
+		}
+
+		LogResourceObject(t, ResourceObjects{Service: newSvc})
+		svc, err = clients.ServingClient.Services.Update(context.Background(), newSvc, metav1.UpdateOptions{})
+		return err
+	})
+}
+
 // PatchService patches the existing service passed in with the applied mutations.
 // Returns the latest service object
 func PatchService(t testing.TB, clients *test.Clients, service *v1.Service, fopt ...rtesting.ServiceOption) (svc *v1.Service, err error) {
@@ -165,8 +184,8 @@ func PatchService(t testing.TB, clients *test.Clients, service *v1.Service, fopt
 	})
 }
 
-// UpdateServiceRouteSpec updates a service to use the route name in names.
-func UpdateServiceRouteSpec(t testing.TB, clients *test.Clients, names test.ResourceNames, rs v1.RouteSpec) (svc *v1.Service, err error) {
+// PatchServiceRouteSpec updates a service to use the route name in names.
+func PatchServiceRouteSpec(t testing.TB, clients *test.Clients, names test.ResourceNames, rs v1.RouteSpec) (svc *v1.Service, err error) {
 	patch := []map[string]interface{}{{
 		"op":    "replace",
 		"path":  "/spec/traffic",


### PR DESCRIPTION
For #11710

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Introduces an UpdateService function and uses it in conformance tests since patch API is not a MUST.
* Renames `UpdateServiceRouteSpec` to `PatchServiceRouteSpec` since it actually uses patch.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
