### PR TITLE
Rollback defaulting the seccomp profile type

### DIFF
--- a/config/core/deployments/activator.yaml
+++ b/config/core/deployments/activator.yaml
@@ -85,8 +85,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/autoscaler.yaml
+++ b/config/core/deployments/autoscaler.yaml
@@ -94,8 +94,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -86,8 +86,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/domainmapping-controller.yaml
+++ b/config/core/deployments/domainmapping-controller.yaml
@@ -82,8 +82,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/domainmapping-webhook.yaml
+++ b/config/core/deployments/domainmapping-webhook.yaml
@@ -90,8 +90,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -92,8 +92,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/hpa-autoscaling/controller.yaml
+++ b/config/hpa-autoscaling/controller.yaml
@@ -83,8 +83,6 @@ spec:
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
 
         ports:
         - name: metrics

--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -64,8 +64,7 @@ spec:
           capabilities:
             drop:
               - ALL
-          seccompProfile:
-            type: RuntimeDefault
+
         env:
         - name: POD_NAME
           valueFrom:

--- a/config/post-install/storage-version-migration.yaml
+++ b/config/post-install/storage-version-migration.yaml
@@ -61,5 +61,3 @@ spec:
           capabilities:
             drop:
               - ALL
-          seccompProfile:
-            type: RuntimeDefault


### PR DESCRIPTION
This can break upgrades on certain clusters (OpenShift)

We should be able to introduce this change back when we target
K8s 1.25

Fixes: https://github.com/knative/serving/issues/13512

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
N/A
```
