### PR TITLE
EnsureCleanup can skip clean up

### DIFF
--- a/test/cleanup.go
+++ b/test/cleanup.go
@@ -73,6 +73,10 @@ func TearDown(clients *Clients, names *ResourceNames) {
 // EnsureCleanup will run the provided cleanup function when the test ends,
 // either via t.Cleanup or on interrupt via CleanupOnInterrupt.
 func EnsureCleanup(t *testing.T, cleanup func()) {
+	if ServingFlags.SkipCleanupOnFail {
+		t.Log("skipping cleanup")
+		return
+	}
 	t.Cleanup(cleanup)
 	CleanupOnInterrupt(cleanup)
 }
@@ -81,10 +85,6 @@ func EnsureCleanup(t *testing.T, cleanup func()) {
 // t.Cleanup, or on interrupt via CleanupOnInterrupt.
 func EnsureTearDown(t *testing.T, clients *Clients, names *ResourceNames) {
 	EnsureCleanup(t, func() {
-		if ServingFlags.SkipCleanupOnFail {
-			t.Log("skipping cleanup")
-			return
-		}
 		TearDown(clients, names)
 	})
 }

--- a/test/conformance/api/v1alpha1/domain_mapping_test.go
+++ b/test/conformance/api/v1alpha1/domain_mapping_test.go
@@ -89,7 +89,7 @@ func TestDomainMapping(t *testing.T) {
 		t.Fatalf("Create(DomainMapping) = %v, expected no error", err)
 	}
 
-	t.Cleanup(func() {
+	test.EnsureCleanup(t, func() {
 		clients.ServingAlphaClient.DomainMappings.Delete(ctx, dm.Name, metav1.DeleteOptions{})
 	})
 
@@ -157,7 +157,7 @@ func TestDomainMapping(t *testing.T) {
 		t.Fatalf("Create(DomainMapping) = %v, expected no error", err)
 	}
 
-	t.Cleanup(func() {
+	test.EnsureCleanup(t, func() {
 		altClients.ServingAlphaClient.DomainMappings.Delete(ctx, altDm.Name, metav1.DeleteOptions{})
 	})
 

--- a/test/conformance/api/v1beta1/domain_mapping_test.go
+++ b/test/conformance/api/v1beta1/domain_mapping_test.go
@@ -89,7 +89,7 @@ func TestDomainMapping(t *testing.T) {
 		t.Fatalf("Create(DomainMapping) = %v, expected no error", err)
 	}
 
-	t.Cleanup(func() {
+	test.EnsureCleanup(t, func() {
 		clients.ServingAlphaClient.DomainMappings.Delete(ctx, dm.Name, metav1.DeleteOptions{})
 	})
 
@@ -157,7 +157,7 @@ func TestDomainMapping(t *testing.T) {
 		t.Fatalf("Create(DomainMapping) = %v, expected no error", err)
 	}
 
-	t.Cleanup(func() {
+	test.EnsureCleanup(t, func() {
 		altClients.ServingAlphaClient.DomainMappings.Delete(ctx, altDm.Name, metav1.DeleteOptions{})
 	})
 

--- a/test/e2e/autotls/domain_mapping_test.go
+++ b/test/e2e/autotls/domain_mapping_test.go
@@ -117,7 +117,7 @@ func TestDomainMappingAutoTLS(t *testing.T) {
 		t.Fatalf("Create(DomainMapping) = %v, expected no error", err)
 	}
 
-	t.Cleanup(func() {
+	test.EnsureCleanup(t, func() {
 		clients.ServingAlphaClient.DomainMappings.Delete(ctx, dm.Name, metav1.DeleteOptions{})
 	})
 

--- a/test/e2e/domainmapping/domain_mapping_test.go
+++ b/test/e2e/domainmapping/domain_mapping_test.go
@@ -95,7 +95,7 @@ func TestBYOCertificate(t *testing.T) {
 		t.Fatalf("Secret creation could not be completed: %v", err)
 	}
 
-	t.Cleanup(func() {
+	test.EnsureCleanup(t, func() {
 		err = clients.KubeClient.CoreV1().Secrets(secret.Namespace).Delete(ctx, secret.Name, metav1.DeleteOptions{})
 		if err != nil {
 			t.Fatalf("Secret %s/%s could not be deleted: %v", secret.Namespace, secret.Name, err)
@@ -125,7 +125,7 @@ func TestBYOCertificate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Problem creating DomainMapping %q: %v", host, err)
 	}
-	t.Cleanup(func() {
+	test.EnsureCleanup(t, func() {
 		clients.ServingAlphaClient.DomainMappings.Delete(ctx, dm.Name, metav1.DeleteOptions{})
 	})
 

--- a/test/e2e/domainmapping/domain_mapping_websocket_test.go
+++ b/test/e2e/domainmapping/domain_mapping_websocket_test.go
@@ -89,7 +89,7 @@ func TestDomainMappingWebsocket(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Problem creating DomainMapping %q: %v", host, err)
 	}
-	t.Cleanup(func() {
+	test.EnsureCleanup(t, func() {
 		clients.ServingBetaClient.DomainMappings.Delete(ctx, dm.Name, metav1.DeleteOptions{})
 	})
 


### PR DESCRIPTION
This PR will help debug tests which use additional resources (e.g. DomainMapping tests).

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Move skipping of cleanup from EnsureTearDown to EnsureCleanup because EnsureCleanup is often used on its own. The flag should be respected in that case.
* Replace occurrences of t.Cleanup with test.EnsureCleanup in tests where t.Cleanup is used directly. This will allow skipping cleanup for these resources as well.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
