### PR TITLE
Refactor request log handler chain in queue proxy

### DIFF
--- a/cmd/queue/main_test.go
+++ b/cmd/queue/main_test.go
@@ -148,7 +148,7 @@ func TestQueueTraceSpans(t *testing.T) {
 				h := queue.ProxyHandler(breaker, network.NewRequestStats(time.Now()), true /*tracingEnabled*/, proxy)
 				h(writer, req)
 			} else {
-				h := health.ProbeHandler(tc.prober, true /*tracingEnabled*/, nil)
+				h := health.ProbeHandler(tc.prober, true /*tracingEnabled*/)
 				req.Header.Set(network.ProbeHeaderName, tc.requestHeader)
 				h(writer, req)
 			}

--- a/pkg/queue/health/handler.go
+++ b/pkg/queue/health/handler.go
@@ -28,16 +28,11 @@ import (
 
 const badProbeTemplate = "unexpected probe header value: "
 
-// ProbeHandler returns a http.HandlerFunc that responds to health checks if the
-// knative network probe header is passed, and otherwise delegates to the next handler.
-func ProbeHandler(prober func() bool, tracingEnabled bool, next http.Handler) http.HandlerFunc {
+// ProbeHandler returns a http.HandlerFunc that responds to health checks.
+// This handler assumes the Knative Probe Header will be passed.
+func ProbeHandler(prober func() bool, tracingEnabled bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ph := network.KnativeProbeHeader(r)
-
-		if ph == "" {
-			next.ServeHTTP(w, r)
-			return
-		}
 
 		var probeSpan *trace.Span
 		if tracingEnabled {


### PR DESCRIPTION
Since we run the request log handler first in both branches I think we can add it right at the end rather than putting it independently in both the HealthCheck and the Inner fields of the drainer. This also means that we'll log requests even when we're draining, which [matches the behaviour before the introduction of drainer](https://github.com/knative/serving/blob/cad72a388cc8cda316c2e9b9207b7bb250b7bd69/cmd/queue/main.go#L324), and is - I think - what we want

Also:

 - moves the creation of drainer down to where half of its fields are set up so we can set them all up at once, and returns a drain func instead.
 - drops the delegation from the probe handler since we only ever call it now after [checking](https://github.com/knative/pkg/blob/main/network/handlers/drain.go#L90) that the request is a probe request (and because previously this was [delegating to a nil handler](https://github.com/knative/serving/blob/main/cmd/queue/main.go#L280) anyway..).

/assign @nader-ziada @psschwei 