### PR TITLE
Remove an unnecessary start delay when resolving a tag to digest

### DIFF
--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -118,7 +118,7 @@ func newControllerWithOptions(
 	}
 
 	digestResolveQueue := workqueue.NewNamedRateLimitingQueue(workqueue.NewMaxOfRateLimiter(
-		workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 1000*time.Second),
+		newItemExponentialFailureRateLimiter(1*time.Second, 1000*time.Second),
 		// 10 qps, 100 bucket size.  This is only for retry speed and its only the overall factor (not per item)
 		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 	), "digests")

--- a/pkg/reconciler/revision/rate_limiter.go
+++ b/pkg/reconciler/revision/rate_limiter.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+// itemExponentialFailureRateLimiter does a simple baseDelay*2^<num-failures> limit
+// dealing with max failures and expiration are up to the caller
+//
+// When num-failures is 0 it will not wait
+//
+// Copyright 2016 The Kubernetes Authors.
+// From: https://github.com/kubernetes/client-go/blob/master/util/workqueue/default_rate_limiters.go
+//
+// TODO - drop this file when we pick up the following upstream change
+// https://github.com/kubernetes/kubernetes/pull/108343
+type itemExponentialFailureRateLimiter struct {
+	failuresLock sync.Mutex
+	failures     map[interface{}]int
+
+	baseDelay time.Duration
+	maxDelay  time.Duration
+}
+
+var _ workqueue.RateLimiter = &itemExponentialFailureRateLimiter{}
+
+func newItemExponentialFailureRateLimiter(baseDelay time.Duration, maxDelay time.Duration) workqueue.RateLimiter {
+	return &itemExponentialFailureRateLimiter{
+		failures:  map[interface{}]int{},
+		baseDelay: baseDelay,
+		maxDelay:  maxDelay,
+	}
+}
+
+func (r *itemExponentialFailureRateLimiter) When(item interface{}) time.Duration {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	failures := r.failures[item]
+	r.failures[item] = failures + 1
+
+	if failures == 0 {
+		return 0
+	}
+
+	// first delay should be baseDelay so offset the count
+	exp := failures - 1
+
+	// The backoff is capped such that 'calculated' value never overflows.
+	backoff := float64(r.baseDelay.Nanoseconds()) * math.Pow(2, float64(exp))
+	if backoff > math.MaxInt64 {
+		return r.maxDelay
+	}
+
+	calculated := time.Duration(backoff)
+	if calculated > r.maxDelay {
+		return r.maxDelay
+	}
+
+	return calculated
+}
+
+func (r *itemExponentialFailureRateLimiter) NumRequeues(item interface{}) int {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+
+	return r.failures[item]
+}
+
+func (r *itemExponentialFailureRateLimiter) Forget(item interface{}) {
+	r.failuresLock.Lock()
+	defer r.failuresLock.Unlock()
+	delete(r.failures, item)
+}


### PR DESCRIPTION
Part of https://github.com/knative/serving/issues/12667

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

ItemExponentialFailureRateLimiter when adding _any_ item will have an initial delay before processing starts. For tag to digest resolution that delay was 1s.  Rather than change our timings we just skip the delay on the first `AddRateLimited`

This PR doesn't _fix_ #12667 since we don't want to carry this long term and want to drop this once K8s adopts the change and we pick it up

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Remove an unnecessary start delay when resolving a tag to digest
```
