### PR TITLE
Split HTTPGetAction.Path into path and query

### DIFF
--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -92,10 +93,16 @@ var transport = func() *http.Transport {
 }()
 
 func getURL(config HTTPProbeConfigOptions) url.URL {
+	// Split config.Path into path and query as it may contain query like "/?foo=bar".
+	pathQuery := strings.Split(config.Path, "?")
+	path := pathQuery[0]
+	query := strings.Join(pathQuery[1:], "?")
+
 	return url.URL{
-		Scheme: string(config.Scheme),
-		Host:   net.JoinHostPort(config.Host, config.Port.String()),
-		Path:   config.Path,
+		Scheme:   string(config.Scheme),
+		Host:     net.JoinHostPort(config.Host, config.Port.String()),
+		Path:     path,
+		RawQuery: query,
 	}
 }
 

--- a/test/e2e/readiness_test.go
+++ b/test/e2e/readiness_test.go
@@ -80,3 +80,46 @@ func TestReadinessAlternatePort(t *testing.T) {
 	}
 
 }
+
+func TestReadinessPathAndQuery(t *testing.T) {
+	t.Parallel()
+
+	clients := Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.Readiness,
+	}
+
+	test.EnsureTearDown(t, clients, &names)
+
+	t.Log("Creating a new Service")
+
+	resources, err := v1test.CreateServiceReady(t, clients, &names,
+		v1opts.WithReadinessProbe(
+			&corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/query?probe=ok",
+					},
+				},
+			}))
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	url := resources.Route.Status.URL.URL()
+	if _, err := pkgTest.CheckEndpointState(
+		context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		url,
+		spoof.MatchesAllOf(spoof.IsStatusOK, spoof.MatchesBody(test.HelloWorldText)),
+		"HelloWorldServesText",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("The endpoint %s for Route %s didn't serve the expected text %q: %v", url, names.Route, test.HelloWorldText, err)
+	}
+
+}

--- a/test/test_images/readiness/readiness.go
+++ b/test/test_images/readiness/readiness.go
@@ -85,6 +85,7 @@ func main() {
 		mainServer.HandleFunc("/healthz", handleHealthz)
 	}
 
+	mainServer.HandleFunc("/query", handleQuery)
 	http.ListenAndServe(":8080", mainServer)
 }
 
@@ -116,6 +117,13 @@ func handleHealthz(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	fmt.Fprint(w, test.HelloWorldText)
+}
+
+func handleQuery(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("probe") == "ok" {
+		fmt.Fprint(w, test.HelloWorldText)
+	}
+	http.Error(w, "no query", http.StatusInternalServerError)
 }
 
 func handleMain(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/14267

`corev1.HTTPGetAction` has `Path` which allows path and query like `/mypath?foo=bar`.
However, Golang's url.URL needs to split it into `Path` and `RawQuery` otherwise `url.String()` encodes `?` into `%3F` like https://github.com/knative/serving/issues/14267.

Hence this patch fix it by split `corev1.HTTPGetAction.Path` into `Path` and `RawQuery`.

**Release Note**

```release-note
ReadinessProbe with path contains a query string is supported now.
```