### PR TITLE
Removing no longer needed todo

### DIFF
--- a/pkg/apis/serving/metadata_validation.go
+++ b/pkg/apis/serving/metadata_validation.go
@@ -89,7 +89,6 @@ func ValidateHasNoAutoscalingAnnotation(annotations map[string]string) (errs *ap
 }
 
 // ValidateContainerConcurrency function validates the ContainerConcurrency field
-// TODO(#5007): Move this to autoscaling.
 func ValidateContainerConcurrency(ctx context.Context, containerConcurrency *int64) *apis.FieldError {
 	if containerConcurrency != nil {
 		cfg := config.FromContextOrDefaults(ctx).Defaults


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

## Proposed Changes

#5007 was [closed](https://github.com/knative/serving/pull/5007#issuecomment-522113819) with a comment of "no longer needed", so this removes the `TODO` referencing it from the codebase.

