### PR TITLE
Add target-utilization to autoscaling config map

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "679f6acd"
+    knative.dev/example-checksum: "36f25a7c"
 data:
   _example: |
     ################################

--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "50900868"
+    knative.dev/example-checksum: "679f6acd"
 data:
   _example: |
     ################################
@@ -73,6 +73,7 @@ data:
     #       the user container may receive, but only the average number of requests
     #       that the revision pods will receive.
     # This config will be deprecated, use target-utilization instead.
+    # Setting to "0" or remove it will disable this option.
     container-concurrency-target-percentage: "0"
 
     # The container concurrency target default is what the Autoscaler will

--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "47c2487f"
+    knative.dev/example-checksum: "50900868"
 data:
   _example: |
     ################################
@@ -40,6 +40,23 @@ data:
     # this example block and unindented to be in the data block
     # to actually change the configuration.
 
+    # This value specifies what percentage of the target (requests per second or concurrency requests) should actually
+    # be targeted by the Autoscaler. This is also known as specifying the hotness at which a replica runs,
+    # which causes the Autoscaler to scale up before the defined hard limit is reached. For example,
+    # if containerConcurrency is set to 10, and the target utilization value is set to 70 (percent),
+    # the Autoscaler will create a new replica when the average number of concurrent requests across
+    # all existing replicas reaches 7.
+    # Note: this limit will be applied to container concurrency or requests per second set at every
+    # level (ConfigMap, Revision Spec or Annotation).
+    # For legacy and backwards compatibility reasons, this value also accepts
+    # fractional values in (0, 1] interval (i.e. 0.7 ⇒ 70%).
+    # Thus minimal percentage value must be greater than 1.0, or it will be
+    # treated as a fraction.
+    # NOTE: that this value does not affect actual number of concurrent requests or requests per second
+    #       the user container may receive, but only the average number of requests
+    #       that the revision pods will receive.
+    target-utilization: "70"
+
     # The Revision ContainerConcurrency field specifies the maximum number
     # of requests the Container can handle at once. Container concurrency
     # target percentage is how much of that maximum to use in a stable
@@ -55,7 +72,8 @@ data:
     # NOTE: that this value does not affect actual number of concurrent requests
     #       the user container may receive, but only the average number of requests
     #       that the revision pods will receive.
-    container-concurrency-target-percentage: "70"
+    # This config will be deprecated, use target-utilization instead.
+    container-concurrency-target-percentage: "0"
 
     # The container concurrency target default is what the Autoscaler will
     # try to maintain when concurrency is used as the scaling metric for the

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -113,12 +113,13 @@ func NewConfigFromMap(data map[string]string) (*autoscalerconfig.Config, error) 
 	}
 
 	// only one of the following should be set, since target utilization have default value,
-	// it is greater than zero regardless of whether set or not
+	// it is greater than zero regardless of whether set or not. Side note: this should be removed once container-concurrency-target-percentage is removed.
 	if _, isTargetDefined := data["target-utilization"]; isTargetDefined && lc.ContainerConcurrencyTargetFraction > 0 {
 		return nil, fmt.Errorf("target-utilization and container-concurrency-target-percentage are mutually exclusive, please remove container-concurrency-target-percentage")
 	}
 
-	// if only ContainerConcurrencyTargetFraction is set, then set the target utilization to its value
+	// If only ContainerConcurrencyTargetFraction is set, then set the target utilization to its value.
+	// This should be removed once container-concurrency-target-percentage is removed.
 	if lc.ContainerConcurrencyTargetFraction > 0 {
 		lc.TargetUtilization = lc.ContainerConcurrencyTargetFraction
 	}

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -137,7 +137,7 @@ func validate(lc *autoscalerconfig.Config) (*autoscalerconfig.Config, error) {
 	}
 
 	if lc.ContainerConcurrencyTargetFraction < 0 || lc.ContainerConcurrencyTargetFraction > 1 {
-		return nil, fmt.Errorf("container-concurrency-target-percentage = %f is outside of valid range of (0, 100]", lc.ContainerConcurrencyTargetFraction)
+		return nil, fmt.Errorf("container-concurrency-target-percentage = %f is outside of valid range of [0, 100]", lc.ContainerConcurrencyTargetFraction)
 	}
 
 	if lc.TargetUtilization <= 0 || lc.TargetUtilization > 1 {

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	cm "knative.dev/pkg/configmap"
+
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
 
@@ -149,11 +150,11 @@ func validate(lc *autoscalerconfig.Config) (*autoscalerconfig.Config, error) {
 	}
 
 	if lc.ContainerConcurrencyTargetFraction < 0 || lc.ContainerConcurrencyTargetFraction > 1 {
-		return nil, fmt.Errorf("container-concurrency-target-percentage = %f is outside of valid range of [0, 100]", lc.ContainerConcurrencyTargetFraction * 100)
+		return nil, fmt.Errorf("container-concurrency-target-percentage = %f is outside of valid range of [0, 100]", lc.ContainerConcurrencyTargetFraction*100)
 	}
 
 	if lc.TargetUtilization <= 0 || lc.TargetUtilization > 1 {
-		return nil, fmt.Errorf("target-utilization = %f is outside of valid range of (0, 100]", lc.TargetUtilization * 100)
+		return nil, fmt.Errorf("target-utilization = %f is outside of valid range of (0, 100]", lc.TargetUtilization*100)
 	}
 
 	if x := lc.ContainerConcurrencyTargetFraction * lc.ContainerConcurrencyTargetDefault; lc.ContainerConcurrencyTargetFraction != 0 && x < autoscaling.TargetMin {

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -112,6 +112,17 @@ func NewConfigFromMap(data map[string]string) (*autoscalerconfig.Config, error) 
 		lc.TargetUtilization /= 100.0
 	}
 
+	// only one of the following should be set, since target utilization have default value,
+	// it is greater than zero regardless of whether set or not
+	if _, isTargetDefined := data["target-utilization"]; isTargetDefined && lc.ContainerConcurrencyTargetFraction > 0 {
+		return nil, fmt.Errorf("target-utilization and container-concurrency-target-percentage are mutually exclusive, please remove container-concurrency-target-percentage")
+	}
+
+	// if only ContainerConcurrencyTargetFraction is set, then set the target utilization to its value
+	if lc.ContainerConcurrencyTargetFraction > 0 {
+		lc.TargetUtilization = lc.ContainerConcurrencyTargetFraction
+	}
+
 	return validate(lc)
 }
 

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -153,7 +153,7 @@ func validate(lc *autoscalerconfig.Config) (*autoscalerconfig.Config, error) {
 	}
 
 	if lc.TargetUtilization <= 0 || lc.TargetUtilization > 1 {
-		return nil, fmt.Errorf("target-utilization = %f is outside of valid range of (0, 100]", lc.TargetUtilization)
+		return nil, fmt.Errorf("target-utilization = %f is outside of valid range of (0, 100]", lc.TargetUtilization * 100)
 	}
 
 	if x := lc.ContainerConcurrencyTargetFraction * lc.ContainerConcurrencyTargetDefault; lc.ContainerConcurrencyTargetFraction != 0 && x < autoscaling.TargetMin {

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -149,7 +149,7 @@ func validate(lc *autoscalerconfig.Config) (*autoscalerconfig.Config, error) {
 	}
 
 	if lc.ContainerConcurrencyTargetFraction < 0 || lc.ContainerConcurrencyTargetFraction > 1 {
-		return nil, fmt.Errorf("container-concurrency-target-percentage = %f is outside of valid range of [0, 100]", lc.ContainerConcurrencyTargetFraction)
+		return nil, fmt.Errorf("container-concurrency-target-percentage = %f is outside of valid range of [0, 100]", lc.ContainerConcurrencyTargetFraction * 100)
 	}
 
 	if lc.TargetUtilization <= 0 || lc.TargetUtilization > 1 {

--- a/pkg/autoscaler/config/config_test.go
+++ b/pkg/autoscaler/config/config_test.go
@@ -52,7 +52,7 @@ func TestNewConfig(t *testing.T) {
 			"enable-scale-to-zero":                    "true",
 			"max-scale-down-rate":                     "3.0",
 			"max-scale-up-rate":                       "1.01",
-			"target-utilization":                      "0.71",
+			"target-utilization":                      "0.8",
 			"container-concurrency-target-percentage": "0.71",
 			"container-concurrency-target-default":    "10.5",
 			"requests-per-second-target-default":      "10.11",
@@ -71,7 +71,7 @@ func TestNewConfig(t *testing.T) {
 			c.TargetBurstCapacity = 12345
 			c.ContainerConcurrencyTargetDefault = 10.5
 			c.ContainerConcurrencyTargetFraction = 0.71
-			c.TargetUtilization = 0.71
+			c.TargetUtilization = 0.8
 			c.RPSTargetDefault = 10.11
 			c.MaxScaleDownRate = 3
 			c.MaxScaleUpRate = 1.01

--- a/pkg/reconciler/autoscaling/resources/metric_test.go
+++ b/pkg/reconciler/autoscaling/resources/metric_test.go
@@ -172,10 +172,10 @@ func pa(options ...PodAutoscalerOption) *autoscalingv1alpha1.PodAutoscaler {
 
 var config = &autoscalerconfig.Config{
 	EnableScaleToZero:                  true,
-	ContainerConcurrencyTargetFraction: 1.0,
+	ContainerConcurrencyTargetFraction: 0,
 	ContainerConcurrencyTargetDefault:  100.0,
 	RPSTargetDefault:                   200.0,
-	TargetUtilization:                  0.7,
+	TargetUtilization:                  1.0,
 	MaxScaleUpRate:                     10.0,
 	StableWindow:                       60 * time.Second,
 	PanicThresholdPercentage:           200,

--- a/pkg/reconciler/autoscaling/resources/target_test.go
+++ b/pkg/reconciler/autoscaling/resources/target_test.go
@@ -263,8 +263,8 @@ func TestResolveMetricTarget(t *testing.T) {
 		wantTarget: 300,
 		wantTotal:  300,
 	}, {
-		name:       "RPS: default CC + 80% TargetUtilization + 75% CC, CC will be ignore",
-		pa:         pa(WithMetricAnnotation(autoscaling.RPS)),
+		name: "RPS: default CC + 80% TargetUtilization + 75% CC, CC will be ignore",
+		pa:   pa(WithMetricAnnotation(autoscaling.RPS)),
 		cfgOpt: func(c autoscalerconfig.Config) *autoscalerconfig.Config {
 			c.TargetUtilization = 0.8
 			c.ContainerConcurrencyTargetFraction = 0.75


### PR DESCRIPTION
Fixes # N/A

For now `TargetUtilization`(https://github.com/knative/serving/blob/main/pkg/autoscaler/config/autoscalerconfig/autoscalerconfig.go#L34) is hard coded and `ContainerConcurrencyTargetFraction` only used for Concurrency.  

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
Expose `TargetUtilization` to autoscaling config map as `target-utilization`, it will take effect in both `concurrency` and `rps` mode. If `container-concurrency-target-percentage` is specified and the `metric` is `concurrency`, it will be used for now for backward consistency.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add target-utilization to autoscaling config map
```
