### PR TITLE
Add a flag to QueueProxy to enable reporting the request latency in header

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -97,6 +97,7 @@ type config struct {
 	ServingService               string `split_words:"true"` // optional
 	ServingRequestMetricsBackend string `split_words:"true"` // optional
 	MetricsCollectorAddress      string `split_words:"true"` // optional
+	ReportLatencyInHeader        bool   `split_words:"true"` // optional
 
 	// Tracing configuration
 	TracingConfigDebug          bool                      `split_words:"true"` // optional
@@ -440,7 +441,7 @@ func requestLogHandler(logger *zap.SugaredLogger, currentHandler http.Handler, e
 
 func requestMetricsHandler(logger *zap.SugaredLogger, currentHandler http.Handler, env config) http.Handler {
 	h, err := queue.NewRequestMetricsHandler(currentHandler, env.ServingNamespace,
-		env.ServingService, env.ServingConfiguration, env.ServingRevision, env.ServingPod)
+		env.ServingService, env.ServingConfiguration, env.ServingRevision, env.ServingPod, env.ReportLatencyInHeader)
 	if err != nil {
 		logger.Errorw("Error setting up request metrics reporter. Request metrics will be unavailable.", zap.Error(err))
 		return currentHandler
@@ -450,7 +451,7 @@ func requestMetricsHandler(logger *zap.SugaredLogger, currentHandler http.Handle
 
 func requestAppMetricsHandler(logger *zap.SugaredLogger, currentHandler http.Handler, breaker *queue.Breaker, env config) http.Handler {
 	h, err := queue.NewAppRequestMetricsHandler(currentHandler, breaker, env.ServingNamespace,
-		env.ServingService, env.ServingConfiguration, env.ServingRevision, env.ServingPod)
+		env.ServingService, env.ServingConfiguration, env.ServingRevision, env.ServingPod, env.ReportLatencyInHeader)
 	if err != nil {
 		logger.Errorw("Error setting up app request metrics reporter. Request metrics will be unavailable.", zap.Error(err))
 		return currentHandler


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
Add a flag to QueueProxy to enable reporting the request_latency/app_request_latency in the response header. We know they are already emitted by QueueProxy as Prometheus metrics:
* app_request_latency is user container latency
* request_latency is user container latency + queue latency

Some Knative users run Knative with an extra layer on top of the Knative networking layer (e.g. Istio), so the architecture looks like:
extra layer (could be a custom load balancer) -> Knative networking layer (e.g. Istio) -> Knative activator -> QueueProxy -> user container

With this change, those users can measure the latency between their custom load balancer and QueueProxy.