### PR TITLE
Bubble up KCertificate Status Message when its not ready

### DIFF
--- a/pkg/apis/serving/v1/route_lifecycle.go
+++ b/pkg/apis/serving/v1/route_lifecycle.go
@@ -174,10 +174,13 @@ func (rs *RouteStatus) MarkCertificateReady(name string) {
 
 // MarkCertificateNotReady marks the RouteConditionCertificateProvisioned
 // condition to indicate that the Certificate is not ready.
-func (rs *RouteStatus) MarkCertificateNotReady(name string) {
+func (rs *RouteStatus) MarkCertificateNotReady(c *v1alpha1.Certificate) {
+	certificateCondition := c.Status.GetCondition("Ready")
+	certMessage := certificateCondition.GetReason()
+
 	routeCondSet.Manage(rs).MarkUnknown(RouteConditionCertificateProvisioned,
 		"CertificateNotReady",
-		"Certificate %s is not ready.", name)
+		"Certificate %s is not ready. Certificate Message: %s", c.Name, certMessage)
 }
 
 // MarkCertificateNotOwned changes the RouteConditionCertificateProvisioned

--- a/pkg/apis/serving/v1/route_lifecycle_test.go
+++ b/pkg/apis/serving/v1/route_lifecycle_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -438,9 +439,35 @@ func TestCertificateReady(t *testing.T) {
 func TestCertificateNotReady(t *testing.T) {
 	r := &RouteStatus{}
 	r.InitializeConditions()
-	r.MarkCertificateNotReady("cert")
+	r.MarkCertificateNotReady(&netv1alpha1.Certificate{})
 
 	apistest.CheckConditionOngoing(r, RouteConditionCertificateProvisioned, t)
+}
+
+func TestCertificateNotReadyWithBubbledUpMessage(t *testing.T) {
+	cert := &netv1alpha1.Certificate{
+		Status: netv1alpha1.CertificateStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{
+					{
+						Type:   "Ready",
+						Status: "False",
+						Reason: "CommonName Too Long",
+					},
+				},
+			},
+		},
+	}
+
+	r := &RouteStatus{}
+	r.InitializeConditions()
+	r.MarkCertificateNotReady(cert)
+
+	expectedCertMessage := "Certificate Message: CommonName Too Long"
+	certMessage := r.Status.GetCondition("Ready").Message
+	if !strings.Contains(certMessage, expectedCertMessage) {
+		t.Errorf("Literal %q not found in status message: %q", expectedCertMessage, certMessage)
+	}
 }
 
 func TestCertificateProvisionFailed(t *testing.T) {

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -265,7 +265,7 @@ func (c *Reconciler) tls(ctx context.Context, host string, r *v1.Route, traffic 
 			tls = append(tls, resources.MakeIngressTLS(cert, dnsNames.List()))
 		} else {
 			acmeChallenges = append(acmeChallenges, cert.Status.HTTP01Challenges...)
-			r.Status.MarkCertificateNotReady(cert.Name)
+			r.Status.MarkCertificateNotReady(cert)
 			// When httpProtocol is enabled, downgrade http scheme.
 			// Explicitly not using the override settings here as to not to muck with
 			// AutoTLS semantics.

--- a/pkg/testing/v1/route.go
+++ b/pkg/testing/v1/route.go
@@ -208,7 +208,7 @@ func MarkUnknownTrafficError(msg string) RouteOption {
 
 // MarkCertificateNotReady calls the method of the same name on .Status
 func MarkCertificateNotReady(r *v1.Route) {
-	r.Status.MarkCertificateNotReady(routenames.Certificate(r))
+	r.Status.MarkCertificateNotReady(&netv1alpha1.Certificate{})
 }
 
 // MarkCertificateNotOwned calls the method of the same name on .Status


### PR DESCRIPTION
Fixes #14250

## Proposed Changes

* KCert Status Message gets bubbled up to its parent Route when it's not ready

## Reproduction Steps
* Given a cluster with Knative serving and autoTLS enabled
* And the domain is configured so that the generated URL contains more than 64 Bytes (Command: kubectl edit configmap config-domain -n knative-serving)
* When a Knative service is created
* Then I should see the Certificate generation error in the status of the Knative Service and Route.

OR

Run [this](https://gist.github.com/xtreme-vikram-yadav/65511ad949e088fbb0e4392f20682e3a) script against a local kind cluster.
Note: Update `KO_DOCKER_REPO` before running the above script.


**Release Note**


```release-note
* Certificate generation errors are bubbled up to its parent Route.
```
