### PR TITLE
Convert freezer request methods to pointer receivers

### DIFF
--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -110,7 +110,7 @@ type ConcurrencyEndpoint struct {
 	token     atomic.Value
 }
 
-func NewConcurrencyEndpoint(e, m string) ConcurrencyEndpoint {
+func NewConcurrencyEndpoint(e, m string) *ConcurrencyEndpoint {
 	c := ConcurrencyEndpoint{
 		endpoint: os.Expand(e, func(s string) string {
 			if s == "HOST_IP" {
@@ -121,7 +121,7 @@ func NewConcurrencyEndpoint(e, m string) ConcurrencyEndpoint {
 		mountPath: m,
 	}
 	c.RefreshToken()
-	return c
+	return &c
 }
 
 // Pause freezes a container, retrying until either successful or a timeout is

--- a/pkg/queue/concurrency_state.go
+++ b/pkg/queue/concurrency_state.go
@@ -51,7 +51,7 @@ func ConcurrencyStateHandler(logger *zap.SugaredLogger, h http.Handler, pause, r
 				// We need to doublecheck this since another request can have reached the
 				// handler meanwhile. We don't want to do anything in that case.
 				if !paused && inFlight.Load() == 0 {
-					logger.Info("Requests dropped to zero")
+					logger.Debug("Requests dropped to zero")
 					pause(logger)
 					paused = true
 					logger.Debug("To-Zero request successfully processed")
@@ -77,7 +77,7 @@ func ConcurrencyStateHandler(logger *zap.SugaredLogger, h http.Handler, pause, r
 			return
 		}
 
-		logger.Info("Requests increased from zero")
+		logger.Debug("Requests increased from zero")
 		resume(logger)
 		paused = false
 		logger.Debug("From-Zero request successfully processed")
@@ -126,17 +126,17 @@ func NewConcurrencyEndpoint(e, m string) ConcurrencyEndpoint {
 
 // Pause freezes a container, retrying until either successful or a timeout is
 // reached, at which point the container is killed
-func (c ConcurrencyEndpoint) Pause(logger *zap.SugaredLogger) {
+func (c *ConcurrencyEndpoint) Pause(logger *zap.SugaredLogger) {
 	retryRequest(logger, c.Request, "pause")
 }
 
 // Resume thaws a container, retrying until either successful or a timeout is
 // reached, at which point the container is killed
-func (c ConcurrencyEndpoint) Resume(logger *zap.SugaredLogger) {
+func (c *ConcurrencyEndpoint) Resume(logger *zap.SugaredLogger) {
 	retryRequest(logger, c.Request, "resume")
 }
 
-func (c ConcurrencyEndpoint) Request(action string) error {
+func (c *ConcurrencyEndpoint) Request(action string) error {
 	bodyText := fmt.Sprintf(`{ "action": %q }`, action)
 	body := bytes.NewBufferString(bodyText)
 	req, err := http.NewRequest(http.MethodPost, c.endpoint, body)


### PR DESCRIPTION
## Proposed Changes

Fixes a bug where the updated service account token was not being used by the various container-freezer request methods. Also changes the level of some logs to debug.

/assign @julz 