### PR TITLE
Don't run tests in parallel in kind

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -199,6 +199,6 @@ jobs:
         # Exclude the control-plane node, which doesn't seem to expose the nodeport service.
         IPS=( $(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}') )
         # Run the tests tagged as e2e on the KinD cluster.
-        go test -race -count=1 -parallel=1 -timeout=20m -tags=e2e ${{ matrix.test-suite }} \
+        go test -race -count=1 -parallel=1 -timeout=30m -tags=e2e ${{ matrix.test-suite }} \
           --ingressendpoint="${IPS[0]}" \
           --enable-alpha --enable-beta

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -199,6 +199,6 @@ jobs:
         # Exclude the control-plane node, which doesn't seem to expose the nodeport service.
         IPS=( $(kubectl get nodes -lkubernetes.io/hostname!=kind-control-plane -ojsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}') )
         # Run the tests tagged as e2e on the KinD cluster.
-        go test -race -count=1 -timeout=20m -tags=e2e ${{ matrix.test-suite }} \
-           --ingressendpoint="${IPS[0]}" \
-           --enable-alpha --enable-beta
+        go test -race -count=1 -parallel=1 -timeout=20m -tags=e2e ${{ matrix.test-suite }} \
+          --ingressendpoint="${IPS[0]}" \
+          --enable-alpha --enable-beta


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As per title. This tries to fix sporadic test failures like https://github.com/knative/serving/runs/4352572386?check_suite_focus=true which failed due to

```
image_pull_error_test.go:86: Failed to validate revision state: the Revision image-pull-error-bwfvekdz-00001 ReadyCondition = (Reason="Unschedulable", Message="0/2 nodes are available: 1 Insufficient cpu, 1 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate."), wantReasons: [ImagePullBackOff ErrImagePull]
```