### PR TITLE
Support parsing host header with port

### DIFF
--- a/pkg/activator/handler/context_handler.go
+++ b/pkg/activator/handler/context_handler.go
@@ -62,7 +62,7 @@ func (h *contextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// name and namespace from the Host header.
 	if name == "" || namespace == "" {
 		parts := strings.SplitN(r.Host, ".", 4)
-		if len(parts) == 4 && parts[2] == "svc" && parts[3] == network.GetClusterDomainName() {
+		if len(parts) == 4 && parts[2] == "svc" && strings.TrimSuffix(parts[3], ":80") == network.GetClusterDomainName() {
 			name, namespace = parts[0], parts[1]
 		}
 	}

--- a/pkg/activator/handler/context_handler.go
+++ b/pkg/activator/handler/context_handler.go
@@ -62,7 +62,7 @@ func (h *contextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// name and namespace from the Host header.
 	if name == "" || namespace == "" {
 		parts := strings.SplitN(r.Host, ".", 4)
-		if len(parts) == 4 && parts[2] == "svc" && strings.TrimSuffix(parts[3], ":80") == network.GetClusterDomainName() {
+		if len(parts) == 4 && parts[2] == "svc" && strings.SplitN(parts[3], ":", 2)[0] == network.GetClusterDomainName() {
 			name, namespace = parts[0], parts[1]
 		}
 	}

--- a/pkg/activator/handler/context_handler_test.go
+++ b/pkg/activator/handler/context_handler_test.go
@@ -72,6 +72,16 @@ func TestContextHandler(t *testing.T) {
 			t.Errorf("StatusCode = %d, want %d, body: %s", got, want, resp.Body.String())
 		}
 	})
+
+	t.Run("with host containing port", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "http://"+network.GetServiceHostname(revID.Name, revID.Namespace)+":80", bytes.NewBufferString(""))
+		handler.ServeHTTP(resp, req)
+
+		if got, want := resp.Code, http.StatusOK; got != want {
+			t.Errorf("StatusCode = %d, want %d, body: %s", got, want, resp.Body.String())
+		}
+	})
 }
 
 func TestContextHandlerError(t *testing.T) {


### PR DESCRIPTION
Fixes #12973

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*  If a request with 'Host' header or host name explicitly contains a port, the activator would fail to parse the name and namespace from the request.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Support for parsing name and namespace in activator from a request when 'Host' header or host name contains a port
```
