### PR TITLE
Updating name of activation-scale

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -191,23 +191,23 @@ func validateMinMaxScale(config *autoscalerconfig.Config, m map[string]string) *
 		errs = errs.Also(validateMaxScaleWithinLimit(k, max, config.MaxScaleLimit))
 	}
 
-	// if ActiveMinScale is also set, validate that min <= nz min <= max
-	if k, v, ok := ActiveMinScale.Get(m); ok {
+	// if ActivationScale is also set, validate that min <= nz min <= max
+	if k, v, ok := ActivationScale.Get(m); ok {
 		if nzMin, err := strconv.ParseInt(v, 10, 32); err != nil {
 			errs = errs.Also(apis.ErrInvalidValue(v, k))
 		} else if min > int32(nzMin) {
 			errs = errs.Also(&apis.FieldError{
-				Message: fmt.Sprintf("min-scale=%d is greater than active-min-scale=%d", min, nzMin),
+				Message: fmt.Sprintf("min-scale=%d is greater than activation-scale=%d", min, nzMin),
 				Paths:   []string{k},
 			})
 		} else if max < int32(nzMin) && max != 0 {
 			errs = errs.Also(&apis.FieldError{
-				Message: fmt.Sprintf("max-scale=%d is less than active-min-scale=%d", max, nzMin),
+				Message: fmt.Sprintf("max-scale=%d is less than activation-scale=%d", max, nzMin),
 				Paths:   []string{k},
 			})
 		} else if nzMin < 2 {
 			errs = errs.Also(&apis.FieldError{
-				Message: fmt.Sprintf("active-min-scale=%d must be greater than 1", nzMin),
+				Message: fmt.Sprintf("activation-scale=%d must be greater than 1", nzMin),
 				Paths:   []string{k},
 			})
 		}

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -130,16 +130,16 @@ func TestValidateAnnotations(t *testing.T) {
 		},
 		annotations: map[string]string{MaxScaleAnnotationKey: "9"},
 	}, {
-		name:        "min-scale, active-min-scale, max-scale all set appropriately",
-		annotations: map[string]string{MinScaleAnnotationKey: "1", ActiveMinScaleKey: "2", MaxScaleAnnotationKey: "3"},
+		name:        "min-scale, activation-scale, max-scale all set appropriately",
+		annotations: map[string]string{MinScaleAnnotationKey: "1", ActivationScaleKey: "2", MaxScaleAnnotationKey: "3"},
 	}, {
-		name:        "min-scale is greater than active-min-scale",
-		annotations: map[string]string{MinScaleAnnotationKey: "3", ActiveMinScaleKey: "2"},
-		expectErr:   "min-scale=3 is greater than active-min-scale=2: " + ActiveMinScaleKey,
+		name:        "min-scale is greater than activation-scale",
+		annotations: map[string]string{MinScaleAnnotationKey: "3", ActivationScaleKey: "2"},
+		expectErr:   "min-scale=3 is greater than activation-scale=2: " + ActivationScaleKey,
 	}, {
-		name:        "max-scale is less than active-min-scale",
-		annotations: map[string]string{MaxScaleAnnotationKey: "1", ActiveMinScaleKey: "2"},
-		expectErr:   "max-scale=1 is less than active-min-scale=2: " + ActiveMinScaleKey,
+		name:        "max-scale is less than activation-scale",
+		annotations: map[string]string{MaxScaleAnnotationKey: "1", ActivationScaleKey: "2"},
+		expectErr:   "max-scale=1 is less than activation-scale=2: " + ActivationScaleKey,
 	}, {
 		name: "valid algorithm on KPA",
 		annotations: map[string]string{

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -217,11 +217,12 @@ const (
 	// but bounding from above.
 	PanicThresholdPercentageMax = 1000.0
 
-	// ActiveMinScale is the minimum, non-zero value that a service should scale to.
-	// For example, if ActiveMinScale = 2, when a service scaled from zero it would
+	// ActivationScale is the minimum, non-zero value that a service should scale to.
+	// For example, if ActivationScale = 2, when a service scaled from zero it would
 	// scale up two replicas in this case. In essence, this allows one to set both a
 	// min-scale value while also preserving the ability to scale to zero.
-	ActiveMinScaleKey = GroupName + "/active-min-scale"
+	// ActivationScale must be >= 2.
+	ActivationScaleKey = GroupName + "/activation-scale"
 )
 
 var (
@@ -232,6 +233,7 @@ var (
 		InitialScaleAnnotationKey,
 		GroupName + "/initialScale",
 	}
+
 	MaxScaleAnnotation = kmap.KeyPriority{
 		MaxScaleAnnotationKey,
 		GroupName + "/maxScale",
@@ -243,8 +245,8 @@ var (
 		MetricAggregationAlgorithmKey,
 		GroupName + "/metricAggregationAlgorithm",
 	}
-	ActiveMinScale = kmap.KeyPriority{
-		ActiveMinScaleKey,
+	ActivationScale = kmap.KeyPriority{
+		ActivationScaleKey,
 	}
 	MinScaleAnnotation = kmap.KeyPriority{
 		MinScaleAnnotationKey,

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -102,10 +102,10 @@ func (pa *PodAutoscaler) ScaleBounds(asConfig *autoscalerconfig.Config) (int32, 
 	return min, max
 }
 
-// ActiveMinScale returns the min-non-zero-replicas annotation value or falise
+// ActivationScale returns the min-non-zero-replicas annotation value or falise
 // if not present or invalid.
-func (pa *PodAutoscaler) ActiveMinScale() (int32, bool) {
-	return pa.annotationInt32(autoscaling.ActiveMinScale)
+func (pa *PodAutoscaler) ActivationScale() (int32, bool) {
+	return pa.annotationInt32(autoscaling.ActivationScale)
 }
 
 // Target returns the target annotation value or false if not present, or invalid.

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -989,7 +989,7 @@ func TestPanicThresholdPercentage(t *testing.T) {
 	}
 }
 
-func TestMinNonZeroReplicasAnnotation(t *testing.T) {
+func TestActivationScaleAnnotation(t *testing.T) {
 	cases := []struct {
 		name        string
 		annotations map[string]string
@@ -1002,12 +1002,12 @@ func TestMinNonZeroReplicasAnnotation(t *testing.T) {
 		wantOK:      false,
 	}, {
 		name:        "present",
-		annotations: map[string]string{autoscaling.ActiveMinScaleKey: "5"},
+		annotations: map[string]string{autoscaling.ActivationScaleKey: "5"},
 		wantValue:   5,
 		wantOK:      true,
 	}, {
 		name:        "invalid",
-		annotations: map[string]string{autoscaling.ActiveMinScaleKey: "5s"},
+		annotations: map[string]string{autoscaling.ActivationScaleKey: "5s"},
 		wantValue:   0,
 		wantOK:      false,
 	}}
@@ -1015,7 +1015,7 @@ func TestMinNonZeroReplicasAnnotation(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			autoscaler := pa(tc.annotations)
-			gotValue, gotOK := autoscaler.ActiveMinScale()
+			gotValue, gotOK := autoscaler.ActivationScale()
 			if gotValue != tc.wantValue {
 				t.Errorf("got = %v, want: %v", gotValue, tc.wantValue)
 			}

--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -198,13 +198,13 @@ func (a *autoscaler) Scale(logger *zap.SugaredLogger, now time.Time) ScaleResult
 	desiredStablePodCount := int32(math.Min(math.Max(dspc, maxScaleDown), maxScaleUp))
 	desiredPanicPodCount := int32(math.Min(math.Max(dppc, maxScaleDown), maxScaleUp))
 
-	//	If ActiveMinScale > 1, then adjust the desired pod counts
-	if a.deciderSpec.ActiveMinScale > 1 {
-		if dspc > 0 && a.deciderSpec.ActiveMinScale > desiredStablePodCount {
-			desiredStablePodCount = a.deciderSpec.ActiveMinScale
+	//	If ActivationScale > 1, then adjust the desired pod counts
+	if a.deciderSpec.ActivationScale > 1 {
+		if dspc > 0 && a.deciderSpec.ActivationScale > desiredStablePodCount {
+			desiredStablePodCount = a.deciderSpec.ActivationScale
 		}
-		if dppc > 0 && a.deciderSpec.ActiveMinScale > desiredPanicPodCount {
-			desiredPanicPodCount = a.deciderSpec.ActiveMinScale
+		if dppc > 0 && a.deciderSpec.ActivationScale > desiredPanicPodCount {
+			desiredPanicPodCount = a.deciderSpec.ActivationScale
 		}
 	}
 

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -321,10 +321,10 @@ func TestAutoscalerStableModeNoTrafficScaleToZero(t *testing.T) {
 	expectScale(t, a, time.Now(), ScaleResult{0, expectedEBC(10, 75, 0, 1), true})
 }
 
-func TestAutoscaleMinActivateScale(t *testing.T) {
+func TestAutoscalerActivationScale(t *testing.T) {
 	metrics := &metricClient{StableConcurrency: 0, PanicConcurrency: 0}
 	a := newTestAutoscalerNoPC(10, 75, metrics)
-	a.deciderSpec.ActiveMinScale = int32(2)
+	a.deciderSpec.ActivationScale = int32(2)
 	expectScale(t, a, time.Now(), ScaleResult{0, expectedEBC(10, 75, 0, 1), true})
 
 	metrics.StableConcurrency = 1.0

--- a/pkg/autoscaler/scaling/multiscaler.go
+++ b/pkg/autoscaler/scaling/multiscaler.go
@@ -76,12 +76,12 @@ type DeciderSpec struct {
 	InitialScale int32
 	// Reachable describes whether the revision is referenced by any route.
 	Reachable bool
-	// ActiveMinScale is the minimum, non-zero value that a service should scale to.
-	// For example, if ActiveMinScale = 2, when a service scaled from zero it would
+	// ActivationScale is the minimum, non-zero value that a service should scale to.
+	// For example, if ActivationScale = 2, when a service scaled from zero it would
 	// scale up two replicas in this case. In essence, this allows one to set both a
 	// min-scale value while also preserving the ability to scale to zero.
-	// ActiveMinScale must be >= 2.
-	ActiveMinScale int32
+	// ActivationScale must be >= 2.
+	ActivationScale int32
 }
 
 // DeciderStatus is the current scale recommendation.

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -66,9 +66,9 @@ func MakeDecider(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig
 		scaleDownDelay = sdd
 	}
 
-	var activeMinScale int32
-	if mnzr, ok := pa.ActiveMinScale(); ok {
-		activeMinScale = mnzr
+	var activationScale int32
+	if mnzr, ok := pa.ActivationScale(); ok {
+		activationScale = mnzr
 	}
 
 	return &scaling.Decider{
@@ -86,7 +86,7 @@ func MakeDecider(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig
 			ScaleDownDelay:      scaleDownDelay,
 			InitialScale:        GetInitialScale(config, pa),
 			Reachable:           pa.Spec.Reachability != autoscalingv1alpha1.ReachabilityUnreachable,
-			ActiveMinScale:      activeMinScale,
+			ActivationScale:     activationScale,
 		},
 	}
 }

--- a/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
@@ -162,14 +162,14 @@ func TestMakeDecider(t *testing.T) {
 				d.Annotations[autoscaling.InitialScaleAnnotationKey] = "2"
 			}),
 	}, {
-		name: "with active-min-scale",
+		name: "with activation-scale",
 		pa: pa(func(pa *autoscalingv1alpha1.PodAutoscaler) {
-			pa.Annotations[autoscaling.ActiveMinScaleKey] = "3"
+			pa.Annotations[autoscaling.ActivationScaleKey] = "3"
 		}),
 		want: decider(withTarget(100.0), withPanicThreshold(2.0), withTotal(100),
 			func(d *scaling.Decider) {
-				d.Spec.ActiveMinScale = 3
-				d.Annotations[autoscaling.ActiveMinScaleKey] = "3"
+				d.Spec.ActivationScale = 3
+				d.Annotations[autoscaling.ActivationScaleKey] = "3"
 			}),
 	}}
 


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

**Release Note**

```release-note
Adds a `autoscaling.knative.dev/activation-scale` annotation that allows the user to set a minimum number of replicas when not scaled to zero. Note that the initial target scale for a revision is still handled by `initial-scale`; `activation-scale` will only apply on subsequent scales from zero. 
```
