### PR TITLE
Construct and run a multi-controller elector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module knative.dev/serving
 
 go 1.18
 
+replace knative.dev/pkg v0.0.0-20221221230956-4fd6eb8652b7 => github.com/mbaynton/knative-pkg v0.0.0-20221223192904-11256db0dcd4
+
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.1-0.20210609063737-0067dc6dcea2
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -714,6 +714,8 @@ github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpe
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mbaynton/knative-pkg v0.0.0-20221223192904-11256db0dcd4 h1:coTlH+ikQqk2U2selreKbQdYU4fcCHY6gC2OGbd6kZc=
+github.com/mbaynton/knative-pkg v0.0.0-20221223192904-11256db0dcd4/go.mod h1:IeUSNPPUpQnM35SjpnfCx0w5/V2RpEc+nmke6oPwpD0=
 github.com/mbilski/exhaustivestruct v1.2.0/go.mod h1:OeTBVxQWoEmB2J2JCHmXWPJ0aksxSUOUy+nvtVEfzXc=
 github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
 github.com/mgechev/revive v1.1.2/go.mod h1:bnXsMr+ZTH09V5rssEI+jHAZ4z+ZdyhgO/zsy3EhK+0=
@@ -1664,8 +1666,6 @@ knative.dev/hack v0.0.0-20221209013717-b9801b4f5a4d h1:nMp1GE3iwrJzABi4xP0xSVOwa
 knative.dev/hack v0.0.0-20221209013717-b9801b4f5a4d/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
 knative.dev/networking v0.0.0-20221222133558-f1db313cf4bb h1:OvP9PC4X7otWXoefupaSKTnvZyKepSfsL4lsfQl3U6Y=
 knative.dev/networking v0.0.0-20221222133558-f1db313cf4bb/go.mod h1:blbKBxynY31TecbiITn02K+haPoocpracN1rdUJImhI=
-knative.dev/pkg v0.0.0-20221221230956-4fd6eb8652b7 h1:YaO4KgF1Kp8BTi1hxMXDRnvsxCFq/wpotOD3jzrHmzw=
-knative.dev/pkg v0.0.0-20221221230956-4fd6eb8652b7/go.mod h1:IeUSNPPUpQnM35SjpnfCx0w5/V2RpEc+nmke6oPwpD0=
 mvdan.cc/gofumpt v0.1.1/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1280,7 +1280,7 @@ knative.dev/networking/pkg/http/stats
 knative.dev/networking/pkg/ingress
 knative.dev/networking/pkg/k8s
 knative.dev/networking/pkg/prober
-# knative.dev/pkg v0.0.0-20221221230956-4fd6eb8652b7
+# knative.dev/pkg v0.0.0-20221221230956-4fd6eb8652b7 => github.com/mbaynton/knative-pkg v0.0.0-20221223192904-11256db0dcd4
 ## explicit; go 1.18
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate


### PR DESCRIPTION
Fixes #13447 
Depends on https://github.com/knative/pkg/pull/2657

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Build one elector and give it promotion/demotion authority over both the autoscaler's controllers

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix duplicate leadership election in autoscaler causing frequent error logs.
```
