### PR TITLE
Adding a resource-quota test

### DIFF
--- a/pkg/testing/v1/service.go
+++ b/pkg/testing/v1/service.go
@@ -494,3 +494,9 @@ func WithPodSecurityContext(secCtx corev1.PodSecurityContext) ServiceOption {
 		s.Spec.Template.Spec.SecurityContext = &secCtx
 	}
 }
+
+func WithNamespace(namespace string) ServiceOption {
+	return func(svc *v1.Service) {
+		svc.ObjectMeta.Namespace = namespace
+	}
+}

--- a/test/config/cluster-resources.yaml
+++ b/test/config/cluster-resources.yaml
@@ -13,3 +13,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: tls
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rq-test

--- a/test/config/resource-quota/resource-quota.yaml
+++ b/test/config/resource-quota/resource-quota.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: rq-e2e-test
+  namespace: rq-test
+spec:
+  hard:
+    cpu: 50m

--- a/test/config/resource-quota/resource-quota.yaml
+++ b/test/config/resource-quota/resource-quota.yaml
@@ -1,9 +1,4 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: rq-test
----
-apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: rq-e2e-test

--- a/test/config/resource-quota/resource-quota.yaml
+++ b/test/config/resource-quota/resource-quota.yaml
@@ -1,4 +1,9 @@
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: rq-test
+---
+apiVersion: v1
 kind: ResourceQuota
 metadata:
   name: rq-e2e-test

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -57,6 +57,7 @@ readonly REPLICAS=3
 readonly BUCKETS=10
 
 export PVC=${PVC:-1}
+export QUOTA=${QUOTA:-1}
 
 # Receives the latest serving version and searches for the same version with major and minor and searches for the latest patch
 function latest_net_istio_version() {
@@ -301,7 +302,9 @@ function install() {
     YTT_FILES+=("${REPO_ROOT_DIR}/test/config/pvc/pvc.yaml")
   fi
 
-  YTT_FILES+=("${REPO_ROOT_DIR}/test/config/resource-quota/resource-quota.yaml")
+  if (( QUOTA )); then
+    YTT_FILES+=("${REPO_ROOT_DIR}/test/config/resource-quota/resource-quota.yaml")
+  fi
 
   local ytt_result=$(mktemp)
   local ytt_post_install_result=$(mktemp)

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -301,6 +301,8 @@ function install() {
     YTT_FILES+=("${REPO_ROOT_DIR}/test/config/pvc/pvc.yaml")
   fi
 
+  YTT_FILES+=("${REPO_ROOT_DIR}/test/config/resource-quota/resource-quota.yaml")
+
   local ytt_result=$(mktemp)
   local ytt_post_install_result=$(mktemp)
   local ytt_flags=""

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -31,11 +31,18 @@
 # shellcheck disable=SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/e2e-common.sh"
 
+# Overrides
+function stage_test_resources() {
+  # Nothing to install before tests.
+  true
+}
+
 # Script entry point.
 
 # Skip installing istio as an add-on.
 # Skip installing a pvc as it is not used in upgrade tests
-PVC=0 initialize "$@" --skip-istio-addon  --min-nodes=4 --max-nodes=4 --cluster-version=1.22 \
+# Skip installing a resource quota as it is not used in upgrade tests
+PVC=0 QUOTA=0 initialize "$@" --skip-istio-addon  --min-nodes=4 --max-nodes=4 --cluster-version=1.22 \
   --install-latest-release
 
 # TODO(#2656): Reduce the timeout after we get this test to consistently passing.

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -31,12 +31,6 @@
 # shellcheck disable=SC1090
 source "$(dirname "${BASH_SOURCE[0]}")/e2e-common.sh"
 
-# Overrides
-function stage_test_resources() {
-  # Nothing to install before tests.
-  true
-}
-
 # Script entry point.
 
 # Skip installing istio as an add-on.

--- a/test/e2e/resource_quota_error_test.go
+++ b/test/e2e/resource_quota_error_test.go
@@ -1,0 +1,126 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"knative.dev/pkg/apis"
+	"knative.dev/serving/pkg/apis/serving"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	serviceresourcenames "knative.dev/serving/pkg/reconciler/service/resources/names"
+	rtesting "knative.dev/serving/pkg/testing/v1"
+	"knative.dev/serving/test"
+	v1test "knative.dev/serving/test/v1"
+)
+
+func TestResourceQuotaError(t *testing.T) {
+	t.Parallel()
+
+	clients := test.Setup(t, "rq-test")
+	const (
+		errorReason    = "RevisionFailed"
+		errorMsgScale  = "Initial scale was never achieved"
+		errorMsgQuota  = "forbidden: exceeded quota"
+		revisionReason = "ProgressDeadlineExceeded"
+	)
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.HelloWorld,
+	}
+
+	test.EnsureTearDown(t, clients, &names)
+
+	t.Log("Creating a new Service", names.Image)
+	resources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("200m"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("500m"),
+		},
+	}
+	var (
+		svc *v1.Service
+		err error
+	)
+	if svc, err = v1test.CreateService(t,
+		clients,
+		names,
+		rtesting.WithNamespace("rq-test"),
+		rtesting.WithResourceRequirements(resources),
+		rtesting.WithConfigAnnotations(map[string]string{serving.ProgressDeadlineAnnotationKey: "5s"}),
+	); err != nil {
+		t.Fatalf("Failed to create Service %s: %v", names.Service, err)
+	}
+
+	names.Config = serviceresourcenames.Configuration(svc)
+	var cond *apis.Condition
+	err = v1test.WaitForServiceState(clients.ServingClient, names.Service, func(r *v1.Service) (bool, error) {
+		cond = r.Status.GetCondition(v1.ServiceConditionConfigurationsReady)
+		if cond != nil && !cond.IsUnknown() {
+			// Can fail with either a progress deadline exceeded error or an exceeded resource quota error
+			if strings.Contains(cond.Message, errorMsgScale) && cond.IsFalse() {
+				return true, nil
+			}
+			if strings.Contains(cond.Message, errorMsgQuota) && cond.IsFalse() {
+				return true, nil
+			}
+			t.Logf("Reason: %s ; Message: %s ; Status: %s", cond.Reason, cond.Message, cond.Status)
+			return true, fmt.Errorf("the service %s was not marked with expected error condition (Reason=%q, Message=%q, Status=%q), but with (Reason=%q, Message=%q, Status=%q)",
+				names.Config, errorReason, errorMsgScale, "False", cond.Reason, cond.Message, cond.Status)
+		}
+		return false, nil
+	}, "ContainerUnscheduleable")
+
+	if err != nil && !cond.IsUnknown() {
+		t.Fatal("Failed to validate service state:", err)
+	}
+
+	revisionName, err := RevisionFromConfiguration(clients, names.Config)
+	if err != nil {
+		t.Fatalf("Failed to get revision from configuration %s: %v", names.Config, err)
+	}
+
+	t.Log("When the containers are not scheduled, the revision should have error status.")
+	err = v1test.CheckRevisionState(clients.ServingClient, revisionName, func(r *v1.Revision) (bool, error) {
+		cond := r.Status.GetCondition(v1.RevisionConditionReady)
+		if cond != nil {
+			// Can fail with either a progress deadline exceeded error or an exceeded resource quota error
+			if cond.Reason == revisionReason && strings.Contains(cond.Message, errorMsgScale) {
+				return true, nil
+			}
+			if strings.Contains(cond.Message, errorMsgQuota) && cond.IsFalse() {
+				return true, nil
+			}
+			return true, fmt.Errorf("the revision %s was not marked with expected error condition (Reason=%q, Message=%q), but with (Reason=%q, Message=%q)",
+				revisionName, revisionReason, errorMsgScale, cond.Reason, cond.Message)
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		t.Fatal("Failed to validate revision state:", err)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

## Proposed Changes

Adds an e2e test to check that revisions blocked from deployment due to exceeding a resource quota shows an error in the kservice status (as detailed [here](https://github.com/knative/serving/issues/4416#issuecomment-803835060)).

It tests for two different types of errors:
* a failure due to an exceeded resource quota: self-explanatory
* a failure due to initial scale never being achieved: in this case, the revision will remain in an "Unknown" status, waiting for a revision to be ready, until it reaches the progress deadline (default 10m). To speed up the test failure, we set a progress-deadline on the revision of `5s`, which will make the test fail in about 35 seconds (5s progress-deadline + 30 hard-coded activation timeout buffer)

