### PR TITLE
Allow to set QP resources per service

### DIFF
--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -118,6 +118,18 @@ const (
 	// It has to be in [0.1,100]
 	QueueSidecarResourcePercentageAnnotationKey = "queue.sidecar." + GroupName + "/resource-percentage"
 
+	// QueueSidecarCPUResourceRequestAnnotationKey is the explicit value of the cpu request for queue-proxy's request resources
+	QueueSidecarCPUResourceRequestAnnotationKey = "queue.sidecar." + GroupName + "/cpu-resource-request"
+
+	// QueueSidecarCPUResourceLimitAnnotationKey is the explicit value of the cpu limit for queue-proxy's limit resources
+	QueueSidecarCPUResourceLimitAnnotationKey = "queue.sidecar." + GroupName + "/cpu-resource-limit"
+
+	// QueueSidecarMemoryResourceRequestAnnotationKey is the explicit value of the memory request for queue-proxy's request resources
+	QueueSidecarMemoryResourceRequestAnnotationKey = "queue.sidecar." + GroupName + "/memory-resource-request"
+
+	// QueueSidecarMemoryResourceLimitAnnotationKey is the explicit value of the memory request for queue-proxy's limit resources
+	QueueSidecarMemoryResourceLimitAnnotationKey = "queue.sidecar." + GroupName + "/memory-resource-limit"
+
 	// VisibilityClusterLocal is the label value for VisibilityLabelKey
 	// that will result to the Route/KService getting a cluster local
 	// domain suffix.
@@ -161,6 +173,22 @@ var (
 	QueueSidecarResourcePercentageAnnotation = kmap.KeyPriority{
 		QueueSidecarResourcePercentageAnnotationKey,
 		"queue.sidecar." + GroupName + "/resourcePercentage",
+	}
+	QueueSidecarCPUResourceRequestAnnotation = kmap.KeyPriority{
+		QueueSidecarCPUResourceRequestAnnotationKey,
+		"queue.sidecar." + GroupName + "/CPUResourceRequest",
+	}
+	QueueSidecarCPUResourceLimitAnnotation = kmap.KeyPriority{
+		QueueSidecarCPUResourceLimitAnnotationKey,
+		"queue.sidecar." + GroupName + "/CPUResourceLimit",
+	}
+	QueueSidecarMemoryResourceRequestAnnotation = kmap.KeyPriority{
+		QueueSidecarMemoryResourceRequestAnnotationKey,
+		"queue.sidecar." + GroupName + "/MemoryResourceRequest",
+	}
+	QueueSidecarMemoryResourceLimitAnnotation = kmap.KeyPriority{
+		QueueSidecarMemoryResourceLimitAnnotationKey,
+		"queue.sidecar." + GroupName + "/MemoryResourceLimit",
 	}
 	ProgressDeadlineAnnotation = kmap.KeyPriority{
 		ProgressDeadlineAnnotationKey,

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -127,8 +127,14 @@ const (
 	// QueueSidecarMemoryResourceRequestAnnotationKey is the explicit value of the memory request for queue-proxy's request resources
 	QueueSidecarMemoryResourceRequestAnnotationKey = "queue.sidecar." + GroupName + "/memory-resource-request"
 
-	// QueueSidecarMemoryResourceLimitAnnotationKey is the explicit value of the memory request for queue-proxy's limit resources
+	// QueueSidecarMemoryResourceLimitAnnotationKey is the explicit value of the memory limit for queue-proxy's limit resources
 	QueueSidecarMemoryResourceLimitAnnotationKey = "queue.sidecar." + GroupName + "/memory-resource-limit"
+
+	// QueueSidecarEphemeralStorageResourceRequestAnnotationKey is the explicit value of the ephemeral storage request for queue-proxy's request resources
+	QueueSidecarEphemeralStorageResourceRequestAnnotationKey = "queue.sidecar." + GroupName + "/ephemeral-storage-resource-request"
+
+	// QueueSidecarEphemeralStorageResourceLimitAnnotationKey is the explicit value of the ephemeral storage limit for queue-proxy's limit resources
+	QueueSidecarEphemeralStorageResourceLimitAnnotationKey = "queue.sidecar." + GroupName + "/ephemeral-storage-resource-limit"
 
 	// VisibilityClusterLocal is the label value for VisibilityLabelKey
 	// that will result to the Route/KService getting a cluster local
@@ -189,6 +195,14 @@ var (
 	QueueSidecarMemoryResourceLimitAnnotation = kmap.KeyPriority{
 		QueueSidecarMemoryResourceLimitAnnotationKey,
 		"queue.sidecar." + GroupName + "/MemoryResourceLimit",
+	}
+	QueueSidecarEphemeralStorageResourceRequestAnnotation = kmap.KeyPriority{
+		QueueSidecarEphemeralStorageResourceRequestAnnotationKey,
+		"queue.sidecar." + GroupName + "/EphemeralStorageResourceRequest",
+	}
+	QueueSidecarEphemeralStorageResourceLimitAnnotation = kmap.KeyPriority{
+		QueueSidecarEphemeralStorageResourceLimitAnnotationKey,
+		"queue.sidecar." + GroupName + "/EphemeralStorageResourceLimit",
 	}
 	ProgressDeadlineAnnotation = kmap.KeyPriority{
 		ProgressDeadlineAnnotationKey,

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -116,6 +116,7 @@ const (
 
 	// QueueSidecarResourcePercentageAnnotationKey is the percentage of user container resources to be used for queue-proxy
 	// It has to be in [0.1,100]
+	// Deprecated: Please consider setting resources explicitly for the QP per service, see `QueueSidecarCPUResourceRequestAnnotationKey` for example.
 	QueueSidecarResourcePercentageAnnotationKey = "queue.sidecar." + GroupName + "/resource-percentage"
 
 	// QueueSidecarCPUResourceRequestAnnotationKey is the explicit value of the cpu request for queue-proxy's request resources

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -183,27 +183,21 @@ var (
 	}
 	QueueSidecarCPUResourceRequestAnnotation = kmap.KeyPriority{
 		QueueSidecarCPUResourceRequestAnnotationKey,
-		"queue.sidecar." + GroupName + "/CPUResourceRequest",
 	}
 	QueueSidecarCPUResourceLimitAnnotation = kmap.KeyPriority{
 		QueueSidecarCPUResourceLimitAnnotationKey,
-		"queue.sidecar." + GroupName + "/CPUResourceLimit",
 	}
 	QueueSidecarMemoryResourceRequestAnnotation = kmap.KeyPriority{
 		QueueSidecarMemoryResourceRequestAnnotationKey,
-		"queue.sidecar." + GroupName + "/MemoryResourceRequest",
 	}
 	QueueSidecarMemoryResourceLimitAnnotation = kmap.KeyPriority{
 		QueueSidecarMemoryResourceLimitAnnotationKey,
-		"queue.sidecar." + GroupName + "/MemoryResourceLimit",
 	}
 	QueueSidecarEphemeralStorageResourceRequestAnnotation = kmap.KeyPriority{
 		QueueSidecarEphemeralStorageResourceRequestAnnotationKey,
-		"queue.sidecar." + GroupName + "/EphemeralStorageResourceRequest",
 	}
 	QueueSidecarEphemeralStorageResourceLimitAnnotation = kmap.KeyPriority{
 		QueueSidecarEphemeralStorageResourceLimitAnnotationKey,
-		"queue.sidecar." + GroupName + "/EphemeralStorageResourceLimit",
 	}
 	ProgressDeadlineAnnotation = kmap.KeyPriority{
 		ProgressDeadlineAnnotationKey,

--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -188,14 +188,15 @@ func validateQueueSidecarAnnotation(m map[string]string) *apis.FieldError {
 	if !ok {
 		return nil
 	}
+	errs := apis.ErrGeneric("Queue proxy resource percentage annotation is deprecated. Please use the available annotations to explicitly set resource values per service").ViaKey(k).At(apis.WarningLevel)
 	value, err := strconv.ParseFloat(v, 64)
 	if err != nil {
-		return apis.ErrInvalidValue(v, apis.CurrentField).ViaKey(k)
+		return errs.Also(apis.ErrInvalidValue(v, apis.CurrentField).ViaKey(k))
 	}
 	if value < 0.1 || value > 100 {
-		return apis.ErrOutOfBoundsValue(value, 0.1, 100.0, apis.CurrentField).ViaKey(k)
+		return errs.Also(apis.ErrOutOfBoundsValue(value, 0.1, 100.0, apis.CurrentField).ViaKey(k))
 	}
-	return nil
+	return errs
 }
 
 // ValidateProgressDeadlineAnnotation validates the revision progress deadline annotation.

--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -199,12 +199,6 @@ func validateQueueSidecarResourceAnnotations(m map[string]string) *apis.FieldErr
 			}
 		}
 	}
-	validate := func(k, v string) *apis.FieldError {
-		if _, err := resource.ParseQuantity(v); err != nil {
-			return errs.Also(apis.ErrInvalidValue(v, apis.CurrentField).ViaKey(k))
-		}
-		return nil
-	}
 	annoKeys := []kmap.KeyPriority{
 		serving.QueueSidecarCPUResourceRequestAnnotation,
 		serving.QueueSidecarCPUResourceLimitAnnotation,
@@ -215,8 +209,11 @@ func validateQueueSidecarResourceAnnotations(m map[string]string) *apis.FieldErr
 	}
 	for _, resAnno := range annoKeys {
 		k, v, ok := resAnno.Get(m)
-		if ok {
-			errs = errs.Also(validate(k, v))
+		if !ok {
+			continue
+		}
+		if _, err := resource.ParseQuantity(v); err != nil {
+			errs = errs.Also(apis.ErrInvalidValue(v, apis.CurrentField).ViaKey(k))
 		}
 	}
 	return errs

--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -23,8 +23,10 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/api/validation"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmap"
 	"knative.dev/pkg/kmp"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/config"
@@ -68,7 +70,7 @@ func (rts *RevisionTemplateSpec) Validate(ctx context.Context) *apis.FieldError 
 	// If the RevisionTemplateSpec has a name specified, then check that
 	// it follows the requirements on the name.
 	errs = errs.Also(validateRevisionName(ctx, rts.Name, rts.GenerateName))
-	errs = errs.Also(validateQueueSidecarAnnotation(rts.Annotations).ViaField("metadata.annotations"))
+	errs = errs.Also(validateQueueSidecarResourceAnnotations(rts.Annotations).ViaField("metadata.annotations"))
 	errs = errs.Also(validateProgressDeadlineAnnotation(rts.Annotations).ViaField("metadata.annotations"))
 	return errs
 }
@@ -179,22 +181,43 @@ func validateTimeoutSeconds(ctx context.Context, timeoutSeconds int64) *apis.Fie
 	return nil
 }
 
-// validateQueueSidecarAnnotation validates QueueSideCarResourcePercentageAnnotation
-func validateQueueSidecarAnnotation(m map[string]string) *apis.FieldError {
+// validateQueueSidecarResourceAnnotations validates QueueSideCarResourcePercentageAnnotation and other QP resource related annotations.
+func validateQueueSidecarResourceAnnotations(m map[string]string) *apis.FieldError {
 	if len(m) == 0 {
 		return nil
 	}
-	k, v, ok := serving.QueueSidecarResourcePercentageAnnotation.Get(m)
-	if !ok {
+
+	var errs *apis.FieldError
+	if k, v, ok := serving.QueueSidecarResourcePercentageAnnotation.Get(m); ok {
+		errs = apis.ErrGeneric("Queue proxy resource percentage annotation is deprecated. Please use the available annotations to explicitly set resource values per service").ViaKey(k).At(apis.WarningLevel)
+		value, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			errs = errs.Also(apis.ErrInvalidValue(v, apis.CurrentField).ViaKey(k))
+		} else {
+			if value < 0.1 || value > 100 {
+				errs = errs.Also(apis.ErrOutOfBoundsValue(value, 0.1, 100.0, apis.CurrentField).ViaKey(k))
+			}
+		}
+	}
+	validate := func(k, v string) *apis.FieldError {
+		if _, err := resource.ParseQuantity(v); err != nil {
+			return errs.Also(apis.ErrInvalidValue(v, apis.CurrentField).ViaKey(k))
+		}
 		return nil
 	}
-	errs := apis.ErrGeneric("Queue proxy resource percentage annotation is deprecated. Please use the available annotations to explicitly set resource values per service").ViaKey(k).At(apis.WarningLevel)
-	value, err := strconv.ParseFloat(v, 64)
-	if err != nil {
-		return errs.Also(apis.ErrInvalidValue(v, apis.CurrentField).ViaKey(k))
+	annoKeys := []kmap.KeyPriority{
+		serving.QueueSidecarCPUResourceRequestAnnotation,
+		serving.QueueSidecarCPUResourceLimitAnnotation,
+		serving.QueueSidecarMemoryResourceRequestAnnotation,
+		serving.QueueSidecarMemoryResourceLimitAnnotation,
+		serving.QueueSidecarEphemeralStorageResourceRequestAnnotation,
+		serving.QueueSidecarEphemeralStorageResourceLimitAnnotation,
 	}
-	if value < 0.1 || value > 100 {
-		return errs.Also(apis.ErrOutOfBoundsValue(value, 0.1, 100.0, apis.CurrentField).ViaKey(k))
+	for _, resAnno := range annoKeys {
+		k, v, ok := resAnno.Get(m)
+		if ok {
+			errs = errs.Also(validate(k, v))
+		}
 	}
 	return errs
 }

--- a/pkg/apis/serving/v1/revision_validation_test.go
+++ b/pkg/apis/serving/v1/revision_validation_test.go
@@ -1093,6 +1093,9 @@ func autoscalerConfigCtx(allowInitialScaleZero bool, initialScale int) context.C
 }
 
 func TestValidateQueueSidecarAnnotation(t *testing.T) {
+	resourcePercentageDeprecationWarning := apis.ErrGeneric("Queue proxy resource percentage annotation is deprecated. Please use the available annotations to explicitly set resource values per service").
+		ViaKey(serving.QueueSidecarResourcePercentageAnnotationKey).At(apis.WarningLevel)
+
 	cases := []struct {
 		name       string
 		annotation map[string]string
@@ -1102,28 +1105,28 @@ func TestValidateQueueSidecarAnnotation(t *testing.T) {
 		annotation: map[string]string{
 			serving.QueueSidecarResourcePercentageAnnotationKey: "0.01982",
 		},
-		expectErr: &apis.FieldError{
+		expectErr: (&apis.FieldError{
 			Message: "expected 0.1 <= 0.01982 <= 100",
 			Paths:   []string{fmt.Sprintf("[%s]", serving.QueueSidecarResourcePercentageAnnotationKey)},
-		},
+		}).Also(resourcePercentageDeprecationWarning),
 	}, {
 		name: "too big for Queue sidecar resource percentage annotation",
 		annotation: map[string]string{
 			serving.QueueSidecarResourcePercentageAnnotationKey: "100.0001",
 		},
-		expectErr: &apis.FieldError{
+		expectErr: (&apis.FieldError{
 			Message: "expected 0.1 <= 100.0001 <= 100",
 			Paths:   []string{fmt.Sprintf("[%s]", serving.QueueSidecarResourcePercentageAnnotationKey)},
-		},
+		}).Also(resourcePercentageDeprecationWarning),
 	}, {
 		name: "Invalid queue sidecar resource percentage annotation",
 		annotation: map[string]string{
 			serving.QueueSidecarResourcePercentageAnnotationKey: "",
 		},
-		expectErr: &apis.FieldError{
+		expectErr: (&apis.FieldError{
 			Message: "invalid value: ",
 			Paths:   []string{fmt.Sprintf("[%s]", serving.QueueSidecarResourcePercentageAnnotationKey)},
-		},
+		}).Also(resourcePercentageDeprecationWarning),
 	}, {
 		name:       "empty annotation",
 		annotation: map[string]string{},
@@ -1137,11 +1140,13 @@ func TestValidateQueueSidecarAnnotation(t *testing.T) {
 		annotation: map[string]string{
 			serving.QueueSidecarResourcePercentageAnnotationKey: "0.1",
 		},
+		expectErr: resourcePercentageDeprecationWarning,
 	}, {
 		name: "valid value for Queue sidecar resource percentage annotation",
 		annotation: map[string]string{
 			serving.QueueSidecarResourcePercentageAnnotationKey: "100",
 		},
+		expectErr: resourcePercentageDeprecationWarning,
 	}}
 
 	for _, c := range cases {

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -138,6 +138,22 @@ func createQueueResources(cfg *deployment.Config, annotations map[string]string,
 		}
 	}
 
+	if requestCPU, ok := resourceFromAnnotation(annotations, serving.QueueSidecarCPUResourceRequestAnnotation); ok {
+		resourceRequests[corev1.ResourceCPU] = requestCPU
+	}
+
+	if limitCPU, ok := resourceFromAnnotation(annotations, serving.QueueSidecarCPUResourceLimitAnnotation); ok {
+		resourceLimits[corev1.ResourceCPU] = limitCPU
+	}
+
+	if requestMemory, ok := resourceFromAnnotation(annotations, serving.QueueSidecarMemoryResourceRequestAnnotation); ok {
+		resourceRequests[corev1.ResourceMemory] = requestMemory
+	}
+
+	if limitMemory, ok := resourceFromAnnotation(annotations, serving.QueueSidecarMemoryResourceLimitAnnotation); ok {
+		resourceLimits[corev1.ResourceMemory] = limitMemory
+	}
+
 	resources := corev1.ResourceRequirements{
 		Requests: resourceRequests,
 	}
@@ -170,6 +186,12 @@ func computeResourceRequirements(resourceQuantity *resource.Quantity, fraction f
 
 	newquantity := boundary.applyBoundary(*resource.NewMilliQuantity(newValue, resource.BinarySI))
 	return true, newquantity
+}
+
+func resourceFromAnnotation(m map[string]string, key kmap.KeyPriority) (resource.Quantity, bool) {
+	_, v, _ := key.Get(m)
+	q, err := resource.ParseQuantity(v)
+	return q, err == nil
 }
 
 func fractionFromPercentage(m map[string]string, key kmap.KeyPriority) (float64, bool) {

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -154,6 +154,14 @@ func createQueueResources(cfg *deployment.Config, annotations map[string]string,
 		resourceLimits[corev1.ResourceMemory] = limitMemory
 	}
 
+	if requestEphmeralStorage, ok := resourceFromAnnotation(annotations, serving.QueueSidecarEphemeralStorageResourceRequestAnnotation); ok {
+		resourceRequests[corev1.ResourceEphemeralStorage] = requestEphmeralStorage
+	}
+
+	if limitEphemeralStorage, ok := resourceFromAnnotation(annotations, serving.QueueSidecarEphemeralStorageResourceLimitAnnotation); ok {
+		resourceLimits[corev1.ResourceEphemeralStorage] = limitEphemeralStorage
+	}
+
 	resources := corev1.ResourceRequirements{
 		Requests: resourceRequests,
 	}

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -570,6 +570,118 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 	}
 }
 
+func TestMakeQueueContainerWithResourceAnnotations(t *testing.T) {
+	tests := []struct {
+		name string
+		rev  *v1.Revision
+		want corev1.Container
+		dc   deployment.Config
+	}{{
+		name: "resources defined via annotations",
+		rev: revision("bar", "foo",
+			func(revision *v1.Revision) {
+				revision.Annotations = map[string]string{
+					serving.QueueSidecarCPUResourceRequestAnnotationKey:    "1",
+					serving.QueueSidecarCPUResourceLimitAnnotationKey:      "2",
+					serving.QueueSidecarMemoryResourceRequestAnnotationKey: "1Gi",
+					serving.QueueSidecarMemoryResourceLimitAnnotationKey:   "2Gi",
+				}
+				revision.Spec.PodSpec.Containers = []corev1.Container{{
+					Name:           servingContainerName,
+					ReadinessProbe: testProbe,
+				}}
+			}),
+		want: queueContainer(func(c *corev1.Container) {
+			c.Env = env(map[string]string{})
+			c.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+				corev1.ResourceCPU:    resource.MustParse("1"),
+			}
+			c.Resources.Limits = corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+				corev1.ResourceCPU:    resource.MustParse("2"),
+			}
+		}),
+	}, {
+		name: "resources defined via annotations with bad values ignored",
+		rev: revision("bar", "foo",
+			func(revision *v1.Revision) {
+				revision.Annotations = map[string]string{
+					serving.QueueSidecarCPUResourceRequestAnnotationKey:    "zzz",
+					serving.QueueSidecarCPUResourceLimitAnnotationKey:      "2",
+					serving.QueueSidecarMemoryResourceRequestAnnotationKey: "Gdx",
+					serving.QueueSidecarMemoryResourceLimitAnnotationKey:   "2Gi",
+				}
+				revision.Spec.PodSpec.Containers = []corev1.Container{{
+					Name:           servingContainerName,
+					ReadinessProbe: testProbe,
+				}}
+			}),
+		want: queueContainer(func(c *corev1.Container) {
+			c.Env = env(map[string]string{})
+			c.Resources.Limits = corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+				corev1.ResourceCPU:    resource.MustParse("2"),
+			}
+		}),
+	}, {
+		name: "resources defined via annotations mixed with percentage annotation",
+		rev: revision("bar", "foo",
+			func(revision *v1.Revision) {
+				revision.Annotations = map[string]string{
+					serving.QueueSidecarCPUResourceLimitAnnotationKey:    "1",
+					serving.QueueSidecarMemoryResourceLimitAnnotationKey: "4Gi",
+					serving.QueueSidecarResourcePercentageAnnotationKey:  "50",
+				}
+				revision.Spec.PodSpec.Containers = []corev1.Container{{
+					Name:           servingContainerName,
+					ReadinessProbe: testProbe,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+							corev1.ResourceCPU:    resource.MustParse("1"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+							corev1.ResourceCPU:    resource.MustParse("2"),
+						},
+					}},
+				}
+			}),
+		want: queueContainer(func(c *corev1.Container) {
+			c.Env = env(map[string]string{})
+			c.Resources.Requests = corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("200Mi"), // hits the boundary for max value
+				corev1.ResourceCPU:    resource.MustParse("100m"),  // hits the boundary for max value
+			}
+			c.Resources.Limits = corev1.ResourceList{ // enforce the desired limits
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+				corev1.ResourceCPU:    resource.MustParse("1"),
+			}
+		}),
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := revConfig()
+			cfg.Deployment = &test.dc
+			got, err := makeQueueContainer(test.rev, cfg)
+			if err != nil {
+				t.Fatal("makeQueueContainer returned error:", err)
+			}
+			test.want.Env = append(test.want.Env, corev1.EnvVar{
+				Name:  "SERVING_READINESS_PROBE",
+				Value: probeJSON(test.rev.Spec.GetContainer()),
+			})
+			sortEnv(got.Env)
+			sortEnv(test.want.Env)
+			if got, want := *got, test.want; !cmp.Equal(got, want, quantityComparer) {
+				t.Errorf("makeQueueContainer (-want, +got) =\n%s", cmp.Diff(want, got, quantityComparer))
+			}
+		})
+	}
+}
+
 func TestProbeGenerationHTTPDefaults(t *testing.T) {
 	rev := revision("bar", "foo",
 		func(revision *v1.Revision) {

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -581,10 +581,12 @@ func TestMakeQueueContainerWithResourceAnnotations(t *testing.T) {
 		rev: revision("bar", "foo",
 			func(revision *v1.Revision) {
 				revision.Annotations = map[string]string{
-					serving.QueueSidecarCPUResourceRequestAnnotationKey:    "1",
-					serving.QueueSidecarCPUResourceLimitAnnotationKey:      "2",
-					serving.QueueSidecarMemoryResourceRequestAnnotationKey: "1Gi",
-					serving.QueueSidecarMemoryResourceLimitAnnotationKey:   "2Gi",
+					serving.QueueSidecarCPUResourceRequestAnnotationKey:              "1",
+					serving.QueueSidecarCPUResourceLimitAnnotationKey:                "2",
+					serving.QueueSidecarMemoryResourceRequestAnnotationKey:           "1Gi",
+					serving.QueueSidecarMemoryResourceLimitAnnotationKey:             "2Gi",
+					serving.QueueSidecarEphemeralStorageResourceRequestAnnotationKey: "500Mi",
+					serving.QueueSidecarEphemeralStorageResourceLimitAnnotationKey:   "600Mi",
 				}
 				revision.Spec.PodSpec.Containers = []corev1.Container{{
 					Name:           servingContainerName,
@@ -594,12 +596,14 @@ func TestMakeQueueContainerWithResourceAnnotations(t *testing.T) {
 		want: queueContainer(func(c *corev1.Container) {
 			c.Env = env(map[string]string{})
 			c.Resources.Requests = corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("1Gi"),
-				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory:           resource.MustParse("1Gi"),
+				corev1.ResourceCPU:              resource.MustParse("1"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("500Mi"),
 			}
 			c.Resources.Limits = corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("2Gi"),
-				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory:           resource.MustParse("2Gi"),
+				corev1.ResourceCPU:              resource.MustParse("2"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("600Mi"),
 			}
 		}),
 	}, {


### PR DESCRIPTION
Part of the work for https://github.com/knative/serving/issues/13861.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds an annotation per resource type. Here is a sample ksvc:
```
apiVersion: serving.knative.dev/v1
kind: Service
spec:
  template:
    metadata:
      labels:
        app: helloworld-go
      annotations:
        queue.sidecar.serving.knative.dev/cpu-resource-request: "1"
        queue.sidecar.serving.knative.dev/cpu-resource-limit: "2"
        queue.sidecar.serving.knative.dev/memory-resource-request: "1Gi"
        queue.sidecar.serving.knative.dev/memory-resource-limit: "2Gi"
        queue.sidecar.serving.knative.dev/ephemeral-storage-resource-request: "400Mi"
        queue.sidecar.serving.knative.dev/ephemeral-storage-resource-limit: "450Mi"
    spec:
 ...
```
* The values passed by the user have higher priority compared to the percentage annotation.
* Tests added.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Queue proxy resources can be configured via annotations at the service level.  The resource percentage annotation is now deprecated.
```
