### PR TITLE
Freeze pod after startup if container-freezer enabled

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -296,6 +296,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, pro
 			}
 		}()
 		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, ce.Pause, ce.Resume)
+		ce.Pause() // start paused
 	}
 	if metricsSupported {
 		composedHandler = requestAppMetricsHandler(logger, composedHandler, breaker, env)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -296,7 +296,11 @@ func buildServer(ctx context.Context, env config, healthState *health.State, pro
 			}
 		}()
 		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, ce.Pause, ce.Resume)
-		ce.Pause() // start paused
+		// start paused
+		if err := ce.Pause(); err != nil {
+			logger.Errorf("Error handling initial start request: %v", err)
+			queue.HandleStateRequestError(logger, ce.Pause)
+		}
 	}
 	if metricsSupported {
 		composedHandler = requestAppMetricsHandler(logger, composedHandler, breaker, env)

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -298,7 +298,7 @@ func buildServer(ctx context.Context, env config, healthState *health.State, pro
 		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, ce.Pause, ce.Resume)
 		// start paused
 		if err := ce.Pause(); err != nil {
-			logger.Errorf("Error handling initial start request: %v", err)
+			logger.Errorf("Error handling initial pause request: %v", err)
 			queue.HandleStateRequestError(logger, ce.Pause)
 		}
 	}

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -54,7 +54,7 @@ func ConcurrencyStateHandler(logger *zap.SugaredLogger, h http.Handler, pause, r
 					logger.Info("Requests dropped to zero")
 					if err := pause(); err != nil {
 						logger.Errorf("Error handling resume request: %v", err)
-						handleStateRequestError(logger, pause)
+						HandleStateRequestError(logger, pause)
 					}
 					paused = true
 					logger.Debug("To-Zero request successfully processed")
@@ -83,7 +83,7 @@ func ConcurrencyStateHandler(logger *zap.SugaredLogger, h http.Handler, pause, r
 		logger.Info("Requests increased from zero")
 		if err := resume(); err != nil {
 			logger.Errorf("Error handling resume request: %v", err)
-			handleStateRequestError(logger, resume)
+			HandleStateRequestError(logger, resume)
 		}
 		paused = false
 		logger.Debug("From-Zero request successfully processed")
@@ -93,8 +93,8 @@ func ConcurrencyStateHandler(logger *zap.SugaredLogger, h http.Handler, pause, r
 	}
 }
 
-// handleStateRequestError handles retry logic
-func handleStateRequestError(logger *zap.SugaredLogger, requestHandler func() error) {
+// HandleStateRequestError handles retry logic
+func HandleStateRequestError(logger *zap.SugaredLogger, requestHandler func() error) {
 	var errReq error
 	retryFunc := func() (bool, error) {
 		errReq = requestHandler()


### PR DESCRIPTION
## Proposed Changes

* :bug: This fixes a bug with the container freezer, where pods were not initially frozen after creation (the pod would run until a request was sent, then it would freeze). 

/area autoscale
/assign @julz @markusthoemmes 