### PR TITLE
Move liveness checks to user container port rather than QP port

### DIFF
--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -93,10 +93,7 @@ func rewriteUserProbe(p *corev1.Probe, userPort int) {
 	}
 	switch {
 	case p.HTTPGet != nil:
-		// For HTTP probes, we route them through the queue container
-		// so that we know the queue proxy is ready/live as well.
-		// It doesn't matter to which queue serving port we are forwarding the probe.
-		p.HTTPGet.Port = intstr.FromInt(networking.BackendHTTPPort)
+		p.HTTPGet.Port = intstr.FromInt(userPort)
 		// With mTLS enabled, Istio rewrites probes, but doesn't spoof the kubelet
 		// user agent, so we need to inject an extra header to be able to distinguish
 		// between probes and real requests.

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -40,7 +40,6 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
 	"knative.dev/serving/pkg/deployment"
-	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/queue"
 
 	_ "knative.dev/pkg/metrics/testing"
@@ -802,7 +801,7 @@ func TestMakePodSpec(t *testing.T) {
 					withLivenessProbe(corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{
 							Path: "/",
-							Port: intstr.FromInt(networking.BackendHTTPPort),
+							Port: intstr.FromInt(v1.DefaultUserPort),
 							HTTPHeaders: []corev1.HTTPHeader{{
 								Name:  network.KubeletProbeHeaderName,
 								Value: queue.Name,


### PR DESCRIPTION
.. Otherwise these get intercepted by the drainer logic in queue proxy, which is not what we want.

This caused the issue in https://github.com/knative/serving/issues/12462 since we ended up with a liveness probe hitting the QP health check logic, which had worked in the past, but now fails since QP's health checks no longer delegate to the user container if the header isn't passed (which is how this worked before).

We could fix https://github.com/knative/serving/issues/12462 by making QP delegate liveness checks as it did in the past, but actually I think this was always a mistake to do: QP shouldn't be involved with liveness checks in the first place (note this is already the case for TCP liveness probes and the default case where there is no liveness probe).

Initially liveness and readiness were routed via the queue proxy so that a single check could check both user container and queue proxy; while this makes some sense for Readiness (because we need this for optimisations in activator that need to check readiness of the whole pod at once), for liveness this is both not needed and actively harmful. A failing liveness probe results in Kubernetes restarting the container the probe is defined on (in this case, the user container), but if the failure comes from QP this will not help (and is actively unhelpful since the wrong container will be restarted). 

(If we want to add a liveness probe to Queue Proxy, we should add that directly rather than modifying the user's probe to go via the Queue Proxy port, that way the right thing will be restarted if there's a deadlock in QP - but we can do that separately).

Fixes #12462.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Changes liveness probes to directly probe the user container rather than queue proxy.
```
