### PR TITLE
Change default target burst capacity

### DIFF
--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "16af78ce"
+    knative.dev/example-checksum: "6551fdf8"
 data:
   _example: |
     ################################
@@ -97,7 +97,7 @@ data:
     # -1 denotes unlimited target-burst-capacity and activator will always
     # be in the request path.
     # Other negative values are invalid.
-    target-burst-capacity: "200"
+    target-burst-capacity: "210"
 
     # When operating in a stable mode, the autoscaler operates on the
     # average concurrency over the stable window.

--- a/config/core/configmaps/autoscaler.yaml
+++ b/config/core/configmaps/autoscaler.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "6551fdf8"
+    knative.dev/example-checksum: "47c2487f"
 data:
   _example: |
     ################################
@@ -97,7 +97,7 @@ data:
     # -1 denotes unlimited target-burst-capacity and activator will always
     # be in the request path.
     # Other negative values are invalid.
-    target-burst-capacity: "210"
+    target-burst-capacity: "211"
 
     # When operating in a stable mode, the autoscaler operates on the
     # average concurrency over the stable window.

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -49,7 +49,7 @@ func defaultConfig() *autoscalerconfig.Config {
 		RPSTargetDefault:  200,
 		MaxScaleUpRate:    1000,
 		MaxScaleDownRate:  2,
-		// TODO(#11926): Consider changing to -1 to default to activator always in path unless overriden
+		// TODO(#11926): Consider changing to -1 to default to activator always in path unless overridden
 		TargetBurstCapacity:           210,
 		PanicWindowPercentage:         10,
 		ActivatorCapacity:             100,

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -50,7 +50,7 @@ func defaultConfig() *autoscalerconfig.Config {
 		MaxScaleUpRate:    1000,
 		MaxScaleDownRate:  2,
 		// TODO(#11926): Consider changing to -1 to default to activator always in path unless overridden
-		TargetBurstCapacity:           210,
+		TargetBurstCapacity:           211,
 		PanicWindowPercentage:         10,
 		ActivatorCapacity:             100,
 		PanicThresholdPercentage:      200,

--- a/pkg/autoscaler/config/config.go
+++ b/pkg/autoscaler/config/config.go
@@ -45,11 +45,12 @@ func defaultConfig() *autoscalerconfig.Config {
 		ContainerConcurrencyTargetFraction: defaultTargetUtilization,
 		ContainerConcurrencyTargetDefault:  100,
 		// TODO(#1956): Tune target usage based on empirical data.
-		TargetUtilization:             defaultTargetUtilization,
-		RPSTargetDefault:              200,
-		MaxScaleUpRate:                1000,
-		MaxScaleDownRate:              2,
-		TargetBurstCapacity:           200,
+		TargetUtilization: defaultTargetUtilization,
+		RPSTargetDefault:  200,
+		MaxScaleUpRate:    1000,
+		MaxScaleDownRate:  2,
+		// TODO(#11926): Consider changing to -1 to default to activator always in path unless overriden
+		TargetBurstCapacity:           210,
 		PanicWindowPercentage:         10,
 		ActivatorCapacity:             100,
 		PanicThresholdPercentage:      200,

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -112,6 +112,7 @@ func defaultConfigMapData() map[string]string {
 		"scale-to-zero-grace-period":              gracePeriod.String(),
 		"tick-interval":                           "2s",
 		"min-scale":                               "0",
+		"target-burst-capacity":                   "200",
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

With the current TBC defaults (200), setting min-scale=2 causes activator to flip in/out of path on each request. This PR sets the default TBC to 210 so as to not be a direct multiple of the container concurrency target default, and thus make it harder to trigger activator flipageddon.

More discussion in (where we considered also setting TBC at `-1` to always keep the activator in path unless overridden before a lazy consensus on just bumping the default slightly):
https://github.com/knative/serving/issues/11926
https://github.com/knative/serving/pull/12241

```release-note
Changes the default target-burst-capacity to 210 in order to fix a configuration issue that caused rapid swapping of activator in/out of path. 
```

/assign @dprotaso @rhuss @evankanderson @nader-ziada 