### PR TITLE
[skip-dot-release] [release 1.6] fix CI issue in release branch

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -49,7 +49,7 @@ jobs:
           ${{ runner.os }}-go-
 
     - name: Setup ko
-      uses: imjasonh/setup-ko@v0.4
+      uses: imjasonh/setup-ko@v0.6
       with:
         version: latest-release
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -589,5 +589,5 @@ function run_ytt() {
 
 
 function run_kapp() {
-  run_go_tool github.com/k14s/kapp/cmd/kapp kapp "$@"
+  run_go_tool github.com/vmware-tanzu/carvel-kapp/cmd/kapp kapp "$@"
 }


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

This PR cherry picks two fixes into a single commit (as both are needed for the CI to pass). First one is ko moving to a new repo and thus we need to use a newer version of the github action. Second one is kapp has a new module which needs to be updated.

