### PR TITLE
Remove unused isAggressive parameter

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -319,7 +319,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 		composedHandler = tracing.HTTPSpanMiddleware(composedHandler)
 	}
 
-	composedHandler = health.ProbeHandler(healthState, rp.ProbeContainer, rp.IsAggressive(), tracingEnabled, composedHandler)
+	composedHandler = health.ProbeHandler(healthState, rp.ProbeContainer, tracingEnabled, composedHandler)
 	composedHandler = network.NewProbeHandler(composedHandler)
 	// We might want sometimes capture the probes/healthchecks in the request
 	// logs. Hence we need to have RequestLogHandler to be the first one.

--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -149,7 +149,7 @@ func TestQueueTraceSpans(t *testing.T) {
 				h := queue.ProxyHandler(breaker, network.NewRequestStats(time.Now()), true /*tracingEnabled*/, proxy)
 				h(writer, req)
 			} else {
-				h := health.ProbeHandler(healthState, tc.prober, true /* isAggressive*/, true /*tracingEnabled*/, nil)
+				h := health.ProbeHandler(healthState, tc.prober, true /*tracingEnabled*/, nil)
 				req.Header.Set(network.ProbeHeaderName, tc.requestHeader)
 				h(writer, req)
 			}

--- a/pkg/queue/health/handler.go
+++ b/pkg/queue/health/handler.go
@@ -29,7 +29,7 @@ const badProbeTemplate = "unexpected probe header value: "
 
 // ProbeHandler returns a http.HandlerFunc that responds to health checks if the
 // knative network probe header is passed, and otherwise delegates to the next handler.
-func ProbeHandler(healthState *State, prober func() bool, isAggressive bool, tracingEnabled bool, next http.Handler) http.HandlerFunc {
+func ProbeHandler(healthState *State, prober func() bool, tracingEnabled bool, next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ph := network.KnativeProbeHeader(r)
 

--- a/pkg/queue/health/handler_test.go
+++ b/pkg/queue/health/handler_test.go
@@ -80,7 +80,7 @@ func TestProbeHandler(t *testing.T) {
 				req.Header.Set(network.ProbeHeaderName, tc.requestHeader)
 			}
 
-			h := ProbeHandler(healthState, tc.prober, true /* isAggressive*/, true /*tracingEnabled*/, incHandler)
+			h := ProbeHandler(healthState, tc.prober, true /*tracingEnabled*/, incHandler)
 			h(writer, req)
 
 			if got, want := writer.Code, tc.wantCode; got != want {

--- a/pkg/queue/readiness/probe.go
+++ b/pkg/queue/readiness/probe.go
@@ -97,8 +97,8 @@ func NewProbeWithHTTP2AutoDetection(v1p *corev1.Probe) *Probe {
 	}
 }
 
-// IsAggressive indicates whether the Knative probe with aggressive retries should be used.
-func (p *Probe) IsAggressive() bool {
+// shouldProbeAggressively indicates whether the Knative probe with aggressive retries should be used.
+func (p *Probe) shouldProbeAggressively() bool {
 	return p.PeriodSeconds == 0
 }
 
@@ -155,7 +155,7 @@ func (p *Probe) probeContainerImpl() bool {
 }
 
 func (p *Probe) doProbe(probe func(time.Duration) error) error {
-	if !p.IsAggressive() {
+	if !p.shouldProbeAggressively() {
 		return probe(time.Duration(p.TimeoutSeconds) * time.Second)
 	}
 


### PR DESCRIPTION
The `isAggressive` parameter in the health state server used to be used to determine whether to cache readiness forever after startup or not, but as of https://github.com/knative/serving/pull/11190 it's an unused parameter and the only thing that needs to know about `periodSeconds=0 => spam readiness checks` is the prober itself.

Also made `probe.IsAggressive()` private since it's no longer used externally, and renamed it for clarity.