### PR TITLE
Use ubuntu 20.04 for kind e2e tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -39,6 +39,9 @@ jobs:
         mkdir -p ~/artifacts/build
         mkdir -p ~/artifacts/registry
 
+    - name: Check cgroups version
+      run: |
+        stat -fc %T /sys/fs/cgroup/
     - uses: actions/cache@v3
       with:
         path: |

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -39,9 +39,6 @@ jobs:
         mkdir -p ~/artifacts/build
         mkdir -p ~/artifacts/registry
 
-    - name: Check cgroups version
-      run: |
-        stat -fc %T /sys/fs/cgroup/
     - uses: actions/cache@v3
       with:
         path: |
@@ -85,7 +82,7 @@ jobs:
   test:
     name: test
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false # Keep running if one leg fails.
       matrix:
@@ -150,10 +147,10 @@ jobs:
       ENABLE_TLS: ${{ matrix.enable-tls || 0 }}
 
     steps:
-    - name: Set up Go 1.18.x
+    - name: Set up Go 1.19.x
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
 
     - uses: actions/cache@v3
       with:

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Github recently made the `ubuntu-latest` runner label refer to Ubuntu 22.04 (before it had been 20.04). 22.04 uses cgroups v2 by default, whereas 20.04 was still using cgroups v1.

It seems that our cgroups conformance tests were written for cgroups v1, as they fail when using cgroups v2 (tested on both Ubuntu 22.04 and Fedora 36).

As a short-term solution, this patch will keep running the e2e tests on Ubuntu 20.04, until we have a chance to rewrite the conformance tests to work with cgroups v2.