### PR TITLE
Fix psp in config manifests 

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -87,9 +87,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.22.9
         - v1.23.6
         - v1.24.0
+        - v1.25.0
 
         ingress:
         - kourier
@@ -109,9 +109,6 @@ jobs:
           # This is attempting to make it a bit clearer what's being tested.
           # See: https://github.com/kubernetes-sigs/kind/releases
           #      https://hub.docker.com/r/kindest/node/tags
-        - k8s-version: v1.22.9
-          kind-version: v0.14.0
-          kind-image-sha: sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
 
         - k8s-version: v1.23.6
           kind-version: v0.14.0
@@ -120,6 +117,10 @@ jobs:
         - k8s-version: v1.24.0
           kind-version: v0.14.0
           kind-image-sha: sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
+
+        - k8s-version: v1.25.0
+          kind-version: v0.15.0
+          kind-image-sha: sha256:428aaa17ec82ccde0131cb2d1ca6547d13cf5fdabcc0bbecf749baa935387cbf
 
         # Disabled due to consistent failures
         # - ingress: gateway_istio
@@ -263,8 +264,7 @@ jobs:
     - name: Install metallb
       shell: bash
       run: |
-        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/namespace.yaml
-        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/metallb.yaml
+        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13/config/manifests/metallb-native.yaml
         kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
         network=$(docker network inspect kind -f "{{(index .IPAM.Config 0).Subnet}}" | cut -d '.' -f1,2)
         cat <<EOF | kubectl apply -f -

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -87,9 +87,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
+        - v1.22.9
         - v1.23.6
         - v1.24.0
-        - v1.25.0
 
         ingress:
         - kourier
@@ -109,6 +109,9 @@ jobs:
           # This is attempting to make it a bit clearer what's being tested.
           # See: https://github.com/kubernetes-sigs/kind/releases
           #      https://hub.docker.com/r/kindest/node/tags
+        - k8s-version: v1.22.9
+          kind-version: v0.14.0
+          kind-image-sha: sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
 
         - k8s-version: v1.23.6
           kind-version: v0.14.0
@@ -117,10 +120,6 @@ jobs:
         - k8s-version: v1.24.0
           kind-version: v0.14.0
           kind-image-sha: sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
-
-        - k8s-version: v1.25.0
-          kind-version: v0.15.0
-          kind-image-sha: sha256:428aaa17ec82ccde0131cb2d1ca6547d13cf5fdabcc0bbecf749baa935387cbf
 
         # Disabled due to consistent failures
         # - ingress: gateway_istio
@@ -264,7 +263,8 @@ jobs:
     - name: Install metallb
       shell: bash
       run: |
-        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13/config/manifests/metallb-native.yaml
+        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/namespace.yaml
+        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/metallb.yaml
         kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
         network=$(docker network inspect kind -f "{{(index .IPAM.Config 0).Subnet}}" | cut -d '.' -f1,2)
         cat <<EOF | kubectl apply -f -

--- a/config/core/deployments/activator.yaml
+++ b/config/core/deployments/activator.yaml
@@ -84,7 +84,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/autoscaler.yaml
+++ b/config/core/deployments/autoscaler.yaml
@@ -93,7 +93,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -85,7 +85,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/domainmapping-controller.yaml
+++ b/config/core/deployments/domainmapping-controller.yaml
@@ -81,7 +81,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/domainmapping-webhook.yaml
+++ b/config/core/deployments/domainmapping-webhook.yaml
@@ -89,7 +89,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -90,7 +90,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/hpa-autoscaling/controller.yaml
+++ b/config/hpa-autoscaling/controller.yaml
@@ -82,7 +82,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -61,6 +61,11 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
         env:
         - name: POD_NAME
           valueFrom:

--- a/config/post-install/storage-version-migration.yaml
+++ b/config/post-install/storage-version-migration.yaml
@@ -58,3 +58,8 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault

--- a/third_party/cert-manager-latest/cert-manager.yaml
+++ b/third_party/cert-manager-latest/cert-manager.yaml
@@ -5160,6 +5160,14 @@ spec:
                 fieldPath: metadata.namespace
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+
       nodeSelector:
         kubernetes.io/os: linux
 ---
@@ -5213,6 +5221,13 @@ spec:
             protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -5288,6 +5303,13 @@ spec:
             failureThreshold: 3
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/third_party/cert-manager-latest/net-certmanager.yaml
+++ b/third_party/cert-manager-latest/net-certmanager.yaml
@@ -216,7 +216,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -320,7 +322,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090

--- a/third_party/contour-latest/contour.yaml
+++ b/third_party/contour-latest/contour.yaml
@@ -4039,6 +4039,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
       restartPolicy: Never
       serviceAccountName: contour-certgen
       securityContext:
@@ -4218,6 +4225,12 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
       dnsPolicy: ClusterFirst
       serviceAccountName: contour
       securityContext:

--- a/third_party/contour-latest/net-contour.yaml
+++ b/third_party/contour-latest/net-contour.yaml
@@ -141,6 +141,8 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
 ---
 

--- a/third_party/gateway-api-latest/net-gateway-api.yaml
+++ b/third_party/gateway-api-latest/net-gateway-api.yaml
@@ -4206,6 +4206,8 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
 
 ---

--- a/third_party/istio-latest/net-istio.yaml
+++ b/third_party/istio-latest/net-istio.yaml
@@ -330,7 +330,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -409,7 +411,13 @@ spec:
             - name: WEBHOOK_NAME
               value: net-istio-webhook
           securityContext:
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090

--- a/third_party/kourier-latest/kourier.yaml
+++ b/third_party/kourier-latest/kourier.yaml
@@ -346,7 +346,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
       restartPolicy: Always
       serviceAccountName: net-kourier
 ---
@@ -444,7 +446,9 @@ spec:
             runAsNonRoot: false
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
             - name: config-volume
               mountPath: /tmp/config


### PR DESCRIPTION
Fixes partially #13308 for podsecuritypolicy (deprecated since 1.21, will be unavailable on 1.25) as we need to support the Pod Security Admission instead which becomes stable in 1.25.

* Running  with knative-serving ns labeled with:
```
  pod-security.kubernetes.io/enforce=restricted \
  pod-security.kubernetes.io/warn=restricted \
  pod-security.kubernetes.io/audit=restricted
```
makes all pods not launching. Errors are as follows on the versions tested 1.23+ (events in the corresponding ns):

> 8s          Warning   FailedCreate        replicaset/autoscaler-99cb65bf               Error creating: pods "autoscaler-99cb65bf-9slvd" is forbidden: violates PodSecurity "restricted:latest": unrestricted capabilities (container "autoscaler" must set securityContext.capabilities.drop=["ALL"]), seccompProfile (pod or container "autoscaler" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")

* Replaces `all` with `ALL` in capabilities section because that is the only acceptable string check [here](https://github.com/kubernetes/kubernetes/blob/6dbec8e25592d47fc8a8269c86d4b5fa838d320b/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted.go#30) and [here](https://github.com/kubernetes/kubernetes/blob/6dbec8e25592d47fc8a8269c86d4b5fa838d320b/staging/src/k8s.io/pod-security-admission/policy/check_capabilities_restricted.go#L94).
* Tested on: Kind v0.15.0 (1.25), v0.14.0(1.24), v0.12.0(v1.23.4)
* Instructions for testing [here](https://gist.github.com/skonto/572cdb1e1372a33da1c376aadd1a5b43).
* TODO: fix third-party projects. Fix queue proxy and user workloads in another PR. This should be tested on a github workflows too.