### PR TITLE
Do not install redundant resources in upgrade tests

### DIFF
--- a/test/conformance.go
+++ b/test/conformance.go
@@ -18,10 +18,11 @@ package test
 
 import (
 	"context"
+	"testing"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 
 	// For our e2e testing, we want this linked first so that our
 	// systen namespace environment variable is defaulted prior to

--- a/test/conformance.go
+++ b/test/conformance.go
@@ -98,6 +98,5 @@ func Setup(t testing.TB, namespace ...string) *Clients {
 	if err != nil {
 		t.Fatal("Couldn't initialize clients", "error", err)
 	}
-
 	return clients
 }

--- a/test/conformance.go
+++ b/test/conformance.go
@@ -17,12 +17,7 @@ limitations under the License.
 package test
 
 import (
-	"context"
 	"testing"
-
-	corev1 "k8s.io/api/core/v1"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	// For our e2e testing, we want this linked first so that our
 	// systen namespace environment variable is defaulted prior to
@@ -102,20 +97,6 @@ func Setup(t testing.TB, namespace ...string) *Clients {
 	clients, err := NewClients(cfg, ns)
 	if err != nil {
 		t.Fatal("Couldn't initialize clients", "error", err)
-	}
-
-	if _, err = clients.KubeClient.CoreV1().Namespaces().
-		Get(context.Background(), ns, metav1.GetOptions{}); apierrs.IsNotFound(err) {
-		// As multiple tests are using the same namespace, try creating the namespace
-		// but do not fail if other tests already created it.
-		if _, err := clients.KubeClient.CoreV1().Namespaces().
-			Create(context.Background(),
-				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
-				metav1.CreateOptions{}); err != nil && !apierrs.IsAlreadyExists(err) {
-			t.Fatalf("Couldn't create test namespace %q: %v", ns, err)
-		}
-	} else if err != nil {
-		t.Fatalf("Couldn't check existence of namespace %q: %v", ns, err)
 	}
 
 	return clients

--- a/test/conformance.go
+++ b/test/conformance.go
@@ -17,6 +17,10 @@ limitations under the License.
 package test
 
 import (
+	"context"
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
 	// For our e2e testing, we want this linked first so that our
@@ -98,5 +102,20 @@ func Setup(t testing.TB, namespace ...string) *Clients {
 	if err != nil {
 		t.Fatal("Couldn't initialize clients", "error", err)
 	}
+
+	if _, err = clients.KubeClient.CoreV1().Namespaces().
+		Get(context.Background(), ns, metav1.GetOptions{}); apierrs.IsNotFound(err) {
+		// As multiple tests are using the same namespace, try creating the namespace
+		// but do not fail if other tests already created it.
+		if _, err := clients.KubeClient.CoreV1().Namespaces().
+			Create(context.Background(),
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+				metav1.CreateOptions{}); err != nil && !apierrs.IsAlreadyExists(err) {
+			t.Fatalf("Couldn't create test namespace %q: %v", ns, err)
+		}
+	} else if err != nil {
+		t.Fatalf("Couldn't check existence of namespace %q: %v", ns, err)
+	}
+
 	return clients
 }

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -31,6 +31,12 @@
 # shellcheck disable=SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/e2e-common.sh"
 
+# Overrides
+function stage_test_resources() {
+  # Nothing to install before tests.
+  true
+}
+
 # Script entry point.
 
 # Skip installing istio as an add-on.

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -45,8 +45,6 @@ TIMEOUT=30m
 
 header "Running upgrade tests"
 
-kubectl delete namespace serving-tests
-
 go_test_e2e -tags=upgrade -timeout=${TIMEOUT} \
   ./test/upgrade \
   --resolvabledomain=$(use_resolvable_domain) || fail_test

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -45,6 +45,8 @@ TIMEOUT=30m
 
 header "Running upgrade tests"
 
+kubectl delete namespace serving-tests
+
 go_test_e2e -tags=upgrade -timeout=${TIMEOUT} \
   ./test/upgrade \
   --resolvabledomain=$(use_resolvable_domain) || fail_test

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -86,7 +86,7 @@ func createNewService(serviceName string, t *testing.T) {
 
 func CreateTestNamespace() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("CreateTestNamespace", func(c pkgupgrade.Context) {
-		createTestNamespace(c.T, "serving-tests")
+		createTestNamespace(c.T, test.ServingFlags.TestNamespace)
 	})
 }
 

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -93,14 +93,9 @@ func CreateTestNamespace() pkgupgrade.Operation {
 func createTestNamespace(t *testing.T, ns string) {
 	clients := e2e.Setup(t)
 	if _, err := clients.KubeClient.CoreV1().Namespaces().
-		Get(context.Background(), ns, metav1.GetOptions{}); apierrs.IsNotFound(err) {
-		if _, err := clients.KubeClient.CoreV1().Namespaces().
-			Create(context.Background(),
-				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
-				metav1.CreateOptions{}); err != nil {
-			t.Fatalf("Couldn't create namespace %q: %v", ns, err)
-		}
-	} else if err != nil {
-		t.Fatalf("Couldn't check existence of namespace %q: %v", ns, err)
+		Create(context.Background(),
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+			metav1.CreateOptions{}); err != nil && !apierrs.IsAlreadyExists(err) {
+		t.Fatalf("Couldn't create namespace %q: %v", ns, err)
 	}
 }

--- a/test/upgrade/upgrade.go
+++ b/test/upgrade/upgrade.go
@@ -22,6 +22,11 @@ import (
 	"net/url"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgupgrade "knative.dev/pkg/test/upgrade"
+
 	// Mysteriously required to support GCP auth (required by k8s libs).
 	// Apparently just importing it is enough. @_@ side effects @_@.
 	// https://github.com/kubernetes/client-go/issues/242
@@ -77,4 +82,25 @@ func createNewService(serviceName string, t *testing.T) {
 	}
 	url := resources.Service.Status.URL.URL()
 	assertServiceResourcesUpdated(t, clients, names, url, test.PizzaPlanetText1)
+}
+
+func CreateTestNamespace() pkgupgrade.Operation {
+	return pkgupgrade.NewOperation("CreateTestNamespace", func(c pkgupgrade.Context) {
+		createTestNamespace(c.T, "serving-tests")
+	})
+}
+
+func createTestNamespace(t *testing.T, ns string) {
+	clients := e2e.Setup(t)
+	if _, err := clients.KubeClient.CoreV1().Namespaces().
+		Get(context.Background(), ns, metav1.GetOptions{}); apierrs.IsNotFound(err) {
+		if _, err := clients.KubeClient.CoreV1().Namespaces().
+			Create(context.Background(),
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+				metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Couldn't create namespace %q: %v", ns, err)
+		}
+	} else if err != nil {
+		t.Fatalf("Couldn't check existence of namespace %q: %v", ns, err)
+	}
 }

--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -39,8 +39,8 @@ func TestServingUpgrades(t *testing.T) {
 		},
 		Installations: pkgupgrade.Installations{
 			Base: []pkgupgrade.Operation{
-				// Do nothing. The initial version is already installed by scripts
-				// together with additional test resources.
+				CreateTestNamespace(),
+				// The initial Knative Serving version is already installed by scripts.
 			},
 			UpgradeWith: []pkgupgrade.Operation{
 				installation.Head(),


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/12372

Simplify running upgrade tests which do not require much of the resources we install. The only required test resource is the namespace and it can be created automatically.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* do not install redundant test resources
* create the test namespace within Golang upgrade tests if the namespace does not exist yet

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
