### PR TITLE
Stabilize TestIdleTimeoutHandler

### DIFF
--- a/pkg/http/handler/timeout_test.go
+++ b/pkg/http/handler/timeout_test.go
@@ -271,18 +271,18 @@ func TestIdleTimeoutHandler(t *testing.T) {
 		firstByteTimeout: longFirstByteTimeout,
 		handler: func(*sync.Mutex, chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Write([]byte(""))
+				w.Write([]byte("foo"))
 				time.Sleep(shortIdleTimeout * 2 / 3)
-				w.Write([]byte(""))
+				w.Write([]byte("bar"))
 				time.Sleep(shortIdleTimeout * 2 / 3)
-				w.Write([]byte(""))
+				w.Write([]byte("baz"))
 				time.Sleep(shortIdleTimeout * 2)
 				panic(http.ErrAbortHandler)
 			})
 		},
 		timeoutMessage: "request timeout",
 		wantStatus:     http.StatusOK,
-		wantBody:       "request timeout",
+		wantBody:       "foobarbazrequest timeout",
 		wantPanic:      false,
 	}, {
 		name:             "no idle timeout",

--- a/pkg/http/handler/timeout_test.go
+++ b/pkg/http/handler/timeout_test.go
@@ -256,16 +256,15 @@ func TestIdleTimeoutHandler(t *testing.T) {
 		firstByteTimeout: longFirstByteTimeout,
 		handler: func(*sync.Mutex, chan error) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Write([]byte(""))
+				w.Write([]byte("foo"))
 				time.Sleep(shortIdleTimeout * 2 / 3)
-				w.Write([]byte(""))
+				w.Write([]byte("bar"))
 				time.Sleep(shortIdleTimeout * 2 / 3)
-				panic(http.ErrAbortHandler)
 			})
 		},
-		wantStatus: http.StatusGatewayTimeout,
-		wantBody:   "request timeout",
-		wantPanic:  true,
+		wantStatus: http.StatusOK,
+		wantBody:   "foobar",
+		wantPanic:  false,
 	}, {
 		name:             "can still timeout after a few successful writes",
 		idleTimeout:      shortIdleTimeout,


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

When writing to the response, one can't assume that it's still possible to override the expected response. That, I  believe, depends on the flushing behavior of the writer. As such, we shouldn't except a panic in this test but rather write a chunked message barely inside the timeout frames and assume it comes through just fine.

/assign @julz @skonto @nealhu 