### PR TITLE
[release-0.23] bump k8s version

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -168,8 +168,7 @@ function delete_dns_record() {
 # Skip installing istio as an add-on
 # Temporarily increasing the cluster size for serving tests to rule out
 # resource/eviction as causes of flakiness.
-# Pin to 1.18 since scale test is super flakey on 1.19
-initialize "$@" --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha --cluster-version=1.18
+initialize "$@" --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha --cluster-version=1.19
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -32,8 +32,7 @@ source $(dirname $0)/e2e-common.sh
 # Skip installing istio as an add-on.
 # Temporarily increasing the cluster size for serving tests to rule out
 # resource/eviction as causes of flakiness.
-# Pin to 1.18 since scale test is super flakey on 1.19
-initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha --cluster-version=1.18 "$@"
+initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha --cluster-version=1.19 "$@"
 
 # Run the tests
 header "Running tests"


### PR DESCRIPTION
1.18 isn't supported on GKE anymore so pin it to 1.19