### PR TITLE
Allow unknown fields in webhooks

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -21,6 +21,7 @@ jobs:
         - v1.19.11
         - v1.20.7
         - v1.21.1
+        - v1.22.0
 
         test-suite:
         - ./test/conformance/runtime
@@ -45,6 +46,11 @@ jobs:
         - k8s-version: v1.21.1
           kind-version: v0.11.1
           kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+          kingress: kourier
+          cluster-suffix: c${{ github.run_id }}.local
+        - k8s-version: v1.22.0
+          kind-version: v0.11.1
+          kind-image-sha: sha256:f97edf7f7ed53c57762b24f90a34fad101386c5bd4d93baeb45449557148c717
           kingress: kourier
           cluster-suffix: c${{ github.run_id }}.local
 

--- a/cmd/domain-mapping-webhook/main.go
+++ b/cmd/domain-mapping-webhook/main.go
@@ -60,7 +60,7 @@ func newDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher
 		store.ToContext,
 
 		// Whether to disallow unknown fields.
-		true,
+		false,
 	)
 }
 
@@ -84,7 +84,7 @@ func newValidatingAdmissionController(ctx context.Context, cmw configmap.Watcher
 		store.ToContext,
 
 		// Whether to disallow unknown fields.
-		true,
+		false,
 	)
 }
 

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -95,7 +95,7 @@ func newDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher
 		store.ToContext,
 
 		// Whether to disallow unknown fields.
-		true,
+		false,
 	)
 }
 
@@ -119,7 +119,7 @@ func newValidationAdmissionController(ctx context.Context, cmw configmap.Watcher
 		store.ToContext,
 
 		// Whether to disallow unknown fields.
-		true,
+		false,
 
 		// Extra validating callbacks to be applied to resources.
 		callbacks,


### PR DESCRIPTION
Given we now have schema validation, we should stop relying on json decoders to block unknown fields. This prevents API additions in new versions of kubernetes breaking Knative (as happened in #11448).

Unfortunately this does leave us without a great solution for things such as Tekton where schema validation bumps against etcd limits, so we may need another approach there. Still, for serving this is a low-cost fix to get things working without - I think! - obvious downsides (due to having schema validation now), and which seems to best match (based on conversations with them) how upstream k8s expects us to hold them.

Also adds k8s 1.22 to CI via the GitHub actions.

Related: #11805 
Fixes: https://github.com/knative/serving/issues/11448

/assign @dprotaso @markusthoemmes
cc @vdemeester 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Stops disallowing unknown fields via the validation webhook. Instead, schema validation should now be used for this purpose.
```
