### PR TITLE
Make conformance tests configurable with custom resource values

### DIFF
--- a/test/conformance/api/v1/resources_test.go
+++ b/test/conformance/api/v1/resources_test.go
@@ -42,14 +42,7 @@ func TestCustomResourcesLimits(t *testing.T) {
 	clients := test.Setup(t)
 
 	t.Log("Creating a new Route and Configuration")
-	withResources := rtesting.WithResourceRequirements(corev1.ResourceRequirements{
-		Limits: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("350Mi"),
-		},
-		Requests: corev1.ResourceList{
-			corev1.ResourceMemory: resource.MustParse("350Mi"),
-		},
-	})
+	withResources := rtesting.WithResourceRequirements(createResources())
 
 	names := test.ResourceNames{
 		Service: test.ObjectNameForTest(t),
@@ -125,4 +118,29 @@ func TestCustomResourcesLimits(t *testing.T) {
 	if err := pokeCowForMB(exceedingMemory); err == nil {
 		t.Fatalf("We shouldn't have got a response from bloating cow with %d MBs of Memory: %v", exceedingMemory, err)
 	}
+}
+
+func createResources() corev1.ResourceRequirements {
+	resources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("350Mi"),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: resource.MustParse("350Mi"),
+		},
+	}
+
+	if test.ServingFlags.CustomCPULimits != "" {
+		resources.Limits[corev1.ResourceCPU] = resource.MustParse(test.ServingFlags.CustomCPULimits)
+	}
+	if test.ServingFlags.CustomMemoryLimits != "" {
+		resources.Limits[corev1.ResourceMemory] = resource.MustParse(test.ServingFlags.CustomMemoryLimits)
+	}
+	if test.ServingFlags.CustomCPURequests != "" {
+		resources.Requests[corev1.ResourceCPU] = resource.MustParse(test.ServingFlags.CustomCPURequests)
+	}
+	if test.ServingFlags.CustomMemoryRequests != "" {
+		resources.Requests[corev1.ResourceMemory] = resource.MustParse(test.ServingFlags.CustomMemoryRequests)
+	}
+	return resources
 }

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -49,6 +49,10 @@ type ServingEnvironmentFlags struct {
 	ExceedingMemoryLimitSize int    // Memory size used to trigger a non-200 response when the service is set with 300MB memory limit.
 	RequestHeaders           string // Extra HTTP request headers sent to the testing deployed KServices.
 	IngressClass             string // Ingress class used for serving.
+	CustomMemoryRequests     string // Memory requests used for services with a specific size.
+	CustomMemoryLimits       string // Memory limits used for services with a specific size.
+	CustomCPURequests        string // CPU requests used for services with a specific size.
+	CustomCPULimits          string // CPU limits used for services with a specific size.
 }
 
 func initializeServingFlags() *ServingEnvironmentFlags {
@@ -102,6 +106,22 @@ func initializeServingFlags() *ServingEnvironmentFlags {
 
 	flag.StringVar(&f.IngressClass, "ingress-class", "",
 		"Set the ingress class in use to this flag in order to skip non-compatible test")
+
+	flag.StringVar(&f.CustomMemoryRequests, "custom-memory-requests", "",
+		"Set this flag to the custom memory request for tests with specific memory request values."+
+			"This should differ from what is used as default. The flag accepts a value acceptable to resource.MustParse.")
+
+	flag.StringVar(&f.CustomMemoryLimits, "custom-memory-limits", "",
+		"Set this flag to the custom memory limit for tests with specific memory limit values."+
+			"This should differ from what is used as default. The flag accepts a value acceptable to resource.MustParse.")
+
+	flag.StringVar(&f.CustomCPURequests, "custom-cpu-requests", "",
+		"Set this flag to the custom cpu request for tests with specific cpu request values."+
+			"This should differ from what is used as default. The flag accepts a value acceptable to resource.MustParse.")
+
+	flag.StringVar(&f.CustomCPULimits, "custom-cpu-limits", "",
+		"Set this flag to the custom cpu limit for tests with specific cpu limit values."+
+			"This should differ from what is used as default. The flag accepts a value acceptable to resource.MustParse.")
 	return &f
 }
 


### PR DESCRIPTION
In response to https://github.com/knative/specs/pull/104

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* make conformance tests requiring specific resource requests/limits configurable so that an installation can deviate from the defaults


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
 NONE
```

Changes are analog to `ExceedingMemoryLimitSize ` 
https://github.com/knative/serving/blob/19cd295c460137ea7f071da449bef08f45c6f928/test/e2e_flags.go#L49
IMO `ExceedingMemoryLimitSize ` is now superfluous, but I don't have enough overview to know for certain.
