### PR TITLE
Revert "Pin GKE to 1.20 until issues/12091 was solved (#12093)"

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -170,8 +170,7 @@ function delete_dns_record() {
 # Skip installing istio as an add-on
 # Temporarily increasing the cluster size for serving tests to rule out
 # resource/eviction as causes of flakiness.
-# Pin to 1.20 since scale test is super flakey on 1.21
-initialize "$@" --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha --cluster-version=1.20
+initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha "$@"
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -32,8 +32,7 @@ source $(dirname $0)/e2e-common.sh
 # Skip installing istio as an add-on.
 # Temporarily increasing the cluster size for serving tests to rule out
 # resource/eviction as causes of flakiness.
-# Pin to 1.20 since scale test is super flakey on 1.21
-initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha --cluster-version=1.20 "$@"
+initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha "$@"
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -36,9 +36,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/e2e-common.sh"
 # Skip installing istio as an add-on.
 # Temporarily increasing the cluster size for serving tests to rule out
 # resource/eviction as causes of flakiness.
-# Pin to 1.20 since scale test is super flakey on 1.21
-initialize "$@" --skip-istio-addon  --min-nodes=4 --max-nodes=4 --cluster-version=1.20 \
-  --install-latest-release
+initialize --skip-istio-addon  --min-nodes=4 --max-nodes=4 --install-latest-release "$@"
 
 # TODO(#2656): Reduce the timeout after we get this test to consistently passing.
 TIMEOUT=30m


### PR DESCRIPTION
This reverts commit a5679c5ba21e2ca8e27331df55a18e289c951ef3.

I cannot find the root cause in [doc](https://cloud.google.com/kubernetes-engine/docs/release-notes
) but it seems GKE 1.21 is stable. Let's see the test on serving repo as well.