### PR TITLE
[wip]Support filtering informer

### DIFF
--- a/test/e2e/domainmapping/domain_mapping_test.go
+++ b/test/e2e/domainmapping/domain_mapping_test.go
@@ -41,7 +41,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	network "knative.dev/networking/pkg"
+	"knative.dev/networking/pkg/apis/networking"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
@@ -85,7 +85,7 @@ func TestBYOCertificate(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: test.AppendRandomString("byocert-secret"),
 			Labels: map[string]string{
-				network.SecretInformerLabelKey: "byocert-secret",
+				networking.CertificateUIDLabelKey: "byocert-secret",
 			},
 		},
 		Type: corev1.SecretTypeTLS,

--- a/third_party/istio-latest/net-istio.yaml
+++ b/third_party/istio-latest/net-istio.yaml
@@ -322,6 +322,8 @@ spec:
             # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
             - name: METRICS_DOMAIN
               value: knative.dev/net-istio
+            - name: ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID
+              value: "true"
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/vendor/knative.dev/networking/pkg/config/config.go
+++ b/vendor/knative.dev/networking/pkg/config/config.go
@@ -139,9 +139,6 @@ const (
 	// QueueProxyCertKey is the config for the secret name, which stores certificates
 	// to serve the TLS traffic from activator to queue-proxy.
 	QueueProxyCertKey = "queue-proxy-cert-secret"
-
-	// SecretInformerLabelKey is used to specify a label selector for informers listing ingress secrets.
-	SecretInformerLabelKey = "certificate.networking.knative.dev"
 )
 
 // HTTPProtocol indicates a type of HTTP endpoint behavior


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- Adds a label using the secret template for supporting filtering informers for the generated secrets
- Part of the work here: https://github.com/knative-sandbox/net-istio/pull/920



<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
BREAKING CHANGE:
Secretes automatically generated due to certificate creation are labeled with a special label key  `network.SecretInformerLabelKey` to support proper filtering from K8s informers in components that consume them.
Users who create secrets manually eg. domainmapping should add this label so that net-istio can list the related secret.
```