### PR TITLE
use ctx setup by the test which has a test logger

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -113,7 +113,7 @@ func TestControllerCanReconcile(t *testing.T) {
 		la.Promote(reconciler.UniversalBucket(), func(reconciler.Bucket, types.NamespacedName) {})
 	}
 
-	err = ctl.Reconciler.Reconcile(context.Background(), testNamespace+"/"+testRevision)
+	err = ctl.Reconciler.Reconcile(ctx, testNamespace+"/"+testRevision)
 	if err != nil {
 		t.Error("Reconcile() =", err)
 	}

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1402,7 +1402,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	// Wait for the Reconcile to complete.
-	if err := ctl.Reconciler.Reconcile(context.Background(), testNamespace+"/"+testRevision); err != nil {
+	if err := ctl.Reconciler.Reconcile(ctx, testNamespace+"/"+testRevision); err != nil {
 		t.Error("Reconcile() =", err)
 	}
 
@@ -1429,7 +1429,7 @@ func TestUpdate(t *testing.T) {
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Update(ctx, kpa, metav1.UpdateOptions{})
 	fakepainformer.Get(ctx).Informer().GetIndexer().Update(kpa)
 
-	if err := ctl.Reconciler.Reconcile(context.Background(), testNamespace+"/"+testRevision); err != nil {
+	if err := ctl.Reconciler.Reconcile(ctx, testNamespace+"/"+testRevision); err != nil {
 		t.Error("Reconcile() =", err)
 	}
 
@@ -1475,7 +1475,7 @@ func TestControllerCreateError(t *testing.T) {
 		la.Promote(reconciler.UniversalBucket(), func(reconciler.Bucket, types.NamespacedName) {})
 	}
 
-	got := ctl.Reconciler.Reconcile(context.Background(), key)
+	got := ctl.Reconciler.Reconcile(ctx, key)
 	if !errors.Is(got, want) {
 		t.Errorf("Reconcile() = %v, wanted %v wrapped", got, want)
 	}
@@ -1518,7 +1518,7 @@ func TestControllerUpdateError(t *testing.T) {
 		la.Promote(reconciler.UniversalBucket(), func(reconciler.Bucket, types.NamespacedName) {})
 	}
 
-	got := ctl.Reconciler.Reconcile(context.Background(), key)
+	got := ctl.Reconciler.Reconcile(ctx, key)
 	if !errors.Is(got, want) {
 		t.Errorf("Reconcile() = %v, wanted %v wrapped", got, want)
 	}
@@ -1560,7 +1560,7 @@ func TestControllerGetError(t *testing.T) {
 		la.Promote(reconciler.UniversalBucket(), func(reconciler.Bucket, types.NamespacedName) {})
 	}
 
-	got := ctl.Reconciler.Reconcile(context.Background(), key)
+	got := ctl.Reconciler.Reconcile(ctx, key)
 	if !errors.Is(got, want) {
 		t.Errorf("Reconcile() = %v, wanted %v wrapped", got, want)
 	}
@@ -1593,7 +1593,7 @@ func TestScaleFailure(t *testing.T) {
 		la.Promote(reconciler.UniversalBucket(), func(reconciler.Bucket, types.NamespacedName) {})
 	}
 
-	if err := ctl.Reconciler.Reconcile(context.Background(), testNamespace+"/"+testRevision); err == nil {
+	if err := ctl.Reconciler.Reconcile(ctx, testNamespace+"/"+testRevision); err == nil {
 		t.Error("Reconcile() = nil, wanted error")
 	}
 }

--- a/pkg/reconciler/domainmapping/reconciler_test.go
+++ b/pkg/reconciler/domainmapping/reconciler_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package domainmapping
 
 import (
-	"context"
 	"testing"
 
 	network "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking"
+	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/serving/pkg/reconciler/domainmapping/config"
 )
 
@@ -71,7 +71,8 @@ func TestAutoTLSEnabled(t *testing.T) {
 		wantAutoTLSEnabled:   true,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := config.ToContext(context.Background(), &config.Config{
+			ctx := logtesting.TestContextWithLogger(t)
+			ctx = config.ToContext(ctx, &config.Config{
 				Network: &network.Config{
 					AutoTLS: tc.configAutoTLSEnabled,
 				},

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -170,7 +170,7 @@ func createRevision(
 	// Since Reconcile looks in the lister, we need to add it to the informer
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
 
-	if err := controller.Reconciler.Reconcile(context.Background(), KeyOrDie(rev)); err == nil {
+	if err := controller.Reconciler.Reconcile(ctx, KeyOrDie(rev)); err == nil {
 		rev, _, _ = addResourcesToInformers(t, ctx, rev)
 	}
 	return rev
@@ -186,7 +186,7 @@ func updateRevision(
 	fakeservingclient.Get(ctx).ServingV1().Revisions(rev.Namespace).Update(ctx, rev, metav1.UpdateOptions{})
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Update(rev)
 
-	if err := controller.Reconciler.Reconcile(context.Background(), KeyOrDie(rev)); err == nil {
+	if err := controller.Reconciler.Reconcile(ctx, KeyOrDie(rev)); err == nil {
 		addResourcesToInformers(t, ctx, rev)
 	}
 }
@@ -449,7 +449,7 @@ func TestStatusUnknownWhenDigestsNotResolvedYet(t *testing.T) {
 
 	fakeservingclient.Get(ctx).ServingV1().Revisions(rev.Namespace).Create(ctx, rev, metav1.CreateOptions{})
 	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
-	if err := controller.Reconciler.Reconcile(context.Background(), KeyOrDie(rev)); err != nil {
+	if err := controller.Reconciler.Reconcile(ctx, KeyOrDie(rev)); err != nil {
 		t.Fatal("Reconcile failed:", err)
 	}
 


### PR DESCRIPTION
Then the log output is associated with the test rather than being printed out to the terminal


