### PR TITLE
Use io and os packages in preference to ioutil

### DIFF
--- a/cmd/queue/execprobe.go
+++ b/cmd/queue/execprobe.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -107,7 +106,7 @@ func probeQueueHealthPath(timeout time.Duration, queueServingPort string, transp
 		defer func() {
 			// Ensure body is read and closed to ensure connection can be re-used via keep-alive.
 			// No point handling errors here, connection just won't be reused.
-			io.Copy(ioutil.Discard, res.Body)
+			io.Copy(io.Discard, res.Body)
 			res.Body.Close()
 		}()
 

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -140,7 +140,7 @@ func TestActivationHandler(t *testing.T) {
 				t.Fatalf("Unexpected response status. Want %d, got %d", test.wantCode, resp.Code)
 			}
 
-			gotBody, err := ioutil.ReadAll(resp.Body)
+			gotBody, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatal("Error reading body:", err)
 			}
@@ -340,7 +340,7 @@ func BenchmarkHandler(b *testing.B) {
 
 		rt := pkgnet.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
 			return &http.Response{
-				Body:       ioutil.NopCloser(bytes.NewReader(body)),
+				Body:       io.NopCloser(bytes.NewReader(body)),
 				StatusCode: http.StatusOK,
 			}, nil
 		})

--- a/pkg/activator/handler/main_test.go
+++ b/pkg/activator/handler/main_test.go
@@ -18,7 +18,7 @@ package handler
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -63,7 +63,7 @@ func BenchmarkHandlerChain(b *testing.B) {
 	body := []byte(randomString(1024))
 	rt := pkgnet.RoundTripperFunc(func(*http.Request) (*http.Response, error) {
 		return &http.Response{
-			Body:       ioutil.NopCloser(bytes.NewReader(body)),
+			Body:       io.NopCloser(bytes.NewReader(body)),
 			StatusCode: http.StatusOK,
 		}, nil
 	})
@@ -72,7 +72,7 @@ func BenchmarkHandlerChain(b *testing.B) {
 	ah := New(ctx, fakeThrottler{}, rt, false, logger)
 	ah = concurrencyReporter.Handler(ah)
 	ah = NewTracingHandler(ah)
-	ah, _ = pkghttp.NewRequestLogHandler(ah, ioutil.Discard, "", nil, false)
+	ah, _ = pkghttp.NewRequestLogHandler(ah, io.Discard, "", nil, false)
 	ah = NewMetricHandler(activatorPodName, ah)
 	ah = NewContextHandler(ctx, ah, configStore)
 	ah = &ProbeHandler{NextHandler: ah}

--- a/pkg/apis/config/defaults.go
+++ b/pkg/apis/config/defaults.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"strings"
 	"text/template"
@@ -144,7 +144,7 @@ func NewDefaultsConfigFromMap(data map[string]string) (*Defaults, error) {
 		return nil, err
 	}
 	// Check that the template properly applies to ObjectMeta.
-	if err := tmpl.Execute(ioutil.Discard, metav1.ObjectMeta{}); err != nil {
+	if err := tmpl.Execute(io.Discard, metav1.ObjectMeta{}); err != nil {
 		return nil, fmt.Errorf("error executing template: %w", err)
 	}
 	templateCache.Add(nc.UserContainerNameTemplate, tmpl)

--- a/pkg/autoscaler/metrics/http_scrape_client_test.go
+++ b/pkg/autoscaler/metrics/http_scrape_client_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -123,7 +123,7 @@ func makeProtoResponse(statusCode int, stat Stat, contentType string) *http.Resp
 	buffer, _ := stat.Marshal()
 	res := &http.Response{
 		StatusCode: statusCode,
-		Body:       ioutil.NopCloser(bytes.NewBuffer(buffer)),
+		Body:       io.NopCloser(bytes.NewBuffer(buffer)),
 	}
 	res.Header = http.Header{}
 	res.Header.Set("Content-Type", contentType)

--- a/pkg/http/request_log_test.go
+++ b/pkg/http/request_log_test.go
@@ -18,7 +18,7 @@ package http
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -234,7 +234,7 @@ func TestSetTemplate(t *testing.T) {
 }
 
 func BenchmarkRequestLogHandlerNoTemplate(b *testing.B) {
-	handler, err := NewRequestLogHandler(baseHandler, ioutil.Discard, "", defaultInputGetter, false)
+	handler, err := NewRequestLogHandler(baseHandler, io.Discard, "", defaultInputGetter, false)
 	if err != nil {
 		b.Fatal("Failed to create handler:", err)
 	}
@@ -259,7 +259,7 @@ func BenchmarkRequestLogHandlerNoTemplate(b *testing.B) {
 func BenchmarkRequestLogHandlerDefaultTemplate(b *testing.B) {
 	// Taken from config-observability.yaml
 	tpl := `{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}`
-	handler, err := NewRequestLogHandler(baseHandler, ioutil.Discard, tpl, defaultInputGetter, false)
+	handler, err := NewRequestLogHandler(baseHandler, io.Discard, tpl, defaultInputGetter, false)
 	if err != nil {
 		b.Fatal("Failed to create handler:", err)
 	}

--- a/pkg/logging/sync_file_writer_test.go
+++ b/pkg/logging/sync_file_writer_test.go
@@ -17,13 +17,12 @@ limitations under the License.
 package logging
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
 
 func TestWrite(t *testing.T) {
-	file, err := ioutil.TempFile("", "sync_file_writer_test")
+	file, err := os.CreateTemp("", "sync_file_writer_test")
 	if err != nil {
 		t.Fatal("failed to create a temp file for the test")
 	}
@@ -35,7 +34,7 @@ func TestWrite(t *testing.T) {
 	file.Close()
 
 	want := "line1\nline2\n"
-	gotBytes, _ := ioutil.ReadFile(file.Name())
+	gotBytes, _ := os.ReadFile(file.Name())
 	got := string(gotBytes)
 	if got != want {
 		t.Errorf("got %v, want %v", got, want)

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -19,7 +19,6 @@ package health
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -182,7 +181,7 @@ func HTTPProbe(config HTTPProbeConfigOptions) error {
 	defer func() {
 		// Ensure body is both read _and_ closed so it can be reused for keep-alive.
 		// No point handling errors, connection just won't be reused.
-		io.Copy(ioutil.Discard, res.Body)
+		io.Copy(io.Discard, res.Body)
 		res.Body.Close()
 	}()
 

--- a/pkg/queue/protobuf_stats_reporter_test.go
+++ b/pkg/queue/protobuf_stats_reporter_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package queue
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -70,7 +70,7 @@ func scrapeProtobufStat(t *testing.T, r *ProtobufStatsReporter) metrics.Stat {
 		t.Fatalf("Expected ServeHTTP status %d but was %d", http.StatusOK, result.StatusCode)
 	}
 
-	b, err := ioutil.ReadAll(result.Body)
+	b, err := io.ReadAll(result.Body)
 	if err != nil {
 		t.Fatal("Expected Read to succeed, got", err)
 	}

--- a/pkg/reconciler/revision/resolve.go
+++ b/pkg/reconciler/revision/resolve.go
@@ -22,8 +22,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -54,7 +54,7 @@ func newResolverTransport(path string, maxIdleConns, maxIdleConnsPerHost int) (*
 		pool = x509.NewCertPool()
 	}
 
-	if crt, err := ioutil.ReadFile(path); err != nil {
+	if crt, err := os.ReadFile(path); err != nil {
 		return nil, err
 	} else if ok := pool.AppendCertsFromPEM(crt); !ok {
 		return nil, errors.New("failed to append k8s cert bundle to cert pool")

--- a/pkg/reconciler/revision/resolve_test.go
+++ b/pkg/reconciler/revision/resolve_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -548,7 +547,7 @@ yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
 func writeCertFile(dir, path string, contents []byte) (string, error) {
 	fp := filepath.Join(dir, path)
 	if contents != nil {
-		if err := ioutil.WriteFile(fp, contents, os.ModePerm); err != nil {
+		if err := os.WriteFile(fp, contents, os.ModePerm); err != nil {
 			return "", err
 		}
 	}

--- a/test/e2e/autotls/config/util.go
+++ b/test/e2e/autotls/config/util.go
@@ -18,7 +18,7 @@ package config
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"golang.org/x/oauth2/google"
@@ -87,7 +87,7 @@ func ChangeDNSRecord(change *dns.Change, svc *dns.Service, dnsProject, dnsZone s
 // GetCloudDNSSvc returns the Cloud DNS Service stub.
 // reference: https://github.com/jetstack/cert-manager/blob/master/pkg/issuer/acme/dns/clouddns/clouddns.go
 func GetCloudDNSSvc(svcAccountKeyFile string) (*dns.Service, error) {
-	data, err := ioutil.ReadFile(svcAccountKeyFile)
+	data, err := os.ReadFile(svcAccountKeyFile)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/autotls/util_test.go
+++ b/test/e2e/autotls/util_test.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -92,7 +92,7 @@ func RuntimeRequestWithExpectations(ctx context.Context, t *testing.T, client *h
 	}
 
 	if resp.StatusCode == http.StatusOK {
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Error("Unable to read response body:", err)
 			DumpResponse(ctx, t, resp)

--- a/test/e2e/websocket.go
+++ b/test/e2e/websocket.go
@@ -18,7 +18,7 @@ package e2e
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -84,7 +84,7 @@ func connect(t *testing.T, clients *test.Clients, domain string) (*websocket.Con
 			return false, nil
 		}
 
-		body, readErr := ioutil.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
 			t.Logf("Connection failed: %v. Failed to read HTTP response: %v", err, readErr)
 			return false, nil

--- a/test/performance/benchmarks/deployment-probe/continuous/main.go
+++ b/test/performance/benchmarks/deployment-probe/continuous/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -56,7 +55,7 @@ var (
 
 func readTemplate() (*v1.Service, error) {
 	path := filepath.Join(os.Getenv("KO_DATA_PATH"), *template+"-template.yaml")
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/test/test_images/emptydir/emptydir.go
+++ b/test/test_images/emptydir/emptydir.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -44,7 +43,7 @@ func init() {
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	content, err := ioutil.ReadFile(path + "/testfile")
+	content, err := os.ReadFile(path + "/testfile")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/test/test_images/hellovolume/hellovolume.go
+++ b/test/test_images/hellovolume/hellovolume.go
@@ -19,9 +19,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -38,7 +38,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "there is no escape", http.StatusBadRequest)
 		return
 	}
-	content, err := ioutil.ReadFile(p)
+	content, err := os.ReadFile(p)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/test/test_images/multicontainer/servingcontainer/servingcontainer.go
+++ b/test/test_images/multicontainer/servingcontainer/servingcontainer.go
@@ -19,7 +19,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -32,7 +32,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	resp, err := ioutil.ReadAll(res.Body)
+	resp, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/test_images/runtime/handlers/cgroup.go
+++ b/test/test_images/runtime/handlers/cgroup.go
@@ -17,7 +17,6 @@ limitations under the License.
 package handlers
 
 import (
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -46,7 +45,7 @@ func cgroups(paths ...string) []*types.Cgroup {
 			continue
 		}
 
-		bc, err := ioutil.ReadFile(path)
+		bc, err := os.ReadFile(path)
 		if err != nil {
 			cgroups = append(cgroups, &types.Cgroup{Name: path, Error: err.Error()})
 			continue
@@ -61,7 +60,7 @@ func cgroups(paths ...string) []*types.Cgroup {
 		// Try to write to the Cgroup. We expect this to fail as a cheap
 		// method for read-only validation
 		newValue := []byte{'9'}
-		err = ioutil.WriteFile(path, newValue, 0644)
+		err = os.WriteFile(path, newValue, 0644)
 		if err != nil {
 			cgroups = append(cgroups, &types.Cgroup{Name: path, Value: &ic, ReadOnly: &yes})
 		} else {

--- a/test/test_images/runtime/handlers/file_access_attempt.go
+++ b/test/test_images/runtime/handlers/file_access_attempt.go
@@ -17,7 +17,6 @@ limitations under the License.
 package handlers
 
 import (
-	"io/ioutil"
 	"os"
 
 	"knative.dev/serving/test/types"
@@ -66,7 +65,7 @@ func checkReadable(path string) error {
 	}
 
 	if file.IsDir() {
-		_, err := ioutil.ReadDir(path)
+		_, err := os.ReadDir(path)
 		return err
 	}
 
@@ -91,7 +90,7 @@ func checkWritable(path string) error {
 	}
 
 	if file.IsDir() {
-		writeFile, err := ioutil.TempFile(path, "random")
+		writeFile, err := os.CreateTemp(path, "random")
 		if writeFile != nil {
 			os.Remove(writeFile.Name())
 		}


### PR DESCRIPTION
Now that we're on go 1.16 [all methods in ioutil have alternatives in other packages](https://pkg.go.dev/io/ioutil). While the ioutil versions aren't going away, the new versions are preferred for new code, so we might as well swap over now so things will be nice and consistent going forward.

/assign @dprotaso @psschwei 