### PR TITLE
Clean up `go_run` functions

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -592,10 +592,10 @@ function overlay_system_namespace() {
 }
 
 function run_ytt() {
-  go_run github.com/vmware-tanzu/carvel-ytt/cmd/ytt@v0.44.1 ytt "$@"
+  go_run github.com/vmware-tanzu/carvel-ytt/cmd/ytt@v0.44.1 "$@"
 }
 
 
 function run_kapp() {
-  go_run github.com/vmware-tanzu/carvel-kapp/cmd/kapp@v0.54.1 kapp "$@"
+  go_run github.com/vmware-tanzu/carvel-kapp/cmd/kapp@v0.54.1 "$@"
 }

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -592,10 +592,10 @@ function overlay_system_namespace() {
 }
 
 function run_ytt() {
-  run_go_tool github.com/vmware-tanzu/carvel-ytt/cmd/ytt ytt "$@"
+  go_run github.com/vmware-tanzu/carvel-ytt/cmd/ytt@v0.44.1 ytt "$@"
 }
 
 
 function run_kapp() {
-  run_go_tool github.com/vmware-tanzu/carvel-kapp/cmd/kapp kapp "$@"
+  go_run github.com/vmware-tanzu/carvel-kapp/cmd/kapp@v0.44.1 kapp "$@"
 }

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -597,5 +597,5 @@ function run_ytt() {
 
 
 function run_kapp() {
-  go_run github.com/vmware-tanzu/carvel-kapp/cmd/kapp@v0.44.1 kapp "$@"
+  go_run github.com/vmware-tanzu/carvel-kapp/cmd/kapp@v0.54.1 kapp "$@"
 }

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -35,7 +35,7 @@ initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --perf --cluster-versi
 header "Running tests"
 
 function run_kperf() {
-  run_go_tool knative.dev/kperf/cmd/kperf kperf "$@"
+  go_run knative.dev/kperf/cmd/kperf@latest kperf "$@"
 }
 
 mkdir -p "${ARTIFACTS}/kperf"

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -35,7 +35,7 @@ initialize --skip-istio-addon --min-nodes=4 --max-nodes=4 --perf --cluster-versi
 header "Running tests"
 
 function run_kperf() {
-  go_run knative.dev/kperf/cmd/kperf@latest kperf "$@"
+  go_run knative.dev/kperf/cmd/kperf@latest "$@"
 }
 
 mkdir -p "${ARTIFACTS}/kperf"


### PR DESCRIPTION
/cc @dprotaso 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* `run_go_tool` has been deprecated a long time ago in favour of `go_run`.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
