### PR TITLE
Use new key names for internal encryption secret data

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -177,7 +177,7 @@ func main() {
 			pool = x509.NewCertPool()
 		}
 
-		if ok := pool.AppendCertsFromPEM(caSecret.Data[certificates.SecretCaCertKey]); !ok {
+		if ok := pool.AppendCertsFromPEM(caSecret.Data[certificates.CaCertName]); !ok {
 			logger.Fatalw("Failed to append ca cert to the RootCAs")
 		}
 
@@ -304,7 +304,7 @@ func main() {
 		if err != nil {
 			logger.Fatalw("failed to get secret", zap.Error(err))
 		}
-		cert, err := tls.X509KeyPair(secret.Data[certificates.SecretCertKey], secret.Data[certificates.SecretPKKey])
+		cert, err := tls.X509KeyPair(secret.Data[certificates.CertName], secret.Data[certificates.PrivateKeyName])
 		if err != nil {
 			logger.Fatalw("failed to load certs", zap.Error(err))
 		}

--- a/pkg/queue/sharedmain/main.go
+++ b/pkg/queue/sharedmain/main.go
@@ -67,10 +67,10 @@ const (
 	drainSleepDuration = 30 * time.Second
 
 	// certPath is the path for the server certificate mounted by queue-proxy.
-	certPath = queue.CertDirectory + "/" + certificates.SecretCertKey
+	certPath = queue.CertDirectory + "/" + certificates.CertName
 
 	// keyPath is the path for the server certificate key mounted by queue-proxy.
-	keyPath = queue.CertDirectory + "/" + certificates.SecretPKKey
+	keyPath = queue.CertDirectory + "/" + certificates.PrivateKeyName
 
 	// PodInfoAnnotationsPath is an exported path for the annotations file
 	// This path is used by QP Options (Extensions).

--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -221,10 +221,10 @@ func (c *Reconciler) reconcileSecret(ctx context.Context, rev *v1.Revision) erro
 	}
 
 	// Verify if secret has been added the data.
-	if _, ok := secret.Data[certificates.SecretCertKey]; !ok {
+	if _, ok := secret.Data[certificates.CertName]; !ok {
 		return fmt.Errorf("public cert in the secret is not ready yet")
 	}
-	if _, ok := secret.Data[certificates.SecretPKKey]; !ok {
+	if _, ok := secret.Data[certificates.PrivateKeyName]; !ok {
 		return fmt.Errorf("private key in the secret is not ready yet")
 	}
 


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Uses new key names for cert data, brought in by https://github.com/knative-sandbox/control-protocol/pull/220
* Done in support of https://github.com/knative-sandbox/net-contour/pull/819 to have compatibility with Contour
* Discussion on Slack [here](https://knative.slack.com/archives/CA4DNJ9A4/p1665503042270749)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
N/A
```
