### PR TITLE
Add setup script for internal-encryption e2e test

### DIFF
--- a/test/e2e-internal-encryption-tests.sh
+++ b/test/e2e-internal-encryption-tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "TODO(KauzClay): Implement Me!"
+exit 0
+


### PR DESCRIPTION
## Proposed Changes

* test does nothing now, will be implemented in a later PR (https://github.com/knative/serving/pull/13536)
* First in a series of PRs to add an e2e test for Internal Encryption feature. Doing things this way so I can get the infra in place first to make development easier and not block others.
* In support of implementing internal encryption for net-contour here: https://github.com/knative-sandbox/net-contour/pull/819. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
N/A
```
