### PR TITLE
Properly shutdown tracer when the work is done

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -192,6 +192,7 @@ func main() {
 	go throttler.Run(ctx, transport, networkConfig.EnableMeshPodAddressability, networkConfig.MeshCompatibilityMode)
 
 	oct := tracing.NewOpenCensusTracer(tracing.WithExporterFull(networking.ActivatorServiceName, env.PodIP, logger))
+	defer oct.Shutdown(context.Background())
 
 	tracerUpdater := configmap.TypeFilter(&tracingconfig.Config{})(func(name string, value interface{}) {
 		cfg := value.(*tracingconfig.Config)


### PR DESCRIPTION
This is a follow-up on https://github.com/knative/pkg/pull/2566

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* The shutdown function will flush any buffered tracing Spans

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
