### PR TITLE
Fix fetching latest net-istio release

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -60,9 +60,8 @@ readonly BUCKETS=10
 LATEST_SERVING_RELEASE_VERSION=$(latest_version)
 
 # Latest net-istio release.
-LATEST_NET_ISTIO_RELEASE_VERSION=$(
-  curl -L --silent "https://api.github.com/repos/knative/net-istio/releases" | grep '"tag_name"' \
-    | cut -f2 -d: | sed "s/[^v0-9.]//g" | sort | tail -n1)
+LATEST_NET_ISTIO_RELEASE_VERSION=$(curl -L --silent "https://api.github.com/repos/knative/net-istio/releases/latest" \
+  | jq -r '.tag_name')
 
 # Parse our custom flags.
 function parse_flags() {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Fix the logic for how we find the latest net-istio release in tests

The current logic is [failing net-istio tests](https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_serving/12210/pull-knative-serving-upgrade-tests/1455491655346950144#1:build-log.txt%3A349). This is the URL it's resolving to: https://github.com/knative-sandbox/net-istio/releases/download/vv1.0.0/net-istio.yaml

I'm just crossing my fingers we have `jq` in CI envs, can switch to some stupid sed nonsense if need be.

I don't know if there is a good reason we were doing version comparisons manually before rather than using GitHub's `/latest` endpoint