### PR TITLE
Skip default probe if container freezer in use

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -162,8 +162,10 @@ func main() {
 	}()
 
 	// Setup probe to run for checking user-application healthiness.
+	// Do not set up probe if concurrency state endpoint is set, as
+	// paused containers don't play well with k8s readiness probes.
 	probe := func() bool { return true }
-	if env.ServingReadinessProbe != "" {
+	if env.ServingReadinessProbe != "" && env.ConcurrencyStateEndpoint == "" {
 		probe = buildProbe(logger, env.ServingReadinessProbe, env.EnableHTTP2AutoDetection).ProbeContainer
 	}
 


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Paused containers and readiness probes are not the best of friends.
Kubernetes has no concept of a paused container, and so the container
freezer does a bit of an end around to actually freeze the
container (using the container runtime rather than doing it
through Kubernetes).

However, because we're doing an end around, paused containers show as
not ready in Kubernetes... and not ready means that the readiness
probe we default in will eventually fail the container. In practice
what happens is a bunch of "aggressive probe errors" before queue
proxy basically becomes unresponsive.

To prevent this from happening, this PR proposes disabling the default
probe when the freezer is enabled (which is done by setting a value
for the concurrency state endpoint). There's future work in the
pipeline that may render this change moot at some point down the
line (such as switching the default probe to a startup one), but for
now this provides a quick solution to make the container freezer
usable outside of demos / toy environments.

/assign @dprotaso  @nader-ziada 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Enabling the container freezer will disable the readiness probe defaulted in by Knative. 
```
