### PR TITLE
Adding Route GET and LIST Conformance test

### DIFF
--- a/test/conformance/api/v1/route_test.go
+++ b/test/conformance/api/v1/route_test.go
@@ -113,11 +113,6 @@ func TestRouteGetAndList(t *testing.T) {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
 
-	// Validate State after Creation
-	if err := validateControlPlane(t, clients, names, "1"); err != nil {
-		t.Error(err)
-	}
-
 	route, err := v1test.GetRoute(clients, names.Route)
 	if err != nil {
 		t.Fatal("Getting route failed")

--- a/test/conformance/api/v1/route_test.go
+++ b/test/conformance/api/v1/route_test.go
@@ -95,6 +95,52 @@ func getRouteURL(clients *test.Clients, names test.ResourceNames) (*url.URL, err
 	return url, err
 }
 
+// TestRouteGetAndList test ROUTE Get and LIST using Service as the only resource that we create, as Route CREATE is not required in the Spec
+func TestRouteGetAndList(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.PizzaPlanet1,
+	}
+
+	// Clean up on test failure or interrupt
+	test.EnsureTearDown(t, clients, &names)
+
+	// Setup initial Service
+	if _, err := v1test.CreateServiceReady(t, clients, &names); err != nil {
+		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
+	}
+
+	// Validate State after Creation
+	if err := validateControlPlane(t, clients, names, "1"); err != nil {
+		t.Error(err)
+	}
+
+	route, err := v1test.GetRoute(clients, names.Route)
+	if err != nil {
+		t.Fatal("Getting route failed")
+	}
+
+	routes, err := v1test.GetRoutes(clients)
+	if err != nil {
+		t.Fatal("Getting routes failed")
+	}
+	var routeFound = false
+	for _, routeItem := range routes.Items {
+		t.Logf("Route Returned: %s", routeItem.Name)
+		if routeItem.Name == route.Name {
+			routeFound = true
+		}
+	}
+
+	if !routeFound {
+		t.Fatal("The Route that was previously created was not found by listing all Routes.")
+	}
+
+}
+
 func TestRouteCreation(t *testing.T) {
 	if test.ServingFlags.DisableOptionalAPI {
 		t.Skip("Route create/patch/replace APIs are not required by Knative Serving API Specification")

--- a/test/conformance/api/v1/route_test.go
+++ b/test/conformance/api/v1/route_test.go
@@ -138,7 +138,6 @@ func TestRouteGetAndList(t *testing.T) {
 	if !routeFound {
 		t.Fatal("The Route that was previously created was not found by listing all Routes.")
 	}
-
 }
 
 func TestRouteCreation(t *testing.T) {

--- a/test/conformance/api/v1/route_test.go
+++ b/test/conformance/api/v1/route_test.go
@@ -95,7 +95,7 @@ func getRouteURL(clients *test.Clients, names test.ResourceNames) (*url.URL, err
 	return url, err
 }
 
-// TestRouteGetAndList test ROUTE Get and LIST using Service as the only resource that we create, as Route CREATE is not required in the Spec
+// TestRouteGetAndList tests Route GET and LIST using Service as the only resource that we create, as Route CREATE is not required in the Spec.
 func TestRouteGetAndList(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)

--- a/test/v1/route.go
+++ b/test/v1/route.go
@@ -54,6 +54,22 @@ func Route(names test.ResourceNames, fopt ...rtesting.RouteOption) *v1.Route {
 	return route
 }
 
+// GetRoute return a route by name
+func GetRoute(clients *test.Clients, routeName string) (route *v1.Route, err error) {
+	return route, reconciler.RetryTestErrors(func(int) (err error) {
+		route, err = clients.ServingClient.Routes.Get(context.Background(), routeName, metav1.GetOptions{})
+		return err
+	})
+}
+
+// GetRoutes return all the available routes
+func GetRoutes(clients *test.Clients) (list *v1.RouteList, err error) {
+	return list, reconciler.RetryTestErrors(func(int) (err error) {
+		list, err = clients.ServingClient.Routes.List(context.Background(), metav1.ListOptions{})
+		return err
+	})
+}
+
 // CreateRoute creates a route in the given namespace using the route name in names
 func CreateRoute(t testing.TB, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.RouteOption) (rt *v1.Route, err error) {
 	route := Route(names, fopt...)

--- a/test/v1/route.go
+++ b/test/v1/route.go
@@ -54,7 +54,7 @@ func Route(names test.ResourceNames, fopt ...rtesting.RouteOption) *v1.Route {
 	return route
 }
 
-// GetRoute return a route by name
+// GetRoute gets a route by name
 func GetRoute(clients *test.Clients, routeName string) (route *v1.Route, err error) {
 	return route, reconciler.RetryTestErrors(func(int) (err error) {
 		route, err = clients.ServingClient.Routes.Get(context.Background(), routeName, metav1.GetOptions{})
@@ -62,7 +62,7 @@ func GetRoute(clients *test.Clients, routeName string) (route *v1.Route, err err
 	})
 }
 
-// GetRoutes return all the available routes
+// GetRoutes returns all the available routes
 func GetRoutes(clients *test.Clients) (list *v1.RouteList, err error) {
 	return list, reconciler.RetryTestErrors(func(int) (err error) {
 		list, err = clients.ServingClient.Routes.List(context.Background(), metav1.ListOptions{})


### PR DESCRIPTION
Fixes #11971

## Proposed Changes

This PR test conformance on Routes Get and List operations 

* A test that creates a Service and then
  * Check that the route is there
* List all routes and check that the previously found route is there
