### PR TITLE
Change HTTP01 test DNS entry to *.{custom-domain}

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -86,7 +86,7 @@ function setup_http01_auto_tls() {
   # Rely on the built-in naming (for logstream)
   unset TLS_SERVICE_NAME
   # The full host name of the Knative Service. This is used to configure the DNS record.
-  export AUTO_TLS_TEST_FULL_HOST_NAME="*.${TLS_TEST_NAMESPACE}.${CUSTOM_DOMAIN_SUFFIX}"
+  export AUTO_TLS_TEST_FULL_HOST_NAME="*.${CUSTOM_DOMAIN_SUFFIX}"
 
   kubectl delete kcert --all -n "${TLS_TEST_NAMESPACE}"
 


### PR DESCRIPTION
Part of https://github.com/knative-sandbox/net-certmanager/issues/214#issuecomment-1400611756

Was testing it via https://github.com/knative/serving/pull/13621

This allows `net-certmanager` to use `commonName` of the form `k.{custom-domain}`