### PR TITLE
Add log message when internal encryption is enabled

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -166,6 +166,7 @@ func main() {
 	// At this moment activator with TLS does not disable HTTP.
 	// See also https://github.com/knative/serving/issues/12808.
 	if tlsEnabled {
+		logger.Info("Internal Encryption is enabled")
 		caSecret, err := kubeClient.CoreV1().Secrets(system.Namespace()).Get(ctx, netcfg.ServingInternalCertName, metav1.GetOptions{})
 		if err != nil {
 			logger.Fatalw("Failed to get secret", zap.Error(err))
@@ -298,7 +299,7 @@ func main() {
 	// Enable TLS server when internal-encryption is specified.
 	// At this moment activator with TLS does not disable HTTP.
 	// See also https://github.com/knative/serving/issues/12808.
-	if networkConfig.InternalEncryption {
+	if tlsEnabled {
 		secret, err := kubeClient.CoreV1().Secrets(system.Namespace()).Get(ctx, netcfg.ServingInternalCertName, metav1.GetOptions{})
 		if err != nil {
 			logger.Fatalw("failed to get secret", zap.Error(err))


### PR DESCRIPTION
When enabling `internal-encryption`, there is no log message about the configuration
and it is hard to debug when users forget to restat.

This patch adds the log line.