### PR TITLE
Resolve ExternalName services to non-externalname services, even across namespaces.

### DIFF
--- a/pkg/reconciler/domainmapping/controller.go
+++ b/pkg/reconciler/domainmapping/controller.go
@@ -25,6 +25,7 @@ import (
 	certificateinformer "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/certificate"
 	domainclaiminformer "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/clusterdomainclaim"
 	ingressinformer "knative.dev/networking/pkg/client/injection/informers/networking/v1alpha1/ingress"
+	serviceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/service"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -42,11 +43,13 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	domainmappingInformer := domainmapping.Get(ctx)
 	ingressInformer := ingressinformer.Get(ctx)
 	domainClaimInformer := domainclaiminformer.Get(ctx)
+	serviceInformer := serviceinformer.Get(ctx)
 
 	r := &Reconciler{
 		certificateLister: certificateInformer.Lister(),
 		ingressLister:     ingressInformer.Lister(),
 		domainClaimLister: domainClaimInformer.Lister(),
+		serviceLister:     serviceInformer.Lister(),
 		netclient:         netclient.Get(ctx),
 	}
 

--- a/pkg/reconciler/domainmapping/resources/ingress.go
+++ b/pkg/reconciler/domainmapping/resources/ingress.go
@@ -39,7 +39,7 @@ func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, backendS
 	return &netv1alpha1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kmeta.ChildName(dm.GetName(), ""),
-			Namespace: dm.Namespace,
+			Namespace: backendServiceNamespace,
 			Annotations: kmeta.FilterMap(kmeta.UnionMaps(map[string]string{
 				networking.IngressClassAnnotationKey: ingressClass,
 			}, dm.GetAnnotations()), func(key string) bool {

--- a/pkg/reconciler/domainmapping/resources/ingress.go
+++ b/pkg/reconciler/domainmapping/resources/ingress.go
@@ -35,7 +35,7 @@ import (
 // backend is always in the same namespace also (as this is required by
 // KIngress).  The created ingress will contain a RewriteHost rule to cause the
 // given hostName to be used as the host.
-func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, hostName, ingressClass string, httpOption netv1alpha1.HTTPOption, tls []netv1alpha1.IngressTLS, acmeChallenges ...netv1alpha1.HTTP01Challenge) *netv1alpha1.Ingress {
+func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, backendServiceNamespace, hostName, ingressClass string, httpOption netv1alpha1.HTTPOption, tls []netv1alpha1.IngressTLS, acmeChallenges ...netv1alpha1.HTTP01Challenge) *netv1alpha1.Ingress {
 	return &netv1alpha1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kmeta.ChildName(dm.GetName(), ""),
@@ -68,7 +68,7 @@ func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, hostName
 									network.OriginalHostHeader: dm.Name,
 								},
 								IngressBackend: netv1alpha1.IngressBackend{
-									ServiceNamespace: dm.Namespace,
+									ServiceNamespace: backendServiceNamespace,
 									ServiceName:      backendServiceName,
 									ServicePort:      intstr.FromInt(80),
 								},

--- a/pkg/reconciler/domainmapping/resources/ingress_test.go
+++ b/pkg/reconciler/domainmapping/resources/ingress_test.go
@@ -232,7 +232,7 @@ func TestMakeIngress(t *testing.T) {
 			})
 			tc.want.OwnerReferences = []metav1.OwnerReference{*kmeta.NewControllerRef(&tc.dm)}
 			got := *MakeIngress(&tc.dm,
-				"the-target-svc", "the-rewrite-host", "the-ingress-class",
+				"the-target-svc", "the-namespace", "the-rewrite-host", "the-ingress-class",
 				netv1alpha1.HTTPOptionEnabled,
 				tc.tls, tc.acmeChallenges...)
 			if diff := cmp.Diff(tc.want, got); diff != "" {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Have DomainMapping resolve externalName Services to their destinations when constructing KIngress objects.
* This should avoid CVE-2021-32783 mitigations by Contour (blocking ExternalName services in HTTPProxy objects).
* Also enables resolution of shorter service names (foo.ns.svc, foo.ns, foo).
* May have improved handling of URLs with ports, though most of that is still TODO.

/hold

The current cross-namespace Service reference probably breaks KIngress today. Figuring out what to do about that.

**Release Note**

```release-note
* Enables DomainMapping to resolve cluster-local addressables that don't end in svc.cluster.local
* DomainMapping now avoids off-cluster redirects via ExternalName. This mitigates CVE-2021-32783

```
