### PR TITLE
Remove the scale-to-zero checking in conformance.

### DIFF
--- a/test/conformance/api/shared/util.go
+++ b/test/conformance/api/shared/util.go
@@ -24,10 +24,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"knative.dev/pkg/pool"
@@ -36,33 +34,12 @@ import (
 	"knative.dev/serving/test"
 )
 
-const scaleToZeroGracePeriod = 30 * time.Second
-
 // DigestResolutionExceptions holds the set of "registry" domains for which
 // digest resolution is not required.  These "registry" domains are generally
 // associated with images that aren't actually published to a registry, but
 // side-loaded into the cluster's container daemon via an operation like
 // `docker load` or `kind load`.
 var DigestResolutionExceptions = sets.NewString("kind.local", "ko.local", "dev.local")
-
-// WaitForScaleToZero will wait for the specified deployment to scale to 0 replicas.
-// Will wait up to 6 times the scaleToZeroGracePeriod (30 seconds) before failing.
-func WaitForScaleToZero(t testing.TB, deploymentName string, clients *test.Clients) error {
-	t.Helper()
-	t.Logf("Waiting for %q to scale to zero", deploymentName)
-
-	return pkgTest.WaitForDeploymentState(
-		context.Background(),
-		clients.KubeClient,
-		deploymentName,
-		func(d *appsv1.Deployment) (bool, error) {
-			return d.Status.ReadyReplicas == 0, nil
-		},
-		"DeploymentIsScaledDown",
-		test.ServingFlags.TestNamespace,
-		scaleToZeroGracePeriod*6,
-	)
-}
 
 // ValidateImageDigest validates the image digest.
 func ValidateImageDigest(t *testing.T, imageName string, imageDigest string) (bool, error) {

--- a/test/conformance/runtime/readiness_probe_test.go
+++ b/test/conformance/runtime/readiness_probe_test.go
@@ -33,10 +33,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	pkgtest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
-	revisionresourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
 	v1opts "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
-	"knative.dev/serving/test/conformance/api/shared"
 	v1test "knative.dev/serving/test/v1"
 )
 
@@ -145,11 +143,6 @@ func TestProbeRuntime(t *testing.T) {
 					spoof.WithHeader(test.ServingFlags.RequestHeader()),
 				); err != nil {
 					t.Fatalf("The endpoint for Route %s at %s didn't return success: %v", names.Route, url, err)
-				}
-
-				// Check if scaling down works even if access from liveness probe exists.
-				if err := shared.WaitForScaleToZero(t, revisionresourcenames.Deployment(resources.Revision), clients); err != nil {
-					t.Fatal("Could not scale to zero:", err)
 				}
 			})
 		}


### PR DESCRIPTION
Conformance should be a measurement of the Knative API and runtime semantics, not the details of how those semantics are implemented.  Scaling to zero is effectively a cost optimization, but should not be a requirement of a
conforming implementation.

For instance, if I were to set `min-scale: "1"` cluster-wide, I should still have a conformant implementation, since the key semantics of the API are still preserved.

**Release Note**

```release-note
API conformance no longer checks for scaling to zero in the presence of runtime probes
```
