### PR TITLE
Allow for additional delete calls without hanging in KPA test

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1609,7 +1609,7 @@ func newTestDeciders() *testDeciders {
 		createCallCount:    atomic.NewUint32(0),
 		createCall:         make(chan struct{}, 1),
 		deleteCallCount:    atomic.NewUint32(0),
-		deleteCall:         make(chan struct{}, 1),
+		deleteCall:         make(chan struct{}, 5),
 		updateCallCount:    atomic.NewUint32(0),
 		updateCall:         make(chan struct{}, 1),
 		deleteBeforeCreate: atomic.NewBool(false),


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

`TestReconcileDeciderCreatesAndDeletes` still fails occasionally due to additional reconciles being enqueued during the test, resulting in multiple delete calls after the test. This is normal reconciler behavior and most likely not harmful to the actual system.

/assign @julz 
