### PR TITLE
Set default domain to cluster's domain

### DIFF
--- a/pkg/reconciler/route/config/domain.go
+++ b/pkg/reconciler/route/config/domain.go
@@ -31,9 +31,12 @@ import (
 const (
 	// DomainConfigName is the config map name for the domain configuration.
 	DomainConfigName = "config-domain"
+)
+
+var (
 	// DefaultDomain holds the domain that Route's live under by default
 	// when no label selector-based options apply.
-	DefaultDomain = "svc.cluster.local"
+	DefaultDomain = "svc." + network.GetClusterDomainName()
 )
 
 // LabelSelector represents map of {key,value} pairs. A single {key,value} in the


### PR DESCRIPTION
Fixes #13955 


## Proposed Changes

* Sets DefaultDomain to cluster's domain instead of hardcoded `svc.cluster.local`


### Release Note
```release-note
Sets DefaultDomain to cluster's domain instead of hardcoded `svc.cluster.local`
```

