### PR TITLE
bump kind to 1.17 in e2e workflow

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -16,7 +16,7 @@ env:
   REGISTRY_NAME: registry.local
   REGISTRY_PORT: 5000
   KO_DOCKER_REPO: registry.local:5000/knative
-  KIND_VERSION: 0.16.0
+  KIND_VERSION: 0.17.0
   GOTESTSUM_VERSION: 1.7.0
   KAPP_VERSION: 0.46.0
   YTT_VERSION: 0.40.1
@@ -87,9 +87,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.23.12
-        - v1.24.6
-        - v1.25.2
+        - v1.23.13
+        - v1.24.7
+        - v1.25.3
 
         ingress:
         - kourier
@@ -109,17 +109,17 @@ jobs:
           # This is attempting to make it a bit clearer what's being tested.
           # See: https://github.com/kubernetes-sigs/kind/releases
           #      https://hub.docker.com/r/kindest/node/tags
-        - k8s-version: v1.23.12
-          kind-version: v0.16.0
-          kind-image-sha: sha256:934835129873881bbfac668e1da74890c749afed16e020cd173b77788841155c
+        - k8s-version: v1.23.13
+          kind-version: v0.17.0
+          kind-image-sha: sha256:ef453bb7c79f0e3caba88d2067d4196f427794086a7d0df8df4f019d5e336b61
 
-        - k8s-version: v1.24.6
-          kind-version: v0.16.0
-          kind-image-sha: sha256:ec13a9319ee30ab5e842517a9dffdb8e3c0e36151ffdef82b41be537ac124fbc
+        - k8s-version: v1.24.7
+          kind-version: v0.17.0
+          kind-image-sha: sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
 
-        - k8s-version: v1.25.2
-          kind-version: v0.16.0
-          kind-image-sha: sha256:6e0f9005eba4010e364aa1bb25c8d7c64f050f744258eb68c4eb40c284c3c0dd
+        - k8s-version: v1.25.3
+          kind-version: v0.17.0
+          kind-image-sha: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
 
         # Disabled due to consistent failures
         # - ingress: gateway_istio


### PR DESCRIPTION

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* kind-version: v0.17.0
* k8s-version: v1.23.13
* k8s-version: v1.24.7
* k8s-version: v1.25.3

 
