### PR TITLE
Pin GKE to 1.20 until issues/12091 was solved

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -170,7 +170,8 @@ function delete_dns_record() {
 # Skip installing istio as an add-on
 # Temporarily increasing the cluster size for serving tests to rule out
 # resource/eviction as causes of flakiness.
-initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha "$@"
+# Pin to 1.20 since scale test is super flakey on 1.21
+initialize "$@" --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha --cluster-version=1.20
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -32,7 +32,8 @@ source $(dirname $0)/e2e-common.sh
 # Skip installing istio as an add-on.
 # Temporarily increasing the cluster size for serving tests to rule out
 # resource/eviction as causes of flakiness.
-initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha "$@"
+# Pin to 1.20 since scale test is super flakey on 1.21
+initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha --cluster-version=1.20 "$@"
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -36,7 +36,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/e2e-common.sh"
 # Skip installing istio as an add-on.
 # Temporarily increasing the cluster size for serving tests to rule out
 # resource/eviction as causes of flakiness.
-initialize --skip-istio-addon  --min-nodes=4 --max-nodes=4 --install-latest-release "$@"
+# Pin to 1.20 since scale test is super flakey on 1.21
+initialize "$@" --skip-istio-addon  --min-nodes=4 --max-nodes=4 --cluster-version=1.20 \
+  --install-latest-release
 
 # TODO(#2656): Reduce the timeout after we get this test to consistently passing.
 TIMEOUT=30m


### PR DESCRIPTION
As per title, GKE 1.21 is unstable as https://github.com/knative/serving/issues/12091.
This patch pin GKE to 1.20 until it was solved.

I created the patch based on https://github.com/knative/serving/pull/11384.