### PR TITLE
Remove kind 1.22 testing, since min-version will be 1.23 in the next release

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -87,8 +87,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.23.6
-        - v1.24.0
+        - v1.23.12
+        - v1.24.6
 
         ingress:
         - kourier
@@ -108,13 +108,13 @@ jobs:
           # This is attempting to make it a bit clearer what's being tested.
           # See: https://github.com/kubernetes-sigs/kind/releases
           #      https://hub.docker.com/r/kindest/node/tags
-        - k8s-version: v1.23.6
+        - k8s-version: v1.23.12
           kind-version: v0.14.0
-          kind-image-sha: sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
+          kind-image-sha: sha256:934835129873881bbfac668e1da74890c749afed16e020cd173b77788841155c
 
-        - k8s-version: v1.24.0
+        - k8s-version: v1.24.6
           kind-version: v0.14.0
-          kind-image-sha: sha256:0866296e693efe1fed79d5e6c7af8df71fc73ae45e3679af05342239cdc5bc8e
+          kind-image-sha: sha256:ec13a9319ee30ab5e842517a9dffdb8e3c0e36151ffdef82b41be537ac124fbc
 
         # Disabled due to consistent failures
         # - ingress: gateway_istio

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -87,7 +87,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.22.9
         - v1.23.6
         - v1.24.0
 
@@ -109,10 +108,6 @@ jobs:
           # This is attempting to make it a bit clearer what's being tested.
           # See: https://github.com/kubernetes-sigs/kind/releases
           #      https://hub.docker.com/r/kindest/node/tags
-        - k8s-version: v1.22.9
-          kind-version: v0.14.0
-          kind-image-sha: sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
-
         - k8s-version: v1.23.6
           kind-version: v0.14.0
           kind-image-sha: sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Remove testing on k8s 1.22 as follow up making min-version 1.23 https://github.com/knative/pkg/pull/2595 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Bump min-version to k8s 1.23, so removing kind 1.22 testing
```
