### PR TITLE
Add missing deployment probes 

### DIFF
--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -89,11 +89,28 @@ spec:
           seccompProfile:
             type: RuntimeDefault
 
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: probes
+            scheme: HTTP
+          periodSeconds: 5
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: probes
+            scheme: HTTP
+          periodSeconds: 5
+          failureThreshold: 5
+
         ports:
         - name: metrics
           containerPort: 9090
         - name: profiling
           containerPort: 8008
+        - name: probes
+          containerPort: 8080
 
 ---
 apiVersion: v1

--- a/config/core/deployments/domainmapping-controller.yaml
+++ b/config/core/deployments/domainmapping-controller.yaml
@@ -85,8 +85,25 @@ spec:
           seccompProfile:
             type: RuntimeDefault
 
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: probes
+            scheme: HTTP
+          periodSeconds: 5
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: probes
+            scheme: HTTP
+          periodSeconds: 5
+          failureThreshold: 5
+
         ports:
         - name: metrics
           containerPort: 9090
         - name: profiling
           containerPort: 8008
+        - name: probes
+          containerPort: 8080

--- a/config/hpa-autoscaling/controller.yaml
+++ b/config/hpa-autoscaling/controller.yaml
@@ -86,11 +86,28 @@ spec:
           seccompProfile:
             type: RuntimeDefault
 
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: probes
+            scheme: HTTP
+          periodSeconds: 5
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: probes
+            scheme: HTTP
+          periodSeconds: 5
+          failureThreshold: 5
+
         ports:
         - name: metrics
           containerPort: 9090
         - name: profiling
           containerPort: 8008
+        - name: probes
+          containerPort: 8080
 
 ---
 apiVersion: v1


### PR DESCRIPTION
partially fixes https://github.com/knative/pkg/issues/1048 for now.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds probes to deployments that don't have them. Webhooks call drain so no need. Activator, autoscaler have already.
* Similar to https://github.com/knative/eventing/pull/6566
* Asked also here https://github.com/knative/serving/issues/13430
* It can be moved to knative.pkg for generic use if we want to.
