### PR TITLE
Add init container defaults

### DIFF
--- a/config/core/configmaps/defaults.yaml
+++ b/config/core/configmaps/defaults.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
   annotations:
-    knative.dev/example-checksum: "cdabec96"
+    knative.dev/example-checksum: "a0feb4c6"
 data:
   _example: |
     ################################
@@ -98,6 +98,13 @@ data:
     # enclosing Service or Configuration, so values such as
     # {{.Name}} are also valid.
     container-name-template: "user-container"
+
+    # init-container-name-template contains a template for the default
+    # init container name, if none is specified.  This field supports
+    # Go templating and is supplied with the ObjectMeta of the
+    # enclosing Service or Configuration, so values such as
+    # {{.Name}} are also valid.
+    init-container-name-template: "init-container"
 
     # container-concurrency specifies the maximum number
     # of requests the Container can handle at once, and requests

--- a/pkg/apis/config/defaults.go
+++ b/pkg/apis/config/defaults.go
@@ -64,9 +64,9 @@ const (
 	// containerConcurrency can be set to zero (i.e. unbounded) by users.
 	DefaultAllowContainerConcurrencyZero = true
 
-	UserContainerTemplateKeyPrefix = "user-container"
+	InitContainerTemplateKeyPrefix = DefaultInitContainerName
 
-	InitContainerTemplateKeyPrefix = "init-container"
+	UserContainerTemplateKeyPrefix = DefaultUserContainerName
 )
 
 var (

--- a/pkg/apis/config/defaults.go
+++ b/pkg/apis/config/defaults.go
@@ -240,14 +240,14 @@ func (d Defaults) InitContainerName(ctx context.Context) string {
 	return containerNameFromTemplateKey(ctx, d.makeInitContainerTemplateKey())
 }
 
-func makeTemplateKey(keyPrefix string, value string) string {
-	return fmt.Sprintf("%s-%s", keyPrefix, value)
-}
-
 func (d Defaults) makeUserContainerTemplateKey() string {
 	return makeTemplateKey(userContainerTemplateKeyPrefix, d.UserContainerNameTemplate)
 }
 
 func (d Defaults) makeInitContainerTemplateKey() string {
 	return makeTemplateKey(initContainerTemplateKeyPrefix, d.InitContainerNameTemplate)
+}
+
+func makeTemplateKey(prefix string, value string) string {
+	return fmt.Sprintf("%s-%s", prefix, value)
 }

--- a/pkg/apis/config/defaults.go
+++ b/pkg/apis/config/defaults.go
@@ -230,7 +230,7 @@ func (d Defaults) UserContainerName(ctx context.Context) string {
 	return containerNameFromTemplate(ctx, d.UserContainerNameTemplate)
 }
 
-// InitContainerName returns the name of the user container based on the context.
+// InitContainerName returns the name of the init container based on the context.
 func (d Defaults) InitContainerName(ctx context.Context) string {
 	return containerNameFromTemplate(ctx, d.InitContainerNameTemplate)
 }

--- a/pkg/apis/config/defaults_test.go
+++ b/pkg/apis/config/defaults_test.go
@@ -78,6 +78,7 @@ func TestDefaultsConfiguration(t *testing.T) {
 			ContainerConcurrencyMaxLimit: 1984,
 			RevisionCPURequest:           &oneTwoThree,
 			UserContainerNameTemplate:    "{{.Name}}",
+			InitContainerNameTemplate:    "{{.Name}}",
 			EnableServiceLinks:           ptr.Bool(true),
 		},
 		data: map[string]string{
@@ -86,6 +87,7 @@ func TestDefaultsConfiguration(t *testing.T) {
 			"revision-cpu-request":             "123m",
 			"container-concurrency-max-limit":  "1984",
 			"container-name-template":          "{{.Name}}",
+			"init-container-name-template":     "{{.Name}}",
 			"allow-container-concurrency-zero": "false",
 			"enable-service-links":             "true",
 		},
@@ -95,6 +97,7 @@ func TestDefaultsConfiguration(t *testing.T) {
 		wantDefaults: &Defaults{
 			RevisionTimeoutSeconds:        DefaultRevisionTimeoutSeconds,
 			MaxRevisionTimeoutSeconds:     DefaultMaxRevisionTimeoutSeconds,
+			InitContainerNameTemplate:     DefaultInitContainerName,
 			UserContainerNameTemplate:     DefaultUserContainerName,
 			ContainerConcurrencyMaxLimit:  DefaultMaxRevisionContainerConcurrency,
 			AllowContainerConcurrencyZero: true,
@@ -109,6 +112,7 @@ func TestDefaultsConfiguration(t *testing.T) {
 		wantDefaults: &Defaults{
 			RevisionTimeoutSeconds:        DefaultRevisionTimeoutSeconds,
 			MaxRevisionTimeoutSeconds:     DefaultMaxRevisionTimeoutSeconds,
+			InitContainerNameTemplate:     DefaultInitContainerName,
 			UserContainerNameTemplate:     DefaultUserContainerName,
 			ContainerConcurrencyMaxLimit:  DefaultMaxRevisionContainerConcurrency,
 			AllowContainerConcurrencyZero: true,
@@ -222,7 +226,8 @@ func TestTemplating(t *testing.T) {
 					Name:      DefaultsConfigName,
 				},
 				Data: map[string]string{
-					"container-name-template": test.template,
+					"container-name-template":      test.template,
+					"init-container-name-template": test.template,
 				},
 			}
 			defCM, err := NewDefaultsConfigFromConfigMap(configMap)
@@ -244,15 +249,20 @@ func TestTemplating(t *testing.T) {
 				Namespace: "guardians",
 			})
 
-			if got, want := def.UserContainerName(ctx), test.want; got != want {
-				t.Errorf("UserContainerName() = %v, wanted %v", got, want)
+			if got, want := ContainerNameFromTemplate(ctx, def.UserContainerNameTemplate, DefaultUserContainerName), test.want; got != want {
+				t.Errorf("ContainerNameFromTemplate() = %v, wanted %v", got, want)
+			}
+
+			if got, want := ContainerNameFromTemplate(ctx, def.InitContainerNameTemplate, DefaultInitContainerName), test.want; got != want {
+				t.Errorf("ContainerNameFromTemplate() = %v, wanted %v", got, want)
 			}
 		})
 	}
 	t.Run("bad-template", func(t *testing.T) {
 		configMap := &corev1.ConfigMap{
 			Data: map[string]string{
-				"container-name-template": "{{animals-being-bros]]",
+				"container-name-template":      "{{animals-being-bros]]",
+				"init-container-name-template": "{{animals-being-bros]]",
 			},
 		}
 		_, err := NewDefaultsConfigFromConfigMap(configMap)

--- a/pkg/apis/config/defaults_test.go
+++ b/pkg/apis/config/defaults_test.go
@@ -265,11 +265,11 @@ func TestTemplating(t *testing.T) {
 				Namespace: "guardians",
 			})
 
-			if got, want := ContainerNameFromTemplateKey(ctx, MakeTemplateKey(UserContainerTemplateKeyPrefix, def.UserContainerNameTemplate)), test.want; got != want {
+			if got, want := def.UserContainerName(ctx), test.want; got != want {
 				t.Errorf("ContainerNameFromTemplate() = %v, wanted %v", got, want)
 			}
 
-			if got, want := ContainerNameFromTemplateKey(ctx, MakeTemplateKey(InitContainerTemplateKeyPrefix, def.InitContainerNameTemplate)), test.want; got != want {
+			if got, want := def.InitContainerName(ctx), test.want; got != want {
 				t.Errorf("ContainerNameFromTemplate() = %v, wanted %v", got, want)
 			}
 		})

--- a/pkg/apis/config/defaults_test.go
+++ b/pkg/apis/config/defaults_test.go
@@ -178,6 +178,22 @@ func TestDefaultsConfiguration(t *testing.T) {
 		data: map[string]string{
 			"container-concurrency-max-limit": "0",
 		},
+	}, {
+		name:    "different user and init container name template values",
+		wantErr: false,
+		wantDefaults: &Defaults{
+			RevisionTimeoutSeconds:        DefaultRevisionTimeoutSeconds,
+			MaxRevisionTimeoutSeconds:     DefaultMaxRevisionTimeoutSeconds,
+			ContainerConcurrencyMaxLimit:  DefaultMaxRevisionContainerConcurrency,
+			AllowContainerConcurrencyZero: DefaultAllowContainerConcurrencyZero,
+			EnableServiceLinks:            ptr.Bool(false),
+			UserContainerNameTemplate:     "{{.Name}}",
+			InitContainerNameTemplate:     "my-template",
+		},
+		data: map[string]string{
+			"container-name-template":      "{{.Name}}",
+			"init-container-name-template": "my-template",
+		},
 	}}
 
 	for _, tt := range configTests {
@@ -249,11 +265,11 @@ func TestTemplating(t *testing.T) {
 				Namespace: "guardians",
 			})
 
-			if got, want := ContainerNameFromTemplate(ctx, def.UserContainerNameTemplate, DefaultUserContainerName), test.want; got != want {
+			if got, want := ContainerNameFromTemplateKey(ctx, MakeTemplateKey(UserContainerTemplateKeyPrefix, def.UserContainerNameTemplate)), test.want; got != want {
 				t.Errorf("ContainerNameFromTemplate() = %v, wanted %v", got, want)
 			}
 
-			if got, want := ContainerNameFromTemplate(ctx, def.InitContainerNameTemplate, DefaultInitContainerName), test.want; got != want {
+			if got, want := ContainerNameFromTemplateKey(ctx, MakeTemplateKey(InitContainerTemplateKeyPrefix, def.InitContainerNameTemplate)), test.want; got != want {
 				t.Errorf("ContainerNameFromTemplate() = %v, wanted %v", got, want)
 			}
 		})

--- a/pkg/apis/config/defaults_test.go
+++ b/pkg/apis/config/defaults_test.go
@@ -266,11 +266,11 @@ func TestTemplating(t *testing.T) {
 			})
 
 			if got, want := def.UserContainerName(ctx), test.want; got != want {
-				t.Errorf("ContainerNameFromTemplate() = %v, wanted %v", got, want)
+				t.Errorf("UserContainerName() = %v, wanted %v", got, want)
 			}
 
 			if got, want := def.InitContainerName(ctx), test.want; got != want {
-				t.Errorf("ContainerNameFromTemplate() = %v, wanted %v", got, want)
+				t.Errorf("InitContainerName() = %v, wanted %v", got, want)
 			}
 		})
 	}

--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -66,9 +66,9 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 	for idx := range rs.PodSpec.InitContainers {
 		containerNames.Insert(rs.PodSpec.InitContainers[idx].Name)
 	}
-	defaultUserContainerName := config.ContainerNameFromTemplateKey(ctx, config.MakeTemplateKey(config.UserContainerTemplateKeyPrefix, cfg.Defaults.UserContainerNameTemplate))
+	defaultUserContainerName := cfg.Defaults.UserContainerName(ctx)
 	applyDefaultContainerNames(rs.PodSpec.Containers, containerNames, defaultUserContainerName)
-	defaultInitContainerName := config.ContainerNameFromTemplateKey(ctx, config.MakeTemplateKey(config.InitContainerTemplateKeyPrefix, cfg.Defaults.InitContainerNameTemplate))
+	defaultInitContainerName := cfg.Defaults.InitContainerName(ctx)
 	applyDefaultContainerNames(rs.PodSpec.InitContainers, containerNames, defaultInitContainerName)
 	for idx := range rs.PodSpec.Containers {
 		rs.applyDefault(ctx, &rs.PodSpec.Containers[idx], cfg)

--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -66,9 +66,9 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 	for idx := range rs.PodSpec.InitContainers {
 		containerNames.Insert(rs.PodSpec.InitContainers[idx].Name)
 	}
-	defaultUserContainerName := config.ContainerNameFromTemplate(ctx, cfg.Defaults.UserContainerNameTemplate, config.DefaultUserContainerName)
+	defaultUserContainerName := config.ContainerNameFromTemplateKey(ctx, config.MakeTemplateKey(config.UserContainerTemplateKeyPrefix, cfg.Defaults.UserContainerNameTemplate))
 	applyDefaultContainerNames(rs.PodSpec.Containers, containerNames, defaultUserContainerName)
-	defaultInitContainerName := config.ContainerNameFromTemplate(ctx, cfg.Defaults.InitContainerNameTemplate, config.DefaultInitContainerName)
+	defaultInitContainerName := config.ContainerNameFromTemplateKey(ctx, config.MakeTemplateKey(config.InitContainerTemplateKeyPrefix, cfg.Defaults.InitContainerNameTemplate))
 	applyDefaultContainerNames(rs.PodSpec.InitContainers, containerNames, defaultInitContainerName)
 	for idx := range rs.PodSpec.Containers {
 		rs.applyDefault(ctx, &rs.PodSpec.Containers[idx], cfg)

--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -166,7 +166,7 @@ func applyDefaultContainerNames(containers []corev1.Container, containerNames se
 		if containers[idx].Name == "" {
 			name := defaultContainerName
 
-			if len(containers) > 1 {
+			if len(containerNames) > 1 {
 				for {
 					name = kmeta.ChildName(defaultContainerName, "-"+strconv.Itoa(nextSuffix))
 					nextSuffix++

--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -59,34 +59,18 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 	}
 
 	// Avoid clashes with user-supplied names when generating defaults.
-	userContainerNames := make(sets.String, len(rs.PodSpec.Containers))
+	containerNames := make(sets.String, len(rs.PodSpec.Containers)+len(rs.PodSpec.InitContainers))
 	for idx := range rs.PodSpec.Containers {
-		userContainerNames.Insert(rs.PodSpec.Containers[idx].Name)
+		containerNames.Insert(rs.PodSpec.Containers[idx].Name)
 	}
-
-	// Default container name based on UserContainerName value from configmap.
-	// In multi-container mode, add a numeric suffix, avoiding clashes with user-supplied names.
-	nextSuffix := 0
-	defaultContainerName := cfg.Defaults.UserContainerName(ctx)
+	for idx := range rs.PodSpec.InitContainers {
+		containerNames.Insert(rs.PodSpec.InitContainers[idx].Name)
+	}
+	defaultUserContainerName := config.ContainerNameFromTemplate(ctx, cfg.Defaults.UserContainerNameTemplate, config.DefaultUserContainerName)
+	applyDefaultContainerNames(rs.PodSpec.Containers, containerNames, defaultUserContainerName)
+	defaultInitContainerName := config.ContainerNameFromTemplate(ctx, cfg.Defaults.InitContainerNameTemplate, config.DefaultInitContainerName)
+	applyDefaultContainerNames(rs.PodSpec.InitContainers, containerNames, defaultInitContainerName)
 	for idx := range rs.PodSpec.Containers {
-		if rs.PodSpec.Containers[idx].Name == "" {
-			name := defaultContainerName
-
-			if len(rs.PodSpec.Containers) > 1 {
-				for {
-					name = kmeta.ChildName(defaultContainerName, "-"+strconv.Itoa(nextSuffix))
-					nextSuffix++
-
-					// Continue until we get a name that doesn't clash with a user-supplied name.
-					if !userContainerNames.Has(name) {
-						break
-					}
-				}
-			}
-
-			rs.PodSpec.Containers[idx].Name = name
-		}
-
 		rs.applyDefault(ctx, &rs.PodSpec.Containers[idx], cfg)
 	}
 }
@@ -170,6 +154,31 @@ func (*RevisionSpec) applyProbes(container *corev1.Container) {
 		}
 		if container.ReadinessProbe.TimeoutSeconds == 0 {
 			container.ReadinessProbe.TimeoutSeconds = 1
+		}
+	}
+}
+
+func applyDefaultContainerNames(containers []corev1.Container, containerNames sets.String, defaultContainerName string) {
+	// Default container name based on ContainerNameFromTemplate value from configmap.
+	// In multi-container mode, add a numeric suffix, avoiding clashes with user-supplied names.
+	nextSuffix := 0
+	for idx := range containers {
+		if containers[idx].Name == "" {
+			name := defaultContainerName
+
+			if len(containers) > 1 {
+				for {
+					name = kmeta.ChildName(defaultContainerName, "-"+strconv.Itoa(nextSuffix))
+					nextSuffix++
+
+					// Continue until we get a name that doesn't clash with a user-supplied name.
+					if !containerNames.Has(name) {
+						break
+					}
+				}
+			}
+
+			containers[idx].Name = name
 		}
 	}
 }

--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -160,13 +160,13 @@ func (*RevisionSpec) applyProbes(container *corev1.Container) {
 
 func applyDefaultContainerNames(containers []corev1.Container, containerNames sets.String, defaultContainerName string) {
 	// Default container name based on ContainerNameFromTemplate value from configmap.
-	// In multi-container mode, add a numeric suffix, avoiding clashes with user-supplied names.
+	// In multi-container or init-container mode, add a numeric suffix, avoiding clashes with user-supplied names.
 	nextSuffix := 0
 	for idx := range containers {
 		if containers[idx].Name == "" {
 			name := defaultContainerName
 
-			if len(containerNames) > 1 {
+			if len(containers) > 1 || containerNames.Has(name) {
 				for {
 					name = kmeta.ChildName(defaultContainerName, "-"+strconv.Itoa(nextSuffix))
 					nextSuffix++

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -729,6 +729,59 @@ func TestRevisionDefaulting(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "multiple init and user containers with same names empty",
+		in: &Revision{
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 8888,
+						}},
+					}, {
+						Name: "",
+					}},
+					InitContainers: []corev1.Container{{
+						Name: "init1",
+					}, {
+						Name: "init2",
+					}, {
+						Name: "",
+					}, {
+						Name: "",
+					}},
+				},
+			},
+		},
+		want: &Revision{
+			Spec: RevisionSpec{
+				TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+				ContainerConcurrency: ptr.Int64(config.DefaultContainerConcurrency),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:           "user-container-0",
+						Resources:      defaultResources,
+						ReadinessProbe: defaultProbe,
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 8888,
+						}},
+					}, {
+						Name:      "user-container-1",
+						Resources: defaultResources,
+					}},
+					InitContainers: []corev1.Container{{
+						Name: "init1",
+					}, {
+						Name: "init2",
+					}, {
+						Name: "init-container-0",
+					}, {
+						Name: "init-container-1",
+					}},
+				},
+			},
+		},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -782,6 +782,59 @@ func TestRevisionDefaulting(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "multiple init and user containers with some conflicting default names",
+		in: &Revision{
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "init-container-0",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 8888,
+						}},
+					}, {
+						Name: "init-container-1",
+					}},
+					InitContainers: []corev1.Container{{
+						Name: "init1",
+					}, {
+						Name: "init2",
+					}, {
+						Name: "",
+					}, {
+						Name: "",
+					}},
+				},
+			},
+		},
+		want: &Revision{
+			Spec: RevisionSpec{
+				TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+				ContainerConcurrency: ptr.Int64(config.DefaultContainerConcurrency),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:           "init-container-0",
+						Resources:      defaultResources,
+						ReadinessProbe: defaultProbe,
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 8888,
+						}},
+					}, {
+						Name:      "init-container-1",
+						Resources: defaultResources,
+					}},
+					InitContainers: []corev1.Container{{
+						Name: "init1",
+					}, {
+						Name: "init2",
+					}, {
+						Name: "init-container-2",
+					}, {
+						Name: "init-container-3",
+					}},
+				},
+			},
+		},
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -677,7 +677,7 @@ func TestRevisionDefaulting(t *testing.T) {
 			},
 		},
 	}, {
-		name: "multiple init containers with same names empty",
+		name: "multiple init containers with some names empty",
 		in: &Revision{
 			Spec: RevisionSpec{
 				PodSpec: corev1.PodSpec{
@@ -730,7 +730,7 @@ func TestRevisionDefaulting(t *testing.T) {
 			},
 		},
 	}, {
-		name: "multiple init and user containers with same names empty",
+		name: "multiple init and user containers with some names empty",
 		in: &Revision{
 			Spec: RevisionSpec{
 				PodSpec: corev1.PodSpec{


### PR DESCRIPTION
As per title, adds support for init container defaults. Currently the container name is set based on a configurable template.
If we need to setup other defaults like cpu limits etc can be done as well in this or another PR.
Goal of the PR is:
-  fix current issue where a missing init container name leads to a failed deployment (a bit too late since validation does not catch it).
- keep the same UX as the one for the user containers.

Part of the work [here](https://github.com/knative/serving/issues/12024).
Sample run with default template:

```
apiVersion: serving.knative.dev/v1
kind: Service
metadata:
  name: initcontainers
  namespace: default
spec:
  template:
    spec:
      containers:
        - imagePullPolicy: Always
          image: docker.io/skonto/emptydir
          volumeMounts:
            - name: data
              mountPath: /data
          env:
            - name: DATA_PATH
              value: /data
      initContainers:
        - imagePullPolicy: Always
          image: busybox
          volumeMounts:
            - name: data
              mountPath: /data
        - imagePullPolicy: Always
          image: busybox
          volumeMounts:
            - name: data
              mountPath: /data              
      volumes:
        - name: data
          emptyDir: {}

```
![image](https://user-images.githubusercontent.com/7945591/138119367-8564a2f6-c3ce-4c67-a0ef-5db2ac1ca5d8.png)
Setting `init-container-name-template: random-template` in cm config-defaults:
![image](https://user-images.githubusercontent.com/7945591/138119842-48f652a4-7765-4549-a080-adbe5df37ee4.png)

/cc @dprotaso @julz @markusthoemmes 