### PR TITLE
Allow setting seccompProfile to enable using restricted security profile

### DIFF
--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -600,12 +600,14 @@ func PodSecurityContextMask(ctx context.Context, in *corev1.PodSecurityContext) 
 	out.RunAsNonRoot = in.RunAsNonRoot
 	out.FSGroup = in.FSGroup
 	out.SupplementalGroups = in.SupplementalGroups
+	out.SeccompProfile = in.SeccompProfile
 
 	// Disallowed
 	// This list is unnecessary, but added here for clarity
 	out.SELinuxOptions = nil
 	out.WindowsOptions = nil
 	out.Sysctls = nil
+	out.FSGroupChangePolicy = nil
 
 	return out
 }
@@ -631,6 +633,9 @@ func SecurityContextMask(ctx context.Context, in *corev1.SecurityContext) *corev
 	// AllowPrivilegeEscalation when unset can behave the same way as true
 	// We do want the ability for folks to set this value to false
 	out.AllowPrivilegeEscalation = in.AllowPrivilegeEscalation
+	// SeccompProfile defaults to "unconstrained", but the safe values are
+	// "RuntimeDefault" or "Localhost" (with localhost path set)
+	out.SeccompProfile = in.SeccompProfile
 
 	// Disallowed
 	// This list is unnecessary, but added here for clarity

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -656,6 +656,9 @@ func TestPodSecurityContextMask(t *testing.T) {
 		RunAsGroup:         ptr.Int64(1),
 		RunAsNonRoot:       ptr.Bool(true),
 		FSGroup:            ptr.Int64(1),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
 
 	want := &corev1.PodSecurityContext{}
@@ -688,6 +691,9 @@ func TestPodSecurityContextMask_FeatureEnabled(t *testing.T) {
 		RunAsGroup:         ptr.Int64(1),
 		RunAsNonRoot:       ptr.Bool(true),
 		FSGroup:            ptr.Int64(1),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
 
 	want := &corev1.PodSecurityContext{
@@ -696,6 +702,9 @@ func TestPodSecurityContextMask_FeatureEnabled(t *testing.T) {
 		RunAsNonRoot:       ptr.Bool(true),
 		FSGroup:            ptr.Int64(1),
 		SupplementalGroups: []int64{1},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
 
 	ctx := config.ToContext(context.Background(),
@@ -728,6 +737,9 @@ func TestSecurityContextMask(t *testing.T) {
 		RunAsNonRoot:             ptr.Bool(true),
 		ReadOnlyRootFilesystem:   ptr.Bool(true),
 		AllowPrivilegeEscalation: ptr.Bool(false),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
 	in := &corev1.SecurityContext{
 		RunAsUser:                ptr.Int64(1),
@@ -739,6 +751,10 @@ func TestSecurityContextMask(t *testing.T) {
 		ReadOnlyRootFilesystem:   ptr.Bool(true),
 		AllowPrivilegeEscalation: ptr.Bool(false),
 		ProcMount:                &mtype,
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+		WindowsOptions: &corev1.WindowsSecurityContextOptions{},
 	}
 
 	got := SecurityContextMask(context.Background(), in)
@@ -767,6 +783,9 @@ func TestSecurityContextMask_FeatureEnabled(t *testing.T) {
 		RunAsNonRoot:             ptr.Bool(true),
 		RunAsUser:                ptr.Int64(1),
 		ReadOnlyRootFilesystem:   ptr.Bool(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
 	in := &corev1.SecurityContext{
 		AllowPrivilegeEscalation: ptr.Bool(false),
@@ -778,6 +797,10 @@ func TestSecurityContextMask_FeatureEnabled(t *testing.T) {
 		RunAsNonRoot:             ptr.Bool(true),
 		RunAsUser:                ptr.Int64(1),
 		SELinuxOptions:           &corev1.SELinuxOptions{},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+		WindowsOptions: &corev1.WindowsSecurityContextOptions{},
 	}
 
 	ctx := config.ToContext(context.Background(),


### PR DESCRIPTION
Fixes #13398

`seccompProfile.type` should only be set to `RuntimeDefault` or `Localhost` in [the `restricted` Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted).
Allow users to set the `seccompProfile` so that they can run Knative user-containers in restricted mode.

Relates to #13376

## Proposed Changes

* Allow users to set `seccompProfile` in PodSecurityContext and SecurityContext

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Services may now set `seccompProfile` in SecurityContext to allow users to comply with the `restricted` Pod Security Standards best-practice
```
