### PR TITLE
Updates to GA version of PodDisruptionBudget

### DIFF
--- a/config/core/deployments/activator-hpa.yaml
+++ b/config/core/deployments/activator-hpa.yaml
@@ -41,7 +41,7 @@ spec:
 # Activator PDB. Currently we permit unavailability of 20% of tasks at the same time.
 # Given the subsetting and that the activators are partially stateful systems, we want
 # a slow rollout of the new versions and slow migration during node upgrades.
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: activator-pdb

--- a/config/core/deployments/webhook-hpa.yaml
+++ b/config/core/deployments/webhook-hpa.yaml
@@ -39,7 +39,7 @@ spec:
         averageUtilization: 100
 ---
 # Webhook PDB.
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: webhook-pdb


### PR DESCRIPTION
Fixes #11488

## Proposed Changes

As release v1.2 will require a minimum Kuberenetes version of 1.21, it's time to update the PodDisruptionBudget API.

/hold
for v1.21 release (though we should probably merge before the release)

**Release Note**

```release-note
PodDisruptionBudget updated to v1 API
```
