### PR TITLE
Refactor autoscaler TestContext

### DIFF
--- a/test/e2e/autoscale.go
+++ b/test/e2e/autoscale.go
@@ -66,7 +66,7 @@ type TestContext struct {
 	clients    *test.Clients
 	names      *test.ResourceNames
 	resources  *v1test.ResourceObjects
-	autoscaler AutoscalerOptions
+	autoscaler *AutoscalerOptions
 }
 
 // AutoscalerOptions holds autoscaling parameters for knative service.
@@ -202,7 +202,7 @@ func toPercentageString(f float64) string {
 // SetupSvc creates a new service, with given service options.
 // It returns a TestContext that has resources, K8s clients and other needed
 // data points.
-func SetupSvc(t *testing.T, aopts AutoscalerOptions, topts test.Options, fopts ...rtesting.ServiceOption) *TestContext {
+func SetupSvc(t *testing.T, aopts *AutoscalerOptions, topts test.Options, fopts ...rtesting.ServiceOption) *TestContext {
 	t.Helper()
 	clients := test.Setup(t, topts)
 

--- a/test/e2e/autoscale.go
+++ b/test/e2e/autoscale.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"knative.dev/pkg/test/logging"
-
 	"github.com/davecgh/go-spew/spew"
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 	"golang.org/x/sync/errgroup"
@@ -62,7 +60,6 @@ const (
 // TestContext includes context for autoscaler testing.
 type TestContext struct {
 	t          *testing.T
-	logf       logging.FormatLogger
 	clients    *test.Clients
 	names      *test.ResourceNames
 	resources  *v1test.ResourceObjects
@@ -218,20 +215,18 @@ func SetupSvc(t *testing.T, aopts *AutoscalerOptions, topts test.Options, fopts 
 				autoscaling.MetricAnnotationKey:            aopts.Metric,
 				autoscaling.TargetAnnotationKey:            strconv.Itoa(aopts.Target),
 				autoscaling.TargetUtilizationPercentageKey: toPercentageString(aopts.TargetUtilization),
-			}),
-			rtesting.WithResourceRequirements(corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("30m"),
-					corev1.ResourceMemory: resource.MustParse("20Mi"),
-				},
-			}),
-			rtesting.WithConfigAnnotations(map[string]string{
 				// Reduce the amount of historical data we need before scaling down to account for
 				// the fact that the chaosduck will only let a bucket leader live for ~30s.  This
 				// value still allows the chaosduck to make us failover, but is low enough that we
 				// should not need to survive multiple rounds of chaos in order to scale a
 				// revision down.
 				autoscaling.WindowAnnotationKey: "30s",
+			}),
+			rtesting.WithResourceRequirements(corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("30m"),
+					corev1.ResourceMemory: resource.MustParse("20Mi"),
+				},
 			}),
 		}, fopts...)...)
 	if err != nil {

--- a/test/e2e/autoscale_hpa_test.go
+++ b/test/e2e/autoscale_hpa_test.go
@@ -129,7 +129,6 @@ func setupHPASvc(t *testing.T, metric string, target int) *TestContext {
 
 	return &TestContext{
 		t:           t,
-		logf:        t.Logf,
 		clients:     clients,
 		names:       names,
 		resources:   resources,
@@ -188,7 +187,7 @@ func generateTrafficAtFixedConcurrencyWithLoad(ctx *TestContext, concurrency int
 		return fmt.Errorf("error creating vegeta target: %w", err)
 	}
 
-	ctx.logf("Maintaining %d concurrent requests.", concurrency)
+	ctx.t.Logf("Maintaining %d concurrent requests.", concurrency)
 	return generateTraffic(ctx, attacker, pacer, stopChan, target)
 }
 
@@ -197,7 +196,7 @@ func assertScaleDownToOne(ctx *TestContext) {
 	if err := waitForScaleToOne(ctx.t, deploymentName, ctx.clients); err != nil {
 		ctx.t.Fatalf("Unable to observe the Deployment named %s scaling down: %v", deploymentName, err)
 	}
-	ctx.logf("Wait for all pods to terminate.")
+	ctx.t.Logf("Wait for all pods to terminate.")
 
 	if err := pkgTest.WaitForPodListState(
 		context.Background(),
@@ -212,12 +211,12 @@ func assertScaleDownToOne(ctx *TestContext) {
 		ctx.t.Fatalf("Waiting for Pod.List to have no non-Evicted pods of %q: %v", deploymentName, err)
 	}
 
-	ctx.logf("The Revision should remain ready after scaling to one.")
+	ctx.t.Logf("The Revision should remain ready after scaling to one.")
 	if err := v1test.CheckRevisionState(ctx.clients.ServingClient, ctx.names.Revision, v1test.IsRevisionReady); err != nil {
 		ctx.t.Fatalf("The Revision %s did not stay Ready after scaling down to one: %v", ctx.names.Revision, err)
 	}
 
-	ctx.logf("Scaled down.")
+	ctx.t.Logf("Scaled down.")
 }
 
 func getDepPods(nsPods []corev1.Pod, deploymentName string) []corev1.Pod {

--- a/test/e2e/autoscale_hpa_test.go
+++ b/test/e2e/autoscale_hpa_test.go
@@ -128,12 +128,14 @@ func setupHPASvc(t *testing.T, metric string, target int) *TestContext {
 	}
 
 	return &TestContext{
-		t:           t,
-		clients:     clients,
-		names:       names,
-		resources:   resources,
-		targetValue: target,
-		metric:      metric,
+		t:         t,
+		clients:   clients,
+		names:     names,
+		resources: resources,
+		autoscaler: &AutoscalerOptions{
+			Metric: metric,
+			Target: target,
+		},
 	}
 }
 

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -51,7 +51,7 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 		t.Run("aggregation-"+algo, func(t *testing.T) {
 			t.Parallel()
 			ctx := SetupSvc(t,
-				AutoscalerOptions{
+				&AutoscalerOptions{
 					Class:             autoscaling.KPA,
 					Metric:            autoscaling.Concurrency,
 					Target:            containerConcurrency,
@@ -89,7 +89,7 @@ func runAutoscaleUpCountPods(t *testing.T, class, metric string) {
 	}
 
 	ctx := SetupSvc(t,
-		AutoscalerOptions{
+		&AutoscalerOptions{
 			Class:             class,
 			Metric:            metric,
 			Target:            target,
@@ -131,7 +131,7 @@ func TestAutoscaleSustaining(t *testing.T) {
 			// normal and panic.
 
 			ctx := SetupSvc(t,
-				AutoscalerOptions{
+				&AutoscalerOptions{
 					Class:             autoscaling.KPA,
 					Metric:            autoscaling.Concurrency,
 					Target:            containerConcurrency,
@@ -157,7 +157,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 	t.Parallel()
 
 	ctx := SetupSvc(t,
-		AutoscalerOptions{
+		&AutoscalerOptions{
 			Class:             autoscaling.KPA,
 			Metric:            autoscaling.Concurrency,
 			Target:            10,
@@ -239,7 +239,7 @@ func TestTargetBurstCapacityMinusOne(t *testing.T) {
 	t.Parallel()
 
 	ctx := SetupSvc(t,
-		AutoscalerOptions{
+		&AutoscalerOptions{
 			Class:             autoscaling.KPA,
 			Metric:            autoscaling.Concurrency,
 			Target:            10,
@@ -273,7 +273,7 @@ func TestTargetBurstCapacityZero(t *testing.T) {
 	t.Parallel()
 
 	ctx := SetupSvc(t,
-		AutoscalerOptions{
+		&AutoscalerOptions{
 			Class:             autoscaling.KPA,
 			Metric:            autoscaling.Concurrency,
 			Target:            10,
@@ -311,7 +311,7 @@ func TestFastScaleToZero(t *testing.T) {
 	t.Parallel()
 
 	ctx := SetupSvc(t,
-		AutoscalerOptions{
+		&AutoscalerOptions{
 			Class:             autoscaling.KPA,
 			Metric:            autoscaling.Concurrency,
 			Target:            containerConcurrency,

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -50,7 +50,14 @@ func TestAutoscaleUpDownUp(t *testing.T) {
 		algo := algo
 		t.Run("aggregation-"+algo, func(t *testing.T) {
 			t.Parallel()
-			ctx := SetupSvc(t, autoscaling.KPA, autoscaling.Concurrency, containerConcurrency, targetUtilization, test.Options{},
+			ctx := SetupSvc(t,
+				AutoscalerOptions{
+					Class:             autoscaling.KPA,
+					Metric:            autoscaling.Concurrency,
+					Target:            containerConcurrency,
+					TargetUtilization: targetUtilization,
+				},
+				test.Options{},
 				rtesting.WithConfigAnnotations(map[string]string{
 					autoscaling.MetricAggregationAlgorithmKey: algo,
 				}))
@@ -81,7 +88,15 @@ func runAutoscaleUpCountPods(t *testing.T, class, metric string) {
 		target = rpsTarget
 	}
 
-	ctx := SetupSvc(t, class, metric, target, targetUtilization, test.Options{})
+	ctx := SetupSvc(t,
+		AutoscalerOptions{
+			Class:             class,
+			Metric:            metric,
+			Target:            target,
+			TargetUtilization: targetUtilization,
+		},
+		test.Options{})
+
 	test.EnsureTearDown(t, ctx.Clients(), ctx.Names())
 
 	ctx.t.Log("The autoscaler spins up additional replicas when traffic increases.")
@@ -115,7 +130,14 @@ func TestAutoscaleSustaining(t *testing.T) {
 			// as long as the traffic sustains, despite whether it is switching modes between
 			// normal and panic.
 
-			ctx := SetupSvc(t, autoscaling.KPA, autoscaling.Concurrency, containerConcurrency, targetUtilization, test.Options{},
+			ctx := SetupSvc(t,
+				AutoscalerOptions{
+					Class:             autoscaling.KPA,
+					Metric:            autoscaling.Concurrency,
+					Target:            containerConcurrency,
+					TargetUtilization: targetUtilization,
+				},
+				test.Options{},
 				rtesting.WithConfigAnnotations(map[string]string{
 					autoscaling.MetricAggregationAlgorithmKey: algo,
 				}))
@@ -134,7 +156,14 @@ func TestTargetBurstCapacity(t *testing.T) {
 	// Activator from the request path.
 	t.Parallel()
 
-	ctx := SetupSvc(t, autoscaling.KPA, autoscaling.Concurrency, 10 /* target concurrency*/, targetUtilization, test.Options{},
+	ctx := SetupSvc(t,
+		AutoscalerOptions{
+			Class:             autoscaling.KPA,
+			Metric:            autoscaling.Concurrency,
+			Target:            10,
+			TargetUtilization: targetUtilization,
+		},
+		test.Options{},
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey:                "7",
 			autoscaling.PanicThresholdPercentageAnnotationKey: "200", // makes panicking rare
@@ -209,7 +238,14 @@ func TestTargetBurstCapacity(t *testing.T) {
 func TestTargetBurstCapacityMinusOne(t *testing.T) {
 	t.Parallel()
 
-	ctx := SetupSvc(t, autoscaling.KPA, autoscaling.Concurrency, 10 /* target concurrency*/, targetUtilization, test.Options{},
+	ctx := SetupSvc(t,
+		AutoscalerOptions{
+			Class:             autoscaling.KPA,
+			Metric:            autoscaling.Concurrency,
+			Target:            10,
+			TargetUtilization: targetUtilization,
+		},
+		test.Options{},
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 		}))
@@ -236,7 +272,14 @@ func TestTargetBurstCapacityMinusOne(t *testing.T) {
 func TestTargetBurstCapacityZero(t *testing.T) {
 	t.Parallel()
 
-	ctx := SetupSvc(t, autoscaling.KPA, autoscaling.Concurrency, 10 /* target concurrency*/, targetUtilization, test.Options{},
+	ctx := SetupSvc(t,
+		AutoscalerOptions{
+			Class:             autoscaling.KPA,
+			Metric:            autoscaling.Concurrency,
+			Target:            10,
+			TargetUtilization: targetUtilization,
+		},
+		test.Options{},
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "0",
 			autoscaling.WindowAnnotationKey:    "10s", // scale faster
@@ -267,7 +310,14 @@ func TestTargetBurstCapacityZero(t *testing.T) {
 func TestFastScaleToZero(t *testing.T) {
 	t.Parallel()
 
-	ctx := SetupSvc(t, autoscaling.KPA, autoscaling.Concurrency, containerConcurrency, targetUtilization, test.Options{},
+	ctx := SetupSvc(t,
+		AutoscalerOptions{
+			Class:             autoscaling.KPA,
+			Metric:            autoscaling.Concurrency,
+			Target:            containerConcurrency,
+			TargetUtilization: targetUtilization,
+		},
+		test.Options{},
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
 			autoscaling.WindowAnnotationKey:    autoscaling.WindowMin.String(),

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -383,7 +383,6 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 
 	f(&TestContext{
 		t:         t,
-		logf:      t.Logf,
 		clients:   clients,
 		names:     names,
 		resources: resources,

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -383,10 +383,6 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 		clients:   clients,
 		names:     names,
 		resources: resources,
-		autoscaler: &AutoscalerOptions{
-			TargetUtilization: targetUtilization,
-			Target:            grpcContainerConcurrency,
-		},
 	}, host, url.Hostname())
 }
 
@@ -427,13 +423,18 @@ func TestGRPCStreamingPingViaActivator(t *testing.T) {
 }
 
 func TestGRPCAutoscaleUpDownUp(t *testing.T) {
+	aOpts := &AutoscalerOptions{
+		TargetUtilization: targetUtilization,
+		Target:            grpcContainerConcurrency,
+	}
 	testGRPC(t,
 		func(ctx *TestContext, host, domain string) {
+			ctx.autoscaler = aOpts
 			autoscaleTest(ctx, host, domain)
 		},
 		rtesting.WithConfigAnnotations(map[string]string{
-			autoscaling.TargetUtilizationPercentageKey: toPercentageString(targetUtilization),
-			autoscaling.TargetAnnotationKey:            strconv.Itoa(grpcContainerConcurrency),
+			autoscaling.TargetUtilizationPercentageKey: toPercentageString(aOpts.TargetUtilization),
+			autoscaling.TargetAnnotationKey:            strconv.Itoa(aOpts.Target),
 			autoscaling.TargetBurstCapacityKey:         "-1",
 			autoscaling.WindowAnnotationKey:            "10s",
 		}),
@@ -445,13 +446,18 @@ func TestGRPCAutoscaleUpDownUp(t *testing.T) {
 }
 
 func TestGRPCLoadBalancing(t *testing.T) {
+	aOpts := &AutoscalerOptions{
+		TargetUtilization: targetUtilization,
+		Target:            grpcContainerConcurrency,
+	}
 	testGRPC(t,
 		func(ctx *TestContext, host, domain string) {
+			ctx.autoscaler = aOpts
 			loadBalancingTest(ctx, host, domain)
 		},
 		rtesting.WithConfigAnnotations(map[string]string{
-			autoscaling.TargetUtilizationPercentageKey: toPercentageString(targetUtilization),
-			autoscaling.TargetAnnotationKey:            strconv.Itoa(grpcContainerConcurrency),
+			autoscaling.TargetUtilizationPercentageKey: toPercentageString(aOpts.TargetUtilization),
+			autoscaling.TargetAnnotationKey:            strconv.Itoa(aOpts.Target),
 			autoscaling.MinScaleAnnotationKey:          strconv.Itoa(grpcMinScale),
 			autoscaling.TargetBurstCapacityKey:         "-1",
 		}),

--- a/test/e2e/grpc_test.go
+++ b/test/e2e/grpc_test.go
@@ -385,6 +385,7 @@ func testGRPC(t *testing.T, f grpcTest, fopts ...rtesting.ServiceOption) {
 		resources: resources,
 		autoscaler: &AutoscalerOptions{
 			TargetUtilization: targetUtilization,
+			Target:            grpcContainerConcurrency,
 		},
 	}, host, url.Hostname())
 }

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -273,7 +273,6 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 	// Wait for the activator endpoints to equalize.
 	if err := waitForActivatorEndpoints(&TestContext{
 		t:         t,
-		logf:      t.Logf,
 		resources: resources,
 		clients:   clients,
 	}); err != nil {

--- a/test/e2e/websocket_test.go
+++ b/test/e2e/websocket_test.go
@@ -149,7 +149,6 @@ func TestWebSocketViaActivator(t *testing.T) {
 	// Wait for the activator endpoints to equalize.
 	if err := waitForActivatorEndpoints(&TestContext{
 		t:         t,
-		logf:      t.Logf,
 		resources: resources,
 		clients:   clients,
 	}); err != nil {

--- a/test/ha/autoscaler_test.go
+++ b/test/ha/autoscaler_test.go
@@ -47,7 +47,14 @@ const (
 )
 
 func TestAutoscalerHA(t *testing.T) {
-	ctx := e2e.SetupSvc(t, autoscaling.KPA, autoscaling.RPS, target, targetUtilization, test.Options{},
+	ctx := e2e.SetupSvc(t,
+		e2e.AutoscalerOptions{
+			Class:             autoscaling.KPA,
+			Metric:            autoscaling.RPS,
+			Target:            target,
+			TargetUtilization: targetUtilization,
+		},
+		test.Options{},
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.WindowAnnotationKey:    autoscaling.WindowMin.String(), // Make sure we scale to zero quickly.
 			autoscaling.TargetBurstCapacityKey: "-1",

--- a/test/ha/autoscaler_test.go
+++ b/test/ha/autoscaler_test.go
@@ -48,7 +48,7 @@ const (
 
 func TestAutoscalerHA(t *testing.T) {
 	ctx := e2e.SetupSvc(t,
-		e2e.AutoscalerOptions{
+		&e2e.AutoscalerOptions{
 			Class:             autoscaling.KPA,
 			Metric:            autoscaling.RPS,
 			Target:            target,

--- a/test/upgrade/autoscaler.go
+++ b/test/upgrade/autoscaler.go
@@ -47,7 +47,7 @@ func AutoscaleSustainingTest() pkgupgrade.BackgroundOperation {
 		// Setup
 		func(c pkgupgrade.Context) {
 			ctx = e2e.SetupSvc(c.T,
-				e2e.AutoscalerOptions{
+				&e2e.AutoscalerOptions{
 					Class:             autoscaling.KPA,
 					Metric:            autoscaling.Concurrency,
 					Target:            containerConcurrency,
@@ -91,7 +91,7 @@ func AutoscaleSustainingWithTBCTest() pkgupgrade.BackgroundOperation {
 		// Setup
 		func(c pkgupgrade.Context) {
 			ctx = e2e.SetupSvc(c.T,
-				e2e.AutoscalerOptions{
+				&e2e.AutoscalerOptions{
 					Class:             autoscaling.KPA,
 					Metric:            autoscaling.Concurrency,
 					Target:            containerConcurrency,

--- a/test/upgrade/autoscaler.go
+++ b/test/upgrade/autoscaler.go
@@ -54,10 +54,10 @@ func AutoscaleSustainingTest() pkgupgrade.BackgroundOperation {
 					TargetUtilization: targetUtilization,
 				},
 				test.Options{DisableLogStream: true},
+				rtesting.WithServiceName("autoscale-sustaining"),
 				rtesting.WithConfigAnnotations(map[string]string{
 					autoscaling.TargetBurstCapacityKey: "0", // Not let Activator in the path.
-				}),
-				rtesting.WithServiceName("autoscale-sustaining"))
+				}))
 			if !test.ServingFlags.DisableLogStream {
 				canceler = streamLogs(c.T, ctx.Clients(), ctx.Names().Service)
 			}

--- a/test/upgrade/autoscaler.go
+++ b/test/upgrade/autoscaler.go
@@ -46,12 +46,18 @@ func AutoscaleSustainingTest() pkgupgrade.BackgroundOperation {
 	return pkgupgrade.NewBackgroundVerification("AutoscaleSustainingTest",
 		// Setup
 		func(c pkgupgrade.Context) {
-			ctx = e2e.SetupSvc(c.T, autoscaling.KPA, autoscaling.Concurrency, containerConcurrency, targetUtilization,
+			ctx = e2e.SetupSvc(c.T,
+				e2e.AutoscalerOptions{
+					Class:             autoscaling.KPA,
+					Metric:            autoscaling.Concurrency,
+					Target:            containerConcurrency,
+					TargetUtilization: targetUtilization,
+				},
 				test.Options{DisableLogStream: true},
-				rtesting.WithServiceName("autoscale-sustaining"),
 				rtesting.WithConfigAnnotations(map[string]string{
 					autoscaling.TargetBurstCapacityKey: "0", // Not let Activator in the path.
-				}))
+				}),
+				rtesting.WithServiceName("autoscale-sustaining"))
 			if !test.ServingFlags.DisableLogStream {
 				canceler = streamLogs(c.T, ctx.Clients(), ctx.Names().Service)
 			}
@@ -84,7 +90,13 @@ func AutoscaleSustainingWithTBCTest() pkgupgrade.BackgroundOperation {
 	return pkgupgrade.NewBackgroundVerification("AutoscaleSustainingWithTBCTest",
 		// Setup
 		func(c pkgupgrade.Context) {
-			ctx = e2e.SetupSvc(c.T, autoscaling.KPA, autoscaling.Concurrency, containerConcurrency, targetUtilization,
+			ctx = e2e.SetupSvc(c.T,
+				e2e.AutoscalerOptions{
+					Class:             autoscaling.KPA,
+					Metric:            autoscaling.Concurrency,
+					Target:            containerConcurrency,
+					TargetUtilization: targetUtilization,
+				},
 				test.Options{DisableLogStream: true},
 				rtesting.WithServiceName("autoscale-sus-tbc"),
 				rtesting.WithConfigAnnotations(map[string]string{


### PR DESCRIPTION
This is a follow up to https://github.com/knative/serving/pull/13587

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Reduce the number of parameters to [SetupSvc](https://github.com/knative/serving/compare/main...mgencur:serving-1:refactor_autoscaler_test?expand=1#diff-7ee6d6f89f5bc13c21578c9e4f10e9000770a3bb1759db3ce8ba9cacd9a94812R202) in autoscaling tests and making it more clear what parameters are passed
* Encapsulate Autoscaler parameters in its own type, better readability.
* Removing the testContext.logf as this is now redundant

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
