### PR TITLE
RandomChoice 2 policy wasn't random when the number of targets is 2 (with equal weight)

### DIFF
--- a/pkg/activator/net/lb_policy.go
+++ b/pkg/activator/net/lb_policy.go
@@ -67,6 +67,10 @@ func randomChoice2Policy(_ context.Context, targets []*podTracker) (func(), *pod
 	// so fine.
 	if pick.getWeight() > alt.getWeight() {
 		pick = alt
+	} else if pick.getWeight() == alt.getWeight() {
+		if rand.Int63()%2 == 0 {
+			pick = alt
+		}
 	}
 	pick.increaseWeight()
 	return pick.decreaseWeight, pick

--- a/pkg/activator/net/lb_policy.go
+++ b/pkg/activator/net/lb_policy.go
@@ -68,6 +68,7 @@ func randomChoice2Policy(_ context.Context, targets []*podTracker) (func(), *pod
 	if pick.getWeight() > alt.getWeight() {
 		pick = alt
 	} else if pick.getWeight() == alt.getWeight() {
+		//nolint:gosec // We don't need cryptographic randomness here.
 		if rand.Int63()%2 == 0 {
 			pick = alt
 		}

--- a/pkg/activator/net/lb_policy_test.go
+++ b/pkg/activator/net/lb_policy_test.go
@@ -25,6 +25,32 @@ import (
 	"knative.dev/serving/pkg/queue"
 )
 
+func TestRandomChoice_TwoTrackersDistribution(t *testing.T) {
+	podTrackers := makeTrackers(2, 0)
+	counts := map[string]int{}
+
+	total := 100
+	for i := 0; i < total; i++ {
+		cb, pt := randomChoice2Policy(context.Background(), podTrackers)
+		cb()
+		counts[pt.dest]++
+	}
+
+	first := counts[podTrackers[0].dest]
+	second := counts[podTrackers[1].dest]
+
+	// probability of this occurring is 0.5^100
+	if first == 0 {
+		t.Error("expected the first tracker to get some requests")
+	}
+	if second == 0 {
+		t.Error("expected the second tracker to get some requests")
+	}
+	if first+second != total {
+		t.Error("expected total requests to equal 100 - was ", first+second)
+	}
+}
+
 func TestRandomChoice2(t *testing.T) {
 	t.Run("1 tracker", func(t *testing.T) {
 		podTrackers := makeTrackers(1, 0)


### PR DESCRIPTION
Fixes: https://github.com/knative/serving/issues/14011
Fixes: https://github.com/knative/serving/issues/12593

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Activator Random Choice 2 Policy will now pick randomly between two targets that have equal weight


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix activator load balancing when using unbounded concurrency and when you have two instances of a revision
```
