### PR TITLE
Implement Stringer for nil podTracker

### DIFF
--- a/pkg/activator/net/throttler.go
+++ b/pkg/activator/net/throttler.go
@@ -89,6 +89,9 @@ func (p *podTracker) getWeight() int32 {
 }
 
 func (p *podTracker) String() string {
+	if p == nil {
+		return "<nil>"
+	}
 	return p.dest
 }
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Implement the `Stringer` interface for nil `podTracker`s.  This sometimes causes spurious fuzzing failures when printing / comparing podTrackers.

