### PR TITLE
support k8s memory suffix

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"knative.dev/pkg/apis"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
 )
@@ -246,7 +248,10 @@ func validateMetric(annotations map[string]string) *apis.FieldError {
 
 func validateMemorySuffix(annotations map[string]string) *apis.FieldError {
 	if memorySuffix, ok := annotations[MemorySuffixAnnotationKey]; ok {
-		if !unitPattern.MatchString(memorySuffix) {
+		target := annotations[TargetAnnotationKey]
+		memoryValue := fmt.Sprintf("%s%s", target, memorySuffix)
+		_, err := resource.ParseQuantity(memoryValue)
+		if err != nil {
 			return apis.ErrInvalidValue(memorySuffix, MemorySuffixAnnotationKey)
 		}
 	}

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -67,16 +67,6 @@ const (
 	// RPS is the requests per second reaching the Pod.
 	RPS = "rps"
 
-	// MemorySuffixAnnotationKey is the annotation to specify which memory suffix
-	// the memory target use. For example,
-	//   autoscaling.knative.dev/metric: memory
-	//   autoscaling.knative.dev/target: 256
-	//   autoscaling.knative.dev/memorySuffix: Mi   # target 256 MiB memory usage
-	MemorySuffixAnnotationKey = GroupName + "/memorySuffix"
-
-	// DefaultSuffix is Mi.
-	DefaultSuffix = "Mi"
-
 	// TargetAnnotationKey is the annotation to specify what metric value the
 	// PodAutoscaler should attempt to maintain. For example,
 	//   autoscaling.knative.dev/metric: cpu
@@ -90,6 +80,16 @@ const (
 	// concurrencies and small target utilization values this can get
 	// below 1.
 	TargetMin = 0.01
+
+	// MemorySuffixAnnotationKey is the annotation to specify which memory suffix
+	// the memory target use. For example,
+	//   autoscaling.knative.dev/metric: memory
+	//   autoscaling.knative.dev/target: 256
+	//   autoscaling.knative.dev/memorySuffix: Mi   # target 256 MiB memory usage
+	MemorySuffixAnnotationKey = GroupName + "/memorySuffix"
+
+	// DefaultSuffix is Mi.
+	DefaultSuffix = "Mi"
 
 	// ScaleToZeroPodRetentionPeriodKey is the annotation to specify the minimum
 	// time duration the last pod will not be scaled down, after autoscaler has

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -67,13 +67,23 @@ const (
 	// RPS is the requests per second reaching the Pod.
 	RPS = "rps"
 
+	// MemorySuffixAnnotationKey is the annotation to specify which memory suffix
+	// the memory target use. For example,
+	//   autoscaling.knative.dev/metric: memory
+	//   autoscaling.knative.dev/target: 256
+	//   autoscaling.knative.dev/memorySuffix: Mi   # target 256 MiB memory usage
+	MemorySuffixAnnotationKey = GroupName + "/memorySuffix"
+
+	// DefaultSuffix is Mi.
+	DefaultSuffix = "Mi"
+
 	// TargetAnnotationKey is the annotation to specify what metric value the
 	// PodAutoscaler should attempt to maintain. For example,
 	//   autoscaling.knative.dev/metric: cpu
 	//   autoscaling.knative.dev/target: "75"   # target 75% cpu utilization
 	// Or
 	//   autoscaling.knative.dev/metric: memory
-	//   autoscaling.knative.dev/target: "100"   # target 100MiB memory usage
+	//   autoscaling.knative.dev/target: "100"   # target 100 MiB memory usage
 	TargetAnnotationKey = GroupName + "/target"
 	// TargetMin is the minimum allowable target.
 	// This can be less than 1 due to the fact that with small container

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -63,6 +63,15 @@ func (pa *PodAutoscaler) Metric() string {
 	return defaultMetric(pa.Class())
 }
 
+// MemorySuffix returns the Memory Suffix from Annotation or `Mi` if none is set.
+func (pa *PodAutoscaler) MemorySuffix() string {
+	if c, ok := pa.Annotations[autoscaling.MemorySuffixAnnotationKey]; ok {
+		return c
+	}
+	// Default to "Mi" class for backward compatibility.
+	return autoscaling.DefaultSuffix
+}
+
 func (pa *PodAutoscaler) annotationInt32(key string) (int32, bool) {
 	if s, ok := pa.Annotations[key]; ok {
 		i, err := strconv.ParseInt(s, 10, 32)
@@ -100,15 +109,6 @@ func (pa *PodAutoscaler) ScaleBounds(asConfig *autoscalerconfig.Config) (int32, 
 // Target returns the target annotation value or false if not present, or invalid.
 func (pa *PodAutoscaler) Target() (float64, bool) {
 	return pa.annotationFloat64(autoscaling.TargetAnnotationKey)
-}
-
-// MemorySuffix returns the Memory Suffix from Annotation or `Mi` if none is set.
-func (pa *PodAutoscaler) MemorySuffix() string {
-	if c, ok := pa.Annotations[autoscaling.MemorySuffixAnnotationKey]; ok {
-		return c
-	}
-	// Default to "Mi" class for backward compatibility.
-	return autoscaling.DefaultSuffix
 }
 
 // TargetUtilization returns the target utilization percentage as a fraction, if

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -102,6 +102,15 @@ func (pa *PodAutoscaler) Target() (float64, bool) {
 	return pa.annotationFloat64(autoscaling.TargetAnnotationKey)
 }
 
+// MemorySuffix returns the Memory Suffix from Annotation or `Mi` if none is set.
+func (pa *PodAutoscaler) MemorySuffix() string {
+	if c, ok := pa.Annotations[autoscaling.MemorySuffixAnnotationKey]; ok {
+		return c
+	}
+	// Default to "Mi" class for backward compatibility.
+	return autoscaling.DefaultSuffix
+}
+
 // TargetUtilization returns the target utilization percentage as a fraction, if
 // the corresponding annotation is set.
 func (pa *PodAutoscaler) TargetUtilization() (float64, bool) {

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"math"
+	"strconv"
 
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -73,12 +74,13 @@ func MakeHPA(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig.Con
 
 	case autoscaling.Memory:
 		if target, ok := pa.Target(); ok {
-			memory := resource.NewQuantity(int64(target)*1024*1024, resource.BinarySI)
+			suffix := pa.MemorySuffix()
+			memory := resource.MustParse(strconv.Itoa(int(math.Ceil(target))) + suffix)
 			hpa.Spec.Metrics = []autoscalingv2beta1.MetricSpec{{
 				Type: autoscalingv2beta1.ResourceMetricSourceType,
 				Resource: &autoscalingv2beta1.ResourceMetricSource{
 					Name:               corev1.ResourceMemory,
-					TargetAverageValue: memory,
+					TargetAverageValue: &memory,
 				},
 			}}
 		}

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
@@ -72,7 +72,7 @@ func TestMakeHPA(t *testing.T) {
 				},
 			})),
 	}, {
-		name: "with an actual memory target",
+		name: "with an actual memory target without suffix",
 		pa:   pa(WithTargetAnnotation("50"), WithMetricAnnotation(autoscaling.Memory)),
 		want: hpa(
 			withAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.Memory),
@@ -85,7 +85,21 @@ func TestMakeHPA(t *testing.T) {
 				},
 			})),
 	}, {
-		name: "with an actual fractional target",
+		name: "with an actual memory target with suffix 'Mi' ",
+		pa:   pa(WithTargetAnnotation("50"), WithMemorySuffixAnnotation("Mi"), WithMetricAnnotation(autoscaling.Memory)),
+		want: hpa(
+			withAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.Memory),
+			withAnnotationValue(autoscaling.TargetAnnotationKey, "50"),
+			withAnnotationValue(autoscaling.MemorySuffixAnnotationKey, "Mi"),
+			withMetric(autoscalingv2beta1.MetricSpec{
+				Type: autoscalingv2beta1.ResourceMetricSourceType,
+				Resource: &autoscalingv2beta1.ResourceMetricSource{
+					Name:               corev1.ResourceMemory,
+					TargetAverageValue: resource.NewQuantity(50*1024*1024, resource.BinarySI),
+				},
+			})),
+	}, {
+		name: "with an actual fractional target Mi",
 		pa:   pa(WithTargetAnnotation("1982.4"), WithMetricAnnotation(autoscaling.CPU)),
 		want: hpa(
 			withAnnotationValue(autoscaling.MetricAnnotationKey, autoscaling.CPU),

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -170,6 +170,13 @@ func WithTargetAnnotation(target string) PodAutoscalerOption {
 	return withAnnotationValue(autoscaling.TargetAnnotationKey, target)
 }
 
+// WithMemorySuffixAnnotation returns a PodAutoscalerOption which sets
+// the PodAutoscaler autoscaling.knative.dev/memorySuffix annotation to the
+// provided value.
+func WithMemorySuffixAnnotation(target string) PodAutoscalerOption {
+	return withAnnotationValue(autoscaling.MemorySuffixAnnotationKey, target)
+}
+
 // WithTUAnnotation returns a PodAutoscalerOption which sets
 // the PodAutoscaler autoscaling.knative.dev/targetUtilizationPercentage
 // annotation to the provided value.


### PR DESCRIPTION
Fixes #11958 

Support k8s memory [suffixes](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) when use `memory` metrics

As commented in PR https://github.com/knative/serving/pull/11668#discussion_r679103930

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->


