### PR TITLE
[release-1.8] Rebuild using Go 1.19.4 (to address CVEs)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module knative.dev/serving
 
+// This comment was added so CI would trigger a point release with a
+// newer version of Go
+// Fixes: https://groups.google.com/g/golang-announce/c/L_3rmdT0BMU
 go 1.18
 
 require (


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/L_3rmdT0BMU

Prow now uses go1.19.4 since - https://github.com/knative/test-infra/pull/3644