### PR TITLE
Fix e2e-common.sh script, make it more portable

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -69,9 +69,14 @@ function latest_net_istio_version() {
   curl -L --silent "https://api.github.com/repos/knative/net-istio/releases" | jq --arg major_minor "$major_minor" -r '[.[].tag_name] | map(select(. | startswith($major_minor))) | sort_by( sub("knative-";"") | sub("v";"") | split(".") | map(tonumber) ) | reverse[0]'
 }
 
+# Searches for the latest version for serving
+function latest_serving_version() {
+  curl -L --silent "https://api.github.com/repos/knative/serving/releases" | jq --arg major_minor "" -r '[.[].tag_name] | map(select(. | startswith($major_minor))) | sort_by( sub("knative-";"") | sub("v";"") | split(".") | map(tonumber) ) | reverse[0]'
+}
+
 # Latest serving release. If user does not supply this as a flag, the latest
-# tagged release on the current branch will be used.
-LATEST_SERVING_RELEASE_VERSION=$(latest_version)
+# tagged release will be used.
+LATEST_SERVING_RELEASE_VERSION=$(latest_serving_version)
 
 # Latest net-istio release.
 LATEST_NET_ISTIO_RELEASE_VERSION=$(latest_net_istio_version "$LATEST_SERVING_RELEASE_VERSION")


### PR DESCRIPTION
Signed-off-by: jwcesign <jwcesign@gmail.com>

Fixes none

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* If other repo want to copy and use this `e2e-command.sh` script, it will have error, because the version get function will use `git tag (other repo may not have right tag)`, which is not portable
* Get real release from website is also a better idea, same with how get istio verion.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
none
```
