### PR TITLE
Fix LatestReadyRevision semantics - it only advances forward

### DIFF
--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -186,7 +186,7 @@ func (c *Reconciler) getSortedCreatedRevisions(ctx context.Context, config *v1.C
 			}
 
 			lcrGen, err := configGeneration(latestCreated)
-			if isBYOName && err != nil {
+			if isBYOName && err == nil {
 				generations = append(generations, strconv.FormatInt(lcrGen, int(10)))
 			}
 			// Add an "In" filter so that the configurations we get back from List have generation

--- a/pkg/reconciler/route/traffic/traffic.go
+++ b/pkg/reconciler/route/traffic/traffic.go
@@ -360,6 +360,9 @@ func (cb *configBuilder) addConfigurationTarget(tt *v1.TrafficTarget) error {
 	if err != nil {
 		return err
 	}
+	if !rev.IsReady() {
+		return errUnreadyRevision(rev)
+	}
 	ntt := tt.DeepCopy()
 	target := RevisionTarget{
 		TrafficTarget: *ntt,

--- a/pkg/reconciler/route/traffic/traffic_test.go
+++ b/pkg/reconciler/route/traffic/traffic_test.go
@@ -69,6 +69,10 @@ var (
 	failedConfig *v1.Configuration
 	failedRev    *v1.Revision
 
+	// failedReadyConfig was ready and then failed
+	failedReadyConfig *v1.Configuration
+	failedReadyRev    *v1.Revision
+
 	// inactiveConfig only has inactiveRevision, and it's not active.
 	inactiveConfig *v1.Configuration
 	inactiveRev    *v1.Revision
@@ -89,7 +93,7 @@ var (
 	// fake lister to return API error.
 	revErrorLister listers.RevisionLister
 
-	cmpOpts = []cmp.Option{cmp.AllowUnexported(Config{})}
+	cmpOpts = []cmp.Option{cmp.AllowUnexported(Config{}, unreadyRevisionError{})}
 )
 
 func setUp() {
@@ -98,6 +102,7 @@ func setUp() {
 	unreadyConfig, unreadyRev = getTestUnreadyConfig("unready")
 	readyUnreadyConfig, readyRevision, newUnreadyRev = createReadyUnreadyConfig("ready-unready")
 	failedConfig, failedRev = getTestFailedConfig("failed")
+	failedReadyConfig, failedReadyRev = getTestFailedReadyConfig("failed-ready")
 	inactiveConfig, inactiveRev = getTestInactiveConfig("inactive")
 	goodConfig, goodOldRev, goodNewRev = getTestReadyConfig("good")
 	niceConfig, niceOldRev, niceNewRev = getTestReadyConfig("nice")
@@ -115,6 +120,7 @@ func setUp() {
 	objs := []runtime.Object{
 		unreadyConfig, unreadyRev,
 		failedConfig, failedRev,
+		failedReadyConfig, failedReadyRev,
 		inactiveConfig, inactiveRev,
 		revDeletedConfig,
 		emptyConfig,
@@ -1157,6 +1163,22 @@ func TestBuildTrafficConfigurationNotRoutableRevision(t *testing.T) {
 	}
 }
 
+func TestBuildTraffic_LatestReadyRevisionFailed(t *testing.T) {
+	_, got := BuildTrafficConfiguration(
+		configLister, revLister,
+		testRouteWithTrafficTargets(WithSpecTraffic(v1.TrafficTarget{
+			ConfigurationName: failedReadyConfig.Name,
+			LatestRevision:    ptr.Bool(true),
+			Percent:           ptr.Int64(100),
+		},
+		)))
+
+	want := errUnreadyRevision(failedReadyRev)
+	if !cmp.Equal(want, got, cmpOpts...) {
+		t.Errorf("Expected %v, saw %v", want, got)
+	}
+}
+
 func TestBuildTrafficConfigurationReadyNotReadyConfig(t *testing.T) {
 	expected := &Config{
 		Targets: map[string]RevisionTargets{
@@ -1543,12 +1565,25 @@ func getTestFailedConfig(name string) (*v1.Configuration, *v1.Revision) {
 	return config, rev
 }
 
+func getTestFailedReadyConfig(name string) (*v1.Configuration, *v1.Revision) {
+	config := testConfig(name + "-config")
+	rev := testRevForConfig(config, name+"-revision")
+	config.Status.SetLatestCreatedRevisionName(rev.Name)
+	config.Status.SetLatestReadyRevisionName(rev.Name)
+	config.Status.MarkLatestCreatedFailed(rev.Name, "Permanently failed")
+
+	rev.Status.MarkContainerHealthyFalse(v1.ReasonContainerMissing, "Should have used ko")
+	return config, rev
+}
+
 func getTestInactiveConfig(name string) (*v1.Configuration, *v1.Revision) {
 	config := testConfig(name + "-config")
 	rev := testRevForConfig(config, name+"-revision")
 	config.Status.SetLatestReadyRevisionName(rev.Name)
 	config.Status.SetLatestCreatedRevisionName(rev.Name)
 	rev.Status.InitializeConditions()
+	rev.Status.MarkContainerHealthyTrue()
+	rev.Status.MarkResourcesAvailableTrue()
 	rev.Status.MarkActiveFalse("Reserve", "blah blah blah")
 	return config, rev
 }

--- a/test/e2e/rollback_byo_test.go
+++ b/test/e2e/rollback_byo_test.go
@@ -119,8 +119,10 @@ func TestRollbackBYOName(t *testing.T) {
 		t.Fatalf("Service %s was not rolled back with byo name %s: %v", names.Service, byoNameOld, err)
 	}
 
-	// Verify that the latest ready revision and latest created revision are both byoNameNew,
-	// which means no new revision is created in the rollback
+	// Verify that the latest ready revision and latest created revision are both rolled back to byoNameOld,
+	// which means no new revision is created in the rollback.
+	//
+	// This is a special case when LatestReady and LatestCreated move backwards
 	err = v1test.WaitForServiceState(clients.ServingClient, names.Service, func(s *v1.Service) (bool, error) {
 		return (s.Status.LatestReadyRevisionName == byoNameOld && s.Status.LatestCreatedRevisionName == byoNameOld), nil
 	}, "ServiceNoNewRevisionCreated")


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/12538 https://github.com/knative/serving/issues/12078

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Configuration traffic targets now check Revision readiness
* ConfigurationStatus.LatesReadyRevision will only advance forward
* This excludes the case where users bring BYO Revision name

From commit message
> The search for latest ready revision (LLR) looked at each revision's
> configurationGeneration label to search for a new candidate.
> 
> Only Revisions with a configurationGeneration in a certain range were
> considered. Prior this inclusive range was [LLR.generation, config.generation].
> 
> The lower bound was incorrect and it should actually be LLR.configGeneration.
> Otherwise LLR generation is fairly low the the set of revisions to consider
> would be quite large for really old Configurations.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix LatestReadyRevision semantics so it only advances forward. When a Revision fails the Configuration & Route will no longer fall back to older revision. The exception is when you rollback to a Revision that is explicitly named.
```
