### PR TITLE
Drop K8s 1.19 as it's no longer supported

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.19.11
         - v1.20.7
         - v1.21.1
         - v1.22.0
@@ -33,11 +32,6 @@ jobs:
           # Map between K8s and KinD versions.
           # This is attempting to make it a bit clearer what's being tested.
           # See: https://github.com/kubernetes-sigs/kind/releases
-        - k8s-version: v1.19.11
-          kind-version: v0.11.1
-          kind-image-sha: sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729
-          kingress: istio
-          cluster-suffix: c${{ github.run_id }}.local
         - k8s-version: v1.20.7
           kind-version: v0.11.1
           kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
@@ -51,7 +45,7 @@ jobs:
         - k8s-version: v1.22.0
           kind-version: v0.11.1
           kind-image-sha: sha256:f97edf7f7ed53c57762b24f90a34fad101386c5bd4d93baeb45449557148c717
-          kingress: kourier
+          kingress: istio
           cluster-suffix: c${{ github.run_id }}.local
 
           # The tests in api/v1alpha1 require the --enable-alpha flag to be set,


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Via https://github.com/knative/pkg/pull/2283

/assign @dprotaso 