### PR TITLE
WIP: Add conformance test for readiness behaviour after startup

### DIFF
--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -20,10 +20,15 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	pkgtest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
 	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
@@ -32,6 +37,11 @@ import (
 	"knative.dev/serving/test/conformance/api/shared"
 	v1test "knative.dev/serving/test/v1"
 )
+
+// readinessPropagationSeconds is how long to poll to allow for readiness probe
+// changes to propagate to ingresses/activator.
+// This is based on the default scaleToZeroGracePeriod.
+const readinessPropagationTime = 30 * time.Second
 
 func TestProbeRuntime(t *testing.T) {
 	t.Parallel()
@@ -131,4 +141,137 @@ func TestProbeRuntime(t *testing.T) {
 			})
 		}
 	}
+}
+
+// This test validates the behaviour of readiness probes *after* initial startup.
+// Note: the current behaviour is not ideal: when periodSeconds > 0 we ignore
+// readiness probes after startup. Also, when a pod goes unready after startup
+// and there are no other pods in the revision we hang, potentially forever,
+// which may not be what a user wants. The goal of this test is to describe the
+// current behaviour, so that we can confidently change it.
+// See https://github.com/knative/serving/issues/10764 & https://github.com/knative/serving/issues/10765.
+func TestProbeRuntimeAfterStartup(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	for _, period := range []int32{0, 1} {
+		period := period
+		t.Run(fmt.Sprintf("period=%d", period), func(t *testing.T) {
+			t.Parallel()
+			names := test.ResourceNames{
+				Service: test.ObjectNameForTest(t),
+				Image:   test.Readiness,
+			}
+
+			test.EnsureTearDown(t, clients, &names)
+			resources, err := v1test.CreateServiceReady(t, clients, &names, v1opts.WithReadinessProbe(
+				&corev1.Probe{
+					PeriodSeconds: period,
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/healthz",
+						},
+					},
+				}))
+			if err != nil {
+				t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+			}
+
+			t.Log("POST to /start-failing")
+			url := resources.Route.Status.URL.URL()
+			client, err := pkgtest.NewSpoofingClient(context.Background(),
+				clients.KubeClient,
+				t.Logf,
+				url.Hostname(),
+				test.ServingFlags.ResolvableDomain,
+				test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
+			if err != nil {
+				t.Fatalf("Failed to create spoofing client: %v", err)
+			}
+
+			url.Path = "/start-failing"
+			startFailing, err := http.NewRequest("POST", url.String(), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.Do(startFailing); err != nil {
+				t.Fatalf("POST to /start-failing failed: %v", err)
+			}
+
+			url.Path = "/"
+			if period == 0 {
+				// When periodSeconds = 0 we expect that once readiness propagates
+				// there will be no ready pods, and therefore the request will time
+				// out. (see https://github.com/knative/serving/issues/10765).
+				if err := wait.PollImmediate(1*time.Second, readinessPropagationTime, func() (bool, error) {
+					startFailing, err := http.NewRequest("GET", url.String(), nil)
+					if err != nil {
+						return false, err
+					}
+
+					// 5 Seconds is enough to be confident the request is timing out.
+					client.Client.Timeout = 5 * time.Second
+
+					resp, err := client.Do(startFailing, func(err error) (bool, error) {
+						if isTimeout(err) {
+							// We're actually expecting a timeout here, so don't retry on timeouts.
+							return false, nil
+						}
+
+						return spoof.DefaultErrorRetryChecker(err)
+					})
+					if isTimeout(err) {
+						// We expect to eventually time out, so this is the success case.
+						return true, nil
+					} else if err != nil {
+						// Other errors are not expected.
+						return false, err
+					} else if resp.StatusCode == http.StatusOK {
+						// We'll continue to get 200s for a while until readiness propagates.
+						return false, nil
+					}
+
+					return false, errors.New("Received non-200 status code (expected to eventually time out)")
+				}); err != nil {
+					t.Fatal("Expected to eventually see request timeout due to all pods becoming unready, but got:", err)
+				}
+			} else {
+				// When periodSeconds > 0 we ignore readinessProbes after startup, so
+				// this request will continue to work, even though all pods are failing
+				// readiness.
+				// (see https://github.com/knative/serving/issues/10764).
+				if err := wait.PollImmediate(1*time.Second, readinessPropagationTime, func() (bool, error) {
+					if _, err = pkgtest.CheckEndpointState(
+						context.Background(),
+						clients.KubeClient,
+						t.Logf,
+						url,
+						v1test.RetryingRouteInconsistency(spoof.MatchesAllOf(spoof.IsStatusOK, spoof.MatchesBody(test.HelloWorldText))),
+						"readinessIsReady",
+						test.ServingFlags.ResolvableDomain,
+						test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+					); err != nil {
+						return false, err
+					}
+
+					// Keep retrying for readinessPropagationTime to allow
+					// readiness to propagate, otherwise we could get a false
+					// positive since ingresses and activator may not have noticed
+					// the readiness change yet.
+					return false, nil
+				}); !errors.Is(err, wait.ErrWaitTimeout) {
+					t.Fatalf("Expected endpoint for Route %s at %s to consistently return success (even though readinessProbe is failing), but got: %v", names.Route, url, err)
+				}
+			}
+		})
+	}
+}
+
+func isTimeout(err error) bool {
+	var ne net.Error
+	if errors.As(err, &ne) {
+		return ne.Timeout()
+	}
+
+	return false
 }

--- a/test/test_images/readiness/readiness.go
+++ b/test/test_images/readiness/readiness.go
@@ -66,6 +66,18 @@ func main() {
 		fmt.Fprint(w, test.HelloWorldText)
 	})
 
+	http.HandleFunc("/start-failing", func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		healthy = false
+		fmt.Fprint(w, "will now fail readiness")
+	})
+
+	http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, test.HelloWorldText)
+	})
+
 	if env := os.Getenv("LISTEN_DELAY"); env != "" {
 		delay, err := time.ParseDuration(env)
 		if err != nil {


### PR DESCRIPTION
Adds test coverage for the current behaviour of readiness probes after startup time (#10764 and #10765 propose changing this behaviour, these tests should give us confidence while doing so).

The periodSeconds>0 test needs to wait for a full 30 seconds in the success case to be reasonably confident that the behaviour it asserts is not a false positive (because for up to this amount of time we could be routing successfully just because activator/ingress is not yet aware that readiness has changed), but I don't think there's a way to avoid that unfortunately.

/hold going to split this in to two PRs since it's a bit big
