### PR TITLE
Reduce allocations from the timeout handler by pooling the timers

### DIFF
--- a/pkg/http/handler/timeout.go
+++ b/pkg/http/handler/timeout.go
@@ -75,12 +75,10 @@ func (h *timeToFirstByteTimeoutHandler) ServeHTTP(w http.ResponseWriter, r *http
 		h.handler.ServeHTTP(tw, r.WithContext(ctx))
 	}()
 
-	var timeoutExpired bool
 	timeout := getTimer(h.timeout)
+	var timeoutExpired bool
 	defer func() {
-		if !timeoutExpired {
-			returnTimer(timeout, timeoutExpired)
-		}
+		returnTimer(timeout, timeoutExpired)
 	}()
 	for {
 		select {
@@ -91,10 +89,6 @@ func (h *timeToFirstByteTimeoutHandler) ServeHTTP(w http.ResponseWriter, r *http
 			return
 		case <-timeout.C:
 			timeoutExpired = true
-			// Return the timer early as it's practically useless from here on. This
-			// prevents very long requests (longer than the timeout) from hogging the
-			// timers unnecessarily.
-			returnTimer(timeout, timeoutExpired)
 			if tw.timeoutAndWriteError(h.body) {
 				return
 			}

--- a/pkg/http/handler/timeout.go
+++ b/pkg/http/handler/timeout.go
@@ -77,9 +77,7 @@ func (h *timeToFirstByteTimeoutHandler) ServeHTTP(w http.ResponseWriter, r *http
 
 	timeout := getTimer(h.timeout)
 	var timeoutExpired bool
-	defer func() {
-		returnTimer(timeout, timeoutExpired)
-	}()
+	defer func() { putTimer(timeout, timeoutExpired) }()
 	for {
 		select {
 		case p, ok := <-done:
@@ -189,7 +187,7 @@ func getTimer(timeout time.Duration) *time.Timer {
 	return time.NewTimer(timeout)
 }
 
-func returnTimer(t *time.Timer, alreadyDrained bool) {
+func putTimer(t *time.Timer, alreadyDrained bool) {
 	if !t.Stop() && !alreadyDrained {
 		// Drain t.C if we've raced expiration of the timer and haven't handled
 		// the signal above yet.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As per title, nothing more to say.

**Note to reviewers:** Please keep me honest on the invariants of `Stop` returning false and thus us properly draining the channel.

## Benchmark results

```
benchmark                                                old ns/op     new ns/op     delta
BenchmarkTimeToFirstByteTimeoutHandler/sequential-16     2023          1843          -8.90%
BenchmarkTimeToFirstByteTimeoutHandler/parallel-16       148           133           -10.47%

benchmark                                                old allocs     new allocs     delta
BenchmarkTimeToFirstByteTimeoutHandler/sequential-16     9              6              -33.33%
BenchmarkTimeToFirstByteTimeoutHandler/parallel-16       9              6              -33.33%

benchmark                                                old bytes     new bytes     delta
BenchmarkTimeToFirstByteTimeoutHandler/sequential-16     830           634           -23.61%
BenchmarkTimeToFirstByteTimeoutHandler/parallel-16       843           639           -24.20%
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz 
