### PR TITLE
Ensure old revision stays Unreachable after Knative Service update

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -167,7 +167,8 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.
 	pa.Status.ServiceName = sks.Status.ServiceName
 
 	// If SKS is not ready — ensure we're not becoming ready.
-	if sks.IsReady() {
+	// Do not use ServerlessService.IsReady() here because this flips to not ready when the generation changes.
+	if sks.Status.GetCondition(nv1alpha1.ServerlessServiceConditionReady).IsTrue() {
 		logger.Debug("SKS is ready, marking SKS status ready")
 		pa.Status.MarkSKSReady()
 	} else {


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/14115 by changing how the Knative PodAutoscaler detects whether a ServerlessService is ready.

Before my change, it called the [`IsReady` function of the ServerlessService](https://github.com/knative/serving/blob/v0.27.2/vendor/knative.dev/networking/pkg/apis/networking/v1alpha1/serverlessservice_lifecycle.go#L95) which is returning false if the generation is different in metadata and status.

Due to it temporarily not being ready, the PodAutoscaler is set to SKSReady=Unknown [here](https://github.com/knative/serving/blob/v0.37.2/pkg/reconciler/autoscaling/kpa/kpa.go#L174).

The PodAutoscaler then goes Ready=False because SKSReady is part of Ready [here](https://github.com/knative/serving/blob/v0.37.2/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go#L34-L38).

The revision inherits the PodAutoscaler status and sets Active=Unknown [here](https://github.com/knative/serving/blob/v0.37.2/pkg/apis/serving/v1/revision_lifecycle.go#L172-L202).

This causes the PodAutoscaler's Reachability to be set to Unknown [here](https://github.com/knative/serving/blob/v0.37.2/pkg/reconciler/revision/resources/pa.go#L60).

Once the PodAutoscaler is not anymore marked as unreachable, the scaling boundary will be set to the min value from the annotation again [here](https://github.com/knative/serving/blob/v0.37.2/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go#L90-L95). This will cause a revision that is being not needed anymore to scale up again for a short moment which causes additional pods.

I am changing the logic in the KPA reconciler to directly look at the Ready condition of the ServerlessService instead of calling its IsReady function.

I need somebody with experience in this area to carefully assess if there are side-effects.

/kind bug

**Release Note**

```release-note
An Unreachable revision is now not anymore causing additional pods to get created while it is scaled down to 0.
```