### PR TITLE
Avoid queue telemetry using hostname as telemetry service name

### DIFF
--- a/pkg/queue/sharedmain/main.go
+++ b/pkg/queue/sharedmain/main.go
@@ -189,7 +189,8 @@ func Main(opts ...Option) error {
 	d.Transport = buildTransport(env)
 
 	if env.TracingConfigBackend != tracingconfig.None {
-		oct := tracing.NewOpenCensusTracer(tracing.WithExporterFull(env.ServingPod, env.ServingPodIP, logger))
+		tracingName := fmt.Sprintf("%s-%s-queue", env.ServingNamespace, env.ServingService)
+		oct := tracing.NewOpenCensusTracer(tracing.WithExporterFull(tracingName, env.ServingPodIP, logger))
 		oct.ApplyConfig(&tracingconfig.Config{
 			Backend:        env.TracingConfigBackend,
 			Debug:          env.TracingConfigDebug,


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Currently traces coming from the queue component will be labeled as a service with the hostname as name, which means that every time a pod is recycled, monitoring tools will show a new host. This PR makes sure to give an unique consistent name to all the queue components of a knative service.
* Traces coming from queue will come as `namespace-service-queue`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
* Have a common opencensus tracing service name for all queue components of a service
```
