### PR TITLE
Autoscaler metric annotations work with global class config

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation.go
+++ b/pkg/apis/autoscaling/annotation_validation.go
@@ -58,7 +58,7 @@ func ValidateAnnotations(ctx context.Context, config *autoscalerconfig.Config, a
 		Also(validateWindow(anns)).
 		Also(validateLastPodRetention(anns)).
 		Also(validateScaleDownDelay(anns)).
-		Also(validateMetric(anns)).
+		Also(validateMetric(config, anns)).
 		Also(validateAlgorithm(anns)).
 		Also(validateInitialScale(config, anns))
 }
@@ -234,9 +234,9 @@ func validateMaxScaleWithinLimit(key string, maxScale, maxScaleLimit int32) (err
 	return errs
 }
 
-func validateMetric(m map[string]string) *apis.FieldError {
+func validateMetric(c *autoscalerconfig.Config, m map[string]string) *apis.FieldError {
 	if _, metric, ok := MetricAnnotation.Get(m); ok {
-		classValue := KPA
+		classValue := c.PodAutoscalerClass
 		if _, c, ok := ClassAnnotation.Get(m); ok {
 			classValue = c
 		}

--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -351,6 +351,12 @@ func TestValidateAnnotations(t *testing.T) {
 		annotations: map[string]string{InitialScaleAnnotationKey: "0"},
 		expectErr:   "invalid value: 0: " + InitialScaleAnnotationKey + "=0 not allowed by cluster",
 	}, {
+		name:        "valid global class HPA with metric CPU",
+		annotations: map[string]string{MetricAnnotationKey: CPU},
+		configMutator: func(c *autoscalerconfig.Config) {
+			c.PodAutoscalerClass = HPA
+		},
+	}, {
 		name: "initial scale is zero and cluster allows",
 		configMutator: func(config *autoscalerconfig.Config) {
 			config.AllowZeroInitialScale = true
@@ -386,5 +392,6 @@ func defaultConfig() *autoscalerconfig.Config {
 	return &autoscalerconfig.Config{
 		AllowZeroInitialScale: false,
 		MaxScaleLimit:         0,
+		PodAutoscalerClass:    KPA,
 	}
 }


### PR DESCRIPTION
Fixes #13869 


## Proposed Changes

* Autoscaler `metric` annotations are evaluated in conjunction with global `class` when no class annotation is set.

**Release Note**

```
Autoscaler metric are validated with global autoscaling class if no class annotation is set.
```
