### PR TITLE
add support for downwardAPI in projected volumes

### DIFF
--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -707,6 +707,59 @@ spec:
                                               description: optional specify whether the ConfigMap or its keys must be defined
                                               type: boolean
                                           x-kubernetes-map-type: atomic
+                                        downwardAPI:
+                                          description: downwardAPI information about the downwardAPI data to project
+                                          type: object
+                                          properties:
+                                            items:
+                                              description: Items is a list of DownwardAPIVolume file
+                                              type: array
+                                              items:
+                                                description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                type: object
+                                                required:
+                                                  - path
+                                                properties:
+                                                  fieldRef:
+                                                    description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                    type: object
+                                                    required:
+                                                      - fieldPath
+                                                    properties:
+                                                      apiVersion:
+                                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                        type: string
+                                                      fieldPath:
+                                                        description: Path of the field to select in the specified API version.
+                                                        type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    type: integer
+                                                    format: int32
+                                                  path:
+                                                    description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                    type: object
+                                                    required:
+                                                      - resource
+                                                    properties:
+                                                      containerName:
+                                                        description: 'Container name: required for volumes, optional for env vars'
+                                                        type: string
+                                                      divisor:
+                                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        description: 'Required: resource to select'
+                                                        type: string
+                                                    x-kubernetes-map-type: atomic
                                         secret:
                                           description: secret information about the secret data to project
                                           type: object

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -686,6 +686,59 @@ spec:
                                       description: optional specify whether the ConfigMap or its keys must be defined
                                       type: boolean
                                   x-kubernetes-map-type: atomic
+                                downwardAPI:
+                                  description: downwardAPI information about the downwardAPI data to project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: Items is a list of DownwardAPIVolume file
+                                      type: array
+                                      items:
+                                        description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                        type: object
+                                        required:
+                                          - path
+                                        properties:
+                                          fieldRef:
+                                            description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                            type: object
+                                            required:
+                                              - fieldPath
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to select in the specified API version.
+                                                type: string
+                                            x-kubernetes-map-type: atomic
+                                          mode:
+                                            description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                            type: string
+                                          resourceFieldRef:
+                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                            type: object
+                                            required:
+                                              - resource
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to select'
+                                                type: string
+                                            x-kubernetes-map-type: atomic
                                 secret:
                                   description: secret information about the secret data to project
                                   type: object

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -711,6 +711,59 @@ spec:
                                               description: optional specify whether the ConfigMap or its keys must be defined
                                               type: boolean
                                           x-kubernetes-map-type: atomic
+                                        downwardAPI:
+                                          description: downwardAPI information about the downwardAPI data to project
+                                          type: object
+                                          properties:
+                                            items:
+                                              description: Items is a list of DownwardAPIVolume file
+                                              type: array
+                                              items:
+                                                description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                type: object
+                                                required:
+                                                  - path
+                                                properties:
+                                                  fieldRef:
+                                                    description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                    type: object
+                                                    required:
+                                                      - fieldPath
+                                                    properties:
+                                                      apiVersion:
+                                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                        type: string
+                                                      fieldPath:
+                                                        description: Path of the field to select in the specified API version.
+                                                        type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    type: integer
+                                                    format: int32
+                                                  path:
+                                                    description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                    type: object
+                                                    required:
+                                                      - resource
+                                                    properties:
+                                                      containerName:
+                                                        description: 'Container name: required for volumes, optional for env vars'
+                                                        type: string
+                                                      divisor:
+                                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        description: 'Required: resource to select'
+                                                        type: string
+                                                    x-kubernetes-map-type: atomic
                                         secret:
                                           description: secret information about the secret data to project
                                           type: object

--- a/hack/schemapatch-config.yaml
+++ b/hack/schemapatch-config.yaml
@@ -29,6 +29,7 @@ k8s.io/api/core/v1.VolumeProjection:
     - Secret
     - ConfigMap
     - ServiceAccountToken
+    - DownwardAPI
 k8s.io/api/core/v1.ConfigMapProjection:
   fieldMask:
     - LocalObjectReference

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -86,9 +86,8 @@ func VolumeProjectionMask(in *corev1.VolumeProjection) *corev1.VolumeProjection 
 	out.ConfigMap = in.ConfigMap
 	out.ServiceAccountToken = in.ServiceAccountToken
 
-	// Disallowed fields
-	// This list is unnecessary, but added here for clarity
-	out.DownwardAPI = nil
+	// TODO(KauzClay): Should this be behind a feature flag like EmptyDir?
+	out.DownwardAPI = in.DownwardAPI
 
 	return out
 }
@@ -143,6 +142,40 @@ func ServiceAccountTokenProjectionMask(in *corev1.ServiceAccountTokenProjection)
 		ExpirationSeconds: in.ExpirationSeconds,
 		Path:              in.Path,
 	}
+
+	return out
+}
+
+// DownwardAPIProjectionMask performs a _shallow_ copy of the Kubernetes DownwardAPIProjection
+// object to a new Kubernetes DownwardAPIProjection object bringing over only the fields allowed
+// in the Knative API. This does not validate the contents or the bounds of the provided fields.
+func DownwardAPIProjectionMask(in *corev1.DownwardAPIProjection) *corev1.DownwardAPIProjection {
+	if in == nil {
+		return nil
+	}
+
+	out := new(corev1.DownwardAPIProjection)
+
+	out.Items = append(out.Items, in.Items...)
+
+	return out
+}
+
+// DownwardAPIVolumeFileMask performs a _shallow_ copy of the Kubernetes DownwardAPIVolumeFileMask
+// object to a new Kubernetes DownwardAPIVolumeFileMask object bringing over only the fields allowed
+// in the Knative API. This does not validate the contents or the bounds of the provided fields.
+func DownwardAPIVolumeFileMask(in *corev1.DownwardAPIVolumeFile) *corev1.DownwardAPIVolumeFile {
+	if in == nil {
+		return nil
+	}
+
+	out := new(corev1.DownwardAPIVolumeFile)
+
+	// Allowed fields
+	out.FieldRef = in.FieldRef
+	out.ResourceFieldRef = in.ResourceFieldRef
+	out.Path = in.Path
+	out.Mode = in.Mode
 
 	return out
 }

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -129,11 +129,11 @@ func TestVolumeProjectionMask(t *testing.T) {
 	if diff, err := kmp.SafeDiff(want, got); err != nil {
 		t.Error("Got error comparing output, err =", err)
 	} else if diff != "" {
-		t.Error("VolumeSourceMask (-want, +got):", diff)
+		t.Error("VolumeProjectionMask (-want, +got):", diff)
 	}
 
 	if got = VolumeProjectionMask(nil); got != nil {
-		t.Errorf("VolumeSourceMask(nil) = %v, want: nil", got)
+		t.Errorf("VolumeProjectionMask(nil) = %v, want: nil", got)
 	}
 }
 

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -79,6 +79,64 @@ func TestVolumeSourceMask(t *testing.T) {
 	}
 }
 
+func TestVolumeProjectionMask(t *testing.T) {
+	want := &corev1.VolumeProjection{
+		DownwardAPI: &corev1.DownwardAPIProjection{
+			Items: []corev1.DownwardAPIVolumeFile{
+				{
+					Path: "labels",
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.labels",
+					},
+				},
+				{
+					Path: "cpu_limit",
+					ResourceFieldRef: &corev1.ResourceFieldSelector{
+						ContainerName: "bar",
+						Resource:      "limits.cpu",
+					},
+				},
+			},
+		},
+	}
+
+	in := &corev1.VolumeProjection{
+		DownwardAPI: &corev1.DownwardAPIProjection{
+			Items: []corev1.DownwardAPIVolumeFile{
+				{
+					Path: "labels",
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.labels",
+					},
+				},
+				{
+					Path: "cpu_limit",
+					ResourceFieldRef: &corev1.ResourceFieldSelector{
+						ContainerName: "bar",
+						Resource:      "limits.cpu",
+					},
+				},
+			},
+		},
+	}
+
+	got := VolumeProjectionMask(in)
+
+	if &want == &got {
+		t.Error("Input and output share addresses. Want different addresses")
+	}
+
+	if diff, err := kmp.SafeDiff(want, got); err != nil {
+		t.Error("Got error comparing output, err =", err)
+	} else if diff != "" {
+		t.Error("VolumeSourceMask (-want, +got):", diff)
+	}
+
+	if got = VolumeProjectionMask(nil); got != nil {
+		t.Errorf("VolumeSourceMask(nil) = %v, want: nil", got)
+	}
+}
+
 func TestPodSpecMask(t *testing.T) {
 	want := &corev1.PodSpec{
 		ServiceAccountName: "default",

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -196,8 +196,12 @@ func validateProjectedVolumeSource(vp corev1.VolumeProjection) *apis.FieldError 
 		specified = append(specified, "serviceAccountToken")
 		errs = errs.Also(validateServiceAccountTokenProjection(vp.ServiceAccountToken).ViaField("serviceAccountToken"))
 	}
+	if vp.DownwardAPI != nil {
+		specified = append(specified, "downwardAPI")
+		errs = errs.Also(validateDownwardAPIProjection(vp.DownwardAPI).ViaField("downwardAPI"))
+	}
 	if len(specified) == 0 {
-		errs = errs.Also(apis.ErrMissingOneOf("secret", "configMap", "serviceAccountToken"))
+		errs = errs.Also(apis.ErrMissingOneOf("secret", "configMap", "serviceAccountToken", "downwardAPI"))
 	} else if len(specified) > 1 {
 		errs = errs.Also(apis.ErrMultipleOneOf(specified...))
 	}
@@ -234,6 +238,28 @@ func validateServiceAccountTokenProjection(sp *corev1.ServiceAccountTokenProject
 	errs := apis.CheckDisallowedFields(*sp, *ServiceAccountTokenProjectionMask(sp))
 	// Audience & ExpirationSeconds are optional
 	if sp.Path == "" {
+		errs = errs.Also(apis.ErrMissingField("path"))
+	}
+	return errs
+}
+
+func validateDownwardAPIProjection(dapi *corev1.DownwardAPIProjection) *apis.FieldError {
+	errs := apis.CheckDisallowedFields(*dapi, *DownwardAPIProjectionMask(dapi))
+	for i, item := range dapi.Items {
+		errs = errs.Also(validateDownwardAPIVolumeFile(&item).ViaFieldIndex("items", i))
+	}
+	return errs
+}
+
+func validateDownwardAPIVolumeFile(vf *corev1.DownwardAPIVolumeFile) *apis.FieldError {
+	errs := apis.CheckDisallowedFields(*vf, *DownwardAPIVolumeFileMask(vf))
+	if vf.FieldRef == nil && vf.ResourceFieldRef == nil {
+		errs = errs.Also(apis.ErrMissingOneOf("fieldRef", "resourceFieldRef"))
+	}
+	if vf.FieldRef != nil && vf.ResourceFieldRef != nil {
+		errs = errs.Also(apis.ErrGeneric("Within a single item, cannot set both", "resourceFieldRef", "fieldRef"))
+	}
+	if vf.Path == "" {
 		errs = errs.Also(apis.ErrMissingField("path"))
 	}
 	return errs

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -245,8 +245,8 @@ func validateServiceAccountTokenProjection(sp *corev1.ServiceAccountTokenProject
 
 func validateDownwardAPIProjection(dapi *corev1.DownwardAPIProjection) *apis.FieldError {
 	errs := apis.CheckDisallowedFields(*dapi, *DownwardAPIProjectionMask(dapi))
-	for i, item := range dapi.Items {
-		errs = errs.Also(validateDownwardAPIVolumeFile(&item).ViaFieldIndex("items", i))
+	for i := range dapi.Items {
+		errs = errs.Also(validateDownwardAPIVolumeFile(&dapi.Items[i]).ViaFieldIndex("items", i))
 	}
 	return errs
 }


### PR DESCRIPTION
Fixes #4190 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds complete support for projectedVolumes
* Old implementation did not support downwardAPI

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adds support for downwardAPI sources in projected volumes on Knative Services
```
