### PR TITLE
Temporarily disable flaky kind test

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -318,6 +318,7 @@ jobs:
         gotestsum --format testname -- \
           -race -count=1 -parallel=1 -tags=e2e \
           -timeout=30m \
+          -short \
           ${{ matrix.test-path }} \
           -skip-cleanup-on-fail \
           ${{ matrix.test-flags || '-enable-alpha -enable-beta' }}

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -97,16 +97,16 @@ func runAutoscaleUpCountPods(t *testing.T, class, metric string) {
 }
 
 func TestAutoscaleSustaining(t *testing.T) {
+	if testing.Short() {
+		// TODO sort out kind issues causing flakiness
+		t.Skip("#13049: Skipped because of excessive flakiness on kind")
+	}
+
 	for _, algo := range []string{
 		autoscaling.MetricAggregationAlgorithmLinear,
 		autoscaling.MetricAggregationAlgorithmWeightedExponential,
 	} {
 		algo := algo
-		if testing.Short() && algo == autoscaling.MetricAggregationAlgorithmWeightedExponential {
-			// TODO sort out kind issues causing flakiness
-			t.Skip("#13049: Skipped because of excessive flakiness on kind")
-		}
-
 		t.Run("aggregation-"+algo, func(t *testing.T) {
 			// When traffic increases, a knative app should scale up and sustain the scale
 			// as long as the traffic sustains, despite whether it is switching modes between

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -102,6 +102,11 @@ func TestAutoscaleSustaining(t *testing.T) {
 		autoscaling.MetricAggregationAlgorithmWeightedExponential,
 	} {
 		algo := algo
+		if testing.Short() && algo == autoscaling.MetricAggregationAlgorithmWeightedExponential {
+			// TODO sort out kind issues causing flakiness
+			t.Skip("#13049: Skipped because of excessive flakiness on kind")
+		}
+
 		t.Run("aggregation-"+algo, func(t *testing.T) {
 			// When traffic increases, a knative app should scale up and sustain the scale
 			// as long as the traffic sustains, despite whether it is switching modes between


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

## Proposed Changes

TestAutoscaleSustaining/aggregation-weighted-exponential is currently
extremely flaky when running on Kind. There were some major updates
made in the recent version of kind, so will need to investigate
further to determine what changed and why things are so flaky. In the
interim, disabling this test so as not to spam the grid with false
negatives (as the test passes fine when running on GKE).

See #13049 for tracking of the Kind investigation.
