### PR TITLE
Fix linting error from new version

### DIFF
--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -125,6 +125,8 @@ const (
 	// points will be missed entirely by the panic window which is
 	// smaller than the stable window. Anything less than 6 seconds
 	// isn't going to work well.
+	//
+	// nolint:revive // False positive, Min means minimum, not minutes.
 	WindowMin = 6 * time.Second
 	// WindowMax is the maximum permitted stable autoscaling window.
 	// This keeps the event horizon to a reasonable enough limit.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As per title. Currently this reports

```
pkg/apis/autoscaling/register.go:128:2: time-naming: var WindowMin is of type time.Duration; don't use unit-specific suffix "Min" (revive)
	WindowMin = 6 * time.Second
	^
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @julz 
