### PR TITLE
add e2e test for timeout with websocket

### DIFF
--- a/test/e2e/domainmapping/domain_mapping_websocket_test.go
+++ b/test/e2e/domainmapping/domain_mapping_websocket_test.go
@@ -106,7 +106,7 @@ func TestDomainMappingWebsocket(t *testing.T) {
 		t.Fatalf("The DomainMapping %s was not marked as Ready: %v", dm.Name, waitErr)
 	}
 
-	if err := e2e.ValidateWebSocketConnection(t, clients, names); err != nil {
+	if err := e2e.ValidateWebSocketConnection(t, clients, names, ""); err != nil {
 		t.Error(err)
 	}
 }

--- a/test/e2e/websocket.go
+++ b/test/e2e/websocket.go
@@ -44,7 +44,7 @@ const message = "Hello, websocket"
 
 // connect attempts to establish WebSocket connection with the Service.
 // It will retry until reaching `connectTimeout` duration.
-func connect(t *testing.T, clients *test.Clients, domain string) (*websocket.Conn, error) {
+func connect(t *testing.T, clients *test.Clients, domain, timeout string) (*websocket.Conn, error) {
 	var (
 		err     error
 		address string
@@ -59,9 +59,10 @@ func connect(t *testing.T, clients *test.Clients, domain string) (*websocket.Con
 		}
 	}
 
-	u := url.URL{Scheme: "ws", Host: net.JoinHostPort(address, mapper("80")), Path: "/"}
+	rawQuery := fmt.Sprintf("timeout=%s", timeout)
+	u := url.URL{Scheme: "ws", Host: net.JoinHostPort(address, mapper("80")), Path: "/", RawQuery: rawQuery}
 	if test.ServingFlags.HTTPS {
-		u = url.URL{Scheme: "wss", Host: net.JoinHostPort(address, mapper("443")), Path: "/"}
+		u = url.URL{Scheme: "wss", Host: net.JoinHostPort(address, mapper("443")), Path: "/", RawQuery: rawQuery}
 	}
 
 	var conn *websocket.Conn
@@ -99,10 +100,10 @@ func connect(t *testing.T, clients *test.Clients, domain string) (*websocket.Con
 	return conn, waitErr
 }
 
-func ValidateWebSocketConnection(t *testing.T, clients *test.Clients, names test.ResourceNames) error {
+func ValidateWebSocketConnection(t *testing.T, clients *test.Clients, names test.ResourceNames, timeoutSeconds string) error {
 	t.Helper()
 	// Establish the websocket connection.
-	conn, err := connect(t, clients, names.URL.Hostname())
+	conn, err := connect(t, clients, names.URL.Hostname(), timeoutSeconds)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/websocket.go
+++ b/test/e2e/websocket.go
@@ -59,7 +59,7 @@ func connect(t *testing.T, clients *test.Clients, domain, timeout string) (*webs
 		}
 	}
 
-	rawQuery := fmt.Sprintf("timeout=%s", timeout)
+	rawQuery := fmt.Sprintf("delay=%s", timeout)
 	u := url.URL{Scheme: "ws", Host: net.JoinHostPort(address, mapper("80")), Path: "/", RawQuery: rawQuery}
 	if test.ServingFlags.HTTPS {
 		u = url.URL{Scheme: "wss", Host: net.JoinHostPort(address, mapper("443")), Path: "/", RawQuery: rawQuery}

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -39,6 +39,7 @@ import (
 
 const (
 	wsServerTestImageName = "wsserver"
+	TimeoutNotSet         = ""
 )
 
 // Connects to a WebSocket target and executes `numReqs` requests.
@@ -53,7 +54,7 @@ func webSocketResponseFreqs(t *testing.T, clients *test.Clients, url string, num
 		g.Go(func() error {
 			// Establish the websocket connection. Since they are persistent
 			// we can't reuse.
-			conn, err := connect(t, clients, url)
+			conn, err := connect(t, clients, url, TimeoutNotSet)
 			if err != nil {
 				return err
 			}
@@ -113,7 +114,7 @@ func TestWebSocket(t *testing.T) {
 	}
 
 	// Validate the websocket connection.
-	if err := ValidateWebSocketConnection(t, clients, names); err != nil {
+	if err := ValidateWebSocketConnection(t, clients, names, TimeoutNotSet); err != nil {
 		t.Error(err)
 	}
 }
@@ -154,7 +155,7 @@ func TestWebSocketViaActivator(t *testing.T) {
 	}); err != nil {
 		t.Fatal("Never got Activator endpoints in the service:", err)
 	}
-	if err := ValidateWebSocketConnection(t, clients, names); err != nil {
+	if err := ValidateWebSocketConnection(t, clients, names, TimeoutNotSet); err != nil {
 		t.Error(err)
 	}
 }
@@ -252,7 +253,7 @@ func TestWebSocketBlueGreenRoute(t *testing.T) {
 
 	// But since network programming takes some time to take effect
 	// and it doesn't have a Status, we'll probe `green` until it's ready first.
-	if err := ValidateWebSocketConnection(t, clients, green); err != nil {
+	if err := ValidateWebSocketConnection(t, clients, green, TimeoutNotSet); err != nil {
 		t.Fatal("Error initializing WS connection:", err)
 	}
 
@@ -273,6 +274,76 @@ func TestWebSocketBlueGreenRoute(t *testing.T) {
 		if got, want := abs(f-numReqs/2), tolerance; got > want {
 			t.Errorf("Target %s got %d responses, expect in [%d, %d] interval", k, f, numReqs/2-tolerance, numReqs/2+tolerance)
 		}
+	}
+}
+
+func TestWebSocketWithTimeout(t *testing.T) {
+	clients := Setup(t)
+
+	testCases := []struct {
+		name                        string
+		timeoutSeconds              int64
+		responseStartTimeoutSeconds int64
+		idleTimeoutSeconds          int64
+		sleep                       string
+		expectError                 bool
+	}{{
+		name:           "does not exceed timeout seconds",
+		timeoutSeconds: 10,
+		sleep:          "2",
+		expectError:    false,
+	}, {
+		name:           "exceeds timeout seconds",
+		timeoutSeconds: 10,
+		sleep:          "20",
+		expectError:    true,
+	}, {
+		name:                        "does not exceed response start timeout seconds",
+		responseStartTimeoutSeconds: 10,
+		sleep:                       "2",
+		expectError:                 false,
+	}, {
+		name:                        "exceeds response start timeout seconds",
+		responseStartTimeoutSeconds: 10,
+		sleep:                       "20",
+		expectError:                 true,
+	}, {
+		name:               "does not exceed idle timeout seconds",
+		idleTimeoutSeconds: 10,
+		sleep:              "2",
+		expectError:        false,
+	}, {
+		name:               "exceeds idle timeout seconds",
+		idleTimeoutSeconds: 10,
+		sleep:              "20",
+		expectError:        true,
+	}}
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+
+			names := test.ResourceNames{
+				Service: test.ObjectNameForTest(t),
+				Image:   wsServerTestImageName,
+			}
+
+			// Clean up in both abnormal and normal exits.
+			test.EnsureTearDown(t, clients, &names)
+
+			_, err := v1test.CreateServiceReady(t, clients, &names,
+				rtesting.WithRevisionTimeoutSeconds(tc.timeoutSeconds),
+				rtesting.WithRevisionResponseStartTimeoutSeconds(tc.responseStartTimeoutSeconds),
+				rtesting.WithRevisionIdleTimeoutSeconds(tc.idleTimeoutSeconds))
+			if err != nil {
+				t.Fatal("Failed to create WebSocket server:", err)
+			}
+			// Validate the websocket connection.
+			err = ValidateWebSocketConnection(t, clients, names, tc.sleep)
+			if (err == nil && tc.expectError) || (err != nil && !tc.expectError) {
+				t.Error(err)
+			}
+		})
 	}
 }
 

--- a/test/test_images/wsserver/echo.go
+++ b/test/test_images/wsserver/echo.go
@@ -31,7 +31,7 @@ import (
 
 const suffixMessageEnv = "SUFFIX"
 
-var timeoutDuration time.Duration
+var delay time.Duration
 
 // Gets the message suffix from envvar. Empty by default.
 func messageSuffix() string {
@@ -51,11 +51,11 @@ var upgrader = websocket.Upgrader{
 
 func handler(w http.ResponseWriter, r *http.Request) {
 	params := r.URL.Query()
-	timeout := params.Get("timeout")
-	if timeout != "" {
-		log.Println("Found timeout header")
-		parsed, _ := strconv.Atoi(timeout)
-		timeoutDuration = time.Duration(parsed) * time.Second
+	d := params.Get("delay")
+	if d != "" {
+		log.Println("Found delay header")
+		parsed, _ := strconv.Atoi(d)
+		delay = time.Duration(parsed) * time.Second
 	}
 
 	if netheader.IsKubeletProbe(r) {
@@ -87,8 +87,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		log.Printf("Successfully received: %q", message)
-		if timeoutDuration > 0 {
-			time.Sleep(timeoutDuration)
+		if delay > 0 {
+			time.Sleep(delay)
 		}
 
 		if err = conn.WriteMessage(messageType, message); err != nil {


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* test timeout when using websocket


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
