### PR TITLE
skip TestHelloHTTP2WithEmptyPortName early

### DIFF
--- a/test/e2e/http2_test.go
+++ b/test/e2e/http2_test.go
@@ -75,6 +75,7 @@ func TestHelloHTTP2WithPortNameH2C(t *testing.T) {
 // should succeed.
 func TestHelloHTTP2WithEmptyPortName(t *testing.T) {
 	t.Parallel()
+	t.Skip("HTTP2 with empty port name is not implemented yet. See: https://github.com/knative/serving/issues/4283")
 
 	clients := Setup(t)
 
@@ -108,5 +109,4 @@ func TestHelloHTTP2WithEmptyPortName(t *testing.T) {
 		t.Fatalf("The endpoint %s for Route %s didn't serve the expected status code %v: %v", url, names.Route, http.StatusUpgradeRequired, err)
 	}
 
-	t.Skip("HTP2 with empty port name is not implemented yet. See: https://github.com/knative/serving/issues/4283")
 }


### PR DESCRIPTION
Related: https://github.com/knative/serving/issues/4283

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* We create a KService and then skip the test - which is unnecessary

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
