### PR TITLE
Allow calls to test.Setup to disable logstream

### DIFF
--- a/test/conformance.go
+++ b/test/conformance.go
@@ -74,12 +74,27 @@ const (
 	MinSplitPercentage = 0.25
 )
 
+type Options struct {
+	Namespace        string
+	DisableLogStream bool
+}
+
 // Setup creates client to run Knative Service requests
-func Setup(t testing.TB, namespace ...string) *Clients {
+func Setup(t testing.TB, opts ...Options) *Clients {
+	var o Options
+	switch len(opts) {
+	case 1:
+		o = opts[0]
+	case 0:
+		o = Options{}
+	default:
+		t.Fatalf("multiple Options supplied to Setup")
+	}
+
 	t.Helper()
 	logging.InitializeLogger()
 
-	if !ServingFlags.DisableLogStream {
+	if !ServingFlags.DisableLogStream && !o.DisableLogStream {
 		cancel := logstream.Start(t)
 		t.Cleanup(cancel)
 	}
@@ -90,8 +105,8 @@ func Setup(t testing.TB, namespace ...string) *Clients {
 	}
 
 	ns := ServingFlags.TestNamespace
-	if len(namespace) > 0 {
-		ns = namespace[0]
+	if len(o.Namespace) > 0 {
+		ns = o.Namespace
 	}
 
 	clients, err := NewClients(cfg, ns)

--- a/test/e2e/autotls/auto_tls_test.go
+++ b/test/e2e/autotls/auto_tls_test.go
@@ -59,7 +59,7 @@ func TestTLS(t *testing.T) {
 }
 
 func TestTLSDisabledWithAnnotation(t *testing.T) {
-	clients := test.Setup(t, test.ServingFlags.TLSTestNamespace)
+	clients := test.Setup(t, test.Options{Namespace: test.ServingFlags.TLSTestNamespace})
 
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),
@@ -85,7 +85,7 @@ func TestTLSDisabledWithAnnotation(t *testing.T) {
 }
 
 func testAutoTLS(t *testing.T) {
-	clients := test.Setup(t, test.ServingFlags.TLSTestNamespace)
+	clients := test.Setup(t, test.Options{Namespace: test.ServingFlags.TLSTestNamespace})
 
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),

--- a/test/e2e/autotls/domain_mapping_test.go
+++ b/test/e2e/autotls/domain_mapping_test.go
@@ -58,7 +58,7 @@ func TestDomainMappingAutoTLS(t *testing.T) {
 
 	ctx := context.Background()
 
-	clients := test.Setup(t, test.ServingFlags.TLSTestNamespace)
+	clients := test.Setup(t, test.Options{Namespace: test.ServingFlags.TLSTestNamespace})
 
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),

--- a/test/e2e/autotls/http_redirect_test.go
+++ b/test/e2e/autotls/http_redirect_test.go
@@ -39,7 +39,7 @@ func TestHttpRedirect(t *testing.T) {
 
 	ctx := context.Background()
 
-	clients := test.Setup(t, test.ServingFlags.TLSTestNamespace)
+	clients := test.Setup(t, test.Options{Namespace: test.ServingFlags.TLSTestNamespace})
 
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -54,7 +54,7 @@ func Setup(t *testing.T) *test.Clients {
 // SetupAlternativeNamespace creates the client objects needed in e2e tests
 // under the alternative namespace.
 func SetupAlternativeNamespace(t *testing.T) *test.Clients {
-	return test.Setup(t, test.ServingFlags.AltTestNamespace)
+	return test.Setup(t, test.Options{Namespace: test.ServingFlags.AltTestNamespace})
 }
 
 // autoscalerCM returns the current autoscaler config map deployed to the

--- a/test/e2e/resource_quota_error_test.go
+++ b/test/e2e/resource_quota_error_test.go
@@ -38,7 +38,7 @@ import (
 func TestResourceQuotaError(t *testing.T) {
 	t.Parallel()
 
-	clients := test.Setup(t, "rq-test")
+	clients := test.Setup(t, test.Options{Namespace: "rq-test"})
 	const (
 		errorReason    = "RevisionFailed"
 		errorMsgScale  = "Initial scale was never achieved"


### PR DESCRIPTION
Fixes #N/A

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Playing with the scaling tests I want some `test.Clients` before running each subtest (ie. scale to 10, scale to 100)- I noticed this would cause the log stream to start - which is unwanted in that scenario

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
