### PR TITLE
[WIP] Stream logs from user pods during upgrades

### DIFF
--- a/test/e2e/autoscale.go
+++ b/test/e2e/autoscale.go
@@ -201,13 +201,13 @@ func toPercentageString(f float64) string {
 // SetupSvc creates a new service, with given service options.
 // It returns a TestContext that has resources, K8s clients and other needed
 // data points.
-func SetupSvc(t *testing.T, class, metric string, target int, targetUtilization float64, fopts ...rtesting.ServiceOption) *TestContext {
+func SetupSvc(t *testing.T, name, class, metric string, target int, targetUtilization float64, fopts ...rtesting.ServiceOption) *TestContext {
 	t.Helper()
 	clients := Setup(t)
 
 	t.Log("Creating a new Route and Configuration")
 	names := &test.ResourceNames{
-		Service: test.ObjectNameForTest(t),
+		Service: name,
 		Image:   autoscaleTestImageName,
 	}
 	resources, err := v1test.CreateServiceReady(t, clients, names,

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -48,7 +48,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 		algo := algo
 		t.Run("aggregation-"+algo, func(t *testing.T) {
 			t.Parallel()
-			ctx := SetupSvc(t, autoscaling.KPA, autoscaling.Concurrency, containerConcurrency, targetUtilization,
+			ctx := SetupSvc(t, test.ObjectNameForTest(t), autoscaling.KPA, autoscaling.Concurrency, containerConcurrency, targetUtilization,
 				rtesting.WithConfigAnnotations(map[string]string{
 					autoscaling.MetricAggregationAlgorithmKey: algo,
 				}))
@@ -79,7 +79,7 @@ func runAutoscaleUpCountPods(t *testing.T, class, metric string) {
 		target = rpsTarget
 	}
 
-	ctx := SetupSvc(t, class, metric, target, targetUtilization)
+	ctx := SetupSvc(t, test.ObjectNameForTest(t), class, metric, target, targetUtilization)
 	test.EnsureTearDown(t, ctx.Clients(), ctx.Names())
 
 	ctx.t.Log("The autoscaler spins up additional replicas when traffic increases.")
@@ -113,7 +113,7 @@ func TestAutoscaleSustaining(t *testing.T) {
 			// as long as the traffic sustains, despite whether it is switching modes between
 			// normal and panic.
 
-			ctx := SetupSvc(t, autoscaling.KPA, autoscaling.Concurrency, containerConcurrency, targetUtilization,
+			ctx := SetupSvc(t, test.ObjectNameForTest(t), autoscaling.KPA, autoscaling.Concurrency, containerConcurrency, targetUtilization,
 				rtesting.WithConfigAnnotations(map[string]string{
 					autoscaling.MetricAggregationAlgorithmKey: algo,
 				}))
@@ -132,7 +132,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 	// Activator from the request path.
 	t.Parallel()
 
-	ctx := SetupSvc(t, autoscaling.KPA, autoscaling.Concurrency, 10 /* target concurrency*/, targetUtilization,
+	ctx := SetupSvc(t, test.ObjectNameForTest(t), autoscaling.KPA, autoscaling.Concurrency, 10 /* target concurrency*/, targetUtilization,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey:                "7",
 			autoscaling.PanicThresholdPercentageAnnotationKey: "200", // makes panicking rare
@@ -207,7 +207,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 func TestTargetBurstCapacityMinusOne(t *testing.T) {
 	t.Parallel()
 
-	ctx := SetupSvc(t, autoscaling.KPA, autoscaling.Concurrency, 10 /* target concurrency*/, targetUtilization,
+	ctx := SetupSvc(t, test.ObjectNameForTest(t), autoscaling.KPA, autoscaling.Concurrency, 10 /* target concurrency*/, targetUtilization,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 		}))
@@ -233,7 +233,7 @@ func TestTargetBurstCapacityMinusOne(t *testing.T) {
 func TestFastScaleToZero(t *testing.T) {
 	t.Parallel()
 
-	ctx := SetupSvc(t, autoscaling.KPA, autoscaling.Concurrency, containerConcurrency, targetUtilization,
+	ctx := SetupSvc(t, test.ObjectNameForTest(t), autoscaling.KPA, autoscaling.Concurrency, containerConcurrency, targetUtilization,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 			autoscaling.WindowAnnotationKey:    autoscaling.WindowMin.String(),

--- a/test/ha/autoscaler_test.go
+++ b/test/ha/autoscaler_test.go
@@ -47,7 +47,7 @@ const (
 )
 
 func TestAutoscalerHA(t *testing.T) {
-	ctx := e2e.SetupSvc(t, autoscaling.KPA, autoscaling.RPS, target, targetUtilization,
+	ctx := e2e.SetupSvc(t, test.ObjectNameForTest(t), autoscaling.KPA, autoscaling.RPS, target, targetUtilization,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey:    autoscaling.WindowMin.String(), // Make sure we scale to zero quickly.
 			autoscaling.TargetBurstCapacityKey: "-1",

--- a/test/upgrade/autoscaler.go
+++ b/test/upgrade/autoscaler.go
@@ -46,7 +46,7 @@ func AutoscaleSustainingTest() pkgupgrade.BackgroundOperation {
 	return pkgupgrade.NewBackgroundVerification("AutoscaleSustainingTest",
 		func(c pkgupgrade.Context) {
 			// Setup
-			ctx = e2e.SetupSvc(c.T, "autoscale-sus", autoscaling.KPA, autoscaling.Concurrency, containerConcurrency, targetUtilization,
+			ctx = e2e.SetupSvc(c.T, "autoscale-sustaining", autoscaling.KPA, autoscaling.Concurrency, containerConcurrency, targetUtilization,
 				rtesting.WithConfigAnnotations(map[string]string{
 					autoscaling.TargetBurstCapacityKey: "0", // Not let Activator in the path.
 				}))

--- a/test/upgrade/autoscaler.go
+++ b/test/upgrade/autoscaler.go
@@ -66,6 +66,7 @@ func AutoscaleSustainingTest() pkgupgrade.BackgroundOperation {
 				c.T.Error("Error: ", err)
 			}
 			c.T.Cleanup(cancel)
+			c.T.Fail()
 		},
 	)
 }

--- a/test/upgrade/probe.go
+++ b/test/upgrade/probe.go
@@ -61,6 +61,7 @@ func ProbeTest() pkgupgrade.BackgroundOperation {
 			test.EnsureTearDown(c.T, clients, names)
 			test.AssertProberSLO(c.T, prober, *successFraction)
 			c.T.Cleanup(cancel)
+			c.T.Fail()
 		},
 	)
 }

--- a/vendor/knative.dev/pkg/test/logstream/interface.go
+++ b/vendor/knative.dev/pkg/test/logstream/interface.go
@@ -30,11 +30,10 @@ import (
 	logstreamv2 "knative.dev/pkg/test/logstream/v2"
 )
 
-// Canceler is the type of a function returned when a logstream is started to be
-// deferred so that the logstream can be stopped when the test is complete.
 type (
+	// Canceler is the type of function returned when a logstream is started to be
+	// deferred so that the logstream can be stopped when the test is complete.
 	Canceler = logstreamv2.Canceler
-	Callback = logstreamv2.Callback
 )
 
 type ti interface {
@@ -54,31 +53,19 @@ func Start(t ti) Canceler {
 			var err error
 			// handle case when ns contains a csv list
 			namespaces := strings.Split(ns, ",")
-			if sysStream, err = initStream(namespaces, true /*filterLines*/, nil /*podPrefixes*/); err != nil {
+			if sysStream, err = initStream(namespaces); err != nil {
 				t.Error("Error initializing logstream", "error", err)
 			}
 		} else {
-			// Otherwise set up a null stream.
+			// Otherwise, set up a null stream.
 			sysStream = &null{}
 		}
 	})
 
-	return sysStream.Start(t, t.Logf)
+	return sysStream.Start(t)
 }
 
-// StartForUserNamespace begins streaming the logs from custom namespaces.
-// Filtering of log lines is disabled in this case so all lines will be printed
-// throught the provided callback.
-// It returns a Canceler which must be called before the test completes.
-func StartForUserNamespace(t ti, callback Callback, namespace string, podPrefixes ...string) Canceler {
-	userStream, err := initStream([]string{namespace}, false /*filterLines*/, podPrefixes)
-	if err != nil {
-		t.Error("Error initializing logstream", "error", err)
-	}
-	return userStream.Start(t, callback)
-}
-
-func initStream(namespaces []string, filterLines bool, podPrefixes []string) (streamer, error) {
+func initStream(namespaces []string) (streamer, error) {
 	config, err := test.Flags.GetRESTConfig()
 	if err != nil {
 		return &null{}, fmt.Errorf("error loading client config: %w", err)
@@ -89,11 +76,11 @@ func initStream(namespaces []string, filterLines bool, podPrefixes []string) (st
 		return &null{}, fmt.Errorf("error creating kubernetes client: %w", err)
 	}
 
-	return &shim{logstreamv2.FromNamespaces(context.Background(), kc, namespaces, filterLines, podPrefixes)}, nil
+	return &shim{logstreamv2.FromNamespaces(context.Background(), kc, namespaces)}, nil
 }
 
 type streamer interface {
-	Start(t ti, c Callback) Canceler
+	Start(t ti) Canceler
 }
 
 var (
@@ -105,9 +92,9 @@ type shim struct {
 	logstreamv2.Source
 }
 
-func (s *shim) Start(t ti, callback Callback) Canceler {
+func (s *shim) Start(t ti) Canceler {
 	name := helpers.ObjectPrefixForTest(t)
-	canceler, err := s.StartStream(name, callback)
+	canceler, err := s.StartStream(name, t.Logf)
 
 	if err != nil {
 		t.Error("Failed to start logstream", "error", err)

--- a/vendor/knative.dev/pkg/test/logstream/null.go
+++ b/vendor/knative.dev/pkg/test/logstream/null.go
@@ -21,7 +21,7 @@ type null struct{}
 var _ streamer = (*null)(nil)
 
 // Start implements streamer
-func (*null) Start(t ti, callback Callback) Canceler {
+func (*null) Start(t ti) Canceler {
 	t.Log("logstream was requested, but SYSTEM_NAMESPACE was unset.")
 	return func() {}
 }

--- a/vendor/knative.dev/pkg/test/logstream/null.go
+++ b/vendor/knative.dev/pkg/test/logstream/null.go
@@ -21,7 +21,7 @@ type null struct{}
 var _ streamer = (*null)(nil)
 
 // Start implements streamer
-func (*null) Start(t ti) Canceler {
+func (*null) Start(t ti, callback Callback) Canceler {
 	t.Log("logstream was requested, but SYSTEM_NAMESPACE was unset.")
 	return func() {}
 }


### PR DESCRIPTION
This PR depends on https://github.com/knative/pkg/pull/2591 to be merged first

Upgrades tests make the user pods (which have queue-proxy container) restart due to updating the queue-proxy image. There can be temporary errors which disappear in the end. Without log streaming, the logs from user pods that were already shutdown are lost.

This PR pulls changes from knative.dev/pkg related to logstream which is now able to stream logs from user namespaces without filtering individual lines but taking into account only user-specified pods. This is because multiple tests are running withing the same namespace in parallel so we need to define which pods belong the the current test.

I'm sending the changes to knative.dev/pkg in parallel and will update the PR when/if they're merged. Currently the changes are hardcoded in the vendor directory.

Note: Streaming logs from the system namespace has been broken because the upgrade tests use multiple `testing.T` and streaming is ended after the "ContinualTests/Setup" phase is finished. We might fix it later when https://github.com/knative/pkg/issues/2421 is implemented.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Stream logs from user pods during upgrades
* Print the logs on error in the test log.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
