### PR TITLE
Remove domainmapping config

### DIFF
--- a/test/config/ytt/core/overlay-config-logging.yaml
+++ b/test/config/ytt/core/overlay-config-logging.yaml
@@ -32,7 +32,6 @@ data:
   loglevel.webhook: "debug"
   loglevel.activator: "debug"
   loglevel.hpaautoscaler: "debug"
-  loglevel.domainmapping: "debug"
   loglevel.net-istio-controller: "debug"
   loglevel.net-certmanager-controller: "debug"
   loglevel.net-contour-controller: "debug"

--- a/test/config/ytt/values.yaml
+++ b/test/config/ytt/values.yaml
@@ -19,8 +19,6 @@ serving:
     - webhook
     - autoscaler-hpa
     - autoscaler
-    - domainmapping-webhook
-    - domain-mapping
 #! for perrformance tests
 influxtoken:
 influxurl:


### PR DESCRIPTION
As per title, this was removed since https://github.com/knative/serving/commit/fc166ac8b459a73116ca5535e168aba2d97a2626