### PR TITLE
Support image resolution for init containers

### DIFF
--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -674,7 +674,7 @@ spec:
                         description: Type of condition.
                         type: string
                 containerStatuses:
-                  description: 'ContainerStatuses is a slice of images present in .Spec.Container[*].Image to their respective digests and their container name. The digests are resolved during the creation of Revision. ContainerStatuses holds the container name and image digests for both serving and non serving containers. ref: http://bit.ly/image-digests'
+                  description: 'ContainerStatuses is a slice of images present in .Spec.Container[*].Image and .Spec.InitContainer[*].Image to their respective digests and their container name. Order within the slice is important as by convention first the regular container info is stored and then if present init container related info. The digests are resolved during the creation of Revision. ContainerStatuses holds the container name and image digests for serving, non serving and init containers. ref: http://bit.ly/image-digests'
                   type: array
                   items:
                     description: ContainerStatus holds the information of container name and image digest value

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -674,7 +674,7 @@ spec:
                         description: Type of condition.
                         type: string
                 containerStatuses:
-                  description: 'ContainerStatuses is a slice of images present in .Spec.Container[*].Image and .Spec.InitContainer[*].Image to their respective digests and their container name. Order within the slice is important as by convention first the regular container info is stored and then if present init container related info. The digests are resolved during the creation of Revision. ContainerStatuses holds the container name and image digests for serving, non serving and init containers. ref: http://bit.ly/image-digests'
+                  description: 'ContainerStatuses is a slice of images present in .Spec.Container[*].Image to their respective digests and their container name. The digests are resolved during the creation of Revision. ContainerStatuses holds the container name and image digests for both serving and non serving containers. ref: http://bit.ly/image-digests'
                   type: array
                   items:
                     description: ContainerStatus holds the information of container name and image digest value
@@ -688,6 +688,17 @@ spec:
                   description: DesiredReplicas reflects the desired amount of pods running this revision.
                   type: integer
                   format: int32
+                initContainerStatuses:
+                  description: 'InitContainerStatuses is a slice of images present in .Spec.InitContainer[*].Image to their respective digests and their container name. The digests are resolved during the creation of Revision. ContainerStatuses holds the container name and image digests for both serving and non serving containers. ref: http://bit.ly/image-digests'
+                  type: array
+                  items:
+                    description: ContainerStatus holds the information of container name and image digest value
+                    type: object
+                    properties:
+                      imageDigest:
+                        type: string
+                      name:
+                        type: string
                 logUrl:
                   description: LogURL specifies the generated logging url for this particular revision based on the revision url template specified in the controller's config.
                   type: string

--- a/docs/serving-api.md
+++ b/docs/serving-api.md
@@ -1439,13 +1439,30 @@ based on the revision url template specified in the controller&rsquo;s config.</
 </td>
 <td>
 <em>(Optional)</em>
-<p>ContainerStatuses is a slice of images present in .Spec.Container[<em>].Image
-and .Spec.InitContainer[</em>].Image to their respective digests and their container name.
-Order within the slice is important as by convention first the regular container info is stored
-and then if present init container related info.
+<p>ContainerStatuses is a slice of images present in .Spec.Container[*].Image
+to their respective digests and their container name.
 The digests are resolved during the creation of Revision.
 ContainerStatuses holds the container name and image digests
-for serving, non serving and init containers.
+for both serving and non serving containers.
+ref: <a href="http://bit.ly/image-digests">http://bit.ly/image-digests</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>initContainerStatuses</code><br/>
+<em>
+<a href="#serving.knative.dev/v1.ContainerStatus">
+[]ContainerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>InitContainerStatuses is a slice of images present in .Spec.InitContainer[*].Image
+to their respective digests and their container name.
+The digests are resolved during the creation of Revision.
+ContainerStatuses holds the container name and image digests
+for both serving and non serving containers.
 ref: <a href="http://bit.ly/image-digests">http://bit.ly/image-digests</a></p>
 </td>
 </tr>

--- a/docs/serving-api.md
+++ b/docs/serving-api.md
@@ -1439,11 +1439,13 @@ based on the revision url template specified in the controller&rsquo;s config.</
 </td>
 <td>
 <em>(Optional)</em>
-<p>ContainerStatuses is a slice of images present in .Spec.Container[*].Image
-to their respective digests and their container name.
+<p>ContainerStatuses is a slice of images present in .Spec.Container[<em>].Image
+and .Spec.InitContainer[</em>].Image to their respective digests and their container name.
+Order within the slice is important as by convention first the regular container info is stored
+and then if present init container related info.
 The digests are resolved during the creation of Revision.
 ContainerStatuses holds the container name and image digests
-for both serving and non serving containers.
+for serving, non serving and init containers.
 ref: <a href="http://bit.ly/image-digests">http://bit.ly/image-digests</a></p>
 </td>
 </tr>

--- a/pkg/apis/serving/v1/revision_types.go
+++ b/pkg/apis/serving/v1/revision_types.go
@@ -129,15 +129,22 @@ type RevisionStatus struct {
 	LogURL string `json:"logUrl,omitempty"`
 
 	// ContainerStatuses is a slice of images present in .Spec.Container[*].Image
-	// and .Spec.InitContainer[*].Image to their respective digests and their container name.
-	// Order within the slice is important as by convention first the regular container info is stored
-	// and then if present init container related info.
+	// to their respective digests and their container name.
 	// The digests are resolved during the creation of Revision.
 	// ContainerStatuses holds the container name and image digests
-	// for serving, non serving and init containers.
+	// for both serving and non serving containers.
 	// ref: http://bit.ly/image-digests
 	// +optional
 	ContainerStatuses []ContainerStatus `json:"containerStatuses,omitempty"`
+
+	// InitContainerStatuses is a slice of images present in .Spec.InitContainer[*].Image
+	// to their respective digests and their container name.
+	// The digests are resolved during the creation of Revision.
+	// ContainerStatuses holds the container name and image digests
+	// for both serving and non serving containers.
+	// ref: http://bit.ly/image-digests
+	// +optional
+	InitContainerStatuses []ContainerStatus `json:"initContainerStatuses,omitempty"`
 
 	// ActualReplicas reflects the amount of ready pods running this revision.
 	// +optional

--- a/pkg/apis/serving/v1/revision_types.go
+++ b/pkg/apis/serving/v1/revision_types.go
@@ -129,10 +129,12 @@ type RevisionStatus struct {
 	LogURL string `json:"logUrl,omitempty"`
 
 	// ContainerStatuses is a slice of images present in .Spec.Container[*].Image
-	// to their respective digests and their container name.
+	// and .Spec.InitContainer[*].Image to their respective digests and their container name.
+	// Order within the slice is important as by convention first the regular container info is stored
+	// and then if present init container related info.
 	// The digests are resolved during the creation of Revision.
 	// ContainerStatuses holds the container name and image digests
-	// for both serving and non serving containers.
+	// for serving, non serving and init containers.
 	// ref: http://bit.ly/image-digests
 	// +optional
 	ContainerStatuses []ContainerStatus `json:"containerStatuses,omitempty"`

--- a/pkg/apis/serving/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/serving/v1/zz_generated.deepcopy.go
@@ -252,6 +252,11 @@ func (in *RevisionStatus) DeepCopyInto(out *RevisionStatus) {
 		*out = make([]ContainerStatus, len(*in))
 		copy(*out, *in)
 	}
+	if in.InitContainerStatuses != nil {
+		in, out := &in.InitContainerStatuses, &out.InitContainerStatuses
+		*out = make([]ContainerStatus, len(*in))
+		copy(*out, *in)
+	}
 	if in.ActualReplicas != nil {
 		in, out := &in.ActualReplicas, &out.ActualReplicas
 		*out = new(int32)

--- a/pkg/reconciler/metric/metric_test.go
+++ b/pkg/reconciler/metric/metric_test.go
@@ -211,14 +211,14 @@ func TestReconcileWithCollector(t *testing.T) {
 
 	scs.AutoscalingV1alpha1().Metrics(m.Namespace).Create(ctx, m, metav1.CreateOptions{})
 
-	if err := wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (bool, error) {
+	if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
 		return collector.createOrUpdateCalls.Load() > 0, nil
 	}); err != nil {
 		t.Fatal("CreateOrUpdate() called 0 times, want non-zero times")
 	}
 
 	scs.AutoscalingV1alpha1().Metrics(m.Namespace).Delete(ctx, m.Name, metav1.DeleteOptions{})
-	if err := wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (bool, error) {
+	if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
 		return collector.deleteCalls.Load() > 0, nil
 	}); err != nil {
 		t.Fatal("Delete() called 0 times, want non-zero times")

--- a/pkg/reconciler/metric/metric_test.go
+++ b/pkg/reconciler/metric/metric_test.go
@@ -211,14 +211,14 @@ func TestReconcileWithCollector(t *testing.T) {
 
 	scs.AutoscalingV1alpha1().Metrics(m.Namespace).Create(ctx, m, metav1.CreateOptions{})
 
-	if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
+	if err := wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (bool, error) {
 		return collector.createOrUpdateCalls.Load() > 0, nil
 	}); err != nil {
 		t.Fatal("CreateOrUpdate() called 0 times, want non-zero times")
 	}
 
 	scs.AutoscalingV1alpha1().Metrics(m.Namespace).Delete(ctx, m.Name, metav1.DeleteOptions{})
-	if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
+	if err := wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (bool, error) {
 		return collector.deleteCalls.Load() > 0, nil
 	}); err != nil {
 		t.Fatal("Delete() called 0 times, want non-zero times")

--- a/pkg/reconciler/revision/background.go
+++ b/pkg/reconciler/revision/background.go
@@ -181,11 +181,10 @@ func (r *backgroundResolver) Resolve(logger *zap.SugaredLogger, rev *v1.Revision
 
 	statuses = make([]v1.ContainerStatus, len(rev.Spec.Containers))
 	for i, container := range rev.Spec.Containers {
-		if resolvedDigest, ok := ret.imagesResolved[container.Image]; ok {
-			statuses[i] = v1.ContainerStatus{
-				Name:        container.Name,
-				ImageDigest: resolvedDigest,
-			}
+		resolvedDigest := ret.imagesResolved[container.Image]
+		statuses[i] = v1.ContainerStatus{
+			Name:        container.Name,
+			ImageDigest: resolvedDigest,
 		}
 	}
 

--- a/pkg/reconciler/revision/background.go
+++ b/pkg/reconciler/revision/background.go
@@ -268,7 +268,6 @@ func (r *backgroundResolver) processWorkItem(item workItem) {
 	}
 
 	if resolveErr != nil {
-		result.imagesResolved = nil
 		result.err = fmt.Errorf("%s: %w", v1.RevisionContainerMissingMessage(item.image, "failed to resolve image to digest"), resolveErr)
 		result.completionCallback()
 		return

--- a/pkg/reconciler/revision/background_test.go
+++ b/pkg/reconciler/revision/background_test.go
@@ -236,7 +236,7 @@ func TestRateLimitPerItem(t *testing.T) {
 	logger := logtesting.TestLogger(t)
 
 	var resolver resolveFunc = func(_ context.Context, img string, _ k8schain.Options, _ sets.String) (string, error) {
-		if img == "img1" {
+		if img == "img1" || img == "init"{
 			return "", nil
 		}
 

--- a/pkg/reconciler/revision/background_test.go
+++ b/pkg/reconciler/revision/background_test.go
@@ -162,7 +162,7 @@ func TestResolveInBackground(t *testing.T) {
 			for i := 0; i < 2; i++ {
 				t.Run(fmt.Sprint("iteration", i), func(t *testing.T) {
 					logger := logtesting.TestLogger(t)
-					statuses, initContainerStatuses, err := subject.Resolve(logger, fakeRevision, k8schain.Options{ServiceAccountName: "san"}, sets.NewString("skip"), timeout)
+					initContainerStatuses, statuses, err := subject.Resolve(logger, fakeRevision, k8schain.Options{ServiceAccountName: "san"}, sets.NewString("skip"), timeout)
 					if err != nil || statuses != nil || initContainerStatuses != nil {
 						// Initial result should be nil, nil, nil since we have nothing in cache.
 						t.Errorf("Resolve() = %v, %v %v, wanted nil, nil, nil", statuses, initContainerStatuses, err)
@@ -177,7 +177,7 @@ func TestResolveInBackground(t *testing.T) {
 						t.Fatalf("Resolver did not report ready")
 					}
 
-					statuses, initContainerStatuses, err = subject.Resolve(logger, fakeRevision, k8schain.Options{}, nil, timeout)
+					initContainerStatuses, statuses, err = subject.Resolve(logger, fakeRevision, k8schain.Options{}, nil, timeout)
 					if got, want := err, tt.wantError; !errors.Is(got, want) {
 						t.Errorf("Resolve() = _, %q, wanted %q", got, want)
 					}
@@ -263,7 +263,7 @@ func TestRateLimitPerItem(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		subject.Clear(types.NamespacedName{Name: revision.Name, Namespace: revision.Namespace})
 		start := time.Now()
-		resolution, initResolution, err := subject.Resolve(logger, revision, k8schain.Options{ServiceAccountName: "san"}, sets.NewString("skip"), 0)
+		initResolution, resolution, err := subject.Resolve(logger, revision, k8schain.Options{ServiceAccountName: "san"}, sets.NewString("skip"), 0)
 		if err != nil || resolution != nil || initResolution != nil {
 			t.Fatalf("Expected Resolve to be nil, nil, nil but got %v, %v, %v", resolution, initResolution, err)
 		}
@@ -284,7 +284,7 @@ func TestRateLimitPerItem(t *testing.T) {
 
 	t.Run("Does not affect other revisions", func(t *testing.T) {
 		start := time.Now()
-		resolution, _, err := subject.Resolve(logger, rev("another-revision", "img1", "img2"), k8schain.Options{ServiceAccountName: "san"}, sets.NewString("skip"), 0)
+		_, resolution, err := subject.Resolve(logger, rev("another-revision", "img1", "img2"), k8schain.Options{ServiceAccountName: "san"}, sets.NewString("skip"), 0)
 		if err != nil || resolution != nil {
 			t.Fatalf("Expected Resolve to be nil, nil but got %v, %v", resolution, err)
 		}
@@ -299,7 +299,7 @@ func TestRateLimitPerItem(t *testing.T) {
 		subject.Forget(types.NamespacedName{Name: revision.Name, Namespace: revision.Namespace})
 
 		start := time.Now()
-		resolution, _, err := subject.Resolve(logger, revision, k8schain.Options{ServiceAccountName: "san"}, sets.NewString("skip"), 0)
+		_, resolution, err := subject.Resolve(logger, revision, k8schain.Options{ServiceAccountName: "san"}, sets.NewString("skip"), 0)
 		if err != nil || resolution != nil {
 			t.Fatalf("Expected Resolve to be nil, nil but got %v, %v", resolution, err)
 		}

--- a/pkg/reconciler/revision/background_test.go
+++ b/pkg/reconciler/revision/background_test.go
@@ -236,7 +236,7 @@ func TestRateLimitPerItem(t *testing.T) {
 	logger := logtesting.TestLogger(t)
 
 	var resolver resolveFunc = func(_ context.Context, img string, _ k8schain.Options, _ sets.String) (string, error) {
-		if img == "img1" || img == "init"{
+		if img == "img1" || img == "init" {
 			return "", nil
 		}
 

--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -121,7 +121,7 @@ func (c *Reconciler) reconcileImageCache(ctx context.Context, rev *v1.Revision) 
 	ns := rev.Namespace
 	// Revisions are immutable.
 	// Updating image results to new revision so there won't be any chance of resource leak.
-	for _, container := range rev.Status.ContainerStatuses {
+	for _, container := range append(rev.Status.ContainerStatuses, rev.Status.InitContainerStatuses...) {
 		imageName := kmeta.ChildName(resourcenames.ImageCache(rev), "-"+container.Name)
 		if _, err := c.imageLister.Images(ns).Get(imageName); apierrs.IsNotFound(err) {
 			if _, err := c.createImageCache(ctx, rev, container.Name, container.ImageDigest); err != nil {

--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -19,7 +19,6 @@ package revision
 import (
 	"context"
 	"fmt"
-
 	"go.uber.org/zap"
 
 	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -19,6 +19,7 @@ package revision
 import (
 	"context"
 	"fmt"
+	
 	"go.uber.org/zap"
 
 	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -19,7 +19,7 @@ package revision
 import (
 	"context"
 	"fmt"
-	
+
 	"go.uber.org/zap"
 
 	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -72,12 +72,6 @@ var (
 
 func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) (bool, error) {
 	totalNumOfContainers := len(rev.Spec.Containers) + len(rev.Spec.InitContainers)
-	if rev.Status.ContainerStatuses == nil {
-		rev.Status.ContainerStatuses = make([]v1.ContainerStatus, 0, len(rev.Spec.Containers))
-	}
-	if rev.Status.InitContainerStatuses == nil {
-		rev.Status.InitContainerStatuses = make([]v1.ContainerStatus, 0, len(rev.Spec.InitContainers))
-	}
 
 	// The image digest has already been resolved.
 	// No need to check for init containers feature flag here because rev.Spec has been validated already
@@ -108,12 +102,8 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) (boo
 	}
 
 	if len(statuses) > 0 || len(initContainerStatuses) > 0 {
-		if len(statuses) > 0 {
-			rev.Status.ContainerStatuses = statuses
-		}
-		if len(initContainerStatuses) > 0 {
-			rev.Status.InitContainerStatuses = initContainerStatuses
-		}
+		rev.Status.ContainerStatuses = statuses
+		rev.Status.InitContainerStatuses = initContainerStatuses
 		return true, nil
 	}
 

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -45,7 +45,7 @@ import (
 )
 
 type resolver interface {
-	Resolve(*zap.SugaredLogger, *v1.Revision, k8schain.Options, sets.String, time.Duration) ([]v1.ContainerStatus, error)
+	Resolve(*zap.SugaredLogger, *v1.Revision, k8schain.Options, sets.String, time.Duration) ([]v1.ContainerStatus, []v1.ContainerStatus, error)
 	Clear(types.NamespacedName)
 	Forget(types.NamespacedName)
 }
@@ -73,12 +73,15 @@ var (
 func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) (bool, error) {
 	totalNumOfContainers := len(rev.Spec.Containers) + len(rev.Spec.InitContainers)
 	if rev.Status.ContainerStatuses == nil {
-		rev.Status.ContainerStatuses = make([]v1.ContainerStatus, 0, totalNumOfContainers)
+		rev.Status.ContainerStatuses = make([]v1.ContainerStatus, 0, len(rev.Spec.Containers))
+	}
+	if rev.Status.InitContainerStatuses == nil {
+		rev.Status.InitContainerStatuses = make([]v1.ContainerStatus, 0, len(rev.Spec.InitContainers))
 	}
 
 	// The image digest has already been resolved.
 	// No need to check for init containers feature flag here because rev.Spec has been validated already
-	if len(rev.Status.ContainerStatuses) == totalNumOfContainers {
+	if len(rev.Status.ContainerStatuses)+len(rev.Status.InitContainerStatuses) == totalNumOfContainers {
 		c.resolver.Clear(types.NamespacedName{Namespace: rev.Namespace, Name: rev.Name})
 		return true, nil
 	}
@@ -95,7 +98,7 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) (boo
 	}
 
 	logger := logging.FromContext(ctx)
-	statuses, err := c.resolver.Resolve(logger, rev, opt, cfgs.Deployment.RegistriesSkippingTagResolving, cfgs.Deployment.DigestResolutionTimeout)
+	statuses, initContainerStatuses, err := c.resolver.Resolve(logger, rev, opt, cfgs.Deployment.RegistriesSkippingTagResolving, cfgs.Deployment.DigestResolutionTimeout)
 	if err != nil {
 		// Clear the resolver so we can retry the digest resolution rather than
 		// being stuck with this error.
@@ -103,8 +106,14 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) (boo
 		rev.Status.MarkContainerHealthyFalse(v1.ReasonContainerMissing, err.Error())
 		return true, err
 	}
-	if len(statuses) > 0 {
-		rev.Status.ContainerStatuses = statuses
+
+	if len(statuses) > 0 || len(initContainerStatuses) > 0 {
+		if len(statuses) > 0 {
+			rev.Status.ContainerStatuses = statuses
+		}
+		if len(initContainerStatuses) > 0 {
+			rev.Status.InitContainerStatuses = initContainerStatuses
+		}
 		return true, nil
 	}
 

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -98,7 +98,7 @@ func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) (boo
 	}
 
 	logger := logging.FromContext(ctx)
-	statuses, initContainerStatuses, err := c.resolver.Resolve(logger, rev, opt, cfgs.Deployment.RegistriesSkippingTagResolving, cfgs.Deployment.DigestResolutionTimeout)
+	initContainerStatuses, statuses, err := c.resolver.Resolve(logger, rev, opt, cfgs.Deployment.RegistriesSkippingTagResolving, cfgs.Deployment.DigestResolutionTimeout)
 	if err != nil {
 		// Clear the resolver so we can retry the digest resolution rather than
 		// being stuck with this error.

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -71,12 +71,14 @@ var (
 )
 
 func (c *Reconciler) reconcileDigest(ctx context.Context, rev *v1.Revision) (bool, error) {
+	totalNumOfContainers := len(rev.Spec.Containers) + len(rev.Spec.InitContainers)
 	if rev.Status.ContainerStatuses == nil {
-		rev.Status.ContainerStatuses = make([]v1.ContainerStatus, 0, len(rev.Spec.Containers))
+		rev.Status.ContainerStatuses = make([]v1.ContainerStatus, 0, totalNumOfContainers)
 	}
 
 	// The image digest has already been resolved.
-	if len(rev.Status.ContainerStatuses) == len(rev.Spec.Containers) {
+	// No need to check for init containers feature flag here because rev.Spec has been validated already
+	if len(rev.Status.ContainerStatuses) == totalNumOfContainers {
 		c.resolver.Clear(types.NamespacedName{Namespace: rev.Namespace, Name: rev.Name})
 		return true, nil
 	}

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -229,16 +229,17 @@ func addResourcesToInformers(t *testing.T, ctx context.Context, rev *v1.Revision
 
 type nopResolver struct{}
 
-func (r *nopResolver) Resolve(_ *zap.SugaredLogger, rev *v1.Revision, _ k8schain.Options, _ sets.String, _ time.Duration) ([]v1.ContainerStatus, error) {
+func (r *nopResolver) Resolve(_ *zap.SugaredLogger, rev *v1.Revision, _ k8schain.Options, _ sets.String, _ time.Duration) ([]v1.ContainerStatus, []v1.ContainerStatus, error) {
 	status := []v1.ContainerStatus{{
 		Name: rev.Spec.Containers[0].Name,
 	}}
 	if len(rev.Spec.InitContainers) > 0 {
-		status = append(status, v1.ContainerStatus{
+		initStatus := []v1.ContainerStatus{{
 			Name: rev.Spec.InitContainers[0].Name,
-		})
+		}}
+		return status, initStatus, nil
 	}
-	return status, nil
+	return status, nil, nil
 }
 
 func (r *nopResolver) Clear(types.NamespacedName)  {}
@@ -336,8 +337,8 @@ func testDefaultsCM() *corev1.ConfigMap {
 
 type notResolvedYetResolver struct{}
 
-func (r *notResolvedYetResolver) Resolve(_ *zap.SugaredLogger, _ *v1.Revision, _ k8schain.Options, _ sets.String, _ time.Duration) ([]v1.ContainerStatus, error) {
-	return nil, nil
+func (r *notResolvedYetResolver) Resolve(_ *zap.SugaredLogger, _ *v1.Revision, _ k8schain.Options, _ sets.String, _ time.Duration) ([]v1.ContainerStatus, []v1.ContainerStatus, error) {
+	return nil, nil, nil
 }
 
 func (r *notResolvedYetResolver) Clear(types.NamespacedName)  {}
@@ -348,8 +349,8 @@ type errorResolver struct {
 	cleared bool
 }
 
-func (r *errorResolver) Resolve(_ *zap.SugaredLogger, _ *v1.Revision, _ k8schain.Options, _ sets.String, _ time.Duration) ([]v1.ContainerStatus, error) {
-	return nil, r.err
+func (r *errorResolver) Resolve(_ *zap.SugaredLogger, _ *v1.Revision, _ k8schain.Options, _ sets.String, _ time.Duration) ([]v1.ContainerStatus, []v1.ContainerStatus, error) {
+	return nil, nil, r.err
 }
 
 func (r *errorResolver) Clear(types.NamespacedName) {

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -240,9 +240,9 @@ func (r *nopResolver) Resolve(_ *zap.SugaredLogger, rev *v1.Revision, _ k8schain
 				Name: rev.Spec.InitContainers[i].Name,
 			})
 		}
-		return status, initStatus, nil
+		return initStatus, status, nil
 	}
-	return status, nil, nil
+	return nil, status, nil
 }
 
 func (r *nopResolver) Clear(types.NamespacedName)  {}

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -234,9 +234,12 @@ func (r *nopResolver) Resolve(_ *zap.SugaredLogger, rev *v1.Revision, _ k8schain
 		Name: rev.Spec.Containers[0].Name,
 	}}
 	if len(rev.Spec.InitContainers) > 0 {
-		initStatus := []v1.ContainerStatus{{
-			Name: rev.Spec.InitContainers[0].Name,
-		}}
+		var initStatus []v1.ContainerStatus
+		for i := range rev.Spec.InitContainers {
+			initStatus = append(initStatus, v1.ContainerStatus{
+				Name: rev.Spec.InitContainers[i].Name,
+			})
+		}
 		return status, initStatus, nil
 	}
 	return status, nil, nil

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -634,7 +634,7 @@ func TestReconcile(t *testing.T) {
 		}},
 		Key: "foo/image-pull-secrets",
 	}, {
-		Name: "first revision reconciliation",
+		Name: "first revision reconciliation with init containers",
 		// Test the simplest successful reconciliation flow.
 		// We feed in a well formed Revision where none of its sub-resources exist,
 		// and we expect it to create them and initialize the Revision's status.
@@ -746,10 +746,10 @@ func withDefaultContainerStatuses() RevisionOption {
 
 func withInitContainerStatuses() RevisionOption {
 	return func(r *v1.Revision) {
-		r.Status.ContainerStatuses = append(r.Status.ContainerStatuses, v1.ContainerStatus{
+		r.Status.InitContainerStatuses = []v1.ContainerStatus{{
 			Name:        "init",
 			ImageDigest: "",
-		})
+		}}
 	}
 }
 

--- a/pkg/reconciler/testing/v1/factory.go
+++ b/pkg/reconciler/testing/v1/factory.go
@@ -119,11 +119,11 @@ func MakeFactory(ctor Ctor) rtesting.Factory {
 		// Validate all Create operations through the serving client.
 		client.PrependReactor("create", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			// TODO(n3wscott): context.Background is the best we can do at the moment, but it should be set-able.
-			return rtesting.ValidateCreates(context.Background(), action)
+			return rtesting.ValidateCreates(ctx, action)
 		})
 		client.PrependReactor("update", "*", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 			// TODO(n3wscott): context.Background is the best we can do at the moment, but it should be set-able.
-			return rtesting.ValidateUpdates(context.Background(), action)
+			return rtesting.ValidateUpdates(ctx, action)
 		})
 
 		actionRecorderList := rtesting.ActionRecorderList{dynamicClient, client, netclient, kubeClient, cachingClient}

--- a/pkg/testing/v1/revision.go
+++ b/pkg/testing/v1/revision.go
@@ -223,7 +223,10 @@ func WithRevisionObservedGeneration(gen int64) RevisionOption {
 func WithRevisionInitContainers() RevisionOption {
 	return func(r *v1.Revision) {
 		r.Spec.InitContainers = []corev1.Container{{
-			Name:  "init",
+			Name:  "init1",
+			Image: "initimage",
+		}, {
+			Name:  "init2",
 			Image: "initimage",
 		}}
 	}

--- a/pkg/testing/v1/revision.go
+++ b/pkg/testing/v1/revision.go
@@ -220,6 +220,15 @@ func WithRevisionObservedGeneration(gen int64) RevisionOption {
 	}
 }
 
+func WithRevisionInitContainers() RevisionOption {
+	return func(r *v1.Revision) {
+		r.Spec.InitContainers = []corev1.Container{{
+			Name:  "init",
+			Image: "initimage",
+		}}
+	}
+}
+
 // Revision creates a revision object with given ns/name and options.
 func Revision(namespace, name string, ro ...RevisionOption) *v1.Revision {
 	r := &v1.Revision{

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -191,3 +191,15 @@ func CreateAndVerifyInitialScaleConfiguration(t *testing.T, clients *test.Client
 		t.Fatal("Configuration does not have the desired number of pods running:", err)
 	}
 }
+
+// Get revision name from configuration.
+func RevisionFromConfiguration(clients *test.Clients, configName string) (string, error) {
+	config, err := clients.ServingClient.Configs.Get(context.Background(), configName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if config.Status.LatestCreatedRevisionName != "" {
+		return config.Status.LatestCreatedRevisionName, nil
+	}
+	return "", fmt.Errorf("no valid revision name found in configuration %s", configName)
+}

--- a/test/e2e/image_pull_error_test.go
+++ b/test/e2e/image_pull_error_test.go
@@ -65,7 +65,7 @@ func TestImagePullError(t *testing.T) {
 		t.Fatal("Failed to validate configuration state:", err)
 	}
 
-	revisionName, err := revisionFromConfiguration(clients, names.Config)
+	revisionName, err := RevisionFromConfiguration(clients, names.Config)
 	if err != nil {
 		t.Fatalf("Failed to get revision from configuration %s: %v", names.Config, err)
 	}

--- a/test/e2e/pod_schedule_error_test.go
+++ b/test/e2e/pod_schedule_error_test.go
@@ -20,14 +20,12 @@ limitations under the License.
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
 	rtesting "knative.dev/serving/pkg/testing/v1"
@@ -87,7 +85,7 @@ func TestPodScheduleError(t *testing.T) {
 		t.Fatal("Failed to validate service state:", err)
 	}
 
-	revisionName, err := revisionFromConfiguration(clients, names.Config)
+	revisionName, err := RevisionFromConfiguration(clients, names.Config)
 	if err != nil {
 		t.Fatalf("Failed to get revision from configuration %s: %v", names.Config, err)
 	}
@@ -108,16 +106,4 @@ func TestPodScheduleError(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to validate revision state:", err)
 	}
-}
-
-// Get revision name from configuration.
-func revisionFromConfiguration(clients *test.Clients, configName string) (string, error) {
-	config, err := clients.ServingClient.Configs.Get(context.Background(), configName, metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-	if config.Status.LatestCreatedRevisionName != "" {
-		return config.Status.LatestCreatedRevisionName, nil
-	}
-	return "", fmt.Errorf("no valid revision name found in configuration %s", configName)
 }


### PR DESCRIPTION
As per title, adds support for image resolution. Part of the work [here](https://github.com/knative/serving/issues/12024).
Introduces a new field in the revision status to keep the init container statuses.
Sample run with:
```
apiVersion: serving.knative.dev/v1
kind: Service
metadata:
  name: initcontainers
  namespace: default
spec:
  template:
    spec:
      containers:
        - imagePullPolicy: Always
          image: docker.io/skonto/emptydir
          volumeMounts:
            - name: data
              mountPath: /data
          env:
            - name: DATA_PATH
              value: /data
      initContainers:
        - imagePullPolicy: Always
          image: busybox
          name: init
          volumeMounts:
            - name: data
              mountPath: /data
      volumes:
        - name: data
          emptyDir: {}
```
![image](https://user-images.githubusercontent.com/7945591/139454381-8f921dc4-9967-4d8f-880e-681e8f3047e7.png)
![image](https://user-images.githubusercontent.com/7945591/139454415-61b21873-dab8-4b20-9765-2646c2073794.png)

