### PR TITLE
Copy healthyPods set to avoid concurrent map access

### DIFF
--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -317,9 +317,10 @@ func (rw *revisionWatcher) checkDests(curDests, prevDests dests) {
 		rw.logger.Debugf("Done probing, got %d healthy pods", len(hs))
 		if !noop || len(reprobe) > 0 {
 			rw.healthyPods = hs
-			// Copy the healthy pods set before sending the update to avoid
-			// concurrent modifications affecting the throttler.
-			rw.sendUpdate("" /*clusterIP*/, sets.NewString(hs.List()...))
+			// Note: it's important that this copies (via hs.Union) the healthy pods
+			// set before sending the update to avoid concurrent modifications
+			// affecting the throttler, which iterates over the set.
+			rw.sendUpdate("" /*clusterIP*/, hs.Union(nil))
 			return
 		}
 		// no-op, and we have successfully probed at least one pod.

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -317,7 +317,9 @@ func (rw *revisionWatcher) checkDests(curDests, prevDests dests) {
 		rw.logger.Debugf("Done probing, got %d healthy pods", len(hs))
 		if !noop || len(reprobe) > 0 {
 			rw.healthyPods = hs
-			rw.sendUpdate("" /*clusterIP*/, hs)
+			// Copy the healthy pods set before sending the update to avoid
+			// concurrent modifications affecting the throttler.
+			rw.sendUpdate("" /*clusterIP*/, sets.NewString(hs.List()...))
 			return
 		}
 		// no-op, and we have successfully probed at least one pod.


### PR DESCRIPTION
The healthyPods set can sometimes be modified without being recreated, which can cause panics when the map is [iterated in throttler](https://github.com/knative/serving/blob/main/pkg/activator/net/throttler.go#L425).

(This can happen via the `rw.healthyPods.Delete(p)` call on L303 when `probePodIPs` is in the no-op case where it [reuses the input set rather than creating a new one](https://github.com/julz/serving/blob/e596b13ce62c7e1bc62ffbfe49f4de3958f2de04/pkg/activator/net/revision_backends.go#L215-L217), meaning the same healthyPods is reused in two checkDests. We saw this happen in production and cause activator to panic+restart).
