### PR TITLE
Change storage version of DomainMapping to v1beta1

### DIFF
--- a/config/core/300-resources/domain-mapping.yaml
+++ b/config/core/300-resources/domain-mapping.yaml
@@ -25,7 +25,7 @@ spec:
   versions:
     - name: v1beta1
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
       additionalPrinterColumns:
@@ -149,7 +149,9 @@ spec:
                   type: string
     - name: v1alpha1
       served: true
-      storage: true
+      storage: false
+      deprecated: true
+      deprecationWarning: The v1alpha1 version of DomainMapping has been deprecated and will be removed in a future release of the API. Please upgrade to v1beta1
       subresources:
         status: {}
       schema:

--- a/config/post-install/storage-version-migration.yaml
+++ b/config/post-install/storage-version-migration.yaml
@@ -47,6 +47,7 @@ spec:
           - "configurations.serving.knative.dev"
           - "revisions.serving.knative.dev"
           - "routes.serving.knative.dev"
+          - "domainmappings.serving.knative.dev"
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/14059

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* This deprecates DomainMapping v1alpha1 and changes the storage version to v1beta1

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
DomainMapping/v1alpha1 is deprecated - use v1beta1 APIs
```
