### PR TITLE
Adding Configuration GET and LIST Conformance test

### DIFF
--- a/test/conformance/api/v1/configuration_test.go
+++ b/test/conformance/api/v1/configuration_test.go
@@ -30,7 +30,7 @@ import (
 	v1test "knative.dev/serving/test/v1"
 )
 
-// TestConfigurationGetAndList tests Getting and  Listing Configurations resources.
+// TestConfigurationGetAndList tests Getting and Listing Configurations resources.
 //   This test doesn't validate the Data Plane, it is just to check the APIs for conformance
 func TestConfigurationGetAndList(t *testing.T) {
 	t.Parallel()
@@ -49,6 +49,8 @@ func TestConfigurationGetAndList(t *testing.T) {
 		t.Fatalf("Failed to create initial Service %v: %v", names.Service, err)
 	}
 
+	config := fetchConfiguration(names.Config, clients, t)
+
 	list, err := v1test.GetConfigurations(clients)
 	if err != nil {
 		t.Fatal("Listing Configurations failed")
@@ -59,7 +61,7 @@ func TestConfigurationGetAndList(t *testing.T) {
 	var configurationFound = false
 	for _, configuration := range list.Items {
 		t.Logf("Configuration Returned: %s", configuration.Name)
-		if configuration.Name == names.Config {
+		if configuration.Name == config.Name {
 			configurationFound = true
 		}
 	}

--- a/test/v1/configuration.go
+++ b/test/v1/configuration.go
@@ -203,3 +203,19 @@ func CheckConfigurationState(client *test.ServingClients, name string, inState f
 func IsConfigurationReady(c *v1.Configuration) (bool, error) {
 	return c.IsReady(), nil
 }
+
+// GetConfiguration gets a configuration by name
+func GetConfiguration(clients *test.Clients, configurationName string) (configuration *v1.Configuration, err error) {
+	return configuration, reconciler.RetryTestErrors(func(int) (err error) {
+		configuration, err = clients.ServingClient.Configs.Get(context.Background(), configurationName, metav1.GetOptions{})
+		return err
+	})
+}
+
+// GetConfigurations returns all the available configurations
+func GetConfigurations(clients *test.Clients) (list *v1.ConfigurationList, err error) {
+	return list, reconciler.RetryTestErrors(func(int) (err error) {
+		list, err = clients.ServingClient.Configs.List(context.Background(), metav1.ListOptions{})
+		return err
+	})
+}

--- a/test/v1/configuration.go
+++ b/test/v1/configuration.go
@@ -204,14 +204,6 @@ func IsConfigurationReady(c *v1.Configuration) (bool, error) {
 	return c.IsReady(), nil
 }
 
-// GetConfiguration gets a configuration by name
-func GetConfiguration(clients *test.Clients, configurationName string) (configuration *v1.Configuration, err error) {
-	return configuration, reconciler.RetryTestErrors(func(int) (err error) {
-		configuration, err = clients.ServingClient.Configs.Get(context.Background(), configurationName, metav1.GetOptions{})
-		return err
-	})
-}
-
 // GetConfigurations returns all the available configurations
 func GetConfigurations(clients *test.Clients) (list *v1.ConfigurationList, err error) {
 	return list, reconciler.RetryTestErrors(func(int) (err error) {


### PR DESCRIPTION
Fixes #12015

## Proposed Changes

This PR test conformance on Configuration Get and List operations 

* A test that creates a Service and then
  * Check that the configuration is there
* List all configurations and check that the previously found config is there