### PR TITLE
Do not append the port to authority

### DIFF
--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -73,9 +73,6 @@ func dial(ctx *TestContext, host, domain string) (*grpc.ClientConn, error) {
 	if !hasPort(host) {
 		host = net.JoinHostPort(host, defaultPort)
 	}
-	if !hasPort(domain) {
-		domain = net.JoinHostPort(domain, defaultPort)
-	}
 
 	secureOpt := grpc.WithInsecure()
 	if test.ServingFlags.HTTPS {

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -73,10 +73,12 @@ func dial(ctx *TestContext, host, domain string) (*grpc.ClientConn, error) {
 	if !hasPort(host) {
 		host = net.JoinHostPort(host, defaultPort)
 	}
-	var err error
-	domain, _, err = net.SplitHostPort(domain)
-	if err != nil {
-		return nil, err
+	if hasPort(domain) {
+		var err error
+		domain, _, err = net.SplitHostPort(domain)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	secureOpt := grpc.WithInsecure()

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -73,16 +73,17 @@ func dial(ctx *TestContext, host, domain string) (*grpc.ClientConn, error) {
 	if !hasPort(host) {
 		host = net.JoinHostPort(host, defaultPort)
 	}
+	var err error
+	domain, _, err = net.SplitHostPort(domain)
+	if err != nil {
+		return nil, err
+	}
 
 	secureOpt := grpc.WithInsecure()
 	if test.ServingFlags.HTTPS {
 		tlsConfig := test.TLSClientConfig(context.Background(), ctx.t.Logf, ctx.clients)
 		// Set ServerName for pseudo hostname with TLS.
-		var err error
-		tlsConfig.ServerName, _, err = net.SplitHostPort(domain)
-		if err != nil {
-			return nil, err
-		}
+		tlsConfig.ServerName = domain
 		secureOpt = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 	}
 


### PR DESCRIPTION
This patch stops to append the port to authority header for gRPC test.

grpc-go recently added the validation for aurhority and server name by https://github.com/grpc/grpc-go/pull/4817
and the host with port in authority gets the following matching error:

```
    grpc_test.go:450: error:  ping gRPC error: ClientConn's authority from transport creds "grpc-load-balancing-dhlqibxf.serving-tests.example.com" and dial option "grpc-load-balancing-dhlqibxf.serving-tests.example.com:443" don't match
```

This patch fixes it.