### PR TITLE
show an error when curling the istio release

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -66,7 +66,7 @@ function latest_net_istio_version() {
   local major_minor
   major_minor=$(echo "$serving_version" | cut -d '.' -f 1,2)
 
-  curl -L --silent "https://api.github.com/repos/knative/net-istio/releases" | jq --arg major_minor "$major_minor" -r '[.[].tag_name] | map(select(. | startswith($major_minor))) | sort_by( sub("knative-";"") | sub("v";"") | split(".") | map(tonumber) ) | reverse[0]'
+  curl -L --show-error --silent "https://api.github.com/repos/knative/net-istio/releases" | jq --arg major_minor "$major_minor" -r '[.[].tag_name] | map(select(. | startswith($major_minor))) | sort_by( sub("knative-";"") | sub("v";"") | split(".") | map(tonumber) ) | reverse[0]'
 }
 
 # Latest serving release. If user does not supply this as a flag, the latest


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Still seeing some failures when curling the istio release - so add some debugging

Will probably change the script to use action's `GITHUB_TOKEN` so the request is authenticated

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
