### PR TITLE
Allow users to set containers[*].securityContext.runAsGroup

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
   annotations:
-    knative.dev/example-checksum: "211d4000"
+    knative.dev/example-checksum: "5b8c26fe"
 data:
   _example: |-
     ################################
@@ -83,7 +83,6 @@ data:
     kubernetes.podspec-runtimeclassname: "disabled"
 
     # This feature allows end-users to set a subset of fields on the Pod's SecurityContext
-    # in addition to expanding the allowable fields within a Container's SecurityContext.
     #
     # When set to "enabled" or "allowed" it allows the following
     # PodSecurityContext properties:
@@ -92,12 +91,6 @@ data:
     # - RunAsNonRoot
     # - SupplementalGroups
     # - RunAsUser
-    #
-    # When set to "enabled" or "allowed" it allows the following
-    # Container SecurityContext properties:
-    # - RunAsNonRoot
-    # - RunAsGroup
-    # - RunAsUser (already allowed without this flag)
     #
     # This feature flag should be used with caution as the PodSecurityContext
     # properties may have a side-effect on non-user sidecar containers that come

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -613,16 +613,10 @@ func SecurityContextMask(ctx context.Context, in *corev1.SecurityContext) *corev
 	out.ReadOnlyRootFilesystem = in.ReadOnlyRootFilesystem
 	out.RunAsUser = in.RunAsUser
 	out.RunAsGroup = in.RunAsGroup
+	// RunAsNonRoot when unset behaves the same way as false
+	// We do want the ability for folks to set this value to true
+	out.RunAsNonRoot = in.RunAsNonRoot
 
-	// Can only be set to 'true' - unless the PodSpecSecurityContext feature flag is enabled
-	if in.RunAsNonRoot != nil && *in.RunAsNonRoot {
-		out.RunAsNonRoot = in.RunAsNonRoot
-	}
-
-	if config.FromContextOrDefaults(ctx).Features.PodSpecSecurityContext != config.Disabled {
-		// Allow setting to false
-		out.RunAsNonRoot = in.RunAsNonRoot
-	}
 	// Disallowed
 	// This list is unnecessary, but added here for clarity
 	out.Privileged = nil

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -609,15 +609,18 @@ func SecurityContextMask(ctx context.Context, in *corev1.SecurityContext) *corev
 	out := new(corev1.SecurityContext)
 
 	// Allowed fields
+	out.Capabilities = in.Capabilities
+	out.ReadOnlyRootFilesystem = in.ReadOnlyRootFilesystem
 	out.RunAsUser = in.RunAsUser
+	out.RunAsGroup = in.RunAsGroup
+
+	// Can only be set to 'true' - unless the PodSpecSecurityContext feature flag is enabled
 	if in.RunAsNonRoot != nil && *in.RunAsNonRoot {
 		out.RunAsNonRoot = in.RunAsNonRoot
 	}
-	out.ReadOnlyRootFilesystem = in.ReadOnlyRootFilesystem
-	out.Capabilities = in.Capabilities
 
 	if config.FromContextOrDefaults(ctx).Features.PodSpecSecurityContext != config.Disabled {
-		out.RunAsGroup = in.RunAsGroup
+		// Allow setting to false
 		out.RunAsNonRoot = in.RunAsNonRoot
 	}
 	// Disallowed

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -722,6 +722,7 @@ func TestSecurityContextMask(t *testing.T) {
 	want := &corev1.SecurityContext{
 		Capabilities:           &corev1.Capabilities{},
 		RunAsUser:              ptr.Int64(1),
+		RunAsGroup:             ptr.Int64(2),
 		RunAsNonRoot:           ptr.Bool(true),
 		ReadOnlyRootFilesystem: ptr.Bool(true),
 	}

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -1392,10 +1392,10 @@ func TestContainerValidation(t *testing.T) {
 		c: corev1.Container{
 			Image: "foo",
 			SecurityContext: &corev1.SecurityContext{
-				RunAsGroup: ptr.Int64(10),
+				Privileged: ptr.Bool(true),
 			},
 		},
-		want: apis.ErrDisallowedFields("securityContext.runAsGroup"),
+		want: apis.ErrDisallowedFields("securityContext.privileged"),
 	}, {
 		name: "not allowed to add a security context capability",
 		c: corev1.Container{


### PR DESCRIPTION
Part of: https://github.com/knative/serving/issues/9067

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow users to set container[*].securityContext.runAsGroup
```
