### PR TITLE
Use existing directory for working directory test

### DIFF
--- a/test/conformance/runtime/workingdir_test.go
+++ b/test/conformance/runtime/workingdir_test.go
@@ -1,4 +1,3 @@
-//go:build e2e
 // +build e2e
 
 /*

--- a/test/conformance/runtime/workingdir_test.go
+++ b/test/conformance/runtime/workingdir_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*
@@ -36,7 +37,9 @@ func TestWorkingDirService(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
 
-	const wd = "/foo/bar/baz"
+	// An existing directory inside the test image but different from
+	// the default working directory.
+	const wd = "/tmp"
 
 	_, ri, err := fetchRuntimeInfo(t, clients, withWorkingDir(wd))
 	if err != nil {

--- a/test/conformance/runtime/workingdir_test.go
+++ b/test/conformance/runtime/workingdir_test.go
@@ -38,7 +38,7 @@ func TestWorkingDirService(t *testing.T) {
 	clients := test.Setup(t)
 
 	// An existing directory inside the test image but different from
-	// the default working directory.
+	// the default working directory /home/nonroot.
 	const wd = "/tmp"
 
 	_, ri, err := fetchRuntimeInfo(t, clients, withWorkingDir(wd))


### PR DESCRIPTION


<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Uses existing directory `/tmp` for working directory test. This is because on some Knative provider platform, it may fail to set up working directory during runtime if the directory doesn't exist. Kubernetes [core/v1.Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core) doesn't define the behavior when the specified working directory doesn't exist.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
