### PR TITLE
Enable emptyDir volumes for Knative Services

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -314,9 +314,6 @@ jobs:
         knative_setup
 
         # Run the tests tagged as e2e on the KinD cluster.
-        # TODO: Remove feature toogle when emptyDir is enabled by default
-        toggle_feature kubernetes.podspec-volumes-emptydir Enabled
-
         echo "SYSTEM_NAMESPACE=$SYSTEM_NAMESPACE" >> $GITHUB_ENV
         echo "GATEWAY_OVERRIDE=$GATEWAY_OVERRIDE" >> $GITHUB_ENV
         echo "GATEWAY_NAMESPACE_OVERRIDE=$GATEWAY_NAMESPACE_OVERRIDE" >> $GITHUB_ENV

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "4d5feafc"
+    knative.dev/example-checksum: "b0b9573d"
 data:
   _example: |-
     ################################
@@ -160,7 +160,7 @@ data:
     # Controls whether volume support for EmptyDir is enabled or not.
     # 1. Enabled: enabling EmptyDir volume support
     # 2. Disabled: disabling EmptyDir volume support
-    kubernetes.podspec-volumes-emptydir: "disabled"
+    kubernetes.podspec-volumes-emptydir: "enabled"
 
     # Controls whether init containers support is enabled or not.
     # 1. Enabled: enabling init containers support

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -63,7 +63,7 @@ func defaultFeaturesConfig() *Features {
 		PodSpecSchedulerName:             Disabled,
 		ContainerSpecAddCapabilities:     Disabled,
 		PodSpecTolerations:               Disabled,
-		PodSpecVolumesEmptyDir:           Disabled,
+		PodSpecVolumesEmptyDir:           Enabled,
 		PodSpecPersistentVolumeClaim:     Disabled,
 		PodSpecPersistentVolumeWrite:     Disabled,
 		QueueProxyMountPodInfo:           Disabled,

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -2316,7 +2316,7 @@ func TestVolumeValidation(t *testing.T) {
 		v: corev1.Volume{
 			Name: "foo",
 		},
-		want: apis.ErrMissingOneOf("secret", "configMap", "projected"),
+		want: apis.ErrMissingOneOf("secret", "configMap", "projected", "emptyDir"),
 	}, {
 		name: "secret volume",
 		v: corev1.Volume{
@@ -2395,7 +2395,7 @@ func TestVolumeValidation(t *testing.T) {
 		v: corev1.Volume{
 			Name: "foo",
 		},
-		want: apis.ErrMissingOneOf("secret", "configMap", "projected"),
+		want: apis.ErrMissingOneOf("secret", "configMap", "projected", "emptyDir"),
 	}, {
 		name: "multiple volume source",
 		v: corev1.Volume{

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -75,14 +75,12 @@ if (( SHORT )); then
 fi
 
 toggle_feature autocreateClusterDomainClaims true config-network || fail_test
-toggle_feature kubernetes.podspec-volumes-emptydir Enabled
 go_test_e2e -timeout=30m \
   ./test/conformance/api/... \
   ./test/conformance/runtime/... \
   ./test/e2e \
   ${parallelism} \
   ${TEST_OPTIONS} || failed=1
-toggle_feature kubernetes.podspec-volumes-emptydir Disabled
 toggle_feature autocreateClusterDomainClaims false config-network || fail_test
 
 toggle_feature tag-header-based-routing Enabled
@@ -113,13 +111,11 @@ kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.ya
 # Run HPA tests
 go_test_e2e -timeout=30m -tags=hpa ./test/e2e ${TEST_OPTIONS} || failed=1
 
-# Run emptyDir, initContainers tests with alpha enabled avoiding any issues with the testing options guard above
+# Run initContainers tests with alpha enabled avoiding any issues with the testing options guard above
 # InitContainers test uses emptyDir.
-toggle_feature kubernetes.podspec-volumes-emptydir Enabled
 toggle_feature kubernetes.podspec-init-containers Enabled
 go_test_e2e -timeout=2m ./test/e2e/initcontainers ${TEST_OPTIONS} || failed=1
 toggle_feature kubernetes.podspec-init-containers Disabled
-toggle_feature kubernetes.podspec-volumes-emptydir Disabled
 
 # RUN PVC tests with default storage class.
 toggle_feature kubernetes.podspec-persistent-volume-claim Enabled

--- a/test/e2e/empty_dir_test.go
+++ b/test/e2e/empty_dir_test.go
@@ -1,0 +1,73 @@
+//go:build e2e
+
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/spoof"
+	. "knative.dev/serving/pkg/testing/v1"
+	"knative.dev/serving/test"
+	v1test "knative.dev/serving/test/v1"
+)
+
+// TestEmptyDir ensure emptyDir volume support works
+func TestEmptyDir(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.Volumes,
+	}
+
+	test.EnsureTearDown(t, clients, &names)
+
+	t.Log("Creating a new Service")
+
+	quantity := resource.MustParse("100M")
+	withVolume := WithVolume("data", "/data", corev1.VolumeSource{
+		EmptyDir: &corev1.EmptyDirVolumeSource{
+			SizeLimit: &quantity,
+		},
+	})
+
+	resources, err := v1test.CreateServiceReady(t, clients, &names, withVolume)
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	url := resources.Route.Status.URL.URL()
+	if _, err := pkgTest.CheckEndpointState(
+		context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		url,
+		spoof.MatchesAllOf(spoof.IsStatusOK, spoof.MatchesBody(test.EmptyDirText)),
+		"EmptyDir Text",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("The endpoint %s for Route %s didn't serve the expected text %q: %v", url, names.Route, test.EmptyDirText, err)
+	}
+}


### PR DESCRIPTION
Part of https://github.com/knative/serving/issues/11664

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

This switches the feature flag to enabled allowing users to
  add emptyDir volumes to their containers.

  This can be useful as a scratch space and for multiple
  containers


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
emptyDir volumes feature flag is now enabled by default
```
