### PR TITLE
Wait latest ready revision without `routingState` label check in conformance tests

### DIFF
--- a/test/conformance/api/v1/blue_green_test.go
+++ b/test/conformance/api/v1/blue_green_test.go
@@ -82,7 +82,7 @@ func TestBlueGreenRoute(t *testing.T) {
 	}
 
 	t.Log("Since the Service was updated a new Revision will be created and the Service will be updated")
-	green.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names)
+	green.Revision, err = v1test.WaitForServiceLatestRevisionForConformanceTest(clients, names)
 	if err != nil {
 		t.Fatalf("Service %s was not updated with the Revision for image %s: %v", names.Service, greenImagePath, err)
 	}

--- a/test/conformance/api/v1/blue_green_test.go
+++ b/test/conformance/api/v1/blue_green_test.go
@@ -82,7 +82,7 @@ func TestBlueGreenRoute(t *testing.T) {
 	}
 
 	t.Log("Since the Service was updated a new Revision will be created and the Service will be updated")
-	green.Revision, err = v1test.WaitForServiceLatestRevision(clients, names)
+	green.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names)
 	if err != nil {
 		t.Fatalf("Service %s was not updated with the Revision for image %s: %v", names.Service, greenImagePath, err)
 	}

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -92,7 +92,7 @@ func TestServiceCreateAndUpdate(t *testing.T) {
 	}
 
 	t.Log("Service should reflect new revision created and ready in status.")
-	names.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names)
+	names.Revision, err = v1test.WaitForServiceLatestRevisionForConformanceTest(clients, names)
 	if err != nil {
 		t.Fatal("New image not reflected in Service:", err)
 	}
@@ -123,7 +123,7 @@ func TestServiceCreateAndUpdate(t *testing.T) {
 	}
 
 	t.Log("Waiting for the new revision to appear as LatestRevision.")
-	if names.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names); err != nil {
+	if names.Revision, err = v1test.WaitForServiceLatestRevisionForConformanceTest(clients, names); err != nil {
 		t.Fatalf("The Service %s was not updated with new revision %s after updating labels in its RevisionTemplateSpec: %v", names.Service, names.Revision, err)
 	}
 
@@ -140,7 +140,7 @@ func TestServiceCreateAndUpdate(t *testing.T) {
 	}
 
 	t.Log("Waiting for the new revision to appear as LatestRevision.")
-	names.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names)
+	names.Revision, err = v1test.WaitForServiceLatestRevisionForConformanceTest(clients, names)
 	if err != nil {
 		t.Fatal("The new revision has not become ready in Service:", err)
 	}
@@ -335,7 +335,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 	}
 
 	t.Log("Since the Service was updated a new Revision will be created")
-	if names.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names); err != nil {
+	if names.Revision, err = v1test.WaitForServiceLatestRevisionForConformanceTest(clients, names); err != nil {
 		t.Fatalf("The Service %s was not updated with new revision %s: %v", names.Service, names.Revision, err)
 	}
 	secondRevision := names.Revision
@@ -433,7 +433,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		t.Fatalf("Update for Service %s with new image %s failed: %v", names.Service, releaseImagePath3, err)
 	}
 	t.Log("Since the Service was updated a new Revision will be created")
-	if names.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names); err != nil {
+	if names.Revision, err = v1test.WaitForServiceLatestRevisionForConformanceTest(clients, names); err != nil {
 		t.Fatalf("The Service %s was not updated with new revision %s: %v", names.Service, names.Revision, err)
 	}
 	thirdRevision := names.Revision
@@ -562,7 +562,7 @@ func TestAnnotationPropagation(t *testing.T) {
 	}
 
 	t.Log("Service should reflect new revision created and ready in status.")
-	names.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names)
+	names.Revision, err = v1test.WaitForServiceLatestRevisionForConformanceTest(clients, names)
 	if err != nil {
 		t.Fatal("New image not reflected in Service:", err)
 	}
@@ -595,7 +595,7 @@ func TestAnnotationPropagation(t *testing.T) {
 	}
 
 	t.Log("Service should reflect new revision created and ready in status.")
-	names.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names)
+	names.Revision, err = v1test.WaitForServiceLatestRevisionForConformanceTest(clients, names)
 	if err != nil {
 		t.Fatal("New image not reflected in Service:", err)
 	}

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -92,7 +92,7 @@ func TestServiceCreateAndUpdate(t *testing.T) {
 	}
 
 	t.Log("Service should reflect new revision created and ready in status.")
-	names.Revision, err = v1test.WaitForServiceLatestRevision(clients, names)
+	names.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names)
 	if err != nil {
 		t.Fatal("New image not reflected in Service:", err)
 	}
@@ -123,7 +123,7 @@ func TestServiceCreateAndUpdate(t *testing.T) {
 	}
 
 	t.Log("Waiting for the new revision to appear as LatestRevision.")
-	if names.Revision, err = v1test.WaitForServiceLatestRevision(clients, names); err != nil {
+	if names.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names); err != nil {
 		t.Fatalf("The Service %s was not updated with new revision %s after updating labels in its RevisionTemplateSpec: %v", names.Service, names.Revision, err)
 	}
 
@@ -140,7 +140,7 @@ func TestServiceCreateAndUpdate(t *testing.T) {
 	}
 
 	t.Log("Waiting for the new revision to appear as LatestRevision.")
-	names.Revision, err = v1test.WaitForServiceLatestRevision(clients, names)
+	names.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names)
 	if err != nil {
 		t.Fatal("The new revision has not become ready in Service:", err)
 	}
@@ -335,7 +335,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 	}
 
 	t.Log("Since the Service was updated a new Revision will be created")
-	if names.Revision, err = v1test.WaitForServiceLatestRevision(clients, names); err != nil {
+	if names.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names); err != nil {
 		t.Fatalf("The Service %s was not updated with new revision %s: %v", names.Service, names.Revision, err)
 	}
 	secondRevision := names.Revision
@@ -433,7 +433,7 @@ func TestServiceWithTrafficSplit(t *testing.T) {
 		t.Fatalf("Update for Service %s with new image %s failed: %v", names.Service, releaseImagePath3, err)
 	}
 	t.Log("Since the Service was updated a new Revision will be created")
-	if names.Revision, err = v1test.WaitForServiceLatestRevision(clients, names); err != nil {
+	if names.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names); err != nil {
 		t.Fatalf("The Service %s was not updated with new revision %s: %v", names.Service, names.Revision, err)
 	}
 	thirdRevision := names.Revision
@@ -562,7 +562,7 @@ func TestAnnotationPropagation(t *testing.T) {
 	}
 
 	t.Log("Service should reflect new revision created and ready in status.")
-	names.Revision, err = v1test.WaitForServiceLatestRevision(clients, names)
+	names.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names)
 	if err != nil {
 		t.Fatal("New image not reflected in Service:", err)
 	}
@@ -595,7 +595,7 @@ func TestAnnotationPropagation(t *testing.T) {
 	}
 
 	t.Log("Service should reflect new revision created and ready in status.")
-	names.Revision, err = v1test.WaitForServiceLatestRevision(clients, names)
+	names.Revision, err = v1test.WaitForServiceLatestRevisionWithoutLabelCheck(clients, names)
 	if err != nil {
 		t.Fatal("New image not reflected in Service:", err)
 	}

--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -201,11 +201,11 @@ func PatchServiceRouteSpec(t testing.TB, clients *test.Clients, names test.Resou
 	})
 }
 
-// WaitForServiceLatestRevisionWithoutLabelCheck takes a revision in through names and compares it to the current state of LatestCreatedRevisionName in Service.
+// WaitForServiceLatestRevisionForConformanceTest takes a revision in through names and compares it to the current state of LatestCreatedRevisionName in Service.
 // Once an update is detected in the LatestCreatedRevisionName, the function waits for the created revision to
 //   1. be set in LatestReadyRevisionName
 // before returning the name of the revision.
-func WaitForServiceLatestRevisionWithoutLabelCheck(clients *test.Clients, names test.ResourceNames) (string, error) {
+func WaitForServiceLatestRevisionForConformanceTest(clients *test.Clients, names test.ResourceNames) (string, error) {
 	return waitForServiceLatestRevision(clients, names, false)
 }
 
@@ -231,6 +231,8 @@ func waitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 
 			// Without this it might happen that the latest created revision is later overridden by a newer one
 			// and the following check for LatestReadyRevisionName would fail. This might happen in upgrade tests.
+			// If we can ensure that the input revision is the current `LatestCreatedRevisionName` and
+			// there is only one new revision being created, it will be sufficient without this check.
 			return CheckRevisionState(clients.ServingClient, revisionName, IsRevisionRoutingActive) == nil, nil
 		}
 		return false, nil


### PR DESCRIPTION
Fixes #11797.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Introduces a new func to wait latest ready revision without `routingState` label check and use it in conformance tests. See https://github.com/knative/serving/issues/11797#issuecomment-897999115 for why we don't need the label check.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
