### PR TITLE
Fixes resource quota test flake

### DIFF
--- a/test/e2e/resource_quota_error_test.go
+++ b/test/e2e/resource_quota_error_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -75,6 +76,8 @@ func TestResourceQuotaError(t *testing.T) {
 		t.Fatalf("Failed to create Service %s: %v", names.Service, err)
 	}
 
+	t.Log("Service created")
+
 	names.Config = serviceresourcenames.Configuration(svc)
 	var cond *apis.Condition
 	err = v1test.WaitForServiceState(clients.ServingClient, names.Service, func(r *v1.Service) (bool, error) {
@@ -102,6 +105,9 @@ func TestResourceQuotaError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get revision from configuration %s: %v", names.Config, err)
 	}
+
+	// testing
+	time.Sleep(45 * time.Second)
 
 	t.Log("When the containers are not scheduled, the revision should have error status.")
 	err = v1test.CheckRevisionState(clients.ServingClient, revisionName, func(r *v1.Revision) (bool, error) {

--- a/test/e2e/resource_quota_error_test.go
+++ b/test/e2e/resource_quota_error_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -106,8 +105,11 @@ func TestResourceQuotaError(t *testing.T) {
 		t.Fatalf("Failed to get revision from configuration %s: %v", names.Config, err)
 	}
 
-	// testing
-	time.Sleep(45 * time.Second)
+	if err := v1test.WaitForRevisionState(
+		clients.ServingClient, revisionName, v1test.IsRevisionFailed, "RevisionFailed",
+	); err != nil {
+		t.Fatalf("The Revision %q did not fail: %v", revisionName, err)
+	}
 
 	t.Log("When the containers are not scheduled, the revision should have error status.")
 	err = v1test.CheckRevisionState(clients.ServingClient, revisionName, func(r *v1.Revision) (bool, error) {

--- a/test/v1/revision.go
+++ b/test/v1/revision.go
@@ -79,6 +79,12 @@ func IsRevisionReady(r *v1.Revision) (bool, error) {
 	return r.IsReady(), nil
 }
 
+// IsRevisionFailed will check the status condition sof the revision and return true if the revision is
+// maked as failed, otherwise it will return false.
+func IsRevisionFailed(r *v1.Revision) (bool, error) {
+	return r.IsFailed(), nil
+}
+
 // IsRevisionRoutingActive will check if the revision is actively routing to a route.
 func IsRevisionRoutingActive(r *v1.Revision) (bool, error) {
 	routingState := r.Labels[serving.RoutingStateLabelKey]

--- a/test/v1/revision.go
+++ b/test/v1/revision.go
@@ -80,7 +80,7 @@ func IsRevisionReady(r *v1.Revision) (bool, error) {
 }
 
 // IsRevisionFailed will check the status condition sof the revision and return true if the revision is
-// maked as failed, otherwise it will return false.
+// marked as failed, otherwise it will return false.
 func IsRevisionFailed(r *v1.Revision) (bool, error) {
 	return r.IsFailed(), nil
 }


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Fixes #13173 

Flake was caused by a race in the revision status, where the revision wasn't marked failed before the test ran. 

To fix that, added a `v1test.WaitForRevisionState()` call to make sure the revision had failed before checking the error messages.

Have run the kind e2e tests about 20 times to check for flakes (10ish with just a simple sleep to avoid the race, and 10ish with WaitForRevisionState) and haven't seen any failures, so think we're good now.