### PR TITLE
Update k8s app labels

### DIFF
--- a/config/core/100-namespace.yaml
+++ b/config/core/100-namespace.yaml
@@ -17,6 +17,6 @@ kind: Namespace
 metadata:
   name: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel

--- a/config/core/200-roles/addressable-resolvers-clusterrole.yaml
+++ b/config/core/200-roles/addressable-resolvers-clusterrole.yaml
@@ -22,7 +22,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -34,10 +34,10 @@ metadata:
   name: knative-serving-addressable-resolver
   labels:
     serving.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-serving
     # Labeled to facilitate aggregated cluster roles that act on Addressables.
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
 
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:

--- a/config/core/200-roles/clusterrole-namespaced.yaml
+++ b/config/core/200-roles/clusterrole-namespaced.yaml
@@ -20,7 +20,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     serving.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -37,7 +37,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     serving.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
     resources: ["*"]
@@ -54,7 +54,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     serving.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
     resources: ["*"]

--- a/config/core/200-roles/clusterrole.yaml
+++ b/config/core/200-roles/clusterrole.yaml
@@ -17,10 +17,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-core
   labels:
-    serving.knative.dev/release: devel
     serving.knative.dev/controller: "true"
+    serving.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces", "secrets", "configmaps", "endpoints", "services", "events", "serviceaccounts"]

--- a/config/core/200-roles/podspecable-bindings-clusterrole.yaml
+++ b/config/core/200-roles/podspecable-bindings-clusterrole.yaml
@@ -18,10 +18,10 @@ metadata:
   name: knative-serving-podspecable-binding
   labels:
     serving.knative.dev/release: devel
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/name: knative-serving
     # Labeled to facilitate aggregated cluster roles that act on PodSpecables.
     duck.knative.dev/podspecable: "true"
-    app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
 
 # Do not use this role directly. These rules will be added to the "podspecable-binder" role.
 rules:

--- a/config/core/200-serviceaccount.yaml
+++ b/config/core/200-serviceaccount.yaml
@@ -18,19 +18,19 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-admin
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -41,10 +41,10 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-admin
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -59,10 +59,10 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-serving-controller-addressable-resolver
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: controller

--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -19,6 +19,8 @@ kind: CustomResourceDefinition
 metadata:
   name: configurations.serving.knative.dev
   labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"

--- a/config/core/300-resources/domain-mapping.yaml
+++ b/config/core/300-resources/domain-mapping.yaml
@@ -17,6 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: domainmappings.serving.knative.dev
   labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:

--- a/config/core/300-resources/metric.yaml
+++ b/config/core/300-resources/metric.yaml
@@ -19,6 +19,8 @@ kind: CustomResourceDefinition
 metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:

--- a/config/core/300-resources/podautoscaler.yaml
+++ b/config/core/300-resources/podautoscaler.yaml
@@ -19,6 +19,8 @@ kind: CustomResourceDefinition
 metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -19,6 +19,8 @@ kind: CustomResourceDefinition
 metadata:
   name: revisions.serving.knative.dev
   labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:

--- a/config/core/300-resources/route.yaml
+++ b/config/core/300-resources/route.yaml
@@ -19,6 +19,8 @@ kind: CustomResourceDefinition
 metadata:
   name: routes.serving.knative.dev
   labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -19,6 +19,8 @@ kind: CustomResourceDefinition
 metadata:
   name: services.serving.knative.dev
   labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"

--- a/config/core/999-cache.yaml
+++ b/config/core/999-cache.yaml
@@ -18,10 +18,10 @@ metadata:
   name: queue-proxy
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: queue-proxy
+    app.kubernetes.io/component: queue-proxy
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.

--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -18,10 +18,10 @@ metadata:
   name: config-autoscaler
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: autoscaler
+    app.kubernetes.io/component: autoscaler
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "604cb513"
 data:

--- a/config/core/configmaps/defaults.yaml
+++ b/config/core/configmaps/defaults.yaml
@@ -18,9 +18,10 @@ metadata:
   name: config-defaults
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "a0feb4c6"
 data:

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -18,9 +18,10 @@ metadata:
   name: config-deployment
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "dd7ee769"
 data:

--- a/config/core/configmaps/domain.yaml
+++ b/config/core/configmaps/domain.yaml
@@ -18,9 +18,10 @@ metadata:
   name: config-domain
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "81552d0b"
 data:

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -18,9 +18,10 @@ metadata:
   name: config-features
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "2897f625"
 data:

--- a/config/core/configmaps/gc.yaml
+++ b/config/core/configmaps/gc.yaml
@@ -18,9 +18,10 @@ metadata:
   name: config-gc
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "51b4d68a"
 data:

--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -18,9 +18,10 @@ metadata:
   name: config-leader-election
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "f7948630"
 data:

--- a/config/core/configmaps/logging.yaml
+++ b/config/core/configmaps/logging.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
   annotations:
     knative.dev/example-checksum: "be93ff10"
 data:

--- a/config/core/configmaps/observability.yaml
+++ b/config/core/configmaps/observability.yaml
@@ -18,9 +18,9 @@ metadata:
   name: config-observability
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "fed4756e"
 data:

--- a/config/core/configmaps/tracing.yaml
+++ b/config/core/configmaps/tracing.yaml
@@ -18,9 +18,9 @@ metadata:
   name: config-tracing
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "26614636"
 data:

--- a/config/core/deployments/activator-hpa.yaml
+++ b/config/core/deployments/activator-hpa.yaml
@@ -18,10 +18,10 @@ metadata:
   name: activator
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: activator
+    app.kubernetes.io/component: activator
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -47,10 +47,10 @@ metadata:
   name: activator-pdb
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: activator
+    app.kubernetes.io/component: activator
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 spec:
   minAvailable: 80%
   selector:

--- a/config/core/deployments/activator.yaml
+++ b/config/core/deployments/activator.yaml
@@ -18,10 +18,10 @@ metadata:
   name: activator
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: activator
+    app.kubernetes.io/component: activator
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
+    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -34,10 +34,10 @@ spec:
       labels:
         app: activator
         role: activator
-        serving.knative.dev/release: devel
-        app.kubernetes.io/name: activator
-        app.kubernetes.io/part-of: knative-serving
+        app.kubernetes.io/component: activator
+        app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
+        serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
       containers:
@@ -131,10 +131,10 @@ metadata:
   namespace: knative-serving
   labels:
     app: activator
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: activator
+    app.kubernetes.io/component: activator
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
+    serving.knative.dev/release: devel
 spec:
   selector:
     app: activator

--- a/config/core/deployments/autoscaler.yaml
+++ b/config/core/deployments/autoscaler.yaml
@@ -18,10 +18,10 @@ metadata:
   name: autoscaler
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: autoscaler
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: autoscaler
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
+    serving.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -33,10 +33,10 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: autoscaler
-        serving.knative.dev/release: devel
-        app.kubernetes.io/name: autoscaler
-        app.kubernetes.io/part-of: knative-serving
+        app.kubernetes.io/component: autoscaler
+        app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
+        serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -121,10 +121,10 @@ kind: Service
 metadata:
   labels:
     app: autoscaler
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: autoscaler
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: autoscaler
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
+    serving.knative.dev/release: devel
   name: autoscaler
   namespace: knative-serving
 spec:

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -18,10 +18,10 @@ metadata:
   name: controller
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -32,10 +32,10 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: controller
-        serving.knative.dev/release: devel
-        app.kubernetes.io/name: controller
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
-        app.kubernetes.io/part-of: knative-serving
+        serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -101,10 +101,10 @@ kind: Service
 metadata:
   labels:
     app: controller
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
   name: controller
   namespace: knative-serving
 spec:

--- a/config/core/deployments/domainmapping-controller.yaml
+++ b/config/core/deployments/domainmapping-controller.yaml
@@ -18,10 +18,10 @@ metadata:
   name: domain-mapping
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: domain-mapping
+    app.kubernetes.io/component: domain-mapping
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -32,10 +32,10 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: domain-mapping
-        serving.knative.dev/release: devel
-        app.kubernetes.io/name: domain-mapping
-        app.kubernetes.io/part-of: knative-serving
+        app.kubernetes.io/component: domain-mapping
+        app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
+        serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:

--- a/config/core/deployments/domainmapping-webhook.yaml
+++ b/config/core/deployments/domainmapping-webhook.yaml
@@ -18,10 +18,10 @@ metadata:
   name: domainmapping-webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: domainmapping-webhook
+    app.kubernetes.io/component: domain-mapping
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -33,10 +33,10 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: domainmapping-webhook
-        app.kubernetes.io/name: domainmapping-webhook
-        app.kubernetes.io/part-of: knative-serving
-        app.kubernetes.io/version: devel
         role: domainmapping-webhook
+        app.kubernetes.io/component: domain-mapping
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/version: devel
         serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
@@ -130,10 +130,10 @@ kind: Service
 metadata:
   labels:
     role: domainmapping-webhook
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: domainmapping-webhook
+    app.kubernetes.io/component: domain-mapping
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
   name: domainmapping-webhook
   namespace: knative-serving
 spec:

--- a/config/core/deployments/webhook-hpa.yaml
+++ b/config/core/deployments/webhook-hpa.yaml
@@ -18,10 +18,10 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -45,10 +45,10 @@ metadata:
   name: webhook-pdb
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 spec:
   minAvailable: 80%
   selector:

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -19,9 +19,9 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: devel
-    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
 spec:
   selector:
     matchLabels:
@@ -35,9 +35,9 @@ spec:
         app: webhook
         role: webhook
         serving.knative.dev/release: devel
-        app.kubernetes.io/name: webhook
+        app.kubernetes.io/component: webhook
         app.kubernetes.io/version: devel
-        app.kubernetes.io/part-of: knative-serving
+        app.kubernetes.io/name: knative-serving
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -133,9 +133,9 @@ metadata:
   labels:
     role: webhook
     serving.knative.dev/release: devel
-    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
   name: webhook
   namespace: knative-serving
 spec:

--- a/config/core/webhooks/configmap-validation.yaml
+++ b/config/core/webhooks/configmap-validation.yaml
@@ -17,10 +17,10 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: configmap-validation-webhook
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:

--- a/config/core/webhooks/defaulting.yaml
+++ b/config/core/webhooks/defaulting.yaml
@@ -17,10 +17,10 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: defaulting-webhook
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:

--- a/config/core/webhooks/domainmapping-defaulting.yaml
+++ b/config/core/webhooks/domainmapping-defaulting.yaml
@@ -17,6 +17,9 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.domainmapping.serving.knative.dev
   labels:
+    app.kubernetes.io/component: domain-mapping
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]

--- a/config/core/webhooks/domainmapping-secret.yaml
+++ b/config/core/webhooks/domainmapping-secret.yaml
@@ -18,5 +18,8 @@ metadata:
   name: domainmapping-webhook-certs
   namespace: knative-serving
   labels:
+    app.kubernetes.io/component: domain-mapping
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
 # The data is populated at install time.

--- a/config/core/webhooks/domainmapping-validation.yaml
+++ b/config/core/webhooks/domainmapping-validation.yaml
@@ -17,10 +17,10 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.domainmapping.serving.knative.dev
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: domainmapping-webhook
+    app.kubernetes.io/component: domain-mapping
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:

--- a/config/core/webhooks/resource-validation.yaml
+++ b/config/core/webhooks/resource-validation.yaml
@@ -17,10 +17,10 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.serving.knative.dev
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: validating-webhook
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:

--- a/config/core/webhooks/secret.yaml
+++ b/config/core/webhooks/secret.yaml
@@ -18,8 +18,8 @@ metadata:
   name: webhook-certs
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 # The data is populated at install time.

--- a/config/hpa-autoscaling/controller.yaml
+++ b/config/hpa-autoscaling/controller.yaml
@@ -18,11 +18,11 @@ metadata:
   name: autoscaler-hpa
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
     autoscaling.knative.dev/autoscaler-provider: hpa
-    app.kubernetes.io/name: autoscaler-hpa
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/component: autoscaler-hpa
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
+    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -33,6 +33,9 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: autoscaler-hpa
+        app.kubernetes.io/component: autoscaler-hpa
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/version: devel
         serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
@@ -95,10 +98,10 @@ kind: Service
 metadata:
   labels:
     app: autoscaler-hpa
-    app.kubernetes.io/name: autoscaler-hpa
-    app.kubernetes.io/part-of: knative-serving
-    app.kubernetes.io/version: devel
     autoscaling.knative.dev/autoscaler-provider: hpa
+    app.kubernetes.io/component: autoscaler-hpa
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
   name: autoscaler-hpa
   namespace: knative-serving

--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -19,10 +19,10 @@ metadata:
   namespace: knative-serving
   labels:
     app: "default-domain"
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: default-domain
+    app.kubernetes.io/component: default-domain-job
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 spec:
   template:
     metadata:
@@ -30,9 +30,9 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: "default-domain"
-        app.kubernetes.io/name: default-domain
+        app.kubernetes.io/component: default-domain-job
+        app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
-        app.kubernetes.io/part-of: knative-serving
     spec:
       serviceAccountName: controller
       containers:
@@ -82,10 +82,10 @@ metadata:
   namespace: knative-serving
   labels:
     app: default-domain
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: default-domain
+    app.kubernetes.io/component: default-domain-job
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 spec:
   selector:
     app: default-domain

--- a/config/post-install/storage-version-migration.yaml
+++ b/config/post-install/storage-version-migration.yaml
@@ -19,10 +19,10 @@ metadata:
   namespace: knative-serving
   labels:
     app: storage-version-migration-serving
-    serving.knative.dev/release: devel
-    app.kubernetes.io/name: storage-version-migration-serving
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: storage-version-migration-job
     app.kubernetes.io/version: devel
-    app.kubernetes.io/part-of: knative-serving
+    serving.knative.dev/release: devel
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -32,7 +32,8 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: storage-version-migration-serving
-        app.kubernetes.io/name: storage-version-migration-serving
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/component: storage-version-migration-job
         app.kubernetes.io/version: devel
     spec:
       serviceAccountName: controller


### PR DESCRIPTION
Follow up on https://github.com/knative/serving/issues/11617

We use /name=serving for all resources and use the /component to
designate different serving components

Different resources with the same /component label contribute to
the function of that component - ie. webhook

