### PR TITLE
[WIP] Fixes ENABLE_HA bug in e2e tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -120,7 +120,7 @@ function parse_flags() {
       ;;
     --enable-ha)
       readonly ENABLE_HA=1
-      return 0
+      return 1
       ;;
     --kind)
       readonly KIND=1

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -119,8 +119,7 @@ function parse_flags() {
       return 1
       ;;
     --enable-ha)
-      echo "DEBUG: setting enable-ha flag"
-      readonly ENABLE_HA=1
+      if [ "$ENABLE_HA" -ne 1 ]; then readonly ENABLE_HA=1; fi
       return 1
       ;;
     --kind)

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -121,6 +121,7 @@ function parse_flags() {
       return 1
       ;;
     --enable-ha)
+      echo "DEBUG: setting enable-ha flag"
       readonly ENABLE_HA=1
       return 1
       ;;

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -119,8 +119,8 @@ function parse_flags() {
       return 1
       ;;
     --enable-ha)
-      if [ "$ENABLE_HA" -ne 1 ]; then readonly ENABLE_HA=1; fi
-      return 1
+      readonly ENABLE_HA=1
+      return 0
       ;;
     --kind)
       readonly KIND=1

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -81,6 +81,7 @@ LATEST_NET_ISTIO_RELEASE_VERSION=$(latest_net_istio_version "$LATEST_SERVING_REL
 function parse_flags() {
   case "$1" in
     --istio-version)
+      echo "DEBUG: setting istio-version flag to $2"          
       [[ $2 =~ ^(stable|latest|head)$ ]] || abort "version format must be 'stable', 'latest', or 'head'"
       readonly ISTIO_VERSION=$2
       readonly INGRESS_CLASS="istio.ingress.networking.knative.dev"
@@ -111,6 +112,7 @@ function parse_flags() {
       return 1
       ;;
     --no-mesh)
+      echo "DEBUG: setting no-mesh flag"
       readonly MESH=0
       return 1
       ;;

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -119,6 +119,7 @@ function parse_flags() {
       return 1
       ;;
     --enable-ha)
+      echo "DEBUG: parsing enable-ha flag"
       if [ "$ENABLE_HA" -ne 1 ]; then readonly ENABLE_HA=1; fi
       return 1
       ;;

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -119,7 +119,6 @@ function parse_flags() {
       return 1
       ;;
     --enable-ha)
-      echo "DEBUG: parsing enable-ha flag"
       if [ "$ENABLE_HA" -ne 1 ]; then readonly ENABLE_HA=1; fi
       return 1
       ;;

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -119,6 +119,7 @@ function parse_flags() {
       return 1
       ;;
     --enable-ha)
+      echo "DEBUG: setting enable-ha flag"
       readonly ENABLE_HA=1
       return 1
       ;;

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -28,7 +28,7 @@
 source $(dirname $0)/e2e-common.sh
 
 # Script entry point.
-initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha --cluster-version=1.22 "$@"
+initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --cluster-version=1.22 "$@"
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -28,7 +28,7 @@
 source $(dirname $0)/e2e-common.sh
 
 # Script entry point.
-initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --cluster-version=1.22 "$@"
+initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha --cluster-version=1.22 "$@"
 
 # Run the tests
 header "Running tests"

--- a/vendor/knative.dev/hack/e2e-tests.sh
+++ b/vendor/knative.dev/hack/e2e-tests.sh
@@ -150,10 +150,10 @@ function initialize() {
     local parameter=$1
     # TODO(chizhg): remove parse_flags logic if no repos are using it.
     # Try parsing flag as a custom one.
-    if function_exists parse_flags && (( parse_script_flags )); then
+    if function_exists parse_flags; then
       parse_flags "$@"
       local skip=$?
-      if [[ ${skip} -ne 0 ]]; then
+      if [[ ${skip} -ne 0 ]] && (( parse_script_flags )); then
         # Skip parsed flag (and possibly argument) and continue
         # Also save it to it's passed through to the test script
         for ((i=1;i<=skip;i++)); do

--- a/vendor/knative.dev/hack/e2e-tests.sh
+++ b/vendor/knative.dev/hack/e2e-tests.sh
@@ -137,15 +137,20 @@ CLOUD_PROVIDER="gke"
 function initialize() {
   local run_tests=0
   local custom_flags=()
+  local parse_script_flags=0
   E2E_SCRIPT="$(get_canonical_path "$0")"
   local e2e_script_command=( "${E2E_SCRIPT}" "--run-tests" )
 
+  for i in "$@"; do
+       if [[ $i == "--parse-flags" ]]; then parse_script_flags=1; fi
+  done
+  
   cd "${REPO_ROOT_DIR}"
   while [[ $# -ne 0 ]]; do
     local parameter=$1
     # TODO(chizhg): remove parse_flags logic if no repos are using it.
     # Try parsing flag as a custom one.
-    if function_exists parse_flags; then
+    if function_exists parse_flags && (( parse_script_flags )); then
       parse_flags "$@"
       local skip=$?
       if [[ ${skip} -ne 0 ]]; then
@@ -186,6 +191,10 @@ function initialize() {
     fi
   fi
 
+  if (( parse_script_flags )); then
+      e2e_script_command+=("--parse-flags")
+  fi
+  
   readonly IS_BOSKOS
   readonly SKIP_TEARDOWNS
 

--- a/vendor/knative.dev/hack/e2e-tests.sh
+++ b/vendor/knative.dev/hack/e2e-tests.sh
@@ -157,10 +157,7 @@ function initialize() {
         # Skip parsed flag (and possibly argument) and continue
         # Also save it to it's passed through to the test script
         for ((i=1;i<=skip;i++)); do
-          case ${1} in
-           --enable-ha) : ;;
-           *) e2e_script_command+=("$1") ;;
-          esac
+          e2e_script_command+=("$1")
           shift
         done
         continue

--- a/vendor/knative.dev/hack/e2e-tests.sh
+++ b/vendor/knative.dev/hack/e2e-tests.sh
@@ -153,11 +153,13 @@ function initialize() {
     if function_exists parse_flags; then
       parse_flags "$@"
       local skip=$?
-      if [[ ${skip} -ne 0 ]] && (( parse_script_flags )); then
+      if [[ ${skip} -ne 0 ]]; then
         # Skip parsed flag (and possibly argument) and continue
         # Also save it to it's passed through to the test script
-        for ((i=1;i<=skip;i++)); do
-          e2e_script_command+=("$1")
+          for ((i=1;i<=skip;i++)); do
+            if (( parse_script_flags )); then
+              e2e_script_command+=("$1")
+            fi 
           shift
         done
         continue

--- a/vendor/knative.dev/hack/e2e-tests.sh
+++ b/vendor/knative.dev/hack/e2e-tests.sh
@@ -152,7 +152,10 @@ function initialize() {
         # Skip parsed flag (and possibly argument) and continue
         # Also save it to it's passed through to the test script
         for ((i=1;i<=skip;i++)); do
-          e2e_script_command+=("$1")
+          case ${1} in
+           --enable-ha) : ;;
+           *) e2e_script_command+=("$1") ;;
+          esac
           shift
         done
         continue

--- a/vendor/knative.dev/hack/e2e-tests.sh
+++ b/vendor/knative.dev/hack/e2e-tests.sh
@@ -142,7 +142,7 @@ function initialize() {
   local e2e_script_command=( "${E2E_SCRIPT}" "--run-tests" )
 
   for i in "$@"; do
-       if [[ $i == "--parse-flags" ]]; then parse_script_flags=1; fi
+       if [[ $i == "--run-tests" ]]; then parse_script_flags=1; fi
   done
   
   cd "${REPO_ROOT_DIR}"
@@ -190,10 +190,6 @@ function initialize() {
     fi
   fi
 
-  if (( parse_script_flags )); then
-      e2e_script_command+=("--parse-flags")
-  fi
-  
   readonly IS_BOSKOS
   readonly SKIP_TEARDOWNS
 


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Fixes #12788 

This fixes an error message that was showing up in the e2e tests -- the `--enable-ha` flag was getting processed twice (once via the `test/e2e-tests.sh` script, and a second time when parsed out into the `kubetest2` args list). It does so by only setting the `ENABLE_HA` envvar to 1 if it does not already equal 1.

