### PR TITLE
Change default target burst capacity

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/part-of: knative-serving
   annotations:
-    knative.dev/example-checksum: "604cb513"
+    knative.dev/example-checksum: "469620f5"
 data:
   _example: |
     ################################
@@ -98,7 +98,7 @@ data:
     # -1 denotes unlimited target-burst-capacity and activator will always
     # be in the request path.
     # Other negative values are invalid.
-    target-burst-capacity: "200"
+    target-burst-capacity: "-1"
 
     # When operating in a stable mode, the autoscaler operates on the
     # average concurrency over the stable window.

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -49,7 +49,7 @@ func defaultConfig() *autoscalerconfig.Config {
 		RPSTargetDefault:              200,
 		MaxScaleUpRate:                1000,
 		MaxScaleDownRate:              2,
-		TargetBurstCapacity:           200,
+		TargetBurstCapacity:           -1,
 		PanicWindowPercentage:         10,
 		ActivatorCapacity:             100,
 		PanicThresholdPercentage:      200,

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -111,6 +111,7 @@ func defaultConfigMapData() map[string]string {
 		"panic-window":                            "10s",
 		"scale-to-zero-grace-period":              gracePeriod.String(),
 		"tick-interval":                           "2s",
+		"target-burst-capacity":                   "200",
 	}
 }
 

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -286,6 +286,12 @@ func TestScaler(t *testing.T) {
 		scaleTo:       0,
 		wantReplicas:  0,
 		wantScaling:   false,
+		configMutator: func(c *config.Config) {
+			// If activator is in the path (TBC = -1), we scale down immediately
+			// because we know that's safe, so for this test we need to make sure
+			// it's not in the path.
+			c.Autoscaler.TargetBurstCapacity = 0
+		},
 		paMutation: func(k *autoscalingv1alpha1.PodAutoscaler) {
 			paMarkInactive(k, time.Now().Add(-gracePeriod))
 		},
@@ -299,6 +305,12 @@ func TestScaler(t *testing.T) {
 		scaleTo:       0,
 		wantReplicas:  0,
 		wantScaling:   false,
+		configMutator: func(c *config.Config) {
+			// If activator is in the path (TBC = -1), we scale down immediately
+			// because we know that's safe, so for this test we need to make sure
+			// it's not in the path.
+			c.Autoscaler.TargetBurstCapacity = 0
+		},
 		paMutation: func(k *autoscalingv1alpha1.PodAutoscaler) {
 			paMarkInactive(k, time.Now().Add(-gracePeriod))
 		},


### PR DESCRIPTION
Fixes #11926.

The current value of TBC takes the activator out of the path quite aggressively, and therefore with min-scale=2 [a single request can cause the activator to flip in and out of the path](http://github.com/knative/serving/issues/11926). Since moving activator in and out of the path rapidly can cause pretty significant load on Istio (etc) this is not ideal.

This PR defaults TBC to -1 (i.e. always in path unless overridden) instead so that people can explicitly opt in to setting TBC based on their actual use case and measured latency problems caused by having activator in the path that they want to resolve. (I'm open to just bumping TBC to a higher number instead, but I personally think it's a bit cleaner and a better default in terms of understandability of the system to not guess the number and have users that have an actual requirement opt-in to the complexity and churn of having this on, so I'm going to wait to see if someone wants to argue the opposite case before changing this :)).

Having activator always in the path does add a small amount of latency and might increase the number of activators needed in the system, but empirically our quite large environments have not seen a problem with this setting.

Side note: an interesting/somewhat related discussion we've had informally a few times is whether a future iteration of KIngress etc might let us move activation in to the ingress itself, or make activator itself an ingress. I leave that thought here for future contributors who may be interested in pulling on that thread one day :).

/assign @markusthoemmes @psschwei 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Changes the default target-burst-capacity to -1, which means the activator is always in the path unless an explicit `target-burst-capacity` annotation is set on the service. 
```
