### PR TITLE
Speed up concurrency state handler tests

### DIFF
--- a/pkg/queue/concurrency_state_test.go
+++ b/pkg/queue/concurrency_state_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package queue
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -74,7 +73,7 @@ func TestConcurrencyStateHandlerParallelSubsumed(t *testing.T) {
 
 	go func() {
 		defer func() { req1 <- struct{}{} }()
-		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", fmt.Sprintf("http://target?req=%d", 1), nil))
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "http://target?req=1", nil))
 	}()
 
 	<-req1 // Wait for req1 to arrive.
@@ -114,14 +113,14 @@ func TestConcurrencyStateHandlerParallelOverlapping(t *testing.T) {
 
 	go func() {
 		defer func() { req1 <- struct{}{} }()
-		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", fmt.Sprintf("http://target?req=%d", 1), nil))
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "http://target?req=1", nil))
 	}()
 
 	<-req1 // Wait for req1 to arrive.
 
 	go func() {
 		defer func() { req2 <- struct{}{} }()
-		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", fmt.Sprintf("http://target?req=%d", 2), nil))
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "http://target?req=2", nil))
 	}()
 
 	<-req2 // Wait for req2 to arrive


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As per title, I was looking if our unit test runtime had regressed and these tests stood out. They take ~5s at HEAD. This reworks them a bit so that they can pass as quickly as the machine permits (0.011s on my machine) while maintaining stable behavior at any speed (such is the hope anyway).

/assign @psschwei @julz 
