### PR TITLE
Force activator always in path when activator CA is specified

### DIFF
--- a/pkg/reconciler/autoscaling/config/store.go
+++ b/pkg/reconciler/autoscaling/config/store.go
@@ -19,6 +19,7 @@ package config
 import (
 	"context"
 
+	network "knative.dev/networking/pkg"
 	"knative.dev/pkg/configmap"
 	asconfig "knative.dev/serving/pkg/autoscaler/config"
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
@@ -31,6 +32,7 @@ type cfgKey struct{}
 type Config struct {
 	Autoscaler *autoscalerconfig.Config
 	Deployment *deployment.Config
+	Network    *network.Config
 }
 
 // FromContext fetch config from context.
@@ -65,6 +67,7 @@ func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value i
 			configmap.Constructors{
 				asconfig.ConfigName:   asconfig.NewConfigFromConfigMap,
 				deployment.ConfigName: deployment.NewConfigFromConfigMap,
+				network.ConfigName:    network.NewConfigFromConfigMap,
 			},
 			onAfterStore...,
 		),
@@ -82,5 +85,6 @@ func (s *Store) Load() *Config {
 	return &Config{
 		Autoscaler: s.UntypedLoad(asconfig.ConfigName).(*autoscalerconfig.Config).DeepCopy(),
 		Deployment: s.UntypedLoad(deployment.ConfigName).(*deployment.Config).DeepCopy(),
+		Network:    s.UntypedLoad(network.ConfigName).(*network.Config).DeepCopy(),
 	}
 }

--- a/pkg/reconciler/autoscaling/config/testdata/config-network.yaml
+++ b/pkg/reconciler/autoscaling/config/testdata/config-network.yaml
@@ -1,0 +1,1 @@
+../../../../../config/core/configmaps/network.yaml

--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ktesting "k8s.io/client-go/testing"
 
+	netpkg "knative.dev/networking/pkg"
 	"knative.dev/networking/pkg/apis/networking"
 	nv1a1 "knative.dev/networking/pkg/apis/networking/v1alpha1"
 	"knative.dev/pkg/configmap"
@@ -93,6 +94,13 @@ func TestControllerCanReconcile(t *testing.T) {
 			Data: map[string]string{
 				deployment.QueueSidecarImageKey: "motorbike-sidecar",
 			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.Namespace(),
+				Name:      netpkg.ConfigName,
+			},
+			Data: map[string]string{},
 		}))
 
 	waitInformers, err := RunAndSyncInformers(ctx, infs...)

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -131,7 +131,11 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.
 	//			this revision, e.g. after a restart) but PA status is inactive (it was
 	//			already scaled to 0).
 	// 2. The excess burst capacity is negative.
-	if want == 0 || decider.Status.ExcessBurstCapacity < 0 || want == scaleUnknown && pa.Status.IsInactive() {
+	if len(config.FromContext(ctx).Network.ActivatorCA) > 0 {
+		// When activator CA is enabled, foce activator always in path.
+		// See: https://github.com/knative/serving/issues/11906
+		mode = nv1alpha1.SKSOperationModeProxy
+	} else if want == 0 || decider.Status.ExcessBurstCapacity < 0 || want == scaleUnknown && pa.Status.IsInactive() {
 		mode = nv1alpha1.SKSOperationModeProxy
 	}
 

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -124,6 +124,12 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.
 	}
 
 	mode := nv1alpha1.SKSOperationModeServe
+	switch {
+	// When activator CA is enabled, force activator always in path.
+	// TODO: This is a temporary state and to be fixed.
+	// See also issues/11906 and issues/12797.
+	case len(config.FromContext(ctx).Network.ActivatorCA) > 0:
+		mode = nv1alpha1.SKSOperationModeProxy
 	// We put activator in the serving path in the following cases:
 	// 1. The revision is scaled to 0:
 	//   a. want == 0
@@ -131,12 +137,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.
 	//			this revision, e.g. after a restart) but PA status is inactive (it was
 	//			already scaled to 0).
 	// 2. The excess burst capacity is negative.
-	if len(config.FromContext(ctx).Network.ActivatorCA) > 0 {
-		// When activator CA is enabled, force activator always in path.
-		// TODO: This is a temporary state and to be fixed.
-		// See also issues/11906 and issues/12797.
-		mode = nv1alpha1.SKSOperationModeProxy
-	} else if want == 0 || decider.Status.ExcessBurstCapacity < 0 || want == scaleUnknown && pa.Status.IsInactive() {
+	case want == 0 || decider.Status.ExcessBurstCapacity < 0 || want == scaleUnknown && pa.Status.IsInactive():
 		mode = nv1alpha1.SKSOperationModeProxy
 	}
 

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -132,8 +132,9 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.
 	//			already scaled to 0).
 	// 2. The excess burst capacity is negative.
 	if len(config.FromContext(ctx).Network.ActivatorCA) > 0 {
-		// When activator CA is enabled, foce activator always in path.
-		// See: https://github.com/knative/serving/issues/11906
+		// When activator CA is enabled, force activator always in path.
+		// TODO: This is a temporary state and to be fixed.
+		// See also issues/11906 and issues/12797.
 		mode = nv1alpha1.SKSOperationModeProxy
 	} else if want == 0 || decider.Status.ExcessBurstCapacity < 0 || want == scaleUnknown && pa.Status.IsInactive() {
 		mode = nv1alpha1.SKSOperationModeProxy


### PR DESCRIPTION
As described in the feature doc of https://github.com/knative/serving/issues/11906,
activator needs to serve TLS traffic for the traffic from ingress.

So, this patch force SKS proxy mode when `activator-ca` in
`config-network` is specified.

Part of https://github.com/knative/serving/issues/11906