### PR TITLE
Add missing RootCA additions to checks

### DIFF
--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -190,7 +190,8 @@ func ScaleToWithin(t *testing.T, scale int, duration time.Duration, latencies La
 					url,
 					v1test.RetryingRouteInconsistency(spoof.MatchesAllOf(spoof.IsStatusOK, spoof.MatchesBody(test.HelloWorldText), abortOnTimeout(ctx))),
 					"WaitForEndpointToServeText",
-					test.ServingFlags.ResolvableDomain)
+					test.ServingFlags.ResolvableDomain,
+					test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
 				if err != nil {
 					t.Error("WaitForEndpointState(expected text) =", err)
 					return fmt.Errorf("WaitForEndpointState(expected text) failed: %w", err)

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -57,7 +57,8 @@ func assertServiceResourcesUpdated(t testing.TB, clients *test.Clients, names te
 		url,
 		v1test.RetryingRouteInconsistency(spoof.MatchesAllOf(spoof.IsStatusOK, pkgTest.EventuallyMatchesBody(expectedText))),
 		"WaitForEndpointToServeText",
-		test.ServingFlags.ResolvableDomain); err != nil {
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS)); err != nil {
 		t.Fatal(fmt.Sprintf("The endpoint for Route %s at %s didn't serve the expected text %q: %v", names.Route, url, expectedText, err))
 	}
 }


### PR DESCRIPTION
As per title, these tests have been lacking the RootCA additions and thus were not compatible with the `--https` flag.

/assign @nak3 