### PR TITLE
TestServiceWithTrafficSplit test changes

### DIFF
--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -310,13 +310,13 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 	desiredTrafficShape := map[string]v1.TrafficTarget{
 		"current": {
 			Tag:            "current",
-			RevisionName:   firstRevision,
+			RevisionName:   objects.Config.Status.LatestReadyRevisionName,
 			Percent:        ptr.Int64(100),
 			LatestRevision: ptr.Bool(false),
 		},
 		"latest": {
 			Tag:            "latest",
-			RevisionName:   names.Revision, // This equals to firstRevison if no new revision was created on service update with target traffic.
+			RevisionName:   objects.Config.Status.LatestReadyRevisionName,
 			LatestRevision: ptr.Bool(true),
 			Percent:        ptr.Int64(0),
 		},

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -298,9 +298,8 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 			RevisionName: firstRevision,
 			Percent:      ptr.Int64(100),
 		}, {
-			Tag:            "latest",
-			LatestRevision: ptr.Bool(true),
-			Percent:        nil,
+			Tag:     "latest",
+			Percent: nil,
 		}},
 	))
 	if err != nil {
@@ -315,10 +314,9 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 			LatestRevision: ptr.Bool(false),
 		},
 		"latest": {
-			Tag:            "latest",
-			RevisionName:   objects.Config.Status.LatestReadyRevisionName,
-			LatestRevision: ptr.Bool(true),
-			Percent:        ptr.Int64(0),
+			Tag:          "latest",
+			RevisionName: objects.Config.Status.LatestReadyRevisionName,
+			Percent:      ptr.Int64(0),
 		},
 	}
 	t.Log("Waiting for Service to become ready with the new shape.")
@@ -354,10 +352,9 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 
 	// Also verify traffic is in the correct shape.
 	desiredTrafficShape["latest"] = v1.TrafficTarget{
-		Tag:            "latest",
-		RevisionName:   secondRevision,
-		LatestRevision: ptr.Bool(true),
-		Percent:        ptr.Int64(0),
+		Tag:          "latest",
+		RevisionName: secondRevision,
+		Percent:      ptr.Int64(0),
 	}
 	t.Log("Waiting for Service to become ready with the new shape.")
 	if err := waitForDesiredTrafficShape(t, names.Service, desiredTrafficShape, clients); err != nil {
@@ -390,8 +387,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 			RevisionName: secondRevision,
 			Percent:      ptr.Int64(50),
 		}, {
-			Tag:            "latest",
-			LatestRevision: ptr.Bool(true),
+			Tag: "latest",
 		}},
 	))
 	if err != nil {
@@ -491,9 +487,8 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 			Tag:     "candidate",
 			Percent: ptr.Int64(50),
 		}, {
-			Tag:            "latest",
-			LatestRevision: ptr.Bool(true),
-			Percent:        nil,
+			Tag:     "latest",
+			Percent: nil,
 		}},
 	))
 	if err != nil {

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -314,9 +314,10 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 			LatestRevision: ptr.Bool(false),
 		},
 		"latest": {
-			Tag:          "latest",
-			RevisionName: objects.Config.Status.LatestReadyRevisionName,
-			Percent:      ptr.Int64(0),
+			Tag:            "latest",
+			RevisionName:   objects.Config.Status.LatestReadyRevisionName,
+			LatestRevision: ptr.Bool(true),
+			Percent:        ptr.Int64(0),
 		},
 	}
 	t.Log("Waiting for Service to become ready with the new shape.")
@@ -352,9 +353,10 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 
 	// Also verify traffic is in the correct shape.
 	desiredTrafficShape["latest"] = v1.TrafficTarget{
-		Tag:          "latest",
-		RevisionName: secondRevision,
-		Percent:      ptr.Int64(0),
+		Tag:            "latest",
+		RevisionName:   secondRevision,
+		LatestRevision: ptr.Bool(true),
+		Percent:        ptr.Int64(0),
 	}
 	t.Log("Waiting for Service to become ready with the new shape.")
 	if err := waitForDesiredTrafficShape(t, names.Service, desiredTrafficShape, clients); err != nil {

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -323,7 +323,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		},
 		"latest": {
 			Tag:            "latest",
-			RevisionName:   names.Revision,
+			RevisionName:   names.Revision, // This equals to firstRevison if no new revision was created on service update with target traffic.
 			LatestRevision: ptr.Bool(true),
 			Percent:        ptr.Int64(0),
 		},

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -287,24 +287,31 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 			RevisionName: firstRevision,
 			Percent:      ptr.Int64(100),
 		}, {
-			Tag:     "latest",
-			Percent: nil,
+			Tag:            "latest",
+			LatestRevision: ptr.Bool(true),
+			Percent:        nil,
 		}},
 	))
 	if err != nil {
 		t.Fatal("Failed to update Service:", err)
 	}
 
+	t.Log("A new Revision could be created even though the traffic target is the only change")
+	names.Revision = "" // Clean up Revision to fetch the latest created one.
+	if names.Revision, err = v1test.WaitForServiceLatestRevision(clients, names); err != nil {
+		t.Fatalf("The Service %s was not updated with new revision %s: %v", names.Service, names.Revision, err)
+	}
+
 	desiredTrafficShape := map[string]v1.TrafficTarget{
 		"current": {
 			Tag:            "current",
-			RevisionName:   objects.Config.Status.LatestReadyRevisionName,
+			RevisionName:   firstRevision,
 			Percent:        ptr.Int64(100),
 			LatestRevision: ptr.Bool(false),
 		},
 		"latest": {
 			Tag:            "latest",
-			RevisionName:   objects.Config.Status.LatestReadyRevisionName,
+			RevisionName:   names.Revision, // This could be the same to firstVersion or a different one
 			LatestRevision: ptr.Bool(true),
 			Percent:        ptr.Int64(0),
 		},
@@ -378,7 +385,8 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 			RevisionName: secondRevision,
 			Percent:      ptr.Int64(50),
 		}, {
-			Tag: "latest",
+			Tag:            "latest",
+			LatestRevision: ptr.Bool(true),
 		}},
 	))
 	if err != nil {
@@ -478,8 +486,9 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 			Tag:     "candidate",
 			Percent: ptr.Int64(50),
 		}, {
-			Tag:     "latest",
-			Percent: nil,
+			Tag:            "latest",
+			LatestRevision: ptr.Bool(true),
+			Percent:        nil,
 		}},
 	))
 	if err != nil {

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -31,17 +31,18 @@ var ServingFlags = initializeServingFlags()
 
 // ServingEnvironmentFlags holds the e2e flags needed only by the serving repo.
 type ServingEnvironmentFlags struct {
-	ResolvableDomain    bool   // Resolve Route controller's `domainSuffix`
-	CustomDomain        string // Indicates the `domainSuffix` for custom domain test.
-	HTTPS               bool   // Indicates where the test service will be created with https
-	Buckets             int    // The number of reconciler buckets configured.
-	Replicas            int    // The number of controlplane replicas being run.
-	EnableAlphaFeatures bool   // Indicates whether we run tests for alpha features
-	EnableBetaFeatures  bool   // Indicates whether we run tests for beta features
-	DisableLogStream    bool   // Indicates whether log streaming is disabled
-	TestNamespace       string // Default namespace for Serving E2E/Conformance tests
-	AltTestNamespace    string // Alternative namespace for running cross-namespace tests in
-	TLSTestNamespace    string // Namespace for Serving TLS tests
+	AlwaysCreateRevisionOnUpdate bool   // Indicates whether a revision will always be created on Service update
+	ResolvableDomain             bool   // Resolve Route controller's `domainSuffix`
+	CustomDomain                 string // Indicates the `domainSuffix` for custom domain test.
+	HTTPS                        bool   // Indicates where the test service will be created with https
+	Buckets                      int    // The number of reconciler buckets configured.
+	Replicas                     int    // The number of controlplane replicas being run.
+	EnableAlphaFeatures          bool   // Indicates whether we run tests for alpha features
+	EnableBetaFeatures           bool   // Indicates whether we run tests for beta features
+	DisableLogStream             bool   // Indicates whether log streaming is disabled
+	TestNamespace                string // Default namespace for Serving E2E/Conformance tests
+	AltTestNamespace             string // Alternative namespace for running cross-namespace tests in
+	TLSTestNamespace             string // Namespace for Serving TLS tests
 }
 
 func initializeServingFlags() *ServingEnvironmentFlags {
@@ -52,6 +53,9 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 
 	flag.StringVar(&f.CustomDomain, "customdomain", "",
 		"Set this flag to the custom domain suffix for domainmapping test.")
+
+	flag.BoolVar(&f.AlwaysCreateRevisionOnUpdate, "alwaysCreateRevisionOnUpdate", false,
+		"Set this flag to true if your implementaion always creates a new Revision when update a Service no matter what the change is.")
 
 	flag.BoolVar(&f.HTTPS, "https", false,
 		"Set this flag to true to run all tests with https.")

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -55,7 +55,7 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 		"Set this flag to the custom domain suffix for domainmapping test.")
 
 	flag.BoolVar(&f.AlwaysCreateRevisionOnUpdate, "always-create-revision-on-update", false,
-		"Set this flag to true if your implementaion always creates a new Revision when update a Service no matter what the change is.")
+		"Set this flag to true if your implementation always creates a new Revision when update a Service no matter what the change is.")
 
 	flag.BoolVar(&f.HTTPS, "https", false,
 		"Set this flag to true to run all tests with https.")

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -54,7 +54,7 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 	flag.StringVar(&f.CustomDomain, "customdomain", "",
 		"Set this flag to the custom domain suffix for domainmapping test.")
 
-	flag.BoolVar(&f.AlwaysCreateRevisionOnUpdate, "alwaysCreateRevisionOnUpdate", false,
+	flag.BoolVar(&f.AlwaysCreateRevisionOnUpdate, "always-create-revision-on-update", false,
 		"Set this flag to true if your implementaion always creates a new Revision when update a Service no matter what the change is.")
 
 	flag.BoolVar(&f.HTTPS, "https", false,


### PR DESCRIPTION
For #11710.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Set `LatestRevision` to false if unset and `Percent` to 0 if unset when comparing service status. Different implementation may not set fields whose value are optional.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
