### PR TITLE
Drop EnableAlphaFeatures from TestHttpRedirect

### DIFF
--- a/test/e2e/autotls/http_redirect_test.go
+++ b/test/e2e/autotls/http_redirect_test.go
@@ -32,9 +32,6 @@ import (
 )
 
 func TestHttpRedirect(t *testing.T) {
-	if !test.ServingFlags.EnableAlphaFeatures {
-		t.Skip("Alpha features not enabled")
-	}
 	t.Parallel()
 
 	ctx := context.Background()


### PR DESCRIPTION
As per design doc attached https://github.com/knative/networking/issues/301,
> After 4 subsequent releases of Alpha stage, this feature will automatically enter Stable phase as the conformance test and E2E test will have been added in the previous phases.

So this patch drops `EnableAlphaFeatures` from `TestHttpRedirect`.

**Release Note**

```release-note
HTTPRedirect feature is marked as stable.
```
