### PR TITLE
Drop the label check in `WaitForServiceLatestRevision` func

### DIFF
--- a/test/v1/service.go
+++ b/test/v1/service.go
@@ -224,9 +224,7 @@ func WaitForServiceLatestRevision(clients *test.Clients, names test.ResourceName
 	if err := WaitForServiceState(clients.ServingClient, names.Service, func(s *v1.Service) (bool, error) {
 		if s.Status.LatestCreatedRevisionName != names.Revision {
 			revisionName = s.Status.LatestCreatedRevisionName
-			// Without this it might happen that the latest created revision is later overridden by a newer one
-			// and the following check for LatestReadyRevisionName would fail.
-			return CheckRevisionState(clients.ServingClient, revisionName, IsRevisionRoutingActive) == nil, nil
+			return true, nil
 		}
 		return false, nil
 	}, "ServiceUpdatedWithRevision"); err != nil {


### PR DESCRIPTION
Fixes #11797. Per discussion in #11823, we should drop the label check in `WaitForServiceLatestRevision` func. If it causes flakiness in upgrade tests, a separate helper func will be introduced for upgrade tests.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
