### PR TITLE
Gives an error if MinNonActiveRevisions is equal to 0 and MaxNonActiveRevisions is not set or not equal to 0 (#12422)

### DIFF
--- a/config/core/configmaps/gc.yaml
+++ b/config/core/configmaps/gc.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
   annotations:
-    knative.dev/example-checksum: "51b4d68a"
+    knative.dev/example-checksum: "45463e45"
 data:
   _example: |
     ################################
@@ -64,6 +64,7 @@ data:
     #
     # Example config to immediately collect any inactive revision:
     #    min-non-active-revisions: "0"
+    #    max-non-active-revisions: "0"
     #    retain-since-create-time: "disabled"
     #    retain-since-last-active-time: "disabled"
     #


### PR DESCRIPTION
Fixes #12422 

## Proposed Changes

* If min-non-active-revisions is set to 0, max-non-active-revisions will be 0 too.

Discussion: Would be worth to return an error if max-non-active-revisions is set with some N value and min-non-active-revisions is set to 0? Like "min-non-active-revisions(%d) must be > 0"
