### PR TITLE
Do not use deprecated func `NewConfigFromConfigMap` in `deprecated_config.go`

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"knative.dev/control-protocol/pkg/certificates"
-	network "knative.dev/networking/pkg"
 	netcfg "knative.dev/networking/pkg/config"
 	netprobe "knative.dev/networking/pkg/http/probe"
 	"knative.dev/pkg/configmap"
@@ -154,7 +153,7 @@ func main() {
 	if err != nil {
 		logger.Fatalw("Failed to fetch network config", zap.Error(err))
 	}
-	networkConfig, err := network.NewConfigFromConfigMap(networkCM)
+	networkConfig, err := netcfg.NewConfigFromMap(networkCM.Data)
 	if err != nil {
 		logger.Fatalw("Failed to construct network config", zap.Error(err))
 	}


### PR DESCRIPTION
Although `NewConfigFromConfigMap` is not marked, it is a function in `deprecated_config.go`.
https://github.com/knative/networking/pull/787 is making as deprecated.

This patch changes to use a func in `knative.dev/networking/pkg/config`, instead.

/cc @dprotaso 