### PR TITLE
Enable Gateway API for kind test

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -97,8 +97,7 @@ jobs:
         - kourier-tls
         - istio
         - contour
-        # Disabled due to consistent failures
-        # - gateway_istio
+        - gateway_istio
 
         test-suite:
         - runtime
@@ -122,11 +121,10 @@ jobs:
           kind-version: v0.17.0
           kind-image-sha: sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
 
-        # Disabled due to consistent failures
-        # - ingress: gateway_istio
-        #   ingress-class: gateway-api
-        #   test-flags: -enable-alpha
-        #   namespace-resources: httproute
+        - ingress: gateway_istio
+          ingress-class: gateway-api
+          test-flags: -enable-alpha
+          namespace-resources: httproute
 
         - ingress: contour
           namespace-resources: httpproxy

--- a/test/config/ytt/kind/ingress/gateway-api-kind.yaml
+++ b/test/config/ytt/kind/ingress/gateway-api-kind.yaml
@@ -1,0 +1,8 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("helpers.lib.yaml", "subset")
+
+#@overlay/match by=subset(kind="Service", namespace="istio-system", name="istio-ingressgateway"), expects="1+"
+---
+spec:
+  #@overlay/merge
+  type: LoadBalancer


### PR DESCRIPTION
As far as testing, the KinD test pases - https://github.com/nak3/serving/actions/runs/4190405898 with the current version.

Related to https://github.com/knative-sandbox/net-gateway-api/issues/275


