### PR TITLE
Adds e2e test for activation-scale

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -338,5 +338,5 @@ jobs:
       if: ${{ failure() }}
       with:
         cluster-resources: nodes,namespaces,crds,${{ matrix.cluster-resources || '' }}
-        namespace-resources: pods,svc,ksvc,route,configuration,revision,king,${{ matrix.namespace-resources || '' }}
+        namespace-resources: configmaps,pods,svc,ksvc,route,configuration,revision,king,${{ matrix.namespace-resources || '' }}
         artifact-name: logs-${{ matrix.k8s-version}}-${{ matrix.ingress }}-${{ matrix.test-suite }}

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -372,15 +372,11 @@ func TestActivationScale(t *testing.T) {
 		}))
 	test.EnsureTearDown(t, ctx.Clients(), ctx.Names())
 
-	t.Log("DEBUGGING: completed setup")
-
 	clients := ctx.Clients()
 	resources, err := testv1.GetResourceObjects(clients, *ctx.names)
 	if err != nil {
 		t.Errorf("error: unable to update resource: %s", err)
 	}
-
-	t.Log("DEBUGGING: resouce gotten")
 
 	// initial scale of revision
 	if err := wait.Poll(1*time.Second, 5*time.Minute, func() (bool, error) {
@@ -389,8 +385,6 @@ func TestActivationScale(t *testing.T) {
 		t.Errorf("error: revision never had active pods")
 	}
 
-	t.Log("DEBUGGING: initial scale complete")
-
 	// scale to zero
 	if err := wait.Poll(1*time.Second, 5*time.Minute, func() (bool, error) {
 		resources, _ = testv1.GetResourceObjects(clients, *ctx.names)
@@ -398,10 +392,6 @@ func TestActivationScale(t *testing.T) {
 	}); err != nil {
 		t.Errorf("error: revision never scaled to zero")
 	}
-
-	t.Log("DEBUGGING: we've scaled to zero")
-
-	t.Log("DEBUGGING: ", resources.Route.Status.URL.URL().Hostname())
 
 	target, err := getVegetaTarget(
 		ctx.clients.KubeClient, ctx.resources.Route.Status.URL.URL().Hostname(), pkgtest.Flags.IngressEndpoint, test.ServingFlags.ResolvableDomain, "sleep", autoscaleSleep)
@@ -421,12 +411,6 @@ func TestActivationScale(t *testing.T) {
 		t.Errorf("unable to send request to service: %v", err)
 	}
 
-	t.Log("DEBUGGING: request sent, we should be activation scaling")
-
-	//defer resp.Body.Close()
-
-	//t.Log("DEBUGGING: response close deferred")
-
 	// wait for revision desired replicas to equal activation scale
 	if err := wait.Poll(1*time.Second, 5*time.Minute, func() (bool, error) {
 		resources, _ = testv1.GetResourceObjects(clients, *ctx.names)
@@ -434,6 +418,4 @@ func TestActivationScale(t *testing.T) {
 	}); err != nil {
 		t.Errorf("error: desired pods never equal to activation scale")
 	}
-
-	t.Log("DEBUGGING: we're done waiting for revision to activation scale")
 }

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -21,6 +21,8 @@ package e2e
 
 import (
 	"context"
+	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -31,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	netcfg "knative.dev/networking/pkg/config"
 	"knative.dev/pkg/system"
+	pkgTest "knative.dev/pkg/test"
 	pkgtest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/networking"
@@ -39,6 +42,7 @@ import (
 	"knative.dev/serving/pkg/resources"
 	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
+	testv1 "knative.dev/serving/test/v1"
 )
 
 func TestAutoscaleUpDownUp(t *testing.T) {
@@ -350,4 +354,87 @@ func TestFastScaleToZero(t *testing.T) {
 	}
 
 	t.Log("Total time to scale down:", time.Since(st))
+}
+
+const activationScale = 5
+
+func TestActivationScale(t *testing.T) {
+	t.Parallel()
+
+	ctx := SetupSvc(t,
+		&AutoscalerOptions{
+			Class:             autoscaling.KPA,
+			Metric:            autoscaling.Concurrency,
+			Target:            6,
+			TargetUtilization: 0.7},
+		test.Options{},
+		rtesting.WithConfigAnnotations(map[string]string{
+			autoscaling.ActivationScaleKey: strconv.Itoa(activationScale),
+		}))
+	test.EnsureTearDown(t, ctx.Clients(), ctx.Names())
+
+	t.Log("DEBUGGING: completed setup")
+
+	clients := ctx.Clients()
+	resources, err := testv1.GetResourceObjects(clients, *ctx.names)
+	if err != nil {
+		t.Errorf("error: unable to update resource: %s", err)
+	}
+
+	t.Log("DEBUGGING: resouce gotten")
+
+	// initial scale of revision
+	if err := wait.Poll(1*time.Second, 5*time.Minute, func() (bool, error) {
+		return *resources.Revision.Status.ActualReplicas > 0, nil
+	}); err != nil {
+		t.Errorf("error: revision never had active pods")
+	}
+
+	t.Log("DEBUGGING: initial scale complete")
+
+	// scale to zero
+	if err := wait.Poll(1*time.Second, 5*time.Minute, func() (bool, error) {
+		resources, _ = testv1.GetResourceObjects(clients, *ctx.names)
+		return *resources.Revision.Status.ActualReplicas == 0, nil
+	}); err != nil {
+		t.Errorf("error: revision never scaled to zero")
+	}
+
+	t.Log("DEBUGGING: we've scaled to zero")
+
+	t.Log("DEBUGGING: ", resources.Route.Status.URL.URL().Hostname())
+
+	target, err := getVegetaTarget(
+		ctx.clients.KubeClient, ctx.resources.Route.Status.URL.URL().Hostname(), pkgTest.Flags.IngressEndpoint, test.ServingFlags.ResolvableDomain, "sleep", autoscaleSleep)
+	if err != nil {
+		t.Errorf("error creating vegeta target: %v", err)
+	}
+
+	// send request, should scale up to activation scale
+	client := http.Client{}
+	req, err := http.NewRequest("GET", "http://"+resources.Route.Status.URL.URL().Host, nil)
+	if err != nil {
+		t.Errorf("unable to create request: %v", err)
+	}
+	req.Host = target.Header["Host"][0]
+	_, err = client.Do(req)
+	if err != nil {
+		t.Errorf("unable to send request to service: %v", err)
+	}
+
+	t.Log("DEBUGGING: request sent, we should be activation scaling")
+
+	//defer resp.Body.Close()
+
+	//t.Log("DEBUGGING: response close deferred")
+
+	// wait for revision desired replicas to equal activation scale
+	if err := wait.Poll(1*time.Second, 5*time.Minute, func() (bool, error) {
+		resources, _ = testv1.GetResourceObjects(clients, *ctx.names)
+		return *resources.Revision.Status.DesiredReplicas == activationScale, nil
+	}); err != nil {
+		t.Errorf("error: desired pods never equal to activation scale")
+	}
+
+	t.Log("DEBUGGING: we're done waiting for revision to activation scale")
 }

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	netcfg "knative.dev/networking/pkg/config"
 	"knative.dev/pkg/system"
-	pkgTest "knative.dev/pkg/test"
 	pkgtest "knative.dev/pkg/test"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/networking"
@@ -405,7 +404,7 @@ func TestActivationScale(t *testing.T) {
 	t.Log("DEBUGGING: ", resources.Route.Status.URL.URL().Hostname())
 
 	target, err := getVegetaTarget(
-		ctx.clients.KubeClient, ctx.resources.Route.Status.URL.URL().Hostname(), pkgTest.Flags.IngressEndpoint, test.ServingFlags.ResolvableDomain, "sleep", autoscaleSleep)
+		ctx.clients.KubeClient, ctx.resources.Route.Status.URL.URL().Hostname(), pkgtest.Flags.IngressEndpoint, test.ServingFlags.ResolvableDomain, "sleep", autoscaleSleep)
 	if err != nil {
 		t.Errorf("error creating vegeta target: %v", err)
 	}

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -394,14 +394,15 @@ func TestActivationScale(t *testing.T) {
 	}
 
 	target, err := getVegetaTarget(
-		ctx.clients.KubeClient, ctx.resources.Route.Status.URL.URL().Hostname(), pkgtest.Flags.IngressEndpoint, test.ServingFlags.ResolvableDomain, "sleep", autoscaleSleep)
+		ctx.clients.KubeClient, ctx.resources.Route.Status.URL.URL().Hostname(),
+		pkgtest.Flags.IngressEndpoint, test.ServingFlags.ResolvableDomain, "sleep", autoscaleSleep)
 	if err != nil {
 		t.Errorf("error creating vegeta target: %v", err)
 	}
 
 	// send request, should scale up to activation scale
 	client := http.Client{}
-	req, err := http.NewRequest("GET", "http://"+resources.Route.Status.URL.URL().Host, nil)
+	req, err := http.NewRequest("GET", target.URL, nil)
 	if err != nil {
 		t.Errorf("unable to create request: %v", err)
 	}

--- a/test/e2e/resource_quota_error_test.go
+++ b/test/e2e/resource_quota_error_test.go
@@ -75,8 +75,6 @@ func TestResourceQuotaError(t *testing.T) {
 		t.Fatalf("Failed to create Service %s: %v", names.Service, err)
 	}
 
-	t.Log("Service created")
-
 	names.Config = serviceresourcenames.Configuration(svc)
 	var cond *apis.Condition
 	err = v1test.WaitForServiceState(clients.ServingClient, names.Service, func(r *v1.Service) (bool, error) {


### PR DESCRIPTION
Fixes #11308 

## Proposed Changes

Adds e2e test for activation-scale (merged in #13136 )

Also, removed an unnecessary log message from the resource quota test (that slipped in by mistake, was using it for local debugging)

/assign @dprotaso 
 


