### PR TITLE
stop the queue-proxy drain if we don't receive a TERM signal

### DIFF
--- a/test/test_images/readiness/service.yaml
+++ b/test/test_images/readiness/service.yaml
@@ -8,3 +8,8 @@ spec:
     spec:
       containers:
       - image: ko://knative.dev/serving/test/test_images/readiness
+        livenessProbe:
+          httpGet:
+            path: /healthz
+          periodSeconds: 1
+          failureThreshold: 1


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/12571

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Queue proxy will stop draining if it has not received a TERM signal. This implies the user container is being restarted and not the pod.



**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Readiness probes no longer fail if the user container is restarted (due to a liveness probe failure)
```
