### PR TITLE
[release-1.7] revision request start timeout should default to revision timeout second

### DIFF
--- a/config/core/configmaps/defaults.yaml
+++ b/config/core/configmaps/defaults.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "4b3e0057"
+    knative.dev/example-checksum: "e7973912"
 data:
   _example: |
     ################################
@@ -57,6 +57,8 @@ data:
     # revision-response-start-timeout-seconds contains the default number of
     # seconds a request will be allowed to stay open while waiting to
     # receive any bytes from the user's application, if none is specified.
+    #
+    # This defaults to 'revision-timeout-seconds'
     revision-response-start-timeout-seconds: "300"
 
     # revision-idle-timeout-seconds contains the default number of

--- a/pkg/apis/config/defaults.go
+++ b/pkg/apis/config/defaults.go
@@ -121,7 +121,6 @@ func NewDefaultsConfigFromMap(data map[string]string) (*Defaults, error) {
 
 		cm.AsInt64("revision-timeout-seconds", &nc.RevisionTimeoutSeconds),
 		cm.AsInt64("max-revision-timeout-seconds", &nc.MaxRevisionTimeoutSeconds),
-		cm.AsInt64("revision-response-start-timeout-seconds", &nc.RevisionRequestStartTimeoutSeconds),
 		cm.AsInt64("revision-idle-timeout-seconds", &nc.RevisionIdleTimeoutSeconds),
 
 		cm.AsInt64("container-concurrency", &nc.ContainerConcurrency),
@@ -133,6 +132,15 @@ func NewDefaultsConfigFromMap(data map[string]string) (*Defaults, error) {
 		cm.AsQuantity("revision-cpu-limit", &nc.RevisionCPULimit),
 		cm.AsQuantity("revision-memory-limit", &nc.RevisionMemoryLimit),
 		cm.AsQuantity("revision-ephemeral-storage-limit", &nc.RevisionEphemeralStorageLimit),
+	); err != nil {
+		return nil, err
+	}
+
+	// We default this to what the user has specified
+	nc.RevisionRequestStartTimeoutSeconds = nc.RevisionTimeoutSeconds
+
+	if err := cm.Parse(data,
+		cm.AsInt64("revision-response-start-timeout-seconds", &nc.RevisionRequestStartTimeoutSeconds),
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/apis/config/defaults_test.go
+++ b/pkg/apis/config/defaults_test.go
@@ -221,6 +221,22 @@ func TestDefaultsConfiguration(t *testing.T) {
 			"container-name-template":      "{{.Name}}",
 			"init-container-name-template": "my-template",
 		},
+	}, {
+		name:    "revision response timeout defaults to revision-timeout-seconds",
+		wantErr: false,
+		data: map[string]string{
+			"revision-timeout-seconds": "200",
+		},
+		wantDefaults: &Defaults{
+			RevisionTimeoutSeconds:             200,
+			RevisionRequestStartTimeoutSeconds: 200,
+			MaxRevisionTimeoutSeconds:          DefaultMaxRevisionTimeoutSeconds,
+			ContainerConcurrencyMaxLimit:       DefaultMaxRevisionContainerConcurrency,
+			AllowContainerConcurrencyZero:      DefaultAllowContainerConcurrencyZero,
+			EnableServiceLinks:                 ptr.Bool(false),
+			InitContainerNameTemplate:          DefaultInitContainerNameTemplate,
+			UserContainerNameTemplate:          DefaultUserContainerNameTemplate,
+		},
 	}}
 
 	for _, tt := range configTests {


### PR DESCRIPTION
Cherry pick of #13255

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
- ConfigMap config-defaults property `revision-response-start-timeout-seconds` now defaults to `revision-timeout-seconds`. This should unblock upgrades who set `revision-timeout-seconds` lower than the default value of 300

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
ConfigMap config-defaults property `revision-response-start-timeout-seconds` now defaults to `revision-timeout-seconds`. This should unblock upgrades who set `revision-timeout-seconds` lower than the default value of 300
```
