### PR TITLE
TestAutoscaleSustaining scales to 8 instead of 10

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -322,7 +322,6 @@ jobs:
         gotestsum --format testname -- \
           -race -count=1 -parallel=1 -tags=e2e \
           -timeout=30m \
-          -short \
           ${{ matrix.test-path }} \
           -skip-cleanup-on-fail \
           ${{ matrix.test-flags || '-enable-alpha -enable-beta' }} \

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -115,11 +115,6 @@ func runAutoscaleUpCountPods(t *testing.T, class, metric string) {
 }
 
 func TestAutoscaleSustaining(t *testing.T) {
-	if testing.Short() {
-		// TODO sort out kind issues causing flakiness
-		t.Skip("#13049: Skipped because of excessive flakiness on kind")
-	}
-
 	for _, algo := range []string{
 		autoscaling.MetricAggregationAlgorithmLinear,
 		autoscaling.MetricAggregationAlgorithmWeightedExponential,
@@ -143,7 +138,7 @@ func TestAutoscaleSustaining(t *testing.T) {
 				}))
 			test.EnsureTearDown(t, ctx.Clients(), ctx.Names())
 
-			AssertAutoscaleUpToNumPods(ctx, 1, 10, time.After(2*time.Minute), false /* quick */)
+			AssertAutoscaleUpToNumPods(ctx, 1, 8, time.After(2*time.Minute), false /* quick */)
 		})
 	}
 }


### PR DESCRIPTION
There's an indication that the client node that sends the requests is not able to generate enough load to actually scale the ksvc to 10. The test runs "vegeta" tool and [configures](https://github.com/knative/serving/blob/main/test/e2e/autoscale.go#L170) number of workers to send requests. However, when the client machine doesn't have enough resources (possibly just 2 vCPUs like KinD) or there are also other tests running in parallel the worker threads are not able to generate enough traffic to scale the ksvc as desired.
We ran into this issue downstream as well, there were no errors on Knative (cluster) side. Increasing the CPU resources for the client machine resolved the issue and it doesn't happen anymore.

Fixes #13049

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Decrease the target scale for TestAutoscaleSustaining. Choose a reasonable default that will work in KinD, Prow cluster and also when running the test in a container. 

I was considering leaving the default to 10 for Prow and when the GOMAXPROCS is lower than 10 use 8. But that is just complicated and unnecessary. Also, GOMAXPROCS in itself doesn't work well in a container where it actually returns the number of CPUs of the whole node.

The KinD tests ran 3 times in this PR without issues.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
