### PR TITLE
update fetching the latest istio release

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -61,8 +61,8 @@ LATEST_SERVING_RELEASE_VERSION=$(latest_version)
 
 # Latest net-istio release.
 LATEST_NET_ISTIO_RELEASE_VERSION=$(
-  curl -L --silent "https://api.github.com/repos/knative/net-istio/releases" | grep '"tag_name"' \
-    | cut -f2 -d: | sed "s/[^v0-9.]//g" | sort | tail -n1)
+  curl -L --silent "https://api.github.com/repos/knative/net-istio/releases" | \
+    jq -r '[.[].tag_name] | sort_by( sub("knative-";"") | sub("v";"") | split(".") | map(tonumber) ) | reverse[0]')
 
 # Parse our custom flags.
 function parse_flags() {


### PR DESCRIPTION
Fixes the breakage in the upgrade script since we've introduced a new tag format `knative-vX.Y.Z` for our releases