### PR TITLE
Removes override of default periodSeconds value

### DIFF
--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -86,7 +86,7 @@ var (
 					}},
 				},
 			},
-			PeriodSeconds: 1,
+			PeriodSeconds: 0,
 		},
 		SecurityContext: queueSecurityContext,
 		Env: []corev1.EnvVar{{

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -240,13 +240,6 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 				}},
 			},
 		}
-
-		// Default PeriodSeconds to 1 if not set to make for the quickest possible startup
-		// time.
-		// TODO(#10973): Remove this once we're on K8s 1.21
-		if httpProbe.PeriodSeconds == 0 {
-			httpProbe.PeriodSeconds = 1
-		}
 	}
 
 	c := &corev1.Container{

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -724,7 +724,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 						}},
 					},
 				},
-				PeriodSeconds:    1,
+				PeriodSeconds:    0,
 				TimeoutSeconds:   0,
 				SuccessThreshold: 3,
 			}


### PR DESCRIPTION
## Proposed Changes

In #10992 we had introduced a workaround to prevent a delay in declaring a container ready due to the async nature of probe timers. Kubernetes introduced a [fix in v1.21](https://github.com/kubernetes/kubernetes/commit/4870e64ac110d6bf62dbd270f8cef557c4bd6d53#diff-acb3209237c09e77cb3f4c876543c4cfb7eda6b110a7ec7c52e48a920ae8c876) (by trigger an immediate run of a readiness probe after startup), and now that we have 1.21 as a minimum version we no longer said workaround.

/assign @julz 

/hold
for v1.21 release (though we should probably merge before the release)

**Release Note**

```release-note
Utilizes Kubernetes's immediate trigger of readiness probes after startup, restores default `periodSeconds` for readiness probe to Kuberentes default (10s)
```