### PR TITLE
add missing 'component' label to webhook template

### DIFF
--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -33,6 +33,7 @@ spec:
       labels:
         app: webhook
         role: webhook
+        app.kubernetes.io/component: webhook
         app.kubernetes.io/version: devel
         app.kubernetes.io/name: knative-serving
     spec:


### PR DESCRIPTION
## Proposed Changes

* Add missing `app.kubernetes.io/component` label in the webhook template

**Release Note**

```release-note
NONE
```
