### PR TITLE
Avoid controller startup race in nscert_test.go

### DIFF
--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -134,6 +134,11 @@ func newTestSetup(t *testing.T, configs ...*corev1.ConfigMap) (
 
 	var eg errgroup.Group
 	eg.Go(func() error { return ctl.RunContext(ctx, 1) })
+
+	// Short pause to ensure that the controller has started
+	// Ick, but this brought test flakiness from 1-in-100 to less than 1-in-2000.
+	time.Sleep(10 * time.Millisecond)
+
 	return ctx, func() {
 		cancel()
 		eg.Wait()


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* In #12174, I saw the unit tests fail _once_ with a race in `TestUpdateDomainTemplate`. Running with `-count=100` on the test suite, I could get around 0-3 failures between `TestUpdateDomainTemplate` and `TestChangeDefaultDomain`. In all cases, it was a timeout on the first read from the `certEvents` chan; some additional logging suggested that the controller thread was "losing" the race with the Namespace create 4 lines after `newTestSetup`. I couldn't see a good way to await the controller starting its loop; a 10ms pause is both probably overkill and an overall 40s out of 923s for running `-count=2000` on my laptop.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
