### PR TITLE
Removing deprecated serving.knative.dev/release label

### DIFF
--- a/config/core/100-namespace.yaml
+++ b/config/core/100-namespace.yaml
@@ -19,4 +19,3 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel

--- a/config/core/200-roles/addressable-resolvers-clusterrole.yaml
+++ b/config/core/200-roles/addressable-resolvers-clusterrole.yaml
@@ -20,7 +20,6 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    serving.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
 aggregationRule:
@@ -33,7 +32,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    serving.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
     # Labeled to facilitate aggregated cluster roles that act on Addressables.

--- a/config/core/200-roles/clusterrole-namespaced.yaml
+++ b/config/core/200-roles/clusterrole-namespaced.yaml
@@ -18,7 +18,6 @@ metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    serving.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
 rules:
@@ -35,7 +34,6 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    serving.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
 rules:
@@ -52,7 +50,6 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    serving.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
 rules:

--- a/config/core/200-roles/clusterrole.yaml
+++ b/config/core/200-roles/clusterrole.yaml
@@ -18,7 +18,6 @@ metadata:
   name: knative-serving-core
   labels:
     serving.knative.dev/controller: "true"
-    serving.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
 rules:

--- a/config/core/200-roles/podspecable-bindings-clusterrole.yaml
+++ b/config/core/200-roles/podspecable-bindings-clusterrole.yaml
@@ -17,7 +17,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    serving.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
     # Labeled to facilitate aggregated cluster roles that act on PodSpecables.

--- a/config/core/200-serviceaccount.yaml
+++ b/config/core/200-serviceaccount.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -30,7 +29,6 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -44,7 +42,6 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -62,7 +59,6 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: controller

--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -21,7 +21,6 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:

--- a/config/core/300-resources/domain-mapping.yaml
+++ b/config/core/300-resources/domain-mapping.yaml
@@ -19,7 +19,6 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev

--- a/config/core/300-resources/metric.yaml
+++ b/config/core/300-resources/metric.yaml
@@ -21,7 +21,6 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev

--- a/config/core/300-resources/podautoscaler.yaml
+++ b/config/core/300-resources/podautoscaler.yaml
@@ -21,7 +21,6 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -21,7 +21,6 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev

--- a/config/core/300-resources/route.yaml
+++ b/config/core/300-resources/route.yaml
@@ -21,7 +21,6 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -21,7 +21,6 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"

--- a/config/core/999-cache.yaml
+++ b/config/core/999-cache.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: queue-proxy
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.

--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "16af78ce"
 data:

--- a/config/core/configmaps/defaults.yaml
+++ b/config/core/configmaps/defaults.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "a0feb4c6"
 data:

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "dd7ee769"
 data:

--- a/config/core/configmaps/domain.yaml
+++ b/config/core/configmaps/domain.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "81552d0b"
 data:

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "d9e300ba"
 data:

--- a/config/core/configmaps/gc.yaml
+++ b/config/core/configmaps/gc.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "45463e45"
 data:

--- a/config/core/configmaps/leader-election.yaml
+++ b/config/core/configmaps/leader-election.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "f4b71f57"
 data:

--- a/config/core/configmaps/logging.yaml
+++ b/config/core/configmaps/logging.yaml
@@ -18,7 +18,6 @@ metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
     app.kubernetes.io/version: devel
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: knative-serving

--- a/config/core/configmaps/observability.yaml
+++ b/config/core/configmaps/observability.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: observability
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "fed4756e"
 data:

--- a/config/core/configmaps/tracing.yaml
+++ b/config/core/configmaps/tracing.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: tracing
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
   annotations:
     knative.dev/example-checksum: "26614636"
 data:

--- a/config/core/deployments/activator-hpa.yaml
+++ b/config/core/deployments/activator-hpa.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -50,7 +49,6 @@ metadata:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 spec:
   minAvailable: 80%
   selector:

--- a/config/core/deployments/activator.yaml
+++ b/config/core/deployments/activator.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: activator
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -37,7 +36,6 @@ spec:
         app.kubernetes.io/component: activator
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
-        serving.knative.dev/release: devel
     spec:
       serviceAccountName: controller
       containers:
@@ -136,7 +134,6 @@ metadata:
     app.kubernetes.io/component: activator
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: devel
 spec:
   selector:
     app: activator

--- a/config/core/deployments/autoscaler.yaml
+++ b/config/core/deployments/autoscaler.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -40,7 +39,6 @@ spec:
         app.kubernetes.io/component: autoscaler
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
-        serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -128,7 +126,6 @@ metadata:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
   name: autoscaler
   namespace: knative-serving
 spec:

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -35,7 +34,6 @@ spec:
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
-        serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -104,7 +102,6 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
   name: controller
   namespace: knative-serving
 spec:

--- a/config/core/deployments/domainmapping-controller.yaml
+++ b/config/core/deployments/domainmapping-controller.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -35,7 +34,6 @@ spec:
         app.kubernetes.io/component: domain-mapping
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
-        serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:

--- a/config/core/deployments/domainmapping-webhook.yaml
+++ b/config/core/deployments/domainmapping-webhook.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -37,7 +36,6 @@ spec:
         app.kubernetes.io/component: domain-mapping
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
-        serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -133,7 +131,6 @@ metadata:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
   name: domainmapping-webhook
   namespace: knative-serving
 spec:

--- a/config/core/deployments/webhook-hpa.yaml
+++ b/config/core/deployments/webhook-hpa.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -48,7 +47,6 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 spec:
   minAvailable: 80%
   selector:

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -18,7 +18,6 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
     app.kubernetes.io/component: webhook
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving
@@ -34,8 +33,6 @@ spec:
       labels:
         app: webhook
         role: webhook
-        serving.knative.dev/release: devel
-        app.kubernetes.io/component: webhook
         app.kubernetes.io/version: devel
         app.kubernetes.io/name: knative-serving
     spec:
@@ -132,7 +129,6 @@ kind: Service
 metadata:
   labels:
     role: webhook
-    serving.knative.dev/release: devel
     app.kubernetes.io/component: webhook
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-serving

--- a/config/core/webhooks/configmap-validation.yaml
+++ b/config/core/webhooks/configmap-validation.yaml
@@ -20,7 +20,6 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:

--- a/config/core/webhooks/defaulting.yaml
+++ b/config/core/webhooks/defaulting.yaml
@@ -20,7 +20,6 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:

--- a/config/core/webhooks/domainmapping-defaulting.yaml
+++ b/config/core/webhooks/domainmapping-defaulting.yaml
@@ -20,7 +20,6 @@ metadata:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:

--- a/config/core/webhooks/domainmapping-secret.yaml
+++ b/config/core/webhooks/domainmapping-secret.yaml
@@ -21,5 +21,4 @@ metadata:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 # The data is populated at install time.

--- a/config/core/webhooks/domainmapping-validation.yaml
+++ b/config/core/webhooks/domainmapping-validation.yaml
@@ -20,7 +20,6 @@ metadata:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:

--- a/config/core/webhooks/resource-validation.yaml
+++ b/config/core/webhooks/resource-validation.yaml
@@ -20,7 +20,6 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:

--- a/config/core/webhooks/secret.yaml
+++ b/config/core/webhooks/secret.yaml
@@ -21,5 +21,4 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 # The data is populated at install time.

--- a/config/hpa-autoscaling/controller.yaml
+++ b/config/hpa-autoscaling/controller.yaml
@@ -22,7 +22,6 @@ metadata:
     app.kubernetes.io/component: autoscaler-hpa
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 spec:
   selector:
     matchLabels:
@@ -36,7 +35,6 @@ spec:
         app.kubernetes.io/component: autoscaler-hpa
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
-        serving.knative.dev/release: devel
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -102,7 +100,6 @@ metadata:
     app.kubernetes.io/component: autoscaler-hpa
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
   name: autoscaler-hpa
   namespace: knative-serving
 spec:

--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -22,7 +22,6 @@ metadata:
     app.kubernetes.io/component: default-domain-job
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 spec:
   template:
     metadata:
@@ -85,7 +84,6 @@ metadata:
     app.kubernetes.io/component: default-domain-job
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 spec:
   selector:
     app: default-domain

--- a/config/post-install/storage-version-migration.yaml
+++ b/config/post-install/storage-version-migration.yaml
@@ -22,7 +22,6 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: storage-version-migration-job
     app.kubernetes.io/version: devel
-    serving.knative.dev/release: devel
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10

--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -74,7 +74,7 @@ fi
 readonly KO_YAML_FLAGS="${KO_YAML_FLAGS} ${KO_FLAGS}"
 
 if [[ -n "${TAG:-}" ]]; then
-  LABEL_YAML_CMD=(sed -e "s|serving.knative.dev/release: devel|serving.knative.dev/release: \"${TAG}\"|" -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG:1}\"|")
+  LABEL_YAML_CMD=(sed -e "s|app.kubernetes.io/version: devel|app.kubernetes.io/version: \"${TAG:1}\"|")
 else
   LABEL_YAML_CMD=(cat)
 fi

--- a/pkg/reconciler/revision/config/testdata/config-tracing.yaml
+++ b/pkg/reconciler/revision/config/testdata/config-tracing.yaml
@@ -18,8 +18,8 @@ metadata:
   name: config-tracing
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
-
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
 data:
   _example: |
     ################################

--- a/test/config/autotls/certmanager/caissuer/config-certmanager.yaml
+++ b/test/config/autotls/certmanager/caissuer/config-certmanager.yaml
@@ -18,7 +18,8 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
     networking.knative.dev/certificate-provider: cert-manager
 data:
   issuerRef: |

--- a/test/config/autotls/certmanager/http01/config-certmanager.yaml
+++ b/test/config/autotls/certmanager/http01/config-certmanager.yaml
@@ -18,7 +18,8 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
     networking.knative.dev/certificate-provider: cert-manager
 data:
   issuerRef: |

--- a/test/config/autotls/certmanager/selfsigned/config-certmanager.yaml
+++ b/test/config/autotls/certmanager/selfsigned/config-certmanager.yaml
@@ -18,7 +18,8 @@ metadata:
   name: config-certmanager
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
     networking.knative.dev/certificate-provider: cert-manager
 data:
   issuerRef: |

--- a/test/config/chaosduck/chaosduck.yaml
+++ b/test/config/chaosduck/chaosduck.yaml
@@ -18,8 +18,8 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
-
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -27,7 +27,8 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -43,7 +44,8 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -60,7 +62,8 @@ metadata:
   name: chaosduck
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: devel
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: devel
 spec:
   selector:
     matchLabels:

--- a/test/config/ytt/ingress/istio/istio-config-dedupe.yaml
+++ b/test/config/ytt/ingress/istio/istio-config-dedupe.yaml
@@ -3,13 +3,13 @@
 #!
 #! As a side-effect we end up with *two* configmap/config-istio resources
 #! in our YAML. We want to keep the profile specific version - which is
-#! the one with the 'serving.knative.dev/release: devel' label
+#! the one with the 'apps.kubernetes.io/name: knative-serving' label
 
 #@ load("@ytt:overlay", "overlay")
 #@ load("helpers.lib.yaml", "system_configmap")
 
 #@ def keep_only_devel(left, right):
-#@   if left["metadata"]["labels"]["serving.knative.dev/release"] == "devel":
+#@   if left["metadata"]["labels"]["apps.kubernetes.io/name"] == "knative-serving":
 #@     return left
 #@   end
 #@ end


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Previously agreed these labels would be dropped in release v1.4
See discussion in https://github.com/knative/serving/issues/12215

Part of #12215 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
`serving.knative.dev/release` labels, deprecated in v1.3, have been removed. Please switch over to using `app.kubernetes.io/name: knative-serving` and `app.kuberentes.io/version: devel`.
```