### PR TITLE
Use `pkgtest.CheckEndpointState` in TestActivationScale instead of raw client

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -401,7 +401,9 @@ func TestActivationScale(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to create request: %v", err)
 	}
-	req.Host = target.Header["Host"][0]
+	if !test.ServingFlags.ResolvableDomain {
+		req.Host = target.Header["Host"][0]
+	}
 	_, err = client.Do(req)
 	if err != nil {
 		t.Errorf("unable to send request to service: %v", err)


### PR DESCRIPTION
On downstream, we are running e2e with `resolvabledomain` enabled and it started getting the following error:

```
--- FAIL: TestActivationScale (69.16s)
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0

goroutine 9093 [running]:
testing.tRunner.func1.2({0x28ac7e0, 0xc00083b248})
        /usr/local/go/src/testing/testing.go:1389 +0x366
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1392 +0x5d2
panic({0x28ac7e0, 0xc00083b248})
        /usr/local/go/src/runtime/panic.go:844 +0x258
knative.dev/serving/test/e2e.TestActivationScale(0xc000c7b860)
        /go/src/knative.dev/serving/test/e2e/autoscale_test.go:404 +0xdd2
testing.tRunner(0xc000c7b860, 0x2abc0e8)
        /usr/local/go/src/testing/testing.go:1439 +0x214
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1486 +0x725
```

The error was caused because `getVegetaTarget()` does not set `Header` in `vegeta.Target` but TestActivationScale accesses to the `target.Header["Host"][0]`.

This patch fixes it.

/cc @psschwei @dprotaso @skonto  @ReToCode 