### PR TITLE
use the same default value for response start timeout as revision timeout

### DIFF
--- a/pkg/apis/config/defaults.go
+++ b/pkg/apis/config/defaults.go
@@ -81,7 +81,7 @@ func defaultDefaultsConfig() *Defaults {
 	return &Defaults{
 		RevisionTimeoutSeconds:             DefaultRevisionTimeoutSeconds,
 		MaxRevisionTimeoutSeconds:          DefaultMaxRevisionTimeoutSeconds,
-		RevisionRequestStartTimeoutSeconds: DefaultRevisionResponseStartTimeoutSeconds,
+		RevisionRequestStartTimeoutSeconds: DefaultRevisionTimeoutSeconds,
 		RevisionIdleTimeoutSeconds:         DefaultRevisionIdleTimeoutSeconds,
 		InitContainerNameTemplate:          DefaultInitContainerNameTemplate,
 		UserContainerNameTemplate:          DefaultUserContainerNameTemplate,


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* use the same default value for response start timeout as revision timeout


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Set the default response start timeout to the same value as the revision timeout
```
