### PR TITLE
SKS Endpoint Informer should only watch endpoints for our private services

### DIFF
--- a/pkg/reconciler/serverlessservice/controller.go
+++ b/pkg/reconciler/serverlessservice/controller.go
@@ -71,8 +71,11 @@ func NewController(
 
 	// Watch all the endpoints that we have attached our label to.
 	endpointsInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: pkgreconciler.LabelExistsFilterFunc(networking.SKSLabelKey),
-		Handler:    controller.HandleAll(impl.EnqueueLabelOfNamespaceScopedResource("" /*any namespace*/, networking.SKSLabelKey)),
+		FilterFunc: pkgreconciler.ChainFilterFuncs(
+			pkgreconciler.LabelExistsFilterFunc(networking.SKSLabelKey),
+			pkgreconciler.LabelFilterFunc(networking.ServiceTypeKey, string(networking.ServiceTypePrivate), false),
+		),
+		Handler: controller.HandleAll(impl.EnqueueLabelOfNamespaceScopedResource("" /*any namespace*/, networking.SKSLabelKey)),
 	})
 
 	// Watch all the services that we have created.


### PR DESCRIPTION
Discovered as part of https://github.com/knative/serving/issues/12091

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Scope the SKS Endpoints informer to only trigger reconciliation when private endpoints change
  * Otherwise we're triggering extra reconciliations when we update the endpoints of the public service.

Note this doesn't really have a big performance effect of the TestScaleToN 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
