### PR TITLE
Update Knative Serving schema

### DIFF
--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -105,6 +105,7 @@ spec:
                       properties:
                         affinity:
                           description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          type: object
                           x-kubernetes-preserve-unknown-fields: true
                         automountServiceAccountToken:
                           description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
@@ -167,10 +168,14 @@ spec:
                                           x-kubernetes-map-type: atomic
                                         fieldRef:
                                           description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
                                           x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                                         resourceFieldRef:
                                           description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
                                           x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in the pod's namespace
                                           type: object
@@ -503,6 +508,7 @@ spec:
                                 type: string
                         dnsConfig:
                           description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          type: object
                           x-kubernetes-preserve-unknown-fields: true
                         dnsPolicy:
                           description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
@@ -513,7 +519,10 @@ spec:
                         hostAliases:
                           description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
                           type: array
-                          x-kubernetes-preserve-unknown-fields: true
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         imagePullSecrets:
                           description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                           type: array
@@ -526,9 +535,12 @@ spec:
                                 type: string
                             x-kubernetes-map-type: atomic
                         initContainers:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                          description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                           type: array
-                          x-kubernetes-preserve-unknown-fields: true
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         nodeSelector:
                           description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
                           type: object
@@ -548,6 +560,7 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                         securityContext:
                           description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          type: object
                           x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
@@ -559,11 +572,17 @@ spec:
                         tolerations:
                           description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
                           type: array
-                          x-kubernetes-preserve-unknown-fields: true
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         topologySpreadConstraints:
                           description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
                           type: array
-                          x-kubernetes-preserve-unknown-fields: true
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                           x-kubernetes-list-map-keys:
                             - topologyKey
                             - whenUnsatisfiable
@@ -622,8 +641,6 @@ spec:
                               persistentVolumeClaim:
                                 description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
                                 type: object
-                                required:
-                                  - claimName
                                 x-kubernetes-preserve-unknown-fields: true
                               projected:
                                 description: Items for all in one resources secrets, configmaps, and downward API

--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -583,10 +583,6 @@ spec:
                             description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
-                          x-kubernetes-list-map-keys:
-                            - topologyKey
-                            - whenUnsatisfiable
-                          x-kubernetes-list-type: map
                         volumes:
                           description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                           type: array

--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -103,6 +103,9 @@ spec:
                       required:
                         - containers
                       properties:
+                        affinity:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          x-kubernetes-preserve-unknown-fields: true
                         automountServiceAccountToken:
                           description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                           type: boolean
@@ -161,6 +164,13 @@ spec:
                                             optional:
                                               description: Specify whether the ConfigMap or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        resourceFieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          x-kubernetes-preserve-unknown-fields: true
                                         secretKeyRef:
                                           description: Selects a key of a secret in the pod's namespace
                                           type: object
@@ -176,7 +186,7 @@ spec:
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
                                               type: boolean
-                                      x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                               envFrom:
                                 description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                 type: array
@@ -194,6 +204,7 @@ spec:
                                         optional:
                                           description: Specify whether the ConfigMap must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
@@ -207,6 +218,7 @@ spec:
                                         optional:
                                           description: Specify whether the Secret must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                               image:
                                 description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                 type: string
@@ -256,10 +268,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -279,7 +296,12 @@ spec:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -307,7 +329,6 @@ spec:
                                       description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                       type: string
                                       default: TCP
-                                  x-kubernetes-preserve-unknown-fields: true
                                 x-kubernetes-list-map-keys:
                                   - containerPort
                                   - protocol
@@ -355,10 +376,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -378,7 +404,12 @@ spec:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -413,21 +444,32 @@ spec:
                                     description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                                     type: object
                                     properties:
+                                      add:
+                                        description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
                                       drop:
                                         description: Removed capabilities
                                         type: array
                                         items:
                                           description: Capability represent POSIX capabilities type
                                           type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   readOnlyRootFilesystem:
                                     description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
+                                  runAsNonRoot:
+                                    description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: boolean
                                   runAsUser:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
-                                x-kubernetes-preserve-unknown-fields: true
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -459,10 +501,19 @@ spec:
                               workingDir:
                                 description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                        dnsConfig:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          x-kubernetes-preserve-unknown-fields: true
+                        dnsPolicy:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          type: string
                         enableServiceLinks:
-                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
                           type: boolean
+                        hostAliases:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          type: array
+                          x-kubernetes-preserve-unknown-fields: true
                         imagePullSecrets:
                           description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                           type: array
@@ -473,6 +524,31 @@ spec:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
+                            x-kubernetes-map-type: atomic
+                        initContainers:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                          type: array
+                          x-kubernetes-preserve-unknown-fields: true
+                        nodeSelector:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-map-type: atomic
+                        priorityClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        runtimeClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        schedulerName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        securityContext:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                           type: string
@@ -480,6 +556,18 @@ spec:
                           description: TimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (send network traffic). If unspecified, a system default will be provided.
                           type: integer
                           format: int64
+                        tolerations:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                          type: array
+                          x-kubernetes-preserve-unknown-fields: true
+                        topologySpreadConstraints:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          type: array
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-list-map-keys:
+                            - topologyKey
+                            - whenUnsatisfiable
+                          x-kubernetes-list-type: map
                         volumes:
                           description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                           type: array
@@ -523,9 +611,20 @@ spec:
                                   optional:
                                     description: Specify whether the ConfigMap or its keys must be defined
                                     type: boolean
+                                x-kubernetes-map-type: atomic
+                              emptyDir:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               name:
                                 description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
+                              persistentVolumeClaim:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                type: object
+                                required:
+                                  - claimName
+                                x-kubernetes-preserve-unknown-fields: true
                               projected:
                                 description: Items for all in one resources secrets, configmaps, and downward API
                                 type: object
@@ -571,6 +670,7 @@ spec:
                                             optional:
                                               description: Specify whether the ConfigMap or its keys must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         secret:
                                           description: information about the secret data to project
                                           type: object
@@ -601,6 +701,7 @@ spec:
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
                                           description: information about the serviceAccountToken data to project
                                           type: object
@@ -651,8 +752,6 @@ spec:
                                   secretName:
                                     description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
-                            x-kubernetes-preserve-unknown-fields: true
-                      x-kubernetes-preserve-unknown-fields: true
             status:
               description: ConfigurationStatus communicates the observed state of the Configuration (from the controller).
               type: object
@@ -675,7 +774,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string

--- a/config/core/300-resources/domain-mapping.yaml
+++ b/config/core/300-resources/domain-mapping.yaml
@@ -116,7 +116,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -222,7 +221,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string

--- a/config/core/300-resources/metric.yaml
+++ b/config/core/300-resources/metric.yaml
@@ -99,7 +99,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string

--- a/config/core/300-resources/podautoscaler.yaml
+++ b/config/core/300-resources/podautoscaler.yaml
@@ -97,6 +97,7 @@ spec:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
+                  x-kubernetes-map-type: atomic
             status:
               description: Status communicates the observed state of the PodAutoscaler (from the controller).
               type: object
@@ -126,7 +127,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -84,6 +84,7 @@ spec:
               properties:
                 affinity:
                   description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                  type: object
                   x-kubernetes-preserve-unknown-fields: true
                 automountServiceAccountToken:
                   description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
@@ -146,10 +147,14 @@ spec:
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
                                   description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  type: object
                                   x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
                                 resourceFieldRef:
                                   description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  type: object
                                   x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's namespace
                                   type: object
@@ -482,6 +487,7 @@ spec:
                         type: string
                 dnsConfig:
                   description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                  type: object
                   x-kubernetes-preserve-unknown-fields: true
                 dnsPolicy:
                   description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
@@ -492,7 +498,10 @@ spec:
                 hostAliases:
                   description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
                   type: array
-                  x-kubernetes-preserve-unknown-fields: true
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 imagePullSecrets:
                   description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                   type: array
@@ -505,9 +514,12 @@ spec:
                         type: string
                     x-kubernetes-map-type: atomic
                 initContainers:
-                  description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                  description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                   type: array
-                  x-kubernetes-preserve-unknown-fields: true
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 nodeSelector:
                   description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
                   type: object
@@ -527,6 +539,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 securityContext:
                   description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                  type: object
                   x-kubernetes-preserve-unknown-fields: true
                 serviceAccountName:
                   description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
@@ -538,11 +551,17 @@ spec:
                 tolerations:
                   description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
                   type: array
-                  x-kubernetes-preserve-unknown-fields: true
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 topologySpreadConstraints:
                   description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
                   type: array
-                  x-kubernetes-preserve-unknown-fields: true
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   x-kubernetes-list-map-keys:
                     - topologyKey
                     - whenUnsatisfiable
@@ -601,8 +620,6 @@ spec:
                       persistentVolumeClaim:
                         description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
                         type: object
-                        required:
-                          - claimName
                         x-kubernetes-preserve-unknown-fields: true
                       projected:
                         description: Items for all in one resources secrets, configmaps, and downward API

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -82,6 +82,9 @@ spec:
               required:
                 - containers
               properties:
+                affinity:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                  x-kubernetes-preserve-unknown-fields: true
                 automountServiceAccountToken:
                   description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                   type: boolean
@@ -140,6 +143,13 @@ spec:
                                     optional:
                                       description: Specify whether the ConfigMap or its key must be defined
                                       type: boolean
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  x-kubernetes-preserve-unknown-fields: true
+                                resourceFieldRef:
+                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  x-kubernetes-preserve-unknown-fields: true
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's namespace
                                   type: object
@@ -155,7 +165,7 @@ spec:
                                     optional:
                                       description: Specify whether the Secret or its key must be defined
                                       type: boolean
-                              x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
                       envFrom:
                         description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                         type: array
@@ -173,6 +183,7 @@ spec:
                                 optional:
                                   description: Specify whether the ConfigMap must be defined
                                   type: boolean
+                              x-kubernetes-map-type: atomic
                             prefix:
                               description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                               type: string
@@ -186,6 +197,7 @@ spec:
                                 optional:
                                   description: Specify whether the Secret must be defined
                                   type: boolean
+                              x-kubernetes-map-type: atomic
                       image:
                         description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                         type: string
@@ -235,10 +247,15 @@ spec:
                               path:
                                 description: Path to access on the HTTP server.
                                 type: string
+                              port:
+                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host. Defaults to HTTP.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -258,7 +275,12 @@ spec:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                              port:
+                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -286,7 +308,6 @@ spec:
                               description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                               type: string
                               default: TCP
-                          x-kubernetes-preserve-unknown-fields: true
                         x-kubernetes-list-map-keys:
                           - containerPort
                           - protocol
@@ -334,10 +355,15 @@ spec:
                               path:
                                 description: Path to access on the HTTP server.
                                 type: string
+                              port:
+                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host. Defaults to HTTP.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -357,7 +383,12 @@ spec:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                              port:
+                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -392,21 +423,32 @@ spec:
                             description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                             type: object
                             properties:
+                              add:
+                                description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                type: array
+                                items:
+                                  description: Capability represent POSIX capabilities type
+                                  type: string
                               drop:
                                 description: Removed capabilities
                                 type: array
                                 items:
                                   description: Capability represent POSIX capabilities type
                                   type: string
-                            x-kubernetes-preserve-unknown-fields: true
                           readOnlyRootFilesystem:
                             description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                            type: integer
+                            format: int64
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
                             description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             type: integer
                             format: int64
-                        x-kubernetes-preserve-unknown-fields: true
                       terminationMessagePath:
                         description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                         type: string
@@ -438,10 +480,19 @@ spec:
                       workingDir:
                         description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                         type: string
-                    x-kubernetes-preserve-unknown-fields: true
+                dnsConfig:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                  x-kubernetes-preserve-unknown-fields: true
+                dnsPolicy:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                  type: string
                 enableServiceLinks:
-                  description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                  description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
                   type: boolean
+                hostAliases:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
                 imagePullSecrets:
                   description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                   type: array
@@ -452,6 +503,31 @@ spec:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
+                    x-kubernetes-map-type: atomic
+                initContainers:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
+                nodeSelector:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-map-type: atomic
+                priorityClassName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                runtimeClassName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                schedulerName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                securityContext:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                  x-kubernetes-preserve-unknown-fields: true
                 serviceAccountName:
                   description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                   type: string
@@ -459,6 +535,18 @@ spec:
                   description: TimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (send network traffic). If unspecified, a system default will be provided.
                   type: integer
                   format: int64
+                tolerations:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
+                topologySpreadConstraints:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-list-map-keys:
+                    - topologyKey
+                    - whenUnsatisfiable
+                  x-kubernetes-list-type: map
                 volumes:
                   description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                   type: array
@@ -502,9 +590,20 @@ spec:
                           optional:
                             description: Specify whether the ConfigMap or its keys must be defined
                             type: boolean
+                        x-kubernetes-map-type: atomic
+                      emptyDir:
+                        description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       name:
                         description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
+                      persistentVolumeClaim:
+                        description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                        type: object
+                        required:
+                          - claimName
+                        x-kubernetes-preserve-unknown-fields: true
                       projected:
                         description: Items for all in one resources secrets, configmaps, and downward API
                         type: object
@@ -550,6 +649,7 @@ spec:
                                     optional:
                                       description: Specify whether the ConfigMap or its keys must be defined
                                       type: boolean
+                                  x-kubernetes-map-type: atomic
                                 secret:
                                   description: information about the secret data to project
                                   type: object
@@ -580,6 +680,7 @@ spec:
                                     optional:
                                       description: Specify whether the Secret or its key must be defined
                                       type: boolean
+                                  x-kubernetes-map-type: atomic
                                 serviceAccountToken:
                                   description: information about the serviceAccountToken data to project
                                   type: object
@@ -630,8 +731,6 @@ spec:
                           secretName:
                             description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                             type: string
-                    x-kubernetes-preserve-unknown-fields: true
-              x-kubernetes-preserve-unknown-fields: true
             status:
               description: RevisionStatus communicates the observed state of the Revision (from the controller).
               type: object
@@ -658,7 +757,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -562,10 +562,6 @@ spec:
                     description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
-                  x-kubernetes-list-map-keys:
-                    - topologyKey
-                    - whenUnsatisfiable
-                  x-kubernetes-list-type: map
                 volumes:
                   description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                   type: array

--- a/config/core/300-resources/route.yaml
+++ b/config/core/300-resources/route.yaml
@@ -83,7 +83,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -123,7 +123,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -157,7 +156,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -107,6 +107,9 @@ spec:
                       required:
                         - containers
                       properties:
+                        affinity:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          x-kubernetes-preserve-unknown-fields: true
                         automountServiceAccountToken:
                           description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                           type: boolean
@@ -165,6 +168,13 @@ spec:
                                             optional:
                                               description: Specify whether the ConfigMap or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        resourceFieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          x-kubernetes-preserve-unknown-fields: true
                                         secretKeyRef:
                                           description: Selects a key of a secret in the pod's namespace
                                           type: object
@@ -180,7 +190,7 @@ spec:
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
                                               type: boolean
-                                      x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                               envFrom:
                                 description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                 type: array
@@ -198,6 +208,7 @@ spec:
                                         optional:
                                           description: Specify whether the ConfigMap must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
@@ -211,6 +222,7 @@ spec:
                                         optional:
                                           description: Specify whether the Secret must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                               image:
                                 description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                 type: string
@@ -260,10 +272,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -283,7 +300,12 @@ spec:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -311,7 +333,6 @@ spec:
                                       description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                       type: string
                                       default: TCP
-                                  x-kubernetes-preserve-unknown-fields: true
                                 x-kubernetes-list-map-keys:
                                   - containerPort
                                   - protocol
@@ -359,10 +380,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -382,7 +408,12 @@ spec:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -417,21 +448,32 @@ spec:
                                     description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                                     type: object
                                     properties:
+                                      add:
+                                        description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
                                       drop:
                                         description: Removed capabilities
                                         type: array
                                         items:
                                           description: Capability represent POSIX capabilities type
                                           type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   readOnlyRootFilesystem:
                                     description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
+                                  runAsNonRoot:
+                                    description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: boolean
                                   runAsUser:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
-                                x-kubernetes-preserve-unknown-fields: true
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -463,10 +505,19 @@ spec:
                               workingDir:
                                 description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                        dnsConfig:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          x-kubernetes-preserve-unknown-fields: true
+                        dnsPolicy:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          type: string
                         enableServiceLinks:
-                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
                           type: boolean
+                        hostAliases:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          type: array
+                          x-kubernetes-preserve-unknown-fields: true
                         imagePullSecrets:
                           description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                           type: array
@@ -477,6 +528,31 @@ spec:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
+                            x-kubernetes-map-type: atomic
+                        initContainers:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                          type: array
+                          x-kubernetes-preserve-unknown-fields: true
+                        nodeSelector:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-map-type: atomic
+                        priorityClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        runtimeClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        schedulerName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        securityContext:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                           type: string
@@ -484,6 +560,18 @@ spec:
                           description: TimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (send network traffic). If unspecified, a system default will be provided.
                           type: integer
                           format: int64
+                        tolerations:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                          type: array
+                          x-kubernetes-preserve-unknown-fields: true
+                        topologySpreadConstraints:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          type: array
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-list-map-keys:
+                            - topologyKey
+                            - whenUnsatisfiable
+                          x-kubernetes-list-type: map
                         volumes:
                           description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                           type: array
@@ -527,9 +615,20 @@ spec:
                                   optional:
                                     description: Specify whether the ConfigMap or its keys must be defined
                                     type: boolean
+                                x-kubernetes-map-type: atomic
+                              emptyDir:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               name:
                                 description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
+                              persistentVolumeClaim:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                type: object
+                                required:
+                                  - claimName
+                                x-kubernetes-preserve-unknown-fields: true
                               projected:
                                 description: Items for all in one resources secrets, configmaps, and downward API
                                 type: object
@@ -575,6 +674,7 @@ spec:
                                             optional:
                                               description: Specify whether the ConfigMap or its keys must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         secret:
                                           description: information about the secret data to project
                                           type: object
@@ -605,6 +705,7 @@ spec:
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
                                           description: information about the serviceAccountToken data to project
                                           type: object
@@ -655,8 +756,6 @@ spec:
                                   secretName:
                                     description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
-                            x-kubernetes-preserve-unknown-fields: true
-                      x-kubernetes-preserve-unknown-fields: true
                 traffic:
                   description: Traffic specifies how to distribute traffic over a collection of revisions and configurations.
                   type: array
@@ -671,7 +770,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -711,7 +810,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -751,7 +849,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -587,10 +587,6 @@ spec:
                             description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
-                          x-kubernetes-list-map-keys:
-                            - topologyKey
-                            - whenUnsatisfiable
-                          x-kubernetes-list-type: map
                         volumes:
                           description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                           type: array

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -109,6 +109,7 @@ spec:
                       properties:
                         affinity:
                           description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          type: object
                           x-kubernetes-preserve-unknown-fields: true
                         automountServiceAccountToken:
                           description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
@@ -171,10 +172,14 @@ spec:
                                           x-kubernetes-map-type: atomic
                                         fieldRef:
                                           description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
                                           x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                                         resourceFieldRef:
                                           description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
                                           x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in the pod's namespace
                                           type: object
@@ -507,6 +512,7 @@ spec:
                                 type: string
                         dnsConfig:
                           description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          type: object
                           x-kubernetes-preserve-unknown-fields: true
                         dnsPolicy:
                           description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
@@ -517,7 +523,10 @@ spec:
                         hostAliases:
                           description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
                           type: array
-                          x-kubernetes-preserve-unknown-fields: true
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         imagePullSecrets:
                           description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                           type: array
@@ -530,9 +539,12 @@ spec:
                                 type: string
                             x-kubernetes-map-type: atomic
                         initContainers:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                          description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                           type: array
-                          x-kubernetes-preserve-unknown-fields: true
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         nodeSelector:
                           description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
                           type: object
@@ -552,6 +564,7 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                         securityContext:
                           description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          type: object
                           x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
@@ -563,11 +576,17 @@ spec:
                         tolerations:
                           description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
                           type: array
-                          x-kubernetes-preserve-unknown-fields: true
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         topologySpreadConstraints:
                           description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
                           type: array
-                          x-kubernetes-preserve-unknown-fields: true
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                           x-kubernetes-list-map-keys:
                             - topologyKey
                             - whenUnsatisfiable
@@ -626,8 +645,6 @@ spec:
                               persistentVolumeClaim:
                                 description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
                                 type: object
-                                required:
-                                  - claimName
                                 x-kubernetes-preserve-unknown-fields: true
                               projected:
                                 description: Items for all in one resources secrets, configmaps, and downward API

--- a/hack/schemapatch-config.yaml
+++ b/hack/schemapatch-config.yaml
@@ -142,6 +142,8 @@ k8s.io/api/core/v1.PodSpec:
         - kubebuilder:pruning:PreserveUnknownFields
     TopologySpreadConstraints:
       description: "This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints"
+      additionalMarkers:
+        - kubebuilder:validation:DropListMapMarkers
       itemOverride:
         description: "This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints"
         additionalMarkers:

--- a/hack/schemapatch-config.yaml
+++ b/hack/schemapatch-config.yaml
@@ -89,16 +89,19 @@ k8s.io/api/core/v1.PodSpec:
       description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
     HostAliases:
       description: "This is accessible behind a feature flag - kubernetes.podspec-hostaliases"
-      additionalMarkers:
-      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
-      - kubebuilder:validation:DropProperties
-      - kubebuilder:pruning:PreserveUnknownFields
+      itemOverride:
+        description: "This is accessible behind a feature flag - kubernetes.podspec-hostaliases"
+        additionalMarkers:
+        # # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+        - kubebuilder:validation:DropProperties
+        - kubebuilder:pruning:PreserveUnknownFields
     InitContainers:
-      description: "This is accessible behind a feature flag - kubernetes.podspec-init-containers"
-      additionalMarkers:
-      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
-      - kubebuilder:validation:DropProperties
-      - kubebuilder:pruning:PreserveUnknownFields
+      itemOverride:
+        description: "This is accessible behind a feature flag - kubernetes.podspec-init-containers"
+        additionalMarkers:
+        # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+        - kubebuilder:validation:DropProperties
+        - kubebuilder:pruning:PreserveUnknownFields
     NodeSelector:
       description: "This is accessible behind a feature flag - kubernetes.podspec-nodeselector"
       additionalMarkers:
@@ -131,16 +134,20 @@ k8s.io/api/core/v1.PodSpec:
       - kubebuilder:pruning:PreserveUnknownFields
     Tolerations:
       description: "This is accessible behind a feature flag - kubernetes.podspec-tolerations"
-      additionalMarkers:
-      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
-      - kubebuilder:validation:DropProperties
-      - kubebuilder:pruning:PreserveUnknownFields
+      itemOverride:
+        description: "This is accessible behind a feature flag - kubernetes.podspec-tolerations"
+        additionalMarkers:
+        # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+        - kubebuilder:validation:DropProperties
+        - kubebuilder:pruning:PreserveUnknownFields
     TopologySpreadConstraints:
       description: "This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints"
-      additionalMarkers:
-      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
-      - kubebuilder:validation:DropProperties
-      - kubebuilder:pruning:PreserveUnknownFields
+      itemOverride:
+        description: "This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints"
+        additionalMarkers:
+        # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+        - kubebuilder:validation:DropProperties
+        - kubebuilder:pruning:PreserveUnknownFields
 k8s.io/api/core/v1.Container:
   fieldMask:
     - Name

--- a/hack/schemapatch-config.yaml
+++ b/hack/schemapatch-config.yaml
@@ -1,52 +1,148 @@
 # This is the config file for schema generation via controller-tool's schemapatch
 # command. It's used by update-schemas.sh.
 k8s.io/api/core/v1.Volume:
-  allowedFields:
+  fieldMask:
     - Name
     - VolumeSource
 k8s.io/api/core/v1.VolumeSource:
-  preserveUnknownFields: true # for feature flagged fields
-  allowedFields:
+  fieldMask:
     - Secret
     - ConfigMap
     - Projected
+    # Following are behind feature flags
+    - EmptyDir
+    - PersistentVolumeClaim
+k8s.io/api/core/v1.PersistentVolumeClaimVolumeSource:
+  description: "This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim"
+  additionalMarkers:
+  # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+  - kubebuilder:validation:DropProperties
+  - kubebuilder:pruning:PreserveUnknownFields
+k8s.io/api/core/v1.EmptyDirVolumeSource:
+  description: "This is accessible behind a feature flag - kubernetes.podspec-emptydir"
+  additionalMarkers:
+  # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+  - kubebuilder:validation:DropProperties
+  - kubebuilder:pruning:PreserveUnknownFields
 k8s.io/api/core/v1.VolumeProjection:
-  allowedFields:
+  fieldMask:
     - Secret
     - ConfigMap
     - ServiceAccountToken
 k8s.io/api/core/v1.ConfigMapProjection:
-  allowedFields:
+  fieldMask:
     - LocalObjectReference
     - Items
     - Optional
 k8s.io/api/core/v1.SecretProjection:
-  allowedFields:
+  fieldMask:
     - LocalObjectReference
     - Items
     - Optional
 k8s.io/api/core/v1.ServiceAccountTokenProjection:
-  allowedFields:
+  fieldMask:
     - Audience
     - ExpirationSeconds
     - Path
 k8s.io/api/core/v1.KeyToPath:
-  allowedFields:
+  fieldMask:
     - Key
     - Path
     - Mode
 k8s.io/api/core/v1.PodSpec:
-  preserveUnknownFields: true # for feature flagged fields
-  allowedFields:
+  fieldMask:
     - ServiceAccountName
     - Containers
     - Volumes
     - ImagePullSecrets
     - EnableServiceLinks
     - AutomountServiceAccountToken
+    # Properties behind feature flags
+    - Affinity
+    - DNSConfig
+    - DNSPolicy
+    - HostAliases
+    - InitContainers
+    - NodeSelector
+    - PriorityClassName
+    - RuntimeClassName
+    - SchedulerName
+    - SecurityContext
+    - Tolerations
+    - TopologySpreadConstraints
+  fieldOverrides:
+    Affinity:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-affinity"
+      additionalMarkers:
+      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+      - kubebuilder:validation:DropProperties
+      - kubebuilder:pruning:PreserveUnknownFields
+    DNSPolicy:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-dnspolicy"
+    DNSConfig:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-dnsconfig"
+      additionalMarkers:
+      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+      - kubebuilder:validation:DropProperties
+      - kubebuilder:pruning:PreserveUnknownFields
+    EnableServiceLinks:
+      description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
+    HostAliases:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-hostaliases"
+      additionalMarkers:
+      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+      - kubebuilder:validation:DropProperties
+      - kubebuilder:pruning:PreserveUnknownFields
+    InitContainers:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-init-containers"
+      additionalMarkers:
+      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+      - kubebuilder:validation:DropProperties
+      - kubebuilder:pruning:PreserveUnknownFields
+    NodeSelector:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-nodeselector"
+      additionalMarkers:
+      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+      - kubebuilder:validation:DropProperties
+      - kubebuilder:pruning:PreserveUnknownFields
+    PriorityClassName:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-priorityclassname"
+      additionalMarkers:
+      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+      - kubebuilder:validation:DropProperties
+      - kubebuilder:pruning:PreserveUnknownFields
+    RuntimeClassName:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname"
+      additionalMarkers:
+      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+      - kubebuilder:validation:DropProperties
+      - kubebuilder:pruning:PreserveUnknownFields
+    SchedulerName:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-schedulername"
+      additionalMarkers:
+      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+      - kubebuilder:validation:DropProperties
+      - kubebuilder:pruning:PreserveUnknownFields
+    SecurityContext:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-securitycontext"
+      additionalMarkers:
+      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+      - kubebuilder:validation:DropProperties
+      - kubebuilder:pruning:PreserveUnknownFields
+    Tolerations:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-tolerations"
+      additionalMarkers:
+      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+      - kubebuilder:validation:DropProperties
+      - kubebuilder:pruning:PreserveUnknownFields
+    TopologySpreadConstraints:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints"
+      additionalMarkers:
+      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+      - kubebuilder:validation:DropProperties
+      - kubebuilder:pruning:PreserveUnknownFields
 k8s.io/api/core/v1.Container:
-  preserveUnknownFields: true # for backwards compat field defaulting
-  allowedFields:
+  fieldMask:
     - Name
     - Args
     - Command
@@ -65,17 +161,19 @@ k8s.io/api/core/v1.Container:
     - VolumeMounts
   fieldOverrides:
     Name:
-      optional: true
+      additionalMarkers:
+      - optional
     Ports:
-      optional: true
+      additionalMarkers:
+      - optional
 k8s.io/api/core/v1.VolumeMount:
-  allowedFields:
+  fieldMask:
     - Name
     - ReadOnly
     - MountPath
     - SubPath
 k8s.io/api/core/v1.Probe:
-  allowedFields:
+  fieldMask:
     - ProbeHandler
     - InitialDelaySeconds
     - TimeoutSeconds
@@ -86,89 +184,107 @@ k8s.io/api/core/v1.Probe:
     PeriodSeconds:
       description: "How often (in seconds) to perform the probe."
 k8s.io/api/core/v1.ProbeHandler:
-  allowedFields:
+  fieldMask:
     - Exec
     - HTTPGet
     - TCPSocket
 k8s.io/api/core/v1.ExecAction:
-  allowedFields:
+  fieldMask:
     - Command
 k8s.io/api/core/v1.HTTPGetAction:
-  preserveUnknownFields: true # for backwards compat field defaulting
-  allowedFields:
+  fieldMask:
     - Host
     - Path
     - Scheme
     - HTTPHeaders
+    - Port
+  fieldOverrides:
+    Port:
+      additionalMarkers:
+      - optional
 k8s.io/api/core/v1.TCPSocketAction:
-  preserveUnknownFields: true # for backwards compat field defaulting
-  allowedFields:
+  fieldMask:
     - Host
+    - Port
+  fieldOverrides:
+    Port:
+      additionalMarkers:
+      - optional
 k8s.io/api/core/v1.ContainerPort:
-  preserveUnknownFields: true # for backwards compat field defaulting
-  allowedFields:
+  fieldMask:
     - ContainerPort
     - Name
     - Protocol
 k8s.io/api/core/v1.EnvVar:
-  allowedFields:
+  fieldMask:
     - Name
     - Value
     - ValueFrom
 k8s.io/api/core/v1.EnvVarSource:
-  preserveUnknownFields: true # for feature flagged fields
-  allowedFields:
+  fieldMask:
     - ConfigMapKeyRef
     - SecretKeyRef
+    - FieldRef
+    - ResourceFieldRef
+  fieldOverrides:
+    FieldRef:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-fieldref"
+      additionalMarkers:
+      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+      - kubebuilder:validation:DropProperties
+      - kubebuilder:pruning:PreserveUnknownFields
+    ResourceFieldRef:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-fieldref"
+      additionalMarkers:
+      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+      - kubebuilder:validation:DropProperties
+      - kubebuilder:pruning:PreserveUnknownFields
 k8s.io/api/core/v1.LocalObjectReference:
-  allowedFields:
+  fieldMask:
     - Name
 k8s.io/api/core/v1.ConfigMapKeySelectorMask:
-  allowedFields:
+  fieldMask:
     - Key
     - Optional
     - LocalObjectReference
 k8s.io/api/core/v1.SecretKeySelectorMask:
-  allowedFields:
+  fieldMask:
     - Key
     - Optional
     - LocalObjectReference
 k8s.io/api/core/v1.ConfigMapEnvSource:
-  allowedFields:
+  fieldMask:
     - Optional
     - LocalObjectReference
 k8s.io/api/core/v1.SecretEnvSource:
-  allowedFields:
+  fieldMask:
     - Optional
     - LocalObjectReference
 k8s.io/api/core/v1.EnvFromSource:
-  allowedFields:
+  fieldMask:
     - Prefix
     - ConfigMapRef
     - SecretRef
 k8s.io/api/core/v1.ResourceRequirementsMask:
-  allowedFields:
+  fieldMask:
     - Limits
     - Requests
-k8s.io/api/core/v1.PodSecurityContext:
-  allowedFields:
-    - RunAsUser
+k8s.io/api/core/v1.SecurityContext:
+  fieldMask:
+    - Capabilities
+    - ReadOnlyRootFilesystem
     - RunAsGroup
     - RunAsNonRoot
-    - FSGroup
-    - SupplementalGroups
-k8s.io/api/core/v1.SecurityContext:
-  preserveUnknownFields: true # for feature flagged fields
-  allowedFields:
     - RunAsUser
-    - ReadOnlyRootFilesystem
-    - Capabilities
 k8s.io/api/core/v1.Capabilities:
-  allowedFields:
+  fieldMask:
+    - Add
     - Drop
-  preserveUnknownFields: true # for feature flagged fields
+  fieldOverrides:
+    Add:
+      description: "This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities"
 k8s.io/api/core/v1.ObjectReference:
-  allowedFields:
+  fieldMask:
     - APIVersion
     - Kind
     - Name

--- a/hack/update-schemas.sh
+++ b/hack/update-schemas.sh
@@ -35,8 +35,8 @@ export PATH="$GOBIN:$PATH"
   cd controller-tools
   go mod init tools
   # Pinned for reproducible builds.
-  go mod edit -replace=sigs.k8s.io/controller-tools@v0.5.0=github.com/markusthoemmes/controller-tools@505dce98ec1d85fd566d13a6b55b8c19deeb765e
-  go get -d sigs.k8s.io/controller-tools/cmd/controller-gen@v0.5.0
+  go mod edit -replace=sigs.k8s.io/controller-tools@v0.9.0=github.com/dprotaso/controller-tools@knative
+  go get -d sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.0
   go install sigs.k8s.io/controller-tools/cmd/controller-gen
 )
 
@@ -46,8 +46,9 @@ for link in $links; do
   cp "$link" "$link.bkp"
 done
 
-SCHEMAPATCH_CONFIG_FILE="$(dirname $0)/schemapatch-config.yaml" controller-gen \
+controller-gen \
   schemapatch:manifests=config/core/300-resources,generateEmbeddedObjectMeta=true \
+  typeOverrides="$(dirname $0)/schemapatch-config.yaml" \
   output:dir=config/core/300-resources \
   paths=./pkg/apis/...
 

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -33,21 +33,12 @@ func VolumeMask(ctx context.Context, in *corev1.Volume) *corev1.Volume {
 	if in == nil {
 		return nil
 	}
-	cfg := config.FromContextOrDefaults(ctx)
 
 	out := new(corev1.Volume)
 
 	// Allowed fields
 	out.Name = in.Name
 	out.VolumeSource = in.VolumeSource
-
-	if cfg.Features.PodSpecVolumesEmptyDir != config.Disabled {
-		out.EmptyDir = in.EmptyDir
-	}
-
-	if cfg.Features.PodSpecPersistentVolumeClaim != config.Disabled {
-		out.PersistentVolumeClaim = in.PersistentVolumeClaim
-	}
 
 	return out
 }

--- a/test/conformance/runtime/container_test.go
+++ b/test/conformance/runtime/container_test.go
@@ -84,19 +84,35 @@ func TestShouldNotContainerConstraints(t *testing.T) {
 		options         func(s *v1.Service)
 		assertIfNoError func(t *testing.T, s *v1.Service)
 	}{{
-		name: "TestLifecycle",
+		name: "TestPoststartHook",
 		options: func(s *v1.Service) {
 			lifecycleHandler := &corev1.ExecAction{
 				Command: []string{"/bin/sh", "-c", "echo Hello from the post start handler > /usr/share/message"},
 			}
 			s.Spec.Template.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
 				PostStart: &corev1.LifecycleHandler{Exec: lifecycleHandler},
-				PreStop:   &corev1.LifecycleHandler{Exec: lifecycleHandler},
 			}
 		},
 		assertIfNoError: func(t *testing.T, svc *v1.Service) {
-			if svc.Spec.Template.Spec.Containers[0].Lifecycle != nil {
-				t.Error("Expected Lifecycle to be pruned")
+			lifecycle := svc.Spec.Template.Spec.Containers[0].Lifecycle
+			if lifecycle != nil && lifecycle.PostStart != nil {
+				t.Error("Expected Lifecycle.PostStart to be pruned")
+			}
+		},
+	}, {
+		name: "TestPrestopHook",
+		options: func(s *v1.Service) {
+			lifecycleHandler := &corev1.ExecAction{
+				Command: []string{"/bin/sh", "-c", "echo Hello from the post start handler > /usr/share/message"},
+			}
+			s.Spec.Template.Spec.Containers[0].Lifecycle = &corev1.Lifecycle{
+				PreStop: &corev1.LifecycleHandler{Exec: lifecycleHandler},
+			}
+		},
+		assertIfNoError: func(t *testing.T, svc *v1.Service) {
+			lifecycle := svc.Spec.Template.Spec.Containers[0].Lifecycle
+			if lifecycle != nil && lifecycle.PreStop != nil {
+				t.Error("Expected Lifecycle.Prestop to be pruned")
 			}
 		},
 	}, {


### PR DESCRIPTION
Part of https://github.com/knative/serving/issues/11980

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

- I've pushed `x-kubernetes-preserve-unknown-fields` markers further down in the schema to the properties behind feature flags
- This should prevent people from supplying a bad known property - ie. misspelling `containerConcurrency` 
- I've omitted the schema for features behind flags - they're essentially the wild west
- After this I'll follow up with a PR to relax our webhooks to _not_ error out on unknown properties

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
CRD schemas have been updated and `x-kubernetes-preserve-unknown-fields` is now only specified for attributes behind feature flags
```
