### PR TITLE
drop safe to evict annotations

### DIFF
--- a/config/core/deployments/activator.yaml
+++ b/config/core/deployments/activator.yaml
@@ -28,8 +28,6 @@ spec:
       role: activator
   template:
     metadata:
-      annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: activator
         role: activator

--- a/config/core/deployments/autoscaler.yaml
+++ b/config/core/deployments/autoscaler.yaml
@@ -32,8 +32,6 @@ spec:
        maxUnavailable: 0
   template:
     metadata:
-      annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: autoscaler
         app.kubernetes.io/component: autoscaler

--- a/config/core/deployments/controller.yaml
+++ b/config/core/deployments/controller.yaml
@@ -27,8 +27,6 @@ spec:
       app: controller
   template:
     metadata:
-      annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: controller
         app.kubernetes.io/component: controller

--- a/config/core/deployments/domainmapping-controller.yaml
+++ b/config/core/deployments/domainmapping-controller.yaml
@@ -27,8 +27,6 @@ spec:
       app: domain-mapping
   template:
     metadata:
-      annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: domain-mapping
         app.kubernetes.io/component: domain-mapping

--- a/config/core/deployments/domainmapping-webhook.yaml
+++ b/config/core/deployments/domainmapping-webhook.yaml
@@ -28,8 +28,6 @@ spec:
       role: domainmapping-webhook
   template:
     metadata:
-      annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: domainmapping-webhook
         role: domainmapping-webhook

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -28,8 +28,6 @@ spec:
       role: webhook
   template:
     metadata:
-      annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: webhook
         role: webhook

--- a/config/hpa-autoscaling/controller.yaml
+++ b/config/hpa-autoscaling/controller.yaml
@@ -28,8 +28,6 @@ spec:
       app: autoscaler-hpa
   template:
     metadata:
-      annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: autoscaler-hpa
         app.kubernetes.io/component: autoscaler-hpa


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/13984

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Drop `cluster-autoscaler.kubernetes.io/safe-to-evict` annotations on our control plane deployments to allow nodes to drain

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Drop `cluster-autoscaler.kubernetes.io/safe-to-evict` annotations on our control plane to allow nodes to drain
```
