### PR TITLE
Bump golangci-lint timeout to prevent errors in actions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  timeout: 5m
+  timeout: 10m
 
   build-tags:
     - e2e


### PR DESCRIPTION
Title. See https://github.com/knative/serving/runs/4354665077?check_suite_focus=true for an occurrence.