### PR TITLE
remove defunct markdown lint and linking variables

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -21,11 +21,6 @@
 # Use the flags --build-tests, --unit-tests and --integration-tests
 # to run a specific set of tests.
 
-# Markdown linting failures don't show up properly in Gubernator resulting
-# in a net-negative contributor experience.
-export DISABLE_MD_LINTING=1
-export DISABLE_MD_LINK_CHECK=1
-
 export GO111MODULE=on
 export GOFLAGS=-mod=vendor
 


### PR DESCRIPTION
Cleans up dead variables in presubmit test script

Addresses https://github.com/knative/hack/issues/200