### PR TITLE
Revert "change mininum TLS version for tag to digest resolution (#13886)"

### DIFF
--- a/pkg/reconciler/revision/resolve.go
+++ b/pkg/reconciler/revision/resolve.go
@@ -64,7 +64,7 @@ func newResolverTransport(path string, maxIdleConns, maxIdleConnsPerHost int) (*
 	transport.MaxIdleConns = maxIdleConns
 	transport.MaxIdleConnsPerHost = maxIdleConnsPerHost
 	transport.TLSClientConfig = &tls.Config{
-		MinVersion: tls.VersionTLS13,
+		MinVersion: tls.VersionTLS12,
 		RootCAs:    pool,
 	}
 


### PR DESCRIPTION
This reverts commit 171cecde61a860cb12984a04070138219e325b0f.

Fixes https://github.com/knative/serving/issues/13937

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Supports TLS1.2 to support quay.io etc.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Revert "change mininum TLS version for tag to digest resolution (#13886)"
```
