### PR TITLE
Use svc.cluster.local as default domain

### DIFF
--- a/config/core/configmaps/domain.yaml
+++ b/config/core/configmaps/domain.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "81552d0b"
+    knative.dev/example-checksum: "26c09de5"
 data:
   _example: |
     ################################
@@ -41,16 +41,6 @@ data:
     # to actually change the configuration.
 
     # Default value for domain.
-    # Although it will match all routes, it is the least-specific rule so it
-    # will only be used if no other domain matches.
-    example.com: |
-
-    # These are example settings of domain.
-    # example.org will be used for routes having app=nonprofit.
-    example.org: |
-      selector:
-        app: nonprofit
-
     # Routes having the cluster domain suffix (by default 'svc.cluster.local')
     # will not be exposed through Ingress. You can define your own label
     # selector to assign that domain suffix to your Route here, or you can set
@@ -61,3 +51,13 @@ data:
     svc.cluster.local: |
       selector:
         app: secret
+
+    # These are example settings of domain.
+    # example.com will be used for all routes, but it is the least-specific rule so it
+    # will only be used if no other domain matches.
+    example.com: |
+
+    # example.org will be used for routes having app=nonprofit.
+    example.org: |
+      selector:
+        app: nonprofit

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -67,10 +67,10 @@ const (
 type key int
 
 var (
-	wildcardDNSNames      = []string{"*.foo.svc.cluster.local"}
+	wildcardDNSNames      = []string{"*.foo.example.com"}
 	defaultCertName       = names.WildcardCertificate(wildcardDNSNames[0])
 	defaultDomainTemplate = "{{.Name}}.{{.Namespace}}.{{.Domain}}"
-	defaultDomain         = "svc.cluster.local"
+	defaultDomain         = "example.com"
 	// Used to pass configuration to tests in TestReconcile
 	netConfigContextKey key
 )
@@ -279,7 +279,7 @@ func TestReconcile(t *testing.T) {
 				Verb:      "delete",
 				Resource:  netv1alpha1.SchemeGroupVersion.WithResource("certificates"),
 			},
-			Name: "foo.svc.cluster.local",
+			Name: "foo.example.com",
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Deleted", "Deleted Knative Certificate %s/%s", "foo", defaultCertName),
@@ -623,7 +623,7 @@ func networkConfig() *netcfg.Config {
 func domainConfig() *routecfg.Domain {
 	domainConfig := &routecfg.Domain{
 		Domains: map[string]*routecfg.LabelSelector{
-			"svc.cluster.local": {},
+			"example.com": {},
 		},
 	}
 	return domainConfig

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -67,7 +67,7 @@ const (
 type key int
 
 var (
-	wildcardDNSNames      = []string{"*.foo.example.com"}
+	wildcardDNSNames      = []string{"*.foo.svc.cluster.local"}
 	defaultCertName       = names.WildcardCertificate(wildcardDNSNames[0])
 	defaultDomainTemplate = "{{.Name}}.{{.Namespace}}.{{.Domain}}"
 	defaultDomain         = "svc.cluster.local"
@@ -161,7 +161,7 @@ func TestNewController(t *testing.T) {
 				Namespace: system.Namespace(),
 			},
 			Data: map[string]string{
-				"example.com": "",
+				"svc.cluster.local": "",
 			}},
 	)
 
@@ -279,7 +279,7 @@ func TestReconcile(t *testing.T) {
 				Verb:      "delete",
 				Resource:  netv1alpha1.SchemeGroupVersion.WithResource("certificates"),
 			},
-			Name: "foo.example.com",
+			Name: "foo.svc.cluster.local",
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "Deleted", "Deleted Knative Certificate %s/%s", "foo", defaultCertName),
@@ -430,7 +430,7 @@ func TestChangeDefaultDomain(t *testing.T) {
 
 	// The certificate should be created with the default domain.
 	cert := <-certEvents
-	if got, want := cert.Spec.DNSNames[0], "*.testns.example.com"; got != want {
+	if got, want := cert.Spec.DNSNames[0], "*.testns.svc.cluster.local"; got != want {
 		t.Errorf("DNSName[0] = %s, want %s", got, want)
 	}
 
@@ -623,7 +623,7 @@ func networkConfig() *netcfg.Config {
 func domainConfig() *routecfg.Domain {
 	domainConfig := &routecfg.Domain{
 		Domains: map[string]*routecfg.LabelSelector{
-			"example.com": {},
+			"svc.cluster.local": {},
 		},
 	}
 	return domainConfig

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -70,7 +70,7 @@ var (
 	wildcardDNSNames      = []string{"*.foo.example.com"}
 	defaultCertName       = names.WildcardCertificate(wildcardDNSNames[0])
 	defaultDomainTemplate = "{{.Name}}.{{.Namespace}}.{{.Domain}}"
-	defaultDomain         = "example.com"
+	defaultDomain         = "svc.cluster.local"
 	// Used to pass configuration to tests in TestReconcile
 	netConfigContextKey key
 )
@@ -110,7 +110,7 @@ func newTestSetup(t *testing.T, configs ...*corev1.ConfigMap) (
 			Namespace: system.Namespace(),
 		},
 		Data: map[string]string{
-			"example.com": "",
+			"svc.cluster.local": "",
 		},
 	}}
 	cms = append(cms, configs...)
@@ -483,8 +483,8 @@ func TestDomainConfigDomain(t *testing.T) {
 			"autoTLS":                          "Enabled",
 			"namespace-wildcard-cert-selector": "{}",
 		},
-		wantCertName: "testns.example.com",
-		wantDNSName:  "*.testns.example.com",
+		wantCertName: "testns.svc.cluster.local",
+		wantDNSName:  "*.testns.svc.cluster.local",
 	}, {
 		name: "default domain",
 		domainCfg: map[string]string{

--- a/pkg/reconciler/route/config/domain.go
+++ b/pkg/reconciler/route/config/domain.go
@@ -33,7 +33,7 @@ const (
 	DomainConfigName = "config-domain"
 	// DefaultDomain holds the domain that Route's live under by default
 	// when no label selector-based options apply.
-	DefaultDomain = "example.com"
+	DefaultDomain = "svc.cluster.local"
 )
 
 // LabelSelector represents map of {key,value} pairs. A single {key,value} in the

--- a/test/config/ytt/core/overlay-config-domain.yaml
+++ b/test/config/ytt/core/overlay-config-domain.yaml
@@ -1,0 +1,8 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("helpers.lib.yaml", "system_configmap")
+
+#@overlay/match by=system_configmap("config-domain"), expects=1
+---
+#@overlay/match-child-defaults missing_ok=True
+data:
+  example.com: |


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Fixes #13182 

**Release Note**

```release-note
Uses the cluster domain suffix `svc.cluster.local` as the default domain. As routes using the cluster domain suffix are not exposed through Ingress, users will need to [configure DNS](https://knative.dev/docs/install/yaml-install/serving/install-serving-with-yaml/#configure-dns) in order to expose their services (most users probably already are).  
```



/hold