### PR TITLE
Updates val webhook selector to reduce invocations

### DIFF
--- a/config/core/configmaps/logging.yaml
+++ b/config/core/configmaps/logging.yaml
@@ -20,6 +20,7 @@ metadata:
   labels:
     serving.knative.dev/release: devel
     app.kubernetes.io/version: devel
+    app.kubernetes.io/component: logging
     app.kubernetes.io/name: knative-serving
   annotations:
     knative.dev/example-checksum: "b0f3c6f2"

--- a/config/core/configmaps/observability.yaml
+++ b/config/core/configmaps/observability.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: observability
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
   annotations:

--- a/config/core/configmaps/tracing.yaml
+++ b/config/core/configmaps/tracing.yaml
@@ -19,6 +19,7 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: tracing
     app.kubernetes.io/version: devel
     serving.knative.dev/release: devel
   annotations:

--- a/config/core/webhooks/configmap-validation.yaml
+++ b/config/core/webhooks/configmap-validation.yaml
@@ -30,7 +30,12 @@ webhooks:
   failurePolicy: Fail
   sideEffects: None
   name: config.webhook.serving.knative.dev
-  namespaceSelector:
-    matchLabels:
-      app.kubernetes.io/name: knative-serving
+  objectSelector:
+    matchExpressions:
+    - key: app.kubernetes.io/name
+      operator: In
+      values: ["knative-serving"]
+    - key: app.kubernetes.io/component
+      operator: In
+      values: ["autoscaler", "controller", "logging", "networking", "observability", "tracing"]
   timeoutSeconds: 10


### PR DESCRIPTION
When we install networking with serving, multiple validating
webhooks are registered.

Previously, the webhooks were configured with just namespace
selectors that are identical. Thus when the config file is updated,
the serving webhook is invoked (which is a noop) and vice-versa
for any serving config maps.

To avoid this, this PR updates the validating webhook to use an
objectSelector and includes an extra label (app.kubernetes.io/component)
to further distinguish net-istio resources from serving resources.

It also adds component labels to several of the configmaps that did
not have them.

Fixes #12594 

**Release Note**

```release-note
Updates serving configmap validating webhook to use an objectSelector to reduce unnecessary webhook invocations
```

Needs the changes in https://github.com/knative/networking/pull/616 to merge and update dependencies here to work
/hold