### PR TITLE
Introduce a flag to set memory used in the resource limit test

### DIFF
--- a/test/conformance/api/v1/resources_test.go
+++ b/test/conformance/api/v1/resources_test.go
@@ -114,7 +114,10 @@ func TestCustomResourcesLimits(t *testing.T) {
 		t.Fatalf("Didn't get a response from bloating cow with %d MBs of Memory: %v", 200, err)
 	}
 
-	if err := pokeCowForMB(500); err == nil {
-		t.Fatalf("We shouldn't have got a response from bloating cow with %d MBs of Memory: %v", 500, err)
+	// ExceedingMemoryLimitSize defaults to 500.
+	// The serverless platform MAY automatically adjust the resource limits.
+	exceedingMemory := test.ServingFlags.ExceedingMemoryLimitSize
+	if err := pokeCowForMB(exceedingMemory); err == nil {
+		t.Fatalf("We shouldn't have got a response from bloating cow with %d MBs of Memory: %v", exceedingMemory, err)
 	}
 }

--- a/test/conformance/api/v1/resources_test.go
+++ b/test/conformance/api/v1/resources_test.go
@@ -115,7 +115,9 @@ func TestCustomResourcesLimits(t *testing.T) {
 	}
 
 	// ExceedingMemoryLimitSize defaults to 500.
-	// The serverless platform MAY automatically adjust the resource limits.
+	// Allows override the memory usage to get a non-200 resposne because the serverless platform
+	// MAY automatically adjust the resource limits.
+	// See https://github.com/knative/specs/blob/main/specs/serving/runtime-contract.md#memory-and-cpu-limits
 	exceedingMemory := test.ServingFlags.ExceedingMemoryLimitSize
 	if err := pokeCowForMB(exceedingMemory); err == nil {
 		t.Fatalf("We shouldn't have got a response from bloating cow with %d MBs of Memory: %v", exceedingMemory, err)

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -31,18 +31,19 @@ var ServingFlags = initializeServingFlags()
 
 // ServingEnvironmentFlags holds the e2e flags needed only by the serving repo.
 type ServingEnvironmentFlags struct {
-	ResolvableDomain    bool   // Resolve Route controller's `domainSuffix`
-	CustomDomain        string // Indicates the `domainSuffix` for custom domain test.
-	HTTPS               bool   // Indicates where the test service will be created with https
-	Buckets             int    // The number of reconciler buckets configured.
-	Replicas            int    // The number of controlplane replicas being run.
-	EnableAlphaFeatures bool   // Indicates whether we run tests for alpha features
-	EnableBetaFeatures  bool   // Indicates whether we run tests for beta features
-	DisableLogStream    bool   // Indicates whether log streaming is disabled
-	DisableOptionalAPI  bool   // Indicates whether to skip conformance tests against optional API
-	TestNamespace       string // Default namespace for Serving E2E/Conformance tests
-	AltTestNamespace    string // Alternative namespace for running cross-namespace tests in
-	TLSTestNamespace    string // Namespace for Serving TLS tests
+	ResolvableDomain         bool   // Resolve Route controller's `domainSuffix`
+	CustomDomain             string // Indicates the `domainSuffix` for custom domain test.
+	HTTPS                    bool   // Indicates where the test service will be created with https
+	Buckets                  int    // The number of reconciler buckets configured.
+	Replicas                 int    // The number of controlplane replicas being run.
+	EnableAlphaFeatures      bool   // Indicates whether we run tests for alpha features
+	EnableBetaFeatures       bool   // Indicates whether we run tests for beta features
+	DisableLogStream         bool   // Indicates whether log streaming is disabled
+	DisableOptionalAPI       bool   // Indicates whether to skip conformance tests against optional API
+	TestNamespace            string // Default namespace for Serving E2E/Conformance tests
+	AltTestNamespace         string // Alternative namespace for running cross-namespace tests in
+	TLSTestNamespace         string // Namespace for Serving TLS tests
+	ExceedingMemoryLimitSize int    // Memory size used to trigger a non-200 response when the service is set with 300MB memory limit.
 }
 
 func initializeServingFlags() *ServingEnvironmentFlags {
@@ -83,6 +84,10 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 
 	flag.StringVar(&f.TLSTestNamespace, "tls-test-namespace", "tls",
 		"Set this flag to change the namespace for running TLS tests.")
+
+	flag.IntVar(&f.ExceedingMemoryLimitSize, "exceeding-memory-limit-size", 500,
+		"Set this flag to the MB of memory consumed by your service in resource limit tests. "+
+			"You service is set with 300 MB memory limit and shoud return a non-200 response when consuming such amount of memory.")
 
 	return &f
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* [Knative runtime contract](https://github.com/knative/specs/blob/main/specs/serving/runtime-contract.md#memory-and-cpu-limits) mentions that `The serverless platform MAY automatically adjust the resource limits (e.g. CPU) based on observed resource usage`. We won't always get non-200 response for a request consuming 500MB memory to a service with 300MB memory limit if the platform automatically adjusts the limit. So provides a flag to override the memory usage (probably a larger value) in order to get a non-200 response.
* We already covers that the correct limit values are populated to the container in https://github.com/knative/serving/blob/main/test/conformance/runtime/cgroup_test.go

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
