### PR TITLE
[WIP] Fix setting inconsistency in gRPC HTTPS tests

### DIFF
--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -81,11 +81,7 @@ func dial(ctx *TestContext, host, domain string) (*grpc.ClientConn, error) {
 	if test.ServingFlags.HTTPS {
 		tlsConfig := test.TLSClientConfig(context.Background(), ctx.t.Logf, ctx.clients)
 		// Set ServerName for pseudo hostname with TLS.
-		var err error
-		tlsConfig.ServerName, _, err = net.SplitHostPort(domain)
-		if err != nil {
-			return nil, err
-		}
+		tlsConfig.ServerName = domain
 		secureOpt = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 	}
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This should unwedge all of the gRPC tests in the HTTPS leg, which are currently failing due to

```
grpc_test.go:393: gRPC ping = ClientConn's authority from transport creds "grpc-unary-ping-qdlahdab.serving-tests.example.com" and dial option "grpc-unary-ping-qdlahdab.serving-tests.example.com:443" don't match
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
