### PR TITLE
[release-1.8] pull in e2e fixes

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -21,6 +21,7 @@ env:
   KAPP_VERSION: 0.46.0
   YTT_VERSION: 0.40.1
   KO_FLAGS: --platform=linux/amd64
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   build:

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -66,7 +66,13 @@ function latest_net_istio_version() {
   local major_minor
   major_minor=$(echo "$serving_version" | cut -d '.' -f 1,2)
 
-  curl -L --silent "https://api.github.com/repos/knative/net-istio/releases" | jq --arg major_minor "$major_minor" -r '[.[].tag_name] | map(select(. | startswith($major_minor))) | sort_by( sub("knative-";"") | sub("v";"") | split(".") | map(tonumber) ) | reverse[0]'
+  local auth=''
+
+  if [ -n "${GITHUB_TOKEN-}" ]; then
+   auth="-H 'Authorization: Bearer $GITHUB_TOKEN'"
+  fi
+
+  curl -L --show-error --silent $auth "https://api.github.com/repos/knative/net-istio/releases" | jq --arg major_minor "$major_minor" -r '[.[].tag_name] | map(select(. | startswith($major_minor))) | sort_by( sub("knative-";"") | sub("v";"") | split(".") | map(tonumber) ) | reverse[0]'
 }
 
 # Latest serving release. If user does not supply this as a flag, the latest


### PR DESCRIPTION
This pulls in the usage of the GITHUB_TOKEN to fetch istio releases when testing