### PR TITLE
Wire up MeshCompatibilityMode to ConfigMap property

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -154,7 +154,7 @@ func main() {
 
 	// Start throttler.
 	throttler := activatornet.NewThrottler(ctx, env.PodIP)
-	go throttler.Run(ctx, transport, networkConfig.EnableMeshPodAddressability)
+	go throttler.Run(ctx, transport, networkConfig.EnableMeshPodAddressability, networkConfig.MeshCompatibilityMode)
 
 	oct := tracing.NewOpenCensusTracer(tracing.WithExporterFull(networking.ActivatorServiceName, env.PodIP, logger))
 

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -137,7 +137,7 @@ func main() {
 	}
 
 	collector := asmetrics.NewMetricCollector(
-		statsScraperFactoryFunc(podLister, networkConfig.EnableMeshPodAddressability), logger)
+		statsScraperFactoryFunc(podLister, networkConfig.EnableMeshPodAddressability, networkConfig.MeshCompatibilityMode), logger)
 
 	// Set up scalers.
 	multiScaler := scaling.NewMultiScaler(ctx.Done(),
@@ -240,7 +240,7 @@ func uniScalerFactoryFunc(podLister corev1listers.PodLister,
 	}
 }
 
-func statsScraperFactoryFunc(podLister corev1listers.PodLister, usePassthroughLb bool) asmetrics.StatsScraperFactory {
+func statsScraperFactoryFunc(podLister corev1listers.PodLister, usePassthroughLb bool, meshMode network.MeshCompatibilityMode) asmetrics.StatsScraperFactory {
 	return func(metric *autoscalingv1alpha1.Metric, logger *zap.SugaredLogger) (asmetrics.StatsScraper, error) {
 		if metric.Spec.ScrapeTarget == "" {
 			return nil, nil
@@ -252,7 +252,7 @@ func statsScraperFactoryFunc(podLister corev1listers.PodLister, usePassthroughLb
 		}
 
 		podAccessor := resources.NewPodAccessor(podLister, metric.Namespace, revisionName)
-		return asmetrics.NewStatsScraper(metric, revisionName, podAccessor, usePassthroughLb, logger), nil
+		return asmetrics.NewStatsScraper(metric, revisionName, podAccessor, usePassthroughLb, meshMode, logger), nil
 	}
 }
 

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -428,19 +428,20 @@ type revisionBackendsManager struct {
 	updateCh         chan revisionDestsUpdate
 	transport        http.RoundTripper
 	usePassthroughLb bool
+	meshMode         network.MeshCompatibilityMode
 	logger           *zap.SugaredLogger
 	probeFrequency   time.Duration
 }
 
 // NewRevisionBackendsManager returns a new RevisionBackendsManager with default
 // probe time out.
-func newRevisionBackendsManager(ctx context.Context, tr http.RoundTripper, usePassthroughLb bool) *revisionBackendsManager {
-	return newRevisionBackendsManagerWithProbeFrequency(ctx, tr, usePassthroughLb, defaultProbeFrequency)
+func newRevisionBackendsManager(ctx context.Context, tr http.RoundTripper, usePassthroughLb bool, meshMode network.MeshCompatibilityMode) *revisionBackendsManager {
+	return newRevisionBackendsManagerWithProbeFrequency(ctx, tr, usePassthroughLb, meshMode, defaultProbeFrequency)
 }
 
 // newRevisionBackendsManagerWithProbeFrequency creates a fully spec'd RevisionBackendsManager.
 func newRevisionBackendsManagerWithProbeFrequency(ctx context.Context, tr http.RoundTripper,
-	usePassthroughLb bool, probeFreq time.Duration) *revisionBackendsManager {
+	usePassthroughLb bool, meshMode network.MeshCompatibilityMode, probeFreq time.Duration) *revisionBackendsManager {
 	rbm := &revisionBackendsManager{
 		ctx:              ctx,
 		revisionLister:   revisioninformer.Get(ctx).Lister(),
@@ -449,6 +450,7 @@ func newRevisionBackendsManagerWithProbeFrequency(ctx context.Context, tr http.R
 		updateCh:         make(chan revisionDestsUpdate),
 		transport:        tr,
 		usePassthroughLb: usePassthroughLb,
+		meshMode:         meshMode,
 		logger:           logging.FromContext(ctx),
 		probeFrequency:   probeFreq,
 	}

--- a/pkg/activator/net/revision_backends.go
+++ b/pkg/activator/net/revision_backends.go
@@ -512,7 +512,7 @@ func (rbm *revisionBackendsManager) getOrCreateRevisionWatcher(rev types.Namespa
 		}
 
 		destsCh := make(chan dests)
-		rw := newRevisionWatcher(rbm.ctx, rev, proto, rbm.updateCh, destsCh, rbm.transport, rbm.serviceLister, rbm.usePassthroughLb, network.MeshCompatibilityModeAuto, rbm.logger)
+		rw := newRevisionWatcher(rbm.ctx, rev, proto, rbm.updateCh, destsCh, rbm.transport, rbm.serviceLister, rbm.usePassthroughLb, rbm.meshMode, rbm.logger)
 		rbm.revisionWatchers[rev] = rw
 		go rw.run(rbm.probeFrequency)
 		return rw, nil

--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -830,7 +830,7 @@ func TestRevisionBackendManagerAddEndpoint(t *testing.T) {
 				t.Fatal("Failed to start informers:", err)
 			}
 
-			rbm := newRevisionBackendsManagerWithProbeFrequency(ctx, rt, false /*usePassthroughLb*/, probeFreq)
+			rbm := newRevisionBackendsManagerWithProbeFrequency(ctx, rt, false /*usePassthroughLb*/, network.MeshCompatibilityModeAuto, probeFreq)
 			defer func() {
 				cancel()
 				waitInformers()
@@ -1288,7 +1288,7 @@ func TestRevisionDeleted(t *testing.T) {
 	ri.Informer().GetIndexer().Add(rev)
 
 	fakeRT := activatortest.FakeRoundTripper{}
-	rbm := newRevisionBackendsManagerWithProbeFrequency(ctx, pkgnetwork.RoundTripperFunc(fakeRT.RT), false /*usePassthroughLb*/, probeFreq)
+	rbm := newRevisionBackendsManagerWithProbeFrequency(ctx, pkgnetwork.RoundTripperFunc(fakeRT.RT), false /*usePassthroughLb*/, network.MeshCompatibilityModeAuto, probeFreq)
 	defer func() {
 		cancel()
 		waitInformers()
@@ -1344,7 +1344,7 @@ func TestServiceDoesNotExist(t *testing.T) {
 			}},
 		},
 	}
-	rbm := newRevisionBackendsManagerWithProbeFrequency(ctx, pkgnetwork.RoundTripperFunc(fakeRT.RT), false /*usePassthroughLb*/, probeFreq)
+	rbm := newRevisionBackendsManagerWithProbeFrequency(ctx, pkgnetwork.RoundTripperFunc(fakeRT.RT), false /*usePassthroughLb*/, network.MeshCompatibilityModeAuto, probeFreq)
 	defer func() {
 		cancel()
 		waitInformers()
@@ -1408,7 +1408,7 @@ func TestServiceMoreThanOne(t *testing.T) {
 			}},
 		},
 	}
-	rbm := newRevisionBackendsManagerWithProbeFrequency(ctx, pkgnetwork.RoundTripperFunc(fakeRT.RT), false /*usePassthroughLb*/, probeFreq)
+	rbm := newRevisionBackendsManagerWithProbeFrequency(ctx, pkgnetwork.RoundTripperFunc(fakeRT.RT), false /*usePassthroughLb*/, network.MeshCompatibilityModeAuto, probeFreq)
 	defer func() {
 		cancel()
 		waitInformers()

--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
+	network "knative.dev/networking/pkg"
 	pkgnet "knative.dev/networking/pkg/apis/networking"
 	endpointsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/endpoints"
 	"knative.dev/pkg/controller"
@@ -491,8 +492,8 @@ func NewThrottler(ctx context.Context, ipAddr string) *Throttler {
 }
 
 // Run starts the throttler and blocks until the context is done.
-func (t *Throttler) Run(ctx context.Context, probeTransport http.RoundTripper, usePassthroughLb bool) {
-	rbm := newRevisionBackendsManager(ctx, probeTransport, usePassthroughLb)
+func (t *Throttler) Run(ctx context.Context, probeTransport http.RoundTripper, usePassthroughLb bool, meshMode network.MeshCompatibilityMode) {
+	rbm := newRevisionBackendsManager(ctx, probeTransport, usePassthroughLb, meshMode)
 	// Update channel is closed when ctx is done.
 	t.run(rbm.updates())
 }

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -38,6 +38,7 @@ import (
 	"knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/resources"
+	network "knative.dev/networking/pkg"
 )
 
 const (
@@ -137,26 +138,12 @@ var client = &http.Client{
 	Transport: keepAliveTransport,
 }
 
-// meshMode determines whether we should attempt to sample for stats via the K8s
-// service, or whether we should attempt to directly gather stats from pods
-// (which is more efficient, but not possible when mesh is enabled).
-type meshMode int
-
-const (
-	// meshModeEnabled causes the service scraper to always sample the k8s service for scraping.
-	meshModeEnabled meshMode = iota
-	// meshModeDisabled causes the service scraper to always use pod IPs directly for scraping.
-	meshModeDisabled
-	// meshModeAuto first attempts direct pod IP scraping, and then falls back to service scraping if needed.
-	meshModeAuto
-)
-
 // serviceScraper scrapes Revision metrics via a K8S service by sampling. Which
 // pod to be picked up to serve the request is decided by K8S. Please see
 // https://kubernetes.io/docs/concepts/services-networking/network-policies/
 // for details.
 type serviceScraper struct {
-	meshMode     meshMode
+	meshMode     network.MeshCompatibilityMode
 	directClient scrapeClient
 	meshClient   scrapeClient
 
@@ -176,7 +163,7 @@ func NewStatsScraper(metric *autoscalingv1alpha1.Metric, revisionName string, po
 	usePassthroughLb bool, logger *zap.SugaredLogger) StatsScraper {
 	directClient := newHTTPScrapeClient(client)
 	meshClient := newHTTPScrapeClient(noKeepaliveClient)
-	return newServiceScraperWithClient(metric, revisionName, podAccessor, usePassthroughLb, meshModeAuto, directClient, meshClient, logger)
+	return newServiceScraperWithClient(metric, revisionName, podAccessor, usePassthroughLb, network.MeshCompatibilityModeAuto, directClient, meshClient, logger)
 }
 
 func newServiceScraperWithClient(
@@ -184,7 +171,7 @@ func newServiceScraperWithClient(
 	revisionName string,
 	podAccessor resources.PodAccessor,
 	usePassthroughLb bool,
-	meshMode meshMode,
+	meshMode network.MeshCompatibilityMode,
 	directClient, meshClient scrapeClient,
 	logger *zap.SugaredLogger) *serviceScraper {
 	svcName := metric.Labels[serving.ServiceLabelKey]
@@ -227,10 +214,10 @@ func (s *serviceScraper) Scrape(window time.Duration) (stat Stat, err error) {
 	}()
 
 	switch s.meshMode {
-	case meshModeEnabled:
+	case network.MeshCompatibilityModeEnabled:
 		s.logger.Debug("Scraping via service due to meshMode setting")
 		return s.scrapeService(window)
-	case meshModeDisabled:
+	case network.MeshCompatibilityModeDisabled:
 		s.logger.Debug("Scraping pods directly due to meshMode setting")
 		return s.scrapePods(window)
 	default:

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -163,7 +163,7 @@ func NewStatsScraper(metric *autoscalingv1alpha1.Metric, revisionName string, po
 	usePassthroughLb bool, meshMode network.MeshCompatibilityMode, logger *zap.SugaredLogger) StatsScraper {
 	directClient := newHTTPScrapeClient(client)
 	meshClient := newHTTPScrapeClient(noKeepaliveClient)
-	return newServiceScraperWithClient(metric, revisionName, podAccessor, usePassthroughLb, network.MeshCompatibilityModeAuto, directClient, meshClient, logger)
+	return newServiceScraperWithClient(metric, revisionName, podAccessor, usePassthroughLb, meshMode, directClient, meshClient, logger)
 }
 
 func newServiceScraperWithClient(

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -32,13 +32,13 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
+	network "knative.dev/networking/pkg"
 	pkgmetrics "knative.dev/pkg/metrics"
 	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/metrics"
 	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/resources"
-	network "knative.dev/networking/pkg"
 )
 
 const (

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -160,7 +160,7 @@ type serviceScraper struct {
 // NewStatsScraper creates a new StatsScraper for the Revision which
 // the given Metric is responsible for.
 func NewStatsScraper(metric *autoscalingv1alpha1.Metric, revisionName string, podAccessor resources.PodAccessor,
-	usePassthroughLb bool, logger *zap.SugaredLogger) StatsScraper {
+	usePassthroughLb bool, meshMode network.MeshCompatibilityMode, logger *zap.SugaredLogger) StatsScraper {
 	directClient := newHTTPScrapeClient(client)
 	meshClient := newHTTPScrapeClient(noKeepaliveClient)
 	return newServiceScraperWithClient(metric, revisionName, podAccessor, usePassthroughLb, network.MeshCompatibilityModeAuto, directClient, meshClient, logger)

--- a/pkg/autoscaler/metrics/stats_scraper_test.go
+++ b/pkg/autoscaler/metrics/stats_scraper_test.go
@@ -36,8 +36,8 @@ import (
 
 	fakepodsinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/pod/fake"
 
-	logtesting "knative.dev/pkg/logging/testing"
 	network "knative.dev/networking/pkg"
+	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/resources"
 
@@ -99,7 +99,7 @@ func TestNewServiceScraperWithClientHappyCase(t *testing.T) {
 	accessor := resources.NewPodAccessor(
 		fakepodsinformer.Get(ctx).Lister(),
 		testNamespace, testRevision)
-	sc := NewStatsScraper(metric, testRevision, accessor, false, logtesting.TestLogger(t))
+	sc := NewStatsScraper(metric, testRevision, accessor, false, network.MeshCompatibilityModeAuto, logtesting.TestLogger(t))
 	if svcS, want := sc.(*serviceScraper), urlFromTarget(testRevision+"-zhudex", testNamespace); svcS.url != want {
 		t.Errorf("scraper.url = %s, want: %s", svcS.url, want)
 	}


### PR DESCRIPTION
subj.

Fixes #11895.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
A new setting, mesh-compatibility-mode, in the networking config map allows an administrator
to explicitly tell Activator and Autoscaler to use Direct Pod IP (most efficient, but not compatible
with mesh being enabled), Cluster IP (less efficient, but needed if mesh is enabled), or to
Autodetect (the current behaviour, and the default, causes Activator and Autoscaler to first attempt
Direct Pod IP communication, and then fall back to Cluster IP if it sees a mesh-related error status
code).
```
