### PR TITLE
fix: set a low value for PDB to avoid blocking node operations

### DIFF
--- a/config/core/deployments/activator-hpa.yaml
+++ b/config/core/deployments/activator-hpa.yaml
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
 spec:
-  minAvailable: 80%
+  minAvailable: 1
   selector:
     matchLabels:
       app: activator

--- a/config/core/deployments/webhook-hpa.yaml
+++ b/config/core/deployments/webhook-hpa.yaml
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/version: devel
 spec:
-  minAvailable: 80%
+  minAvailable: 1
   selector:
     matchLabels:
       app: webhook


### PR DESCRIPTION
Fixes #9990

Following the discussion #9990 I think the default configuration is not good. With the current configuration and 2 replicas the PodDisruptionBudget gives this status:

```yaml
$ kubectl get pdb -o yaml
[...]
  status:
[...]
    currentHealthy: 2
    desiredHealthy: 2
    disruptionsAllowed: 0
    expectedPods: 2
    observedGeneration: 1
```
A disruptionsAllowed equals to 0 mean that PDB will prevent pod eviction. This lead to timeout or issues when clusters are upgraded. I suggest to set to 1 which ensure a better configuration.
