### PR TITLE
Bump go version in kind-e2e tests to v1.18

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -29,10 +29,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Go 1.17.x
+    - name: Set up Go 1.18.x
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.x
+        go-version: 1.18.x
 
     - name: Setup Cache Directories
       run: |


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

We bumped the min go version in https://github.com/knative/pkg/pull/2548, so we should probably build using it when running the kind e2e tests