### PR TITLE
[WIP] Remove readiness probe when using container freezer

### DIFF
--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -1135,6 +1135,7 @@ func TestMakePodSpec(t *testing.T) {
 					c.Image = "ubuntu@sha256:deadbeef"
 				}),
 				queueContainer(func(container *corev1.Container) {
+					container.ReadinessProbe = nil
 					container.VolumeMounts = []corev1.VolumeMount{{
 						Name:      varTokenVolume.Name,
 						MountPath: "/var/run/secrets/tokens",

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -228,6 +228,7 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		// except period here. See below.
 
 		startupProbe = container.ReadinessProbe.DeepCopy()
+		startupProbe.PeriodSeconds = 1
 		startupProbe.Handler = corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Port: intstr.FromInt(int(servingPort.ContainerPort)),
@@ -237,14 +238,6 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 				}},
 			},
 		}
-
-		// Default PeriodSeconds to 1 if not set to make for the quickest possible startup
-		// time.
-		// TODO(#10973): Remove this once we're on K8s 1.21
-		if startupProbe.PeriodSeconds == 0 {
-			startupProbe.PeriodSeconds = 1
-		}
-
 	}
 
 	c := &corev1.Container{

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -225,8 +225,8 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		// execprobe would have used (which will then check the user container).
 		// Unlike the StartupProbe, we don't need to override any of the other settings
 		// except period here. See below.
-		// If the Container-Freezer has been enabled, the readiness probe is disabled,
-		// so as not to continuously probe a frozen container
+		// Only add probe if Container-Freezer is not enabled so as not to continuously
+		// probe a frozen container
 		if cfg.Deployment.ConcurrencyStateEndpoint == "" {
 
 			httpProbe = container.ReadinessProbe.DeepCopy()

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -321,6 +321,7 @@ func TestMakeQueueContainer(t *testing.T) {
 			ConcurrencyStateEndpoint: "freeze-proxy",
 		},
 		want: queueContainer(func(c *corev1.Container) {
+			c.ReadinessProbe = nil
 			c.Env = env(map[string]string{
 				"CONCURRENCY_STATE_ENDPOINT":   "freeze-proxy",
 				"CONCURRENCY_STATE_TOKEN_PATH": "/var/run/secrets/tokens/state-token",


### PR DESCRIPTION
## Proposed Changes

Piggybacking off discussion from #10978 , this PR disables the readiness probe when the container-freezer is enabled. This resolves an issue where we were getting an `agressive probe error` on frozen containers after a few minutes and simplifies things a bit (as there shouldn't be any change in status on a frozen container, so probing it is most likely not returning any relevant new information).

/assign @markusthoemmes  @julz 

**Release Note**

```release-note
When using the container-freezer, disables the readiness probe so as not to continuously probe frozen containers
```
