### PR TITLE
fix: requests are sent to all pods even if cc=1 and the parity of activatorCount and podTracker is different

### DIFF
--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -251,7 +251,8 @@ func (rt *revisionThrottler) calculateCapacity(size, activatorCount int) int {
 		// limit is math.MaxInt32 so in practice this should never be a real limit.
 		targetCapacity = revisionMaxConcurrency
 	} else if targetCapacity > 0 {
-		targetCapacity = minOneOrValue(targetCapacity / minOneOrValue(activatorCount))
+		// If targetCapacity is not divisible by activatorCount, set targetCapacity to the rounded-up integer.
+		targetCapacity = minOneOrValue(int(math.Ceil(float64(targetCapacity) / float64(minOneOrValue(activatorCount)))))
 	}
 
 	return targetCapacity

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -225,7 +225,6 @@ func TestThrottlerUpdateCapacity(t *testing.T) {
 
 func TestThrottlerCalculateCapacity(t *testing.T) {
 	logger := TestLogger(t)
-
 	tests := []struct {
 		name                 string
 		numActivators        int32
@@ -758,7 +757,7 @@ func TestActivatorsIndexUpdate(t *testing.T) {
 	// so we now know that the rest is set statically.
 	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
 		// Capacity doesn't exceed 1 in this test.
-		return rt.breaker.Capacity() == 1, nil
+		return rt.breaker.Capacity() == 2, nil
 	}); err != nil {
 		t.Fatal("Timed out waiting for the capacity to be updated")
 	}
@@ -854,19 +853,19 @@ func TestMultipleActivators(t *testing.T) {
 	// so we now know that we got and processed both the activator endpoints
 	// and the application endpoints.
 	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
-		return rt.breaker.Capacity() == 1, nil
+		return rt.breaker.Capacity() == 2, nil
 	}); err != nil {
 		t.Fatal("Timed out waiting for the capacity to be updated")
 	}
 	t.Log("This activator idx =", rt.activatorIndex.Load())
 
-	// Test with 2 activators, 3 endpoints we can send 1 request and the second times out.
+	// Test with 2 activators, 3 endpoints we can send 2 requests and the third times out.
 	var mux sync.Mutex
 	mux.Lock() // Lock the mutex so all requests are blocked in the Try function.
 
 	reqCtx, cancel2 := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel2()
-	resultChan := throttler.try(reqCtx, 2 /*requests*/, func(string) error {
+	resultChan := throttler.try(reqCtx, 3 /*requests*/, func(string) error {
 		mux.Lock()
 		return nil
 	})

--- a/pkg/activator/net/throttler_test.go
+++ b/pkg/activator/net/throttler_test.go
@@ -149,35 +149,35 @@ func TestThrottlerUpdateCapacity(t *testing.T) {
 	}, {
 		// Now test with podIP trackers in tow.
 		// Simple case.
-		name:                 "numActivators: 1, capacity: 0, cc: 10, trackers(1, 10)",
+		name:                 "numActivators: 1, capacity: 0, cc: 10, pods: 1",
 		capacity:             0,
 		numActivators:        1,
 		containerConcurrency: 10,
 		podTrackers:          makeTrackers(1, 10),
 		want:                 10,
 	}, {
-		name:                 "2 backends. numActivators: 1, capacity: -1, cc: 10, trackers(2, 10)",
+		name:                 "2 backends. numActivators: 1, capacity: -1, cc: 10, pods: 2",
 		capacity:             -1,
 		numActivators:        1,
 		containerConcurrency: 10,
 		podTrackers:          makeTrackers(2, 10),
 		want:                 20,
 	}, {
-		name:                 "2 activators. numActivators: 2, capacity: -1, cc: 10, trackers(2, 10)",
+		name:                 "2 activators. numActivators: 2, capacity: -1, cc: 10, pods: 2",
 		capacity:             -1,
 		numActivators:        2,
 		containerConcurrency: 10,
 		podTrackers:          makeTrackers(2, 10),
 		want:                 10,
 	}, {
-		name:                 "3 pods, index 0. numActivators: 2, index: 0, capacity: -1, cc: 10, trackers(3, 10)",
+		name:                 "numActivators: 2, index: 0, pods: 3, cc: 1. Capacity is expected to 20 (2 * 10)",
 		capacity:             -1,
 		numActivators:        2,
 		containerConcurrency: 10,
 		podTrackers:          makeTrackers(3, 10),
 		want:                 20,
 	}, {
-		name:                 "3 pods, index 1. numActivators: 2, index: 1, capacity: -1, cc: 10, trackers(3, 10)",
+		name:                 "numActivators: 2, index: 1, pods: 3, cc: 1. Capacity is expected to 10 (1 * 10)",
 		capacity:             -1,
 		numActivators:        2,
 		activatorIndex:       1,
@@ -185,13 +185,21 @@ func TestThrottlerUpdateCapacity(t *testing.T) {
 		podTrackers:          makeTrackers(3, 10),
 		want:                 10,
 	}, {
-		name:                 "numActivators: 2, index: 1, capacity: 5, cc: 1, trackers(5, 1), return 3 instead of 2",
+		name:                 "numActivators: 2, index: 0, pods: 5, cc: 1. Capacity is expected to 3 (2 + 1)",
 		capacity:             5,
 		numActivators:        2,
 		activatorIndex:       0,
 		containerConcurrency: 1,
 		podTrackers:          makeTrackers(5, 1),
 		want:                 3,
+	}, {
+		name:                 "numActivators: 2, index: 1, pods: 5, cc: 1. Capacity is expected to 2",
+		capacity:             5,
+		numActivators:        2,
+		activatorIndex:       1,
+		containerConcurrency: 1,
+		podTrackers:          makeTrackers(5, 1),
+		want:                 2,
 	}, {
 		name:                 "Infinite capacity with podIP trackers.",
 		capacity:             1,


### PR DESCRIPTION
Fixes #12734

### Issue
When cc=1 and the parity of `activatorCount` and `podTracker` is different like the conditions below, requests are sent to some pods, but not all.

- 2 activators
- no istio sidecar injection
- 5 replica servers
- CC: 1
- TBC : -1

### Solution
This issue occurs due to an incorrect calculation of `targetCapacity`.
Example:
If `podTracker`=3, `assignedTracker`=2 and `activatorCount`=2, the expected `targetCapacity` should be 2. However, in the current implementation `targetCapacity` is calculated as 1.

I've fixed this issue by following two steps.

#### step 1. Change `assignSlice` logic
Actual:
If the number of pods is not divisible by the number of activators, any remaining pods are shared across all activators.
```
Activator1: pod1, pod2, pod5
Activator2: pod3, pod4, pod5
```
Expected:
Instead of this implementation, we can allocate one pod to each activator exclusively.
```
Activator1: pod1, pod2, pod5
Activator2: pod3, pod4
```

#### step 2. Change `calculateCapacity`
By step 1, we can calculate the `targetCapacity` as CC * the number of assigned pods.

I think this problem is specific to cc=1 case.
If cc is greater than 1, `targetCapacity` should be larger than assignedPods according to the current implementation.

**Release Note**

```release-note
NONE
```
