### PR TITLE
Pass ko flags to podspeed preparation step

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -138,7 +138,7 @@ rm "${ARTIFACTS}/k8s.log-$(basename "${E2E_SCRIPT}").txt"
 
 header "Collecting performance data"
 
-cat <<EOF | ko apply -f -
+cat <<EOF | ko apply $(ko_flags) -f -
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

As per title, this passes the configured ko flags to the preparation step for `podspeed`, mainly to make sure the image gets built for the correct architectures.

This should fix the s390x leg, where the build is currently failing due to this, see https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-serving-s390x-kourier-tests/1465516172643405824

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
