### PR TITLE
Set TLS minimum version to 1.3 for Ingress to Activator

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -285,7 +285,7 @@ func main() {
 		name, server := "https", pkgnet.NewServer(":"+strconv.Itoa(networking.BackendHTTPSPort), ah)
 		go func(name string, s *http.Server) {
 			s.TLSConfig = &tls.Config{
-				MinVersion:     tls.VersionTLS12,
+				MinVersion:     tls.VersionTLS13,
 				GetCertificate: certCache.GetCertificate,
 			}
 			// Don't forward ErrServerClosed as that indicates we're already shutting down.


### PR DESCRIPTION
## Proposed Changes

This patch sets TLS minimum version to 1.3 for Ingress to Activator

**Release Note**

```release-note
Traffic from Ingress to Activator/QP uses TLS 1.3 when internal encryption is enabled.
```

Fix https://github.com/knative/serving/issues/14057