### PR TITLE
Skip a few more conformance tests against optional API

### DIFF
--- a/test/conformance/runtime/envpropagation_test.go
+++ b/test/conformance/runtime/envpropagation_test.go
@@ -34,6 +34,9 @@ func TestSecretsViaEnv(t *testing.T) {
 	clients := test.Setup(t)
 
 	t.Run("env", func(t *testing.T) {
+		if test.ServingFlags.DisableOptionalAPI {
+			t.Skip("Container.env.valueFrom is not required by Knative Serving API Specification")
+		}
 		t.Parallel()
 
 		err := fetchEnvironmentAndVerify(t, clients, WithEnv(corev1.EnvVar{
@@ -77,6 +80,9 @@ func TestConfigsViaEnv(t *testing.T) {
 	clients := test.Setup(t)
 
 	t.Run("env", func(t *testing.T) {
+		if test.ServingFlags.DisableOptionalAPI {
+			t.Skip("Container.env.valueFrom is not required by Knative Serving API Specification")
+		}
 		t.Parallel()
 
 		err := fetchEnvironmentAndVerify(t, clients, WithEnv(corev1.EnvVar{

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -152,6 +152,9 @@ func TestProbeRuntime(t *testing.T) {
 // which may not be what a user wants.
 // See https://github.com/knative/serving/issues/10765.
 func TestProbeRuntimeAfterStartup(t *testing.T) {
+	if test.ServingFlags.DisableOptionalAPI {
+		t.Skip("Container.readinessProbe is not required by Knative Serving API Specification")
+	}
 	t.Parallel()
 	clients := test.Setup(t)
 


### PR DESCRIPTION
A followup PR for #11769. Skip a few more tests against optional API.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
