### PR TITLE
Fixing the panicRPSM parameter in autoscaler

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -284,7 +284,7 @@ func (a *autoscaler) Scale(logger *zap.SugaredLogger, now time.Time) ScaleResult
 			excessBurstCapacityM.M(excessBCF),
 			desiredPodCountM.M(int64(desiredPodCount)),
 			stableRPSM.M(observedStableValue),
-			panicRPSM.M(observedStableValue),
+			panicRPSM.M(observedPanicValue),
 			targetRPSM.M(spec.TargetValue),
 		)
 	default:

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -215,7 +215,7 @@ func TestAutoscalerMetricsWithRPS(t *testing.T) {
 	expectScale(t, a, time.Now().Add(61*time.Second), ScaleResult{10, ebc, true})
 	wantMetrics := []metricstest.Metric{
 		metricstest.FloatMetric(stableRPSM.Name(), 100, nil).WithResource(wantResource),
-		metricstest.FloatMetric(panicRPSM.Name(), 100, nil).WithResource(wantResource),
+		metricstest.FloatMetric(panicRPSM.Name(), 99, nil).WithResource(wantResource),
 		metricstest.IntMetric(desiredPodCountM.Name(), 10, nil).WithResource(wantResource),
 		metricstest.FloatMetric(targetRPSM.Name(), spec.TargetValue, nil).WithResource(wantResource),
 		metricstest.FloatMetric(excessBurstCapacityM.Name(), float64(ebc), nil).WithResource(wantResource),


### PR DESCRIPTION
The value of panicRPSM was set as observedStableValue, but it should have been observedPanicValue.

Fixes #12909


## Proposed Changes
Changed panicRPSM.M(observedStableValue) to panicRPSM.M(observedPanicValue) in autoscaler.

*
*
*

**Release Note**

```
The value of panicRPSM was set as observedStableValue, but it should have been observedPanicValue as part of the metric collection.

```
