### PR TITLE
[WIP] Change min and max TLS version to v1.3 for internal encryption (between Ingress to Activator)

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -285,7 +285,8 @@ func main() {
 		name, server := "https", pkgnet.NewServer(":"+strconv.Itoa(networking.BackendHTTPSPort), ah)
 		go func(name string, s *http.Server) {
 			s.TLSConfig = &tls.Config{
-				MinVersion:     tls.VersionTLS12,
+				MinVersion:     tls.VersionTLS13,
+				MaxVersion:     tls.VersionTLS13,
 				GetCertificate: certCache.GetCertificate,
 			}
 			// Don't forward ErrServerClosed as that indicates we're already shutting down.

--- a/pkg/http/proxy_test.go
+++ b/pkg/http/proxy_test.go
@@ -130,7 +130,8 @@ func TestNewHeaderPruningProxyHTTPS(t *testing.T) {
 	rootCAs := x509.NewCertPool()
 	rootCAs.AddCert(server.Certificate())
 	tlsConf := &tls.Config{
-		MinVersion: tls.VersionTLS12,
+		MinVersion: tls.VersionTLS13,
+		MaxVersion: tls.VersionTLS13,
 		RootCAs:    rootCAs,
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Change minimum and maximum TLS version (from 1.2 to 1.3) when internal encryption is activated (between `Ingress` to `Activator`)

TLS 1.3 comes with numerous enhancements, such as a quicker TLS handshake and more secure cipher suites.

**Release Note**

```release-note
* Activator uses TLS version 1.3 when internal encryption is activated for communication with Ingress
```