### PR TITLE
Add net-gateway-api to Kind test

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -17,10 +17,11 @@ jobs:
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
-        k8s-version:
-        - v1.20.7
-        - v1.21.1
-        - v1.22.2
+        cluster:
+        - v1.20.7/contour
+        - v1.21.1/kourier
+        - v1.22.2/istio
+        - v1.22.2/gateway-api
 
         test-suite:
         - ./test/conformance/runtime
@@ -31,20 +32,29 @@ jobs:
           # Map between K8s and KinD versions.
           # This is attempting to make it a bit clearer what's being tested.
           # See: https://github.com/kubernetes-sigs/kind/releases
-        - k8s-version: v1.20.7
+        - cluster: v1.20.7/contour
+          k8s-version: v1.20.7
           kind-version: v0.11.1
           kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
           kingress: contour
           cluster-suffix: c${{ github.run_id }}.local
-        - k8s-version: v1.21.1
+        - cluster: v1.21.1/kourier
+          k8s-version: v1.21.1
           kind-version: v0.11.1
           kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
           kingress: kourier
           cluster-suffix: c${{ github.run_id }}.local
-        - k8s-version: v1.22.2
+        - cluster: v1.22.2/istio
+          k8s-version: v1.22.2
           kind-version: v0.11.1
           kind-image-sha: sha256:f638a08c1f68fe2a99e724ace6df233a546eaf6713019a0b310130a4f91ebe7f
           kingress: istio
+          cluster-suffix: c${{ github.run_id }}.local
+        - cluster: v1.22.2/gateway-api
+          k8s-version: v1.22.2
+          kind-version: v0.11.1
+          kind-image-sha: sha256:f638a08c1f68fe2a99e724ace6df233a546eaf6713019a0b310130a4f91ebe7f
+          kingress: gateway-api
           cluster-suffix: c${{ github.run_id }}.local
 
     env:


### PR DESCRIPTION
This patch adds net-gateway-api to Kind.
I changed the matrix key as `<K8S_VERSION>/<INGRESS>`
(e.g. `v1.20.7/contour`) because duplicated k8s-version key does not
work well.