### PR TITLE
Allow probes to explicitly set the port to the containerPort (#8288)

### DIFF
--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -366,6 +366,7 @@ func HTTPGetActionMask(in *corev1.HTTPGetAction) *corev1.HTTPGetAction {
 	out.Path = in.Path
 	out.Scheme = in.Scheme
 	out.HTTPHeaders = in.HTTPHeaders
+	out.Port = in.Port
 
 	return out
 }
@@ -381,6 +382,7 @@ func TCPSocketActionMask(in *corev1.TCPSocketAction) *corev1.TCPSocketAction {
 
 	// Allowed fields
 	out.Host = in.Host
+	out.Port = in.Port
 
 	return out
 }

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -309,6 +309,7 @@ func TestHTTPGetActionMask(t *testing.T) {
 		Path:        "/bar",
 		Scheme:      corev1.URISchemeHTTP,
 		HTTPHeaders: []corev1.HTTPHeader{{}},
+		Port:        intstr.FromInt(8080),
 	}
 	in := &corev1.HTTPGetAction{
 		Host:        "foo",
@@ -338,10 +339,11 @@ func TestHTTPGetActionMask(t *testing.T) {
 func TestTCPSocketActionMask(t *testing.T) {
 	want := &corev1.TCPSocketAction{
 		Host: "foo",
+		Port: intstr.FromString("https"),
 	}
 	in := &corev1.TCPSocketAction{
 		Host: "foo",
-		Port: intstr.FromInt(8080),
+		Port: intstr.FromString("https"),
 	}
 
 	got := TCPSocketActionMask(in)

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
@@ -324,14 +325,19 @@ func ValidatePodSpec(ctx context.Context, ps corev1.PodSpec) *apis.FieldError {
 		errs = errs.Also(err.ViaField("volumes"))
 	}
 
+	err, port := validateContainersPorts(ps.Containers)
+	if err != nil {
+		errs = errs.Also(err.ViaField("containers[*]"))
+	}
+
 	switch len(ps.Containers) {
 	case 0:
 		errs = errs.Also(apis.ErrMissingField("containers"))
 	case 1:
-		errs = errs.Also(ValidateContainer(ctx, ps.Containers[0], volumes).
+		errs = errs.Also(ValidateContainer(ctx, ps.Containers[0], volumes, port).
 			ViaFieldIndex("containers", 0))
 	default:
-		errs = errs.Also(validateContainers(ctx, ps.Containers, volumes))
+		errs = errs.Also(validateContainers(ctx, ps.Containers, volumes, port))
 	}
 	if ps.ServiceAccountName != "" {
 		for _, err := range validation.IsDNS1123Subdomain(ps.ServiceAccountName) {
@@ -356,20 +362,20 @@ func validateInitContainers(ctx context.Context, containers []corev1.Container, 
 	return errs
 }
 
-func validateContainers(ctx context.Context, containers []corev1.Container, volumes map[string]corev1.Volume) (errs *apis.FieldError) {
+func validateContainers(ctx context.Context, containers []corev1.Container, volumes map[string]corev1.Volume, port intstr.IntOrString) (errs *apis.FieldError) {
 	features := config.FromContextOrDefaults(ctx).Features
 	if features.MultiContainer != config.Enabled {
 		return errs.Also(&apis.FieldError{Message: fmt.Sprintf("multi-container is off, "+
 			"but found %d containers", len(containers))})
 	}
-	errs = errs.Also(validateContainersPorts(containers).ViaField("containers"))
 	for i := range containers {
 		// Probes are not allowed on other than serving container,
 		// ref: http://bit.ly/probes-condition
 		if len(containers[i].Ports) == 0 {
+			// Note, if we allow readiness/liveness checks on sidecars, we should pass in an *empty* port here, not the main container's port.
 			errs = errs.Also(validateSidecarContainer(WithinSidecarContainer(ctx), containers[i], volumes).ViaFieldIndex("containers", i))
 		} else {
-			errs = errs.Also(ValidateContainer(WithinUserContainer(ctx), containers[i], volumes).ViaFieldIndex("containers", i))
+			errs = errs.Also(ValidateContainer(WithinUserContainer(ctx), containers[i], volumes, port).ViaFieldIndex("containers", i))
 		}
 	}
 	return errs
@@ -386,21 +392,35 @@ func AllMountedVolumes(containers []corev1.Container) sets.String {
 	return volumeNames
 }
 
-// validateContainersPorts validates port when specified multiple containers
-func validateContainersPorts(containers []corev1.Container) *apis.FieldError {
+// validateContainersPorts validates port when specified multiple containers,
+// and returns the single serving port if error is nil
+func validateContainersPorts(containers []corev1.Container) (*apis.FieldError, intstr.IntOrString) {
 	var count int
+	var port = intstr.IntOrString{IntVal: 8080, StrVal: "http"}
 	for i := range containers {
-		count += len(containers[i].Ports)
+		if c := len(containers[i].Ports); c > 0 {
+			count += c
+			if containers[i].Ports[0].ContainerPort != 0 {
+				port.IntVal = containers[i].Ports[0].ContainerPort
+			}
+			if containers[i].Ports[0].Name != "" {
+				port.StrVal = containers[i].Ports[0].Name
+			}
+		}
 	}
 	// When no container ports are specified.
-	if count == 0 {
-		return apis.ErrMissingField("ports")
+	if count == 0 && len(containers) > 1 {
+		return apis.ErrMissingField("ports"), port
 	}
 	// More than one container sections have ports.
 	if count > 1 {
-		return apis.ErrMultipleOneOf("ports")
+		return &apis.FieldError{
+			Message: "more than one container port is set",
+			Paths:   []string{"ports"},
+			Details: "Only a single port is allowed across all containers",
+		}, port
 	}
-	return nil
+	return nil, port
 }
 
 // validateSidecarContainer validate fields for non serving containers
@@ -447,25 +467,12 @@ func validateInitContainer(ctx context.Context, container corev1.Container, volu
 }
 
 // ValidateContainer validate fields for serving containers
-func ValidateContainer(ctx context.Context, container corev1.Container, volumes map[string]corev1.Volume) (errs *apis.FieldError) {
-	// Single container cannot have multiple ports
-	errs = errs.Also(portValidation(container.Ports).ViaField("ports"))
+func ValidateContainer(ctx context.Context, container corev1.Container, volumes map[string]corev1.Volume, port intstr.IntOrString) (errs *apis.FieldError) {
 	// Liveness Probes
-	errs = errs.Also(validateProbe(container.LivenessProbe).ViaField("livenessProbe"))
+	errs = errs.Also(validateProbe(container.LivenessProbe, port).ViaField("livenessProbe"))
 	// Readiness Probes
-	errs = errs.Also(validateReadinessProbe(container.ReadinessProbe).ViaField("readinessProbe"))
+	errs = errs.Also(validateReadinessProbe(container.ReadinessProbe, port).ViaField("readinessProbe"))
 	return errs.Also(validate(ctx, container, volumes))
-}
-
-func portValidation(containerPorts []corev1.ContainerPort) *apis.FieldError {
-	if len(containerPorts) > 1 {
-		return &apis.FieldError{
-			Message: "More than one container port is set",
-			Paths:   []string{apis.CurrentField},
-			Details: "Only a single port is allowed",
-		}
-	}
-	return nil
 }
 
 func validate(ctx context.Context, container corev1.Container, volumes map[string]corev1.Volume) *apis.FieldError {
@@ -653,12 +660,12 @@ func validateContainerPortBasic(port corev1.ContainerPort) *apis.FieldError {
 	return errs
 }
 
-func validateReadinessProbe(p *corev1.Probe) *apis.FieldError {
+func validateReadinessProbe(p *corev1.Probe, port intstr.IntOrString) *apis.FieldError {
 	if p == nil {
 		return nil
 	}
 
-	errs := validateProbe(p)
+	errs := validateProbe(p, port)
 
 	if p.PeriodSeconds < 0 {
 		errs = errs.Also(apis.ErrOutOfBoundsValue(p.PeriodSeconds, 0, math.MaxInt32, "periodSeconds"))
@@ -700,7 +707,7 @@ func validateReadinessProbe(p *corev1.Probe) *apis.FieldError {
 	return errs
 }
 
-func validateProbe(p *corev1.Probe) *apis.FieldError {
+func validateProbe(p *corev1.Probe, port intstr.IntOrString) *apis.FieldError {
 	if p == nil {
 		return nil
 	}
@@ -714,10 +721,18 @@ func validateProbe(p *corev1.Probe) *apis.FieldError {
 	if h.HTTPGet != nil {
 		handlers = append(handlers, "httpGet")
 		errs = errs.Also(apis.CheckDisallowedFields(*h.HTTPGet, *HTTPGetActionMask(h.HTTPGet))).ViaField("httpGet")
+		getPort := h.HTTPGet.Port
+		if (getPort.StrVal != "" && getPort.StrVal != port.StrVal) || (getPort.IntVal != 0 && getPort.IntVal != port.IntVal) {
+			errs = errs.Also(apis.ErrInvalidValue(getPort.String(), "httpGet.port", "May only probe containerPort"))
+		}
 	}
 	if h.TCPSocket != nil {
 		handlers = append(handlers, "tcpSocket")
 		errs = errs.Also(apis.CheckDisallowedFields(*h.TCPSocket, *TCPSocketActionMask(h.TCPSocket))).ViaField("tcpSocket")
+		tcpPort := h.TCPSocket.Port
+		if (tcpPort.StrVal != "" && tcpPort.StrVal != port.StrVal) || (tcpPort.IntVal != 0 && tcpPort.IntVal != port.IntVal) {
+			errs = errs.Also(apis.ErrInvalidValue(tcpPort.String(), "tcpSocket.port", "May only probe containerPort"))
+		}
 	}
 	if h.Exec != nil {
 		handlers = append(handlers, "exec")

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -1460,7 +1460,7 @@ func TestContainerValidation(t *testing.T) {
 				}
 				ctx = config.ToContext(ctx, cfg)
 			}
-			err, port := validateContainersPorts([]corev1.Container{test.c})
+			port, err := validateContainersPorts([]corev1.Container{test.c})
 
 			got := err.Also(ValidateContainer(ctx, test.c, test.volumes, port))
 			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {

--- a/pkg/apis/serving/v1/revision_validation_test.go
+++ b/pkg/apis/serving/v1/revision_validation_test.go
@@ -397,6 +397,7 @@ func TestRevisionSpecValidation(t *testing.T) {
 					Image: "busybox",
 				}, {
 					Image: "helloworld",
+					Ports: []corev1.ContainerPort{{}},
 				}},
 			},
 		},


### PR DESCRIPTION
Fixes #8288

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Accept specs which specify an explicit probe on the containerPort.
  * Baseline Kubernetes does not permit TCP / HTTP probes without a port specified. Requiring these to be unset makes it hard to build generic tools for both k8s Deployment/etc and Knative, and seems overly restrictive.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow setting TCP and HTTP port to be equal to containerPort on readiness and liveness probes.
```
