### PR TITLE
Ensure the autoscaler only has a single elector

### DIFF
--- a/cmd/autoscaler/leaderelection.go
+++ b/cmd/autoscaler/leaderelection.go
@@ -65,7 +65,7 @@ func setupSharedElector(ctx context.Context, controllers []*controller.Impl) (le
 	// MaybeEnqueueBucketKey when we promote buckets
 	noopEnqueue := func(reconciler.Bucket, types.NamespacedName) {}
 
-	el, err := leaderelection.BuildElector(ctx, coalese(reconcilers), queueName, noopEnqueue)
+	el, err := leaderelection.BuildElector(ctx, coalesce(reconcilers), queueName, noopEnqueue)
 
 	if err != nil {
 		return nil, err
@@ -85,7 +85,7 @@ func setupSharedElector(ctx context.Context, controllers []*controller.Impl) (le
 	return el, nil
 }
 
-func coalese(reconcilers []*leaderAware) reconciler.LeaderAware {
+func coalesce(reconcilers []*leaderAware) reconciler.LeaderAware {
 	return &reconciler.LeaderAwareFuncs{
 		PromoteFunc: func(b reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
 			for _, r := range reconcilers {

--- a/cmd/autoscaler/leaderelection.go
+++ b/cmd/autoscaler/leaderelection.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/leaderelection"
+	"knative.dev/pkg/reconciler"
+)
+
+func setupSharedElector(ctx context.Context, controllers []*controller.Impl) (leaderelection.Elector, error) {
+	var (
+		// the elector component config on the ctx will override this value
+		// so we leave this empty
+		queueName string
+
+		// we leave this 'nil' since since we will use each controller's
+		// MaybeEnqueueBucketKey when we promote buckets
+		enq func(reconciler.Bucket, types.NamespacedName)
+	)
+
+	el, err := leaderelection.BuildElector(ctx, leaderAware(controllers), queueName, enq)
+
+	if err != nil {
+		return nil, err
+	}
+
+	electorWithBuckets, ok := el.(leaderelection.ElectorWithInitialBuckets)
+	if !ok || len(electorWithBuckets.InitialBuckets()) == 0 {
+		return el, nil
+	}
+
+	for _, c := range controllers {
+		r, ok := c.Reconciler.(reconciler.LeaderAware)
+		if !ok {
+			continue
+		}
+		for _, b := range electorWithBuckets.InitialBuckets() {
+			// Controller hasn't started yet so need to enqueue anything
+			r.Promote(b, nil)
+		}
+	}
+	return el, nil
+}
+
+func leaderAware(controllers []*controller.Impl) reconciler.LeaderAware {
+	return &reconciler.LeaderAwareFuncs{
+		PromoteFunc: func(b reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+			for _, c := range controllers {
+				if r, ok := c.Reconciler.(reconciler.LeaderAware); ok {
+					c := c
+					r.Promote(b, c.MaybeEnqueueBucketKey)
+				}
+			}
+			return nil
+		},
+		DemoteFunc: func(b reconciler.Bucket) {
+			for _, c := range controllers {
+				if r, ok := c.Reconciler.(reconciler.LeaderAware); ok {
+					r.Demote(b)
+				}
+			}
+		},
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/13447

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Only run a single elector in the autoscaler (kpa and metrics controller share the same buckets)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Autoscaler now runs a single leader election go routine
```
