### PR TITLE
Don't default Revision values when BYO name is unchanged.

### DIFF
--- a/pkg/apis/serving/v1/configuration_defaults.go
+++ b/pkg/apis/serving/v1/configuration_defaults.go
@@ -25,7 +25,9 @@ import (
 
 type configSpecKey struct{}
 
-// WithConfigurationSpec stores a ConfigurationSpec in the context,
+// WithConfigurationSpec stores a ConfigurationSpec in the context, to allow
+// ConfigurationSpec.SetDefaults to determine whether the update would create a
+// new Revision.
 func WithConfigurationSpec(ctx context.Context, spec *ConfigurationSpec) context.Context {
 	return context.WithValue(ctx, configSpecKey{}, spec)
 }

--- a/pkg/apis/serving/v1/configuration_defaults.go
+++ b/pkg/apis/serving/v1/configuration_defaults.go
@@ -23,33 +23,40 @@ import (
 	"knative.dev/serving/pkg/apis/serving"
 )
 
+type configSpecKey struct{}
+
+// WithConfigurationSpec stores a ConfigurationSpec in the context,
+func WithConfigurationSpec(ctx context.Context, spec *ConfigurationSpec) context.Context {
+	return context.WithValue(ctx, configSpecKey{}, spec)
+}
+
+func previousConfigSpec(ctx context.Context) *ConfigurationSpec {
+	if spec, ok := ctx.Value(configSpecKey{}).(*ConfigurationSpec); ok {
+		return spec
+	}
+	return nil
+}
+
 // SetDefaults implements apis.Defaultable
 func (c *Configuration) SetDefaults(ctx context.Context) {
 	ctx = apis.WithinParent(ctx, c.ObjectMeta)
+
+	var prevSpec *ConfigurationSpec
+	if prev, ok := apis.GetBaseline(ctx).(*Configuration); ok && prev != nil {
+		prevSpec = &prev.Spec
+		ctx = WithConfigurationSpec(ctx, prevSpec)
+	}
+
 	c.Spec.SetDefaults(apis.WithinSpec(ctx))
+
 	if c.GetOwnerReferences() == nil {
-		if apis.IsInUpdate(ctx) {
-			serving.SetUserInfo(ctx, apis.GetBaseline(ctx).(*Configuration).Spec, c.Spec, c)
-		} else {
-			serving.SetUserInfo(ctx, nil, c.Spec, c)
-		}
+		serving.SetUserInfo(ctx, prevSpec, &c.Spec, c)
 	}
 }
 
 // SetDefaults implements apis.Defaultable
 func (cs *ConfigurationSpec) SetDefaults(ctx context.Context) {
-	if apis.IsInUpdate(ctx) {
-		var prev ConfigurationSpec
-		prevConfig, ok := apis.GetBaseline(ctx).(*Configuration)
-		if ok {
-			prev = prevConfig.Spec
-		} else {
-			prevSvc, ok := apis.GetBaseline(ctx).(*Service)
-			if !ok {
-				panic("expected a Configuration or Service baseline")
-			}
-			prev = prevSvc.Spec.ConfigurationSpec
-		}
+	if prev := previousConfigSpec(ctx); prev != nil {
 		newName := cs.Template.ObjectMeta.Name
 		oldName := prev.Template.ObjectMeta.Name
 		if newName != "" && newName == oldName {

--- a/pkg/apis/serving/v1/configuration_defaults.go
+++ b/pkg/apis/serving/v1/configuration_defaults.go
@@ -25,10 +25,10 @@ import (
 
 type configSpecKey struct{}
 
-// WithConfigurationSpec stores a ConfigurationSpec in the context, to allow
-// ConfigurationSpec.SetDefaults to determine whether the update would create a
-// new Revision.
-func WithConfigurationSpec(ctx context.Context, spec *ConfigurationSpec) context.Context {
+// WithPreviousConfigurationSpec stores the pre-update ConfigurationSpec in the
+// context, to allow ConfigurationSpec.SetDefaults to determine whether the
+// update would create a new Revision.
+func WithPreviousConfigurationSpec(ctx context.Context, spec *ConfigurationSpec) context.Context {
 	return context.WithValue(ctx, configSpecKey{}, spec)
 }
 
@@ -46,7 +46,7 @@ func (c *Configuration) SetDefaults(ctx context.Context) {
 	var prevSpec *ConfigurationSpec
 	if prev, ok := apis.GetBaseline(ctx).(*Configuration); ok && prev != nil {
 		prevSpec = &prev.Spec
-		ctx = WithConfigurationSpec(ctx, prevSpec)
+		ctx = WithPreviousConfigurationSpec(ctx, prevSpec)
 	}
 
 	c.Spec.SetDefaults(apis.WithinSpec(ctx))

--- a/pkg/apis/serving/v1/service_defaults.go
+++ b/pkg/apis/serving/v1/service_defaults.go
@@ -26,13 +26,16 @@ import (
 // SetDefaults implements apis.Defaultable
 func (s *Service) SetDefaults(ctx context.Context) {
 	ctx = apis.WithinParent(ctx, s.ObjectMeta)
-	s.Spec.SetDefaults(apis.WithinSpec(ctx))
 
-	if apis.IsInUpdate(ctx) {
-		serving.SetUserInfo(ctx, apis.GetBaseline(ctx).(*Service).Spec, s.Spec, s)
-	} else {
-		serving.SetUserInfo(ctx, nil, s.Spec, s)
+	var prevSpec *ServiceSpec
+	if prev, ok := apis.GetBaseline(ctx).(*Service); ok && prev != nil {
+		prevSpec = &prev.Spec
+		ctx = WithConfigurationSpec(ctx, &prev.Spec.ConfigurationSpec)
 	}
+
+	s.Spec.SetDefaults(apis.WithinSpec(ctx))
+	serving.SetUserInfo(ctx, prevSpec, &s.Spec, s)
+
 }
 
 // SetDefaults implements apis.Defaultable

--- a/pkg/apis/serving/v1/service_defaults.go
+++ b/pkg/apis/serving/v1/service_defaults.go
@@ -30,7 +30,7 @@ func (s *Service) SetDefaults(ctx context.Context) {
 	var prevSpec *ServiceSpec
 	if prev, ok := apis.GetBaseline(ctx).(*Service); ok && prev != nil {
 		prevSpec = &prev.Spec
-		ctx = WithConfigurationSpec(ctx, &prev.Spec.ConfigurationSpec)
+		ctx = WithPreviousConfigurationSpec(ctx, &prev.Spec.ConfigurationSpec)
 	}
 
 	s.Spec.SetDefaults(apis.WithinSpec(ctx))


### PR DESCRIPTION
Fixes #11512

## Proposed Changes

* If updating a Configuration using BYO revision names, do _not_ apply Revision defaulting (as the attempt to create / update the Revision will fail with a "revisions are immutable" error.

I wasn't entirely sure how we wanted to handle the fact that the ConfigurationSpec could be embedded in a Service or a Configuration. If we'd prefer, I can smuggle it into and out of the `context`, which would make it easier for other projects to interact with Configuration validation. I did the current approach first because it was simpler.

**Release Note**

```release-note
* Changes to Pod or Revision-level defaults during Knative upgrades will no longer be attempted (and failed) when supplying your own Revision name.
```
