### PR TITLE
Add test for readiness behaviour after startup when periodSeconds is 0

### DIFF
--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -187,7 +187,7 @@ func TestProbeRuntimeAfterStartup(t *testing.T) {
 	}
 
 	url.Path = "/start-failing"
-	startFailing, err := http.NewRequest("POST", url.String(), nil)
+	startFailing, err := http.NewRequest(http.MethodPost, url.String(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestProbeRuntimeAfterStartup(t *testing.T) {
 	// there will be no ready pods, and therefore the request will time
 	// out. (see https://github.com/knative/serving/issues/10765).
 	if err := wait.PollImmediate(1*time.Second, readinessPropagationTime, func() (bool, error) {
-		startFailing, err := http.NewRequest("GET", url.String(), nil)
+		startFailing, err := http.NewRequest(http.MethodGet, url.String(), nil)
 		if err != nil {
 			return false, err
 		}
@@ -235,9 +235,5 @@ func TestProbeRuntimeAfterStartup(t *testing.T) {
 
 func isTimeout(err error) bool {
 	var ne net.Error
-	if errors.As(err, &ne) {
-		return ne.Timeout()
-	}
-
-	return false
+	return errors.As(err, &ne) && ne.Timeout()
 }

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -20,10 +20,15 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	pkgtest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
 	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
@@ -32,6 +37,11 @@ import (
 	"knative.dev/serving/test/conformance/api/shared"
 	v1test "knative.dev/serving/test/v1"
 )
+
+// readinessPropagationTime is how long to poll to allow for readiness probe
+// changes to propagate to ingresses/activator.
+// This is based on the default scaleToZeroGracePeriod.
+const readinessPropagationTime = 30 * time.Second
 
 func TestProbeRuntime(t *testing.T) {
 	t.Parallel()
@@ -131,4 +141,103 @@ func TestProbeRuntime(t *testing.T) {
 			})
 		}
 	}
+}
+
+// This test validates the behaviour of readiness probes *after* initial startup.
+// The current behaviour is not ideal: when a pod goes unready after startup
+// and there are no other pods in the revision we hang, potentially forever,
+// which may not be what a user wants.
+// See https://github.com/knative/serving/issues/10765.
+func TestProbeRuntimeAfterStartup(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.Readiness,
+	}
+
+	test.EnsureTearDown(t, clients, &names)
+	resources, err := v1test.CreateServiceReady(t, clients, &names, v1opts.WithReadinessProbe(
+		&corev1.Probe{
+			// This behaviour is only the case where periodSeconds=0, because probes
+			// are ignored after startup when periodSeconds>0
+			// See https://github.com/knative/serving/issues/10764.
+			PeriodSeconds: 0,
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz",
+				},
+			},
+		}))
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	t.Log("POST to /start-failing")
+	url := resources.Route.Status.URL.URL()
+	client, err := pkgtest.NewSpoofingClient(context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		url.Hostname(),
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
+	if err != nil {
+		t.Fatalf("Failed to create spoofing client: %v", err)
+	}
+
+	url.Path = "/start-failing"
+	startFailing, err := http.NewRequest("POST", url.String(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Do(startFailing); err != nil {
+		t.Fatalf("POST to /start-failing failed: %v", err)
+	}
+
+	url.Path = "/"
+	// When periodSeconds = 0 we expect that once readiness propagates
+	// there will be no ready pods, and therefore the request will time
+	// out. (see https://github.com/knative/serving/issues/10765).
+	if err := wait.PollImmediate(1*time.Second, readinessPropagationTime, func() (bool, error) {
+		startFailing, err := http.NewRequest("GET", url.String(), nil)
+		if err != nil {
+			return false, err
+		}
+
+		// 5 Seconds is enough to be confident the request is timing out.
+		client.Client.Timeout = 5 * time.Second
+
+		resp, err := client.Do(startFailing, func(err error) (bool, error) {
+			if isTimeout(err) {
+				// We're actually expecting a timeout here, so don't retry on timeouts.
+				return false, nil
+			}
+
+			return spoof.DefaultErrorRetryChecker(err)
+		})
+		if isTimeout(err) {
+			// We expect to eventually time out, so this is the success case.
+			return true, nil
+		} else if err != nil {
+			// Other errors are not expected.
+			return false, err
+		} else if resp.StatusCode == http.StatusOK {
+			// We'll continue to get 200s for a while until readiness propagates.
+			return false, nil
+		}
+
+		return false, errors.New("Received non-200 status code (expected to eventually time out)")
+	}); err != nil {
+		t.Fatal("Expected to eventually see request timeout due to all pods becoming unready, but got:", err)
+	}
+}
+
+func isTimeout(err error) bool {
+	var ne net.Error
+	if errors.As(err, &ne) {
+		return ne.Timeout()
+	}
+
+	return false
 }

--- a/test/test_images/readiness/readiness.go
+++ b/test/test_images/readiness/readiness.go
@@ -66,6 +66,18 @@ func main() {
 		fmt.Fprint(w, test.HelloWorldText)
 	})
 
+	http.HandleFunc("/start-failing", func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		healthy = false
+		fmt.Fprint(w, "will now fail readiness")
+	})
+
+	http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, test.HelloWorldText)
+	})
+
 	if env := os.Getenv("LISTEN_DELAY"); env != "" {
 		delay, err := time.ParseDuration(env)
 		if err != nil {


### PR DESCRIPTION
Coverage for the behaviour described in https://github.com/knative/serving/issues/10765. We probably want to change this behaviour (once we figure out a better alternative), in the meantime this test documents the current situation and will give us confidence when we fix this.

/assign @dprotaso @markusthoemmes 