### PR TITLE
Add logic to retry pause/resume for pod freezer

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -300,7 +300,8 @@ func buildServer(ctx context.Context, env config, healthState *health.State, rp 
 	var composedHandler http.Handler = httpProxy
 	if concurrencyStateEnabled {
 		logger.Info("Concurrency state endpoint set, tracking request counts, using endpoint: ", env.ConcurrencyStateEndpoint)
-		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, queue.Pause(env.ConcurrencyStateEndpoint), queue.Resume(env.ConcurrencyStateEndpoint))
+		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler,
+			queue.Pause(env.ConcurrencyStateEndpoint), queue.Resume(env.ConcurrencyStateEndpoint), queue.RelaunchUserContainer(env.ConcurrencyStateEndpoint))
 	}
 	if metricsSupported {
 		composedHandler = requestAppMetricsHandler(logger, composedHandler, breaker, env)


### PR DESCRIPTION
Feature https://github.com/knative/serving/issues/11834

# Proposed Changes
* There is three kinds of error: noError,internalError,responseStatusConflictError,responseExecError.
   * noError, everythings works.
   * internalError, error happends related QP.
   * responseStatusConflictError, this happen when request resume/pause when the user-contianer is in resume/pause state.
   * responseExecError, the pause/resuem command is failed.
* When internalError happens, using `os.Exit(1)` to restart QP
* when responseStatusConflictError happens, just ignore it.
* when responseExecError happens, we will try three more times. If failed, QP will send `delete-pod` command to daemon, the daemon will delete the contianers of the pod(treat like relaunch the pod).


