### PR TITLE
Use CreateRouteReady in TestRouteCreation

### DIFF
--- a/test/conformance/api/v1/route_test.go
+++ b/test/conformance/api/v1/route_test.go
@@ -161,7 +161,7 @@ func TestRouteCreation(t *testing.T) {
 	}
 	objects.Config = config
 
-	route, err := v1test.CreateRoute(t, clients, names)
+	route, err := v1test.CreateRouteReady(t, clients, names)
 	if err != nil {
 		t.Fatal("Failed to create Route:", err)
 	}

--- a/test/v1/route.go
+++ b/test/v1/route.go
@@ -70,6 +70,22 @@ func GetRoutes(clients *test.Clients) (list *v1.RouteList, err error) {
 	})
 }
 
+// CreateRouteReady creates a new Route in state 'Ready'. Returns error if the Route does not come up correctly.
+func CreateRouteReady(t testing.TB, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.RouteOption) (*v1.Route, error) {
+	t.Log("Creating a new Route", "route", names.Route)
+	_, err := CreateRoute(t, clients, names, fopt...)
+	if err != nil {
+		return nil, err
+	}
+
+	t.Log("Waiting for Route to transition to Ready.", "route", names.Route)
+	if err = WaitForRouteState(clients.ServingClient, names.Route, IsRouteReady, "Route is ready"); err != nil {
+		t.Fatal("Route did not become ready:", err)
+	}
+
+	return clients.ServingClient.Routes.Get(context.Background(), names.Route, metav1.GetOptions{})
+}
+
 // CreateRoute creates a route in the given namespace using the route name in names
 func CreateRoute(t testing.TB, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.RouteOption) (rt *v1.Route, err error) {
 	route := Route(names, fopt...)


### PR DESCRIPTION
This patch adds CreateRouteReady in TestRouteCreation.
The TestRouteCreation creates route with `CreateRoute()` but it does not
check Route status so it fails to get URL sometimes.

[Example log - Failed to get URL from route](https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-continuous/1453874291505369088)
```
    route_test.go:178: Failed to get URL from route route-creation-hhyxulfw: route "route-creation-hhyxulfw" is not in desired state, got: &{TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:route-creation-hhyxulfw GenerateName: Namespace:serving-tests SelfLink: UID:869f498d-85ef-4dbf-8ed0-b92ca4dacf9f ResourceVersion:13470 Generation:1 CreationTimestamp:2021-10-29 00:56:59 +0000 UTC DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[] Annotations:map[serving.knative.dev/creator:prow-job@knative-tests.iam.gserviceaccount.com serving.knative.dev/lastModifier:prow-job@knative-tests.iam.gserviceaccount.com] OwnerReferences:[] Finalizers:[routes.serving.knative.dev] ClusterName: ManagedFields:[{Manager:controller Operation:Update APIVersion:serving.knative.dev/v1 Time:2021-10-29 00:56:59 +0000 UTC FieldsType:FieldsV1 FieldsV1:{"f:metadata":{"f:finalizers":{".":{},"v:\"routes.serving.knative.dev\"":{}}}}} {Manager:v1.test Operation:Update APIVersion:serving.knative.dev/v1 Time:2021-10-29 00:56:59 +0000 UTC FieldsType:FieldsV1 FieldsV1:{"f:spec":{".":{},"f:traffic":{}},"f:status":{}}}]} Spec:{Traffic:[{Tag:route-creation-hhyxulfw RevisionName: ConfigurationName:route-creation-hhyxulfw LatestRevision:0xc0009a999f Percent:0xc0009a99a8 URL:}]} Status:{Status:{ObservedGeneration:0 Conditions:[] Annotations:map[]} RouteStatusFields:{URL: Address:<nil> Traffic:[]}}}
```

Part of https://github.com/knative/serving/issues/11795 (Fixes case-1 https://github.com/knative/serving/issues/11795#issuecomment-970125113)