### PR TITLE
Add serviceAccountToken via projected volume when concurrency state endpoint set

### DIFF
--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
   annotations:
-    knative.dev/example-checksum: "d42e2c33"
+    knative.dev/example-checksum: "9448bd0c"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -83,5 +83,10 @@ data:
     # concurrencyStateEndpoint is the endpoint that queue-proxy calls when its traffic
     # drops to zero or scales up from zero.
     # If omitted, queue proxy takes no action (this is the default behavior).
+    # When enabled, a serviceAccountToken will be mounted to queue-proxy using a
+    # projected volume. This requires the Service Account Token Volume Projection feature
+    # to be enabled. For details, see this link:
+    # https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection
+    #
     # NOTE THAT THIS IS AN EXPERIMENTAL / ALPHA FEATURE
     concurrencyStateEndpoint: ""

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/zap"
 )
 
+//nolint:gosec // Filepath, not hardcoded credentials
 const ConcurrencyStateTokenVolumeMountPath = "/var/run/secrets/tokens"
 
 // ConcurrencyStateHandler tracks the in flight requests for the pod. When the requests

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -22,6 +22,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const ConcurrencyStateTokenVolumeMountPath = "/var/run/secrets/tokens"
+
 // ConcurrencyStateHandler tracks the in flight requests for the pod. When the requests
 // drop to zero, it runs the `pause` function, and when requests scale up from zero, it
 // runs the `resume` function. If either of `pause` or `resume` are not passed, it runs


### PR DESCRIPTION
Fixes #11833 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Mount a projected volume to the queue-proxy container, containing a `serviceAccountToken`, when a `concurrencyStateEndpoint` is set. The concurrency state handler will use this token for authentication with the pod freezer service (running outside of QP).

This is part of the work to add the Pod Freezer capability to knative (see #11694  for more details)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
