### PR TITLE
Pass serviceAccountToken to freezer service

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -300,7 +300,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	var composedHandler http.Handler = httpProxy
 	if concurrencyStateEnabled {
 		logger.Info("Concurrency state endpoint set, tracking request counts, using endpoint: ", env.ConcurrencyStateEndpoint)
-		ce := queue.NewConcurrencyEndpoint(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateToken, "")
+		ce := queue.NewConcurrencyEndpoint(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateToken)
 		go func() {
 			for range time.NewTicker(1 * time.Minute).C {
 				ce.RefreshToken()

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -106,6 +106,7 @@ type config struct {
 
 	// Concurrency State Endpoint configuration
 	ConcurrencyStateEndpoint string `split_words:"true"` // optional
+	ConcurrencyStateToken    string `split_words:"true"` // optional
 }
 
 func init() {
@@ -300,7 +301,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	var composedHandler http.Handler = httpProxy
 	if concurrencyStateEnabled {
 		logger.Info("Concurrency state endpoint set, tracking request counts, using endpoint: ", env.ConcurrencyStateEndpoint)
-		ce := queue.NewConcurrencyEndpoint(env.ConcurrencyStateEndpoint, queue.ConcurrencyStateToken)
+		ce := queue.NewConcurrencyEndpoint(env.ConcurrencyStateEndpoint, env.ConcurrencyStateToken)
 		go func() {
 			for range time.NewTicker(1 * time.Minute).C {
 				ce.RefreshToken()

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -300,7 +300,8 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	var composedHandler http.Handler = httpProxy
 	if concurrencyStateEnabled {
 		logger.Info("Concurrency state endpoint set, tracking request counts, using endpoint: ", env.ConcurrencyStateEndpoint)
-		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, queue.Pause(env.ConcurrencyStateEndpoint), queue.Resume(env.ConcurrencyStateEndpoint), queue.ConcurrencyStateToken)
+		cs := queue.ConcurrencyEndpoint{Endpoint: env.ConcurrencyStateEndpoint, MountPath: queue.ConcurrencyStateToken}
+		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, cs.Pause, cs.Resume)
 	}
 	if metricsSupported {
 		composedHandler = requestAppMetricsHandler(logger, composedHandler, breaker, env)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -105,8 +105,8 @@ type config struct {
 	TracingConfigZipkinEndpoint string                    `split_words:"true"` // optional
 
 	// Concurrency State Endpoint configuration
-	ConcurrencyStateEndpoint string `split_words:"true"` // optional
-	ConcurrencyStateToken    string `split_words:"true"` // optional
+	ConcurrencyStateEndpoint  string `split_words:"true"` // optional
+	ConcurrencyStateTokenPath string `split_words:"true"` // optional
 }
 
 func init() {
@@ -301,7 +301,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	var composedHandler http.Handler = httpProxy
 	if concurrencyStateEnabled {
 		logger.Info("Concurrency state endpoint set, tracking request counts, using endpoint: ", env.ConcurrencyStateEndpoint)
-		ce := queue.NewConcurrencyEndpoint(env.ConcurrencyStateEndpoint, env.ConcurrencyStateToken)
+		ce := queue.NewConcurrencyEndpoint(env.ConcurrencyStateEndpoint, env.ConcurrencyStateTokenPath)
 		go func() {
 			for range time.NewTicker(1 * time.Minute).C {
 				ce.RefreshToken()

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -300,7 +300,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	var composedHandler http.Handler = httpProxy
 	if concurrencyStateEnabled {
 		logger.Info("Concurrency state endpoint set, tracking request counts, using endpoint: ", env.ConcurrencyStateEndpoint)
-		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, queue.Pause(env.ConcurrencyStateEndpoint), queue.Resume(env.ConcurrencyStateEndpoint))
+		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, queue.Pause(env.ConcurrencyStateEndpoint), queue.Resume(env.ConcurrencyStateEndpoint), queue.ConcurrencyStateToken)
 	}
 	if metricsSupported {
 		composedHandler = requestAppMetricsHandler(logger, composedHandler, breaker, env)

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -114,6 +114,7 @@ func (c ConcurrencyEndpoint) Request(action string) error {
 	}
 	c.RefreshToken()
 	token := fmt.Sprint(c.token.Load())
+	//	fmt.Println(c.token.Load())
 	req.Header.Add("Token", token)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -130,6 +131,6 @@ func (c ConcurrencyEndpoint) RefreshToken() error {
 	if err != nil {
 		return fmt.Errorf("could not read token: %w", err)
 	}
-	c.token.Store(token)
+	c.token.Store(string(token))
 	return nil
 }

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -124,7 +124,7 @@ func (c ConcurrencyEndpoint) Request(action string) error {
 	return nil
 }
 
-func (c ConcurrencyEndpoint) RefreshToken() error {
+func (c *ConcurrencyEndpoint) RefreshToken() error {
 	token, err := os.ReadFile(c.MountPath)
 	if err != nil {
 		return fmt.Errorf("could not read token: %w", err)
@@ -133,11 +133,11 @@ func (c ConcurrencyEndpoint) RefreshToken() error {
 	return nil
 }
 
-func NewConcurrencyEndpoint(e, m, t string) ConcurrencyEndpoint {
+func NewConcurrencyEndpoint(e, m string) ConcurrencyEndpoint {
 	c := ConcurrencyEndpoint{
 		Endpoint:  e,
 		MountPath: m,
 	}
-	c.token.Store(t)
+	c.RefreshToken()
 	return c
 }

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -27,11 +27,6 @@ import (
 	"go.uber.org/zap"
 )
 
-//nolint:gosec // Filepath, not hardcoded credentials
-const ConcurrencyStateTokenVolumeMountPath = "/var/run/secrets/tokens"
-const ConcurrencyStateTokenName = "state-token"
-const ConcurrencyStateToken = ConcurrencyStateTokenVolumeMountPath + "/" + ConcurrencyStateTokenName
-
 // ConcurrencyStateHandler tracks the in flight requests for the pod. When the requests
 // drop to zero, it runs the `pause` function, and when requests scale up from zero, it
 // runs the `resume` function. If either of `pause` or `resume` are not passed, it runs

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -112,9 +112,7 @@ func (c ConcurrencyEndpoint) Request(action string) error {
 	if err != nil {
 		return fmt.Errorf("unable to create request: %w", err)
 	}
-	c.RefreshToken()
 	token := fmt.Sprint(c.token.Load())
-	//	fmt.Println(c.token.Load())
 	req.Header.Add("Token", token)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -133,4 +131,13 @@ func (c ConcurrencyEndpoint) RefreshToken() error {
 	}
 	c.token.Store(string(token))
 	return nil
+}
+
+func NewConcurrencyEndpoint(e, m, t string) ConcurrencyEndpoint {
+	c := ConcurrencyEndpoint{
+		Endpoint:  e,
+		MountPath: m,
+	}
+	c.token.Store(t)
+	return c
 }

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -19,7 +19,6 @@ package queue
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"sync"
@@ -159,7 +158,7 @@ func (t *Token) Get() string {
 }
 
 func refreshToken(tokenCfg *Token, tokenMountPath string) error {
-	token, err := ioutil.ReadFile(tokenMountPath)
+	token, err := os.ReadFile(tokenMountPath)
 	if err != nil {
 		return fmt.Errorf("could not read token: %w", err)
 	}

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -36,6 +36,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+//nolint:gosec // Filepath, not hardcoded credentials
+const concurrencyStateTokenVolumeMountPath = "/var/run/secrets/tokens"
+const concurrencyStateTokenName = "state-token"
+const concurrencyStateToken = concurrencyStateTokenVolumeMountPath + "/" + concurrencyStateTokenName
+
 var (
 	varLogVolume = corev1.Volume{
 		Name: "knative-var-log",
@@ -57,7 +62,7 @@ var (
 				Sources: []corev1.VolumeProjection{{
 					ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
 						ExpirationSeconds: ptr.Int64(600),
-						Path:              queue.ConcurrencyStateTokenName,
+						Path:              concurrencyStateTokenName,
 						Audience:          "concurrency-state-hook"},
 				}},
 			},
@@ -66,7 +71,7 @@ var (
 
 	varTokenVolumeMount = corev1.VolumeMount{
 		Name:      varTokenVolume.Name,
-		MountPath: queue.ConcurrencyStateTokenVolumeMountPath,
+		MountPath: concurrencyStateTokenVolumeMountPath,
 	}
 
 	// This PreStop hook is actually calling an endpoint on the queue-proxy

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -57,7 +57,7 @@ var (
 				Sources: []corev1.VolumeProjection{{
 					ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
 						ExpirationSeconds: ptr.Int64(600),
-						Path:              "state-token",
+						Path:              queue.ConcurrencyStateTokenName,
 						Audience:          "concurrency-state-hook"},
 				}},
 			},

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -1133,6 +1133,7 @@ func TestMakePodSpec(t *testing.T) {
 					}}
 				},
 					withEnvVar("CONCURRENCY_STATE_ENDPOINT", `freeze-proxy`),
+					withEnvVar("CONCURRENCY_STATE_TOKEN", `/var/run/secrets/tokens/state-token`),
 				),
 			},
 			withAppendedVolumes(varTokenVolume),

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -172,6 +172,9 @@ var (
 			Name:  "CONCURRENCY_STATE_ENDPOINT",
 			Value: "",
 		}, {
+			Name:  "CONCURRENCY_STATE_TOKEN",
+			Value: "/var/run/secrets/tokens/state-token",
+		}, {
 			Name:  "ENABLE_HTTP2_AUTO_DETECTION",
 			Value: "false",
 		}},

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -172,7 +172,7 @@ var (
 			Name:  "CONCURRENCY_STATE_ENDPOINT",
 			Value: "",
 		}, {
-			Name:  "CONCURRENCY_STATE_TOKEN",
+			Name:  "CONCURRENCY_STATE_TOKEN_PATH",
 			Value: "/var/run/secrets/tokens/state-token",
 		}, {
 			Name:  "ENABLE_HTTP2_AUTO_DETECTION",
@@ -1136,7 +1136,7 @@ func TestMakePodSpec(t *testing.T) {
 					}}
 				},
 					withEnvVar("CONCURRENCY_STATE_ENDPOINT", `freeze-proxy`),
-					withEnvVar("CONCURRENCY_STATE_TOKEN", `/var/run/secrets/tokens/state-token`),
+					withEnvVar("CONCURRENCY_STATE_TOKEN_PATH", `/var/run/secrets/tokens/state-token`),
 				),
 			},
 			withAppendedVolumes(varTokenVolume),

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -343,6 +343,13 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		}},
 	}
 
+	if cfg.Deployment.ConcurrencyStateEndpoint != "" {
+		c.Env = append(c.Env, corev1.EnvVar{
+			Name:  "CONCURRENCY_STATE_TOKEN",
+			Value: concurrencyStateToken,
+		})
+	}
+
 	return c, nil
 }
 

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -338,7 +338,7 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 			Name:  "CONCURRENCY_STATE_ENDPOINT",
 			Value: cfg.Deployment.ConcurrencyStateEndpoint,
 		}, {
-			Name:  "CONCURRENCY_STATE_TOKEN",
+			Name:  "CONCURRENCY_STATE_TOKEN_PATH",
 			Value: concurrencyStateToken,
 		}, {
 			Name:  "ENABLE_HTTP2_AUTO_DETECTION",

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -338,16 +338,12 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 			Name:  "CONCURRENCY_STATE_ENDPOINT",
 			Value: cfg.Deployment.ConcurrencyStateEndpoint,
 		}, {
+			Name:  "CONCURRENCY_STATE_TOKEN",
+			Value: concurrencyStateToken,
+		}, {
 			Name:  "ENABLE_HTTP2_AUTO_DETECTION",
 			Value: strconv.FormatBool(cfg.Features.AutoDetectHTTP2 == apicfg.Enabled),
 		}},
-	}
-
-	if cfg.Deployment.ConcurrencyStateEndpoint != "" {
-		c.Env = append(c.Env, corev1.EnvVar{
-			Name:  "CONCURRENCY_STATE_TOKEN",
-			Value: concurrencyStateToken,
-		})
 	}
 
 	return c, nil

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -847,6 +847,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 
 var defaultEnv = map[string]string{
 	"CONCURRENCY_STATE_ENDPOINT":       "",
+	"CONCURRENCY_STATE_TOKEN":          "/var/run/secrets/tokens/state-token",
 	"CONTAINER_CONCURRENCY":            "0",
 	"ENABLE_HTTP2_AUTO_DETECTION":      "false",
 	"ENABLE_PROFILING":                 "false",

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -322,8 +322,8 @@ func TestMakeQueueContainer(t *testing.T) {
 		},
 		want: queueContainer(func(c *corev1.Container) {
 			c.Env = env(map[string]string{
-				"CONCURRENCY_STATE_ENDPOINT": "freeze-proxy",
-				"CONCURRENCY_STATE_TOKEN":    "/var/run/secrets/tokens/state-token",
+				"CONCURRENCY_STATE_ENDPOINT":   "freeze-proxy",
+				"CONCURRENCY_STATE_TOKEN_PATH": "/var/run/secrets/tokens/state-token",
 			})
 		}),
 	}, {
@@ -847,7 +847,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 
 var defaultEnv = map[string]string{
 	"CONCURRENCY_STATE_ENDPOINT":       "",
-	"CONCURRENCY_STATE_TOKEN":          "/var/run/secrets/tokens/state-token",
+	"CONCURRENCY_STATE_TOKEN_PATH":     "/var/run/secrets/tokens/state-token",
 	"CONTAINER_CONCURRENCY":            "0",
 	"ENABLE_HTTP2_AUTO_DETECTION":      "false",
 	"ENABLE_PROFILING":                 "false",

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -323,6 +323,7 @@ func TestMakeQueueContainer(t *testing.T) {
 		want: queueContainer(func(c *corev1.Container) {
 			c.Env = env(map[string]string{
 				"CONCURRENCY_STATE_ENDPOINT": "freeze-proxy",
+				"CONCURRENCY_STATE_TOKEN":    "/var/run/secrets/tokens/state-token",
 			})
 		}),
 	}, {


### PR DESCRIPTION
Fixes #11904 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Pass serviceAccountToken to freezer service via projected volume

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Pass serviceAccountToken to freezer service via projected volume
```

This is part of the work to add the Pod Freezer capability to knative (see #11694 for more details)

WIP until #11802  and #11820 merge