### PR TITLE
Use hashing to compare deployment specs for equality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	golang.org/x/time v0.1.0
 	google.golang.org/api v0.96.0
 	google.golang.org/grpc v1.48.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.25.4
 	k8s.io/apiextensions-apiserver v0.25.4
 	k8s.io/apimachinery v0.25.4
@@ -147,7 +148,6 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo v0.0.0-20221011193443-fad74ee6edd9 // indirect
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/klog/v2 v2.80.2-0.20221028030830-9ae4992afb54 // indirect

--- a/pkg/reconciler/revision/resources/constants.go
+++ b/pkg/reconciler/revision/resources/constants.go
@@ -22,4 +22,9 @@ const (
 
 	// AppLabelKey is the label defining the application's name.
 	AppLabelKey = "app"
+
+	// DeploymentSpecHashAnnotationKey is the annotation used in a Deployment to store the
+	// hash of the client-side generated spec to compare it on reconciliations to determine
+	// if it has changed.
+	DeploymentSpecHashAnnotationKey = "serving.knative.dev/deployment-spec-hash"
 )

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -1587,6 +1587,15 @@ func TestMakeDeployment(t *testing.T) {
 			if err != nil {
 				t.Fatal("Got unexpected error:", err)
 			}
+
+			// Verify that there is a deployment-spec-hash annotation
+			if got.Annotations[DeploymentSpecHashAnnotationKey] == "" {
+				t.Errorf("Response from MakeDeployment misses deployment spec hash")
+			}
+
+			// Remove the annotation because we cannot foresee its expected value
+			delete(got.Annotations, DeploymentSpecHashAnnotationKey)
+
 			if diff := cmp.Diff(test.want, got, quantityComparer); diff != "" {
 				t.Errorf("MakeDeployment (-want, +got) =\n%s", diff)
 			}


### PR DESCRIPTION
Fixes #13204

## Proposed Changes

We are running Knative at scale with thousands of services. We observed that there are frequent updates of the Kubernetes Deployment related to a Knative Revision. Most of these update operations are no-ops caused by an incorrect assumption that a locally built Deployment spec can be compared with the latest spec from the server object. This does not work because the server object has defaulting applied.

The proposed change

* Introduces an annotation `serving.knative.dev/deployment-spec-hash` on the Deployment where the hash of the client-side created Deployment spec is stored.
* In case of updates, this hash is used to compare against the newest version.
* In case they are the same, the update call is omitted.

This saves us around 150k Update operations per day in our largest cluster.

**Release Note**

```release-note
The revision reconciler now omits updates to the Deployment object when there are no changes to be made
```
