### PR TITLE
add a check for routingState when setting PA reachability

### DIFF
--- a/pkg/reconciler/revision/resources/pa.go
+++ b/pkg/reconciler/revision/resources/pa.go
@@ -47,13 +47,15 @@ func MakePA(rev *v1.Revision) *autoscalingv1alpha1.PodAutoscaler {
 			Reachability: func() autoscalingv1alpha1.ReachabilityType {
 				// If the Revision has failed to become Ready, then mark the PodAutoscaler as unreachable.
 				if rev.Status.GetCondition(v1.RevisionConditionReady).IsFalse() {
+					if rev.GetRoutingState() == v1.RoutingStatePending || rev.GetRoutingState() == v1.RoutingStateReserve {
+						return autoscalingv1alpha1.ReachabilityUnreachable
+					}
 					// Make sure that we don't do this when a newly failing revision is
 					// marked reachable by outside forces.
 					if !rev.IsReachable() {
 						return autoscalingv1alpha1.ReachabilityUnreachable
 					}
 				}
-
 				// We don't know the reachability if the revision has just been created
 				// or it is activating.
 				if rev.Status.GetCondition(v1.RevisionConditionActive).IsUnknown() {

--- a/pkg/reconciler/revision/resources/pa_test.go
+++ b/pkg/reconciler/revision/resources/pa_test.go
@@ -203,6 +203,9 @@ func TestMakePA(t *testing.T) {
 					Namespace: "blah",
 					Name:      "batman",
 					UID:       "4321",
+					Labels: map[string]string{
+						serving.RoutingStateLabelKey: string(v1.RoutingStatePending),
+					},
 				},
 				Spec: v1.RevisionSpec{
 					ContainerConcurrency: ptr.Int64(0),


### PR DESCRIPTION
Fixes #11218 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* add a check for Revision's  RoutingState when setting PA reachability

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
