### PR TITLE
Use default logger configuration

### DIFF
--- a/test/upgrade/upgrade_test.go
+++ b/test/upgrade/upgrade_test.go
@@ -22,14 +22,12 @@ package upgrade
 import (
 	"testing"
 
-	"go.uber.org/zap"
 	_ "knative.dev/pkg/system/testing"
 	pkgupgrade "knative.dev/pkg/test/upgrade"
 	"knative.dev/serving/test/upgrade/installation"
 )
 
 func TestServingUpgrades(t *testing.T) {
-	c := newUpgradeConfig(t)
 	suite := pkgupgrade.Suite{
 		Tests: pkgupgrade.Tests{
 			PreUpgrade:    ServingPreUpgradeTests(),
@@ -50,13 +48,5 @@ func TestServingUpgrades(t *testing.T) {
 			},
 		},
 	}
-	suite.Execute(c)
-}
-
-func newUpgradeConfig(t *testing.T) pkgupgrade.Configuration {
-	log, err := zap.NewDevelopment()
-	if err != nil {
-		t.Fatal(err)
-	}
-	return pkgupgrade.Configuration{T: t, Log: log}
+	suite.Execute(pkgupgrade.Configuration{T: t})
 }


### PR DESCRIPTION
This is a follow up on knative/pkg#2293 and uses a default logger which
is defined in the upgrade framework.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* use a default logger which is defined in the upgrade framework
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
