### PR TITLE
Adding k8s 1.23.0 to GA action e2e workflows

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -18,10 +18,10 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         cluster:
-        - v1.20.7/contour
         - v1.21.1/kourier
         - v1.22.2/istio
-        - v1.22.2/gateway-api
+        - v1.23.0/contour
+        - v1.23.0/gateway-api
 
         test-suite:
         - ./test/conformance/runtime
@@ -32,12 +32,6 @@ jobs:
           # Map between K8s and KinD versions.
           # This is attempting to make it a bit clearer what's being tested.
           # See: https://github.com/kubernetes-sigs/kind/releases
-        - cluster: v1.20.7/contour
-          k8s-version: v1.20.7
-          kind-version: v0.11.1
-          kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
-          kingress: contour
-          cluster-suffix: c${{ github.run_id }}.local
         - cluster: v1.21.1/kourier
           k8s-version: v1.21.1
           kind-version: v0.11.1
@@ -50,10 +44,16 @@ jobs:
           kind-image-sha: sha256:f638a08c1f68fe2a99e724ace6df233a546eaf6713019a0b310130a4f91ebe7f
           kingress: istio
           cluster-suffix: c${{ github.run_id }}.local
-        - cluster: v1.22.2/gateway-api
-          k8s-version: v1.22.2
+        - cluster: v1.23.0/contour
+          k8s-version: v1.23.0
           kind-version: v0.11.1
-          kind-image-sha: sha256:f638a08c1f68fe2a99e724ace6df233a546eaf6713019a0b310130a4f91ebe7f
+          kind-image-sha: sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
+          kingress: contour
+          cluster-suffix: c${{ github.run_id }}.local
+        - cluster: v1.23.0/gateway-api
+          k8s-version: v1.23.0
+          kind-version: v0.11.1
+          kind-image-sha: sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
           kingress: gateway-api
           cluster-suffix: c${{ github.run_id }}.local
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

As per title.

using only `istio` and `net-gateway-api` as that was for 1.22.x used as well

/assign @nak3 