### PR TITLE
Advancing pvc e2e test to beta

### DIFF
--- a/test/e2e/pvc/pvc_test.go
+++ b/test/e2e/pvc/pvc_test.go
@@ -38,8 +38,8 @@ const (
 
 // TestPersistentVolumeClaims tests pvc support.
 func TestPersistentVolumeClaims(t *testing.T) {
-	if !test.ServingFlags.EnableAlphaFeatures {
-		t.Skip("Alpha features not enabled")
+	if !test.ServingFlags.EnableBetaFeatures {
+		t.Skip("Beta features not enabled")
 	}
 	t.Parallel()
 	clients := test.Setup(t)


### PR DESCRIPTION
Part of #12438. Moving the pvc test from e2e and alpha to conformance and beta as the test would be nearly identically, similar to: https://github.com/knative/serving/pull/12167. 

@skonto fyi.