### PR TITLE
use GKE 1.23 clusters in CI

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -159,7 +159,7 @@ function delete_dns_record() {
 }
 
 # Script entry point.
-initialize "$@" --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha --cluster-version=1.22
+initialize "$@" --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha --cluster-version=1.23
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -28,7 +28,7 @@
 source $(dirname $0)/e2e-common.sh
 
 # Script entry point.
-initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha --cluster-version=1.22 "$@"
+initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --enable-ha --cluster-version=1.23 "$@"
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -42,7 +42,7 @@ function stage_test_resources() {
 # Skip installing istio as an add-on.
 # Skip installing a pvc as it is not used in upgrade tests
 # Skip installing a resource quota as it is not used in upgrade tests
-PVC=0 QUOTA=0 initialize "$@" --skip-istio-addon  --min-nodes=4 --max-nodes=4 --cluster-version=1.22 \
+PVC=0 QUOTA=0 initialize "$@" --skip-istio-addon  --min-nodes=4 --max-nodes=4 --cluster-version=1.23 \
   --install-latest-release
 
 # TODO(#2656): Reduce the timeout after we get this test to consistently passing.

--- a/test/performance/performance-tests-mako.sh
+++ b/test/performance/performance-tests-mako.sh
@@ -31,7 +31,7 @@ source $(dirname $0)/../e2e-common.sh
 # Skip installing istio as an add-on.
 # Temporarily increasing the cluster size for serving tests to rule out
 # resource/eviction as causes of flakiness.
-initialize --skip-istio-addon --min-nodes=10 --max-nodes=10 --perf --cluster-version=1.22 "$@"
+initialize --skip-istio-addon --min-nodes=10 --max-nodes=10 --perf --cluster-version=1.23 "$@"
 
 # Run tests serially in the mesh and https scenarios.
 parallelism=""

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -30,7 +30,7 @@ source $(dirname $0)/../e2e-common.sh
 # Skip installing istio as an add-on.
 # Temporarily increasing the cluster size for serving tests to rule out
 # resource/eviction as causes of flakiness.
-initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --perf --cluster-version=1.22 "$@"
+initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --perf --cluster-version=1.23 "$@"
 
 header "Running tests"
 


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Knative v1.8 will have [minimum k8s version v1.23](https://github.com/knative/community/blob/main/mechanics/RELEASE-SCHEDULE.md?plain=1#L14) and GKE v1.23 is [now available](https://cloud.google.com/kubernetes-engine/docs/release-notes-regular#September_02_2022) in the regular release channel. 

/assign @dprotaso 