### PR TITLE
Make Kingress reconciled with DomainMapping when adding a new label

### DIFF
--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -262,12 +262,14 @@ func (r *Reconciler) reconcileIngress(ctx context.Context, dm *v1alpha1.DomainMa
 	} else if err != nil {
 		return nil, err
 	} else if !equality.Semantic.DeepEqual(ingress.Spec, desired.Spec) ||
-		!equality.Semantic.DeepEqual(ingress.Annotations, desired.Annotations) {
+		!equality.Semantic.DeepEqual(ingress.Annotations, desired.Annotations) ||
+		!equality.Semantic.DeepEqual(ingress.Labels, desired.Labels) {
 
 		// Don't modify the informers copy
 		origin := ingress.DeepCopy()
 		origin.Spec = desired.Spec
 		origin.Annotations = desired.Annotations
+		origin.Labels = desired.Labels
 		updated, err := r.netclient.NetworkingV1alpha1().Ingresses(origin.Namespace).Update(ctx, origin, metav1.UpdateOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to update Ingress: %w", err)


### PR DESCRIPTION
Fixes #13135 

**Release Note**
```
Fixed domain mapping reconciler to update the Kingress label when adding a new label to domain mapping. 
```