### PR TITLE
roles: Don't specify rules when using aggregationRules.

### DIFF
--- a/config/core/200-roles/addressable-resolvers-clusterrole.yaml
+++ b/config/core/200-roles/addressable-resolvers-clusterrole.yaml
@@ -27,7 +27,6 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       duck.knative.dev/addressable: "true"
-# rules: [] # Rules are automatically filled in by the controller manager.
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/core/200-roles/addressable-resolvers-clusterrole.yaml
+++ b/config/core/200-roles/addressable-resolvers-clusterrole.yaml
@@ -27,7 +27,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       duck.knative.dev/addressable: "true"
-rules: [] # Rules are automatically filled in by the controller manager.
+# rules: [] # Rules are automatically filled in by the controller manager.
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/core/200-serviceaccount.yaml
+++ b/config/core/200-serviceaccount.yaml
@@ -35,7 +35,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       serving.knative.dev/controller: "true"
-rules: [] # Rules are automatically filled in by the controller manager.
+# rules: [] # Rules are automatically filled in by the controller manager.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/config/core/200-serviceaccount.yaml
+++ b/config/core/200-serviceaccount.yaml
@@ -35,7 +35,6 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       serving.knative.dev/controller: "true"
-# rules: [] # Rules are automatically filled in by the controller manager.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Proposed Changes

According to the Kubernetes API specification:

> If AggregationRule is set, then the Rules are controller managed and
direct changes to Rules will be stomped by the controller.

This changes the configuration to be in line with the documentation. The
issue we ran into was when using FluxCD to manage our clusters, it was
constantly trying to reconcile the `knative-serving-admin` ClusterRole
via a `kubectl apply`. Because the list of roles was specified in the
input yaml, the apply was clearing out the roles list every so often. In
the brief window between the apply clearing the roles, and the cluster
re-creating them we would have spurious permissions errors. Once we
changed the config to no longer specify the rules, as the documentation
suggests, the permissions errors went away and things started to
function better as a result.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
