### PR TITLE
Change minimum TLS version to 1.3

### DIFF
--- a/pkg/reconciler/revision/resolve.go
+++ b/pkg/reconciler/revision/resolve.go
@@ -64,7 +64,7 @@ func newResolverTransport(path string, maxIdleConns, maxIdleConnsPerHost int) (*
 	transport.MaxIdleConns = maxIdleConns
 	transport.MaxIdleConnsPerHost = maxIdleConnsPerHost
 	transport.TLSClientConfig = &tls.Config{
-		MinVersion: tls.VersionTLS12,
+		MinVersion: tls.VersionTLS13,
 		RootCAs:    pool,
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Change minimum TLS version (from 1.2 to 1.3) for tag to digest resolution 

TLS 1.3 comes with numerous enhancements, such as a quicker TLS handshake and more secure cipher suites.

**Release Note**

```release-note
* Controller uses TLS 1.3 as the minimum version when communicating with image registries for tag to digest resolution
```