### PR TITLE
Add endpoint call for pod freezer

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -299,8 +299,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first.
 	var composedHandler http.Handler = httpProxy
 	if concurrencyStateEnabled {
-		logger.Info("Concurrency state endpoint set, tracking request counts")
-		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, nil, nil)
+		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, queue.Pause, queue.Resume, env.ConcurrencyStateEndpoint)
 	}
 	if metricsSupported {
 		composedHandler = requestAppMetricsHandler(logger, composedHandler, breaker, env)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -300,11 +300,11 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	var composedHandler http.Handler = httpProxy
 	if concurrencyStateEnabled {
 		logger.Info("Concurrency state endpoint set, tracking request counts, using endpoint: ", env.ConcurrencyStateEndpoint)
-		pause, err := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessageBody{Action: "pause"})
+		pause, err := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessage{Action: "pause"})
 		if err != nil {
 			logger.Fatalf("pause function creation failed: %w", err)
 		}
-		resume, err := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessageBody{Action: "resume"})
+		resume, err := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessage{Action: "resume"})
 		if err != nil {
 			logger.Fatalf("resume function creation failed: %w", err)
 		}

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -300,16 +300,8 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	var composedHandler http.Handler = httpProxy
 	if concurrencyStateEnabled {
 		logger.Info("Concurrency state endpoint set, tracking request counts, using endpoint: ", env.ConcurrencyStateEndpoint)
-		pauseMsg, err := queue.CreateConcurrencyStateMessageBody(queue.ConcurrencyStateMessageBody{Action: "pause"})
-		if err != nil {
-			logger.Errorf("unable to create concurrency state pause message body: %s", err)
-		}
-		resumeMsg, err := queue.CreateConcurrencyStateMessageBody(queue.ConcurrencyStateMessageBody{Action: "resume"})
-		if err != nil {
-			logger.Errorf("unable to create concurrency state resume message body: %s", err)
-		}
-		pause := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, pauseMsg)
-		resume := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, resumeMsg)
+		pause := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessageBody{Action: "pause"})
+		resume := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessageBody{Action: "resume"})
 		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, pause, resume)
 	}
 	if metricsSupported {

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -300,8 +300,14 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	var composedHandler http.Handler = httpProxy
 	if concurrencyStateEnabled {
 		logger.Info("Concurrency state endpoint set, tracking request counts, using endpoint: ", env.ConcurrencyStateEndpoint)
-		pause := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessageBody{Action: "pause"})
-		resume := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessageBody{Action: "resume"})
+		pause, err := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessageBody{Action: "pause"})
+		if err != nil {
+			logger.Fatalf("pause function creation failed: %w", err)
+		}
+		resume, err := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessageBody{Action: "resume"})
+		if err != nil {
+			logger.Fatalf("resume function creation failed: %w", err)
+		}
 		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, pause, resume)
 	}
 	if metricsSupported {

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -300,15 +300,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	var composedHandler http.Handler = httpProxy
 	if concurrencyStateEnabled {
 		logger.Info("Concurrency state endpoint set, tracking request counts, using endpoint: ", env.ConcurrencyStateEndpoint)
-		pause, err := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessage{Action: "pause"})
-		if err != nil {
-			logger.Fatalf("pause function creation failed: %w", err)
-		}
-		resume, err := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessage{Action: "resume"})
-		if err != nil {
-			logger.Fatalf("resume function creation failed: %w", err)
-		}
-		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, pause, resume)
+		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, queue.Pause(env.ConcurrencyStateEndpoint), queue.Resume(env.ConcurrencyStateEndpoint))
 	}
 	if metricsSupported {
 		composedHandler = requestAppMetricsHandler(logger, composedHandler, breaker, env)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -299,7 +299,10 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first.
 	var composedHandler http.Handler = httpProxy
 	if concurrencyStateEnabled {
-		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, queue.Pause, queue.Resume, env.ConcurrencyStateEndpoint)
+		logger.Info("Concurrency state endpoint set, tracking request counts, using endpoint: ", env.ConcurrencyStateEndpoint)
+		pause := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessageBody{Action: "pause"})
+		resume := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessageBody{Action: "resume"})
+		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, pause, resume)
 	}
 	if metricsSupported {
 		composedHandler = requestAppMetricsHandler(logger, composedHandler, breaker, env)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -300,8 +300,16 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	var composedHandler http.Handler = httpProxy
 	if concurrencyStateEnabled {
 		logger.Info("Concurrency state endpoint set, tracking request counts, using endpoint: ", env.ConcurrencyStateEndpoint)
-		pause := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessageBody{Action: "pause"})
-		resume := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateMessageBody{Action: "resume"})
+		pauseMsg, err := queue.CreateConcurrencyStateMessageBody(queue.ConcurrencyStateMessageBody{Action: "pause"})
+		if err != nil {
+			logger.Errorf("unable to create concurrency state pause message body: %s", err)
+		}
+		resumeMsg, err := queue.CreateConcurrencyStateMessageBody(queue.ConcurrencyStateMessageBody{Action: "resume"})
+		if err != nil {
+			logger.Errorf("unable to create concurrency state resume message body: %s", err)
+		}
+		pause := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, pauseMsg)
+		resume := queue.ConcurrencyStateRequest(env.ConcurrencyStateEndpoint, resumeMsg)
 		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, pause, resume)
 	}
 	if metricsSupported {

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
   annotations:
-    knative.dev/example-checksum: "e3a807cf"
+    knative.dev/example-checksum: "e82fcbd0"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
   annotations:
-    knative.dev/example-checksum: "9448bd0c"
+    knative.dev/example-checksum: "e3a807cf"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -81,7 +81,9 @@ data:
     queueSidecarEphemeralStorageLimit: "1024Mi"
 
     # concurrencyStateEndpoint is the endpoint that queue-proxy calls when its traffic
-    # drops to zero or scales up from zero.
+    # drops to zero or scales up from zero. The endpoint will need to include both
+    # the endpoint and the port that will be accessed, for example:
+    # http://pod-freezer.knative-serving.svc.cluster.local:9696
     # If omitted, queue proxy takes no action (this is the default behavior).
     # When enabled, a serviceAccountToken will be mounted to queue-proxy using a
     # projected volume. This requires the Service Account Token Volume Projection feature

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -93,7 +93,7 @@ func ConcurrencyStateHandler(logger *zap.SugaredLogger, h http.Handler, pause, r
 	}
 }
 
-// ConcurrencyState Request sends a request to the concurrency state endpoint.
+// concurrencyStateRequest sends a request to the concurrency state endpoint.
 func concurrencyStateRequest(endpoint string, action string) func() error {
 	return func() error {
 		bodyText := fmt.Sprintf(`{ "action": %q }`, action)

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -84,7 +84,7 @@ func ConcurrencyStateHandler(logger *zap.SugaredLogger, h http.Handler, pause, r
 		logger.Info("Requests increased from zero")
 		if err := resume(); err != nil {
 			logger.Errorf("Error handling resume request: %v", err)
-			panic(err)
+			os.Exit(1)
 		}
 		paused = false
 		logger.Debug("From-Zero request successfully processed")
@@ -94,8 +94,8 @@ func ConcurrencyStateHandler(logger *zap.SugaredLogger, h http.Handler, pause, r
 	}
 }
 
-// ConcurrencyState Request sends to the concurrency state endpoint
-func ConcurrencyStateRequest(endpoint string, action ConcurrencyStateMessageBody) (func() error, error) {
+// ConcurrencyState Request sends a request to the concurrency state endpoint.
+func ConcurrencyStateRequest(endpoint string, action ConcurrencyStateMessage) (func() error, error) {
 	bodyText, err := json.Marshal(action)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create message body: %w", err)
@@ -118,6 +118,6 @@ func ConcurrencyStateRequest(endpoint string, action ConcurrencyStateMessageBody
 	}, nil
 }
 
-type ConcurrencyStateMessageBody struct {
+type ConcurrencyStateMessage struct {
 	Action string `json:"action"`
 }

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -95,11 +95,10 @@ func ConcurrencyStateHandler(logger *zap.SugaredLogger, h http.Handler, pause, r
 }
 
 // ConcurrencyState Request sends to the concurrency state endpoint
-func ConcurrencyStateRequest(endpoint string, action ConcurrencyStateMessageBody) func() error {
-	bodyText, err := CreateConcurrencyStateMessageBody(action)
+func ConcurrencyStateRequest(endpoint string, action ConcurrencyStateMessageBody) (func() error, error) {
+	bodyText, err := json.Marshal(action)
 	if err != nil {
-		_ = fmt.Errorf("unable to create message body: %w", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("unable to create message body: %w", err)
 	}
 	return func() error {
 		body := bytes.NewBuffer(bodyText)
@@ -116,11 +115,7 @@ func ConcurrencyStateRequest(endpoint string, action ConcurrencyStateMessageBody
 			return fmt.Errorf("expected 200 response, got: %d: %s", resp.StatusCode, resp.Status)
 		}
 		return nil
-	}
-}
-
-func CreateConcurrencyStateMessageBody(action ConcurrencyStateMessageBody) ([]byte, error) {
-	return json.Marshal(action)
+	}, nil
 }
 
 type ConcurrencyStateMessageBody struct {

--- a/pkg/queue/concurrency_state_test.go
+++ b/pkg/queue/concurrency_state_test.go
@@ -151,7 +151,10 @@ func TestConcurrencyStateRequestHeader(t *testing.T) {
 			}
 		}
 	}))
-	pause := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessageBody{Action: "test"})
+	pause, err := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessageBody{Action: "test"})
+	if err != nil {
+		t.Errorf("unable to create pause function: %s", err)
+	}
 	if err := pause(); err != nil {
 		t.Errorf("header check returned an error: %s", err)
 	}
@@ -170,7 +173,10 @@ func TestConcurrencyStateRequestRequest(t *testing.T) {
 		}
 	}))
 
-	pause := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessageBody{Action: "test"})
+	pause, err := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessageBody{Action: "test"})
+	if err != nil {
+		t.Errorf("unable to create pause function: %s", err)
+	}
 	if err := pause(); err != nil {
 		t.Errorf("request test returned an error: %s", err)
 	}
@@ -182,7 +188,10 @@ func TestConcurrencyStateRequestResponse(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	pause := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessageBody{Action: "test"})
+	pause, err := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessageBody{Action: "test"})
+	if err != nil {
+		t.Errorf("unable to create pause function: %s", err)
+	}
 	if err := pause(); err == nil {
 		t.Errorf("failed function did not return an error")
 	}

--- a/pkg/queue/concurrency_state_test.go
+++ b/pkg/queue/concurrency_state_test.go
@@ -151,10 +151,7 @@ func TestConcurrencyStateRequestHeader(t *testing.T) {
 			}
 		}
 	}))
-	pause, err := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessage{Action: "test"})
-	if err != nil {
-		t.Errorf("unable to create pause function: %s", err)
-	}
+	pause := Pause(ts.URL)
 	if err := pause(); err != nil {
 		t.Errorf("header check returned an error: %s", err)
 	}
@@ -163,20 +160,17 @@ func TestConcurrencyStateRequestHeader(t *testing.T) {
 func TestConcurrencyStateRequestRequest(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		var m ConcurrencyStateMessage
+		var m struct{ Action string }
 		err := json.NewDecoder(r.Body).Decode(&m)
 		if err != nil {
 			t.Errorf("unable to parse message body: %s", err)
 		}
-		if m.Action != "test" {
-			t.Errorf("improper message body, expected 'test' and got: %s", m.Action)
+		if m.Action != "pause" {
+			t.Errorf("improper message body, expected 'pause' and got: %s", m.Action)
 		}
 	}))
 
-	pause, err := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessage{Action: "test"})
-	if err != nil {
-		t.Errorf("unable to create pause function: %s", err)
-	}
+	pause := Pause(ts.URL)
 	if err := pause(); err != nil {
 		t.Errorf("request test returned an error: %s", err)
 	}
@@ -188,10 +182,7 @@ func TestConcurrencyStateRequestResponse(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	pause, err := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessage{Action: "test"})
-	if err != nil {
-		t.Errorf("unable to create pause function: %s", err)
-	}
+	pause := Pause(ts.URL)
 	if err := pause(); err == nil {
 		t.Errorf("failed function did not return an error")
 	}

--- a/pkg/queue/concurrency_state_test.go
+++ b/pkg/queue/concurrency_state_test.go
@@ -157,7 +157,7 @@ func TestConcurrencyStateRequestHeader(t *testing.T) {
 	}
 }
 
-func TestConcurrencyStateRequestRequest(t *testing.T) {
+func TestConcurrencyStatePauseRequest(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		var m struct{ Action string }
@@ -172,6 +172,25 @@ func TestConcurrencyStateRequestRequest(t *testing.T) {
 
 	pause := Pause(ts.URL)
 	if err := pause(); err != nil {
+		t.Errorf("request test returned an error: %s", err)
+	}
+}
+
+func TestConcurrencyStateResumeRequest(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		var m struct{ Action string }
+		err := json.NewDecoder(r.Body).Decode(&m)
+		if err != nil {
+			t.Errorf("unable to parse message body: %s", err)
+		}
+		if m.Action != "resume" {
+			t.Errorf("improper message body, expected 'resume' and got: %s", m.Action)
+		}
+	}))
+
+	resume := Resume(ts.URL)
+	if err := resume(); err != nil {
 		t.Errorf("request test returned an error: %s", err)
 	}
 }

--- a/pkg/queue/concurrency_state_test.go
+++ b/pkg/queue/concurrency_state_test.go
@@ -151,7 +151,7 @@ func TestConcurrencyStateRequestHeader(t *testing.T) {
 			}
 		}
 	}))
-	pause := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessageBody{Action: "test"})
+	pause := ConcurrencyStateRequest(ts.URL, nil)
 	if err := pause(); err != nil {
 		t.Errorf("header check returned an error: %s", err)
 	}
@@ -169,7 +169,12 @@ func TestConcurrencyStateRequestRequest(t *testing.T) {
 			t.Errorf("improper message body, expected 'test' and got: %s", m.Action)
 		}
 	}))
-	pause := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessageBody{Action: "test"})
+
+	pauseMsg, err := CreateConcurrencyStateMessageBody(ConcurrencyStateMessageBody{Action: "test"})
+	if err != nil {
+		t.Errorf("unable to create message body: %s", err)
+	}
+	pause := ConcurrencyStateRequest(ts.URL, pauseMsg)
 	if err := pause(); err != nil {
 		t.Errorf("request test returned an error: %s", err)
 	}
@@ -181,7 +186,7 @@ func TestConcurrencyStateRequestResponse(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	pause := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessageBody{Action: "test"})
+	pause := ConcurrencyStateRequest(ts.URL, nil)
 	if err := pause(); err == nil {
 		t.Errorf("failed function did not return an error")
 	}

--- a/pkg/queue/concurrency_state_test.go
+++ b/pkg/queue/concurrency_state_test.go
@@ -151,7 +151,7 @@ func TestConcurrencyStateRequestHeader(t *testing.T) {
 			}
 		}
 	}))
-	pause, err := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessageBody{Action: "test"})
+	pause, err := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessage{Action: "test"})
 	if err != nil {
 		t.Errorf("unable to create pause function: %s", err)
 	}
@@ -163,7 +163,7 @@ func TestConcurrencyStateRequestHeader(t *testing.T) {
 func TestConcurrencyStateRequestRequest(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		var m ConcurrencyStateMessageBody
+		var m ConcurrencyStateMessage
 		err := json.NewDecoder(r.Body).Decode(&m)
 		if err != nil {
 			t.Errorf("unable to parse message body: %s", err)
@@ -173,7 +173,7 @@ func TestConcurrencyStateRequestRequest(t *testing.T) {
 		}
 	}))
 
-	pause, err := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessageBody{Action: "test"})
+	pause, err := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessage{Action: "test"})
 	if err != nil {
 		t.Errorf("unable to create pause function: %s", err)
 	}
@@ -188,7 +188,7 @@ func TestConcurrencyStateRequestResponse(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	pause, err := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessageBody{Action: "test"})
+	pause, err := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessage{Action: "test"})
 	if err != nil {
 		t.Errorf("unable to create pause function: %s", err)
 	}

--- a/pkg/queue/concurrency_state_test.go
+++ b/pkg/queue/concurrency_state_test.go
@@ -151,7 +151,7 @@ func TestConcurrencyStateRequestHeader(t *testing.T) {
 			}
 		}
 	}))
-	pause := ConcurrencyStateRequest(ts.URL, nil)
+	pause := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessageBody{Action: "test"})
 	if err := pause(); err != nil {
 		t.Errorf("header check returned an error: %s", err)
 	}
@@ -170,11 +170,7 @@ func TestConcurrencyStateRequestRequest(t *testing.T) {
 		}
 	}))
 
-	pauseMsg, err := CreateConcurrencyStateMessageBody(ConcurrencyStateMessageBody{Action: "test"})
-	if err != nil {
-		t.Errorf("unable to create message body: %s", err)
-	}
-	pause := ConcurrencyStateRequest(ts.URL, pauseMsg)
+	pause := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessageBody{Action: "test"})
 	if err := pause(); err != nil {
 		t.Errorf("request test returned an error: %s", err)
 	}
@@ -186,7 +182,7 @@ func TestConcurrencyStateRequestResponse(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	pause := ConcurrencyStateRequest(ts.URL, nil)
+	pause := ConcurrencyStateRequest(ts.URL, ConcurrencyStateMessageBody{Action: "test"})
 	if err := pause(); err == nil {
 		t.Errorf("failed function did not return an error")
 	}


### PR DESCRIPTION
Fixes #11832 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add call to endpoint for when the request count for a pod scales to/from zero.

This is part of the work to add the Pod Freezer capability to knative (see #11694 for more details)

Note: there is a skeleton of a freeze/thaw service available [here](https://github.com/psschwei/pod-freezer), which is a refactoring of julz's [freeze-proxy daemon](https://github.com/julz/freeze-proxy) into a standalone service. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
 Add call to `concurrencyStateEndpoint` when the request count for a pod scales to/from zero.
```
