### PR TITLE
[release-1.2] Drop MaxDurationSeconds from the RevisionSpec 

### DIFF
--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -474,10 +474,6 @@ spec:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
-                        maxDurationSeconds:
-                          description: MaxDurationSeconds is the maximum duration in seconds a request will be allowed to stay open.
-                          type: integer
-                          format: int64
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                           type: string

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -453,10 +453,6 @@ spec:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
-                maxDurationSeconds:
-                  description: MaxDurationSeconds is the maximum duration in seconds a request will be allowed to stay open.
-                  type: integer
-                  format: int64
                 serviceAccountName:
                   description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                   type: string

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -478,10 +478,6 @@ spec:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
-                        maxDurationSeconds:
-                          description: MaxDurationSeconds is the maximum duration in seconds a request will be allowed to stay open.
-                          type: integer
-                          format: int64
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                           type: string

--- a/docs/serving-api.md
+++ b/docs/serving-api.md
@@ -920,19 +920,6 @@ layer will wait for a request delivered to a container to begin replying
 (send network traffic). If unspecified, a system default will be provided.</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>maxDurationSeconds</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>MaxDurationSeconds is the maximum duration in seconds a request will be allowed
-to stay open.</p>
-</td>
-</tr>
 </table>
 </td>
 </tr>
@@ -1395,19 +1382,6 @@ layer will wait for a request delivered to a container to begin replying
 (send network traffic). If unspecified, a system default will be provided.</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>maxDurationSeconds</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>MaxDurationSeconds is the maximum duration in seconds a request will be allowed
-to stay open.</p>
-</td>
-</tr>
 </tbody>
 </table>
 <h3 id="serving.knative.dev/v1.RevisionStatus">RevisionStatus
@@ -1606,19 +1580,6 @@ int64
 <p>TimeoutSeconds is the maximum duration in seconds that the request routing
 layer will wait for a request delivered to a container to begin replying
 (send network traffic). If unspecified, a system default will be provided.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>maxDurationSeconds</code><br/>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>MaxDurationSeconds is the maximum duration in seconds a request will be allowed
-to stay open.</p>
 </td>
 </tr>
 </table>

--- a/pkg/apis/serving/v1/revision_types.go
+++ b/pkg/apis/serving/v1/revision_types.go
@@ -88,11 +88,6 @@ type RevisionSpec struct {
 	// (send network traffic). If unspecified, a system default will be provided.
 	// +optional
 	TimeoutSeconds *int64 `json:"timeoutSeconds,omitempty"`
-
-	// MaxDurationSeconds is the maximum duration in seconds a request will be allowed
-	// to stay open.
-	// +optional
-	MaxDurationSeconds *int64 `json:"maxDurationSeconds,omitempty"`
 }
 
 const (

--- a/pkg/apis/serving/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/serving/v1/zz_generated.deepcopy.go
@@ -230,11 +230,6 @@ func (in *RevisionSpec) DeepCopyInto(out *RevisionSpec) {
 		*out = new(int64)
 		**out = **in
 	}
-	if in.MaxDurationSeconds != nil {
-		in, out := &in.MaxDurationSeconds, &out.MaxDurationSeconds
-		*out = new(int64)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -110,9 +110,6 @@ var (
 			Name:  "REVISION_TIMEOUT_SECONDS",
 			Value: "45",
 		}, {
-			Name:  "MAX_DURATION_SECONDS",
-			Value: "100",
-		}, {
 			Name: "SERVING_POD",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
@@ -266,8 +263,7 @@ func defaultRevision() *v1.Revision {
 			UID: "1234",
 		},
 		Spec: v1.RevisionSpec{
-			TimeoutSeconds:     ptr.Int64(45),
-			MaxDurationSeconds: ptr.Int64(100),
+			TimeoutSeconds: ptr.Int64(45),
 		},
 	}
 }
@@ -419,8 +415,7 @@ func withContainers(containers []corev1.Container) RevisionOption {
 			PodSpec: corev1.PodSpec{
 				Containers: containers,
 			},
-			TimeoutSeconds:     ptr.Int64(45),
-			MaxDurationSeconds: ptr.Int64(100),
+			TimeoutSeconds: ptr.Int64(45),
 		}
 	}
 }

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -193,10 +193,6 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 	if rev.Spec.TimeoutSeconds != nil {
 		ts = *rev.Spec.TimeoutSeconds
 	}
-	maxDurationTS := int64(0)
-	if rev.Spec.MaxDurationSeconds != nil {
-		maxDurationTS = *rev.Spec.MaxDurationSeconds
-	}
 	ports := queueNonServingPorts
 	if cfg.Observability.EnableProfiling {
 		ports = append(ports, profilingPort)
@@ -271,9 +267,6 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		}, {
 			Name:  "REVISION_TIMEOUT_SECONDS",
 			Value: strconv.Itoa(int(ts)),
-		}, {
-			Name:  "MAX_DURATION_SECONDS",
-			Value: strconv.Itoa(int(maxDurationTS)),
 		}, {
 			Name: "SERVING_POD",
 			ValueFrom: &corev1.EnvVarSource{

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -255,19 +255,6 @@ func TestMakeQueueContainer(t *testing.T) {
 			})
 		}),
 	}, {
-		name: "custom maxDurationSeconds",
-		rev: revision("bar", "foo",
-			withContainers(containers),
-			func(revision *v1.Revision) {
-				revision.Spec.MaxDurationSeconds = ptr.Int64(99)
-			},
-		),
-		want: queueContainer(func(c *corev1.Container) {
-			c.Env = env(map[string]string{
-				"MAX_DURATION_SECONDS": "99",
-			})
-		}),
-	}, {
 		name: "default resource config",
 		rev: revision("bar", "foo",
 			withContainers(containers)),
@@ -692,8 +679,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 			SuccessThreshold: 3,
 		},
 		rev: v1.RevisionSpec{
-			TimeoutSeconds:     ptr.Int64(45),
-			MaxDurationSeconds: ptr.Int64(100),
+			TimeoutSeconds: ptr.Int64(45),
 			PodSpec: corev1.PodSpec{
 				Containers: []corev1.Container{{
 					Name: servingContainerName,
@@ -733,8 +719,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 	}, {
 		name: "tcp defaults",
 		rev: v1.RevisionSpec{
-			TimeoutSeconds:     ptr.Int64(45),
-			MaxDurationSeconds: ptr.Int64(100),
+			TimeoutSeconds: ptr.Int64(45),
 			PodSpec: corev1.PodSpec{
 				Containers: []corev1.Container{{
 					Name: servingContainerName,
@@ -790,8 +775,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 			InitialDelaySeconds: 3,
 		},
 		rev: v1.RevisionSpec{
-			TimeoutSeconds:     ptr.Int64(45),
-			MaxDurationSeconds: ptr.Int64(100),
+			TimeoutSeconds: ptr.Int64(45),
 			PodSpec: corev1.PodSpec{
 				Containers: []corev1.Container{{
 					Name: servingContainerName,
@@ -872,7 +856,6 @@ var defaultEnv = map[string]string{
 	"METRICS_COLLECTOR_ADDRESS":        "",
 	"QUEUE_SERVING_PORT":               "8012",
 	"REVISION_TIMEOUT_SECONDS":         "45",
-	"MAX_DURATION_SECONDS":             "100",
 	"SERVING_CONFIGURATION":            "",
 	"SERVING_ENABLE_PROBE_REQUEST_LOG": "false",
 	"SERVING_ENABLE_REQUEST_LOG":       "false",

--- a/pkg/testing/v1/service.go
+++ b/pkg/testing/v1/service.go
@@ -182,13 +182,6 @@ func WithRevisionTimeoutSeconds(revisionTimeoutSeconds int64) ServiceOption {
 	}
 }
 
-// WithMaxDurationSeconds sets revision max duration timeout
-func WithMaxDurationSeconds(maxDurationSeconds int64) ServiceOption {
-	return func(service *v1.Service) {
-		service.Spec.Template.Spec.MaxDurationSeconds = ptr.Int64(maxDurationSeconds)
-	}
-}
-
 // WithServiceAccountName sets revision service account name
 func WithServiceAccountName(serviceAccountName string) ServiceOption {
 	return func(service *v1.Service) {

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -37,7 +37,7 @@ import (
 
 // sendRequests send a request to "endpoint", returns error if unexpected response code, nil otherwise.
 func sendRequest(t *testing.T, clients *test.Clients, endpoint *url.URL,
-	initialSleep, sleep time.Duration, expectedResponseCode int, expectedBody string) error {
+	initialSleep, sleep time.Duration, expectedResponseCode int) error {
 	client, err := pkgtest.NewSpoofingClient(context.Background(), clients.KubeClient, t.Logf, endpoint.Hostname(), test.ServingFlags.ResolvableDomain, test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
 	if err != nil {
 		return fmt.Errorf("error creating Spoofing client: %w", err)
@@ -57,6 +57,7 @@ func sendRequest(t *testing.T, clients *test.Clients, endpoint *url.URL,
 	if err != nil {
 		return fmt.Errorf("failed to create new HTTP request: %w", err)
 	}
+	spoof.WithHeader(test.ServingFlags.RequestHeader())(req)
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -67,12 +68,6 @@ func sendRequest(t *testing.T, clients *test.Clients, endpoint *url.URL,
 	if expectedResponseCode != resp.StatusCode {
 		return fmt.Errorf("response status code = %v, want = %v, response = %v", resp.StatusCode, expectedResponseCode, resp)
 	}
-	if expectedBody != "" {
-		gotBody := string(resp.Body)
-		if expectedBody != gotBody {
-			return fmt.Errorf("response body = %v, want = %v, response = %v", gotBody, expectedBody, resp)
-		}
-	}
 
 	return nil
 }
@@ -80,75 +75,30 @@ func sendRequest(t *testing.T, clients *test.Clients, endpoint *url.URL,
 func TestRevisionTimeout(t *testing.T) {
 	t.Parallel()
 	clients := test.Setup(t)
-	neverExpireMaxDurationSeconds := int64(100)
 
 	testCases := []struct {
-		name               string
-		timeoutSeconds     int64
-		maxDurationSeconds int64
-		initialSleep       time.Duration
-		sleep              time.Duration
-		expectedStatus     int
-		expectedBody       string
+		name           string
+		timeoutSeconds int64
+		initialSleep   time.Duration
+		sleep          time.Duration
+		expectedStatus int
+		expectedBody   string
 	}{{
-		name:           "does not exceed timeout seconds, no max duration timeout set",
+		name:           "does not exceed timeout seconds",
 		timeoutSeconds: 10,
 		initialSleep:   2 * time.Second,
 		expectedStatus: http.StatusOK,
 	}, {
-		name:           "exceeds timeout seconds, no max duration timeout set",
+		name:           "exceeds timeout seconds",
 		timeoutSeconds: 10,
 		initialSleep:   12 * time.Second,
 		expectedStatus: http.StatusGatewayTimeout,
-		expectedBody:   "request timeout",
 	}, {
-		name:           "writes first byte before timeout, no max duration timeout set",
+		name:           "writes first byte before timeout",
 		timeoutSeconds: 10,
 		expectedStatus: http.StatusOK,
 		sleep:          15 * time.Second,
 		initialSleep:   0,
-	}, {
-		name:               "does not exceed timeout seconds, long max duration timeout has no effect",
-		timeoutSeconds:     10,
-		maxDurationSeconds: neverExpireMaxDurationSeconds,
-		initialSleep:       2 * time.Second,
-		expectedStatus:     http.StatusOK,
-	}, {
-		name:               "exceeds timeout seconds, long max duration timeout has no effect",
-		timeoutSeconds:     10,
-		maxDurationSeconds: neverExpireMaxDurationSeconds,
-		initialSleep:       12 * time.Second,
-		expectedStatus:     http.StatusGatewayTimeout,
-		expectedBody:       "request timeout",
-	}, {
-		name:               "writes first byte before timeout, long max duration timeout has no effect",
-		timeoutSeconds:     10,
-		maxDurationSeconds: neverExpireMaxDurationSeconds,
-		expectedStatus:     http.StatusOK,
-		sleep:              15 * time.Second,
-		initialSleep:       0,
-	}, {
-		name:               "exceeds max duration timeout",
-		timeoutSeconds:     15,
-		maxDurationSeconds: 10,
-		initialSleep:       12 * time.Second,
-		expectedStatus:     http.StatusGatewayTimeout,
-		expectedBody:       "request timeout",
-	}, {
-		name:               "exceeds multiple timeouts",
-		timeoutSeconds:     10,
-		maxDurationSeconds: 10,
-		initialSleep:       12 * time.Second,
-		expectedStatus:     http.StatusGatewayTimeout,
-		expectedBody:       "request timeout",
-	}, {
-		name:               "writes first byte (HTTP OK), max duration violated, request can still timeout",
-		timeoutSeconds:     10,
-		maxDurationSeconds: 12,
-		expectedStatus:     http.StatusOK,
-		sleep:              15 * time.Second,
-		initialSleep:       0,
-		expectedBody:       "request timeout",
 	}}
 
 	for _, tc := range testCases {
@@ -165,7 +115,7 @@ func TestRevisionTimeout(t *testing.T) {
 			test.EnsureTearDown(t, clients, &names)
 
 			t.Log("Creating a new Service ")
-			resources, err := v1test.CreateServiceReady(t, clients, &names, WithRevisionTimeoutSeconds(tc.timeoutSeconds), WithMaxDurationSeconds(tc.maxDurationSeconds))
+			resources, err := v1test.CreateServiceReady(t, clients, &names, WithRevisionTimeoutSeconds(tc.timeoutSeconds))
 			if err != nil {
 				t.Fatal("Failed to create Service:", err)
 			}
@@ -181,13 +131,14 @@ func TestRevisionTimeout(t *testing.T) {
 				spoof.IsOneOfStatusCodes(http.StatusOK, http.StatusGatewayTimeout),
 				"CheckSuccessfulResponse",
 				test.ServingFlags.ResolvableDomain,
-				test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS)); err != nil {
+				test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+				spoof.WithHeader(test.ServingFlags.RequestHeader())); err != nil {
 				t.Fatalf("Error probing %s: %v", serviceURL, err)
 			}
 
-			if err := sendRequest(t, clients, serviceURL, tc.initialSleep, tc.sleep, tc.expectedStatus, tc.expectedBody); err != nil {
-				t.Errorf("Failed request with initialSleep %v, sleep %v, with revision timeout %ds, expecting status %v and body %q: %v",
-					tc.initialSleep, tc.sleep, tc.timeoutSeconds, tc.expectedStatus, tc.expectedBody, err)
+			if err := sendRequest(t, clients, serviceURL, tc.initialSleep, tc.sleep, tc.expectedStatus); err != nil {
+				t.Errorf("Failed request with initialSleep %v, sleep %v, with revision timeout %ds, expecting status %v: %v",
+					tc.initialSleep, tc.sleep, tc.timeoutSeconds, tc.expectedStatus, err)
 			}
 		})
 	}

--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -57,7 +57,6 @@ func sendRequest(t *testing.T, clients *test.Clients, endpoint *url.URL,
 	if err != nil {
 		return fmt.Errorf("failed to create new HTTP request: %w", err)
 	}
-	spoof.WithHeader(test.ServingFlags.RequestHeader())(req)
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -68,7 +67,6 @@ func sendRequest(t *testing.T, clients *test.Clients, endpoint *url.URL,
 	if expectedResponseCode != resp.StatusCode {
 		return fmt.Errorf("response status code = %v, want = %v, response = %v", resp.StatusCode, expectedResponseCode, resp)
 	}
-
 	return nil
 }
 
@@ -78,11 +76,11 @@ func TestRevisionTimeout(t *testing.T) {
 
 	testCases := []struct {
 		name           string
+		shouldScaleTo0 bool
 		timeoutSeconds int64
 		initialSleep   time.Duration
 		sleep          time.Duration
 		expectedStatus int
-		expectedBody   string
 	}{{
 		name:           "does not exceed timeout seconds",
 		timeoutSeconds: 10,
@@ -103,7 +101,6 @@ func TestRevisionTimeout(t *testing.T) {
 
 	for _, tc := range testCases {
 		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -131,13 +128,12 @@ func TestRevisionTimeout(t *testing.T) {
 				spoof.IsOneOfStatusCodes(http.StatusOK, http.StatusGatewayTimeout),
 				"CheckSuccessfulResponse",
 				test.ServingFlags.ResolvableDomain,
-				test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
-				spoof.WithHeader(test.ServingFlags.RequestHeader())); err != nil {
+				test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS)); err != nil {
 				t.Fatalf("Error probing %s: %v", serviceURL, err)
 			}
 
 			if err := sendRequest(t, clients, serviceURL, tc.initialSleep, tc.sleep, tc.expectedStatus); err != nil {
-				t.Errorf("Failed request with initialSleep %v, sleep %v, with revision timeout %ds, expecting status %v: %v",
+				t.Errorf("Failed request with initialSleep %v, sleep %v, with revision timeout %ds and expecting status %v: %v",
 					tc.initialSleep, tc.sleep, tc.timeoutSeconds, tc.expectedStatus, err)
 			}
 		})


### PR DESCRIPTION
We added MaxDurationSeconds (#12322) because the behaviour of
RevisionSpec.Timeout changed from total duration to time to first byte.

In hindsight changing the behaviour of Timeout was a mistake since
it goes against the original specification.

Thus we're going to create a path for migration and the first part is
to remove MaxDurationSeconds from the RevisionSpec.

Part of https://github.com/knative/serving/issues/12634

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
We dropped the alpha field RevisionSpec.MaxDurationSeconds - see https://github.com/knative/serving/issues/12634 for more details
```
