### PR TITLE
Fix scrape_time metric registration

### DIFF
--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -77,7 +77,7 @@ var (
 )
 
 func init() {
-	if err := view.Register(
+	if err := pkgmetrics.RegisterResourceView(
 		&view.View{
 			Description: "The time to scrape metrics in milliseconds",
 			Measure:     scrapeTimeM,


### PR DESCRIPTION
## Proposed Changes

* I noticed that the `scrape_time` metric is never exported at Prometheus side. Registration has a context that is bound to a revision when the scraper per revision is [set](https://github.com/knative/serving/blob/ef2ac455b5f214bd9605eab71a3ee7300b003324/pkg/autoscaler/metrics/stats_scraper.go#L177), so we should use RegisterResourceView to register the view with all resources.
* To reproduce I run autoscale-go and checked the autoscaler endpoint (9090). After this change I see the [metric](https://gist.github.com/skonto/5448a174a85ccf7d74d27a69f594821a):
```
# HELP autoscaler_scrape_time The time to scrape metrics in milliseconds
# TYPE autoscaler_scrape_time histogram
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="1"} 0
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="2"} 343
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="5"} 379
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="10"} 388
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="20"} 388
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="50"} 388
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="100"} 388
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="200"} 388
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="500"} 388
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="1000"} 388
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="2000"} 388
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="5000"} 388
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="10000"} 388
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="20000"} 388
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="50000"} 388
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="100000"} 388
autoscaler_scrape_time_bucket{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go",le="+Inf"} 388
autoscaler_scrape_time_sum{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go"} 493.9999999999997
autoscaler_scrape_time_count{configuration_name="autoscale-go",namespace_name="default",revision_name="autoscale-go-00001",service_name="autoscale-go"} 388```