### PR TITLE
Add security_mode metric tag to request metrics

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -158,8 +158,8 @@ func main() {
 		logger.Fatalw("Failed to construct network config", zap.Error(err))
 	}
 
-	// Enable TLS against queue-proxy when internal-encryption is enabled.
-	tlsEnabled := networkConfig.InternalEncryption
+	// Enable TLS against queue-proxy when dataplane-trust != disabled.
+	tlsEnabled := networkConfig.InternalTLSEnabled()
 
 	var certCache *certificate.CertCache
 

--- a/pkg/activator/config/store.go
+++ b/pkg/activator/config/store.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"go.uber.org/atomic"
+	netcfg "knative.dev/networking/pkg/config"
 	"knative.dev/pkg/configmap"
 	tracingconfig "knative.dev/pkg/tracing/config"
 )
@@ -29,6 +30,7 @@ type cfgKey struct{}
 // Config is the configuration for the activator.
 type Config struct {
 	Tracing *tracingconfig.Config
+	Network *netcfg.Config
 }
 
 // FromContext obtains a Config injected into the passed context.
@@ -51,15 +53,23 @@ func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value i
 	// Append an update function to run after a ConfigMap has updated to update the
 	// current state of the Config.
 	onAfterStore = append(onAfterStore, func(_ string, _ interface{}) {
-		s.current.Store(&Config{
-			Tracing: s.UntypedLoad(tracingconfig.ConfigName).(*tracingconfig.Config).DeepCopy(),
-		})
+		c := &Config{}
+		tracing := s.UntypedLoad(tracingconfig.ConfigName)
+		if tracing != nil {
+			c.Tracing = tracing.(*tracingconfig.Config).DeepCopy()
+		}
+		network := s.UntypedLoad(netcfg.ConfigMapName)
+		if network != nil {
+			c.Network = network.(*netcfg.Config).DeepCopy()
+		}
+		s.current.Store(c)
 	})
 	s.UntypedStore = configmap.NewUntypedStore(
 		"activator",
 		logger,
 		configmap.Constructors{
 			tracingconfig.ConfigName: tracingconfig.NewTracingConfigFromConfigMap,
+			netcfg.ConfigMapName:     netcfg.NewConfigFromConfigMap,
 		},
 		onAfterStore...,
 	)

--- a/pkg/activator/config/store_test.go
+++ b/pkg/activator/config/store_test.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	netcfg "knative.dev/networking/pkg/config"
 	ltesting "knative.dev/pkg/logging/testing"
 	tracingconfig "knative.dev/pkg/tracing/config"
 )
@@ -35,16 +36,29 @@ var tracingConfig = &corev1.ConfigMap{
 	},
 }
 
+var networkingConfig = &corev1.ConfigMap{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: netcfg.ConfigMapName,
+	},
+	Data: map[string]string{
+		"dataplane-trust": "Disabled",
+	},
+}
+
 func TestStore(t *testing.T) {
 	logger := ltesting.TestLogger(t)
 	store := NewStore(logger)
 	store.OnConfigChanged(tracingConfig)
+	store.OnConfigChanged(networkingConfig)
 
 	ctx := store.ToContext(context.Background())
 	cfg := FromContext(ctx)
 
 	if got, want := cfg.Tracing.Backend, tracingconfig.None; got != want {
 		t.Fatalf("Tracing.Backend = %v, want %v", got, want)
+	}
+	if got, want := cfg.Network.DataplaneTrust, netcfg.TrustDisabled; got != want {
+		t.Fatalf("Networking.DataplaneTrust = %v, want %v", got, want)
 	}
 
 	newConfig := &corev1.ConfigMap{

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -326,6 +326,7 @@ func revision(namespace, name string) *v1.Revision {
 func setupConfigStore(t testing.TB, logger *zap.SugaredLogger) *activatorconfig.Store {
 	configStore := activatorconfig.NewStore(logger)
 	configStore.OnConfigChanged(tracingConfig(false))
+	configStore.OnConfigChanged(networkConfig(false))
 	return configStore
 }
 

--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -20,8 +20,10 @@ import (
 	"net/http"
 	"time"
 
+	"go.opencensus.io/tag"
 	pkgmetrics "knative.dev/pkg/metrics"
 	"knative.dev/serving/pkg/activator"
+	activatorconfig "knative.dev/serving/pkg/activator/config"
 	"knative.dev/serving/pkg/apis/serving"
 	pkghttp "knative.dev/serving/pkg/http"
 	"knative.dev/serving/pkg/metrics"
@@ -45,6 +47,9 @@ func (h *MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rev := RevisionFrom(r.Context())
 	reporterCtx, _ := metrics.PodRevisionContext(h.podName, activator.Name,
 		rev.Namespace, rev.Labels[serving.ServiceLabelKey], rev.Labels[serving.ConfigurationLabelKey], rev.Name)
+
+	securityMode := activatorconfig.FromContext(r.Context()).Network.DataplaneTrust
+	reporterCtx, _ = tag.New(reporterCtx, tag.Upsert(metrics.SecurityMode, string(securityMode)))
 
 	start := time.Now()
 

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -26,10 +26,15 @@ import (
 	"testing"
 
 	"go.opencensus.io/resource"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	netcfg "knative.dev/networking/pkg/config"
+	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics/metricstest"
 	_ "knative.dev/pkg/metrics/testing"
 	"knative.dev/serving/pkg/activator"
+	activatorconfig "knative.dev/serving/pkg/activator/config"
 	"knative.dev/serving/pkg/apis/serving"
 	"knative.dev/serving/pkg/metrics"
 )
@@ -108,13 +113,19 @@ func TestRequestMetricHandler(t *testing.T) {
 					metrics.LabelContainerName:     activator.Name,
 					metrics.LabelResponseCode:      strconv.Itoa(labelCode),
 					metrics.LabelResponseCodeClass: strconv.Itoa(labelCode/100) + "xx",
+					metrics.LabelSecurityMode:      string(netcfg.TrustDisabled),
 				}
 
 				metricstest.AssertMetric(t, metricstest.IntMetric(requestCountM.Name(), 1, wantTags).WithResource(wantResource))
 				metricstest.AssertMetricExists(t, responseTimeInMsecM.Name())
 			}()
 
+			cm := networkConfig(false)
+
 			reqCtx := WithRevisionAndID(context.Background(), rev, types.NamespacedName{Namespace: testNamespace, Name: testRevName})
+			configStore := activatorconfig.NewStore(logging.FromContext(reqCtx))
+			configStore.OnConfigChanged(cm)
+			reqCtx = configStore.ToContext(reqCtx)
 			handler.ServeHTTP(resp, req.WithContext(reqCtx))
 		})
 	}
@@ -147,4 +158,17 @@ func BenchmarkMetricHandler(b *testing.B) {
 			}
 		})
 	})
+}
+
+func networkConfig(internalTLSEnabled bool) *corev1.ConfigMap {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: netcfg.ConfigMapName,
+		},
+		Data: map[string]string{},
+	}
+	if internalTLSEnabled {
+		cm.Data["dataplane-trust"] = string(netcfg.TrustEnabled)
+	}
+	return cm
 }

--- a/pkg/activator/handler/metrics.go
+++ b/pkg/activator/handler/metrics.go
@@ -57,19 +57,19 @@ func register() {
 			Description: "Concurrent requests that are routed to Activator",
 			Measure:     requestConcurrencyM,
 			Aggregation: view.LastValue(),
-			TagKeys:     []tag.Key{metrics.PodKey, metrics.ContainerKey},
+			TagKeys:     []tag.Key{metrics.PodKey, metrics.ContainerKey, metrics.SecurityMode},
 		},
 		&view.View{
 			Description: "The number of requests that are routed to Activator",
 			Measure:     requestCountM,
 			Aggregation: view.Count(),
-			TagKeys:     []tag.Key{metrics.PodKey, metrics.ContainerKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey},
+			TagKeys:     []tag.Key{metrics.PodKey, metrics.ContainerKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey, metrics.SecurityMode},
 		},
 		&view.View{
 			Description: "The response time in millisecond",
 			Measure:     responseTimeInMsecM,
 			Aggregation: defaultLatencyDistribution,
-			TagKeys:     []tag.Key{metrics.PodKey, metrics.ContainerKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey},
+			TagKeys:     []tag.Key{metrics.PodKey, metrics.ContainerKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey, metrics.SecurityMode},
 		},
 	); err != nil {
 		panic(err)

--- a/pkg/metrics/key.go
+++ b/pkg/metrics/key.go
@@ -61,6 +61,9 @@ const (
 	// LabelResponseTimeout is the label timeout.
 	LabelResponseTimeout = metricskey.LabelResponseTimeout
 
+	// LabelSecurityMode is the label for Security Mode Knative is configured to use (see dataplane-trust in config-networking).
+	LabelSecurityMode = "security_mode"
+
 	// ValueUnknown is the default value if the field is unknown, e.g. project will be unknown if Knative
 	// is not running on GKE.
 	ValueUnknown = metricskey.ValueUnknown
@@ -77,4 +80,5 @@ var (
 	ResponseCodeKey      = tag.MustNewKey(LabelResponseCode)
 	ResponseCodeClassKey = tag.MustNewKey(LabelResponseCodeClass)
 	RouteTagKey          = tag.MustNewKey(LabelRouteTag)
+	SecurityMode         = tag.MustNewKey(LabelSecurityMode)
 )

--- a/pkg/queue/request_metric.go
+++ b/pkg/queue/request_metric.go
@@ -25,6 +25,7 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
+	netcfg "knative.dev/networking/pkg/config"
 	netheader "knative.dev/networking/pkg/http/header"
 	pkgmetrics "knative.dev/pkg/metrics"
 	pkghttp "knative.dev/serving/pkg/http"
@@ -62,8 +63,9 @@ var (
 )
 
 type requestMetricsHandler struct {
-	next     http.Handler
-	statsCtx context.Context
+	next         http.Handler
+	statsCtx     context.Context
+	securityMode netcfg.Trust
 }
 
 type appRequestMetricsHandler struct {
@@ -74,8 +76,8 @@ type appRequestMetricsHandler struct {
 
 // NewRequestMetricsHandler creates an http.Handler that emits request metrics.
 func NewRequestMetricsHandler(next http.Handler,
-	ns, service, config, rev, pod string) (http.Handler, error) {
-	keys := []tag.Key{metrics.PodKey, metrics.ContainerKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey, metrics.RouteTagKey}
+	ns, service, config, rev, pod string, securityMode netcfg.Trust) (http.Handler, error) {
+	keys := []tag.Key{metrics.PodKey, metrics.ContainerKey, metrics.ResponseCodeKey, metrics.ResponseCodeClassKey, metrics.RouteTagKey, metrics.SecurityMode}
 	if err := pkgmetrics.RegisterResourceView(
 		&view.View{
 			Description: "The number of requests that are routed to queue-proxy",
@@ -99,14 +101,17 @@ func NewRequestMetricsHandler(next http.Handler,
 	}
 
 	return &requestMetricsHandler{
-		next:     next,
-		statsCtx: ctx,
+		next:         next,
+		statsCtx:     ctx,
+		securityMode: securityMode,
 	}, nil
 }
 
 func (h *requestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rr := pkghttp.NewResponseRecorder(w, http.StatusOK)
 	startTime := time.Now()
+
+	ctx, _ := tag.New(h.statsCtx, tag.Upsert(metrics.SecurityMode, string(h.securityMode)))
 
 	defer func() {
 		// Filter probe requests for revision metrics.
@@ -119,13 +124,13 @@ func (h *requestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		latency := time.Since(startTime)
 		routeTag := GetRouteTagNameFromRequest(r)
 		if err != nil {
-			ctx := metrics.AugmentWithResponseAndRouteTag(h.statsCtx,
+			ctx = metrics.AugmentWithResponseAndRouteTag(ctx,
 				http.StatusInternalServerError, routeTag)
 			pkgmetrics.RecordBatch(ctx, requestCountM.M(1),
 				responseTimeInMsecM.M(float64(latency.Milliseconds())))
 			panic(err)
 		}
-		ctx := metrics.AugmentWithResponseAndRouteTag(h.statsCtx,
+		ctx = metrics.AugmentWithResponseAndRouteTag(ctx,
 			rr.ResponseCode, routeTag)
 		pkgmetrics.RecordBatch(ctx, requestCountM.M(1),
 			responseTimeInMsecM.M(float64(latency.Milliseconds())))

--- a/pkg/queue/sharedmain/main.go
+++ b/pkg/queue/sharedmain/main.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"knative.dev/networking/pkg/certificates"
+	netcfg "knative.dev/networking/pkg/config"
 	netstats "knative.dev/networking/pkg/http/stats"
 	pkglogging "knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
@@ -103,6 +104,9 @@ type config struct {
 	TracingConfigBackend        tracingconfig.BackendType `split_words:"true"` // optional
 	TracingConfigSampleRate     float64                   `split_words:"true"` // optional
 	TracingConfigZipkinEndpoint string                    `split_words:"true"` // optional
+
+	// SecurityMode is the trust level for internal encryption, see config-networking.data.dataplane-trust
+	SecurityMode netcfg.Trust `split_words:"true" required:"true"`
 
 	Env
 }
@@ -395,7 +399,7 @@ func requestLogHandler(logger *zap.SugaredLogger, currentHandler http.Handler, e
 
 func requestMetricsHandler(logger *zap.SugaredLogger, currentHandler http.Handler, env config) http.Handler {
 	h, err := queue.NewRequestMetricsHandler(currentHandler, env.ServingNamespace,
-		env.ServingService, env.ServingConfiguration, env.ServingRevision, env.ServingPod)
+		env.ServingService, env.ServingConfiguration, env.ServingRevision, env.ServingPod, env.SecurityMode)
 	if err != nil {
 		logger.Errorw("Error setting up request metrics reporter. Request metrics will be unavailable.", zap.Error(err))
 		return currentHandler

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -43,6 +43,7 @@ import (
 	"knative.dev/serving/pkg/deployment"
 	"knative.dev/serving/pkg/queue"
 
+	netcfg "knative.dev/networking/pkg/config"
 	_ "knative.dev/pkg/metrics/testing"
 	. "knative.dev/serving/pkg/testing/v1"
 )
@@ -188,6 +189,9 @@ var (
 		}, {
 			Name:  "ENABLE_HTTP2_AUTO_DETECTION",
 			Value: "false",
+		}, {
+			Name:  "SECURITY_MODE",
+			Value: "",
 		}, {
 			Name:  "ROOT_CA",
 			Value: "",
@@ -529,6 +533,7 @@ func TestMakePodSpec(t *testing.T) {
 		defaults *apicfg.Defaults
 		dc       deployment.Config
 		fc       apicfg.Features
+		nc       netcfg.Config
 		want     *corev1.PodSpec
 	}{{
 		name: "user-defined user port, queue proxy have PORT env",
@@ -1348,6 +1353,7 @@ func TestMakePodSpec(t *testing.T) {
 			cfg.Observability = &test.oc
 			cfg.Deployment = &test.dc
 			cfg.Features = &test.fc
+			cfg.Network = &test.nc
 			if test.defaults != nil {
 				cfg.Defaults = test.defaults
 			}

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -414,6 +414,9 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 			Name:  "ENABLE_HTTP2_AUTO_DETECTION",
 			Value: strconv.FormatBool(cfg.Features.AutoDetectHTTP2 == apicfg.Enabled),
 		}, {
+			Name:  "SECURITY_MODE",
+			Value: string(cfg.Network.DataplaneTrust),
+		}, {
 			Name:  "ROOT_CA",
 			Value: cfg.Deployment.QueueSidecarRootCA,
 		}},

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -417,6 +417,18 @@ func TestMakeQueueContainer(t *testing.T) {
 				"ENABLE_HTTP2_AUTO_DETECTION": "false",
 			})
 		}),
+	}, {
+		name: "SecurityMode set",
+		rev: revision("bar", "foo",
+			withContainers(containers)),
+		nc: netcfg.Config{
+			DataplaneTrust: netcfg.TrustEnabled,
+		},
+		want: queueContainer(func(c *corev1.Container) {
+			c.Env = env(map[string]string{
+				"SECURITY_MODE": "enabled",
+			})
+		}),
 	}}
 
 	for _, test := range tests {
@@ -434,6 +446,7 @@ func TestMakeQueueContainer(t *testing.T) {
 				Logging:       &test.lc,
 				Observability: &test.oc,
 				Deployment:    &test.dc,
+				Network:       &test.nc,
 				Config: &apicfg.Config{
 					Features: &test.fc,
 				},
@@ -1049,6 +1062,7 @@ var defaultEnv = map[string]string{
 	"REVISION_TIMEOUT_SECONDS":                         "45",
 	"REVISION_RESPONSE_START_TIMEOUT_SECONDS":          "0",
 	"REVISION_IDLE_TIMEOUT_SECONDS":                    "0",
+	"SECURITY_MODE":                                    "",
 	"SERVING_CONFIGURATION":                            "",
 	"SERVING_ENABLE_PROBE_REQUEST_LOG":                 "false",
 	"SERVING_ENABLE_REQUEST_LOG":                       "false",


### PR DESCRIPTION
Fixes #

In support of: https://github.com/knative/serving/pull/14092
Relies on: https://github.com/knative/networking/pull/842

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* activator can dynamically pick up changes in config-network
* activator metrics handler sets security mode tag on request metrics based on the network config value from context
* queue proxy also sets security mode metric. Security mode is set as an env var

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Activator and QueueProxy now tag certain request metrics with "security_mode" data that corresponds to the value of dataplane-trust on config-network
```
