### PR TITLE
Update comment referencing now-deleted exec probe

### DIFF
--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -208,10 +208,10 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 	var httpProbe, execProbe *corev1.Probe
 	var userProbeJSON string
 	if container.ReadinessProbe != nil {
-		// During startup we want to poll the container faster than Kubernetes will
-		// allow, so we use an ExecProbe which starts immediately and then polls
-		// every 25ms. We encode the original probe as JSON in an environment
-		// variable for this probe to use.
+		// The activator attempts to detect readiness itself by checking the Queue
+		// Proxy's health endpoint rather than waiting for Kubernetes to check and
+		// propagate the Ready state. We encode the original probe as JSON in an
+		// environment variable for this health endpoint to use.
 		userProbe := container.ReadinessProbe.DeepCopy()
 		applyReadinessProbeDefaultsForExec(userProbe, userPort)
 


### PR DESCRIPTION
We [no longer do an exec probe at startup](https://github.com/knative/serving/pull/11965) in the Queue Proxy, but we _do_ still use the endpoint for the Activator's direct readiness check optimisation. This PR updates the comment to reference the actually-still-existing usage of the probe.