### PR TITLE
Remove deprecated loadbalancer status

### DIFF
--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -76,9 +76,6 @@ func TestNewMakeK8SService(t *testing.T) {
 		route: r,
 		ingress: &netv1alpha1.Ingress{
 			Status: netv1alpha1.IngressStatus{
-				DeprecatedLoadBalancer: &netv1alpha1.LoadBalancerStatus{
-					Ingress: []netv1alpha1.LoadBalancerIngressStatus{{}},
-				},
 				PublicLoadBalancer: &netv1alpha1.LoadBalancerStatus{
 					Ingress: []netv1alpha1.LoadBalancerIngressStatus{{}},
 				},
@@ -94,13 +91,6 @@ func TestNewMakeK8SService(t *testing.T) {
 		route: r,
 		ingress: &netv1alpha1.Ingress{
 			Status: netv1alpha1.IngressStatus{
-				DeprecatedLoadBalancer: &netv1alpha1.LoadBalancerStatus{
-					Ingress: []netv1alpha1.LoadBalancerIngressStatus{{
-						Domain: "domain.com",
-					}, {
-						DomainInternal: "domain.com",
-					}},
-				},
 				PublicLoadBalancer: &netv1alpha1.LoadBalancerStatus{
 					Ingress: []netv1alpha1.LoadBalancerIngressStatus{{
 						Domain: "domain.com",
@@ -124,9 +114,6 @@ func TestNewMakeK8SService(t *testing.T) {
 		route: r,
 		ingress: &netv1alpha1.Ingress{
 			Status: netv1alpha1.IngressStatus{
-				DeprecatedLoadBalancer: &netv1alpha1.LoadBalancerStatus{
-					Ingress: []netv1alpha1.LoadBalancerIngressStatus{{Domain: "domain.com"}},
-				},
 				PublicLoadBalancer: &netv1alpha1.LoadBalancerStatus{
 					Ingress: []netv1alpha1.LoadBalancerIngressStatus{{Domain: "domain.com"}},
 				},
@@ -150,9 +137,6 @@ func TestNewMakeK8SService(t *testing.T) {
 		route: r,
 		ingress: &netv1alpha1.Ingress{
 			Status: netv1alpha1.IngressStatus{
-				DeprecatedLoadBalancer: &netv1alpha1.LoadBalancerStatus{
-					Ingress: []netv1alpha1.LoadBalancerIngressStatus{{DomainInternal: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system")}},
-				},
 				PublicLoadBalancer: &netv1alpha1.LoadBalancerStatus{
 					Ingress: []netv1alpha1.LoadBalancerIngressStatus{{DomainInternal: pkgnet.GetServiceHostname("istio-ingressgateway", "istio-system")}},
 				},
@@ -177,9 +161,6 @@ func TestNewMakeK8SService(t *testing.T) {
 		route: r,
 		ingress: &netv1alpha1.Ingress{
 			Status: netv1alpha1.IngressStatus{
-				DeprecatedLoadBalancer: &netv1alpha1.LoadBalancerStatus{
-					Ingress: []netv1alpha1.LoadBalancerIngressStatus{{MeshOnly: true}},
-				},
 				PublicLoadBalancer: &netv1alpha1.LoadBalancerStatus{
 					Ingress: []netv1alpha1.LoadBalancerIngressStatus{{MeshOnly: true}},
 				},
@@ -202,9 +183,6 @@ func TestNewMakeK8SService(t *testing.T) {
 		targetName: "my-target-name",
 		ingress: &netv1alpha1.Ingress{
 			Status: netv1alpha1.IngressStatus{
-				DeprecatedLoadBalancer: &netv1alpha1.LoadBalancerStatus{
-					Ingress: []netv1alpha1.LoadBalancerIngressStatus{{MeshOnly: true}},
-				},
 				PublicLoadBalancer: &netv1alpha1.LoadBalancerStatus{
 					Ingress: []netv1alpha1.LoadBalancerIngressStatus{{MeshOnly: true}},
 				},

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -265,14 +265,6 @@ func TestCreateRouteForOneReserveRevision(t *testing.T) {
 		t.Error("Unexpected rule spec diff (-want +got):", diff)
 	}
 
-	// Update ingress loadbalancer to trigger placeholder service creation.
-	ci.Status = v1alpha1.IngressStatus{
-		DeprecatedLoadBalancer: &v1alpha1.LoadBalancerStatus{
-			Ingress: []v1alpha1.LoadBalancerIngressStatus{{
-				DomainInternal: "test-domain",
-			}},
-		},
-	}
 	fakeingressinformer.Get(ctx).Informer().GetIndexer().Update(ci)
 	ctl.Reconciler.Reconcile(context.Background(), KeyOrDie(route))
 


### PR DESCRIPTION
`ingress.status.LoadBalancer` was deprecated since 1 year ago,
https://github.com/knative/networking/pull/137

This patch removes it.

**Release Note**

```release-note
NONE
```
