### PR TITLE
Deployment probe fixes

### DIFF
--- a/cmd/domain-mapping-webhook/main.go
+++ b/cmd/domain-mapping-webhook/main.go
@@ -98,7 +98,7 @@ func main() {
 		SecretName:  "domainmapping-webhook-certs",
 	})
 
-	sharedmain.WebhookMainWithContext(ctx, "domainmapping-webhook",
+	sharedmain.WebhookMainWithContext(sharedmain.WithHealthProbesDisabled(ctx), "domainmapping-webhook",
 		certificates.NewController,
 		newDefaultingAdmissionController,
 		newValidatingAdmissionController,

--- a/cmd/domain-mapping-webhook/main.go
+++ b/cmd/domain-mapping-webhook/main.go
@@ -98,7 +98,8 @@ func main() {
 		SecretName:  "domainmapping-webhook-certs",
 	})
 
-	sharedmain.WebhookMainWithContext(sharedmain.WithHealthProbesDisabled(ctx), "domainmapping-webhook",
+	ctx = sharedmain.WithHealthProbesDisabled(ctx)
+	sharedmain.WebhookMainWithContext(ctx, "domainmapping-webhook",
 		certificates.NewController,
 		newDefaultingAdmissionController,
 		newValidatingAdmissionController,

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -163,7 +163,7 @@ func main() {
 		SecretName:  "webhook-certs",
 	})
 
-	sharedmain.WebhookMainWithContext(ctx, "webhook",
+	sharedmain.WebhookMainWithContext(sharedmain.WithHealthProbesDisabled(ctx), "webhook",
 		certificates.NewController,
 		newDefaultingAdmissionController,
 		newValidationAdmissionController,

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -163,7 +163,8 @@ func main() {
 		SecretName:  "webhook-certs",
 	})
 
-	sharedmain.WebhookMainWithContext(sharedmain.WithHealthProbesDisabled(ctx), "webhook",
+	ctx = sharedmain.WithHealthProbesDisabled(ctx)
+	sharedmain.WebhookMainWithContext(ctx, "webhook",
 		certificates.NewController,
 		newDefaultingAdmissionController,
 		newValidationAdmissionController,

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -95,14 +95,14 @@ spec:
             port: probes
             scheme: HTTP
           periodSeconds: 5
-          failureThreshold: 5
+          failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /readiness
             port: probes
             scheme: HTTP
           periodSeconds: 5
-          failureThreshold: 5
+          failureThreshold: 6
 
         ports:
         - name: metrics

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -95,14 +95,14 @@ spec:
             port: probes
             scheme: HTTP
           periodSeconds: 5
-          failureThreshold: 3
+          failureThreshold: 6
         readinessProbe:
           httpGet:
             path: /readiness
             port: probes
             scheme: HTTP
           periodSeconds: 5
-          failureThreshold: 6
+          failureThreshold: 3
 
         ports:
         - name: metrics

--- a/config/core/deployments/domainmapping-controller.yaml
+++ b/config/core/deployments/domainmapping-controller.yaml
@@ -91,14 +91,14 @@ spec:
             port: probes
             scheme: HTTP
           periodSeconds: 5
-          failureThreshold: 5
+          failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /readiness
             port: probes
             scheme: HTTP
           periodSeconds: 5
-          failureThreshold: 5
+          failureThreshold: 6
 
         ports:
         - name: metrics

--- a/config/core/deployments/domainmapping-controller.yaml
+++ b/config/core/deployments/domainmapping-controller.yaml
@@ -91,14 +91,14 @@ spec:
             port: probes
             scheme: HTTP
           periodSeconds: 5
-          failureThreshold: 3
+          failureThreshold: 6
         readinessProbe:
           httpGet:
             path: /readiness
             port: probes
             scheme: HTTP
           periodSeconds: 5
-          failureThreshold: 6
+          failureThreshold: 3
 
         ports:
         - name: metrics

--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -46,7 +46,6 @@ spec:
         readinessProbe:
           httpGet:
             port: 8080
-          failureThreshold: 3
         livenessProbe:
           httpGet:
             port: 8080

--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -46,6 +46,7 @@ spec:
         readinessProbe:
           httpGet:
             port: 8080
+          failureThreshold: 3
         livenessProbe:
           httpGet:
             port: 8080


### PR DESCRIPTION
* In https://github.com/knative/serving/pull/13563 we added defaults probes but some need to be adjusted to avoid bugs like https://github.com/knative/serving/issues/9077.
* In https://github.com/knative/pkg/pull/2671 healthchecks were added to sharedmain that are on by default. For certain deployments like webhooks these need to be disabled because we specify our own healthchecks on a different port and with different settings.

