### PR TITLE
Use resolvabledomain flag in TestHPAAutoscaleUpDownUp

### DIFF
--- a/test/e2e/autoscale_hpa_test.go
+++ b/test/e2e/autoscale_hpa_test.go
@@ -114,7 +114,7 @@ func setupHPASvc(t *testing.T, metric string, target int) *TestContext {
 		names.URL,
 		spoof.MatchesAllOf(spoof.IsStatusOK),
 		"CheckingEndpointAfterCreate",
-		false,
+		test.ServingFlags.ResolvableDomain,
 		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
 	); err != nil {
 		t.Fatalf("Error probing %s: %v", names.URL.Hostname(), err)


### PR DESCRIPTION
As per title, this patch changes to respect resolvabledomain flag.

/cc @skonto @markusthoemmes 