### PR TITLE
Bump kind to 0.19

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -16,7 +16,7 @@ env:
   REGISTRY_NAME: registry.local
   REGISTRY_PORT: 5000
   KO_DOCKER_REPO: registry.local:5000/knative
-  KIND_VERSION: 0.17.0
+  KIND_VERSION: 0.19.0
   GOTESTSUM_VERSION: 1.7.0
   KAPP_VERSION: 0.46.0
   YTT_VERSION: 0.40.1
@@ -87,9 +87,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.24.7
-        - v1.25.3
-        - v1.26.0
+        - v1.25.9
+        - v1.26.4
+        - v1.27.1
 
         ingress:
         - kourier
@@ -109,17 +109,17 @@ jobs:
           # This is attempting to make it a bit clearer what's being tested.
           # See: https://github.com/kubernetes-sigs/kind/releases
           #      https://hub.docker.com/r/kindest/node/tags
-        - k8s-version: v1.24.7
-          kind-version: v0.17.0
-          kind-image-sha: sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
+        - k8s-version: v1.25.9
+          kind-version: v0.19.0
+          kind-image-sha: sha256:c08d6c52820aa42e533b70bce0c2901183326d86dcdcbedecc9343681db45161
 
-        - k8s-version: v1.25.3
-          kind-version: v0.17.0
-          kind-image-sha: sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
+        - k8s-version: v1.26.4
+          kind-version: v0.19.0
+          kind-image-sha: f4c0d87be03d6bea69f5e5dc0adb678bb498a190ee5c38422bf751541cebe92e
 
-        - k8s-version: v1.26.0
-          kind-version: v0.17.0
-          kind-image-sha: sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
+        - k8s-version: v1.27.1
+          kind-version: v0.19.0
+          kind-image-sha: sha256:b7d12ed662b873bd8510879c1846e87c7e676a79fefc93e17b2a52989d3ff42b
 
         # Disabled due to consistent failures
         # - ingress: gateway_istio

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -115,7 +115,7 @@ jobs:
 
         - k8s-version: v1.26.4
           kind-version: v0.19.0
-          kind-image-sha: f4c0d87be03d6bea69f5e5dc0adb678bb498a190ee5c38422bf751541cebe92e
+          kind-image-sha: sha256:f4c0d87be03d6bea69f5e5dc0adb678bb498a190ee5c38422bf751541cebe92e
 
         - k8s-version: v1.27.1
           kind-version: v0.19.0


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Set Kind_version : 0.19 
* Set   k8s-version:
        - v1.25.9
        - v1.26.4
        - v1.27.1
* Updated sha's

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
