### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/knative-boilerplate.yaml
+++ b/.github/workflows/knative-boilerplate.yaml
@@ -21,9 +21,16 @@ on:
   pull_request:
     branches: [ 'main', 'master', 'release-*' ]
 
+permissions:
+  contents: read
+
 jobs:
 
   check:
+    permissions:
+      checks: write  # for reviewdog to create check
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: write  # for reviewdog to add comment to the PR
     name: Boilerplate Check
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/knative-donotsubmit.yaml
+++ b/.github/workflows/knative-donotsubmit.yaml
@@ -21,9 +21,16 @@ on:
   pull_request:
     branches: [ 'main', 'master', 'release-*' ]
 
+permissions:
+  contents: read
+
 jobs:
 
   donotsubmit:
+    permissions:
+      checks: write  # for reviewdog to create check
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: write  # for reviewdog to add comment to the PR
     name: Do Not Submit
     runs-on: ubuntu-latest
 

--- a/.github/workflows/knative-go-build.yaml
+++ b/.github/workflows/knative-go-build.yaml
@@ -9,6 +9,11 @@ on:
   pull_request:
     branches: [ 'main', 'release-*' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: none
     uses: knative/actions/.github/workflows/go-build.yaml@main

--- a/.github/workflows/knative-go-test.yaml
+++ b/.github/workflows/knative-go-test.yaml
@@ -12,6 +12,11 @@ on:
   pull_request:
     branches: [ 'main', 'release-*' ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
+    permissions:
+      contents: none
     uses: knative/actions/.github/workflows/go-test.yaml@main

--- a/.github/workflows/knative-releasability.yaml
+++ b/.github/workflows/knative-releasability.yaml
@@ -21,8 +21,13 @@ on:
         description: 'Slack Channel? (release-#)'
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   releasability:
+    permissions:
+      contents: none
     uses: knative/actions/.github/workflows/releasability.yaml@main
     with:
       releaseFamily: ${{ github.event.inputs.releaseFamily || 'v1.5' }}

--- a/.github/workflows/knative-release-notes.yaml
+++ b/.github/workflows/knative-release-notes.yaml
@@ -19,8 +19,13 @@ on:
         description: 'End Tag (defaults to HEAD of the target branch)'
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   release-notes:
+    permissions:
+      contents: none
     uses: knative/actions/.github/workflows/release-notes.yaml@main
     with:
       branch: ${{ github.event.inputs.branch }}

--- a/.github/workflows/knative-security.yaml
+++ b/.github/workflows/knative-security.yaml
@@ -12,6 +12,11 @@ on:
   pull_request:
     branches: [ 'main', 'release-*' ]
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      contents: none
     uses: knative/actions/.github/workflows/security.yaml@main

--- a/.github/workflows/knative-stale.yaml
+++ b/.github/workflows/knative-stale.yaml
@@ -8,7 +8,12 @@ on:
   schedule:
   - cron: '0 1 * * *'
 
+permissions:
+  contents: read
+
 jobs:
 
   stale:
+    permissions:
+      contents: none
     uses: knative/actions/.github/workflows/stale.yaml@main

--- a/.github/workflows/knative-style.yaml
+++ b/.github/workflows/knative-style.yaml
@@ -9,7 +9,12 @@ on:
   pull_request:
     branches: [ 'main', 'release-*' ]
 
+permissions:
+  contents: read
+
 jobs:
 
   style:
+    permissions:
+      contents: none
     uses: knative/actions/.github/workflows/style.yaml@main

--- a/.github/workflows/knative-verify.yaml
+++ b/.github/workflows/knative-verify.yaml
@@ -21,6 +21,11 @@ on:
   pull_request:
     branches: [ 'main', 'release-*' ]
 
+permissions:
+  contents: read
+
 jobs:
   verify:
+    permissions:
+      contents: none
     uses: knative/actions/.github/workflows/verify-codegen.yaml@main

--- a/.github/workflows/knative-vulnerability.yaml
+++ b/.github/workflows/knative-vulnerability.yaml
@@ -22,8 +22,14 @@ on:
     - cron: '0 1 1,15 * *' # 6am Pacific, 1st of the month to not exceed limits (200 total for all repos).
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   snyk:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
