### PR TITLE
make the contour ttl overlay work when the field isn't present

### DIFF
--- a/test/config/ytt/ingress/contour/contour-ttl.yaml
+++ b/test/config/ytt/ingress/contour/contour-ttl.yaml
@@ -2,11 +2,13 @@
 #@ load("helpers.lib.yaml", "subset")
 
 #@overlay/match by=subset(namespace="contour-internal", kind="Job"), expects=1
+#@overlay/match-child-defaults missing_ok=True
 ---
 spec:
   ttlSecondsAfterFinished: 60
 
 #@overlay/match by=subset(namespace="contour-external", kind="Job"), expects=1
+#@overlay/match-child-defaults missing_ok=True
 ---
 spec:
   ttlSecondsAfterFinished: 60


### PR DESCRIPTION
Unblocks: https://github.com/knative/serving/pull/12726