### PR TITLE
HPA revisions ready when min pods ready

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/hpa_test.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa_test.go
@@ -183,7 +183,7 @@ func TestReconcile(t *testing.T) {
 		}},
 		Key: key(testNamespace, testRevision),
 	}, {
-		Name: "reconcile sks becomes ready",
+		Name: "reconcile sks becomes ready, scale target not initialized",
 		Objects: []runtime.Object{
 			hpa(pa(testNamespace, testRevision, WithHPAClass, WithPASKSNotReady("I wasn't ready yet :-("),
 				WithMetricAnnotation("cpu"))),
@@ -193,10 +193,27 @@ func TestReconcile(t *testing.T) {
 		},
 		WantStatusUpdates: []ktesting.UpdateActionImpl{{
 			Object: pa(testNamespace, testRevision, WithHPAClass, withScales(0, 0),
-				WithPASKSReady, WithTraffic, WithScaleTargetInitialized,
+				WithPASKSReady, WithTraffic,
 				WithPAStatusService(testRevision), WithPAMetricsService(privateSvc)),
 		}},
 		Key: key(testNamespace, testRevision),
+	}, {
+		Name: "reconcile sks becmes ready, scale target initialized",
+		Objects: []runtime.Object{
+			hpa(pa(testNamespace, testRevision, WithHPAClass, WithMetricAnnotation("cpu")), withHPAScaleStatus(1, 1)),
+			pa(testNamespace, testRevision, WithHPAClass, withScales(1, 0), WithPASKSNotReady("crufty"), WithTraffic),
+			deploy(testNamespace, testRevision),
+			sks(testNamespace, testRevision, WithDeployRef("bar"), WithSKSReady),
+		},
+		WantStatusUpdates: []ktesting.UpdateActionImpl{{
+			Object: pa(testNamespace, testRevision, WithHPAClass, WithPASKSReady, WithTraffic,
+				WithScaleTargetInitialized, withScales(1, 1),
+				WithPAStatusService(testRevision), WithPAMetricsService(privateSvc)),
+		}},
+		Key: key(testNamespace, testRevision),
+		WantUpdates: []ktesting.UpdateActionImpl{{
+			Object: sks(testNamespace, testRevision, WithDeployRef(deployName), WithSKSReady),
+		}},
 	}, {
 		Name: "reconcile sks",
 		Objects: []runtime.Object{


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Revisions managed by the HPA autoscaler will only be marked ready when the
number of ready pods is greater than or equal to the min-scale or
initial-scale value.

Fixes #12769 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
When using the Horizontal Pod Autoscaler (HPA), revisions will only be marked as ready after the initial-scale / min-scale value is reached. For example, if `min-scale: "4"`, the revision will not be marked ready until all four pods are ready. Note that revisions may take slightly longer to become ready after this change. See https://knative.dev/docs/serving/autoscaling/scale-bounds/ for more details.
```
