### PR TITLE
WIP: Feature: added PodSpec.HostIPC extension

### DIFF
--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -570,6 +570,9 @@ spec:
                           description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
+                        hostIPC:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
+                          type: boolean
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                           type: string

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -549,6 +549,9 @@ spec:
                   description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                hostIPC:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
+                  type: boolean
                 serviceAccountName:
                   description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                   type: string

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -574,6 +574,9 @@ spec:
                           description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
+                        hostIPC:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
+                          type: boolean
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                           type: string

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -118,6 +118,11 @@ data:
     # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-security-context
     kubernetes.podspec-securitycontext: "disabled"
 
+    # Indicates whether hostIPC support is enabled
+    #
+    # Disabled by default
+    kubernetes.podspec-hostipc: "disabled"
+
     # Indicates whether Kubernetes PriorityClassName support is enabled
     #
     # WARNING: Cannot safely be disabled once enabled.

--- a/hack/schemapatch-config.yaml
+++ b/hack/schemapatch-config.yaml
@@ -65,6 +65,7 @@ k8s.io/api/core/v1.PodSpec:
     - InitContainers
     - NodeSelector
     - PriorityClassName
+    - HostIPC
     - RuntimeClassName
     - SchedulerName
     - SecurityContext
@@ -128,6 +129,12 @@ k8s.io/api/core/v1.PodSpec:
       - kubebuilder:pruning:PreserveUnknownFields
     SecurityContext:
       description: "This is accessible behind a feature flag - kubernetes.podspec-securitycontext"
+      additionalMarkers:
+      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+      - kubebuilder:validation:DropProperties
+      - kubebuilder:pruning:PreserveUnknownFields
+    HostIPC:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-hostipc"
       additionalMarkers:
       # Part of a feature flag - so we want to omit the schema and preserve unknown fields
       - kubebuilder:validation:DropProperties

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -59,6 +59,7 @@ func defaultFeaturesConfig() *Features {
 		PodSpecNodeSelector:              Disabled,
 		PodSpecRuntimeClassName:          Disabled,
 		PodSpecSecurityContext:           Disabled,
+		PodSpecHostIPC:                   Disabled,
 		PodSpecPriorityClassName:         Disabled,
 		PodSpecSchedulerName:             Disabled,
 		ContainerSpecAddCapabilities:     Disabled,
@@ -89,11 +90,13 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 		asFlag("kubernetes.podspec-nodeselector", &nc.PodSpecNodeSelector),
 		asFlag("kubernetes.podspec-runtimeclassname", &nc.PodSpecRuntimeClassName),
 		asFlag("kubernetes.podspec-securitycontext", &nc.PodSpecSecurityContext),
+		asFlag("kubernetes.podspec-hostipc", &nc.PodSpecHostIPC),
 		asFlag("kubernetes.podspec-priorityclassname", &nc.PodSpecPriorityClassName),
 		asFlag("kubernetes.podspec-schedulername", &nc.PodSpecSchedulerName),
 		asFlag("kubernetes.containerspec-addcapabilities", &nc.ContainerSpecAddCapabilities),
 		asFlag("kubernetes.podspec-tolerations", &nc.PodSpecTolerations),
 		asFlag("kubernetes.podspec-volumes-emptydir", &nc.PodSpecVolumesEmptyDir),
+		asFlag("kubernetes.podspec-hostipc", &nc.PodSpecHostIPC),
 		asFlag("kubernetes.podspec-init-containers", &nc.PodSpecInitContainers),
 		asFlag("kubernetes.podspec-persistent-volume-claim", &nc.PodSpecPersistentVolumeClaim),
 		asFlag("kubernetes.podspec-persistent-volume-write", &nc.PodSpecPersistentVolumeWrite),
@@ -123,6 +126,7 @@ type Features struct {
 	PodSpecNodeSelector              Flag
 	PodSpecRuntimeClassName          Flag
 	PodSpecSecurityContext           Flag
+	PodSpecHostIPC                   Flag
 	PodSpecPriorityClassName         Flag
 	PodSpecSchedulerName             Flag
 	ContainerSpecAddCapabilities     Flag

--- a/pkg/apis/config/features_test.go
+++ b/pkg/apis/config/features_test.go
@@ -83,6 +83,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 			"kubernetes.podspec-nodeselector":              "Enabled",
 			"kubernetes.podspec-runtimeclassname":          "Enabled",
 			"kubernetes.podspec-securitycontext":           "Enabled",
+			"kubernetes.podspec-hostipc":                   "Enabled",
 			"kubernetes.podspec-tolerations":               "Enabled",
 			"kubernetes.podspec-priorityclassname":         "Enabled",
 			"kubernetes.podspec-schedulername":             "Enabled",
@@ -323,6 +324,24 @@ func TestFeaturesConfiguration(t *testing.T) {
 		}),
 		data: map[string]string{
 			"kubernetes.podspec-securitycontext": "Disabled",
+		},
+	}, {
+		name:    "security context Allowed",
+		wantErr: false,
+		wantFeatures: defaultWith(&Features{
+			PodSpecSecurityContext: Allowed,
+		}),
+		data: map[string]string{
+			"kubernetes.podspec-hostipc": "Allowed",
+		},
+	}, {
+		name:    "security context disabled",
+		wantErr: false,
+		wantFeatures: defaultWith(&Features{
+			PodSpecSecurityContext: Disabled,
+		}),
+		data: map[string]string{
+			"kubernetes.podspec-hostipc": "Disabled",
 		},
 	}, {
 		name:    "kubernetes.containerspec-addcapabilities Disabled",

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -224,7 +224,9 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	if cfg.Features.PodSpecDNSConfig != config.Disabled {
 		out.DNSConfig = in.DNSConfig
 	}
-
+	if cfg.Features.PodSpecHostIPC != config.Disabled {
+		out.HostIPC = in.HostIPC
+	}
 	// Disallowed fields
 	// This list is unnecessary, but added here for clarity
 	out.RestartPolicy = ""
@@ -233,7 +235,6 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.NodeName = ""
 	out.HostNetwork = false
 	out.HostPID = false
-	out.HostIPC = false
 	out.ShareProcessNamespace = nil
 	out.Hostname = ""
 	out.Subdomain = ""


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Add extension to enable hostIPC in pod spec. This is necessary to run gpu jobs using VGPUs in kserve.
Kserve already allows this spec in InferenceService, but its not copied to pod spec of revision deployment by knative.
This PR enables a new extension in config-features to allow hostIPC to be used.

Related: https://github.com/knative/serving/issues/12830#issue-1196602731

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add feature extension to enable hostIPC in pod specs.
```
