### PR TITLE
[wip] fix shellcheck errors higher than warnings

### DIFF
--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -60,7 +60,7 @@ EOF
 }
 
 function cleanup_custom_domain() {
-  kubectl delete ConfigMap config-domain -n ${SYSTEM_NAMESPACE}
+  kubectl delete ConfigMap config-domain -n "${SYSTEM_NAMESPACE}"
 }
 
 function setup_auto_tls_common() {
@@ -93,12 +93,12 @@ function setup_http01_auto_tls() {
 
   if [[ -z "${MESH}" ]]; then
     echo "Install cert-manager no-mesh ClusterIssuer"
-    kubectl apply -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/http01/issuer.yaml
+    kubectl apply -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/http01/issuer.yaml
   else
     echo "Install cert-manager mesh ClusterIssuer"
-    kubectl apply -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/http01/mesh-issuer.yaml
+    kubectl apply -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/http01/mesh-issuer.yaml
   fi
-  kubectl apply -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/http01/config-certmanager.yaml
+  kubectl apply -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/http01/config-certmanager.yaml
   setup_dns_record
 }
 
@@ -109,7 +109,7 @@ function setup_selfsigned_per_ksvc_auto_tls() {
   export TLS_SERVICE_NAME="self-per-ksvc"
 
   kubectl delete kcert --all -n "${TLS_TEST_NAMESPACE}"
-  kubectl apply -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/selfsigned/
+  kubectl apply -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/selfsigned/
 }
 
 function setup_selfsigned_per_namespace_auto_tls() {
@@ -136,7 +136,7 @@ function cleanup_per_selfsigned_namespace_auto_tls() {
   # Disable namespace cert for all namespaces
   toggle_feature namespace-wildcard-cert-selector "" config-network
 
-  kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/selfsigned/ --ignore-not-found=true
+  kubectl delete -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/selfsigned/ --ignore-not-found=true
 }
 
 function setup_dns_record() {
@@ -186,21 +186,21 @@ add_trap "cleanup_auto_tls_common" EXIT SIGKILL SIGTERM SIGQUIT
 
 subheader "Auto TLS test for per-ksvc certificate provision using self-signed CA"
 setup_selfsigned_per_ksvc_auto_tls
-go_test_e2e -timeout=10m ./test/e2e/autotls/ ${AUTO_TLS_TEST_OPTIONS} || failed=1
-kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/selfsigned/
+go_test_e2e -timeout=10m ./test/e2e/autotls/ "${AUTO_TLS_TEST_OPTIONS}" || failed=1
+kubectl delete -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/selfsigned/
 
 subheader "Auto TLS test for per-namespace certificate provision using self-signed CA"
 setup_selfsigned_per_namespace_auto_tls
 add_trap "cleanup_per_selfsigned_namespace_auto_tls" SIGKILL SIGTERM SIGQUIT
-go_test_e2e -timeout=10m ./test/e2e/autotls/ ${AUTO_TLS_TEST_OPTIONS} || failed=1
+go_test_e2e -timeout=10m ./test/e2e/autotls/ "${AUTO_TLS_TEST_OPTIONS}" || failed=1
 cleanup_per_selfsigned_namespace_auto_tls
 
 if [[ ${RUN_HTTP01_AUTO_TLS_TESTS} -eq 1 ]]; then
   subheader "Auto TLS test for per-ksvc certificate provision using HTTP01 challenge"
   setup_http01_auto_tls
   add_trap "delete_dns_record" SIGKILL SIGTERM SIGQUIT
-  go_test_e2e -timeout=10m ./test/e2e/autotls/ ${AUTO_TLS_TEST_OPTIONS} || failed=1
-  kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/http01/
+  go_test_e2e -timeout=10m ./test/e2e/autotls/ "${AUTO_TLS_TEST_OPTIONS}" || failed=1
+  kubectl delete -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/http01/
   delete_dns_record
 fi
 

--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source $(dirname $0)/e2e-common.sh
+source "$(dirname "$0")/e2e-common.sh"
 
 function setup_auto_tls_env_variables() {
   # DNS zone for the testing domain.
@@ -38,7 +38,8 @@ function setup_auto_tls_env_variables() {
   if [[ -z "${GATEWAY_OVERRIDE}" ]]; then
     INGRESS_SERVICE="istio-ingressgateway"
   fi
-  local IP=$(kubectl get svc -n ${INGRESS_NAMESPACE} ${INGRESS_SERVICE} -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
+  local IP
+  IP=$(kubectl get svc -n "${INGRESS_NAMESPACE}" "${INGRESS_SERVICE}" -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
   export AUTO_TLS_TEST_INGRESS_IP=${IP}
 }
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -569,6 +569,7 @@ function stage_test_resources() {
 
   mkdir -p "${target_dir}"
 
+  # shellcheck disable=SC2044
   for file in $(find -L "${source_dir}" -type f -name "*.yaml"); do
     if [[ "${file}" == *"test/config/ytt"* ]]; then
       continue
@@ -580,7 +581,8 @@ function stage_test_resources() {
       local ko_target
       ko_target="$(mktemp -d)/$(basename "${file}")"
       echo building "${file/$REPO_ROOT_DIR/}"
-      ko resolve "$(ko_flags)" -f "${file}" > "${ko_target}" || fail_test "failed to build test resource"
+      # shellcheck disable=SC2046
+      ko resolve $(ko_flags) -f "${file}" > "${ko_target}" || fail_test "failed to build test resource"
       file="${ko_target}"
     fi
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -65,12 +65,12 @@ function latest_net_istio_version() {
   local url="https://api.github.com/repos/knative/net-istio/releases"
   local curl_output
   curl_output=$(mktemp)
-  local curl_flags='-L --show-error --silent'
+  curl_flags=("-L" "--show-error" "--silent")
 
   if [ -n "${GITHUB_TOKEN-}" ]; then
-    curl "${curl_flags}" -H "Authorization: Bearer $GITHUB_TOKEN" "${url}" > "${curl_output}"
+    curl "${curl_flags[@]}" -H "Authorization: Bearer $GITHUB_TOKEN" "${url}" > "${curl_output}"
   else
-    curl "${curl_flags}" "${url}" > "${curl_output}"
+    curl "${curl_flags[@]}" "${url}" > "${curl_output}"
   fi
 
   jq --arg major_minor "$major_minor" -r \
@@ -80,7 +80,7 @@ function latest_net_istio_version() {
     sub("v";"") |
     split(".") |
     map(tonumber) ) |
-    reverse[0]' $curl_output
+    reverse[0]' "${curl_output}"
 }
 
 # Latest serving release. If user does not supply this as a flag, the latest

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -60,7 +60,7 @@ export QUOTA=${QUOTA:-1}
 function latest_net_istio_version() {
   local serving_version=$1
   local major_minor
-  major_minor=$(echo "$serving_version" | cut -d '.' -f 1,2)
+  major_minor=$(echo "${serving_version}" | cut -d '.' -f 1,2)
 
   local url="https://api.github.com/repos/knative/net-istio/releases"
   local curl_output
@@ -70,7 +70,7 @@ function latest_net_istio_version() {
   if [ -n "${GITHUB_TOKEN-}" ]; then
     curl "${curl_flags}" -H "Authorization: Bearer $GITHUB_TOKEN" "${url}" > "${curl_output}"
   else
-    curl "${curl_flags}" $url > "${curl_output}"
+    curl "${curl_flags}" "${url}" > "${curl_output}"
   fi
 
   jq --arg major_minor "$major_minor" -r \

--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -72,7 +72,8 @@ function download_net_istio_yamls() {
   # Point to our local copy
   net_istio_yaml="${target_dir}/$(basename "${net_istio_yaml}")"
 
-  local sha=$(head -n 1 ${net_istio_yaml} | grep "# Generated when HEAD was" | sed 's/^.* //')
+  local sha
+  sha=$(head -n 1 "${net_istio_yaml}" | grep "# Generated when HEAD was" | sed 's/^.* //')
   if [[ -z "${sha:-}" ]]; then
     sha="191bc5fe5a4b35b64f70577c3e44e44fb699cc5f"
     echo "Hard coded NET_ISTIO_COMMIT: ${sha}"
@@ -80,8 +81,10 @@ function download_net_istio_yamls() {
     echo "Got NET_ISTIO_COMMIT from ${1}: ${sha}"
   fi
 
-  local istio_yaml="$(net_istio_file_url "$sha" istio.yaml)"
-  local istio_config_yaml="$(net_istio_file_url "$sha" config-istio.yaml)"
+  local istio_yaml
+  istio_yaml="$(net_istio_file_url "${sha}" istio.yaml)"
+  local istio_config_yaml
+  istio_config_yaml="$(net_istio_file_url "${sha}" config-istio.yaml)"
 
   wget -P "${target_dir}" "${istio_yaml}" \
     || fail_test "Unable to get istio install file ${istio_yaml}"

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -53,7 +53,7 @@ header "Running upgrade tests"
 go_test_e2e -tags=upgrade -timeout=${TIMEOUT} \
   ./test/upgrade \
   --disable-logstream \
-  --resolvabledomain=$(use_resolvable_domain) || fail_test
+  --resolvabledomain="$(use_resolvable_domain)" || fail_test
 
 # Remove the kail log file if the test flow passes.
 # This is for preventing too many large log files to be uploaded to GCS in CI.

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -24,7 +24,7 @@
 export GO111MODULE=on
 export GOFLAGS=-mod=vendor
 
-source $(dirname $0)/../vendor/knative.dev/hack/presubmit-tests.sh
+source "$(dirname "$0")/../vendor/knative.dev/hack/presubmit-tests.sh"
 
 # We use the default build, unit and integration test runners.
 

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -42,6 +42,6 @@ function upload_test_images() {
   ko resolve --jobs=4 ${platform} ${tag_option} -RBf "${image_dir}" > /dev/null
 }
 
-: ${KO_DOCKER_REPO:?"You must set 'KO_DOCKER_REPO', see DEVELOPMENT.md"}
+: "${KO_DOCKER_REPO:?"You must set 'KO_DOCKER_REPO', see DEVELOPMENT.md"}"
 
-upload_test_images $@
+upload_test_images "$@"


### PR DESCRIPTION
As part of enabling the shell style checks, we need to ensure that all shellcheck warnings have been addressed:


Most of them have been fixed except one:

```
 REDACTED  C02CW0CDP3YY  ~  Desktop  Git  serving   shellcheck-fixes  7✎  $  shellcheck test/*.sh -S warning

In test/e2e-common.sh line 568:
        for file in $(find -L "${source_dir}" -type f -name "*.yaml"); do
                    ^-- SC2044 (warning): For loops over find output are fragile. Use find -exec or a while read loop.

For more information:
  https://www.shellcheck.net/wiki/SC2044 -- For loops over find output are fr...
```