### PR TITLE
add app: webhook label to webhook service

### DIFF
--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -129,6 +129,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app: webhook
     role: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/version: devel


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add an app label to the webhook service. This aligns with the other component services ([activator](https://github.com/knative/serving/blob/main/config/core/deployments/activator.yaml#L133), [controller](https://github.com/knative/serving/blob/main/config/core/deployments/controller.yaml#L118)).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Label the webhook service with "app: webhook" label
```
