### PR TITLE
Address 503s when the autoscaler is being rolled

### DIFF
--- a/config/core/deployments/activator.yaml
+++ b/config/core/deployments/activator.yaml
@@ -105,7 +105,7 @@ spec:
             - name: k-kubelet-probe
               value: "activator"
           periodSeconds: 5
-          failureThreshold: 1
+          failureThreshold: 5
         livenessProbe:
           httpGet:
             port: 8012

--- a/config/core/deployments/autoscaler.yaml
+++ b/config/core/deployments/autoscaler.yaml
@@ -27,6 +27,10 @@ spec:
   selector:
     matchLabels:
       app: autoscaler
+  strategy:
+     type: RollingUpdate
+     rollingUpdate:
+       maxUnavailable: 0
   template:
     metadata:
       annotations:


### PR DESCRIPTION
The activator's readiness depends on the status of web socket connection
to the autoscaler. When the connection is down the activator will report
ready=false. This can occur when the autoscaler deployment is updating.

PR #12614 made the activator's readiness aggressively fail after
a single probe failure. This didn't seem to impact istio (maybe it retries?) but with 
contour it started returning 503s since the activator started to report ready=false
immediately.

This PR does two things to mitigate 503s:
- bump the activator readiness threshold to give the autoscaler more time to
  rollout/startup. This still remains lower than the drain duration
- Update the autoscaler rollout strategy so we spin up a new instance
  prior to bring down the older one. This is done using maxUnavailable=0

Fixes https://github.com/knative/serving/issues/12524 flake

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Ensure the activator drains properly and the autoscaler rolls out conservatively. This helps avoid hitting 503s during upgrade.
```
