### PR TITLE
Drop relatively useless logging

### DIFF
--- a/pkg/reconciler/configuration/controller.go
+++ b/pkg/reconciler/configuration/controller.go
@@ -41,7 +41,6 @@ func NewController(
 	configurationInformer := configurationinformer.Get(ctx)
 	revisionInformer := revisioninformer.Get(ctx)
 
-	logger.Info("Setting up ConfigMap receivers")
 	configStore := config.NewStore(logger.Named("config-store"))
 	configStore.WatchConfigs(cmw)
 
@@ -54,7 +53,6 @@ func NewController(
 		return controller.Options{ConfigStore: configStore}
 	})
 
-	logger.Info("Setting up event handlers")
 	configurationInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	revisionInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/pkg/reconciler/domainmapping/controller.go
+++ b/pkg/reconciler/domainmapping/controller.go
@@ -62,7 +62,6 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		return controller.Options{ConfigStore: configStore}
 	})
 
-	logger.Info("Setting up event handlers")
 	domainmappingInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	handleControllerOf := cache.FilteringResourceEventHandler{

--- a/pkg/reconciler/gc/controller.go
+++ b/pkg/reconciler/gc/controller.go
@@ -48,8 +48,6 @@ func NewController(
 		revisionLister: revisionInformer.Lister(),
 	}
 	return configreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
-		logger.Info("Setting up event handlers")
-
 		// Since the gc controller came from the configuration controller, having event handlers
 		// on both configuration and revision matches the existing behaviors of the configuration
 		// controller. This is to minimize risk heading into v1.
@@ -61,7 +59,6 @@ func NewController(
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
 
-		logger.Info("Setting up ConfigMap receivers with resync func")
 		configsToResync := []interface{}{
 			&gcconfig.Config{},
 		}
@@ -70,7 +67,6 @@ func NewController(
 			impl.GlobalResync(revisionInformer.Informer())
 		})
 
-		logger.Info("Setting up ConfigMap receivers")
 		configStore := configns.NewStore(logging.WithLogger(ctx, logger.Named("config-store")), resync)
 		configStore.WatchConfigs(cmw)
 

--- a/pkg/reconciler/labeler/controller.go
+++ b/pkg/reconciler/labeler/controller.go
@@ -46,7 +46,6 @@ func NewController(
 	configInformer := configurationinformer.Get(ctx)
 	revisionInformer := revisioninformer.Get(ctx)
 
-	logger.Info("Setting up ConfigMap receivers")
 	configStore := config.NewStore(logger.Named("config-store"))
 	configStore.WatchConfigs(cmw)
 
@@ -59,7 +58,6 @@ func NewController(
 		}
 	})
 
-	logger.Info("Setting up event handlers")
 	routeInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	// Make sure trackers are deleted once the observers are removed.

--- a/pkg/reconciler/metric/controller.go
+++ b/pkg/reconciler/metric/controller.go
@@ -25,7 +25,6 @@ import (
 
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
 )
 
 // NewController initializes the controller and is called by the generated code.
@@ -35,15 +34,12 @@ func NewController(
 	cmw configmap.Watcher,
 	collector metrics.Collector,
 ) *controller.Impl {
-	logger := logging.FromContext(ctx)
 	metricInformer := metricinformer.Get(ctx)
 
 	c := &reconciler{
 		collector: collector,
 	}
 	impl := metricreconciler.NewImpl(ctx, c)
-
-	logger.Info("Setting up event handlers")
 
 	// Watch all the Metric objects.
 	metricInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))

--- a/pkg/reconciler/nscert/controller.go
+++ b/pkg/reconciler/nscert/controller.go
@@ -47,15 +47,13 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	}
 
 	impl := namespacereconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
-		logger.Info("Setting up event handlers")
 		nsInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 		knCertificateInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-			FilterFunc: controller.FilterControllerGVK(corev1.SchemeGroupVersion.WithKind("Namespace")),
+			FilterFunc: controller.FilterControllerGK(corev1.SchemeGroupVersion.WithKind("Namespace").GroupKind()),
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
 
-		logger.Info("Setting up ConfigMap receivers")
 		configsToResync := []interface{}{
 			&network.Config{},
 			&routecfg.Domain{},

--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -128,7 +128,6 @@ func newControllerWithOptions(
 	c.resolver = resolver
 
 	// Set up an event handler for when the resource types of interest change
-	logger.Info("Setting up event handlers")
 	revisionInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	handleMatchingControllers := cache.FilteringResourceEventHandler{

--- a/pkg/reconciler/route/controller.go
+++ b/pkg/reconciler/route/controller.go
@@ -90,7 +90,6 @@ func newController(
 	})
 	c.enqueueAfter = impl.EnqueueAfter
 
-	logger.Info("Setting up event handlers")
 	routeInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	handleControllerOf := cache.FilteringResourceEventHandler{

--- a/pkg/reconciler/serverlessservice/controller.go
+++ b/pkg/reconciler/serverlessservice/controller.go
@@ -66,8 +66,6 @@ func NewController(
 	}
 	impl := sksreconciler.NewImpl(ctx, c)
 
-	logger.Info("Setting up event handlers")
-
 	// Watch all the SKS objects.
 	sksInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 

--- a/pkg/reconciler/service/controller.go
+++ b/pkg/reconciler/service/controller.go
@@ -46,7 +46,6 @@ func NewController(
 	configurationInformer := configurationinformer.Get(ctx)
 	revisionInformer := revisioninformer.Get(ctx)
 
-	logger.Info("Setting up ConfigMap receivers")
 	configStore := cfgmap.NewStore(logger.Named("config-store"))
 	configStore.WatchConfigs(cmw)
 
@@ -61,7 +60,6 @@ func NewController(
 	}
 	impl := ksvcreconciler.NewImpl(ctx, c, opts)
 
-	logger.Info("Setting up event handlers")
 	serviceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	handleControllerOf := cache.FilteringResourceEventHandler{


### PR DESCRIPTION
/kind cleanup

The "Setting up event handlers" log statements have been around (and copied!) forever, and are next to useless.  For whatever reason this has bugged me for the last time, and I've made it my personal mission to destroy them (and any adjacent useless logging they have encouraged).

I also noticed a case where we were using a `GVK` filter, which should probably be `GK` for future-proofing.

```release-note

```
