### PR TITLE
don't propagate kebab-case annotations to internal networking types

### DIFF
--- a/pkg/reconciler/domainmapping/resources/ingress.go
+++ b/pkg/reconciler/domainmapping/resources/ingress.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -42,9 +41,7 @@ func MakeIngress(dm *servingv1alpha1.DomainMapping, backendServiceName, hostName
 			Namespace: dm.Namespace,
 			Annotations: kmeta.FilterMap(kmeta.UnionMaps(map[string]string{
 				networking.IngressClassAnnotationKey: ingressClass,
-			}, dm.GetAnnotations()), func(key string) bool {
-				return key == corev1.LastAppliedConfigAnnotation
-			}),
+			}, dm.GetAnnotations()), routeresources.ExcludedAnnotations.Has),
 			Labels: kmeta.UnionMaps(dm.Labels, map[string]string{
 				serving.DomainMappingUIDLabelKey:       string(dm.UID),
 				serving.DomainMappingNamespaceLabelKey: dm.Namespace,

--- a/pkg/reconciler/route/resources/certificate.go
+++ b/pkg/reconciler/route/resources/certificate.go
@@ -24,7 +24,6 @@ import (
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	networkingv1alpha1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/kmeta"
@@ -43,9 +42,7 @@ func MakeCertificate(owner kmeta.OwnerRefableAccessor, ownerLabelKey string, dns
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(owner)},
 			Annotations: kmeta.FilterMap(kmeta.UnionMaps(map[string]string{
 				networking.CertificateClassAnnotationKey: certClass,
-			}, owner.GetAnnotations()), func(key string) bool {
-				return key == corev1.LastAppliedConfigAnnotation
-			}),
+			}, owner.GetAnnotations()), ExcludedAnnotations.Has),
 			Labels: map[string]string{
 				ownerLabelKey: owner.GetName(),
 			},

--- a/pkg/reconciler/route/resources/filters.go
+++ b/pkg/reconciler/route/resources/filters.go
@@ -18,7 +18,9 @@ package resources
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	network "knative.dev/networking/pkg"
+	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/serving/pkg/apis/serving"
 )
 
@@ -26,3 +28,14 @@ import (
 func IsClusterLocalService(svc *corev1.Service) bool {
 	return svc.GetLabels()[network.VisibilityLabelKey] == serving.VisibilityClusterLocal
 }
+
+// ExcludedAnnotations is the set of annotations that should not propagate to the
+// Ingress or Certificate Resources
+var ExcludedAnnotations = sets.NewString(
+	corev1.LastAppliedConfigAnnotation,
+
+	// We're probably never going to drop support for the older annotation casing (camelCase)
+	// so we don't need to propagate these to the internal types
+	networking.CertificateClassAnnotationAltKey,
+	networking.IngressClassAnnotationAltKey,
+)

--- a/pkg/reconciler/route/resources/ingress.go
+++ b/pkg/reconciler/route/resources/ingress.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"go.uber.org/zap"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -98,9 +97,7 @@ func MakeIngressWithRollout(
 			Annotations: kmeta.FilterMap(kmeta.UnionMaps(map[string]string{
 				networking.IngressClassAnnotationKey: ingressClass,
 				networking.RolloutAnnotationKey:      serializeRollout(ctx, ro),
-			}, r.GetAnnotations()), func(key string) bool {
-				return key == corev1.LastAppliedConfigAnnotation
-			}),
+			}, r.GetAnnotations()), ExcludedAnnotations.Has),
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(r)},
 		},
 		Spec: spec,


### PR DESCRIPTION
note: a prior knative.dev/networking dependency bump added support for this already [here](- 
https://github.com/knative/serving/pull/12315/files#diff-3cbf862804033eee2a74359afd3314ab56212340da183a31a3d62f3cc2a186d0R113-R143)


This PR just ensures kebab case annotations aren't propagated to the KIngress & KCert since not all implementation recognize them
- don't set alternate annotations on internal networking types

Part of https://github.com/knative/serving/issues/12103
