### PR TITLE
Fix unexpanded Webhook rules in YAML manifests

### DIFF
--- a/config/core/webhooks/defaulting.yaml
+++ b/config/core/webhooks/defaulting.yaml
@@ -33,21 +33,100 @@ webhooks:
   rules:
   - apiGroups:
     - autoscaling.internal.knative.dev
-    - networking.internal.knative.dev
-    - serving.knative.dev
     apiVersions:
-    - "*"
+    - v1alpha1
     operations:
     - CREATE
     - UPDATE
-    scope: "*"
     resources:
     - metrics
+    - metrics/status
+    scope: '*'
+  - apiGroups:
+    - autoscaling.internal.knative.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
     - podautoscalers
+    - podautoscalers/status
+    scope: '*'
+  - apiGroups:
+    - networking.internal.knative.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
     - certificates
+    - certificates/status
+    scope: '*'
+  - apiGroups:
+    - networking.internal.knative.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
     - ingresses
+    - ingresses/status
+    scope: '*'
+  - apiGroups:
+    - networking.internal.knative.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
     - serverlessservices
+    - serverlessservices/status
+    scope: '*'
+  - apiGroups:
+    - serving.knative.dev
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
     - configurations
+    - configurations/status
+    scope: '*'
+  - apiGroups:
+    - serving.knative.dev
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
     - revisions
+    - revisions/status
+    scope: '*'
+  - apiGroups:
+    - serving.knative.dev
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
     - routes
+    - routes/status
+    scope: '*'
+  - apiGroups:
+    - serving.knative.dev
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
     - services
+    - services/status
+    scope: '*'

--- a/config/core/webhooks/domainmapping-defaulting.yaml
+++ b/config/core/webhooks/domainmapping-defaulting.yaml
@@ -34,11 +34,22 @@ webhooks:
   - apiGroups:
     - serving.knative.dev
     apiVersions:
-    - "*"
+    - v1alpha1
     operations:
     - CREATE
     - UPDATE
-    scope: "*"
     resources:
     - domainmappings
     - domainmappings/status
+    scope: '*'
+  - apiGroups:
+    - serving.knative.dev
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - domainmappings
+    - domainmappings/status
+    scope: '*'

--- a/config/core/webhooks/domainmapping-validation.yaml
+++ b/config/core/webhooks/domainmapping-validation.yaml
@@ -34,12 +34,24 @@ webhooks:
   - apiGroups:
     - serving.knative.dev
     apiVersions:
-    - "*"
+    - v1alpha1
     operations:
     - CREATE
     - UPDATE
     - DELETE
-    scope: "*"
     resources:
     - domainmappings
     - domainmappings/status
+    scope: '*'
+  - apiGroups:
+    - serving.knative.dev
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - domainmappings
+    - domainmappings/status
+    scope: '*'

--- a/config/core/webhooks/resource-validation.yaml
+++ b/config/core/webhooks/resource-validation.yaml
@@ -33,22 +33,109 @@ webhooks:
   rules:
   - apiGroups:
     - autoscaling.internal.knative.dev
-    - networking.internal.knative.dev
-    - serving.knative.dev
     apiVersions:
-    - "*"
+    - v1alpha1
     operations:
     - CREATE
     - UPDATE
     - DELETE
-    scope: "*"
     resources:
     - metrics
+    - metrics/status
+    scope: '*'
+  - apiGroups:
+    - autoscaling.internal.knative.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
     - podautoscalers
+    - podautoscalers/status
+    scope: '*'
+  - apiGroups:
+    - networking.internal.knative.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
     - certificates
+    - certificates/status
+    scope: '*'
+  - apiGroups:
+    - networking.internal.knative.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
     - ingresses
+    - ingresses/status
+    scope: '*'
+  - apiGroups:
+    - networking.internal.knative.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
     - serverlessservices
+    - serverlessservices/status
+    scope: '*'
+  - apiGroups:
+    - serving.knative.dev
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
     - configurations
+    - configurations/status
+    scope: '*'
+  - apiGroups:
+    - serving.knative.dev
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
     - revisions
+    - revisions/status
+    scope: '*'
+  - apiGroups:
+    - serving.knative.dev
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
     - routes
+    - routes/status
+    scope: '*'
+  - apiGroups:
+    - serving.knative.dev
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
     - services
+    - services/status
+    scope: '*'


### PR DESCRIPTION
Fixes #13449

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* statically configures webhook rules to prevent configuration drift with GitOps and other declarative configuration management strategies.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
