### PR TITLE
Drop unneeded if blocks from validation

### DIFF
--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -317,17 +317,12 @@ func ValidatePodSpec(ctx context.Context, ps corev1.PodSpec) *apis.FieldError {
 	errs = errs.Also(ValidatePodSecurityContext(ctx, ps.SecurityContext).ViaField("securityContext"))
 
 	volumes, err := ValidateVolumes(ctx, ps.Volumes, AllMountedVolumes(append(ps.InitContainers, ps.Containers...)))
+	errs = errs.Also(err.ViaField("volumes"))
 
 	errs = errs.Also(validateInitContainers(ctx, ps.InitContainers, volumes))
 
-	if err != nil {
-		errs = errs.Also(err.ViaField("volumes"))
-	}
-
 	port, err := validateContainersPorts(ps.Containers)
-	if err != nil {
-		errs = errs.Also(err.ViaField("containers[*]"))
-	}
+	errs = errs.Also(err.ViaField("containers[*]"))
 
 	switch len(ps.Containers) {
 	case 0:


### PR DESCRIPTION
`apis.FieldError.Also` handles the error being nil so we don't need to also (ha ha) test that. This also moves the `err.Also(viaField("volumes"))` up so it's below the place the error actually might've been returned.

/assign @dprotaso @psschwei 
