### PR TITLE
[WIP] Add a flag to QueueProxy to enable reporting the request latency in header

### DIFF
--- a/cmd/queue/main.go
+++ b/cmd/queue/main.go
@@ -99,6 +99,7 @@ type config struct {
 	ServingService               string `split_words:"true"` // optional
 	ServingRequestMetricsBackend string `split_words:"true"` // optional
 	MetricsCollectorAddress      string `split_words:"true"` // optional
+	ReportLatencyInHeader        bool   `split_words:"true"` // optional
 
 	// Tracing configuration
 	TracingConfigDebug          bool                      `split_words:"true"` // optional
@@ -446,7 +447,7 @@ func requestLogHandler(logger *zap.SugaredLogger, currentHandler http.Handler, e
 
 func requestMetricsHandler(logger *zap.SugaredLogger, currentHandler http.Handler, env config) http.Handler {
 	h, err := queue.NewRequestMetricsHandler(currentHandler, env.ServingNamespace,
-		env.ServingService, env.ServingConfiguration, env.ServingRevision, env.ServingPod)
+		env.ServingService, env.ServingConfiguration, env.ServingRevision, env.ServingPod, env.ReportLatencyInHeader)
 	if err != nil {
 		logger.Errorw("Error setting up request metrics reporter. Request metrics will be unavailable.", zap.Error(err))
 		return currentHandler
@@ -456,7 +457,7 @@ func requestMetricsHandler(logger *zap.SugaredLogger, currentHandler http.Handle
 
 func requestAppMetricsHandler(logger *zap.SugaredLogger, currentHandler http.Handler, breaker *queue.Breaker, env config) http.Handler {
 	h, err := queue.NewAppRequestMetricsHandler(currentHandler, breaker, env.ServingNamespace,
-		env.ServingService, env.ServingConfiguration, env.ServingRevision, env.ServingPod)
+		env.ServingService, env.ServingConfiguration, env.ServingRevision, env.ServingPod, env.ReportLatencyInHeader)
 	if err != nil {
 		logger.Errorw("Error setting up app request metrics reporter. Request metrics will be unavailable.", zap.Error(err))
 		return currentHandler

--- a/pkg/http/delayed_writer.go
+++ b/pkg/http/delayed_writer.go
@@ -1,0 +1,67 @@
+package http
+
+import (
+	"net/http"
+)
+
+var (
+	_ http.Flusher        = (*DelayedWriter)(nil)
+	_ http.ResponseWriter = (*DelayedWriter)(nil)
+)
+
+// DelayedWriter is an implementation of http.ResponseWriter. It delays writing to the output until RealFlush is called.
+type DelayedWriter struct {
+	ResponseCode int
+
+	writer         http.ResponseWriter
+	headerRecorded bool
+
+	buffer        []byte
+	bytesBuffered int
+}
+
+// NewDelayedWriter creates an http.ResponseWriter that delays writing.
+func NewDelayedWriter(w http.ResponseWriter) *DelayedWriter {
+	return &DelayedWriter{
+		writer: w,
+	}
+}
+
+// Flush does nothing.
+func (dw *DelayedWriter) Flush() {}
+
+// RealFlush flushes the buffer (both header and body) to the client.
+func (dw *DelayedWriter) RealFlush() {
+	dw.writer.WriteHeader(dw.ResponseCode)
+	_, err := dw.writer.Write(dw.buffer[:dw.bytesBuffered])
+	if err != nil {
+		panic(err)
+	}
+	dw.writer.(http.Flusher).Flush()
+}
+
+// Header returns the header map that will be sent by WriteHeader.
+func (dw *DelayedWriter) Header() http.Header {
+	return dw.writer.Header()
+}
+
+// Write only writes the data to the buffer, not the output.
+func (dw *DelayedWriter) Write(p []byte) (int, error) {
+	if len(dw.buffer) == 0 {
+		dw.buffer = make([]byte, 32*1024)
+		dw.bytesBuffered = 0
+	}
+	bytesCopied := copy(dw.buffer[dw.bytesBuffered:], p)
+	dw.bytesBuffered += bytesCopied
+	return bytesCopied, nil
+}
+
+// WriteHeader only records the response code rather than send the HTTP response header.
+func (dw *DelayedWriter) WriteHeader(code int) {
+	if dw.headerRecorded {
+		return
+	}
+
+	dw.headerRecorded = true
+	dw.ResponseCode = code
+}

--- a/pkg/queue/request_metric.go
+++ b/pkg/queue/request_metric.go
@@ -133,7 +133,7 @@ func (h *requestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		pkgmetrics.RecordBatch(ctx, requestCountM.M(1),
 			responseTimeInMsecM.M(float64(latency.Milliseconds())))
 		if h.reportLatencyInHeader {
-			rr.Header().Add("request_latency", string(latency))
+			rr.Header().Add("queue_proxy_request_latency", string(latency))
 		}
 	}()
 
@@ -203,7 +203,7 @@ func (h *appRequestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		pkgmetrics.RecordBatch(ctx, appRequestCountM.M(1),
 			appResponseTimeInMsecM.M(float64(latency.Milliseconds())))
 		if h.reportLatencyInHeader {
-			rr.Header().Add("app_request_latency", string(latency))
+			rr.Header().Add("queue_proxy_app_request_latency", string(latency))
 		}
 	}()
 	h.next.ServeHTTP(rr, r)

--- a/pkg/queue/request_metric.go
+++ b/pkg/queue/request_metric.go
@@ -133,7 +133,7 @@ func (h *requestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		pkgmetrics.RecordBatch(ctx, requestCountM.M(1),
 			responseTimeInMsecM.M(float64(latency.Milliseconds())))
 		if h.reportLatencyInHeader {
-			rr.Header().Add("queue_proxy_request_latency", string(latency))
+			rr.Header().Add("queue_proxy_request_latency_ms", string(latency.Milliseconds()))
 		}
 	}()
 
@@ -203,7 +203,7 @@ func (h *appRequestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		pkgmetrics.RecordBatch(ctx, appRequestCountM.M(1),
 			appResponseTimeInMsecM.M(float64(latency.Milliseconds())))
 		if h.reportLatencyInHeader {
-			rr.Header().Add("queue_proxy_app_request_latency", string(latency))
+			rr.Header().Add("queue_proxy_app_request_latency_ms", string(latency.Milliseconds()))
 		}
 	}()
 	h.next.ServeHTTP(rr, r)


### PR DESCRIPTION
[WIP] Add a flag to QueueProxy to enable reporting the request latency in header

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
Add a flag to QueueProxy to enable reporting the request_latency/app_request_latency in the response header. They are already emitted by QueueProxy as Prometheus metrics:
* `app_request_latency` is user container latency
* `request_latency` is user container latency + queue latency

Some Knative users run Knative with an extra layer on top of the Knative networking layer, so the architecture looks like:
extra layer (could be a custom load balancer) -> Knative networking layer -> Knative activator -> QueueProxy -> user container

With this change, those users can measure the latency between their custom load balancer and QueueProxy (i.e. the additional overhead imposed by their system).