### PR TITLE
Add idle timeout to queue proxy

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -73,14 +73,13 @@ var (
 )
 
 type config struct {
-	ContainerConcurrency       int    `split_words:"true" required:"true"`
-	QueueServingPort           string `split_words:"true" required:"true"`
-	UserPort                   string `split_words:"true" required:"true"`
-	RevisionTimeoutSeconds     int    `split_words:"true" required:"true"`
-	ServingReadinessProbe      string `split_words:"true" required:"true"`
-	RevisionIdleTimeoutSeconds int    `split_words:"true" default:"-1"` // optional
-	EnableProfiling            bool   `split_words:"true"`              // optional
-	EnableHTTP2AutoDetection   bool   `split_words:"true"`              // optional
+	ContainerConcurrency     int    `split_words:"true" required:"true"`
+	QueueServingPort         string `split_words:"true" required:"true"`
+	UserPort                 string `split_words:"true" required:"true"`
+	RevisionTimeoutSeconds   int    `split_words:"true" required:"true"`
+	ServingReadinessProbe    string `split_words:"true" required:"true"`
+	EnableProfiling          bool   `split_words:"true"` // optional
+	EnableHTTP2AutoDetection bool   `split_words:"true"` // optional
 
 	// Logging configuration
 	ServingLoggingConfig         string `split_words:"true" required:"true"`
@@ -296,7 +295,8 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	tracingEnabled := env.TracingConfigBackend != tracingconfig.None
 	concurrencyStateEnabled := env.ConcurrencyStateEndpoint != ""
 	firstByteTimeout := time.Duration(env.RevisionTimeoutSeconds) * time.Second
-	idleTimeout := time.Duration(env.RevisionIdleTimeoutSeconds) * time.Second
+	// hardcoded to always disable idle timeout for now, will expose this later
+	idleTimeout := -1 * time.Second
 
 	// Create queue handler chain.
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first.

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -296,7 +296,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	concurrencyStateEnabled := env.ConcurrencyStateEndpoint != ""
 	firstByteTimeout := time.Duration(env.RevisionTimeoutSeconds) * time.Second
 	// hardcoded to always disable idle timeout for now, will expose this later
-	idleTimeout := -1 * time.Second
+	var idleTimeout time.Duration
 
 	// Create queue handler chain.
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first.

--- a/pkg/http/handler/timeout.go
+++ b/pkg/http/handler/timeout.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"context"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"sync"
@@ -28,14 +29,16 @@ import (
 	"knative.dev/pkg/websocket"
 )
 
-type timeToFirstByteTimeoutHandler struct {
-	handler http.Handler
-	timeout time.Duration
-	body    string
+type timeoutHandler struct {
+	handler          http.Handler
+	firstByteTimeout time.Duration
+	idleTimeout      time.Duration
+	body             string
 }
 
-// NewTimeToFirstByteTimeoutHandler returns a Handler that runs `h` with the
-// given timeout in which the first byte of the response must be written.
+// NewTimeoutHandler returns a Handler that runs `h` with the
+// given timeout in which the first byte of the response must be written,
+// and with the given idle timeout
 //
 // The new Handler calls h.ServeHTTP to handle each request, but if a
 // call runs for longer than its time limit, the handler responds with
@@ -49,15 +52,19 @@ type timeToFirstByteTimeoutHandler struct {
 // https://golang.org/pkg/net/http/#Handler.
 //
 // The implementation is largely inspired by http.TimeoutHandler.
-func NewTimeToFirstByteTimeoutHandler(h http.Handler, msg string, timeout time.Duration) http.Handler {
-	return &timeToFirstByteTimeoutHandler{
-		handler: h,
-		body:    msg,
-		timeout: timeout,
+func NewTimeoutHandler(h http.Handler, msg string, firstByteTimeout time.Duration, idleTimeout time.Duration) http.Handler {
+	if idleTimeout < 0 {
+		idleTimeout = math.MaxInt64 * time.Nanosecond
+	}
+	return &timeoutHandler{
+		handler:          h,
+		body:             msg,
+		firstByteTimeout: firstByteTimeout,
+		idleTimeout:      idleTimeout,
 	}
 }
 
-func (h *timeToFirstByteTimeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
@@ -75,9 +82,16 @@ func (h *timeToFirstByteTimeoutHandler) ServeHTTP(w http.ResponseWriter, r *http
 		h.handler.ServeHTTP(tw, r.WithContext(ctx))
 	}()
 
-	timeout := getTimer(h.timeout)
-	var timeoutDrained bool
-	defer func() { putTimer(timeout, timeoutDrained) }()
+	firstByteTimeout := getTimer(h.firstByteTimeout)
+	var firstByteTimeoutDrained bool
+
+	idleTimeout := getTimer(h.idleTimeout)
+	var idleTimeoutDrained bool
+
+	defer func() {
+		putTimer(firstByteTimeout, firstByteTimeoutDrained)
+		putTimer(idleTimeout, idleTimeoutDrained)
+	}()
 	for {
 		select {
 		case p, ok := <-done:
@@ -85,11 +99,18 @@ func (h *timeToFirstByteTimeoutHandler) ServeHTTP(w http.ResponseWriter, r *http
 				panic(p)
 			}
 			return
-		case <-timeout.C:
-			timeoutDrained = true
-			if tw.timeoutAndWriteError(h.body) {
+		case <-firstByteTimeout.C:
+			firstByteTimeoutDrained = true
+			if tw.tryFirstByteTimeoutAndWriteError(h.body) {
 				return
 			}
+		case <-idleTimeout.C:
+			timedOut, timeToNextTimeout := tw.tryIdleTimeoutAndWriteError(h.idleTimeout, h.body)
+			if timedOut {
+				idleTimeoutDrained = true
+				return
+			}
+			idleTimeout.Reset(timeToNextTimeout)
 		}
 	}
 }
@@ -104,9 +125,9 @@ func (h *timeToFirstByteTimeoutHandler) ServeHTTP(w http.ResponseWriter, r *http
 type timeoutWriter struct {
 	w http.ResponseWriter
 
-	mu        sync.Mutex
-	timedOut  bool
-	wroteOnce bool
+	mu            sync.Mutex
+	timedOut      bool
+	lastWriteTime time.Time
 }
 
 var _ http.Flusher = (*timeoutWriter)(nil)
@@ -141,7 +162,7 @@ func (tw *timeoutWriter) Write(p []byte) (int, error) {
 		return 0, http.ErrHandlerTimeout
 	}
 
-	tw.wroteOnce = true
+	tw.lastWriteTime = time.Now()
 	return tw.w.Write(p)
 }
 
@@ -151,29 +172,52 @@ func (tw *timeoutWriter) WriteHeader(code int) {
 	if tw.timedOut {
 		return
 	}
-	tw.wroteOnce = true
+	tw.lastWriteTime = time.Now()
 	tw.w.WriteHeader(code)
 }
 
-// timeoutAndWriteError writes an error to the responsewriter if
+// tryFirstByteTimeoutAndWriteError writes an error to the responsewriter if
 // nothing has been written to the writer before. Returns whether
 // an error was written or not.
 //
 // If this writes an error, all subsequent calls to Write will
 // result in http.ErrHandlerTimeout.
-func (tw *timeoutWriter) timeoutAndWriteError(msg string) bool {
+func (tw *timeoutWriter) tryFirstByteTimeoutAndWriteError(msg string) bool {
 	tw.mu.Lock()
 	defer tw.mu.Unlock()
 
-	if !tw.wroteOnce {
-		tw.w.WriteHeader(http.StatusGatewayTimeout)
-		io.WriteString(tw.w, msg)
-
-		tw.timedOut = true
+	if tw.lastWriteTime.IsZero() {
+		tw.timeoutAndWriteError(msg)
 		return true
 	}
 
 	return false
+}
+
+// tryIdleTimeoutAndWriteError writes an error to the responsewriter if
+// nothing has been written to the writer within the idleTimeout period. Returns whether
+// an error was written or not and time left to the next timeout
+//
+// If this writes an error, all subsequent calls to Write will
+// result in http.ErrHandlerTimeout.
+func (tw *timeoutWriter) tryIdleTimeoutAndWriteError(idleTimeout time.Duration, msg string) (timedOut bool, timeToNextTimeout time.Duration) {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+
+	timeSinceLastWrite := time.Since(tw.lastWriteTime)
+	if timeSinceLastWrite > idleTimeout {
+		tw.timeoutAndWriteError(msg)
+		return true, 0
+	}
+
+	return false, idleTimeout - timeSinceLastWrite
+}
+
+func (tw *timeoutWriter) timeoutAndWriteError(msg string) {
+	tw.w.WriteHeader(http.StatusGatewayTimeout)
+	io.WriteString(tw.w, msg)
+
+	tw.timedOut = true
 }
 
 var timerPool sync.Pool

--- a/pkg/http/handler/timeout_test.go
+++ b/pkg/http/handler/timeout_test.go
@@ -31,7 +31,7 @@ func TestTimeoutWriterAllowsForAdditionalWritesBeforeTimeout(t *testing.T) {
 	handler := &timeoutWriter{w: recorder}
 	handler.WriteHeader(http.StatusOK)
 	handler.tryFirstByteTimeoutAndWriteError("error")
-	handler.tryIdleTimeoutAndWriteError(10*time.Second, "error")
+	handler.tryIdleTimeoutAndWriteError(time.Now(), 10*time.Second, "error")
 	if _, err := io.WriteString(handler, "test"); err != nil {
 		t.Fatalf("handler.Write() = %v, want no error", err)
 	}
@@ -71,6 +71,35 @@ func TestTimeoutWriterErrorsWriteAfterTimeout(t *testing.T) {
 	handler.timeoutAndWriteError("error")
 	if _, err := handler.Write([]byte("hello")); !errors.Is(err, http.ErrHandlerTimeout) {
 		t.Errorf("ErrHandlerTimeout got %v, want: %s", err, http.ErrHandlerTimeout)
+	}
+}
+
+func TestDisabledOptionalTimerHasNoTimerAllocated(t *testing.T) {
+	optTimer := newOptionalTimer(nil)
+	wantExists := false
+	var wantTimer *time.Timer
+
+	if gotExists, gotTimer := optTimer.Timer(); gotExists != wantExists || gotTimer != wantTimer {
+		t.Errorf("For disabled optionalTimer, got timer exists: %t, want timer exists: %t, got timer: %v, want: %v", gotExists, wantExists, gotTimer, wantTimer)
+	}
+}
+
+func TestEnabledOptionalTimerHasTimerAllocated(t *testing.T) {
+	optTimer := newOptionalTimer(time.NewTimer(1))
+	gotExists, _ := optTimer.Timer()
+
+	wantExists := true
+	if gotExists != wantExists {
+		t.Errorf("For enabled optionalTimer, got timer exists: %t, want timer exists: %t", gotExists, wantExists)
+	}
+}
+
+func TestEnabledOptionalTimerReturnsChannelOfInnerTimer(t *testing.T) {
+	optTimer := newOptionalTimer(time.NewTimer(1))
+	_, innerTimer := optTimer.Timer()
+
+	if innerTimer.C != optTimer.C() {
+		t.Errorf("Enabled optionalTimer.C() should return the channel of its inner timer")
 	}
 }
 

--- a/pkg/http/handler/timeout_test.go
+++ b/pkg/http/handler/timeout_test.go
@@ -26,11 +26,12 @@ import (
 	"time"
 )
 
-func TestTimeoutWriterAllowsForAdditionalWrites(t *testing.T) {
+func TestTimeoutWriterAllowsForAdditionalWritesBeforeTimeout(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	handler := &timeoutWriter{w: recorder}
 	handler.WriteHeader(http.StatusOK)
-	handler.timeoutAndWriteError("error")
+	handler.tryFirstByteTimeoutAndWriteError("error")
+	handler.tryIdleTimeoutAndWriteError(10*time.Second, "error")
 	if _, err := io.WriteString(handler, "test"); err != nil {
 		t.Fatalf("handler.Write() = %v, want no error", err)
 	}
@@ -54,7 +55,7 @@ func TestTimeoutWriterDoesntFlushAfterTimeout(t *testing.T) {
 	}
 }
 
-func TestTimeoutWriterFlushesAfterTimeout(t *testing.T) {
+func TestTimeoutWriterFlushesBeforeTimeout(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	handler := &timeoutWriter{w: recorder}
 	handler.Flush()
@@ -73,24 +74,68 @@ func TestTimeoutWriterErrorsWriteAfterTimeout(t *testing.T) {
 	}
 }
 
+type timeoutHandlerTestScenario struct {
+	name             string
+	firstByteTimeout time.Duration
+	idleTimeout      time.Duration
+	handler          func(mux *sync.Mutex, writeErrors chan error) http.Handler
+	timeoutMessage   string
+	wantStatus       int
+	wantBody         string
+	wantWriteError   bool
+	wantPanic        bool
+}
+
+func testTimeoutScenario(t *testing.T, scenarios []timeoutHandlerTestScenario) {
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+			var reqMux sync.Mutex
+			writeErrors := make(chan error, 1)
+			rr := httptest.NewRecorder()
+			handler := NewTimeoutHandler(scenario.handler(&reqMux, writeErrors), scenario.timeoutMessage, scenario.firstByteTimeout, scenario.idleTimeout)
+
+			defer func() {
+				if scenario.wantPanic {
+					if recovered := recover(); recovered != http.ErrAbortHandler { //nolint // False positive for errors.Is check
+						t.Errorf("Recover = %v, want: %v", recovered, http.ErrAbortHandler)
+					}
+				}
+			}()
+
+			reqMux.Lock() // Will cause an inner 'Lock' to block. ServeHTTP will exit early if the call times out.
+			handler.ServeHTTP(rr, req)
+			reqMux.Unlock() // Allows the inner 'Lock' to go through to complete potential writes.
+
+			if status := rr.Code; status != scenario.wantStatus {
+				t.Errorf("Handler returned wrong status code: got %v want %v", status, scenario.wantStatus)
+			}
+
+			if rr.Body.String() != scenario.wantBody {
+				t.Errorf("Handler returned unexpected body: got %q want %q", rr.Body.String(), scenario.wantBody)
+			}
+
+			if scenario.wantWriteError {
+				if err := <-writeErrors; !errors.Is(err, http.ErrHandlerTimeout) {
+					t.Error("Expected a timeout error, got", err)
+				}
+			}
+		})
+	}
+}
+
 func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 	const (
 		immediateTimeout = 0 * time.Millisecond
 		longTimeout      = 1 * time.Minute // Super long, not supposed to hit this.
+		noIdleTimeout    = -1 * time.Millisecond
 	)
 
-	tests := []struct {
-		name           string
-		timeout        time.Duration
-		handler        func(mux *sync.Mutex, writeErrors chan error) http.Handler
-		timeoutMessage string
-		wantStatus     int
-		wantBody       string
-		wantWriteError bool
-		wantPanic      bool
-	}{{
-		name:    "all good",
-		timeout: longTimeout,
+	scenarios := []timeoutHandlerTestScenario{{
+		name:             "all good",
+		firstByteTimeout: longTimeout,
+		idleTimeout:      noIdleTimeout,
 		handler: func(*sync.Mutex, chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Write([]byte("hi"))
@@ -99,8 +144,9 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 		wantStatus: http.StatusOK,
 		wantBody:   "hi",
 	}, {
-		name:    "custom timeout message",
-		timeout: immediateTimeout,
+		name:             "custom timeout message",
+		firstByteTimeout: immediateTimeout,
+		idleTimeout:      noIdleTimeout,
 		handler: func(mux *sync.Mutex, writeErrors chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				mux.Lock()
@@ -114,8 +160,9 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 		wantBody:       "request timeout",
 		wantWriteError: true,
 	}, {
-		name:    "propagate panic",
-		timeout: longTimeout,
+		name:             "propagate panic",
+		firstByteTimeout: longTimeout,
+		idleTimeout:      noIdleTimeout,
 		handler: func(*sync.Mutex, chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				panic(http.ErrAbortHandler)
@@ -125,8 +172,9 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 		wantBody:   "request timeout",
 		wantPanic:  true,
 	}, {
-		name:    "timeout before panic",
-		timeout: immediateTimeout,
+		name:             "timeout before panic",
+		firstByteTimeout: immediateTimeout,
+		idleTimeout:      noIdleTimeout,
 		handler: func(*sync.Mutex, chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				time.Sleep(1 * time.Second)
@@ -138,45 +186,123 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 		wantBody:       "request timeout",
 		wantPanic:      false,
 	}}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, "/", nil)
-
-			var reqMux sync.Mutex
-			writeErrors := make(chan error, 1)
-			rr := httptest.NewRecorder()
-			handler := NewTimeToFirstByteTimeoutHandler(test.handler(&reqMux, writeErrors), test.timeoutMessage, test.timeout)
-
-			defer func() {
-				if test.wantPanic {
-					if recovered := recover(); recovered != http.ErrAbortHandler { //nolint // False positive for errors.Is check
-						t.Errorf("Recover = %v, want: %v", recovered, http.ErrAbortHandler)
-					}
-				}
-			}()
-
-			reqMux.Lock() // Will cause an inner 'Lock' to block. ServeHTTP will exit early if the call times out.
-			handler.ServeHTTP(rr, req)
-			reqMux.Unlock() // Allows the inner 'Lock' to go through to complete potential writes.
-
-			if status := rr.Code; status != test.wantStatus {
-				t.Errorf("Handler returned wrong status code: got %v want %v", status, test.wantStatus)
-			}
-
-			if rr.Body.String() != test.wantBody {
-				t.Errorf("Handler returned unexpected body: got %q want %q", rr.Body.String(), test.wantBody)
-			}
-
-			if test.wantWriteError {
-				if err := <-writeErrors; !errors.Is(err, http.ErrHandlerTimeout) {
-					t.Error("Expected a timeout error, got", err)
-				}
-			}
-		})
-	}
+	testTimeoutScenario(t, scenarios)
 }
 
-func BenchmarkTimeToFirstByteTimeoutHandler(b *testing.B) {
+func TestIdleTimeoutHandler(t *testing.T) {
+	const (
+		noIdleTimeout        = -1 * time.Millisecond
+		shortIdleTimeout     = 100 * time.Millisecond
+		longIdleTimeout      = 1 * time.Minute // Super long, not supposed to hit this.
+		longFirstByteTimeout = 1 * time.Minute // Super long, not supposed to hit this.
+	)
+
+	scenarios := []timeoutHandlerTestScenario{{
+		name:             "all good",
+		firstByteTimeout: longFirstByteTimeout,
+		idleTimeout:      longIdleTimeout,
+		handler: func(*sync.Mutex, chan error) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("hi"))
+			})
+		},
+		wantStatus: http.StatusOK,
+		wantBody:   "hi",
+	}, {
+		name:             "custom timeout message",
+		idleTimeout:      shortIdleTimeout,
+		firstByteTimeout: longFirstByteTimeout,
+		handler: func(mux *sync.Mutex, writeErrors chan error) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mux.Lock()
+				defer mux.Unlock()
+				_, werr := w.Write([]byte("hi"))
+				writeErrors <- werr
+			})
+		},
+		timeoutMessage: "request timeout",
+		wantStatus:     http.StatusGatewayTimeout,
+		wantBody:       "request timeout",
+		wantWriteError: true,
+	}, {
+		name:             "propagate panic",
+		idleTimeout:      longIdleTimeout,
+		firstByteTimeout: longFirstByteTimeout,
+		handler: func(*sync.Mutex, chan error) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				panic(http.ErrAbortHandler)
+			})
+		},
+		wantStatus: http.StatusGatewayTimeout,
+		wantBody:   "request timeout",
+		wantPanic:  true,
+	}, {
+		name:             "timeout before panic",
+		idleTimeout:      shortIdleTimeout,
+		firstByteTimeout: longFirstByteTimeout,
+		handler: func(*sync.Mutex, chan error) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				time.Sleep(1 * time.Second)
+				panic(http.ErrAbortHandler)
+			})
+		},
+		timeoutMessage: "request timeout",
+		wantStatus:     http.StatusGatewayTimeout,
+		wantBody:       "request timeout",
+		wantPanic:      false,
+	}, {
+		name:             "successful writes prevent timeout",
+		idleTimeout:      shortIdleTimeout,
+		firstByteTimeout: longFirstByteTimeout,
+		handler: func(*sync.Mutex, chan error) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(""))
+				time.Sleep(shortIdleTimeout * 2 / 3)
+				w.Write([]byte(""))
+				time.Sleep(shortIdleTimeout * 2 / 3)
+				panic(http.ErrAbortHandler)
+			})
+		},
+		wantStatus: http.StatusGatewayTimeout,
+		wantBody:   "request timeout",
+		wantPanic:  true,
+	}, {
+		name:             "can still timeout after a few successful writes",
+		idleTimeout:      shortIdleTimeout,
+		firstByteTimeout: longFirstByteTimeout,
+		handler: func(*sync.Mutex, chan error) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(""))
+				time.Sleep(shortIdleTimeout * 2 / 3)
+				w.Write([]byte(""))
+				time.Sleep(shortIdleTimeout * 2 / 3)
+				w.Write([]byte(""))
+				time.Sleep(shortIdleTimeout * 2)
+				panic(http.ErrAbortHandler)
+			})
+		},
+		timeoutMessage: "request timeout",
+		wantStatus:     http.StatusOK,
+		wantBody:       "request timeout",
+		wantPanic:      false,
+	}, {
+		name:             "no idle timeout",
+		idleTimeout:      noIdleTimeout,
+		firstByteTimeout: longFirstByteTimeout,
+		handler: func(*sync.Mutex, chan error) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				panic(http.ErrAbortHandler)
+			})
+		},
+		wantStatus: http.StatusGatewayTimeout,
+		wantBody:   "request timeout",
+		wantPanic:  true,
+	},
+	}
+	testTimeoutScenario(t, scenarios)
+}
+
+func BenchmarkTimeoutHandler(b *testing.B) {
 	writes := [][]byte{[]byte("this"), []byte("is"), []byte("a"), []byte("test")}
 	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
@@ -184,7 +310,7 @@ func BenchmarkTimeToFirstByteTimeoutHandler(b *testing.B) {
 			w.Write(write)
 		}
 	})
-	handler := NewTimeToFirstByteTimeoutHandler(baseHandler, "test", 10*time.Minute)
+	handler := NewTimeoutHandler(baseHandler, "test", 10*time.Minute, 10*time.Minute)
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
 
 	b.Run("sequential", func(b *testing.B) {

--- a/pkg/http/handler/timeout_test.go
+++ b/pkg/http/handler/timeout_test.go
@@ -74,35 +74,6 @@ func TestTimeoutWriterErrorsWriteAfterTimeout(t *testing.T) {
 	}
 }
 
-func TestDisabledOptionalTimerHasNoTimerAllocated(t *testing.T) {
-	optTimer := newOptionalTimer(nil)
-	wantExists := false
-	var wantTimer *time.Timer
-
-	if gotExists, gotTimer := optTimer.Timer(); gotExists != wantExists || gotTimer != wantTimer {
-		t.Errorf("For disabled optionalTimer, got timer exists: %t, want timer exists: %t, got timer: %v, want: %v", gotExists, wantExists, gotTimer, wantTimer)
-	}
-}
-
-func TestEnabledOptionalTimerHasTimerAllocated(t *testing.T) {
-	optTimer := newOptionalTimer(time.NewTimer(1))
-	gotExists, _ := optTimer.Timer()
-
-	wantExists := true
-	if gotExists != wantExists {
-		t.Errorf("For enabled optionalTimer, got timer exists: %t, want timer exists: %t", gotExists, wantExists)
-	}
-}
-
-func TestEnabledOptionalTimerReturnsChannelOfInnerTimer(t *testing.T) {
-	optTimer := newOptionalTimer(time.NewTimer(1))
-	_, innerTimer := optTimer.Timer()
-
-	if innerTimer.C != optTimer.C() {
-		t.Errorf("Enabled optionalTimer.C() should return the channel of its inner timer")
-	}
-}
-
 type timeoutHandlerTestScenario struct {
 	name             string
 	firstByteTimeout time.Duration

--- a/pkg/http/handler/timeout_test.go
+++ b/pkg/http/handler/timeout_test.go
@@ -129,7 +129,7 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 	const (
 		immediateTimeout = 0 * time.Millisecond
 		longTimeout      = 1 * time.Minute // Super long, not supposed to hit this.
-		noIdleTimeout    = -1 * time.Millisecond
+		noIdleTimeout    = 0 * time.Millisecond
 	)
 
 	scenarios := []timeoutHandlerTestScenario{{
@@ -191,7 +191,7 @@ func TestTimeToFirstByteTimeoutHandler(t *testing.T) {
 
 func TestIdleTimeoutHandler(t *testing.T) {
 	const (
-		noIdleTimeout        = -1 * time.Millisecond
+		noIdleTimeout        = 0 * time.Millisecond
 		shortIdleTimeout     = 100 * time.Millisecond
 		longIdleTimeout      = 1 * time.Minute // Super long, not supposed to hit this.
 		longFirstByteTimeout = 1 * time.Minute // Super long, not supposed to hit this.
@@ -299,7 +299,9 @@ func TestIdleTimeoutHandler(t *testing.T) {
 		wantPanic:  true,
 	},
 	}
+
 	testTimeoutScenario(t, scenarios)
+
 }
 
 func BenchmarkTimeoutHandler(b *testing.B) {


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/10852

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add idle timeout to queue proxy
* Refactor timeout handler tests

benchmark before and after the change (needed to do some manual renaming in the benchmark output because benchmark test name changed)
```
benchmark                                 old ns/op     new ns/op     delta
BenchmarkTimeoutHandler/sequential-12     1311          2180          +66.29%
BenchmarkTimeoutHandler/parallel-12       182           274           +50.52%

benchmark                                 old allocs     new allocs     delta
BenchmarkTimeoutHandler/sequential-12     6              6              +0.00%
BenchmarkTimeoutHandler/parallel-12       6              6              +0.00%

benchmark                                 old bytes     new bytes     delta
BenchmarkTimeoutHandler/sequential-12     647           673           +4.02%
BenchmarkTimeoutHandler/parallel-12       645           666           +3.26%
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
