### PR TITLE
Standardizing how we enable request logs handler

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -328,11 +328,10 @@ func buildServer(ctx context.Context, env config, healthState *health.State, pro
 
 	composedHandler = health.ProbeHandler(healthState, probeContainer, tracingEnabled, composedHandler)
 	composedHandler = network.NewProbeHandler(composedHandler)
-	// We might want sometimes to capture the probes/healthchecks in the request
+	// We might sometimes want to capture the probes/healthchecks in the request
 	// logs. Hence we need to have RequestLogHandler to be the first one.
 	if env.ServingEnableRequestLog {
-		logger.Info("push request log handler enabled")
-		composedHandler = pushRequestLogHandler(logger, composedHandler, env)
+		composedHandler = requestLogHandler(logger, composedHandler, env)
 	}
 
 	return pkgnet.NewServer(":"+env.QueueServingPort, composedHandler)
@@ -414,7 +413,7 @@ func buildMetricsServer(promStatReporter *queue.PrometheusStatsReporter, protobu
 	}
 }
 
-func pushRequestLogHandler(logger *zap.SugaredLogger, currentHandler http.Handler, env config) http.Handler {
+func requestLogHandler(logger *zap.SugaredLogger, currentHandler http.Handler, env config) http.Handler {
 	revInfo := &pkghttp.RequestLogRevision{
 		Name:          env.ServingRevision,
 		Namespace:     env.ServingNamespace,


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

For all but one of the optional handlers in queue proxy, we use a fairly standard pattern to enable them

```golang
if <condition> {
    composedHandler = <chain in optional handler>
}
```

The only one that didn't follow this pattern was `pushRequestLogHandler`, which this PR takes care of.

/assign @julz @markusthoemmes 
