### PR TITLE
Fix path validation when running tests on Windows

### DIFF
--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -628,18 +628,18 @@ func validateVolumeMounts(mounts []corev1.VolumeMount, volumes map[string]corev1
 
 		if vm.MountPath == "" {
 			errs = errs.Also(apis.ErrMissingField("mountPath").ViaIndex(i))
-		} else if reservedPaths.Has(filepath.Clean(vm.MountPath)) {
+		} else if reservedPaths.Has(path.Clean(vm.MountPath)) {
 			errs = errs.Also((&apis.FieldError{
-				Message: fmt.Sprintf("mountPath %q is a reserved path", filepath.Clean(vm.MountPath)),
+				Message: fmt.Sprintf("mountPath %q is a reserved path", path.Clean(vm.MountPath)),
 				Paths:   []string{"mountPath"},
 			}).ViaIndex(i))
-		} else if !filepath.IsAbs(vm.MountPath) {
+		} else if !path.IsAbs(vm.MountPath) {
 			errs = errs.Also(apis.ErrInvalidValue(vm.MountPath, "mountPath").ViaIndex(i))
-		} else if seenMountPath.Has(filepath.Clean(vm.MountPath)) {
+		} else if seenMountPath.Has(path.Clean(vm.MountPath)) {
 			errs = errs.Also(apis.ErrInvalidValue(
 				fmt.Sprintf("%q must be unique", vm.MountPath), "mountPath").ViaIndex(i))
 		}
-		seenMountPath.Insert(filepath.Clean(vm.MountPath))
+		seenMountPath.Insert(path.Clean(vm.MountPath))
 
 		shouldCheckReadOnlyVolume := volumes[vm.Name].EmptyDir == nil && volumes[vm.Name].PersistentVolumeClaim == nil
 		if shouldCheckReadOnlyVolume && !vm.ReadOnly {


### PR DESCRIPTION
I was running the `k8s_validation` tests on my Windows machine, and noticed all the filepath tests failing.
`path/filepath` requests OS-native path handling, but we want to use `path`, because we're validating containers which will
run on Linux, regardless of the host operating system.

## Proposed Changes

* Make file path validation tests pass on Windows.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
