### PR TITLE
Updates selector labels to `app.kubernetes.io`

### DIFF
--- a/config/core/webhooks/configmap-validation.yaml
+++ b/config/core/webhooks/configmap-validation.yaml
@@ -32,7 +32,7 @@ webhooks:
   name: config.webhook.serving.knative.dev
   namespaceSelector:
     matchExpressions:
-    - key: app.kubernetes.io/part-of
+    - key: app.kubernetes.io/name
       operator: In
       values:
       - knative-serving

--- a/config/core/webhooks/configmap-validation.yaml
+++ b/config/core/webhooks/configmap-validation.yaml
@@ -31,9 +31,6 @@ webhooks:
   sideEffects: None
   name: config.webhook.serving.knative.dev
   namespaceSelector:
-    matchExpressions:
-    - key: app.kubernetes.io/name
-      operator: In
-      values:
-      - knative-serving
+    matchLabels:
+      app.kubernetes.io/name: knative-serving
   timeoutSeconds: 10

--- a/config/core/webhooks/configmap-validation.yaml
+++ b/config/core/webhooks/configmap-validation.yaml
@@ -32,6 +32,8 @@ webhooks:
   name: config.webhook.serving.knative.dev
   namespaceSelector:
     matchExpressions:
-    - key: serving.knative.dev/release
-      operator: Exists
+    - key: app.kubernetes.io/part-of
+      operator: In
+      values:
+      - knative-serving
   timeoutSeconds: 10

--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -51,7 +51,7 @@ metadata:
   name: config-domain
   namespace: ${SYSTEM_NAMESPACE}
   labels:
-    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
 data:
   ${CUSTOM_DOMAIN_SUFFIX}: ""

--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -51,7 +51,6 @@ metadata:
   name: config-domain
   namespace: ${SYSTEM_NAMESPACE}
   labels:
-    serving.knative.dev/release: devel
     app.kubernetes.io/part-of: knative-serving
     app.kubernetes.io/version: devel
 data:

--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -52,6 +52,8 @@ metadata:
   namespace: ${SYSTEM_NAMESPACE}
   labels:
     serving.knative.dev/release: devel
+    app.kubernetes.io/part-of: knative-serving
+    app.kubernetes.io/version: devel
 data:
   ${CUSTOM_DOMAIN_SUFFIX}: ""
 EOF


### PR DESCRIPTION
Part of #12215 

## Proposed Changes

* Drop usage of `serving.knative.dev/release` in selectors for Knative resources in favor of the recommended `app.kubernetes.io`

**Release Note**

```release-note
Switches selectors for Knative resources to use the recommended `app.kubernetes.io` labels
```

/assign @dprotaso 