### PR TITLE
allow unknown fields in our webhooks since our CRD schemas are now specified

### DIFF
--- a/cmd/domain-mapping-webhook/main.go
+++ b/cmd/domain-mapping-webhook/main.go
@@ -59,8 +59,9 @@ func newDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher
 		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
 		store.ToContext,
 
-		// Whether to disallow unknown fields.
-		true,
+		// Whether to disallow unknown fields. We set this to 'false' since
+		// our CRDs have schemas
+		false,
 	)
 }
 
@@ -83,8 +84,9 @@ func newValidatingAdmissionController(ctx context.Context, cmw configmap.Watcher
 		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
 		store.ToContext,
 
-		// Whether to disallow unknown fields.
-		true,
+		// Whether to disallow unknown fields. We set this to 'false' since
+		// our CRDs have schemas
+		false,
 	)
 }
 

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -95,8 +95,9 @@ func newDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher
 		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
 		store.ToContext,
 
-		// Whether to disallow unknown fields.
-		true,
+		// Whether to disallow unknown fields. We set this to 'false' since
+		// our CRDs have schemas
+		false,
 	)
 }
 
@@ -119,8 +120,9 @@ func newValidationAdmissionController(ctx context.Context, cmw configmap.Watcher
 		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
 		store.ToContext,
 
-		// Whether to disallow unknown fields.
-		true,
+		// Whether to disallow unknown fields. We set this to 'false' since
+		// our CRDs have schemas
+		false,
 
 		// Extra validating callbacks to be applied to resources.
 		callbacks,


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/11980

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* allow unknown fields in our webhooks since our CRD schemas are now specified in (https://github.com/knative/serving/issues/11980)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Our webhooks no longer reject unknown fields since they're pruned by the K8s API server
```
