### PR TITLE
Reduce the period and failure threshold for activator readiness

### DIFF
--- a/config/core/deployments/activator.yaml
+++ b/config/core/deployments/activator.yaml
@@ -104,13 +104,15 @@ spec:
             httpHeaders:
             - name: k-kubelet-probe
               value: "activator"
-          failureThreshold: 12
+          periodSeconds: 5
+          failureThreshold: 1
         livenessProbe:
           httpGet:
             port: 8012
             httpHeaders:
             - name: k-kubelet-probe
               value: "activator"
+          periodSeconds: 10
           failureThreshold: 12
           initialDelaySeconds: 15
 


### PR DESCRIPTION
The default drain timeout is 45 seconds which was much shorter than
the time it takes the activator to be recognized as not ready (2 minutes)

This was resulting in 503s since the activator was receiving traffic when it
was not expecting it

Fixes [test/upgrade.TestServingUpgrades/VerifyContinualTests/ProbeTest](https://github.com/knative/serving/issues/12524) flake

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Increase the activator readiness probe frequency so that it drains properly. This helps avoid hitting 503s when rolling the activator.
```
