### PR TITLE
Note autocreate-cluster-domain-claims property in error message

### DIFF
--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -342,7 +342,7 @@ func (r *Reconciler) reconcileDomainClaim(ctx context.Context, dm *v1alpha1.Doma
 func (r *Reconciler) createDomainClaim(ctx context.Context, dm *v1alpha1.DomainMapping) error {
 	if !config.FromContext(ctx).Network.AutocreateClusterDomainClaims {
 		dm.Status.MarkDomainClaimNotOwned()
-		return fmt.Errorf("no ClusterDomainClaim found for domain %q", dm.Name)
+		return fmt.Errorf("no ClusterDomainClaim found for domain %q (and autocreate-cluster-domain-claims property is not true)", dm.Name)
 	}
 
 	_, err := r.netclient.NetworkingV1alpha1().ClusterDomainClaims().Create(ctx, resources.MakeDomainClaim(dm), metav1.CreateOptions{})

--- a/pkg/reconciler/domainmapping/table_test.go
+++ b/pkg/reconciler/domainmapping/table_test.go
@@ -757,7 +757,7 @@ func TestReconcileAutocreateClaimsDisabled(t *testing.T) {
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", "Updated %q finalizers", "first-reconcile.com"),
-			Eventf(corev1.EventTypeWarning, "InternalError", `no ClusterDomainClaim found for domain "first-reconcile.com"`),
+			Eventf(corev1.EventTypeWarning, "InternalError", `no ClusterDomainClaim found for domain "first-reconcile.com" (and autocreate-cluster-domain-claims property is not true)`),
 		},
 	}, {
 		Name: "first reconcile, claim exists and is owned",


### PR DESCRIPTION
A few people have been very validly confused by the default for
autocreate-cluster-domain-claims being false, and the error message in
this case didn't help a user discover why things weren't working. Now it
does.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Improves the error message when a DomainMapping cannot be reconciled because autocreate-cluster-domain-claims is false and the CDC does not exist.
```

/assign @n3wscott 
