### PR TITLE
simplify net-gateway-api install

### DIFF
--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -18,6 +18,32 @@ function is_ingress_class() {
   [[ "${INGRESS_CLASS}" == *"${1}"* ]]
 }
 
+function stage_gateway_api_resources() {
+  # This installs an istio version that works with the v1alpha1 gateway api
+  header "Staging Gateway API Resources"
+
+  local gateway_dir="${E2E_YAML_DIR}/gateway-api/install"
+  mkdir -p "${gateway_dir}"
+
+  # TODO: if we switch to istio 1.12 we can reuse stage_istio_head
+  curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION=1.11.4 sh -
+
+  local params="--set values.global.proxy.clusterDomain=${CLUSTER_DOMAIN}"
+  if (( KIND )); then
+    params="${params} --set values.gateways.istio-ingressgateway.type=NodePort"
+  fi
+
+  cat <<EOF > "${gateway_dir}/istio.yaml"
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+---
+EOF
+
+  $HOME/.istioctl/bin/istioctl manifest generate $params >> "${gateway_dir}/istio.yaml"
+}
+
 function stage_istio_head() {
   header "Staging Istio YAML (HEAD)"
   local istio_head_dir="${E2E_YAML_DIR}/istio/HEAD/install"


### PR DESCRIPTION
Include gateway apis's istio as part of the single one shot `kapp` install for our e2e tests