### PR TITLE
[github-actions] Using k8s 1.22.2 version

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -20,7 +20,7 @@ jobs:
         k8s-version:
         - v1.20.7
         - v1.21.1
-        - v1.22.0
+        - v1.22.2
 
         test-suite:
         - ./test/conformance/runtime
@@ -42,9 +42,9 @@ jobs:
           kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
           kingress: kourier
           cluster-suffix: c${{ github.run_id }}.local
-        - k8s-version: v1.22.0
+        - k8s-version: v1.22.2
           kind-version: v0.11.1
-          kind-image-sha: sha256:f97edf7f7ed53c57762b24f90a34fad101386c5bd4d93baeb45449557148c717
+          kind-image-sha: sha256:f638a08c1f68fe2a99e724ace6df233a546eaf6713019a0b310130a4f91ebe7f
           kingress: istio
           cluster-suffix: c${{ github.run_id }}.local
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Using k8s 1.22.2 version in kind-e2e workflow
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
