### PR TITLE
Add default cluster-side min-scale

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "604cb513"
+    knative.dev/example-checksum: "b4401cf4"
 data:
   _example: |
     ################################
@@ -186,6 +186,10 @@ data:
     # allow-zero-initial-scale controls whether either the cluster-wide initial-scale flag,
     # or the "autoscaling.knative.dev/initialScale" annotation, can be set to 0.
     allow-zero-initial-scale: "false"
+
+    # min-scale is the cluster-wide default value for the min scale of a revision,
+    # unless overridden by the "autoscaling.knative.dev/minScale" annotation.
+    min-scale: "0"
 
     # max-scale is the cluster-wide default value for the max scale of a revision,
     # unless overridden by the "autoscaling.knative.dev/maxScale" annotation.

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -86,7 +86,10 @@ func (pa *PodAutoscaler) annotationFloat64(key string) (float64, bool) {
 func (pa *PodAutoscaler) ScaleBounds(asConfig *autoscalerconfig.Config) (int32, int32) {
 	var min int32
 	if pa.Spec.Reachability != ReachabilityUnreachable {
-		min, _ = pa.annotationInt32(autoscaling.MinScaleAnnotationKey)
+		min = asConfig.MinScale
+		if paMin, ok := pa.annotationInt32(autoscaling.MinScaleAnnotationKey); ok {
+			min = paMin
+		}
 	}
 
 	max := asConfig.MaxScale

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -596,6 +596,13 @@ func TestScaleBounds(t *testing.T) {
 		max:     "sandwich",
 		wantMin: 0,
 		wantMax: 0,
+	}, {
+		name: "min-scale set but unreachable",
+		config: autoscalerconfig.Config{
+			MinScale: 2,
+		},
+		reachability: ReachabilityUnreachable,
+		wantMin:      0,
 	}}
 
 	for _, tc := range cases {

--- a/pkg/autoscaler/config/autoscalerconfig/autoscalerconfig.go
+++ b/pkg/autoscaler/config/autoscalerconfig/autoscalerconfig.go
@@ -50,6 +50,10 @@ type Config struct {
 	// services. This can be set to 0 iff AllowZeroInitialScale is true.
 	InitialScale int32
 
+	// MinScale is the default min scale for any revision created without an
+	// autoscaling.knative.dev/minScale annotation
+	MinScale int32
+
 	// MaxScale is the default max scale for any revision created without an
 	// autoscaling.knative.dev/maxScale annotation
 	MaxScale int32

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -60,6 +60,7 @@ func defaultConfig() *autoscalerconfig.Config {
 		PodAutoscalerClass:            autoscaling.KPA,
 		AllowZeroInitialScale:         false,
 		InitialScale:                  1,
+		MinScale:                      0,
 		MaxScale:                      0,
 		MaxScaleLimit:                 0,
 	}
@@ -86,6 +87,7 @@ func NewConfigFromMap(data map[string]string) (*autoscalerconfig.Config, error) 
 		cm.AsFloat64("panic-threshold-percentage", &lc.PanicThresholdPercentage),
 
 		cm.AsInt32("initial-scale", &lc.InitialScale),
+		cm.AsInt32("min-scale", &lc.MinScale),
 		cm.AsInt32("max-scale", &lc.MaxScale),
 		cm.AsInt32("max-scale-limit", &lc.MaxScaleLimit),
 
@@ -176,6 +178,10 @@ func validate(lc *autoscalerconfig.Config) (*autoscalerconfig.Config, error) {
 		return nil, fmt.Errorf("initial-scale = %v, must be at least 0 (or at least 1 when allow-zero-initial-scale is false)", lc.InitialScale)
 	}
 
+	if lc.MinScale < 0 {
+		return nil, fmt.Errorf("min-scale = %v, must be at least 0", lc.MinScale)
+	}
+
 	var minMaxScale int32
 	if lc.MaxScaleLimit > 0 {
 		// Default maxScale must be set if maxScaleLimit is set.
@@ -189,6 +195,10 @@ func validate(lc *autoscalerconfig.Config) (*autoscalerconfig.Config, error) {
 
 	if lc.MaxScaleLimit < 0 {
 		return nil, fmt.Errorf("max-scale-limit = %v, must be at least 0", lc.MaxScaleLimit)
+	}
+
+	if lc.MinScale > lc.MaxScale && lc.MaxScale > 0 {
+		return nil, fmt.Errorf("min-scale (%d) must be less than max-scale (%d)", lc.MinScale, lc.MaxScale)
 	}
 
 	return lc, nil

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -133,10 +133,14 @@ func TestNewConfig(t *testing.T) {
 		name: "with toggles explicitly flipped",
 		input: map[string]string{
 			"enable-scale-to-zero": "false",
+			"min-scale":            "1",
+			"max-scale":            "2",
 		},
 		want: func() *autoscalerconfig.Config {
 			c := defaultConfig()
 			c.EnableScaleToZero = false
+			c.MinScale = 1
+			c.MaxScale = 2
 			return c
 		}(),
 	}, {
@@ -144,11 +148,15 @@ func TestNewConfig(t *testing.T) {
 		input: map[string]string{
 			"enable-scale-to-zero":       "false",
 			"scale-to-zero-grace-period": "33s",
+			"min-scale":                  "1",
+			"max-scale":                  "2",
 		},
 		want: func() *autoscalerconfig.Config {
 			c := defaultConfig()
 			c.EnableScaleToZero = false
 			c.ScaleToZeroGracePeriod = 33 * time.Second
+			c.MinScale = 1
+			c.MaxScale = 2
 			return c
 		}(),
 	}, {
@@ -350,6 +358,23 @@ func TestNewConfig(t *testing.T) {
 			"max-scale-limit": "11",
 		},
 		wantErr: true,
+	}, {
+		name: "with max scale less than min-scale",
+		input: map[string]string{
+			"min-scale": "4",
+			"max-scale": "3",
+		},
+		wantErr: true,
+	}, {
+		name: "with min scale set but max-scale not set",
+		input: map[string]string{
+			"min-scale": "4",
+		},
+		want: func() *autoscalerconfig.Config {
+			c := defaultConfig()
+			c.MinScale = 4
+			return c
+		}(),
 	}, {
 		name: "with valid default max scale and max scale limit",
 		input: map[string]string{

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -111,6 +111,7 @@ func defaultConfigMapData() map[string]string {
 		"panic-window":                            "10s",
 		"scale-to-zero-grace-period":              gracePeriod.String(),
 		"tick-interval":                           "2s",
+		"min-scale":                               "0",
 	}
 }
 
@@ -118,6 +119,7 @@ func initialScaleZeroASConfig() *autoscalerconfig.Config {
 	ac, _ := asconfig.NewConfigFromMap(defaultConfigMapData())
 	ac.AllowZeroInitialScale = true
 	ac.InitialScale = 0
+	ac.MinScale = 0
 	ac.EnableScaleToZero = true
 	return ac
 }


### PR DESCRIPTION
based on a slack conversation: https://knative.slack.com/archives/C94SPR60H/p1637002245043400

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* add a cluster-wide config value for min-scale

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add cluster wide default min-scale
```
