### PR TITLE
feat: secure-pod-defaults is enabled by default

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "51805dd0"
+    knative.dev/example-checksum: "43e1a61b"
 data:
   _example: |-
     ################################
@@ -40,16 +40,19 @@ data:
     # this example block and unindented to be in the data block
     # to actually change the configuration.
 
-    # Default SecurityContext settings to secure-by-default values
-    # if unset.
-    #
     # Indicates whether secure-pod-defaults support is enabled
+<<<<<<< HEAD
 <<<<<<< HEAD
 =======
 
     # WARNING: Cannot safely be disabled once enabled.
     # See: https://knative.dev/docs/serving/feature-flags/#secure-pod-defaults
 >>>>>>> 21ca62711 (Add link to secure-pod-defaults documentation)
+=======
+
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: TBD
+>>>>>>> 3eec2d1c9 (Update tests to use SecurityContextto account for enabling secure-pod-defaults)
     secure-pod-defaults: "enabled"
 
     # Indicates whether multi container support is enabled

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "4c668645"
+    knative.dev/example-checksum: "3c7d91f6"
 data:
   _example: |-
     ################################

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "cee81616"
+    knative.dev/example-checksum: "51805dd0"
 data:
   _example: |-
     ################################
@@ -44,6 +44,12 @@ data:
     # if unset.
     #
     # Indicates whether secure-pod-defaults support is enabled
+<<<<<<< HEAD
+=======
+
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#secure-pod-defaults
+>>>>>>> 21ca62711 (Add link to secure-pod-defaults documentation)
     secure-pod-defaults: "enabled"
 
     # Indicates whether multi container support is enabled

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "43e1a61b"
+    knative.dev/example-checksum: "4c668645"
 data:
   _example: |-
     ################################
@@ -41,18 +41,9 @@ data:
     # to actually change the configuration.
 
     # Indicates whether secure-pod-defaults support is enabled
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-
+    #
     # WARNING: Cannot safely be disabled once enabled.
     # See: https://knative.dev/docs/serving/feature-flags/#secure-pod-defaults
->>>>>>> 21ca62711 (Add link to secure-pod-defaults documentation)
-=======
-
-    # WARNING: Cannot safely be disabled once enabled.
-    # See: TBD
->>>>>>> 3eec2d1c9 (Update tests to use SecurityContextto account for enabling secure-pod-defaults)
     secure-pod-defaults: "enabled"
 
     # Indicates whether multi container support is enabled

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "f2fc138e"
+    knative.dev/example-checksum: "cee81616"
 data:
   _example: |-
     ################################
@@ -43,9 +43,8 @@ data:
     # Default SecurityContext settings to secure-by-default values
     # if unset.
     #
-    # This value will default to "enabled" in a future release,
-    # probably Knative 1.10
-    secure-pod-defaults: "disabled"
+    # Indicates whether secure-pod-defaults support is enabled
+    secure-pod-defaults: "enabled"
 
     # Indicates whether multi container support is enabled
     #

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -72,7 +72,7 @@ func defaultFeaturesConfig() *Features {
 		PodSpecInitContainers:            Disabled,
 		PodSpecDNSPolicy:                 Disabled,
 		PodSpecDNSConfig:                 Disabled,
-		SecurePodDefaults:                Disabled,
+		SecurePodDefaults:                Enabled,
 		TagHeaderBasedRouting:            Disabled,
 		AutoDetectHTTP2:                  Disabled,
 	}

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -809,7 +809,11 @@ func TestPodSecurityContextMask(t *testing.T) {
 		},
 	}
 
-	want := &corev1.PodSecurityContext{}
+	want := &corev1.PodSecurityContext{
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
 	ctx := context.Background()
 
 	got := PodSecurityContextMask(ctx, in)

--- a/pkg/apis/serving/v1/configuration_defaults_test.go
+++ b/pkg/apis/serving/v1/configuration_defaults_test.go
@@ -76,6 +76,16 @@ func TestConfigurationDefaulting(t *testing.T) {
 								Image:          "busybox",
 								Resources:      defaultResources,
 								ReadinessProbe: defaultProbe,
+								SecurityContext: &corev1.SecurityContext{
+									Capabilities: &corev1.Capabilities{
+										Drop: []corev1.Capability{"ALL"},
+									},
+									RunAsNonRoot:             ptr.Bool(true),
+									AllowPrivilegeEscalation: ptr.Bool(false),
+									SeccompProfile: &corev1.SeccompProfile{
+										Type: corev1.SeccompProfileTypeRuntimeDefault,
+									},
+								},
 							}},
 						},
 						TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -111,6 +121,16 @@ func TestConfigurationDefaulting(t *testing.T) {
 								Image:          "busybox",
 								Resources:      defaultResources,
 								ReadinessProbe: defaultProbe,
+								SecurityContext: &corev1.SecurityContext{
+									Capabilities: &corev1.Capabilities{
+										Drop: []corev1.Capability{"ALL"},
+									},
+									RunAsNonRoot:             ptr.Bool(true),
+									AllowPrivilegeEscalation: ptr.Bool(false),
+									SeccompProfile: &corev1.SeccompProfile{
+										Type: corev1.SeccompProfileTypeRuntimeDefault,
+									},
+								},
 							}},
 						},
 						TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -148,6 +168,16 @@ func TestConfigurationDefaulting(t *testing.T) {
 								Image:          "busybox",
 								Resources:      defaultResources,
 								ReadinessProbe: defaultProbe,
+								SecurityContext: &corev1.SecurityContext{
+									Capabilities: &corev1.Capabilities{
+										Drop: []corev1.Capability{"ALL"},
+									},
+									RunAsNonRoot:             ptr.Bool(true),
+									AllowPrivilegeEscalation: ptr.Bool(false),
+									SeccompProfile: &corev1.SeccompProfile{
+										Type: corev1.SeccompProfileTypeRuntimeDefault,
+									},
+								},
 							}},
 						},
 						TimeoutSeconds:       ptr.Int64(60),

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -91,6 +91,16 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name:           config.DefaultUserContainerName,
 						Resources:      defaultResources,
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 				},
 			},
@@ -123,6 +133,16 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name:           config.DefaultUserContainerName,
 						Resources:      defaultResources,
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 				},
 			},
@@ -158,6 +178,16 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name:           config.DefaultUserContainerName,
 						Resources:      defaultResources,
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 					EnableServiceLinks: ptr.Bool(true),
 				},
@@ -189,6 +219,16 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name:           config.DefaultUserContainerName,
 						Resources:      defaultResources,
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 					EnableServiceLinks: ptr.Bool(true),
 				},
@@ -220,6 +260,16 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name:           config.DefaultUserContainerName,
 						Resources:      defaultResources,
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 					EnableServiceLinks: ptr.Bool(false),
 				},
@@ -254,6 +304,16 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name:           config.DefaultUserContainerName,
 						Resources:      defaultResources,
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 					EnableServiceLinks: ptr.Bool(false),
 				},
@@ -289,6 +349,16 @@ func TestRevisionDefaulting(t *testing.T) {
 						}},
 						Resources:      defaultResources,
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 				},
 				ContainerConcurrency: ptr.Int64(1),
@@ -322,6 +392,16 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name:           config.DefaultUserContainerName,
 						Resources:      defaultResources,
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 				},
 			},
@@ -362,6 +442,16 @@ func TestRevisionDefaulting(t *testing.T) {
 								},
 							},
 						},
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 				},
 			},
@@ -399,6 +489,16 @@ func TestRevisionDefaulting(t *testing.T) {
 								},
 							},
 						},
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 				},
 			},
@@ -430,6 +530,16 @@ func TestRevisionDefaulting(t *testing.T) {
 							SuccessThreshold: 1,
 							TimeoutSeconds:   1, // Added as k8s default
 						},
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 						Resources: defaultResources,
 					}},
 				},
@@ -452,6 +562,16 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name:           config.DefaultUserContainerName,
 						Resources:      defaultResources,
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 				},
 			},
@@ -503,6 +623,16 @@ func TestRevisionDefaulting(t *testing.T) {
 							},
 						},
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 				},
 			},
@@ -532,12 +662,32 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name:           "busybox",
 						Resources:      defaultResources,
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8888,
 						}},
 					}, {
 						Name:      "helloworld",
 						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 				},
 			},
@@ -578,31 +728,111 @@ func TestRevisionDefaulting(t *testing.T) {
 					Containers: []corev1.Container{{
 						Name:      "user-container-1",
 						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name:           "user-container-0",
 						Resources:      defaultResources,
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8888,
 						}},
 					}, {
 						Name:      "user-container-3",
 						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name:      "user-container-2",
 						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name:      "user-container-5",
 						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name:      "user-container-6",
 						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name:      "user-container-7",
 						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name:      "user-container-4",
 						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 				},
 			},
@@ -661,17 +891,57 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name:           "busybox",
 						Resources:      defaultResources,
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8888,
 						}},
 					}, {
 						Name:      "helloworld",
 						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 					InitContainers: []corev1.Container{{
 						Name: "init1",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name: "init2",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 				},
 			},
@@ -710,21 +980,81 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name:           "busybox",
 						Resources:      defaultResources,
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8888,
 						}},
 					}, {
 						Name:      "helloworld",
 						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 					InitContainers: []corev1.Container{{
 						Name: "init1",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name: "init2",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name: "init-container-0",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name: "init-container-1",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 				},
 			},
@@ -763,21 +1093,81 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name:           "user-container-0",
 						Resources:      defaultResources,
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8888,
 						}},
 					}, {
 						Name:      "user-container-1",
 						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 					InitContainers: []corev1.Container{{
 						Name: "init1",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name: "init2",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name: "init-container-0",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name: "init-container-1",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 				},
 			},
@@ -816,21 +1206,81 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name:           "init-container-0",
 						Resources:      defaultResources,
 						ReadinessProbe: defaultProbe,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8888,
 						}},
 					}, {
 						Name:      "init-container-1",
 						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 					InitContainers: []corev1.Container{{
 						Name: "init1",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name: "init2",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name: "init-container-2",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}, {
 						Name: "init-container-3",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+							RunAsNonRoot:             ptr.Bool(true),
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+						},
 					}},
 				},
 			},

--- a/pkg/apis/serving/v1/service_defaults_test.go
+++ b/pkg/apis/serving/v1/service_defaults_test.go
@@ -87,6 +87,16 @@ func TestServiceDefaulting(t *testing.T) {
 									Image:          "busybox",
 									Resources:      defaultResources,
 									ReadinessProbe: defaultProbe,
+									SecurityContext: &corev1.SecurityContext{
+										Capabilities: &corev1.Capabilities{
+											Drop: []corev1.Capability{"ALL"},
+										},
+										RunAsNonRoot:             ptr.Bool(true),
+										AllowPrivilegeEscalation: ptr.Bool(false),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+									},
 								}},
 							},
 							TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -130,6 +140,17 @@ func TestServiceDefaulting(t *testing.T) {
 									Image:          "busybox",
 									Resources:      defaultResources,
 									ReadinessProbe: defaultProbe,
+									SecurityContext: &corev1.SecurityContext{
+										Capabilities: &corev1.Capabilities{
+											Drop: []corev1.Capability{"ALL"},
+										},
+										RunAsNonRoot:             ptr.Bool(true),
+										AllowPrivilegeEscalation: ptr.Bool(false),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type:             corev1.SeccompProfileTypeRuntimeDefault,
+											LocalhostProfile: nil,
+										},
+									},
 								}},
 							},
 							TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
@@ -176,6 +197,16 @@ func TestServiceDefaulting(t *testing.T) {
 									Image:          "busybox",
 									Resources:      defaultResources,
 									ReadinessProbe: defaultProbe,
+									SecurityContext: &corev1.SecurityContext{
+										Capabilities: &corev1.Capabilities{
+											Drop: []corev1.Capability{"ALL"},
+										},
+										RunAsNonRoot:             ptr.Bool(true),
+										AllowPrivilegeEscalation: ptr.Bool(false),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+									},
 								}},
 								EnableServiceLinks: ptr.Bool(true),
 							},
@@ -233,6 +264,16 @@ func TestServiceDefaulting(t *testing.T) {
 									Image:          "busybox",
 									Resources:      defaultResources,
 									ReadinessProbe: defaultProbe,
+									SecurityContext: &corev1.SecurityContext{
+										Capabilities: &corev1.Capabilities{
+											Drop: []corev1.Capability{"ALL"},
+										},
+										RunAsNonRoot:             ptr.Bool(true),
+										AllowPrivilegeEscalation: ptr.Bool(false),
+										SeccompProfile: &corev1.SeccompProfile{
+											Type: corev1.SeccompProfileTypeRuntimeDefault,
+										},
+									},
 								}},
 							},
 							TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -679,7 +679,10 @@ func TestReconcile(t *testing.T) {
 				withDefaultContainerStatuses(), withInitContainerStatuses(), WithRevisionObservedGeneration(1)),
 		}},
 		Key: "foo/first-reconcile",
-		Ctx: defaultconfig.ToContext(context.Background(), &defaultconfig.Config{Features: &defaultconfig.Features{PodSpecInitContainers: defaultconfig.Enabled}}),
+		Ctx: defaultconfig.ToContext(context.Background(), &defaultconfig.Config{Features: &defaultconfig.Features{
+			PodSpecInitContainers: defaultconfig.Enabled,
+			SecurePodDefaults:     defaultconfig.Enabled,
+		}}),
 	}, {
 		Name: "first revision reconciliation with PVC, PVC enabled",
 		// Test the simplest successful reconciliation flow.
@@ -703,6 +706,7 @@ func TestReconcile(t *testing.T) {
 		Ctx: defaultconfig.ToContext(context.Background(), &defaultconfig.Config{Features: &defaultconfig.Features{
 			PodSpecPersistentVolumeClaim: defaultconfig.Enabled,
 			PodSpecPersistentVolumeWrite: defaultconfig.Enabled,
+			SecurePodDefaults:            defaultconfig.Enabled,
 		}}),
 	}}
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -29,6 +29,7 @@ export GATEWAY_API_VERSION=${GATEWAY_API_VERSION:-""}
 export CERTIFICATE_CLASS=${CERTIFICATE_CLASS:-""}
 # Only build linux/amd64 bit images
 export KO_FLAGS="${KO_FLAGS:---platform=linux/amd64}"
+export ENABLE_GKE_TELEMETRY=true
 
 export RUN_HTTP01_AUTO_TLS_TESTS=${RUN_HTTP01_AUTO_TLS_TESTS:-0}
 export HTTPS=${HTTPS:-0}


### PR DESCRIPTION
Fixes #14029

## Proposed Changes

* `secure-pod-defaults` is now enabled by default on the config-features ConfigMap


