### PR TITLE
Change label and annotation key names in tests from camelCase to lowercase with dash

### DIFF
--- a/test/conformance/api/v1/configuration_test.go
+++ b/test/conformance/api/v1/configuration_test.go
@@ -56,8 +56,8 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 
 	t.Log("Updating labels of Configuration", names.Config)
 	newLabels := map[string]string{
-		"labelX": "abc",
-		"labelY": "def",
+		"label-x": "abc",
+		"label-y": "def",
 	}
 	// Copy over new labels.
 	cfg.Labels = kmeta.UnionMaps(cfg.Labels, newLabels)
@@ -89,8 +89,8 @@ func TestUpdateConfigurationMetadata(t *testing.T) {
 
 	t.Log("Updating annotations of Configuration", names.Config)
 	newAnnotations := map[string]string{
-		"annotationA": "123",
-		"annotationB": "456",
+		"annotation-a": "123",
+		"annotation-b": "456",
 	}
 	cfg.Annotations = kmeta.UnionMaps(cfg.Annotations, newAnnotations)
 	cfg, err = clients.ServingClient.Configs.Update(context.Background(), cfg, metav1.UpdateOptions{})

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -114,8 +114,8 @@ func TestServiceCreateAndUpdate(t *testing.T) {
 	t.Logf("Updating labels of the RevisionTemplateSpec for service %s.", names.Service)
 	metadata := metav1.ObjectMeta{
 		Labels: map[string]string{
-			"labelX": "abc",
-			"labelY": "def",
+			"label-x": "abc",
+			"label-y": "def",
 		},
 	}
 	if objects.Service, err = v1test.PatchService(t, clients, objects.Service, rtesting.WithServiceTemplateMeta(metadata)); err != nil {
@@ -131,8 +131,8 @@ func TestServiceCreateAndUpdate(t *testing.T) {
 	t.Log("Updating annotations of RevisionTemplateSpec for service", names.Service)
 	metadata = metav1.ObjectMeta{
 		Annotations: map[string]string{
-			"annotationA": "123",
-			"annotationB": "456",
+			"annotation-a": "123",
+			"annotation-b": "456",
 		},
 	}
 	if objects.Service, err = v1test.PatchService(t, clients, objects.Service, rtesting.WithServiceTemplateMeta(metadata)); err != nil {


### PR DESCRIPTION
Per [k8s API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#label-selector-and-annotation-conventions), label and annotation key names should be all lowercase, with words separated by dashes instead of camelCase.