### PR TITLE
Bump Istio version for gateway-api to 1.12.2

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -37,24 +37,28 @@ jobs:
           kind-version: v0.11.1
           kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
           kingress: kourier
+          test-flags: "--enable-alpha --enable-beta"
           cluster-suffix: c${{ github.run_id }}.local
         - cluster: v1.22.2/istio
           k8s-version: v1.22.2
           kind-version: v0.11.1
           kind-image-sha: sha256:f638a08c1f68fe2a99e724ace6df233a546eaf6713019a0b310130a4f91ebe7f
           kingress: istio
+          test-flags: "--enable-alpha --enable-beta"
           cluster-suffix: c${{ github.run_id }}.local
         - cluster: v1.23.0/contour
           k8s-version: v1.23.0
           kind-version: v0.11.1
           kind-image-sha: sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
           kingress: contour
+          test-flags: "--enable-alpha --enable-beta"
           cluster-suffix: c${{ github.run_id }}.local
         - cluster: v1.23.0/gateway-api
           k8s-version: v1.23.0
           kind-version: v0.11.1
           kind-image-sha: sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac
           kingress: gateway-api
+          test-flags: "--enable-alpha"
           cluster-suffix: c${{ github.run_id }}.local
 
     env:
@@ -215,5 +219,5 @@ jobs:
         toggle_feature kubernetes.podspec-volumes-emptydir Enabled
         go test -race -count=1 -parallel=1 -timeout=30m -tags=e2e ${{ matrix.test-suite }} \
           --ingressendpoint="${IPS[0]}" \
-          --enable-alpha --enable-beta
+        ${{ matrix.test-flags }}
         toggle_feature kubernetes.podspec-volumes-emptydir Disabled

--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -26,7 +26,7 @@ function stage_gateway_api_resources() {
   mkdir -p "${gateway_dir}"
 
   # TODO: if we switch to istio 1.12 we can reuse stage_istio_head
-  curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION=1.11.4 sh -
+  curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION=1.12.2 sh -
 
   local params="--set values.global.proxy.clusterDomain=${CLUSTER_DOMAIN}"
   if (( KIND )); then

--- a/third_party/gateway-api-latest/istio-gateway.yaml
+++ b/third_party/gateway-api-latest/istio-gateway.yaml
@@ -20,7 +20,7 @@ metadata:
   name: knative-local-gateway
   namespace: istio-system
   labels:
-    serving.knative.dev/release: "v20220125-1a7d3eb6"
+    serving.knative.dev/release: "v20220204-285bccce"
     networking.knative.dev/ingress-provider: istio
     experimental.istio.io/disable-gateway-port-translation: "true"
 spec:
@@ -48,25 +48,22 @@ spec:
 # limitations under the License.
 
 kind: Gateway
-apiVersion: networking.x-k8s.io/v1alpha1
+apiVersion: gateway.networking.k8s.io/v1alpha2
 metadata:
   name: knative-local-gateway
   namespace: istio-system
 spec:
   gatewayClassName: istio
   addresses:
-    - type: NamedAddress
+    - type: Hostname
       value: knative-local-gateway
   listeners:
-    - protocol: HTTP
+    - name: default
       port: 80
-      routes:
-        kind: HTTPRoute
-        selector:
-          matchLabels:
-            networking.knative.dev/visibility: "cluster-local"
+      protocol: HTTP
+      allowedRoutes:
         namespaces:
-          from: "All"
+          from: All
 
 ---
 # Copyright 2021 The Knative Authors
@@ -84,38 +81,22 @@ spec:
 # limitations under the License.
 
 kind: Gateway
-apiVersion: networking.x-k8s.io/v1alpha1
+apiVersion: gateway.networking.k8s.io/v1alpha2
 metadata:
   name: knative-gateway
   namespace: istio-system
 spec:
   gatewayClassName: istio
   addresses:
-    - type: NamedAddress
+    - type: Hostname
       value: istio-ingressgateway
   listeners:
-    - protocol: HTTP
+    - name: default
       port: 80
-      routes:
-        kind: HTTPRoute
-        selector:
-          matchLabels:
-            networking.knative.dev/visibility: ""
+      protocol: HTTP
+      allowedRoutes:
         namespaces:
-          from: "All"
-    - protocol: HTTPS
-      port: 443
-      tls:
-        mode: Terminate
-        routeOverride:
-          certificate: Allow
-      routes:
-        kind: HTTPRoute
-        selector:
-          matchLabels:
-            networking.knative.dev/visibility: ""
-        namespaces:
-          from: "All"
+          from: All
 
 ---
 # Copyright 2021 The Knative Authors
@@ -132,11 +113,11 @@ spec:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.x-k8s.io/v1alpha1
+apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: GatewayClass
 metadata:
   name: istio
 spec:
-  controller: istio.io/gateway-controller
+  controllerName: istio.io/gateway-controller
 
 ---

--- a/third_party/gateway-api-latest/net-gateway-api.yaml
+++ b/third_party/gateway-api-latest/net-gateway-api.yaml
@@ -1,182 +1,13 @@
-# Generated with "kubectl kustomize https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.3.0"
+# Generated with "kubectl kustomize https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0"
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
   creationTimestamp: null
-  name: backendpolicies.networking.x-k8s.io
+  name: gatewayclasses.gateway.networking.k8s.io
 spec:
-  group: networking.x-k8s.io
-  names:
-    categories:
-      - gateway-api
-    kind: BackendPolicy
-    listKind: BackendPolicyList
-    plural: backendpolicies
-    shortNames:
-      - bp
-    singular: backendpolicy
-  scope: Namespaced
-  versions:
-    - additionalPrinterColumns:
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: BackendPolicy defines policies associated with backends. For the purpose of this API, a backend is defined as any resource that a route can forward traffic to. A common example of a backend is a Service. Configuration that is implementation specific may be represented with similar implementation specific custom resources.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec defines the desired state of BackendPolicy.
-              properties:
-                backendRefs:
-                  description: "BackendRefs define which backends this policy should be applied to. This policy can only apply to backends within the same namespace. If more than one BackendPolicy targets the same backend, precedence must be given to the oldest BackendPolicy. \n Support: Core"
-                  items:
-                    description: BackendRef identifies an API object within the same namespace as the BackendPolicy.
-                    properties:
-                      group:
-                        description: Group is the group of the referent.
-                        maxLength: 253
-                        type: string
-                      kind:
-                        description: Kind is the kind of the referent.
-                        maxLength: 253
-                        type: string
-                      name:
-                        description: Name is the name of the referent.
-                        maxLength: 253
-                        type: string
-                      port:
-                        description: Port is the port of the referent. If unspecified, this policy applies to all ports on the backend.
-                        format: int32
-                        maximum: 65535
-                        minimum: 1
-                        type: integer
-                    required:
-                      - group
-                      - kind
-                      - name
-                    type: object
-                  maxItems: 16
-                  type: array
-                tls:
-                  description: "TLS is the TLS configuration for these backends. \n Support: Extended"
-                  properties:
-                    certificateAuthorityRef:
-                      description: "CertificateAuthorityRef is a reference to a Kubernetes object that contains one or more trusted CA certificates. The CA certificates are used to establish a TLS handshake to backends listed in BackendRefs. The referenced object MUST reside in the same namespace as BackendPolicy. \n CertificateAuthorityRef can reference a standard Kubernetes resource, i.e. ConfigMap, or an implementation-specific custom resource. \n When stored in a Secret, certificates must be PEM encoded and specified within the \"ca.crt\" data field of the Secret. When multiple certificates are specified, the certificates MUST be concatenated by new lines. \n CertificateAuthorityRef can also reference a standard Kubernetes resource, i.e. ConfigMap, or an implementation-specific custom resource. \n Support: Extended"
-                      properties:
-                        group:
-                          description: Group is the group of the referent.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        kind:
-                          description: Kind is kind of the referent.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        name:
-                          description: Name is the name of the referent.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                      required:
-                        - group
-                        - kind
-                        - name
-                      type: object
-                    options:
-                      additionalProperties:
-                        type: string
-                      description: "Options are a list of key/value pairs to give extended options to the provider. \n Support: Implementation-specific"
-                      type: object
-                  type: object
-              required:
-                - backendRefs
-              type: object
-            status:
-              description: Status defines the current state of BackendPolicy.
-              properties:
-                conditions:
-                  description: Conditions describe the current conditions of the BackendPolicy.
-                  items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
-                        maxLength: 32768
-                        type: string
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    type: object
-                  maxItems: 8
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
-  creationTimestamp: null
-  name: gatewayclasses.networking.x-k8s.io
-spec:
-  group: networking.x-k8s.io
+  group: gateway.networking.k8s.io
   names:
     categories:
       - gateway-api
@@ -195,10 +26,14 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-      name: v1alpha1
+        - jsonPath: .spec.description
+          name: Description
+          priority: 1
+          type: string
+      name: v1alpha2
       schema:
         openAPIV3Schema:
-          description: "GatewayClass describes a class of Gateways available to the user for creating Gateway resources. \n GatewayClass is a Cluster level resource."
+          description: "GatewayClass describes a class of Gateways available to the user for creating Gateway resources. \n It is recommended that this resource be used as a template for Gateways. This means that a Gateway is based on the state of the GatewayClass at the time it was created and changes to the GatewayClass or associated parameters are not propagated down to existing Gateways. This recommendation is intended to limit the blast radius of changes to GatewayClass or associated parameters. If implementations choose to propagate GatewayClass changes to existing Gateways, that MUST be clearly documented by the implementation. \n Whenever one or more Gateways are using a GatewayClass, implementations MUST add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer on the associated GatewayClass. This ensures that a GatewayClass associated with a Gateway is not deleted while in use. \n GatewayClass is a Cluster level resource."
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -211,9 +46,15 @@ spec:
             spec:
               description: Spec defines the desired state of GatewayClass.
               properties:
-                controller:
-                  description: "Controller is a domain/path string that indicates the controller that is managing Gateways of this class. \n Example: \"acme.io/gateway-controller\". \n This field is not mutable and cannot be empty. \n The format of this field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names). \n Support: Core"
+                controllerName:
+                  description: "ControllerName is the name of the controller that is managing Gateways of this class. The value of this field MUST be a domain prefixed path. \n Example: \"example.net/gateway-controller\". \n This field is not mutable and cannot be empty. \n Support: Core"
                   maxLength: 253
+                  minLength: 1
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                  type: string
+                description:
+                  description: Description helps describe a GatewayClass with more details.
+                  maxLength: 64
                   type: string
                 parametersRef:
                   description: "ParametersRef is a reference to a resource that contains the configuration parameters corresponding to the GatewayClass. This is optional if the controller does not require any additional configuration. \n ParametersRef can reference a standard Kubernetes resource, i.e. ConfigMap, or an implementation-specific custom resource. The resource can be cluster-scoped or namespace-scoped. \n If the referent cannot be found, the GatewayClass's \"InvalidParameters\" status condition will be true. \n Support: Custom"
@@ -221,12 +62,13 @@ spec:
                     group:
                       description: Group is the group of the referent.
                       maxLength: 253
-                      minLength: 1
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     kind:
                       description: Kind is kind of the referent.
-                      maxLength: 253
+                      maxLength: 63
                       minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                       type: string
                     name:
                       description: Name is the name of the referent.
@@ -234,16 +76,10 @@ spec:
                       minLength: 1
                       type: string
                     namespace:
-                      description: Namespace is the namespace of the referent. This field is required when scope is set to "Namespace" and ignored when scope is set to "Cluster".
-                      maxLength: 253
+                      description: Namespace is the namespace of the referent. This field is required when referring to a Namespace-scoped resource and MUST be unset when referring to a Cluster-scoped resource.
+                      maxLength: 63
                       minLength: 1
-                      type: string
-                    scope:
-                      default: Cluster
-                      description: Scope represents if the referent is a Cluster or Namespace scoped resource. This may be set to "Cluster" or "Namespace".
-                      enum:
-                        - Cluster
-                        - Namespace
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                   required:
                     - group
@@ -251,7 +87,7 @@ spec:
                     - name
                   type: object
               required:
-                - controller
+                - controllerName
               type: object
             status:
               default:
@@ -259,8 +95,8 @@ spec:
                   - lastTransitionTime: "1970-01-01T00:00:00Z"
                     message: Waiting for controller
                     reason: Waiting
-                    status: "False"
-                    type: Admitted
+                    status: Unknown
+                    type: Accepted
               description: Status defines the current state of GatewayClass.
               properties:
                 conditions:
@@ -268,8 +104,8 @@ spec:
                     - lastTransitionTime: "1970-01-01T00:00:00Z"
                       message: Waiting for controller
                       reason: Waiting
-                      status: "False"
-                      type: Admitted
+                      status: Unknown
+                      type: Accepted
                   description: "Conditions is the current status from the controller for this GatewayClass. \n Controllers should prefer to publish conditions using values of GatewayClassConditionType for the type of each Condition."
                   items:
                     description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
@@ -318,6 +154,8 @@ spec:
                     - type
                   x-kubernetes-list-type: map
               type: object
+          required:
+            - spec
           type: object
       served: true
       storage: true
@@ -334,11 +172,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
   creationTimestamp: null
-  name: gateways.networking.x-k8s.io
+  name: gateways.gateway.networking.k8s.io
 spec:
-  group: networking.x-k8s.io
+  group: gateway.networking.k8s.io
   names:
     categories:
       - gateway-api
@@ -354,13 +192,19 @@ spec:
         - jsonPath: .spec.gatewayClassName
           name: Class
           type: string
+        - jsonPath: .status.addresses[*].value
+          name: Address
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-      name: v1alpha1
+      name: v1alpha2
       schema:
         openAPIV3Schema:
-          description: "Gateway represents an instantiation of a service-traffic handling infrastructure by binding Listeners to a set of IP addresses. \n Implementations should add the `gateway-exists-finalizer.networking.x-k8s.io` finalizer on the associated GatewayClass whenever Gateway(s) is running. This ensures that a GatewayClass associated with a Gateway(s) is not deleted while in use."
+          description: Gateway represents an instance of a service-traffic handling infrastructure by binding Listeners to a set of IP addresses.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -374,15 +218,16 @@ spec:
               description: Spec defines the desired state of Gateway.
               properties:
                 addresses:
-                  description: "Addresses requested for this gateway. This is optional and behavior can depend on the GatewayClass. If a value is set in the spec and the requested address is invalid, the GatewayClass MUST indicate this in the associated entry in GatewayStatus.Addresses. \n If no Addresses are specified, the GatewayClass may schedule the Gateway in an implementation-defined manner, assigning an appropriate set of Addresses. \n The GatewayClass MUST bind all Listeners to every GatewayAddress that it assigns to the Gateway. \n Support: Core"
+                  description: "Addresses requested for this Gateway. This is optional and behavior can depend on the implementation. If a value is set in the spec and the requested address is invalid or unavailable, the implementation MUST indicate this in the associated entry in GatewayStatus.Addresses. \n The Addresses field represents a request for the address(es) on the \"outside of the Gateway\", that traffic bound for this Gateway will use. This could be the IP address or hostname of an external load balancer or other networking infrastructure, or some other address that traffic will be sent to. \n The .listener.hostname field is used to route traffic that has already arrived at the Gateway to the correct in-cluster destination. \n If no Addresses are specified, the implementation MAY schedule the Gateway in an implementation-specific manner, assigning an appropriate set of Addresses. \n The implementation MUST bind all Listeners to every GatewayAddress that it assigns to the Gateway and add a corresponding entry in GatewayStatus.Addresses. \n Support: Core"
                   items:
                     description: GatewayAddress describes an address that can be bound to a Gateway.
                     properties:
                       type:
                         default: IPAddress
-                        description: "Type of the address. \n Support: Extended"
+                        description: Type of the address.
                         enum:
                           - IPAddress
+                          - Hostname
                           - NamedAddress
                         type: string
                       value:
@@ -401,40 +246,42 @@ spec:
                   minLength: 1
                   type: string
                 listeners:
-                  description: "Listeners associated with this Gateway. Listeners define logical endpoints that are bound on this Gateway's addresses. At least one Listener MUST be specified. \n An implementation MAY group Listeners by Port and then collapse each group of Listeners into a single Listener if the implementation determines that the Listeners in the group are \"compatible\". An implementation MAY also group together and collapse compatible Listeners belonging to different Gateways. \n For example, an implementation might consider Listeners to be compatible with each other if all of the following conditions are met: \n 1. Either each Listener within the group specifies the \"HTTP\"    Protocol or each Listener within the group specifies either    the \"HTTPS\" or \"TLS\" Protocol. \n 2. Each Listener within the group specifies a Hostname that is unique    within the group. \n 3. As a special case, one Listener within a group may omit Hostname,    in which case this Listener matches when no other Listener    matches. \n If the implementation does collapse compatible Listeners, the hostname provided in the incoming client request MUST be matched to a Listener to find the correct set of Routes. The incoming hostname MUST be matched using the Hostname field for each Listener in order of most to least specific. That is, exact matches must be processed before wildcard matches. \n If this field specifies multiple Listeners that have the same Port value but are not compatible, the implementation must raise a \"Conflicted\" condition in the Listener status. \n Support: Core"
+                  description: "Listeners associated with this Gateway. Listeners define logical endpoints that are bound on this Gateway's addresses. At least one Listener MUST be specified. \n Each listener in a Gateway must have a unique combination of Hostname, Port, and Protocol. \n An implementation MAY group Listeners by Port and then collapse each group of Listeners into a single Listener if the implementation determines that the Listeners in the group are \"compatible\". An implementation MAY also group together and collapse compatible Listeners belonging to different Gateways. \n For example, an implementation might consider Listeners to be compatible with each other if all of the following conditions are met: \n 1. Either each Listener within the group specifies the \"HTTP\"    Protocol or each Listener within the group specifies either    the \"HTTPS\" or \"TLS\" Protocol. \n 2. Each Listener within the group specifies a Hostname that is unique    within the group. \n 3. As a special case, one Listener within a group may omit Hostname,    in which case this Listener matches when no other Listener    matches. \n If the implementation does collapse compatible Listeners, the hostname provided in the incoming client request MUST be matched to a Listener to find the correct set of Routes. The incoming hostname MUST be matched using the Hostname field for each Listener in order of most to least specific. That is, exact matches must be processed before wildcard matches. \n If this field specifies multiple Listeners that have the same Port value but are not compatible, the implementation must raise a \"Conflicted\" condition in the Listener status. \n Support: Core"
                   items:
-                    description: Listener embodies the concept of a logical endpoint where a Gateway can accept network connections. Each listener in a Gateway must have a unique combination of Hostname, Port, and Protocol. This will be enforced by a validating webhook.
+                    description: Listener embodies the concept of a logical endpoint where a Gateway accepts network connections.
                     properties:
-                      hostname:
-                        description: "Hostname specifies the virtual hostname to match for protocol types that define this concept. When unspecified, \"\", or `*`, all hostnames are matched. This field can be omitted for protocols that don't require hostname based matching. \n Hostname is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: \n 1. IP literals are not allowed. 2. The `:` delimiter is not respected because ports are not allowed. \n Hostname can be \"precise\" which is a domain name without the terminating dot of a network host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain name prefixed with a single wildcard label (e.g. `*.example.com`). The wildcard character `*` must appear by itself as the first DNS label and matches only a single label. \n Support: Core"
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      port:
-                        description: "Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules. \n Support: Core"
-                        format: int32
-                        maximum: 65535
-                        minimum: 1
-                        type: integer
-                      protocol:
-                        description: "Protocol specifies the network protocol this listener expects to receive. The GatewayClass MUST apply the Hostname match appropriately for each protocol: \n * For the \"TLS\" protocol, the Hostname match MUST be   applied to the [SNI](https://tools.ietf.org/html/rfc6066#section-3)   server name offered by the client. * For the \"HTTP\" protocol, the Hostname match MUST be   applied to the host portion of the   [effective request URI](https://tools.ietf.org/html/rfc7230#section-5.5)   or the [:authority pseudo-header](https://tools.ietf.org/html/rfc7540#section-8.1.2.3) * For the \"HTTPS\" protocol, the Hostname match MUST be   applied at both the TLS and HTTP protocol layers. \n Support: Core"
-                        type: string
-                      routes:
-                        description: "Routes specifies a schema for associating routes with the Listener using selectors. A Route is a resource capable of servicing a request and allows a cluster operator to expose a cluster resource (i.e. Service) by externally-reachable URL, load-balance traffic and terminate SSL/TLS.  Typically, a route is a \"HTTPRoute\" or \"TCPRoute\" in group \"networking.x-k8s.io\", however, an implementation may support other types of resources. \n The Routes selector MUST select a set of objects that are compatible with the application protocol specified in the Protocol field. \n Although a client request may technically match multiple route rules, only one rule may ultimately receive the request. Matching precedence MUST be determined in order of the following criteria: \n * The most specific match. For example, the most specific HTTPRoute match   is determined by the longest matching combination of hostname and path. * The oldest Route based on creation timestamp. For example, a Route with   a creation timestamp of \"2020-09-08 01:02:03\" is given precedence over   a Route with a creation timestamp of \"2020-09-08 01:02:04\". * If everything else is equivalent, the Route appearing first in   alphabetical order (namespace/name) should be given precedence. For   example, foo/bar is given precedence over foo/baz. \n All valid portions of a Route selected by this field should be supported. Invalid portions of a Route can be ignored (sometimes that will mean the full Route). If a portion of a Route transitions from valid to invalid, support for that portion of the Route should be dropped to ensure consistency. For example, even if a filter specified by a Route is invalid, the rest of the Route should still be supported. \n Support: Core"
+                      allowedRoutes:
+                        default:
+                          namespaces:
+                            from: Same
+                        description: "AllowedRoutes defines the types of routes that MAY be attached to a Listener and the trusted namespaces where those Route resources MAY be present. \n Although a client request may match multiple route rules, only one rule may ultimately receive the request. Matching precedence MUST be determined in order of the following criteria: \n * The most specific match as defined by the Route type. * The oldest Route based on creation timestamp. For example, a Route with   a creation timestamp of \"2020-09-08 01:02:03\" is given precedence over   a Route with a creation timestamp of \"2020-09-08 01:02:04\". * If everything else is equivalent, the Route appearing first in   alphabetical order (namespace/name) should be given precedence. For   example, foo/bar is given precedence over foo/baz. \n All valid rules within a Route attached to this Listener should be implemented. Invalid Route rules can be ignored (sometimes that will mean the full Route). If a Route rule transitions from valid to invalid, support for that Route rule should be dropped to ensure consistency. For example, even if a filter specified by a Route rule is invalid, the rest of the rules within that Route should still be supported. \n Support: Core"
                         properties:
-                          group:
-                            default: networking.x-k8s.io
-                            description: "Group is the group of the route resource to select. Omitting the value or specifying the empty string indicates the networking.x-k8s.io API group. For example, use the following to select an HTTPRoute: \n routes:   kind: HTTPRoute \n Otherwise, if an alternative API group is desired, specify the desired group: \n routes:   group: acme.io   kind: FooRoute \n Support: Core"
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                          kind:
-                            description: "Kind is the kind of the route resource to select. \n Kind MUST correspond to kinds of routes that are compatible with the application protocol specified in the Listener's Protocol field. \n If an implementation does not support or recognize this resource type, it SHOULD set the \"ResolvedRefs\" condition to false for this listener with the \"InvalidRoutesRef\" reason. \n Support: Core"
-                            type: string
+                          kinds:
+                            description: "Kinds specifies the groups and kinds of Routes that are allowed to bind to this Gateway Listener. When unspecified or empty, the kinds of Routes selected are determined using the Listener protocol. \n A RouteGroupKind MUST correspond to kinds of Routes that are compatible with the application protocol specified in the Listener's Protocol field. If an implementation does not support or recognize this resource type, it MUST set the \"ResolvedRefs\" condition to False for this Listener with the \"InvalidRoutesRef\" reason. \n Support: Core"
+                            items:
+                              description: RouteGroupKind indicates the group and kind of a Route resource.
+                              properties:
+                                group:
+                                  default: gateway.networking.k8s.io
+                                  description: Group is the group of the Route.
+                                  maxLength: 253
+                                  pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                kind:
+                                  description: Kind is the kind of the Route.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                  type: string
+                              required:
+                                - kind
+                              type: object
+                            maxItems: 8
+                            type: array
                           namespaces:
                             default:
                               from: Same
-                            description: "Namespaces indicates in which namespaces Routes should be selected for this Gateway. This is restricted to the namespace of this Gateway by default. \n Support: Core"
+                            description: "Namespaces indicates namespaces from which Routes may be attached to this Listener. This is restricted to the namespace of this Gateway by default. \n Support: Core"
                             properties:
                               from:
                                 default: Same
@@ -475,99 +322,96 @@ spec:
                                     type: object
                                 type: object
                             type: object
-                          selector:
-                            description: "Selector specifies a set of route labels used for selecting routes to associate with the Gateway. If this Selector is defined, only routes matching the Selector are associated with the Gateway. An empty Selector matches all routes. \n Support: Core"
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                    - key
-                                    - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                        required:
-                          - kind
                         type: object
+                      hostname:
+                        description: "Hostname specifies the virtual hostname to match for protocol types that define this concept. When unspecified, all hostnames are matched. This field is ignored for protocols that don't require hostname based matching. \n Implementations MUST apply Hostname matching appropriately for each of the following protocols: \n * TLS: The Listener Hostname MUST match the SNI. * HTTP: The Listener Hostname MUST match the Host header of the request. * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP   protocol layers as described above. If an implementation does not   ensure that both the SNI and Host header match the Listener hostname,   it MUST clearly document that. \n For HTTPRoute and TLSRoute resources, there is an interaction with the `spec.hostnames` array. When both listener and route specify hostnames, there MUST be an intersection between the values for a Route to be accepted. For more information, refer to the Route specific Hostnames documentation. \n Support: Core"
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      name:
+                        description: "Name is the name of the Listener. \n Support: Core"
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      port:
+                        description: "Port is the network port. Multiple listeners may use the same port, subject to the Listener compatibility rules. \n Support: Core"
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      protocol:
+                        description: "Protocol specifies the network protocol this listener expects to receive. \n Support: Core"
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[a-zA-Z0-9]([-a-zSA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                        type: string
                       tls:
-                        description: "TLS is the TLS configuration for the Listener. This field is required if the Protocol field is \"HTTPS\" or \"TLS\" and ignored otherwise. \n The association of SNIs to Certificate defined in GatewayTLSConfig is defined based on the Hostname field for this listener. \n The GatewayClass MUST use the longest matching SNI out of all available certificates for any TLS handshake. \n Support: Core"
+                        description: "TLS is the TLS configuration for the Listener. This field is required if the Protocol field is \"HTTPS\" or \"TLS\". It is invalid to set this field if the Protocol field is \"HTTP\", \"TCP\", or \"UDP\". \n The association of SNIs to Certificate defined in GatewayTLSConfig is defined based on the Hostname field for this listener. \n The GatewayClass MUST use the longest matching SNI out of all available certificates for any TLS handshake. \n Support: Core"
                         properties:
-                          certificateRef:
-                            description: "CertificateRef is a reference to a Kubernetes object that contains a TLS certificate and private key. This certificate is used to establish a TLS handshake for requests that match the hostname of the associated listener. The referenced object MUST reside in the same namespace as Gateway. \n This field is required when mode is set to \"Terminate\" (default) and optional otherwise. \n CertificateRef can reference a standard Kubernetes resource, i.e. Secret, or an implementation-specific custom resource. \n Support: Core (Kubernetes Secrets) \n Support: Implementation-specific (Other resource types)"
-                            properties:
-                              group:
-                                description: Group is the group of the referent.
-                                maxLength: 253
-                                minLength: 1
-                                type: string
-                              kind:
-                                description: Kind is kind of the referent.
-                                maxLength: 253
-                                minLength: 1
-                                type: string
-                              name:
-                                description: Name is the name of the referent.
-                                maxLength: 253
-                                minLength: 1
-                                type: string
-                            required:
-                              - group
-                              - kind
-                              - name
-                            type: object
+                          certificateRefs:
+                            description: "CertificateRefs contains a series of references to Kubernetes objects that contains TLS certificates and private keys. These certificates are used to establish a TLS handshake for requests that match the hostname of the associated listener. \n A single CertificateRef to a Kubernetes Secret has \"Core\" support. Implementations MAY choose to support attaching multiple certificates to a Listener, but this behavior is implementation-specific. \n References to a resource in different namespace are invalid UNLESS there is a ReferencePolicy in the target namespace that allows the certificate to be attached. If a ReferencePolicy does not allow this reference, the \"ResolvedRefs\" condition MUST be set to False for this listener with the \"InvalidCertificateRef\" reason. \n This field is required to have at least one element when the mode is set to \"Terminate\" (default) and is optional otherwise. \n CertificateRefs can reference to standard Kubernetes resources, i.e. Secret, or implementation-specific custom resources. \n Support: Core - A single reference to a Kubernetes Secret \n Support: Implementation-specific (More than one reference or other resource types)"
+                            items:
+                              description: "SecretObjectReference identifies an API object including its namespace, defaulting to Secret. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object."
+                              properties:
+                                group:
+                                  default: ""
+                                  description: Group is the group of the referent. For example, "networking.k8s.io". When unspecified (empty string), core API group is inferred.
+                                  maxLength: 253
+                                  pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                kind:
+                                  default: Secret
+                                  description: Kind is kind of the referent. For example "HTTPRoute" or "Service".
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                  type: string
+                                name:
+                                  description: Name is the name of the referent.
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                                namespace:
+                                  description: "Namespace is the namespace of the backend. When unspecified, the local namespace is inferred. \n Note that when a namespace is specified, a ReferencePolicy object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferencePolicy documentation for details. \n Support: Core"
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            maxItems: 64
+                            type: array
                           mode:
                             default: Terminate
-                            description: "Mode defines the TLS behavior for the TLS session initiated by the client. There are two possible modes: - Terminate: The TLS session between the downstream client   and the Gateway is terminated at the Gateway. This mode requires   certificateRef to be set. - Passthrough: The TLS session is NOT terminated by the Gateway. This   implies that the Gateway can't decipher the TLS stream except for   the ClientHello message of the TLS protocol.   CertificateRef field is ignored in this mode. \n Support: Core"
+                            description: "Mode defines the TLS behavior for the TLS session initiated by the client. There are two possible modes: \n - Terminate: The TLS session between the downstream client   and the Gateway is terminated at the Gateway. This mode requires   certificateRefs to be set and contain at least one element. - Passthrough: The TLS session is NOT terminated by the Gateway. This   implies that the Gateway can't decipher the TLS stream except for   the ClientHello message of the TLS protocol.   CertificateRefs field is ignored in this mode. \n Support: Core"
                             enum:
                               - Terminate
                               - Passthrough
                             type: string
                           options:
                             additionalProperties:
+                              description: AnnotationValue is the value of an annotation in Gateway API. This is used for validation of maps such as TLS options. This roughly matches Kubernetes annotation validation, although the length validation in that case is based on the entire size of the annotations struct.
+                              maxLength: 4096
+                              minLength: 0
                               type: string
-                            description: "Options are a list of key/value pairs to give extended options to the provider. \n There variation among providers as to how ciphersuites are expressed. If there is a common subset for expressing ciphers then it will make sense to loft that as a core API construct. \n Support: Implementation-specific"
-                            type: object
-                          routeOverride:
-                            default:
-                              certificate: Deny
-                            description: "RouteOverride dictates if TLS settings can be configured via Routes or not. \n CertificateRef must be defined even if `routeOverride.certificate` is set to 'Allow' as it will be used as the default certificate for the listener. \n Support: Core"
-                            properties:
-                              certificate:
-                                default: Deny
-                                description: "Certificate dictates if TLS certificates can be configured via Routes. If set to 'Allow', a TLS certificate for a hostname defined in a Route takes precedence over the certificate defined in Gateway. \n Support: Core"
-                                enum:
-                                  - Allow
-                                  - Deny
-                                type: string
+                            description: "Options are a list of key/value pairs to enable extended TLS configuration for each implementation. For example, configuring the minimum TLS version or supported cipher suites. \n A set of common keys MAY be defined by the API in the future. To avoid any ambiguity, implementation-specific definitions MUST use domain-prefixed names, such as `example.com/my-custom-option`. Un-prefixed names are reserved for key names defined by Gateway API. \n Support: Implementation-specific"
+                            maxProperties: 16
                             type: object
                         type: object
                     required:
+                      - name
                       - port
                       - protocol
-                      - routes
                     type: object
                   maxItems: 64
                   minItems: 1
                   type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
               required:
                 - gatewayClassName
                 - listeners
@@ -578,20 +422,21 @@ spec:
                   - lastTransitionTime: "1970-01-01T00:00:00Z"
                     message: Waiting for controller
                     reason: NotReconciled
-                    status: "False"
+                    status: Unknown
                     type: Scheduled
               description: Status defines the current state of Gateway.
               properties:
                 addresses:
-                  description: "Addresses lists the IP addresses that have actually been bound to the Gateway. These addresses may differ from the addresses in the Spec, e.g. if the Gateway automatically assigns an address from a reserved pool. \n These addresses should all be of type \"IPAddress\"."
+                  description: Addresses lists the IP addresses that have actually been bound to the Gateway. These addresses may differ from the addresses in the Spec, e.g. if the Gateway automatically assigns an address from a reserved pool.
                   items:
                     description: GatewayAddress describes an address that can be bound to a Gateway.
                     properties:
                       type:
                         default: IPAddress
-                        description: "Type of the address. \n Support: Extended"
+                        description: Type of the address.
                         enum:
                           - IPAddress
+                          - Hostname
                           - NamedAddress
                         type: string
                       value:
@@ -609,7 +454,7 @@ spec:
                     - lastTransitionTime: "1970-01-01T00:00:00Z"
                       message: Waiting for controller
                       reason: NotReconciled
-                      status: "False"
+                      status: Unknown
                       type: Scheduled
                   description: "Conditions describe the current conditions of the Gateway. \n Implementations should prefer to express Gateway conditions using the `GatewayConditionType` and `GatewayConditionReason` constants so that operators and tools can converge on a common vocabulary to describe Gateway state. \n Known condition types are: \n * \"Scheduled\" * \"Ready\""
                   items:
@@ -663,6 +508,10 @@ spec:
                   items:
                     description: ListenerStatus is the status associated with a Listener.
                     properties:
+                      attachedRoutes:
+                        description: AttachedRoutes represents the total number of Routes that have been successfully attached to this Listener.
+                        format: int32
+                        type: integer
                       conditions:
                         description: Conditions describe the current condition of this listener.
                         items:
@@ -711,31 +560,48 @@ spec:
                         x-kubernetes-list-map-keys:
                           - type
                         x-kubernetes-list-type: map
-                      hostname:
-                        description: Hostname is the Listener hostname value for which this message is reporting the status.
+                      name:
+                        description: Name is the name of the Listener that this status corresponds to.
                         maxLength: 253
                         minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
-                      port:
-                        description: Port is the unique Listener port value for which this message is reporting the status.
-                        format: int32
-                        maximum: 65535
-                        minimum: 1
-                        type: integer
-                      protocol:
-                        description: Protocol is the Listener protocol value for which this message is reporting the status.
-                        type: string
+                      supportedKinds:
+                        description: "SupportedKinds is the list indicating the Kinds supported by this listener. This MUST represent the kinds an implementation supports for that Listener configuration. \n If kinds are specified in Spec that are not supported, they MUST NOT appear in this list and an implementation MUST set the \"ResolvedRefs\" condition to \"False\" with the \"InvalidRouteKinds\" reason. If both valid and invalid Route kinds are specified, the implementation MUST reference the valid Route kinds that have been specified."
+                        items:
+                          description: RouteGroupKind indicates the group and kind of a Route resource.
+                          properties:
+                            group:
+                              default: gateway.networking.k8s.io
+                              description: Group is the group of the Route.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              description: Kind is the kind of the Route.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                          required:
+                            - kind
+                          type: object
+                        maxItems: 8
+                        type: array
                     required:
+                      - attachedRoutes
                       - conditions
-                      - port
-                      - protocol
+                      - name
+                      - supportedKinds
                     type: object
                   maxItems: 64
                   type: array
                   x-kubernetes-list-map-keys:
-                    - port
+                    - name
                   x-kubernetes-list-type: map
               type: object
+          required:
+            - spec
           type: object
       served: true
       storage: true
@@ -752,11 +618,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
   creationTimestamp: null
-  name: httproutes.networking.x-k8s.io
+  name: httproutes.gateway.networking.k8s.io
 spec:
-  group: networking.x-k8s.io
+  group: gateway.networking.k8s.io
   names:
     categories:
       - gateway-api
@@ -773,10 +639,10 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-      name: v1alpha1
+      name: v1alpha2
       schema:
         openAPIV3Schema:
-          description: HTTPRoute is the Schema for the HTTPRoute resource.
+          description: HTTPRoute provides a way to route HTTP requests. This includes the capability to match requests by hostname, path, header, or query param. Filters can be used to specify additional processing steps. Backends specify where matching requests should be routed.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -789,201 +655,89 @@ spec:
             spec:
               description: Spec defines the desired state of HTTPRoute.
               properties:
-                gateways:
-                  default:
-                    allow: SameNamespace
-                  description: Gateways defines which Gateways can use this Route.
-                  properties:
-                    allow:
-                      default: SameNamespace
-                      description: 'Allow indicates which Gateways will be allowed to use this route. Possible values are: * All: Gateways in any namespace can use this route. * FromList: Only Gateways specified in GatewayRefs may use this route. * SameNamespace: Only Gateways in the same namespace may use this route.'
-                      enum:
-                        - All
-                        - FromList
-                        - SameNamespace
-                      type: string
-                    gatewayRefs:
-                      description: GatewayRefs must be specified when Allow is set to "FromList". In that case, only Gateways referenced in this list will be allowed to use this route. This field is ignored for other values of "Allow".
-                      items:
-                        description: GatewayReference identifies a Gateway in a specified namespace.
-                        properties:
-                          name:
-                            description: Name is the name of the referent.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                          namespace:
-                            description: Namespace is the namespace of the referent.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                        required:
-                          - name
-                          - namespace
-                        type: object
-                      type: array
-                  type: object
                 hostnames:
-                  description: "Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request. Hostname is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: \n 1. IPs are not allowed. 2. The `:` delimiter is not respected because ports are not allowed. \n Incoming requests are matched against the hostnames before the HTTPRoute rules. If no hostname is specified, traffic is routed based on the HTTPRouteRules. \n Hostname can be \"precise\" which is a domain name without the terminating dot of a network host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain name prefixed with a single wildcard label (e.g. `*.example.com`). The wildcard character `*` must appear by itself as the first DNS label and matches only a single label. You cannot have a wildcard label by itself (e.g. Host == `*`). Requests will be matched against the Host field in the following order: \n 1. If Host is precise, the request matches this rule if    the HTTP Host header is equal to Host. 2. If Host is a wildcard, then the request matches this rule if    the HTTP Host header is to equal to the suffix    (removing the first label) of the wildcard rule. \n Support: Core"
+                  description: "Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request. This matches the RFC 1123 definition of a hostname with 2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard    label must appear by itself as the first label. \n If a hostname is specified by both the Listener and HTTPRoute, there must be at least one intersecting hostname for the HTTPRoute to be attached to the Listener. For example: \n * A Listener with `test.example.com` as the hostname matches HTTPRoutes   that have either not specified any hostnames, or have specified at   least one of `test.example.com` or `*.example.com`. * A Listener with `*.example.com` as the hostname matches HTTPRoutes   that have either not specified any hostnames or have specified at least   one hostname that matches the Listener hostname. For example,   `test.example.com` and `*.example.com` would both match. On the other   hand, `example.com` and `test.example.net` would not match. \n If both the Listener and HTTPRoute have specified hostnames, any HTTPRoute hostnames that do not match the Listener hostname MUST be ignored. For example, if a Listener specified `*.example.com`, and the HTTPRoute specified `test.example.com` and `test.example.net`, `test.example.net` must not be considered for a match. \n If both the Listener and HTTPRoute have specified hostnames, and none match with the criteria above, then the HTTPRoute is not accepted. The implementation must raise an 'Accepted' Condition with a status of `False` in the corresponding RouteParentStatus. \n Support: Core"
                   items:
-                    description: Hostname is used to specify a hostname that should be matched.
+                    description: "Hostname is the fully qualified domain name of a network host. This matches the RFC 1123 definition of a hostname with 2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard    label must appear by itself as the first label. \n Hostname can be \"precise\" which is a domain name without the terminating dot of a network host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain name prefixed with a single wildcard label (e.g. `*.example.com`). \n Note that as per RFC1035 and RFC1123, a *label* must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character. No other punctuation is allowed."
                     maxLength: 253
                     minLength: 1
+                    pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   maxItems: 16
+                  type: array
+                parentRefs:
+                  description: "ParentRefs references the resources (usually Gateways) that a Route wants to be attached to. Note that the referenced parent resource needs to allow this for the attachment to be complete. For Gateways, that means the Gateway needs to allow attachment from Routes of this kind and namespace. \n The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources such as one of the route kinds. \n It is invalid to reference an identical parent more than once. It is valid to reference multiple distinct sections within the same parent resource, such as 2 Listeners within a Gateway. \n It is possible to separately reference multiple distinct objects that may be collapsed by an implementation. For example, some implementations may choose to merge compatible Gateway Listeners together. If that is the case, the list of routes attached to those resources should also be merged."
+                  items:
+                    description: "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object."
+                    properties:
+                      group:
+                        default: gateway.networking.k8s.io
+                        description: "Group is the group of the referent. \n Support: Core"
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Gateway
+                        description: "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)"
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: "Name is the name of the referent. \n Support: Core"
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                      sectionName:
+                        description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  maxItems: 32
                   type: array
                 rules:
                   default:
                     - matches:
                         - path:
-                            type: Prefix
+                            type: PathPrefix
                             value: /
                   description: Rules are a list of HTTP matchers, filters and actions.
                   items:
-                    description: HTTPRouteRule defines semantics for matching an HTTP request based on conditions, optionally executing additional processing steps, and forwarding the request to an API object.
+                    description: HTTPRouteRule defines semantics for matching an HTTP request based on conditions (matches), processing it (filters), and forwarding the request to an API object (backendRefs).
                     properties:
-                      filters:
-                        description: "Filters define the filters that are applied to requests that match this rule. \n The effects of ordering of multiple behaviors are currently unspecified. This can change in the future based on feedback during the alpha stage. \n Conformance-levels at this level are defined based on the type of filter: \n - ALL core filters MUST be supported by all implementations. - Implementers are encouraged to support extended filters. - Implementation-specific custom filters have no API guarantees across   implementations. \n Specifying a core filter multiple times has unspecified or custom conformance. \n Support: Core"
+                      backendRefs:
+                        description: "If unspecified or invalid (refers to a non-existent resource or a Service with no endpoints), the rule performs no forwarding. If there are also no filters specified that would result in a response being sent, a HTTP 503 status code is returned. 503 responses must be sent so that the overall weight is respected; if an invalid backend is requested to have 80% of requests, then 80% of requests must get a 503 instead. \n Support: Core for Kubernetes Service Support: Custom for any other resource \n Support for weight: Core"
                         items:
-                          description: 'HTTPRouteFilter defines additional processing steps that must be completed during the request or response lifecycle. HTTPRouteFilters are meant as an extension point to express additional processing that may be done in Gateway implementations. Some examples include request or response modification, implementing authentication strategies, rate-limiting, and traffic shaping. API guarantee/conformance is defined based on the type of the filter. TODO(hbagdi): re-render CRDs once controller-tools supports union tags: - https://github.com/kubernetes-sigs/controller-tools/pull/298 - https://github.com/kubernetes-sigs/controller-tools/issues/461'
+                          description: HTTPBackendRef defines how a HTTPRoute should forward an HTTP request.
                           properties:
-                            extensionRef:
-                              description: "ExtensionRef is an optional, implementation-specific extension to the \"filter\" behavior.  For example, resource \"myroutefilter\" in group \"networking.acme.io\"). ExtensionRef MUST NOT be used for core and extended filters. \n Support: Implementation-specific"
-                              properties:
-                                group:
-                                  description: Group is the group of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                kind:
-                                  description: Kind is kind of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                name:
-                                  description: Name is the name of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                              required:
-                                - group
-                                - kind
-                                - name
-                              type: object
-                            requestHeaderModifier:
-                              description: "RequestHeaderModifier defines a schema for a filter that modifies request headers. \n Support: Core"
-                              properties:
-                                add:
-                                  additionalProperties:
-                                    type: string
-                                  description: "Add adds the given header (name, value) to the request before the action. It appends to any existing values associated with the header name. \n Input:   GET /foo HTTP/1.1   my-header: foo \n Config:   add: {\"my-header\": \"bar\"} \n Output:   GET /foo HTTP/1.1   my-header: foo   my-header: bar \n Support: Extended"
-                                  type: object
-                                remove:
-                                  description: "Remove the given header(s) from the HTTP request before the action. The value of RemoveHeader is a list of HTTP header names. Note that the header names are case-insensitive [RFC-2616 4.2]. \n Input:   GET /foo HTTP/1.1   my-header1: foo   my-header2: bar   my-header3: baz \n Config:   remove: [\"my-header1\", \"my-header3\"] \n Output:   GET /foo HTTP/1.1   my-header2: bar \n Support: Extended"
-                                  items:
-                                    type: string
-                                  maxItems: 16
-                                  type: array
-                                set:
-                                  additionalProperties:
-                                    type: string
-                                  description: "Set overwrites the request with the given header (name, value) before the action. \n Input:   GET /foo HTTP/1.1   my-header: foo \n Config:   set: {\"my-header\": \"bar\"} \n Output:   GET /foo HTTP/1.1   my-header: bar \n Support: Extended"
-                                  type: object
-                              type: object
-                            requestMirror:
-                              description: "RequestMirror defines a schema for a filter that mirrors requests. \n Support: Extended"
-                              properties:
-                                backendRef:
-                                  description: "BackendRef is a local object reference to mirror matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
-                                  properties:
-                                    group:
-                                      description: Group is the group of the referent.
-                                      maxLength: 253
-                                      minLength: 1
-                                      type: string
-                                    kind:
-                                      description: Kind is kind of the referent.
-                                      maxLength: 253
-                                      minLength: 1
-                                      type: string
-                                    name:
-                                      description: Name is the name of the referent.
-                                      maxLength: 253
-                                      minLength: 1
-                                      type: string
-                                  required:
-                                    - group
-                                    - kind
-                                    - name
-                                  type: object
-                                port:
-                                  description: "Port specifies the destination port number to use for the backend referenced by the ServiceName or BackendRef field. \n If unspecified, the destination port in the request is used when forwarding to a backendRef or serviceName."
-                                  format: int32
-                                  maximum: 65535
-                                  minimum: 1
-                                  type: integer
-                                serviceName:
-                                  description: "ServiceName refers to the name of the Service to mirror matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Core"
-                                  maxLength: 253
-                                  type: string
-                              type: object
-                            type:
-                              description: "Type identifies the type of filter to apply. As with other API fields, types are classified into three conformance levels: \n - Core: Filter types and their corresponding configuration defined by   \"Support: Core\" in this package, e.g. \"RequestHeaderModifier\". All   implementations must support core filters. \n - Extended: Filter types and their corresponding configuration defined by   \"Support: Extended\" in this package, e.g. \"RequestMirror\". Implementers   are encouraged to support extended filters. \n - Custom: Filters that are defined and supported by specific vendors.   In the future, filters showing convergence in behavior across multiple   implementations will be considered for inclusion in extended or core   conformance levels. Filter-specific configuration for such filters   is specified using the ExtensionRef field. `Type` should be set to   \"ExtensionRef\" for custom filters. \n Implementers are encouraged to define custom implementation types to extend the core API with implementation-specific behavior."
-                              enum:
-                                - RequestHeaderModifier
-                                - RequestMirror
-                                - ExtensionRef
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        maxItems: 16
-                        type: array
-                      forwardTo:
-                        description: ForwardTo defines the backend(s) where matching requests should be sent. If unspecified, the rule performs no forwarding. If unspecified and no filters are specified that would result in a response being sent, a 503 error code is returned.
-                        items:
-                          description: HTTPRouteForwardTo defines how a HTTPRoute should forward a request.
-                          properties:
-                            backendRef:
-                              description: "BackendRef is a reference to a backend to forward matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
-                              properties:
-                                group:
-                                  description: Group is the group of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                kind:
-                                  description: Kind is kind of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                name:
-                                  description: Name is the name of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                              required:
-                                - group
-                                - kind
-                                - name
-                              type: object
                             filters:
-                              description: "Filters defined at this-level should be executed if and only if the request is being forwarded to the backend defined here. \n Support: Custom (For broader support of filters, use the Filters field in HTTPRouteRule.)"
+                              description: "Filters defined at this level should be executed if and only if the request is being forwarded to the backend defined here. \n Support: Custom (For broader support of filters, use the Filters field in HTTPRouteRule.)"
                               items:
-                                description: 'HTTPRouteFilter defines additional processing steps that must be completed during the request or response lifecycle. HTTPRouteFilters are meant as an extension point to express additional processing that may be done in Gateway implementations. Some examples include request or response modification, implementing authentication strategies, rate-limiting, and traffic shaping. API guarantee/conformance is defined based on the type of the filter. TODO(hbagdi): re-render CRDs once controller-tools supports union tags: - https://github.com/kubernetes-sigs/controller-tools/pull/298 - https://github.com/kubernetes-sigs/controller-tools/issues/461'
+                                description: HTTPRouteFilter defines processing steps that must be completed during the request or response lifecycle. HTTPRouteFilters are meant as an extension point to express processing that may be done in Gateway implementations. Some examples include request or response modification, implementing authentication strategies, rate-limiting, and traffic shaping. API guarantee/conformance is defined based on the type of the filter.
                                 properties:
                                   extensionRef:
-                                    description: "ExtensionRef is an optional, implementation-specific extension to the \"filter\" behavior.  For example, resource \"myroutefilter\" in group \"networking.acme.io\"). ExtensionRef MUST NOT be used for core and extended filters. \n Support: Implementation-specific"
+                                    description: "ExtensionRef is an optional, implementation-specific extension to the \"filter\" behavior.  For example, resource \"myroutefilter\" in group \"networking.example.net\"). ExtensionRef MUST NOT be used for core and extended filters. \n Support: Implementation-specific"
                                     properties:
                                       group:
-                                        description: Group is the group of the referent.
+                                        description: Group is the group of the referent. For example, "networking.k8s.io". When unspecified (empty string), core API group is inferred.
                                         maxLength: 253
-                                        minLength: 1
+                                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                         type: string
                                       kind:
-                                        description: Kind is kind of the referent.
-                                        maxLength: 253
+                                        description: Kind is kind of the referent. For example "HTTPRoute" or "Service".
+                                        maxLength: 63
                                         minLength: 1
+                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                                         type: string
                                       name:
                                         description: Name is the name of the referent.
@@ -999,64 +753,139 @@ spec:
                                     description: "RequestHeaderModifier defines a schema for a filter that modifies request headers. \n Support: Core"
                                     properties:
                                       add:
-                                        additionalProperties:
-                                          type: string
-                                        description: "Add adds the given header (name, value) to the request before the action. It appends to any existing values associated with the header name. \n Input:   GET /foo HTTP/1.1   my-header: foo \n Config:   add: {\"my-header\": \"bar\"} \n Output:   GET /foo HTTP/1.1   my-header: foo   my-header: bar \n Support: Extended"
-                                        type: object
+                                        description: "Add adds the given header(s) (name, value) to the request before the action. It appends to any existing values associated with the header name. \n Input:   GET /foo HTTP/1.1   my-header: foo \n Config:   add:   - name: \"my-header\"     value: \"bar\" \n Output:   GET /foo HTTP/1.1   my-header: foo   my-header: bar"
+                                        items:
+                                          description: HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.
+                                          properties:
+                                            name:
+                                              description: "Name is the name of the HTTP Header to be matched. Name matching MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2). \n If multiple entries specify equivalent header names, the first entry with an equivalent name MUST be considered for a match. Subsequent entries with an equivalent header name MUST be ignored. Due to the case-insensitivity of header names, \"foo\" and \"Foo\" are considered equivalent."
+                                              maxLength: 256
+                                              minLength: 1
+                                              pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                              type: string
+                                            value:
+                                              description: Value is the value of HTTP Header to be matched.
+                                              maxLength: 4096
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
                                       remove:
-                                        description: "Remove the given header(s) from the HTTP request before the action. The value of RemoveHeader is a list of HTTP header names. Note that the header names are case-insensitive [RFC-2616 4.2]. \n Input:   GET /foo HTTP/1.1   my-header1: foo   my-header2: bar   my-header3: baz \n Config:   remove: [\"my-header1\", \"my-header3\"] \n Output:   GET /foo HTTP/1.1   my-header2: bar \n Support: Extended"
+                                        description: "Remove the given header(s) from the HTTP request before the action. The value of Remove is a list of HTTP header names. Note that the header names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2). \n Input:   GET /foo HTTP/1.1   my-header1: foo   my-header2: bar   my-header3: baz \n Config:   remove: [\"my-header1\", \"my-header3\"] \n Output:   GET /foo HTTP/1.1   my-header2: bar"
                                         items:
                                           type: string
                                         maxItems: 16
                                         type: array
                                       set:
-                                        additionalProperties:
-                                          type: string
-                                        description: "Set overwrites the request with the given header (name, value) before the action. \n Input:   GET /foo HTTP/1.1   my-header: foo \n Config:   set: {\"my-header\": \"bar\"} \n Output:   GET /foo HTTP/1.1   my-header: bar \n Support: Extended"
-                                        type: object
+                                        description: "Set overwrites the request with the given header (name, value) before the action. \n Input:   GET /foo HTTP/1.1   my-header: foo \n Config:   set:   - name: \"my-header\"     value: \"bar\" \n Output:   GET /foo HTTP/1.1   my-header: bar"
+                                        items:
+                                          description: HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.
+                                          properties:
+                                            name:
+                                              description: "Name is the name of the HTTP Header to be matched. Name matching MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2). \n If multiple entries specify equivalent header names, the first entry with an equivalent name MUST be considered for a match. Subsequent entries with an equivalent header name MUST be ignored. Due to the case-insensitivity of header names, \"foo\" and \"Foo\" are considered equivalent."
+                                              maxLength: 256
+                                              minLength: 1
+                                              pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                              type: string
+                                            value:
+                                              description: Value is the value of HTTP Header to be matched.
+                                              maxLength: 4096
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
                                     type: object
                                   requestMirror:
-                                    description: "RequestMirror defines a schema for a filter that mirrors requests. \n Support: Extended"
+                                    description: "RequestMirror defines a schema for a filter that mirrors requests. Requests are sent to the specified destination, but responses from that destination are ignored. \n Support: Extended"
                                     properties:
                                       backendRef:
-                                        description: "BackendRef is a local object reference to mirror matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
+                                        description: "BackendRef references a resource where mirrored requests are sent. \n If the referent cannot be found, this BackendRef is invalid and must be dropped from the Gateway. The controller must ensure the \"ResolvedRefs\" condition on the Route status is set to `status: False` and not configure this backend in the underlying implementation. \n If there is a cross-namespace reference to an *existing* object that is not allowed by a ReferencePolicy, the controller must ensure the \"ResolvedRefs\"  condition on the Route is set to `status: False`, with the \"RefNotPermitted\" reason and not configure this backend in the underlying implementation. \n In either error case, the Message of the `ResolvedRefs` Condition should be used to provide more detail about the problem. \n Support: Extended for Kubernetes Service Support: Custom for any other resource"
                                         properties:
                                           group:
-                                            description: Group is the group of the referent.
+                                            default: ""
+                                            description: Group is the group of the referent. For example, "networking.k8s.io". When unspecified (empty string), core API group is inferred.
                                             maxLength: 253
-                                            minLength: 1
+                                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                             type: string
                                           kind:
-                                            description: Kind is kind of the referent.
-                                            maxLength: 253
+                                            default: Service
+                                            description: Kind is kind of the referent. For example "HTTPRoute" or "Service".
+                                            maxLength: 63
                                             minLength: 1
+                                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                                             type: string
                                           name:
                                             description: Name is the name of the referent.
                                             maxLength: 253
                                             minLength: 1
                                             type: string
+                                          namespace:
+                                            description: "Namespace is the namespace of the backend. When unspecified, the local namespace is inferred. \n Note that when a namespace is specified, a ReferencePolicy object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferencePolicy documentation for details. \n Support: Core"
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                            type: string
+                                          port:
+                                            description: Port specifies the destination port number to use for this resource. Port is required when the referent is a Kubernetes Service. For other resources, destination port might be derived from the referent resource or this field.
+                                            format: int32
+                                            maximum: 65535
+                                            minimum: 1
+                                            type: integer
                                         required:
-                                          - group
-                                          - kind
                                           - name
                                         type: object
+                                    required:
+                                      - backendRef
+                                    type: object
+                                  requestRedirect:
+                                    description: "RequestRedirect defines a schema for a filter that responds to the request with an HTTP redirection. \n Support: Core"
+                                    properties:
+                                      hostname:
+                                        description: "Hostname is the hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used. \n Support: Core"
+                                        maxLength: 253
+                                        minLength: 1
+                                        pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        type: string
                                       port:
-                                        description: "Port specifies the destination port number to use for the backend referenced by the ServiceName or BackendRef field. \n If unspecified, the destination port in the request is used when forwarding to a backendRef or serviceName."
+                                        description: "Port is the port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used. \n Support: Extended"
                                         format: int32
                                         maximum: 65535
                                         minimum: 1
                                         type: integer
-                                      serviceName:
-                                        description: "ServiceName refers to the name of the Service to mirror matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Core"
-                                        maxLength: 253
+                                      scheme:
+                                        description: "Scheme is the scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used. \n Support: Extended"
+                                        enum:
+                                          - http
+                                          - https
                                         type: string
+                                      statusCode:
+                                        default: 302
+                                        description: "StatusCode is the HTTP status code to be used in response. \n Support: Core"
+                                        enum:
+                                          - 301
+                                          - 302
+                                        type: integer
                                     type: object
                                   type:
-                                    description: "Type identifies the type of filter to apply. As with other API fields, types are classified into three conformance levels: \n - Core: Filter types and their corresponding configuration defined by   \"Support: Core\" in this package, e.g. \"RequestHeaderModifier\". All   implementations must support core filters. \n - Extended: Filter types and their corresponding configuration defined by   \"Support: Extended\" in this package, e.g. \"RequestMirror\". Implementers   are encouraged to support extended filters. \n - Custom: Filters that are defined and supported by specific vendors.   In the future, filters showing convergence in behavior across multiple   implementations will be considered for inclusion in extended or core   conformance levels. Filter-specific configuration for such filters   is specified using the ExtensionRef field. `Type` should be set to   \"ExtensionRef\" for custom filters. \n Implementers are encouraged to define custom implementation types to extend the core API with implementation-specific behavior."
+                                    description: "Type identifies the type of filter to apply. As with other API fields, types are classified into three conformance levels: \n - Core: Filter types and their corresponding configuration defined by   \"Support: Core\" in this package, e.g. \"RequestHeaderModifier\". All   implementations must support core filters. \n - Extended: Filter types and their corresponding configuration defined by   \"Support: Extended\" in this package, e.g. \"RequestMirror\". Implementers   are encouraged to support extended filters. \n - Custom: Filters that are defined and supported by specific vendors.   In the future, filters showing convergence in behavior across multiple   implementations will be considered for inclusion in extended or core   conformance levels. Filter-specific configuration for such filters   is specified using the ExtensionRef field. `Type` should be set to   \"ExtensionRef\" for custom filters. \n Implementers are encouraged to define custom implementation types to extend the core API with implementation-specific behavior. \n If a reference to a custom filter type cannot be resolved, the filter MUST NOT be skipped. Instead, requests that would have been processed by that filter MUST receive a HTTP error response."
                                     enum:
                                       - RequestHeaderModifier
                                       - RequestMirror
+                                      - RequestRedirect
                                       - ExtensionRef
                                     type: string
                                 required:
@@ -1064,47 +893,66 @@ spec:
                                 type: object
                               maxItems: 16
                               type: array
+                            group:
+                              default: ""
+                              description: Group is the group of the referent. For example, "networking.k8s.io". When unspecified (empty string), core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              default: Service
+                              description: Kind is kind of the referent. For example "HTTPRoute" or "Service".
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: "Namespace is the namespace of the backend. When unspecified, the local namespace is inferred. \n Note that when a namespace is specified, a ReferencePolicy object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferencePolicy documentation for details. \n Support: Core"
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
                             port:
-                              description: "Port specifies the destination port number to use for the backend referenced by the ServiceName or BackendRef field. If unspecified, the destination port in the request is used when forwarding to a backendRef or serviceName. \n Support: Core"
+                              description: Port specifies the destination port number to use for this resource. Port is required when the referent is a Kubernetes Service. For other resources, destination port might be derived from the referent resource or this field.
                               format: int32
                               maximum: 65535
                               minimum: 1
                               type: integer
-                            serviceName:
-                              description: "ServiceName refers to the name of the Service to forward matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n The protocol to use should be specified with the AppProtocol field on Service resources. This field was introduced in Kubernetes 1.18. If using an earlier version of Kubernetes, a `networking.x-k8s.io/app-protocol` annotation on the BackendPolicy resource may be used to define the protocol. If the AppProtocol field is available, this annotation should not be used. The AppProtocol field, when populated, takes precedence over the annotation in the BackendPolicy resource. For custom backends, it is encouraged to add a semantically-equivalent field in the Custom Resource Definition. \n Support: Core"
-                              maxLength: 253
-                              type: string
                             weight:
                               default: 1
-                              description: "Weight specifies the proportion of HTTP requests forwarded to the backend referenced by the ServiceName or BackendRef field. This is computed as weight/(sum of all weights in this ForwardTo list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. Weight is not a percentage and the sum of weights does not need to equal 100. \n If only one backend is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Core"
+                              description: "Weight specifies the proportion of requests forwarded to the referenced backend. This is computed as weight/(sum of all weights in this BackendRefs list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. Weight is not a percentage and the sum of weights does not need to equal 100. \n If only one backend is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support for this field varies based on the context where used."
                               format: int32
                               maximum: 1000000
                               minimum: 0
                               type: integer
+                          required:
+                            - name
                           type: object
                         maxItems: 16
                         type: array
-                      matches:
-                        default:
-                          - path:
-                              type: Prefix
-                              value: /
-                        description: "Matches define conditions used for matching the rule against incoming HTTP requests. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. \n For example, take the following matches configuration: \n ``` matches: - path:     value: \"/foo\"   headers:     values:       version: \"2\" - path:     value: \"/v2/foo\" ``` \n For a request to match against this rule, a request should satisfy EITHER of the two conditions: \n - path prefixed with `/foo` AND contains the header `version: \"2\"` - path prefix of `/v2/foo` \n See the documentation for HTTPRouteMatch on how to specify multiple match conditions that should be ANDed together. \n If no matches are specified, the default is a prefix path match on \"/\", which has the effect of matching every HTTP request. \n Each client request MUST map to a maximum of one route rule. If a request matches multiple rules, matching precedence MUST be determined in order of the following criteria, continuing on ties: \n * The longest matching hostname. * The longest matching path. * The largest number of header matches. \n If ties still exist across multiple Routes, matching precedence MUST be determined in order of the following criteria, continuing on ties: \n * The oldest Route based on creation timestamp. For example, a Route with   a creation timestamp of \"2020-09-08 01:02:03\" is given precedence over   a Route with a creation timestamp of \"2020-09-08 01:02:04\". * The Route appearing first in alphabetical order by   \"<namespace>/<name>\". For example, foo/bar is given precedence over   foo/baz. \n If ties still exist within the Route that has been given precedence, matching precedence MUST be granted to the first matching rule meeting the above criteria."
+                      filters:
+                        description: "Filters define the filters that are applied to requests that match this rule. \n The effects of ordering of multiple behaviors are currently unspecified. This can change in the future based on feedback during the alpha stage. \n Conformance-levels at this level are defined based on the type of filter: \n - ALL core filters MUST be supported by all implementations. - Implementers are encouraged to support extended filters. - Implementation-specific custom filters have no API guarantees across   implementations. \n Specifying a core filter multiple times has unspecified or custom conformance. \n Support: Core"
                         items:
-                          description: "HTTPRouteMatch defines the predicate used to match requests to a given action. Multiple match types are ANDed together, i.e. the match will evaluate to true only if all conditions are satisfied. \n For example, the match below will match a HTTP request only if its path starts with `/foo` AND it contains the `version: \"1\"` header: \n ``` match:   path:     value: \"/foo\"   headers:     values:       version: \"1\" ```"
+                          description: HTTPRouteFilter defines processing steps that must be completed during the request or response lifecycle. HTTPRouteFilters are meant as an extension point to express processing that may be done in Gateway implementations. Some examples include request or response modification, implementing authentication strategies, rate-limiting, and traffic shaping. API guarantee/conformance is defined based on the type of the filter.
                           properties:
                             extensionRef:
-                              description: "ExtensionRef is an optional, implementation-specific extension to the \"match\" behavior. For example, resource \"myroutematcher\" in group \"networking.acme.io\". If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
+                              description: "ExtensionRef is an optional, implementation-specific extension to the \"filter\" behavior.  For example, resource \"myroutefilter\" in group \"networking.example.net\"). ExtensionRef MUST NOT be used for core and extended filters. \n Support: Implementation-specific"
                               properties:
                                 group:
-                                  description: Group is the group of the referent.
+                                  description: Group is the group of the referent. For example, "networking.k8s.io". When unspecified (empty string), core API group is inferred.
                                   maxLength: 253
-                                  minLength: 1
+                                  pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                   type: string
                                 kind:
-                                  description: Kind is kind of the referent.
-                                  maxLength: 253
+                                  description: Kind is kind of the referent. For example "HTTPRoute" or "Service".
+                                  maxLength: 63
                                   minLength: 1
+                                  pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                                   type: string
                                 name:
                                   description: Name is the name of the referent.
@@ -1116,110 +964,272 @@ spec:
                                 - kind
                                 - name
                               type: object
-                            headers:
-                              description: Headers specifies a HTTP request header matcher.
+                            requestHeaderModifier:
+                              description: "RequestHeaderModifier defines a schema for a filter that modifies request headers. \n Support: Core"
                               properties:
-                                type:
-                                  default: Exact
-                                  description: "Type specifies how to match against the value of the header. \n Support: Core (Exact) \n Support: Custom (RegularExpression, ImplementationSpecific) \n Since RegularExpression PathType has custom conformance, implementations can support POSIX, PCRE or any other dialects of regular expressions. Please read the implementation's documentation to determine the supported dialect. \n HTTP Header name matching MUST be case-insensitive (RFC 2616 - section 4.2)."
-                                  enum:
-                                    - Exact
-                                    - RegularExpression
-                                    - ImplementationSpecific
-                                  type: string
-                                values:
-                                  additionalProperties:
+                                add:
+                                  description: "Add adds the given header(s) (name, value) to the request before the action. It appends to any existing values associated with the header name. \n Input:   GET /foo HTTP/1.1   my-header: foo \n Config:   add:   - name: \"my-header\"     value: \"bar\" \n Output:   GET /foo HTTP/1.1   my-header: foo   my-header: bar"
+                                  items:
+                                    description: HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.
+                                    properties:
+                                      name:
+                                        description: "Name is the name of the HTTP Header to be matched. Name matching MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2). \n If multiple entries specify equivalent header names, the first entry with an equivalent name MUST be considered for a match. Subsequent entries with an equivalent header name MUST be ignored. Due to the case-insensitivity of header names, \"foo\" and \"Foo\" are considered equivalent."
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      value:
+                                        description: Value is the value of HTTP Header to be matched.
+                                        maxLength: 4096
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  maxItems: 16
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                remove:
+                                  description: "Remove the given header(s) from the HTTP request before the action. The value of Remove is a list of HTTP header names. Note that the header names are case-insensitive (see https://datatracker.ietf.org/doc/html/rfc2616#section-4.2). \n Input:   GET /foo HTTP/1.1   my-header1: foo   my-header2: bar   my-header3: baz \n Config:   remove: [\"my-header1\", \"my-header3\"] \n Output:   GET /foo HTTP/1.1   my-header2: bar"
+                                  items:
                                     type: string
-                                  description: "Values is a map of HTTP Headers to be matched. It MUST contain at least one entry. \n The HTTP header field name to match is the map key, and the value of the HTTP header is the map value. HTTP header field name matching MUST be case-insensitive. \n Multiple match values are ANDed together, meaning, a request must match all the specified headers to select the route."
+                                  maxItems: 16
+                                  type: array
+                                set:
+                                  description: "Set overwrites the request with the given header (name, value) before the action. \n Input:   GET /foo HTTP/1.1   my-header: foo \n Config:   set:   - name: \"my-header\"     value: \"bar\" \n Output:   GET /foo HTTP/1.1   my-header: bar"
+                                  items:
+                                    description: HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.
+                                    properties:
+                                      name:
+                                        description: "Name is the name of the HTTP Header to be matched. Name matching MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2). \n If multiple entries specify equivalent header names, the first entry with an equivalent name MUST be considered for a match. Subsequent entries with an equivalent header name MUST be ignored. Due to the case-insensitivity of header names, \"foo\" and \"Foo\" are considered equivalent."
+                                        maxLength: 256
+                                        minLength: 1
+                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                        type: string
+                                      value:
+                                        description: Value is the value of HTTP Header to be matched.
+                                        maxLength: 4096
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  maxItems: 16
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                              type: object
+                            requestMirror:
+                              description: "RequestMirror defines a schema for a filter that mirrors requests. Requests are sent to the specified destination, but responses from that destination are ignored. \n Support: Extended"
+                              properties:
+                                backendRef:
+                                  description: "BackendRef references a resource where mirrored requests are sent. \n If the referent cannot be found, this BackendRef is invalid and must be dropped from the Gateway. The controller must ensure the \"ResolvedRefs\" condition on the Route status is set to `status: False` and not configure this backend in the underlying implementation. \n If there is a cross-namespace reference to an *existing* object that is not allowed by a ReferencePolicy, the controller must ensure the \"ResolvedRefs\"  condition on the Route is set to `status: False`, with the \"RefNotPermitted\" reason and not configure this backend in the underlying implementation. \n In either error case, the Message of the `ResolvedRefs` Condition should be used to provide more detail about the problem. \n Support: Extended for Kubernetes Service Support: Custom for any other resource"
+                                  properties:
+                                    group:
+                                      default: ""
+                                      description: Group is the group of the referent. For example, "networking.k8s.io". When unspecified (empty string), core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      default: Service
+                                      description: Kind is kind of the referent. For example "HTTPRoute" or "Service".
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    namespace:
+                                      description: "Namespace is the namespace of the backend. When unspecified, the local namespace is inferred. \n Note that when a namespace is specified, a ReferencePolicy object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferencePolicy documentation for details. \n Support: Core"
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    port:
+                                      description: Port specifies the destination port number to use for this resource. Port is required when the referent is a Kubernetes Service. For other resources, destination port might be derived from the referent resource or this field.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                  required:
+                                    - name
                                   type: object
                               required:
-                                - values
+                                - backendRef
                               type: object
+                            requestRedirect:
+                              description: "RequestRedirect defines a schema for a filter that responds to the request with an HTTP redirection. \n Support: Core"
+                              properties:
+                                hostname:
+                                  description: "Hostname is the hostname to be used in the value of the `Location` header in the response. When empty, the hostname of the request is used. \n Support: Core"
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                port:
+                                  description: "Port is the port to be used in the value of the `Location` header in the response. When empty, port (if specified) of the request is used. \n Support: Extended"
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                                scheme:
+                                  description: "Scheme is the scheme to be used in the value of the `Location` header in the response. When empty, the scheme of the request is used. \n Support: Extended"
+                                  enum:
+                                    - http
+                                    - https
+                                  type: string
+                                statusCode:
+                                  default: 302
+                                  description: "StatusCode is the HTTP status code to be used in response. \n Support: Core"
+                                  enum:
+                                    - 301
+                                    - 302
+                                  type: integer
+                              type: object
+                            type:
+                              description: "Type identifies the type of filter to apply. As with other API fields, types are classified into three conformance levels: \n - Core: Filter types and their corresponding configuration defined by   \"Support: Core\" in this package, e.g. \"RequestHeaderModifier\". All   implementations must support core filters. \n - Extended: Filter types and their corresponding configuration defined by   \"Support: Extended\" in this package, e.g. \"RequestMirror\". Implementers   are encouraged to support extended filters. \n - Custom: Filters that are defined and supported by specific vendors.   In the future, filters showing convergence in behavior across multiple   implementations will be considered for inclusion in extended or core   conformance levels. Filter-specific configuration for such filters   is specified using the ExtensionRef field. `Type` should be set to   \"ExtensionRef\" for custom filters. \n Implementers are encouraged to define custom implementation types to extend the core API with implementation-specific behavior. \n If a reference to a custom filter type cannot be resolved, the filter MUST NOT be skipped. Instead, requests that would have been processed by that filter MUST receive a HTTP error response."
+                              enum:
+                                - RequestHeaderModifier
+                                - RequestMirror
+                                - RequestRedirect
+                                - ExtensionRef
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        maxItems: 16
+                        type: array
+                      matches:
+                        default:
+                          - path:
+                              type: PathPrefix
+                              value: /
+                        description: "Matches define conditions used for matching the rule against incoming HTTP requests. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. \n For example, take the following matches configuration: \n ``` matches: - path:     value: \"/foo\"   headers:   - name: \"version\"     value: \"v2\" - path:     value: \"/v2/foo\" ``` \n For a request to match against this rule, a request must satisfy EITHER of the two conditions: \n - path prefixed with `/foo` AND contains the header `version: v2` - path prefix of `/v2/foo` \n See the documentation for HTTPRouteMatch on how to specify multiple match conditions that should be ANDed together. \n If no matches are specified, the default is a prefix path match on \"/\", which has the effect of matching every HTTP request. \n Proxy or Load Balancer routing configuration generated from HTTPRoutes MUST prioritize rules based on the following criteria, continuing on ties. Precedence must be given to the the Rule with the largest number of: \n * Characters in a matching non-wildcard hostname. * Characters in a matching hostname. * Characters in a matching path. * Header matches. * Query param matches. \n If ties still exist across multiple Routes, matching precedence MUST be determined in order of the following criteria, continuing on ties: \n * The oldest Route based on creation timestamp. * The Route appearing first in alphabetical order by   \"<namespace>/<name>\". \n If ties still exist within the Route that has been given precedence, matching precedence MUST be granted to the first matching rule meeting the above criteria."
+                        items:
+                          description: "HTTPRouteMatch defines the predicate used to match requests to a given action. Multiple match types are ANDed together, i.e. the match will evaluate to true only if all conditions are satisfied. \n For example, the match below will match a HTTP request only if its path starts with `/foo` AND it contains the `version: v1` header: \n ``` match:   path:     value: \"/foo\"   headers:   - name: \"version\"     value \"v1\" ```"
+                          properties:
+                            headers:
+                              description: Headers specifies HTTP request header matchers. Multiple match values are ANDed together, meaning, a request must match all the specified headers to select the route.
+                              items:
+                                description: HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request headers.
+                                properties:
+                                  name:
+                                    description: "Name is the name of the HTTP Header to be matched. Name matching MUST be case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2). \n If multiple entries specify equivalent header names, only the first entry with an equivalent name MUST be considered for a match. Subsequent entries with an equivalent header name MUST be ignored. Due to the case-insensitivity of header names, \"foo\" and \"Foo\" are considered equivalent. \n When a header is repeated in an HTTP request, it is implementation-specific behavior as to how this is represented. Generally, proxies should follow the guidance from the RFC: https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding processing a repeated header, with special handling for \"Set-Cookie\"."
+                                    maxLength: 256
+                                    minLength: 1
+                                    pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                    type: string
+                                  type:
+                                    default: Exact
+                                    description: "Type specifies how to match against the value of the header. \n Support: Core (Exact) \n Support: Custom (RegularExpression) \n Since RegularExpression HeaderMatchType has custom conformance, implementations can support POSIX, PCRE or any other dialects of regular expressions. Please read the implementation's documentation to determine the supported dialect."
+                                    enum:
+                                      - Exact
+                                      - RegularExpression
+                                    type: string
+                                  value:
+                                    description: Value is the value of HTTP Header to be matched.
+                                    maxLength: 4096
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              maxItems: 16
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            method:
+                              description: "Method specifies HTTP method matcher. When specified, this route will be matched only if the request has the specified method. \n Support: Extended"
+                              enum:
+                                - GET
+                                - HEAD
+                                - POST
+                                - PUT
+                                - DELETE
+                                - CONNECT
+                                - OPTIONS
+                                - TRACE
+                                - PATCH
+                              type: string
                             path:
                               default:
-                                type: Prefix
+                                type: PathPrefix
                                 value: /
                               description: Path specifies a HTTP request path matcher. If this field is not specified, a default prefix match on the "/" path is provided.
                               properties:
                                 type:
-                                  default: Prefix
-                                  description: "Type specifies how to match against the path Value. \n Support: Core (Exact, Prefix) \n Support: Custom (RegularExpression, ImplementationSpecific) \n Since RegularExpression PathType has custom conformance, implementations can support POSIX, PCRE or any other dialects of regular expressions. Please read the implementation's documentation to determine the supported dialect."
+                                  default: PathPrefix
+                                  description: "Type specifies how to match against the path Value. \n Support: Core (Exact, PathPrefix) \n Support: Custom (RegularExpression)"
                                   enum:
                                     - Exact
-                                    - Prefix
+                                    - PathPrefix
                                     - RegularExpression
-                                    - ImplementationSpecific
                                   type: string
                                 value:
                                   default: /
                                   description: Value of the HTTP path to match against.
+                                  maxLength: 1024
                                   type: string
                               type: object
                             queryParams:
-                              description: QueryParams specifies a HTTP query parameter matcher.
-                              properties:
-                                type:
-                                  default: Exact
-                                  description: "Type specifies how to match against the value of the query parameter. \n Support: Extended (Exact) \n Support: Custom (RegularExpression, ImplementationSpecific) \n Since RegularExpression QueryParamMatchType has custom conformance, implementations can support POSIX, PCRE or any other dialects of regular expressions. Please read the implementation's documentation to determine the supported dialect."
-                                  enum:
-                                    - Exact
-                                    - RegularExpression
-                                    - ImplementationSpecific
-                                  type: string
-                                values:
-                                  additionalProperties:
+                              description: QueryParams specifies HTTP query parameter matchers. Multiple match values are ANDed together, meaning, a request must match all the specified query parameters to select the route.
+                              items:
+                                description: HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP query parameters.
+                                properties:
+                                  name:
+                                    description: Name is the name of the HTTP query param to be matched. This must be an exact string match. (See https://tools.ietf.org/html/rfc7230#section-2.7.3).
+                                    maxLength: 256
+                                    minLength: 1
                                     type: string
-                                  description: "Values is a map of HTTP query parameters to be matched. It MUST contain at least one entry. \n The query parameter name to match is the map key, and the value of the query parameter is the map value. \n Multiple match values are ANDed together, meaning, a request must match all the specified query parameters to select the route. \n HTTP query parameter matching MUST be case-sensitive for both keys and values. (See https://tools.ietf.org/html/rfc7230#section-2.7.3). \n Note that the query parameter key MUST always be an exact match by string comparison."
-                                  type: object
-                              required:
-                                - values
-                              type: object
+                                  type:
+                                    default: Exact
+                                    description: "Type specifies how to match against the value of the query parameter. \n Support: Extended (Exact) \n Support: Custom (RegularExpression) \n Since RegularExpression QueryParamMatchType has custom conformance, implementations can support POSIX, PCRE or any other dialects of regular expressions. Please read the implementation's documentation to determine the supported dialect."
+                                    enum:
+                                      - Exact
+                                      - RegularExpression
+                                    type: string
+                                  value:
+                                    description: Value is the value of HTTP query param to be matched.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              maxItems: 16
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                           type: object
                         maxItems: 8
                         type: array
                     type: object
                   maxItems: 16
                   type: array
-                tls:
-                  description: "TLS defines the TLS certificate to use for Hostnames defined in this Route. This configuration only takes effect if the AllowRouteOverride field is set to true in the associated Gateway resource. \n Collisions can happen if multiple HTTPRoutes define a TLS certificate for the same hostname. In such a case, conflict resolution guiding principles apply, specifically, if hostnames are same and two different certificates are specified then the certificate in the oldest resource wins. \n Please note that HTTP Route-selection takes place after the TLS Handshake (ClientHello). Due to this, TLS certificate defined here will take precedence even if the request has the potential to match multiple routes (in case multiple HTTPRoutes share the same hostname). \n Support: Core"
-                  properties:
-                    certificateRef:
-                      description: "CertificateRef is a reference to a Kubernetes object that contains a TLS certificate and private key. This certificate is used to establish a TLS handshake for requests that match the hostname of the associated HTTPRoute. The referenced object MUST reside in the same namespace as HTTPRoute. \n This field is required when the TLS configuration mode of the associated Gateway listener is set to \"Passthrough\". \n CertificateRef can reference a standard Kubernetes resource, i.e. Secret, or an implementation-specific custom resource. \n Support: Core (Kubernetes Secrets) \n Support: Implementation-specific (Other resource types)"
-                      properties:
-                        group:
-                          description: Group is the group of the referent.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        kind:
-                          description: Kind is kind of the referent.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        name:
-                          description: Name is the name of the referent.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                      required:
-                        - group
-                        - kind
-                        - name
-                      type: object
-                  required:
-                    - certificateRef
-                  type: object
               type: object
             status:
               description: Status defines the current state of HTTPRoute.
               properties:
-                gateways:
-                  description: "Gateways is a list of Gateways that are associated with the route, and the status of the route with respect to each Gateway. When a Gateway selects this route, the controller that manages the Gateway must add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route is modified. \n A maximum of 100 Gateways will be represented in this list. If this list is full, there may be additional Gateways using this Route that are not included in the list. An empty list means the route has not been admitted by any Gateway."
+                parents:
+                  description: "Parents is a list of parent resources (usually Gateways) that are associated with the route, and the status of the route with respect to each parent. When this route attaches to a parent, the controller that manages the parent must add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route or gateway is modified. \n Note that parent references that cannot be resolved by an implementation of this API will not be added to this list. Implementations of this API can only populate Route status for the Gateways/parent resources they are responsible for. \n A maximum of 32 Gateways will be represented in this list. An empty list means the route has not been attached to any Gateway."
                   items:
-                    description: RouteGatewayStatus describes the status of a route with respect to an associated Gateway.
+                    description: RouteParentStatus describes the status of a route with respect to an associated Parent.
                     properties:
                       conditions:
-                        description: Conditions describes the status of the route with respect to the Gateway. The "Admitted" condition must always be specified by controllers to indicate whether the route has been admitted or rejected by the Gateway, and why. Note that the route's availability is also subject to the Gateway's own status conditions and listener status.
+                        description: "Conditions describes the status of the route with respect to the Gateway. Note that the route's availability is also subject to the Gateway's own status conditions and listener status. \n If the Route's ParentRef specifies an existing Gateway that supports Routes of this kind AND that Gateway's controller has sufficient access, then that Gateway's controller MUST set the \"Accepted\" condition on the Route, to indicate whether the route has been accepted or rejected by the Gateway, and why. \n A Route MUST be considered \"Accepted\" if at least one of the Route's rules is implemented by the Gateway. \n There are a number of cases where the \"Accepted\" condition may not be set due to lack of controller visibility, that includes when: \n * The Route refers to a non-existent parent. * The Route is of a type that the controller does not support. * The Route is in a namespace the the controller does not have access to."
                         items:
                           description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                           properties:
@@ -1262,39 +1272,64 @@ spec:
                             - type
                           type: object
                         maxItems: 8
+                        minItems: 1
                         type: array
                         x-kubernetes-list-map-keys:
                           - type
                         x-kubernetes-list-type: map
-                      gatewayRef:
-                        description: GatewayRef is a reference to a Gateway object that is associated with the route.
+                      controllerName:
+                        description: "ControllerName is a domain/path string that indicates the name of the controller that wrote this status. This corresponds with the controllerName field on GatewayClass. \n Example: \"example.net/gateway-controller\". \n The format of this field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)."
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                        type: string
+                      parentRef:
+                        description: ParentRef corresponds with a ParentRef in the spec that this RouteParentStatus struct describes the status of.
                         properties:
-                          controller:
-                            description: "Controller is a domain/path string that indicates the controller implementing the Gateway. This corresponds with the controller field on GatewayClass. \n Example: \"acme.io/gateway-controller\". \n The format of this field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)."
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: "Group is the group of the referent. \n Support: Core"
                             maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Gateway
+                            description: "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                             type: string
                           name:
-                            description: Name is the name of the referent.
+                            description: "Name is the name of the referent. \n Support: Core"
                             maxLength: 253
                             minLength: 1
                             type: string
                           namespace:
-                            description: Namespace is the namespace of the referent.
+                            description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          sectionName:
+                            description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
                             maxLength: 253
                             minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                         required:
                           - name
-                          - namespace
                         type: object
                     required:
-                      - gatewayRef
+                      - controllerName
+                      - parentRef
                     type: object
-                  maxItems: 100
+                  maxItems: 32
                   type: array
               required:
-                - gateways
+                - parents
               type: object
+          required:
+            - spec
           type: object
       served: true
       storage: true
@@ -1311,11 +1346,123 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
   creationTimestamp: null
-  name: tcproutes.networking.x-k8s.io
+  name: referencepolicies.gateway.networking.k8s.io
 spec:
-  group: networking.x-k8s.io
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+      - gateway-api
+    kind: ReferencePolicy
+    listKind: ReferencePolicyList
+    plural: referencepolicies
+    shortNames:
+      - refpol
+    singular: referencepolicy
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: "ReferencePolicy identifies kinds of resources in other namespaces that are trusted to reference the specified kinds of resources in the same namespace as the policy. \n Each ReferencePolicy can be used to represent a unique trust relationship. Additional Reference Policies can be used to add to the set of trusted sources of inbound references for the namespace they are defined within. \n All cross-namespace references in Gateway API (with the exception of cross-namespace Gateway-route attachment) require a ReferencePolicy. \n Support: Core"
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of ReferencePolicy.
+              properties:
+                from:
+                  description: "From describes the trusted namespaces and kinds that can reference the resources described in \"To\". Each entry in this list must be considered to be an additional place that references can be valid from, or to put this another way, entries must be combined using OR. \n Support: Core"
+                  items:
+                    description: ReferencePolicyFrom describes trusted namespaces and kinds.
+                    properties:
+                      group:
+                        description: "Group is the group of the referent. When empty, the Kubernetes core API group is inferred. \n Support: Core"
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: "Kind is the kind of the referent. Although implementations may support additional resources, the following Route types are part of the \"Core\" support level for this field: \n * HTTPRoute * TCPRoute * TLSRoute * UDPRoute"
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      namespace:
+                        description: "Namespace is the namespace of the referent. \n Support: Core"
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                    required:
+                      - group
+                      - kind
+                    type: object
+                  maxItems: 16
+                  minItems: 1
+                  type: array
+                to:
+                  description: "To describes the resources that may be referenced by the resources described in \"From\". Each entry in this list must be considered to be an additional place that references can be valid to, or to put this another way, entries must be combined using OR. \n Support: Core"
+                  items:
+                    description: ReferencePolicyTo describes what Kinds are allowed as targets of the references.
+                    properties:
+                      group:
+                        description: "Group is the group of the referent. When empty, the Kubernetes core API group is inferred. \n Support: Core"
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: "Kind is the kind of the referent. Although implementations may support additional resources, the following types are part of the \"Core\" support level for this field: \n * Service"
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent. When unspecified or empty, this policy refers to all resources of the specified Group and Kind in the local namespace.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    required:
+                      - group
+                      - kind
+                    type: object
+                  maxItems: 16
+                  minItems: 1
+                  type: array
+              required:
+                - from
+                - to
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
+  creationTimestamp: null
+  name: tcproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
   names:
     categories:
       - gateway-api
@@ -1329,10 +1476,10 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-      name: v1alpha1
+      name: v1alpha2
       schema:
         openAPIV3Schema:
-          description: TCPRoute is the Schema for the TCPRoute resource.
+          description: TCPRoute provides a way to route TCP requests. When combined with a Gateway listener, it can be used to forward connections on the port specified by the listener to a set of backends specified by the TCPRoute.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -1345,127 +1492,99 @@ spec:
             spec:
               description: Spec defines the desired state of TCPRoute.
               properties:
-                gateways:
-                  default:
-                    allow: SameNamespace
-                  description: Gateways defines which Gateways can use this Route.
-                  properties:
-                    allow:
-                      default: SameNamespace
-                      description: 'Allow indicates which Gateways will be allowed to use this route. Possible values are: * All: Gateways in any namespace can use this route. * FromList: Only Gateways specified in GatewayRefs may use this route. * SameNamespace: Only Gateways in the same namespace may use this route.'
-                      enum:
-                        - All
-                        - FromList
-                        - SameNamespace
-                      type: string
-                    gatewayRefs:
-                      description: GatewayRefs must be specified when Allow is set to "FromList". In that case, only Gateways referenced in this list will be allowed to use this route. This field is ignored for other values of "Allow".
-                      items:
-                        description: GatewayReference identifies a Gateway in a specified namespace.
-                        properties:
-                          name:
-                            description: Name is the name of the referent.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                          namespace:
-                            description: Namespace is the namespace of the referent.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                        required:
-                          - name
-                          - namespace
-                        type: object
-                      type: array
-                  type: object
+                parentRefs:
+                  description: "ParentRefs references the resources (usually Gateways) that a Route wants to be attached to. Note that the referenced parent resource needs to allow this for the attachment to be complete. For Gateways, that means the Gateway needs to allow attachment from Routes of this kind and namespace. \n The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources such as one of the route kinds. \n It is invalid to reference an identical parent more than once. It is valid to reference multiple distinct sections within the same parent resource, such as 2 Listeners within a Gateway. \n It is possible to separately reference multiple distinct objects that may be collapsed by an implementation. For example, some implementations may choose to merge compatible Gateway Listeners together. If that is the case, the list of routes attached to those resources should also be merged."
+                  items:
+                    description: "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object."
+                    properties:
+                      group:
+                        default: gateway.networking.k8s.io
+                        description: "Group is the group of the referent. \n Support: Core"
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Gateway
+                        description: "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)"
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: "Name is the name of the referent. \n Support: Core"
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                      sectionName:
+                        description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  maxItems: 32
+                  type: array
                 rules:
                   description: Rules are a list of TCP matchers and actions.
                   items:
                     description: TCPRouteRule is the configuration for a given rule.
                     properties:
-                      forwardTo:
-                        description: ForwardTo defines the backend(s) where matching requests should be sent.
+                      backendRefs:
+                        description: "BackendRefs defines the backend(s) where matching requests should be sent. If unspecified or invalid (refers to a non-existent resource or a Service with no endpoints), the underlying implementation MUST actively reject connection attempts to this backend. Connection rejections must respect weight; if an invalid backend is requested to have 80% of connections, then 80% of connections must be rejected instead. \n Support: Core for Kubernetes Service Support: Custom for any other resource \n Support for weight: Extended"
                         items:
-                          description: RouteForwardTo defines how a Route should forward a request.
+                          description: "BackendRef defines how a Route should forward a request to a Kubernetes resource. \n Note that when a namespace is specified, a ReferencePolicy object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferencePolicy documentation for details."
                           properties:
-                            backendRef:
-                              description: "BackendRef is a reference to a backend to forward matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
-                              properties:
-                                group:
-                                  description: Group is the group of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                kind:
-                                  description: Kind is kind of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                name:
-                                  description: Name is the name of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                              required:
-                                - group
-                                - kind
-                                - name
-                              type: object
+                            group:
+                              default: ""
+                              description: Group is the group of the referent. For example, "networking.k8s.io". When unspecified (empty string), core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              default: Service
+                              description: Kind is kind of the referent. For example "HTTPRoute" or "Service".
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: "Namespace is the namespace of the backend. When unspecified, the local namespace is inferred. \n Note that when a namespace is specified, a ReferencePolicy object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferencePolicy documentation for details. \n Support: Core"
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
                             port:
-                              description: "Port specifies the destination port number to use for the backend referenced by the ServiceName or BackendRef field. If unspecified, the destination port in the request is used when forwarding to a backendRef or serviceName. \n Support: Core"
+                              description: Port specifies the destination port number to use for this resource. Port is required when the referent is a Kubernetes Service. For other resources, destination port might be derived from the referent resource or this field.
                               format: int32
                               maximum: 65535
                               minimum: 1
                               type: integer
-                            serviceName:
-                              description: "ServiceName refers to the name of the Service to forward matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n The protocol to use is defined using AppProtocol field (introduced in Kubernetes 1.18) in the Service resource. In the absence of the AppProtocol field a `networking.x-k8s.io/app-protocol` annotation on the BackendPolicy resource may be used to define the protocol. If the AppProtocol field is available, this annotation should not be used. The AppProtocol field, when populated, takes precedence over the annotation in the BackendPolicy resource. For custom backends, it is encouraged to add a semantically-equivalent field in the Custom Resource Definition. \n Support: Core"
-                              maxLength: 253
-                              type: string
                             weight:
                               default: 1
-                              description: "Weight specifies the proportion of HTTP requests forwarded to the backend referenced by the ServiceName or BackendRef field. This is computed as weight/(sum of all weights in this ForwardTo list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. Weight is not a percentage and the sum of weights does not need to equal 100. \n If only one backend is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Extended"
+                              description: "Weight specifies the proportion of requests forwarded to the referenced backend. This is computed as weight/(sum of all weights in this BackendRefs list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. Weight is not a percentage and the sum of weights does not need to equal 100. \n If only one backend is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support for this field varies based on the context where used."
                               format: int32
                               maximum: 1000000
                               minimum: 0
                               type: integer
+                          required:
+                            - name
                           type: object
                         maxItems: 16
                         minItems: 1
                         type: array
-                      matches:
-                        description: "Matches define conditions used for matching the rule against incoming TCP connections. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. If unspecified (i.e. empty), this Rule will match all requests for the associated Listener. \n Each client request MUST map to a maximum of one route rule. If a request matches multiple rules, matching precedence MUST be determined in order of the following criteria, continuing on ties: \n * The most specific match specified by ExtensionRef. Each implementation   that supports ExtensionRef may have different ways of determining the   specificity of the referenced extension. \n If ties still exist across multiple Routes, matching precedence MUST be determined in order of the following criteria, continuing on ties: \n * The oldest Route based on creation timestamp. For example, a Route with   a creation timestamp of \"2020-09-08 01:02:03\" is given precedence over   a Route with a creation timestamp of \"2020-09-08 01:02:04\". * The Route appearing first in alphabetical order by   \"<namespace>/<name>\". For example, foo/bar is given precedence over   foo/baz. \n If ties still exist within the Route that has been given precedence, matching precedence MUST be granted to the first matching rule meeting the above criteria."
-                        items:
-                          description: TCPRouteMatch defines the predicate used to match connections to a given action.
-                          properties:
-                            extensionRef:
-                              description: "ExtensionRef is an optional, implementation-specific extension to the \"match\" behavior.  For example, resource \"mytcproutematcher\" in group \"networking.acme.io\". If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
-                              properties:
-                                group:
-                                  description: Group is the group of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                kind:
-                                  description: Kind is kind of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                name:
-                                  description: Name is the name of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                              required:
-                                - group
-                                - kind
-                                - name
-                              type: object
-                          type: object
-                        maxItems: 8
-                        type: array
-                    required:
-                      - forwardTo
                     type: object
                   maxItems: 16
                   minItems: 1
@@ -1476,13 +1595,13 @@ spec:
             status:
               description: Status defines the current state of TCPRoute.
               properties:
-                gateways:
-                  description: "Gateways is a list of Gateways that are associated with the route, and the status of the route with respect to each Gateway. When a Gateway selects this route, the controller that manages the Gateway must add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route is modified. \n A maximum of 100 Gateways will be represented in this list. If this list is full, there may be additional Gateways using this Route that are not included in the list. An empty list means the route has not been admitted by any Gateway."
+                parents:
+                  description: "Parents is a list of parent resources (usually Gateways) that are associated with the route, and the status of the route with respect to each parent. When this route attaches to a parent, the controller that manages the parent must add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route or gateway is modified. \n Note that parent references that cannot be resolved by an implementation of this API will not be added to this list. Implementations of this API can only populate Route status for the Gateways/parent resources they are responsible for. \n A maximum of 32 Gateways will be represented in this list. An empty list means the route has not been attached to any Gateway."
                   items:
-                    description: RouteGatewayStatus describes the status of a route with respect to an associated Gateway.
+                    description: RouteParentStatus describes the status of a route with respect to an associated Parent.
                     properties:
                       conditions:
-                        description: Conditions describes the status of the route with respect to the Gateway. The "Admitted" condition must always be specified by controllers to indicate whether the route has been admitted or rejected by the Gateway, and why. Note that the route's availability is also subject to the Gateway's own status conditions and listener status.
+                        description: "Conditions describes the status of the route with respect to the Gateway. Note that the route's availability is also subject to the Gateway's own status conditions and listener status. \n If the Route's ParentRef specifies an existing Gateway that supports Routes of this kind AND that Gateway's controller has sufficient access, then that Gateway's controller MUST set the \"Accepted\" condition on the Route, to indicate whether the route has been accepted or rejected by the Gateway, and why. \n A Route MUST be considered \"Accepted\" if at least one of the Route's rules is implemented by the Gateway. \n There are a number of cases where the \"Accepted\" condition may not be set due to lack of controller visibility, that includes when: \n * The Route refers to a non-existent parent. * The Route is of a type that the controller does not support. * The Route is in a namespace the the controller does not have access to."
                         items:
                           description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                           properties:
@@ -1525,39 +1644,64 @@ spec:
                             - type
                           type: object
                         maxItems: 8
+                        minItems: 1
                         type: array
                         x-kubernetes-list-map-keys:
                           - type
                         x-kubernetes-list-type: map
-                      gatewayRef:
-                        description: GatewayRef is a reference to a Gateway object that is associated with the route.
+                      controllerName:
+                        description: "ControllerName is a domain/path string that indicates the name of the controller that wrote this status. This corresponds with the controllerName field on GatewayClass. \n Example: \"example.net/gateway-controller\". \n The format of this field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)."
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                        type: string
+                      parentRef:
+                        description: ParentRef corresponds with a ParentRef in the spec that this RouteParentStatus struct describes the status of.
                         properties:
-                          controller:
-                            description: "Controller is a domain/path string that indicates the controller implementing the Gateway. This corresponds with the controller field on GatewayClass. \n Example: \"acme.io/gateway-controller\". \n The format of this field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)."
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: "Group is the group of the referent. \n Support: Core"
                             maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Gateway
+                            description: "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                             type: string
                           name:
-                            description: Name is the name of the referent.
+                            description: "Name is the name of the referent. \n Support: Core"
                             maxLength: 253
                             minLength: 1
                             type: string
                           namespace:
-                            description: Namespace is the namespace of the referent.
+                            description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          sectionName:
+                            description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
                             maxLength: 253
                             minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                         required:
                           - name
-                          - namespace
                         type: object
                     required:
-                      - gatewayRef
+                      - controllerName
+                      - parentRef
                     type: object
-                  maxItems: 100
+                  maxItems: 32
                   type: array
               required:
-                - gateways
+                - parents
               type: object
+          required:
+            - spec
           type: object
       served: true
       storage: true
@@ -1574,11 +1718,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
   creationTimestamp: null
-  name: tlsroutes.networking.x-k8s.io
+  name: tlsroutes.gateway.networking.k8s.io
 spec:
-  group: networking.x-k8s.io
+  group: gateway.networking.k8s.io
   names:
     categories:
       - gateway-api
@@ -1592,7 +1736,7 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-      name: v1alpha1
+      name: v1alpha2
       schema:
         openAPIV3Schema:
           description: "The TLSRoute resource is similar to TCPRoute, but can be configured to match against TLS-specific metadata. This allows more flexibility in matching streams for a given TLS listener. \n If you need to forward traffic to a single target for a TLS listener, you could choose to use a TCPRoute with a TLS listener."
@@ -1608,136 +1752,109 @@ spec:
             spec:
               description: Spec defines the desired state of TLSRoute.
               properties:
-                gateways:
-                  default:
-                    allow: SameNamespace
-                  description: Gateways defines which Gateways can use this Route.
-                  properties:
-                    allow:
-                      default: SameNamespace
-                      description: 'Allow indicates which Gateways will be allowed to use this route. Possible values are: * All: Gateways in any namespace can use this route. * FromList: Only Gateways specified in GatewayRefs may use this route. * SameNamespace: Only Gateways in the same namespace may use this route.'
-                      enum:
-                        - All
-                        - FromList
-                        - SameNamespace
-                      type: string
-                    gatewayRefs:
-                      description: GatewayRefs must be specified when Allow is set to "FromList". In that case, only Gateways referenced in this list will be allowed to use this route. This field is ignored for other values of "Allow".
-                      items:
-                        description: GatewayReference identifies a Gateway in a specified namespace.
-                        properties:
-                          name:
-                            description: Name is the name of the referent.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                          namespace:
-                            description: Namespace is the namespace of the referent.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                        required:
-                          - name
-                          - namespace
-                        type: object
-                      type: array
-                  type: object
+                hostnames:
+                  description: "Hostnames defines a set of SNI names that should match against the SNI attribute of TLS ClientHello message in TLS handshake. This matches the RFC 1123 definition of a hostname with 2 notable exceptions: \n 1. IPs are not allowed in SNI names per RFC 6066. 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard    label must appear by itself as the first label. \n If a hostname is specified by both the Listener and TLSRoute, there must be at least one intersecting hostname for the TLSRoute to be attached to the Listener. For example: \n * A Listener with `test.example.com` as the hostname matches TLSRoutes   that have either not specified any hostnames, or have specified at   least one of `test.example.com` or `*.example.com`. * A Listener with `*.example.com` as the hostname matches TLSRoutes   that have either not specified any hostnames or have specified at least   one hostname that matches the Listener hostname. For example,   `test.example.com` and `*.example.com` would both match. On the other   hand, `example.com` and `test.example.net` would not match. \n If both the Listener and TLSRoute have specified hostnames, any TLSRoute hostnames that do not match the Listener hostname MUST be ignored. For example, if a Listener specified `*.example.com`, and the TLSRoute specified `test.example.com` and `test.example.net`, `test.example.net` must not be considered for a match. \n If both the Listener and TLSRoute have specified hostnames, and none match with the criteria above, then the TLSRoute is not accepted. The implementation must raise an 'Accepted' Condition with a status of `False` in the corresponding RouteParentStatus. \n Support: Core"
+                  items:
+                    description: "Hostname is the fully qualified domain name of a network host. This matches the RFC 1123 definition of a hostname with 2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard    label must appear by itself as the first label. \n Hostname can be \"precise\" which is a domain name without the terminating dot of a network host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain name prefixed with a single wildcard label (e.g. `*.example.com`). \n Note that as per RFC1035 and RFC1123, a *label* must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character. No other punctuation is allowed."
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  maxItems: 16
+                  type: array
+                parentRefs:
+                  description: "ParentRefs references the resources (usually Gateways) that a Route wants to be attached to. Note that the referenced parent resource needs to allow this for the attachment to be complete. For Gateways, that means the Gateway needs to allow attachment from Routes of this kind and namespace. \n The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources such as one of the route kinds. \n It is invalid to reference an identical parent more than once. It is valid to reference multiple distinct sections within the same parent resource, such as 2 Listeners within a Gateway. \n It is possible to separately reference multiple distinct objects that may be collapsed by an implementation. For example, some implementations may choose to merge compatible Gateway Listeners together. If that is the case, the list of routes attached to those resources should also be merged."
+                  items:
+                    description: "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object."
+                    properties:
+                      group:
+                        default: gateway.networking.k8s.io
+                        description: "Group is the group of the referent. \n Support: Core"
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Gateway
+                        description: "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)"
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: "Name is the name of the referent. \n Support: Core"
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                      sectionName:
+                        description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  maxItems: 32
+                  type: array
                 rules:
                   description: Rules are a list of TLS matchers and actions.
                   items:
                     description: TLSRouteRule is the configuration for a given rule.
                     properties:
-                      forwardTo:
-                        description: ForwardTo defines the backend(s) where matching requests should be sent.
+                      backendRefs:
+                        description: "BackendRefs defines the backend(s) where matching requests should be sent. If unspecified or invalid (refers to a non-existent resource or a Service with no endpoints), the rule performs no forwarding; if no filters are specified that would result in a response being sent, the underlying implementation must actively reject request attempts to this backend, by rejecting the connection or returning a 503 status code. Request rejections must respect weight; if an invalid backend is requested to have 80% of requests, then 80% of requests must be rejected instead. \n Support: Core for Kubernetes Service Support: Custom for any other resource \n Support for weight: Extended"
                         items:
-                          description: RouteForwardTo defines how a Route should forward a request.
+                          description: "BackendRef defines how a Route should forward a request to a Kubernetes resource. \n Note that when a namespace is specified, a ReferencePolicy object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferencePolicy documentation for details."
                           properties:
-                            backendRef:
-                              description: "BackendRef is a reference to a backend to forward matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
-                              properties:
-                                group:
-                                  description: Group is the group of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                kind:
-                                  description: Kind is kind of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                name:
-                                  description: Name is the name of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                              required:
-                                - group
-                                - kind
-                                - name
-                              type: object
+                            group:
+                              default: ""
+                              description: Group is the group of the referent. For example, "networking.k8s.io". When unspecified (empty string), core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              default: Service
+                              description: Kind is kind of the referent. For example "HTTPRoute" or "Service".
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: "Namespace is the namespace of the backend. When unspecified, the local namespace is inferred. \n Note that when a namespace is specified, a ReferencePolicy object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferencePolicy documentation for details. \n Support: Core"
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
                             port:
-                              description: "Port specifies the destination port number to use for the backend referenced by the ServiceName or BackendRef field. If unspecified, the destination port in the request is used when forwarding to a backendRef or serviceName. \n Support: Core"
+                              description: Port specifies the destination port number to use for this resource. Port is required when the referent is a Kubernetes Service. For other resources, destination port might be derived from the referent resource or this field.
                               format: int32
                               maximum: 65535
                               minimum: 1
                               type: integer
-                            serviceName:
-                              description: "ServiceName refers to the name of the Service to forward matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n The protocol to use is defined using AppProtocol field (introduced in Kubernetes 1.18) in the Service resource. In the absence of the AppProtocol field a `networking.x-k8s.io/app-protocol` annotation on the BackendPolicy resource may be used to define the protocol. If the AppProtocol field is available, this annotation should not be used. The AppProtocol field, when populated, takes precedence over the annotation in the BackendPolicy resource. For custom backends, it is encouraged to add a semantically-equivalent field in the Custom Resource Definition. \n Support: Core"
-                              maxLength: 253
-                              type: string
                             weight:
                               default: 1
-                              description: "Weight specifies the proportion of HTTP requests forwarded to the backend referenced by the ServiceName or BackendRef field. This is computed as weight/(sum of all weights in this ForwardTo list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. Weight is not a percentage and the sum of weights does not need to equal 100. \n If only one backend is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Extended"
+                              description: "Weight specifies the proportion of requests forwarded to the referenced backend. This is computed as weight/(sum of all weights in this BackendRefs list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. Weight is not a percentage and the sum of weights does not need to equal 100. \n If only one backend is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support for this field varies based on the context where used."
                               format: int32
                               maximum: 1000000
                               minimum: 0
                               type: integer
+                          required:
+                            - name
                           type: object
                         maxItems: 16
                         minItems: 1
                         type: array
-                      matches:
-                        description: "Matches define conditions used for matching the rule against incoming TLS connections. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. If unspecified (i.e. empty), this Rule will match all requests for the associated Listener. \n Each client request MUST map to a maximum of one route rule. If a request matches multiple rules, matching precedence MUST be determined in order of the following criteria, continuing on ties: \n * The longest matching SNI. * The longest matching precise SNI (without a wildcard). This means that   \"b.example.com\" should be given precedence over \"*.example.com\". * The most specific match specified by ExtensionRef. Each implementation   that supports ExtensionRef may have different ways of determining the   specificity of the referenced extension. \n If ties still exist across multiple Routes, matching precedence MUST be determined in order of the following criteria, continuing on ties: \n * The oldest Route based on creation timestamp. For example, a Route with   a creation timestamp of \"2020-09-08 01:02:03\" is given precedence over   a Route with a creation timestamp of \"2020-09-08 01:02:04\". * The Route appearing first in alphabetical order by   \"<namespace>/<name>\". For example, foo/bar is given precedence over   foo/baz. \n If ties still exist within the Route that has been given precedence, matching precedence MUST be granted to the first matching rule meeting the above criteria."
-                        items:
-                          description: TLSRouteMatch defines the predicate used to match connections to a given action.
-                          properties:
-                            extensionRef:
-                              description: "ExtensionRef is an optional, implementation-specific extension to the \"match\" behavior.  For example, resource \"mytlsroutematcher\" in group \"networking.acme.io\". If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
-                              properties:
-                                group:
-                                  description: Group is the group of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                kind:
-                                  description: Kind is kind of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                name:
-                                  description: Name is the name of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                              required:
-                                - group
-                                - kind
-                                - name
-                              type: object
-                            snis:
-                              description: "SNIs defines a set of SNI names that should match against the SNI attribute of TLS ClientHello message in TLS handshake. \n SNI can be \"precise\" which is a domain name without the terminating dot of a network host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain name prefixed with a single wildcard label (e.g. `*.example.com`). The wildcard character `*` must appear by itself as the first DNS label and matches only a single label. You cannot have a wildcard label by itself (e.g. Host == `*`). \n Requests will be matched against the Host field in the following order: \n 1. If SNI is precise, the request matches this rule if the SNI in    ClientHello is equal to one of the defined SNIs. 2. If SNI is a wildcard, then the request matches this rule if the    SNI is to equal to the suffix (removing the first label) of the    wildcard rule. 3. If SNIs is unspecified, all requests associated with the gateway TLS    listener will match. This can be used to define a default backend    for a TLS listener. \n Support: Core"
-                              items:
-                                description: Hostname is used to specify a hostname that should be matched.
-                                maxLength: 253
-                                minLength: 1
-                                type: string
-                              maxItems: 16
-                              type: array
-                          type: object
-                        maxItems: 8
-                        type: array
-                    required:
-                      - forwardTo
                     type: object
                   maxItems: 16
                   minItems: 1
@@ -1748,13 +1865,13 @@ spec:
             status:
               description: Status defines the current state of TLSRoute.
               properties:
-                gateways:
-                  description: "Gateways is a list of Gateways that are associated with the route, and the status of the route with respect to each Gateway. When a Gateway selects this route, the controller that manages the Gateway must add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route is modified. \n A maximum of 100 Gateways will be represented in this list. If this list is full, there may be additional Gateways using this Route that are not included in the list. An empty list means the route has not been admitted by any Gateway."
+                parents:
+                  description: "Parents is a list of parent resources (usually Gateways) that are associated with the route, and the status of the route with respect to each parent. When this route attaches to a parent, the controller that manages the parent must add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route or gateway is modified. \n Note that parent references that cannot be resolved by an implementation of this API will not be added to this list. Implementations of this API can only populate Route status for the Gateways/parent resources they are responsible for. \n A maximum of 32 Gateways will be represented in this list. An empty list means the route has not been attached to any Gateway."
                   items:
-                    description: RouteGatewayStatus describes the status of a route with respect to an associated Gateway.
+                    description: RouteParentStatus describes the status of a route with respect to an associated Parent.
                     properties:
                       conditions:
-                        description: Conditions describes the status of the route with respect to the Gateway. The "Admitted" condition must always be specified by controllers to indicate whether the route has been admitted or rejected by the Gateway, and why. Note that the route's availability is also subject to the Gateway's own status conditions and listener status.
+                        description: "Conditions describes the status of the route with respect to the Gateway. Note that the route's availability is also subject to the Gateway's own status conditions and listener status. \n If the Route's ParentRef specifies an existing Gateway that supports Routes of this kind AND that Gateway's controller has sufficient access, then that Gateway's controller MUST set the \"Accepted\" condition on the Route, to indicate whether the route has been accepted or rejected by the Gateway, and why. \n A Route MUST be considered \"Accepted\" if at least one of the Route's rules is implemented by the Gateway. \n There are a number of cases where the \"Accepted\" condition may not be set due to lack of controller visibility, that includes when: \n * The Route refers to a non-existent parent. * The Route is of a type that the controller does not support. * The Route is in a namespace the the controller does not have access to."
                         items:
                           description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                           properties:
@@ -1797,39 +1914,64 @@ spec:
                             - type
                           type: object
                         maxItems: 8
+                        minItems: 1
                         type: array
                         x-kubernetes-list-map-keys:
                           - type
                         x-kubernetes-list-type: map
-                      gatewayRef:
-                        description: GatewayRef is a reference to a Gateway object that is associated with the route.
+                      controllerName:
+                        description: "ControllerName is a domain/path string that indicates the name of the controller that wrote this status. This corresponds with the controllerName field on GatewayClass. \n Example: \"example.net/gateway-controller\". \n The format of this field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)."
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                        type: string
+                      parentRef:
+                        description: ParentRef corresponds with a ParentRef in the spec that this RouteParentStatus struct describes the status of.
                         properties:
-                          controller:
-                            description: "Controller is a domain/path string that indicates the controller implementing the Gateway. This corresponds with the controller field on GatewayClass. \n Example: \"acme.io/gateway-controller\". \n The format of this field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)."
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: "Group is the group of the referent. \n Support: Core"
                             maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Gateway
+                            description: "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                             type: string
                           name:
-                            description: Name is the name of the referent.
+                            description: "Name is the name of the referent. \n Support: Core"
                             maxLength: 253
                             minLength: 1
                             type: string
                           namespace:
-                            description: Namespace is the namespace of the referent.
+                            description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          sectionName:
+                            description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
                             maxLength: 253
                             minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                         required:
                           - name
-                          - namespace
                         type: object
                     required:
-                      - gatewayRef
+                      - controllerName
+                      - parentRef
                     type: object
-                  maxItems: 100
+                  maxItems: 32
                   type: array
               required:
-                - gateways
+                - parents
               type: object
+          required:
+            - spec
           type: object
       served: true
       storage: true
@@ -1846,11 +1988,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
   creationTimestamp: null
-  name: udproutes.networking.x-k8s.io
+  name: udproutes.gateway.networking.k8s.io
 spec:
-  group: networking.x-k8s.io
+  group: gateway.networking.k8s.io
   names:
     categories:
       - gateway-api
@@ -1864,10 +2006,10 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
-      name: v1alpha1
+      name: v1alpha2
       schema:
         openAPIV3Schema:
-          description: UDPRoute is a resource that specifies how a Gateway should forward UDP traffic.
+          description: UDPRoute provides a way to route UDP traffic. When combined with a Gateway listener, it can be used to forward traffic on the port specified by the listener to a set of backends specified by the UDPRoute.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -1880,127 +2022,99 @@ spec:
             spec:
               description: Spec defines the desired state of UDPRoute.
               properties:
-                gateways:
-                  default:
-                    allow: SameNamespace
-                  description: Gateways defines which Gateways can use this Route.
-                  properties:
-                    allow:
-                      default: SameNamespace
-                      description: 'Allow indicates which Gateways will be allowed to use this route. Possible values are: * All: Gateways in any namespace can use this route. * FromList: Only Gateways specified in GatewayRefs may use this route. * SameNamespace: Only Gateways in the same namespace may use this route.'
-                      enum:
-                        - All
-                        - FromList
-                        - SameNamespace
-                      type: string
-                    gatewayRefs:
-                      description: GatewayRefs must be specified when Allow is set to "FromList". In that case, only Gateways referenced in this list will be allowed to use this route. This field is ignored for other values of "Allow".
-                      items:
-                        description: GatewayReference identifies a Gateway in a specified namespace.
-                        properties:
-                          name:
-                            description: Name is the name of the referent.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                          namespace:
-                            description: Namespace is the namespace of the referent.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                        required:
-                          - name
-                          - namespace
-                        type: object
-                      type: array
-                  type: object
+                parentRefs:
+                  description: "ParentRefs references the resources (usually Gateways) that a Route wants to be attached to. Note that the referenced parent resource needs to allow this for the attachment to be complete. For Gateways, that means the Gateway needs to allow attachment from Routes of this kind and namespace. \n The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources such as one of the route kinds. \n It is invalid to reference an identical parent more than once. It is valid to reference multiple distinct sections within the same parent resource, such as 2 Listeners within a Gateway. \n It is possible to separately reference multiple distinct objects that may be collapsed by an implementation. For example, some implementations may choose to merge compatible Gateway Listeners together. If that is the case, the list of routes attached to those resources should also be merged."
+                  items:
+                    description: "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object."
+                    properties:
+                      group:
+                        default: gateway.networking.k8s.io
+                        description: "Group is the group of the referent. \n Support: Core"
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Gateway
+                        description: "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)"
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: "Name is the name of the referent. \n Support: Core"
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                      sectionName:
+                        description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  maxItems: 32
+                  type: array
                 rules:
                   description: Rules are a list of UDP matchers and actions.
                   items:
                     description: UDPRouteRule is the configuration for a given rule.
                     properties:
-                      forwardTo:
-                        description: ForwardTo defines the backend(s) where matching requests should be sent.
+                      backendRefs:
+                        description: "BackendRefs defines the backend(s) where matching requests should be sent. If unspecified or invalid (refers to a non-existent resource or a Service with no endpoints), the underlying implementation MUST actively reject connection attempts to this backend. Packet drops must respect weight; if an invalid backend is requested to have 80% of the packets, then 80% of packets must be dropped instead. \n Support: Core for Kubernetes Service Support: Custom for any other resource \n Support for weight: Extended"
                         items:
-                          description: RouteForwardTo defines how a Route should forward a request.
+                          description: "BackendRef defines how a Route should forward a request to a Kubernetes resource. \n Note that when a namespace is specified, a ReferencePolicy object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferencePolicy documentation for details."
                           properties:
-                            backendRef:
-                              description: "BackendRef is a reference to a backend to forward matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
-                              properties:
-                                group:
-                                  description: Group is the group of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                kind:
-                                  description: Kind is kind of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                name:
-                                  description: Name is the name of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                              required:
-                                - group
-                                - kind
-                                - name
-                              type: object
+                            group:
+                              default: ""
+                              description: Group is the group of the referent. For example, "networking.k8s.io". When unspecified (empty string), core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              default: Service
+                              description: Kind is kind of the referent. For example "HTTPRoute" or "Service".
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: "Namespace is the namespace of the backend. When unspecified, the local namespace is inferred. \n Note that when a namespace is specified, a ReferencePolicy object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferencePolicy documentation for details. \n Support: Core"
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
                             port:
-                              description: "Port specifies the destination port number to use for the backend referenced by the ServiceName or BackendRef field. If unspecified, the destination port in the request is used when forwarding to a backendRef or serviceName. \n Support: Core"
+                              description: Port specifies the destination port number to use for this resource. Port is required when the referent is a Kubernetes Service. For other resources, destination port might be derived from the referent resource or this field.
                               format: int32
                               maximum: 65535
                               minimum: 1
                               type: integer
-                            serviceName:
-                              description: "ServiceName refers to the name of the Service to forward matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n The protocol to use is defined using AppProtocol field (introduced in Kubernetes 1.18) in the Service resource. In the absence of the AppProtocol field a `networking.x-k8s.io/app-protocol` annotation on the BackendPolicy resource may be used to define the protocol. If the AppProtocol field is available, this annotation should not be used. The AppProtocol field, when populated, takes precedence over the annotation in the BackendPolicy resource. For custom backends, it is encouraged to add a semantically-equivalent field in the Custom Resource Definition. \n Support: Core"
-                              maxLength: 253
-                              type: string
                             weight:
                               default: 1
-                              description: "Weight specifies the proportion of HTTP requests forwarded to the backend referenced by the ServiceName or BackendRef field. This is computed as weight/(sum of all weights in this ForwardTo list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. Weight is not a percentage and the sum of weights does not need to equal 100. \n If only one backend is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Extended"
+                              description: "Weight specifies the proportion of requests forwarded to the referenced backend. This is computed as weight/(sum of all weights in this BackendRefs list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. Weight is not a percentage and the sum of weights does not need to equal 100. \n If only one backend is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support for this field varies based on the context where used."
                               format: int32
                               maximum: 1000000
                               minimum: 0
                               type: integer
+                          required:
+                            - name
                           type: object
                         maxItems: 16
                         minItems: 1
                         type: array
-                      matches:
-                        description: "Matches define conditions used for matching the rule against incoming UDP connections. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. If unspecified (i.e. empty), this Rule will match all requests for the associated Listener. \n Each client request MUST map to a maximum of one route rule. If a request matches multiple rules, matching precedence MUST be determined in order of the following criteria, continuing on ties: \n * The most specific match specified by ExtensionRef. Each implementation   that supports ExtensionRef may have different ways of determining the   specificity of the referenced extension. \n If ties still exist across multiple Routes, matching precedence MUST be determined in order of the following criteria, continuing on ties: \n * The oldest Route based on creation timestamp. For example, a Route with   a creation timestamp of \"2020-09-08 01:02:03\" is given precedence over   a Route with a creation timestamp of \"2020-09-08 01:02:04\". * The Route appearing first in alphabetical order by   \"<namespace>/<name>\". For example, foo/bar is given precedence over   foo/baz. \n If ties still exist within the Route that has been given precedence, matching precedence MUST be granted to the first matching rule meeting the above criteria."
-                        items:
-                          description: UDPRouteMatch defines the predicate used to match packets to a given action.
-                          properties:
-                            extensionRef:
-                              description: "ExtensionRef is an optional, implementation-specific extension to the \"match\" behavior.  For example, resource \"myudproutematcher\" in group \"networking.acme.io\". If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
-                              properties:
-                                group:
-                                  description: Group is the group of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                kind:
-                                  description: Kind is kind of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                                name:
-                                  description: Name is the name of the referent.
-                                  maxLength: 253
-                                  minLength: 1
-                                  type: string
-                              required:
-                                - group
-                                - kind
-                                - name
-                              type: object
-                          type: object
-                        maxItems: 8
-                        type: array
-                    required:
-                      - forwardTo
                     type: object
                   maxItems: 16
                   minItems: 1
@@ -2011,13 +2125,13 @@ spec:
             status:
               description: Status defines the current state of UDPRoute.
               properties:
-                gateways:
-                  description: "Gateways is a list of Gateways that are associated with the route, and the status of the route with respect to each Gateway. When a Gateway selects this route, the controller that manages the Gateway must add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route is modified. \n A maximum of 100 Gateways will be represented in this list. If this list is full, there may be additional Gateways using this Route that are not included in the list. An empty list means the route has not been admitted by any Gateway."
+                parents:
+                  description: "Parents is a list of parent resources (usually Gateways) that are associated with the route, and the status of the route with respect to each parent. When this route attaches to a parent, the controller that manages the parent must add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route or gateway is modified. \n Note that parent references that cannot be resolved by an implementation of this API will not be added to this list. Implementations of this API can only populate Route status for the Gateways/parent resources they are responsible for. \n A maximum of 32 Gateways will be represented in this list. An empty list means the route has not been attached to any Gateway."
                   items:
-                    description: RouteGatewayStatus describes the status of a route with respect to an associated Gateway.
+                    description: RouteParentStatus describes the status of a route with respect to an associated Parent.
                     properties:
                       conditions:
-                        description: Conditions describes the status of the route with respect to the Gateway. The "Admitted" condition must always be specified by controllers to indicate whether the route has been admitted or rejected by the Gateway, and why. Note that the route's availability is also subject to the Gateway's own status conditions and listener status.
+                        description: "Conditions describes the status of the route with respect to the Gateway. Note that the route's availability is also subject to the Gateway's own status conditions and listener status. \n If the Route's ParentRef specifies an existing Gateway that supports Routes of this kind AND that Gateway's controller has sufficient access, then that Gateway's controller MUST set the \"Accepted\" condition on the Route, to indicate whether the route has been accepted or rejected by the Gateway, and why. \n A Route MUST be considered \"Accepted\" if at least one of the Route's rules is implemented by the Gateway. \n There are a number of cases where the \"Accepted\" condition may not be set due to lack of controller visibility, that includes when: \n * The Route refers to a non-existent parent. * The Route is of a type that the controller does not support. * The Route is in a namespace the the controller does not have access to."
                         items:
                           description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                           properties:
@@ -2060,39 +2174,64 @@ spec:
                             - type
                           type: object
                         maxItems: 8
+                        minItems: 1
                         type: array
                         x-kubernetes-list-map-keys:
                           - type
                         x-kubernetes-list-type: map
-                      gatewayRef:
-                        description: GatewayRef is a reference to a Gateway object that is associated with the route.
+                      controllerName:
+                        description: "ControllerName is a domain/path string that indicates the name of the controller that wrote this status. This corresponds with the controllerName field on GatewayClass. \n Example: \"example.net/gateway-controller\". \n The format of this field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)."
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                        type: string
+                      parentRef:
+                        description: ParentRef corresponds with a ParentRef in the spec that this RouteParentStatus struct describes the status of.
                         properties:
-                          controller:
-                            description: "Controller is a domain/path string that indicates the controller implementing the Gateway. This corresponds with the controller field on GatewayClass. \n Example: \"acme.io/gateway-controller\". \n The format of this field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)."
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: "Group is the group of the referent. \n Support: Core"
                             maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Gateway
+                            description: "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                             type: string
                           name:
-                            description: Name is the name of the referent.
+                            description: "Name is the name of the referent. \n Support: Core"
                             maxLength: 253
                             minLength: 1
                             type: string
                           namespace:
-                            description: Namespace is the namespace of the referent.
+                            description: "Namespace is the namespace of the referent. When unspecified (or empty string), this refers to the local namespace of the Route. \n Support: Core"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          sectionName:
+                            description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
                             maxLength: 253
                             minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                         required:
                           - name
-                          - namespace
                         type: object
                     required:
-                      - gatewayRef
+                      - controllerName
+                      - parentRef
                     type: object
-                  maxItems: 100
+                  maxItems: 32
                   type: array
               required:
-                - gateways
+                - parents
               type: object
+          required:
+            - spec
           type: object
       served: true
       storage: true
@@ -2125,7 +2264,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-gateway-api-admin
   labels:
-    serving.knative.dev/release: "v20220125-1a7d3eb6"
+    serving.knative.dev/release: "v20220204-285bccce"
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
@@ -2137,10 +2276,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-gateway-api-core
   labels:
-    serving.knative.dev/release: "v20220125-1a7d3eb6"
+    serving.knative.dev/release: "v20220204-285bccce"
     serving.knative.dev/controller: "true"
 rules:
-  - apiGroups: ["networking.x-k8s.io"]
+  - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["httproutes", "gateways"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
 
@@ -2165,7 +2304,7 @@ metadata:
   name: config-gateway
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v20220125-1a7d3eb6"
+    serving.knative.dev/release: "v20220204-285bccce"
 data:
   _example: |
     ################################
@@ -2219,9 +2358,9 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: net-gateway-api
     app.kubernetes.io/component: net-gateway-api
-    app.kubernetes.io/version: "20220125-1a7d3eb6"
+    app.kubernetes.io/version: "20220204-285bccce"
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: "v20220125-1a7d3eb6"
+    serving.knative.dev/release: "v20220204-285bccce"
 spec:
   replicas: 1
   selector:
@@ -2247,7 +2386,7 @@ spec:
         - name: controller
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-nightly/knative.dev/net-gateway-api/cmd/controller@sha256:11fe78f11c506273390046f284564c541f18c562745a190abba218971d3542ca
+          image: gcr.io/knative-nightly/knative.dev/net-gateway-api/cmd/controller@sha256:f6a13d853686aabab5fc82713f06d03b94ca5f5f0047565ffc809ec63f0a60f7
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Since net-gateway-api updates to v0.4.0 (v1alpha2), we need to bump
Istio version for it in `test/e2e-networking-library.sh`.

Also, v1alpha2 dropped the support of host-rewrite (DomainMapping),
this PR exclude `--enable-beta` in github action.

Fix https://github.com/knative/serving/pull/12585
