### PR TITLE
Don't explicitly require a service account key for autotls dns tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	go.uber.org/automaxprocs v1.4.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
-	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65
 	google.golang.org/api v0.70.0
@@ -137,6 +136,7 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
+	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/test/e2e/autotls/config/dnscleanup/main.go
+++ b/test/e2e/autotls/config/dnscleanup/main.go
@@ -34,7 +34,7 @@ func main() {
 		IP:     env.IngressIP,
 		Domain: env.FullHostName,
 	}
-	if err := config.DeleteDNSRecord(record, env.CloudDNSServiceAccountKeyFile, env.CloudDNSProject, env.DNSZone); err != nil {
+	if err := config.DeleteDNSRecord(record, env.CloudDNSProject, env.DNSZone); err != nil {
 		log.Fatal("Failed to setup DNS record: ", err)
 	}
 }

--- a/test/e2e/autotls/config/dnssetup/main.go
+++ b/test/e2e/autotls/config/dnssetup/main.go
@@ -60,7 +60,7 @@ func setupDNSRecord() error {
 
 func createDNSRecord(dnsRecord *config.DNSRecord) error {
 	record := config.MakeRecordSet(dnsRecord)
-	svc, err := config.GetCloudDNSSvc(env.CloudDNSServiceAccountKeyFile)
+	svc, err := config.GetCloudDNSSvc()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
/cc @dprotaso @kvmware 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* We will be removing service accounts keys from tests and require that all code to authenticate with the [Google Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc) instead of a service account key.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
