### PR TITLE
Allow probes to be defined for sidecar containers

### DIFF
--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -888,7 +888,7 @@ func TestPodSpecMultiContainerValidation(t *testing.T) {
 			Details: "Only a single port is allowed across all containers",
 		},
 	}, {
-		name: "flag enabled: multiple containers with livelinessProbe targeting main container's port",
+		name: "flag enabled: multiple containers with livenessProbe targeting main container's port",
 		ps: corev1.PodSpec{
 			Containers: []corev1.Container{{
 				Name:  "container-a",

--- a/test/e2e/multicontainer_probes_test.go
+++ b/test/e2e/multicontainer_probes_test.go
@@ -1,0 +1,122 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	corev1 "k8s.io/api/core/v1"
+
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/spoof"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/test"
+	v1test "knative.dev/serving/test/v1"
+)
+
+func TestMultiContainerProbes(t *testing.T) {
+	if !test.ServingFlags.EnableBetaFeatures {
+		t.Skip()
+	}
+	t.Parallel()
+
+	clients := Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.ServingContainer,
+		Sidecars: []string{
+			test.SidecarContainer,
+		},
+	}
+
+	containers := []corev1.Container{{
+		Image: pkgTest.ImagePath(names.Image),
+		Ports: []corev1.ContainerPort{{
+			ContainerPort: 8881,
+		}},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(8881),
+				},
+			},
+		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(8881),
+				},
+			},
+		},
+	}, {
+		Image: pkgTest.ImagePath(names.Sidecars[0]), // sidecar container with probes defined
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(8882),
+				},
+			},
+		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Port: intstr.FromInt(8882),
+				},
+			},
+		},
+	}}
+
+	// Please see the comment in test/v1/configuration.go.
+	if !test.ServingFlags.DisableOptionalAPI {
+		for _, c := range containers {
+			c.ImagePullPolicy = corev1.PullIfNotPresent
+		}
+	}
+
+	test.EnsureTearDown(t, clients, &names)
+
+	t.Log("Creating a new Service")
+
+	resources, err := v1test.CreateServiceReady(t, clients, &names, func(svc *v1.Service) {
+		svc.Spec.Template.Spec.Containers = containers
+	})
+
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	url := resources.Route.Status.URL.URL()
+	if _, err := pkgTest.CheckEndpointState(
+		context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		url,
+		spoof.MatchesAllOf(spoof.IsStatusOK, spoof.MatchesBody(test.MultiContainerResponse)),
+		"MulticontainerServesExpectedText",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("The endpoint %s for Route %s didn't serve the expected text %q: %v", url, names.Route, test.MultiContainerResponse, err)
+	}
+}

--- a/test/e2e/multicontainer_probes_test.go
+++ b/test/e2e/multicontainer_probes_test.go
@@ -2,7 +2,7 @@
 // +build e2e
 
 /*
-Copyright 2020 The Knative Authors
+Copyright 2023 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,9 +23,8 @@ import (
 	"context"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"


### PR DESCRIPTION
Issue - [Link](https://github.com/knative/serving/issues/8949)

This PR allows sidecar containers to have liveness & readiness probes to be defined.

- Before: We wouldn’t not allow liveness & readiness probes to be defined for the sidecar containers.
- Now: We would allow those to be defined, but probe port (either liveness or readiness) can’t be the same as the main container’s port.

The following is an example yaml file that creates a primary container on port 8080 and a sidecar container on port 8081. This type of configuration was not allowed before.

```
apiVersion: serving.knative.dev/v1
kind: Service
metadata:
  name: hello
spec:
  template:
    metadata:
      creationTimestamp: null
      annotations:
        autoscaling.knative.dev/min-scale: "1"
    spec:
      containerConcurrency: 0
      containers:
        - image: "ghcr.io/knative/helloworld-go:latest"
          name: main-container
          ports:
            - containerPort: 8080
              name: http1
              protocol: TCP
          livenessProbe:
            initialDelaySeconds: 20
            periodSeconds: 10
            timeoutSeconds: 5
            failureThreshold: 1
            successThreshold: 1
            httpGet:
              path: /
              port: 8080
          readinessProbe:
            initialDelaySeconds: 2
            periodSeconds: 10
            timeoutSeconds: 5
            failureThreshold: 1
            successThreshold: 1
            httpGet:
              path: /
              port: 8080
          resources: {}
        - image: "karanjagtiani/go-server:latest"
          name: sidecar-container
          livenessProbe:
            initialDelaySeconds: 20
            periodSeconds: 10
            timeoutSeconds: 5
            failureThreshold: 1
            successThreshold: 1
            httpGet:
              path: /
              port: 8081
          readinessProbe:
            initialDelaySeconds: 2
            periodSeconds: 10
            timeoutSeconds: 5
            failureThreshold: 1
            successThreshold: 1
            httpGet:
              path: /
              port: 8081
          resources: {}
      enableServiceLinks: false
      timeoutSeconds: 300
  traffic:
    - latestRevision: true
      percent: 100
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
With the recent update in Knative Revisions validation, liveness and readiness probes can now be defined for sidecar containers.
```
