### PR TITLE
Uses shorter name for some tests

### DIFF
--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -81,17 +81,17 @@ func TestRevisionTimeout(t *testing.T) {
 		sleep          time.Duration
 		expectedStatus int
 	}{{
-		name:           "when pods already exist, and it does not exceed timeout seconds",
+		name:           "does not exceed timeout seconds",
 		timeoutSeconds: 10,
 		initialSleep:   2 * time.Second,
 		expectedStatus: http.StatusOK,
 	}, {
-		name:           "when pods already exist, and it does exceed timeout seconds",
+		name:           "exceeds timeout seconds",
 		timeoutSeconds: 10,
 		initialSleep:   12 * time.Second,
 		expectedStatus: http.StatusGatewayTimeout,
 	}, {
-		name:           "when pods already exist, and it writes first byte before timeout",
+		name:           "writes first byte before timeout",
 		timeoutSeconds: 10,
 		expectedStatus: http.StatusOK,
 		sleep:          15 * time.Second,


### PR DESCRIPTION
The name of test case is used to generate the service name for testing. For the changed conformance tests, the name length reaches 63 (which I think is the maximum supported by knative). However some other implementation (like Cloud Run) has a shorter name limitation. 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Makes the test case names shorter to generate shorter service name for testing.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
