### PR TITLE
Drop unused ytt patch for Ingress ServiceType

### DIFF
--- a/test/config/ytt/kind/ingress/istio-kind.yaml
+++ b/test/config/ytt/kind/ingress/istio-kind.yaml
@@ -1,8 +1,0 @@
-#@ load("@ytt:overlay", "overlay")
-#@ load("helpers.lib.yaml", "subset")
-
-#@overlay/match by=subset(kind="Service", namespace="istio-system", name="istio-ingressgateway"), expects="1+"
----
-spec:
-  #@overlay/merge
-  type: LoadBalancer

--- a/test/config/ytt/kind/ingress/kourier-kind.yaml
+++ b/test/config/ytt/kind/ingress/kourier-kind.yaml
@@ -1,9 +1,0 @@
-#@ load("@ytt:overlay", "overlay")
-#@ load("helpers.lib.yaml", "subset")
-
-
-#@overlay/match by=subset(kind="Deployment", name="3scale-kourier-gateway")
----
-spec:
-  #@overlay/match missing_ok=True
-  replicas: 1

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -312,7 +312,6 @@ function install() {
 
   if (( KIND )); then
     YTT_FILES+=("${REPO_ROOT_DIR}/test/config/ytt/kind/core")
-    YTT_FILES+=("${REPO_ROOT_DIR}/test/config/ytt/kind/ingress/${ingress}-kind.yaml")
   fi
 
   if (( PVC )); then


### PR DESCRIPTION
This patch drops unused ytt config.

Since Istio and Kourier both dropped `NodePort`, the ytt patch is not necessary now.

* https://github.com/knative-sandbox/net-istio/pull/1136
* https://github.com/knative-sandbox/net-kourier/pull/1067

**Release Note**

```release-note
NONE
```
