### PR TITLE
Remove controller-managed webhook rules

### DIFF
--- a/config/core/webhooks/defaulting.yaml
+++ b/config/core/webhooks/defaulting.yaml
@@ -30,24 +30,3 @@ webhooks:
   sideEffects: None
   name: webhook.serving.knative.dev
   timeoutSeconds: 10
-  rules:
-  - apiGroups:
-    - autoscaling.internal.knative.dev
-    - networking.internal.knative.dev
-    - serving.knative.dev
-    apiVersions:
-    - "*"
-    operations:
-    - CREATE
-    - UPDATE
-    scope: "*"
-    resources:
-    - metrics
-    - podautoscalers
-    - certificates
-    - ingresses
-    - serverlessservices
-    - configurations
-    - revisions
-    - routes
-    - services

--- a/config/core/webhooks/domainmapping-defaulting.yaml
+++ b/config/core/webhooks/domainmapping-defaulting.yaml
@@ -30,15 +30,3 @@ webhooks:
   sideEffects: None
   name: webhook.domainmapping.serving.knative.dev
   timeoutSeconds: 10
-  rules:
-  - apiGroups:
-    - serving.knative.dev
-    apiVersions:
-    - "*"
-    operations:
-    - CREATE
-    - UPDATE
-    scope: "*"
-    resources:
-    - domainmappings
-    - domainmappings/status

--- a/config/core/webhooks/domainmapping-validation.yaml
+++ b/config/core/webhooks/domainmapping-validation.yaml
@@ -30,16 +30,3 @@ webhooks:
   sideEffects: None
   name: validation.webhook.domainmapping.serving.knative.dev
   timeoutSeconds: 10
-  rules:
-  - apiGroups:
-    - serving.knative.dev
-    apiVersions:
-    - "*"
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    scope: "*"
-    resources:
-    - domainmappings
-    - domainmappings/status

--- a/config/core/webhooks/resource-validation.yaml
+++ b/config/core/webhooks/resource-validation.yaml
@@ -30,25 +30,3 @@ webhooks:
   sideEffects: None
   name: validation.webhook.serving.knative.dev
   timeoutSeconds: 10
-  rules:
-  - apiGroups:
-    - autoscaling.internal.knative.dev
-    - networking.internal.knative.dev
-    - serving.knative.dev
-    apiVersions:
-    - "*"
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    scope: "*"
-    resources:
-    - metrics
-    - podautoscalers
-    - certificates
-    - ingresses
-    - serverlessservices
-    - configurations
-    - revisions
-    - routes
-    - services


### PR DESCRIPTION
Fixes #13449

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* removes webhook rules as part of the defined manifests as these are authoritatively managed by a controller

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
