### PR TITLE
Move `WithPodSecurityContext()` util to the common place

### DIFF
--- a/pkg/testing/v1/service.go
+++ b/pkg/testing/v1/service.go
@@ -481,8 +481,16 @@ var (
 	}
 )
 
+// WithInitContainer adds init container to a service.
 func WithInitContainer(p corev1.Container) ServiceOption {
 	return func(s *v1.Service) {
 		s.Spec.Template.Spec.InitContainers = []corev1.Container{p}
+	}
+}
+
+// WithPodSecurityContext assigns security context to a service.
+func WithPodSecurityContext(secCtx corev1.PodSecurityContext) ServiceOption {
+	return func(s *v1.Service) {
+		s.Spec.Template.Spec.SecurityContext = &secCtx
 	}
 }

--- a/test/e2e/pvc/pvc_test.go
+++ b/test/e2e/pvc/pvc_test.go
@@ -85,9 +85,3 @@ func TestPersistentVolumeClaims(t *testing.T) {
 		t.Fatalf("The endpoint %s for Route %s didn't serve the expected text %q: %v", url, names.Route, test.EmptyDirText, err)
 	}
 }
-
-func WithPodSecurityContext(secCtx corev1.PodSecurityContext) ServiceOption {
-	return func(s *v1.Service) {
-		s.Spec.Template.Spec.SecurityContext = &secCtx
-	}
-}


### PR DESCRIPTION
This patch refactors nit.

Since all `WithXXX()` util func are located in `pkg/testing/v1/service.go`,
this patch also moves `WithPodSecurityContext()` util in `pvc_test.go` there.
