### PR TITLE
Custom Metrics HPA Autoscaler

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -221,7 +221,10 @@ func validateMetric(annotations map[string]string) *apis.FieldError {
 				return nil
 			}
 		case HPA:
-			if metric != "" {
+			switch metric {
+			case "":
+				break
+			default:
 				return nil
 			}
 		default:

--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -221,11 +221,9 @@ func validateMetric(annotations map[string]string) *apis.FieldError {
 				return nil
 			}
 		case HPA:
-			return nil
-			// switch metric {
-			// case CPU, Memory:
-			// 	return nil
-			// }
+			if metric != "" {
+				return nil
+			}
 		default:
 			// Leave other classes of PodAutoscaler alone.
 			return nil

--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -221,10 +221,11 @@ func validateMetric(annotations map[string]string) *apis.FieldError {
 				return nil
 			}
 		case HPA:
-			switch metric {
-			case CPU, Memory:
-				return nil
-			}
+			return nil
+			// switch metric {
+			// case CPU, Memory:
+			// 	return nil
+			// }
 		default:
 			// Leave other classes of PodAutoscaler alone.
 			return nil

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -317,8 +317,8 @@ func TestValidateAnnotations(t *testing.T) {
 		expectErr:   "invalid value: cpu: " + MetricAnnotationKey,
 	}, {
 		name:        "invalid metric for HPA class",
-		annotations: map[string]string{MetricAnnotationKey: "metrics", ClassAnnotationKey: HPA},
-		expectErr:   "invalid value: metrics: " + MetricAnnotationKey,
+		annotations: map[string]string{MetricAnnotationKey: "", ClassAnnotationKey: HPA},
+		expectErr:   "invalid value: : " + MetricAnnotationKey,
 	}, {
 		name:        "valid class KPA with metric RPS",
 		annotations: map[string]string{MetricAnnotationKey: RPS},

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -85,17 +85,22 @@ func MakeHPA(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig.Con
 					},
 				},
 			}}
-		}
-	default:
-		if target, ok := pa.Target(); ok {
-			targetQuantity := resource.NewQuantity(int64(target), resource.DecimalSI)
-			hpa.Spec.Metrics = []autoscalingv2beta1.MetricSpec{{
-				Type: autoscalingv2beta1.PodsMetricSourceType,
-				Pods: &autoscalingv2beta1.PodsMetricSource{
-					MetricName:         pa.Metric(),
-					TargetAverageValue: *targetQuantity,
-				},
-			}}
+		default:
+			if target, ok := pa.Target(); ok {
+				targetQuantity := resource.NewQuantity(int64(target), resource.DecimalSI)
+				hpa.Spec.Metrics = []autoscalingv2beta2.MetricSpec{{
+					Type: autoscalingv2beta2.PodsMetricSourceType,
+					Pods: &autoscalingv2beta2.PodsMetricSource{
+						Metric: autoscalingv2beta2.MetricIdentifier{
+							Name: pa.Metric(),
+						},
+						Target: autoscalingv2beta2.MetricTarget{
+							Type:         autoscalingv2beta2.AverageValueMetricType,
+							AverageValue: targetQuantity,
+						},
+					},
+				}}
+			}
 		}
 	}
 

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -86,6 +86,17 @@ func MakeHPA(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig.Con
 				},
 			}}
 		}
+	default:
+		if target, ok := pa.Target(); ok {
+			targetQuantity := resource.NewQuantity(int64(target), resource.DecimalSI)
+			hpa.Spec.Metrics = []autoscalingv2beta1.MetricSpec{{
+				Type: autoscalingv2beta1.PodsMetricSourceType,
+				Pods: &autoscalingv2beta1.PodsMetricSource{
+					MetricName:         pa.Metric(),
+					TargetAverageValue: *targetQuantity,
+				},
+			}}
+		}
 	}
 
 	if window, hasWindow := pa.Window(); hasWindow {

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
@@ -141,8 +141,13 @@ func TestMakeHPA(t *testing.T) {
 			withMetric(autoscalingv2beta2.MetricSpec{
 				Type: autoscalingv2beta2.PodsMetricSourceType,
 				Pods: &autoscalingv2beta2.PodsMetricSource{
-					MetricName:         "customMetric",
-					TargetAverageValue: *resource.NewQuantity(50, resource.DecimalSI),
+					Metric: autoscalingv2beta2.MetricIdentifier{
+						Name: "customMetric",
+					},
+					Target: autoscalingv2beta2.MetricTarget{
+						Type:         autoscalingv2beta2.AverageValueMetricType,
+						AverageValue: resource.NewQuantity(50, resource.DecimalSI),
+					},
 				},
 			})),
 	}}

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa_test.go
@@ -132,6 +132,19 @@ func TestMakeHPA(t *testing.T) {
 				},
 			}),
 		),
+	}, {
+		name: "with custom metric",
+		pa:   pa(WithTargetAnnotation("50"), WithMetricAnnotation("customMetric")),
+		want: hpa(
+			withAnnotationValue(autoscaling.MetricAnnotationKey, "customMetric"),
+			withAnnotationValue(autoscaling.TargetAnnotationKey, "50"),
+			withMetric(autoscalingv2beta2.MetricSpec{
+				Type: autoscalingv2beta2.PodsMetricSourceType,
+				Pods: &autoscalingv2beta2.PodsMetricSource{
+					MetricName:         "customMetric",
+					TargetAverageValue: *resource.NewQuantity(50, resource.DecimalSI),
+				},
+			})),
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes #3134 

This is based on #4112 , but tries to have a simpler solution with no  added annotations, by assuming that any metric name other than `cpu` or `memory` is a custom metric name.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* For HPA autoscaler if the metric name is not `cpu` or `memory` then it will be used as a custom metric on the pods with the target value used as averageUtilization value.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Metrics with names other than "cpu" or "memory" are allowed as pod custom metrics.
```
