### PR TITLE
Fix racey tests by not adding things directly to the informer cache

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -1308,18 +1308,13 @@ func TestReconcileDeciderCreatesAndDeletes(t *testing.T) {
 
 	pod := makeReadyPods(1, testNamespace, testRevision)[0].(*corev1.Pod)
 	fakekubeclient.Get(ctx).CoreV1().Pods(testNamespace).Create(ctx, pod, metav1.CreateOptions{})
-	fakefilteredpodsinformer.Get(ctx, serving.RevisionUID).Informer().GetIndexer().Add(pod)
 
 	newDeployment(ctx, t, fakedynamicclient.Get(ctx), testRevision+"-deployment", 3)
 
 	kpa := revisionresources.MakePA(rev)
-	sks := sks(testNamespace, testRevision, WithDeployRef(kpa.Spec.ScaleTargetRef.Name),
-		WithSKSReady)
+	sks := sks(testNamespace, testRevision, WithDeployRef(kpa.Spec.ScaleTargetRef.Name), WithSKSReady)
 	fakenetworkingclient.Get(ctx).NetworkingV1alpha1().ServerlessServices(testNamespace).Create(ctx, sks, metav1.CreateOptions{})
-	fakesksinformer.Get(ctx).Informer().GetIndexer().Add(sks)
-
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(ctx, kpa, metav1.CreateOptions{})
-	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
 
 	// Start controller after creating initial resources so it observes a steady state.
 	eg.Go(func() error { return ctl.RunContext(ctx, 1) })

--- a/pkg/reconciler/route/queueing_test.go
+++ b/pkg/reconciler/route/queueing_test.go
@@ -35,8 +35,6 @@ import (
 	cfgmap "knative.dev/serving/pkg/apis/config"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
-	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
-	fakerouteinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/route/fake"
 	"knative.dev/serving/pkg/gc"
 	"knative.dev/serving/pkg/reconciler/route/config"
 
@@ -120,13 +118,9 @@ func TestNewRouteCallsSyncHandler(t *testing.T) {
 	if _, err := servingClient.ServingV1().Revisions(rev.Namespace).Create(ctx, rev, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Unexpected error creating revision:", err)
 	}
-	fakerevisioninformer.Get(ctx).Informer().GetIndexer().Add(rev)
-
 	if _, err := servingClient.ServingV1().Routes(route.Namespace).Create(ctx, route, metav1.CreateOptions{}); err != nil {
 		t.Fatal("Unexpected error creating route:", err)
 	}
-	fakerouteinformer.Get(ctx).Informer().GetIndexer().Add(route)
-
 	if err := h.WaitForHooks(time.Second * 3); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/reconciler/serverlessservice/global_resync_test.go
+++ b/pkg/reconciler/serverlessservice/global_resync_test.go
@@ -67,17 +67,14 @@ func TestGlobalResyncOnActivatorChange(t *testing.T) {
 	// Create activator endpoints.
 	aEps := activatorEndpoints(WithSubsets)
 	kubeClnt.CoreV1().Endpoints(aEps.Namespace).Create(ctx, aEps, metav1.CreateOptions{})
-	epsInformer.Informer().GetIndexer().Add(aEps)
 
 	// Private endpoints are supposed to exist, since we're using selector mode for the service.
 	privEps := endpointspriv(ns1, sks1)
 	kubeClnt.CoreV1().Endpoints(privEps.Namespace).Create(ctx, privEps, metav1.CreateOptions{})
-	epsInformer.Informer().GetIndexer().Add(privEps)
 
 	// This is passive, so no endpoints.
 	privEps = endpointspriv(ns2, sks2, withOtherSubsets)
 	kubeClnt.CoreV1().Endpoints(privEps.Namespace).Create(ctx, privEps, metav1.CreateOptions{})
-	epsInformer.Informer().GetIndexer().Add(privEps)
 
 	waitInformers, err := RunAndSyncInformers(ctx, informers...)
 	if err != nil {


### PR DESCRIPTION
If informers are running it's not necessary and causes races

Example bad code:
```go
SomeFakeClient.Create(item)
// reconciliation of item can occur in the meantime
SomeInformer.Lister().Add(item) // this resets the updated item that was reconciled
```

Fixes: https://github.com/knative/serving/issues/12782