### PR TITLE
Temporarily disable dep check

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,6 +28,10 @@ linters:
     - errcheck
 
 linters-settings:
+  staticcheck:
+    checks:
+      - all
+      - '-SA1019' # disable deprecation rule TODO: remove once the new networking api is used
   depguard:
     include-go-root: true
     packages:


### PR DESCRIPTION
CI fails due to the changes in the networking api, for example check: #12952. There are a lot of deprecated statements in the code base we should fix in a subsequent PR. This temporarily unblocks PRs.

/cc @dprotaso 