### PR TITLE
Speed up TestRateLimitPerItem

### DIFF
--- a/pkg/reconciler/revision/background_test.go
+++ b/pkg/reconciler/revision/background_test.go
@@ -241,7 +241,7 @@ func TestRateLimitPerItem(t *testing.T) {
 	}()
 
 	revision := rev("rev", "img1", "img2")
-	for i := 0; i < 2; i++ {
+	for i := 0; i < 4; i++ {
 		subject.Clear(types.NamespacedName{Name: revision.Name, Namespace: revision.Namespace})
 		start := time.Now()
 		resolution, err := subject.Resolve(revision, k8schain.Options{ServiceAccountName: "san"}, sets.NewString("skip"), 0)


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As per title. A bit of a friday cleanup. This test takes 1.65s at HEAD and 0.066s with this change. It shouldn't be prone to a timing issue (i.e. being slow) since we just compare that our latency is never smaller than expected, which should always be true, even on occasional slow systems.

/assign @julz 
