### PR TITLE
Modify GC checksum so its not a float64

### DIFF
--- a/config/core/configmaps/gc.yaml
+++ b/config/core/configmaps/gc.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "45463e45"
+    knative.dev/example-checksum: "aa3813a8"
 data:
   _example: |
     ################################
@@ -39,7 +39,6 @@ data:
     # These sample configuration options may be copied out of
     # this example block and unindented to be in the data block
     # to actually change the configuration.
-
 
     # ---------------------------------------
     # Garbage Collector Settings
@@ -72,7 +71,7 @@ data:
     #     retain-since-last-active-time: "disabled"
     #     max-non-active-revisions: "10"
     #
-    # Example config to disable all GC:
+    # Example config to disable all garbage collection:
     #     retain-since-create-time: "disabled"
     #     retain-since-last-active-time: "disabled"
     #     max-non-active-revisions: "disabled"


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

This PR introduces a trivial change to the example block to update the
generated checksum.

The previous value was 45463e45, which if not quoted will render as a
float64. This caused problems when applied via kapp through the CI,
because the annotation needs to be of type string, even if not
quoted (which was what was happening with kapp).

This new checksum, since it starts with "aa", shouldn't have that
problem.

Given the incredibly low odds of this having happened in the first
place, I'm off to buy a lottery ticket now... :)