### PR TITLE
Hpa stabilization window

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -158,10 +158,6 @@ func validateLastPodRetention(annotations map[string]string) *apis.FieldError {
 
 func validateWindow(annotations map[string]string) *apis.FieldError {
 	if w, ok := annotations[WindowAnnotationKey]; ok {
-		// if annotations[ClassAnnotationKey] == HPA && (annotations[MetricAnnotationKey] == CPU || annotations[MetricAnnotationKey] == Memory) {
-		// 	return apis.ErrInvalidKeyName(WindowAnnotationKey, apis.CurrentField, fmt.Sprintf("%s for %s %s", HPA,
-		// 		MetricAnnotationKey, annotations[MetricAnnotationKey]))
-		// }
 		switch d, err := time.ParseDuration(w); {
 		case err != nil:
 			return apis.ErrInvalidValue(w, WindowAnnotationKey)

--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -158,10 +158,10 @@ func validateLastPodRetention(annotations map[string]string) *apis.FieldError {
 
 func validateWindow(annotations map[string]string) *apis.FieldError {
 	if w, ok := annotations[WindowAnnotationKey]; ok {
-		if annotations[ClassAnnotationKey] == HPA && (annotations[MetricAnnotationKey] == CPU || annotations[MetricAnnotationKey] == Memory) {
-			return apis.ErrInvalidKeyName(WindowAnnotationKey, apis.CurrentField, fmt.Sprintf("%s for %s %s", HPA,
-				MetricAnnotationKey, annotations[MetricAnnotationKey]))
-		}
+		// if annotations[ClassAnnotationKey] == HPA && (annotations[MetricAnnotationKey] == CPU || annotations[MetricAnnotationKey] == Memory) {
+		// 	return apis.ErrInvalidKeyName(WindowAnnotationKey, apis.CurrentField, fmt.Sprintf("%s for %s %s", HPA,
+		// 		MetricAnnotationKey, annotations[MetricAnnotationKey]))
+		// }
 		switch d, err := time.ParseDuration(w); {
 		case err != nil:
 			return apis.ErrInvalidValue(w, WindowAnnotationKey)

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -18,7 +18,6 @@ package autoscaling
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -239,10 +238,6 @@ func TestValidateAnnotations(t *testing.T) {
 		annotations: map[string]string{WindowAnnotationKey: "1m9s82ms"},
 		expectErr:   "must be specified with at most second precision: " + WindowAnnotationKey,
 	}, {
-		name:        "annotation /window is invalid for class HPA and metric CPU",
-		annotations: map[string]string{WindowAnnotationKey: "7s", ClassAnnotationKey: HPA, MetricAnnotationKey: CPU},
-		expectErr:   fmt.Sprintf("invalid key name %q: \n%s for %s %s", WindowAnnotationKey, HPA, MetricAnnotationKey, CPU),
-	}, {
 		name:        "annotation /window is valid for class KPA",
 		annotations: map[string]string{WindowAnnotationKey: "7s", ClassAnnotationKey: KPA},
 		expectErr:   "",
@@ -250,10 +245,6 @@ func TestValidateAnnotations(t *testing.T) {
 		name:        "annotation /window is valid for other than HPA and KPA class",
 		annotations: map[string]string{WindowAnnotationKey: "7s", ClassAnnotationKey: "test"},
 		expectErr:   "",
-	}, {
-		name:        "value too short and invalid class for /window annotation",
-		annotations: map[string]string{WindowAnnotationKey: "1s", ClassAnnotationKey: HPA, MetricAnnotationKey: CPU},
-		expectErr:   fmt.Sprintf("invalid key name %q: \n%s for %s %s", WindowAnnotationKey, HPA, MetricAnnotationKey, CPU),
 	}, {
 		name:        "value too long and valid class for /window annotation",
 		annotations: map[string]string{WindowAnnotationKey: "365h", ClassAnnotationKey: KPA},

--- a/pkg/reconciler/autoscaling/hpa/resources/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/resources/hpa.go
@@ -58,7 +58,6 @@ func MakeHPA(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig.Con
 	if min > 0 {
 		hpa.Spec.MinReplicas = &min
 	}
-	window, hasWindow := pa.Window()
 
 	if target, ok := pa.Target(); ok {
 		switch pa.Metric() {
@@ -88,7 +87,8 @@ func MakeHPA(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig.Con
 			}}
 		}
 	}
-	if hasWindow {
+
+	if window, hasWindow := pa.Window(); hasWindow {
 		windowSeconds := int32(window.Seconds())
 		hpa.Spec.Behavior = &autoscalingv2beta2.HorizontalPodAutoscalerBehavior{
 			ScaleDown: &autoscalingv2beta2.HPAScalingRules{
@@ -96,13 +96,6 @@ func MakeHPA(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig.Con
 			},
 			ScaleUp: &autoscalingv2beta2.HPAScalingRules{
 				StabilizationWindowSeconds: &windowSeconds,
-				Policies: []autoscalingv2beta2.HPAScalingPolicy{
-					{
-						Type:          "Pods",
-						Value:         1,
-						PeriodSeconds: 120,
-					},
-				},
 			},
 		}
 	}


### PR DESCRIPTION
The default stabilization window for HPA is 300s and can be set to different values. The meaning of this window is very similar to the KPA window, so we can use the same annotation.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Set HPA stabilization window from autoscaling window annotation


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
HPA autoscaler stabilization window can be set from autoscaling window annotation
```
