### PR TITLE
Always set `ENABLE_HTTP2_AUTO_DETECTION` envvar

### DIFF
--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -181,6 +181,9 @@ var (
 		}, {
 			Name:  "CONCURRENCY_STATE_ENDPOINT",
 			Value: "",
+		}, {
+			Name:  "ENABLE_HTTP2_AUTO_DETECTION",
+			Value: "false",
 		}},
 	}
 

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -366,7 +366,7 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 			Value: cfg.Deployment.ConcurrencyStateEndpoint,
 		}, {
 			Name:  "ENABLE_HTTP2_AUTO_DETECTION",
-			Value: strconv.FormatBool(autoDetectHTTP2Status(cfg)),
+			Value: strconv.FormatBool(cfg.Features.AutoDetectHTTP2 == apicfg.Enabled),
 		}},
 	}
 
@@ -405,11 +405,4 @@ func applyReadinessProbeDefaultsForExec(p *corev1.Probe, port int32) {
 	if p.PeriodSeconds > 0 && p.TimeoutSeconds < 1 {
 		p.TimeoutSeconds = 1
 	}
-}
-
-func autoDetectHTTP2Status(cfg *config.Config) bool {
-	if cfg.Features.AutoDetectHTTP2 == apicfg.Enabled {
-		return true
-	}
-	return false
 }

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -364,15 +364,10 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		}, {
 			Name:  "CONCURRENCY_STATE_ENDPOINT",
 			Value: cfg.Deployment.ConcurrencyStateEndpoint,
-		}},
-	}
-
-	// Only add this if it's really enabled to avoid upgrade churn due to changing the deployment.
-	if cfg.Features.AutoDetectHTTP2 == apicfg.Enabled {
-		c.Env = append(c.Env, corev1.EnvVar{
+		}, {
 			Name:  "ENABLE_HTTP2_AUTO_DETECTION",
-			Value: "true",
-		})
+			Value: strconv.FormatBool(autoDetectHttp2Status(cfg)),
+		}},
 	}
 
 	return c, nil
@@ -409,5 +404,13 @@ func applyReadinessProbeDefaultsForExec(p *corev1.Probe, port int32) {
 
 	if p.PeriodSeconds > 0 && p.TimeoutSeconds < 1 {
 		p.TimeoutSeconds = 1
+	}
+}
+
+func autoDetectHttp2Status(cfg *config.Config) bool {
+	if cfg.Features.AutoDetectHTTP2 == apicfg.Enabled {
+		return true
+	} else {
+		return false
 	}
 }

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -366,7 +366,7 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 			Value: cfg.Deployment.ConcurrencyStateEndpoint,
 		}, {
 			Name:  "ENABLE_HTTP2_AUTO_DETECTION",
-			Value: strconv.FormatBool(autoDetectHttp2Status(cfg)),
+			Value: strconv.FormatBool(autoDetectHTTP2Status(cfg)),
 		}},
 	}
 
@@ -407,10 +407,9 @@ func applyReadinessProbeDefaultsForExec(p *corev1.Probe, port int32) {
 	}
 }
 
-func autoDetectHttp2Status(cfg *config.Config) bool {
+func autoDetectHTTP2Status(cfg *config.Config) bool {
 	if cfg.Features.AutoDetectHTTP2 == apicfg.Enabled {
 		return true
-	} else {
-		return false
 	}
+	return false
 }

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -333,7 +333,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			AutoDetectHTTP2: apicfg.Disabled,
 		},
 		dc: deployment.Config{
-			ProgressDeadline: 5678 * time.Second,
+			ProgressDeadline: 0 * time.Second,
 		},
 		want: queueContainer(func(c *corev1.Container) {
 			c.Env = env(map[string]string{

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -323,6 +323,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		want: queueContainer(func(c *corev1.Container) {
 			c.Env = env(map[string]string{
 				"CONCURRENCY_STATE_ENDPOINT": "freeze-proxy",
+			})
 		}),
 	}, {
 		name: "HTTP2 autodetection disabled",
@@ -337,7 +338,6 @@ func TestMakeQueueContainer(t *testing.T) {
 		want: queueContainer(func(c *corev1.Container) {
 			c.Env = env(map[string]string{
 				"ENABLE_HTTP2_AUTO_DETECTION": "false",
->>>>>>> 3bbf5fef9 (add test for when disabled)
 			})
 		}),
 	}, {

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -874,6 +874,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 var defaultEnv = map[string]string{
 	"CONCURRENCY_STATE_ENDPOINT":       "",
 	"CONTAINER_CONCURRENCY":            "0",
+	"ENABLE_HTTP2_AUTO_DETECTION":      "false",
 	"ENABLE_PROFILING":                 "false",
 	"METRICS_DOMAIN":                   metrics.Domain(),
 	"METRICS_COLLECTOR_ADDRESS":        "",

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -323,6 +323,21 @@ func TestMakeQueueContainer(t *testing.T) {
 		want: queueContainer(func(c *corev1.Container) {
 			c.Env = env(map[string]string{
 				"CONCURRENCY_STATE_ENDPOINT": "freeze-proxy",
+		}),
+	}, {
+		name: "HTTP2 autodetection disabled",
+		rev: revision("bar", "foo",
+			withContainers(containers)),
+		fc: apicfg.Features{
+			AutoDetectHTTP2: apicfg.Disabled,
+		},
+		dc: deployment.Config{
+			ProgressDeadline: 5678 * time.Second,
+		},
+		want: queueContainer(func(c *corev1.Container) {
+			c.Env = env(map[string]string{
+				"ENABLE_HTTP2_AUTO_DETECTION": "false",
+>>>>>>> 3bbf5fef9 (add test for when disabled)
 			})
 		}),
 	}, {


### PR DESCRIPTION
Based on [discussion](https://github.com/knative/serving/pull/11699#discussion_r681078090) in #11699 , the `if` block used to only set the `ENABLE_HTTP2_AUTO_DETECTION` envvar if the feature is enabled is no longer needed. 

`ENABLE_HTTP2_AUTO_DETECTION` will be set to `false` if not explicitly enabled. 

If it is enabled, it will be set to `true` (no change in this case).

/assign @markusthoemmes 

```release-note
Set `ENABLE_HTTP2_AUTO_DETECTION` to `false` by default if the feature is not enabled.
```
