### PR TITLE
Adding test for automountServiceAccountToken=true

### DIFF
--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -148,6 +148,15 @@ func TestPodSpecValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
+		name: "with automountServiceAccountToken = true ",
+		ps: corev1.PodSpec{
+			AutomountServiceAccountToken: ptr.Bool(true),
+			Containers: []corev1.Container{{
+				Image: "helloworld",
+			}},
+		},
+		want: apis.ErrDisallowedFields("automountServiceAccountToken"),
+	}, {
 		name: "with volume name collision",
 		ps: corev1.PodSpec{
 			Containers: []corev1.Container{{

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -148,7 +148,7 @@ func TestPodSpecValidation(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		name: "with automountServiceAccountToken = true ",
+		name: "with automountServiceAccountToken = true",
 		ps: corev1.PodSpec{
 			AutomountServiceAccountToken: ptr.Bool(true),
 			Containers: []corev1.Container{{


### PR DESCRIPTION
Addition to  #11723 , adding an additional unit test for `automountServiceAccountToken: true`, which slipped through the cracks when updating to only allow that to be set to `false`.

```release-note
NONE
```
