### PR TITLE
Add dir_denylist at the top level

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,3 +6,9 @@ approvers:
 - autoscaling-wg-leads
 - networking-wg-leads
 - knative-release-leads
+
+dir_denylist:
+# Ignore OWNERS files in vendor (so we can stop stripping them out)
+- ^vendor/
+# Directory for testing
+- ^hack/boilerplate

--- a/hack/boilerplate/OWNERS
+++ b/hack/boilerplate/OWNERS
@@ -1,0 +1,3 @@
+# Sample OWNERS file which should be ignored by the top-level OWNERS (for testing)
+approvers:
+- kvmware


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds `dir_denylist` option from Prow so that we may be able to just use `go mod vendor; go mod tidy` rather than needing a custom script.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
