### PR TITLE
Make some of the unit tests a bit more robust

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,6 @@ require (
 	knative.dev/caching v0.0.0-20220323214256-defaf7bb4375
 	knative.dev/hack v0.0.0-20220318020218-14f832e506f8
 	knative.dev/networking v0.0.0-20220323170318-55757e9c20d6
-	knative.dev/pkg v0.0.0-20220318185521-e6e3cf03d765
+	knative.dev/pkg v0.0.0-20220325182149-2daa86aa8fe9
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2156,8 +2156,9 @@ knative.dev/hack v0.0.0-20220318020218-14f832e506f8/go.mod h1:PHt8x8yX5Z9pPquBEf
 knative.dev/networking v0.0.0-20220323170318-55757e9c20d6 h1:3dutSZL6nk/Rt30n0AAq5WfwRJBkHFBHRLdMosDnDh4=
 knative.dev/networking v0.0.0-20220323170318-55757e9c20d6/go.mod h1:tI+j9UGI4eHeinQktrQpHNS0pZ+XII1yF7ZtGyemkm0=
 knative.dev/pkg v0.0.0-20220318133418-7f16595277b2/go.mod h1:nKJ2L4o7or3j58eqMK843kbIM0SiYnAXXsisfEQECS8=
-knative.dev/pkg v0.0.0-20220318185521-e6e3cf03d765 h1:6ma46SWoj3Oiplz29qk8GZiYKhVAmx7CWzl9iHT7iFU=
 knative.dev/pkg v0.0.0-20220318185521-e6e3cf03d765/go.mod h1:nKJ2L4o7or3j58eqMK843kbIM0SiYnAXXsisfEQECS8=
+knative.dev/pkg v0.0.0-20220325182149-2daa86aa8fe9 h1:QTG8xMhewa6mFoYqM+pirfqBCxXzwj4xnXnl1ybYUGY=
+knative.dev/pkg v0.0.0-20220325182149-2daa86aa8fe9/go.mod h1:nKJ2L4o7or3j58eqMK843kbIM0SiYnAXXsisfEQECS8=
 mvdan.cc/gofumpt v0.1.1/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1336,8 +1336,10 @@ func TestReconcileDeciderCreatesAndDeletes(t *testing.T) {
 	if err := wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
 		newKPA, err := fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(kpa.Namespace).Get(
 			ctx, kpa.Name, metav1.GetOptions{})
-		if err != nil {
-			return true, err
+		if err != nil && apierrors.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
+			return false, err
 		}
 		return newKPA.IsReady() && newKPA.Status.GetDesiredScale() == 1, nil
 	}); err != nil {

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -138,10 +138,6 @@ func newTestSetup(t *testing.T, configs ...*corev1.ConfigMap) (
 	var eg errgroup.Group
 	eg.Go(func() error { return ctl.RunContext(ctx, 1) })
 
-	// Short pause to ensure that the controller has started
-	// Ick, but this brought test flakiness from 1-in-100 to less than 1-in-2000.
-	time.Sleep(10 * time.Millisecond)
-
 	return ctx, func() {
 		cancel()
 		eg.Wait()

--- a/pkg/reconciler/serverlessservice/global_resync_test.go
+++ b/pkg/reconciler/serverlessservice/global_resync_test.go
@@ -32,6 +32,7 @@ import (
 	fakedynamicclient "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	"knative.dev/serving/pkg/client/injection/ducks/autoscaling/v1alpha1/podscalable"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -111,8 +112,13 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 	}
 
 	// Wait for the SKSs to be reconciled
-	waitForObservedGen(ctx, networking, ns1, sks1, 1)
-	waitForObservedGen(ctx, networking, ns2, sks2, 1)
+	if err := waitForObservedGen(ctx, networking, ns1, sks1, 1); err != nil {
+		t.Fatalf("failed to observe generation change for %q: %v", sks1, err)
+	}
+
+	if err := waitForObservedGen(ctx, networking, ns2, sks2, 1); err != nil {
+		t.Fatalf("failed to observe generation change for %q: %v", sks2, err)
+	}
 
 	t.Log("Updating the activator endpoints now...")
 	// Now that we have established the baseline, update the activator endpoints.
@@ -124,7 +130,9 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 	// Actively wait for the endpoints to change their value.
 	if err := wait.PollImmediate(25*time.Millisecond, 5*time.Second, func() (bool, error) {
 		ep, err := epsInformer.Lister().Endpoints(ns1).Get(sks1)
-		if err != nil {
+		if err != nil && apierrors.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
 			return false, err
 		}
 		if cmp.Equal(ep.Subsets, resources.FilterSubsetPorts(sksObj1, aEps.Subsets)) {
@@ -137,9 +145,12 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 }
 
 func waitForObservedGen(ctx context.Context, client networkingv1alpha1.NetworkingV1alpha1Interface, ns, name string, generation int64) error {
-	return wait.PollImmediate(10*time.Millisecond, 5*time.Second, func() (bool, error) {
+	return wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (bool, error) {
 		sks, err := client.ServerlessServices(ns).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
+
+		if err != nil && apierrors.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
 			return false, err
 		}
 		return sks.Status.ObservedGeneration == 1, nil

--- a/vendor/knative.dev/pkg/controller/controller.go
+++ b/vendor/knative.dev/pkg/controller/controller.go
@@ -468,6 +468,13 @@ func (c *Impl) RunContext(ctx context.Context, threadiness int) error {
 		if err != nil {
 			return err
 		}
+		if ib, ok := le.(kle.ElectorWithInitialBuckets); ok {
+			for _, b := range ib.InitialBuckets() {
+				// No need to provide an enq function since the controller
+				// is not processing items
+				la.Promote(b, nil)
+			}
+		}
 		sg.Add(1)
 		go func() {
 			defer sg.Done()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1096,7 +1096,7 @@ knative.dev/networking/pkg/client/injection/reconciler/networking/v1alpha1/serve
 knative.dev/networking/pkg/client/listers/networking/v1alpha1
 knative.dev/networking/pkg/ingress
 knative.dev/networking/pkg/prober
-# knative.dev/pkg v0.0.0-20220318185521-e6e3cf03d765
+# knative.dev/pkg v0.0.0-20220325182149-2daa86aa8fe9
 ## explicit
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate


### PR DESCRIPTION
Running tests with `GOMAXPROCS=1` causes flakes to surface more reliably.

In addition to https://github.com/knative/pkg/pull/2473 these changes were necessary to help with the flakes



Fixes: https://github.com/knative/serving/issues/12782
Fixes: https://github.com/knative/serving/issues/12720
Fixes: https://github.com/knative/serving/issues/12697
Fixes: https://github.com/knative/serving/issues/12616
Fixes: https://github.com/knative/serving/issues/12562
Fixes: https://github.com/knative/serving/issues/12558
Fixes: https://github.com/knative/serving/issues/12495
Fixes: https://github.com/knative/serving/issues/12490
Fixes: https://github.com/knative/serving/issues/12457
Fixes: https://github.com/knative/serving/issues/12463
Fixes: https://github.com/knative/serving/issues/12456
Fixes: https://github.com/knative/serving/issues/12452
Fixes: https://github.com/knative/serving/issues/12179
Fixes: https://github.com/knative/serving/issues/12170
