### PR TITLE
Adds slack links to CNCF Knative slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/knative/serving)](https://goreportcard.com/report/knative/serving)
 [![Releases](https://img.shields.io/github/release-pre/knative/serving.svg?sort=semver)](https://github.com/knative/serving/releases)
 [![LICENSE](https://img.shields.io/github/license/knative/serving.svg)](https://github.com/knative/serving/blob/main/LICENSE)
-[![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://slack.cncf.io)
+[![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](cloud-native.slack.com/archives/C04LGHDR9K7)
 [![codecov](https://codecov.io/gh/knative/serving/branch/main/graph/badge.svg)](https://codecov.io/gh/knative/serving)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5913/badge)](https://bestpractices.coreinfrastructure.org/projects/5913)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/knative/serving)](https://goreportcard.com/report/knative/serving)
 [![Releases](https://img.shields.io/github/release-pre/knative/serving.svg?sort=semver)](https://github.com/knative/serving/releases)
 [![LICENSE](https://img.shields.io/github/license/knative/serving.svg)](https://github.com/knative/serving/blob/main/LICENSE)
-[![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](cloud-native.slack.com/archives/C04LGHDR9K7)
+[![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://cloud-native.slack.com/archives/C04LGHDR9K7)
 [![codecov](https://codecov.io/gh/knative/serving/branch/main/graph/badge.svg)](https://codecov.io/gh/knative/serving)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5913/badge)](https://bestpractices.coreinfrastructure.org/projects/5913)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/knative/serving)](https://goreportcard.com/report/knative/serving)
 [![Releases](https://img.shields.io/github/release-pre/knative/serving.svg?sort=semver)](https://github.com/knative/serving/releases)
 [![LICENSE](https://img.shields.io/github/license/knative/serving.svg)](https://github.com/knative/serving/blob/main/LICENSE)
-[![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://knative.slack.com)
+[![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://slack.cncf.io)
 [![codecov](https://codecov.io/gh/knative/serving/branch/main/graph/badge.svg)](https://codecov.io/gh/knative/serving)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5913/badge)](https://bestpractices.coreinfrastructure.org/projects/5913)
 

--- a/support/COMMUNITY_CONTACTS.md
+++ b/support/COMMUNITY_CONTACTS.md
@@ -41,7 +41,7 @@ community contact's duty (subject to change) is as followed:
   user to
   [open an usablity issue](https://github.com/knative/ux/issues/new?assignees=&labels=kind%2Ffriction-point&template=friction-point-template.md&title=)
   and to join the channel
-  [#user-experience](https://cloud-native.slack.com/archives/C04LY5G9ED7) to capture
+  [#knative-documentation](https://cloud-native.slack.com/archives/C04LY5G9ED7) to capture
   user feedback.
 - [Triage issues in the serving repo](./TRIAGE.md). Quick links:
   - [Untriaged issues](https://github.com/knative/serving/issues?q=is%3Aissue+is%3Aopen+-label%3Atriage%2Faccepted+-label%3Atriage%2Fneeds-user-input)

--- a/support/COMMUNITY_CONTACTS.md
+++ b/support/COMMUNITY_CONTACTS.md
@@ -36,12 +36,12 @@ community contact's duty (subject to change) is as followed:
   mailing list.
 - Add your self as a member of Slack user group `@serving-help`
 - Check Slack channel
-  [#serving-questions](https://knative.slack.com/archives/C0186KU7STW) for
+  [#knative-serving](https://cloud-native.slack.com/archives/C04LMU0AX60) for
   unanswered questions. Any questions that relates to usability please instruct
   user to
   [open an usablity issue](https://github.com/knative/ux/issues/new?assignees=&labels=kind%2Ffriction-point&template=friction-point-template.md&title=)
   and to join the channel
-  [#user-experience](https://knative.slack.com/archives/C01JBD1LSF3) to capture
+  [#user-experience](https://slack.cncf.io/) to capture
   user feedback.
 - [Triage issues in the serving repo](./TRIAGE.md). Quick links:
   - [Untriaged issues](https://github.com/knative/serving/issues?q=is%3Aissue+is%3Aopen+-label%3Atriage%2Faccepted+-label%3Atriage%2Fneeds-user-input)

--- a/support/COMMUNITY_CONTACTS.md
+++ b/support/COMMUNITY_CONTACTS.md
@@ -41,7 +41,7 @@ community contact's duty (subject to change) is as followed:
   user to
   [open an usablity issue](https://github.com/knative/ux/issues/new?assignees=&labels=kind%2Ffriction-point&template=friction-point-template.md&title=)
   and to join the channel
-  [#user-experience](https://slack.cncf.io/) to capture
+  [#user-experience](https://cloud-native.slack.com/archives/C04LY5G9ED7) to capture
   user feedback.
 - [Triage issues in the serving repo](./TRIAGE.md). Quick links:
   - [Untriaged issues](https://github.com/knative/serving/issues?q=is%3Aissue+is%3Aopen+-label%3Atriage%2Faccepted+-label%3Atriage%2Fneeds-user-input)

--- a/support/support.rotation
+++ b/support/support.rotation
@@ -3,7 +3,7 @@
 # Begin metadata
 #@ title: Serving
 #@ slack: #serving-questions
-#@ slacklink: https://knative.slack.com/archives/C0186KU7STW
+#@ slacklink: https://slack.cncf.io
 
 2021-09-27T01:00:00Z | dprotaso
 2021-10-04T01:00:00Z | carlisia

--- a/support/support.rotation
+++ b/support/support.rotation
@@ -3,7 +3,7 @@
 # Begin metadata
 #@ title: Serving
 #@ slack: #serving-questions
-#@ slacklink: https://slack.cncf.io
+#@ slacklink: https://cloud-native.slack.com/archives/C04LMU0AX60
 
 2021-09-27T01:00:00Z | dprotaso
 2021-10-04T01:00:00Z | carlisia


### PR DESCRIPTION
Signed-off-by: Vishal Choudhary <sendtovishalchoudhary@gmail.com>

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
Adds link to the Knative CNCF Slack Channel

* This PR adds link to the CNCF Knative Slack channel.
* adds link to [#knative-serving](https://cloud-native.slack.com/archives/C04LMU0AX60)
