### PR TITLE
handling retries within pause/resume functions

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -293,9 +293,8 @@ func buildServer(ctx context.Context, env config, drainer *pkghandler.Drainer, p
 		}()
 		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, ce.Pause, ce.Resume)
 		// start paused
-		if err := ce.Pause(); err != nil {
+		if err := ce.Pause(logger); err != nil {
 			logger.Errorf("Error handling initial pause request: %v", err)
-			queue.HandleStateRequestError(logger, ce.Pause)
 		}
 	}
 	if metricsSupported {

--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -293,9 +293,7 @@ func buildServer(ctx context.Context, env config, drainer *pkghandler.Drainer, p
 		}()
 		composedHandler = queue.ConcurrencyStateHandler(logger, composedHandler, ce.Pause, ce.Resume)
 		// start paused
-		if err := ce.Pause(logger); err != nil {
-			logger.Errorf("Error handling initial pause request: %v", err)
-		}
+		ce.Pause(logger)
 	}
 	if metricsSupported {
 		composedHandler = requestAppMetricsHandler(logger, composedHandler, breaker, env)

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -94,12 +94,12 @@ func retryRequest(logger *zap.SugaredLogger, requestHandler func(string) error, 
 	retryFunc := func() (bool, error) {
 		errReq = requestHandler(request)
 		if errReq != nil {
-			logger.Errorf("request failed: %s", errReq)
+			logger.Errorw(fmt.Sprintf("%s request failed", request), zap.Error(errReq))
 		}
 		return errReq == nil, nil
 	}
 	if err := wait.PollImmediate(time.Millisecond*200, 15*time.Minute, retryFunc); err != nil {
-		logger.Fatalf("%s request failed: %v", request, err)
+		logger.Fatalw(fmt.Sprintf("%s request failed", request), zap.Error(err))
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Proposed Changes

Handles errors for pause/resume Container-Freezer requests within the pause/resume functions themselves, rather than externally (as per suggestion [here](https://github.com/knative/serving/pull/12168#pullrequestreview-798114739)).

/assign @julz @markusthoemmes 