### PR TITLE
Simplify `net_istio_file_url()` in test script

### DIFF
--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -103,17 +103,13 @@ function net_istio_file_url() {
   local sha="$1"
   local file="$2"
 
-  local profile="istio"
-  if (( KIND )); then
-    profile+="-kind"
-  else
-    profile+="-ci"
-  fi
-  if [[ $MESH -eq 0 ]]; then
-    profile+="-no"
-  fi
+  local profile="istio-ci-no-mesh"
 
-  profile+="-mesh"
+  if (( KIND )); then
+    profile="istio-kind-no-mesh"
+  elif (( MESH )); then
+    profile="istio-ci-mesh"
+  fi
 
   echo "https://raw.githubusercontent.com/knative-sandbox/net-istio/${sha}/third_party/istio-${ISTIO_VERSION}/${profile}/${file}"
 }


### PR DESCRIPTION
Current Istio profile has "append" style like:

```
  local profile="istio"
  if (( KIND )); then
    profile+="-kind"
  else
    profile+="-ci"
  fi
  if [[ $MESH -eq 0 ]]; then
    profile+="-no"
  fi

  profile+="-mesh"
```

It is difficult to read so this patch changes it.

Note, https://github.com/knative-sandbox/net-istio/pull/826 will remove istio-kind-mesh profile as it is not used.