### PR TITLE
fix e2e script & some tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -40,7 +40,12 @@ GO_TEST_FLAGS=""
 E2E_TEST_FLAGS="${TEST_OPTIONS}"
 
 if [ -z "${E2E_TEST_FLAGS}" ]; then
-  E2E_TEST_FLAGS=" -enable-alpha -enable-beta -resolvabledomain=$(use_resolvable_domain) -ingress-class=${INGRESS_CLASS}"
+  E2E_TEST_FLAGS="-resolvabledomain=$(use_resolvable_domain) -ingress-class=${INGRESS_CLASS}"
+
+  # Drop testing alpha and beta features with the Gateway API
+  if [[ "${INGRESS_CLASS}" != *"gateway-api"* ]]; then
+    E2E_TEST_FLAGS+=" -enable-alpha -enable-beta"
+  fi
 fi
 
 if (( HTTPS )); then

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -36,69 +36,54 @@ header "Running tests"
 failed=0
 
 # Run tests serially in the mesh and https scenarios.
-parallelism=""
-use_https=""
-if (( MESH )); then
-  parallelism="-parallel 1"
+GO_TEST_FLAGS=""
+E2E_TEST_FLAGS="${TEST_OPTIONS}"
+
+if [ -z "${E2E_TEST_FLAGS}" ]; then
+  E2E_TEST_FLAGS=" -enable-alpha -enable-beta -resolvabledomain=$(use_resolvable_domain) -ingress-class=${INGRESS_CLASS}"
 fi
 
 if (( HTTPS )); then
-  use_https="--https"
+  E2E_TEST_FLAGS+=" -https"
   toggle_feature autoTLS Enabled config-network
   kubectl apply -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/caissuer/
   add_trap "kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
 fi
 
-# Run conformance and e2e tests.
-
-# Currently only Istio, Contour and Kourier implement the alpha features.
-alpha=""
-if [[ -z "${INGRESS_CLASS}" \
-  || "${INGRESS_CLASS}" == "istio.ingress.networking.knative.dev" \
-  || "${INGRESS_CLASS}" == "contour.ingress.networking.knative.dev" \
-  || "${INGRESS_CLASS}" == "kourier.ingress.networking.knative.dev" ]]; then
-  alpha="--enable-alpha"
+if (( MESH )); then
+  GO_TEST_FLAGS+=" -parallel 1"
 fi
 
-# Currently only Istio, Contour and Kourier implement the beta features.
-beta=""
-if [[ -z "${INGRESS_CLASS}" \
-  || "${INGRESS_CLASS}" == "istio.ingress.networking.knative.dev" \
-  || "${INGRESS_CLASS}" == "contour.ingress.networking.knative.dev" \
-  || "${INGRESS_CLASS}" == "kourier.ingress.networking.knative.dev" ]]; then
-  beta="--enable-beta"
-fi
-
-TEST_OPTIONS="${TEST_OPTIONS:-${alpha} ${beta} --resolvabledomain=$(use_resolvable_domain) ${use_https} --ingress-class=${INGRESS_CLASS}}"
 if (( SHORT )); then
-  TEST_OPTIONS+=" -short"
+  GO_TEST_FLAGS+=" -short"
 fi
+
 
 toggle_feature autocreateClusterDomainClaims true config-network || fail_test
 go_test_e2e -timeout=30m \
+  ${GO_TEST_FLAGS} \
   ./test/conformance/api/... \
   ./test/conformance/runtime/... \
-  ./test/e2e \
-  "${parallelism}" \
-  ${TEST_OPTIONS} || failed=1
+  ./test/e2e -- \
+  ${E2E_TEST_FLAGS} || failed=1
 toggle_feature autocreateClusterDomainClaims false config-network || fail_test
 
 toggle_feature tag-header-based-routing Enabled
-go_test_e2e -timeout=2m ./test/e2e/tagheader ${TEST_OPTIONS} || failed=1
+go_test_e2e -timeout=2m ./test/e2e/tagheader ${E2E_TEST_FLAGS} || failed=1
 toggle_feature tag-header-based-routing Disabled
 
 toggle_feature allow-zero-initial-scale true config-autoscaler || fail_test
-go_test_e2e -timeout=2m ./test/e2e/initscale ${TEST_OPTIONS} || failed=1
+go_test_e2e -timeout=2m ./test/e2e/initscale ${E2E_TEST_FLAGS} || failed=1
 toggle_feature allow-zero-initial-scale false config-autoscaler || fail_test
 
 toggle_feature autocreateClusterDomainClaims true config-network || fail_test
-go_test_e2e -timeout=2m ./test/e2e/domainmapping ${TEST_OPTIONS} || failed=1
+go_test_e2e -timeout=2m ./test/e2e/domainmapping ${E2E_TEST_FLAGS} || failed=1
 toggle_feature autocreateClusterDomainClaims false config-network || fail_test
 
 kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml > "${TMP_DIR}"/config-gc.yaml
 add_trap "kubectl replace cm 'config-gc' -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml" SIGKILL SIGTERM SIGQUIT
 immediate_gc
-go_test_e2e -timeout=2m ./test/e2e/gc ${TEST_OPTIONS} || failed=1
+go_test_e2e -timeout=2m ./test/e2e/gc ${E2E_TEST_FLAGS} || failed=1
 kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f "${TMP_DIR}"/config-gc.yaml
 
 # Run scale tests.
@@ -106,36 +91,36 @@ kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f "${TMP_DIR}"/config-gc.
 # sub-test. If this is not larger than the maximum scale tested then the test
 # simply cannot pass.
 # TODO - Renable once we get this reliably passing on GKE 1.21
-# go_test_e2e -timeout=20m -parallel=300 ./test/scale ${TEST_OPTIONS} || failed=1
+# go_test_e2e -timeout=20m -parallel=300 ./test/scale ${E2E_TEST_FLAGS} || failed=1
 
 # Run HPA tests
-go_test_e2e -timeout=30m -tags=hpa ./test/e2e ${TEST_OPTIONS} || failed=1
+go_test_e2e -timeout=30m -tags=hpa ./test/e2e ${E2E_TEST_FLAGS} || failed=1
 
 # Run initContainers tests with alpha enabled avoiding any issues with the testing options guard above
 # InitContainers test uses emptyDir.
 toggle_feature kubernetes.podspec-init-containers Enabled
-go_test_e2e -timeout=2m ./test/e2e/initcontainers ${TEST_OPTIONS} || failed=1
+go_test_e2e -timeout=2m ./test/e2e/initcontainers ${E2E_TEST_FLAGS} || failed=1
 toggle_feature kubernetes.podspec-init-containers Disabled
 
 # RUN PVC tests with default storage class.
 toggle_feature kubernetes.podspec-persistent-volume-claim Enabled
 toggle_feature kubernetes.podspec-persistent-volume-write Enabled
 toggle_feature kubernetes.podspec-securitycontext Enabled
-go_test_e2e -timeout=5m ./test/e2e/pvc ${TEST_OPTIONS} || failed=1
+go_test_e2e -timeout=5m ./test/e2e/pvc ${E2E_TEST_FLAGS} || failed=1
 toggle_feature kubernetes.podspec-securitycontext Disabled
 toggle_feature kubernetes.podspec-persistent-volume-write Disabled
 toggle_feature kubernetes.podspec-persistent-volume-claim Disabled
 
 # RUN secure pod defaults test in a separate install.
 toggle_feature secure-pod-defaults Enabled
-go_test_e2e -timeout=3m ./test/e2e/securedefaults ${TEST_OPTIONS} || failed=1
+go_test_e2e -timeout=3m ./test/e2e/securedefaults ${E2E_TEST_FLAGS} || failed=1
 toggle_feature secure-pod-defaults Disabled
 
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.
 toggle_feature autocreateClusterDomainClaims true config-network || fail_test
 go_test_e2e -timeout=25m -failfast -parallel=1 ./test/ha \
-  ${TEST_OPTIONS} \
+  ${E2E_TEST_FLAGS} \
   -replicas="${REPLICAS:-1}" \
   -buckets="${BUCKETS:-1}" \
   -spoofinterval="10ms" || failed=1

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -69,7 +69,7 @@ go_test_e2e -timeout=30m \
   ${GO_TEST_FLAGS} \
   ./test/conformance/api/... \
   ./test/conformance/runtime/... \
-  ./test/e2e -- \
+  ./test/e2e \
   ${E2E_TEST_FLAGS} || failed=1
 toggle_feature autocreateClusterDomainClaims false config-network || fail_test
 

--- a/test/e2e/autoscale.go
+++ b/test/e2e/autoscale.go
@@ -153,7 +153,7 @@ func generateTraffic(
 func newVegetaHTTPClient(ctx *TestContext, url *url.URL) *http.Client {
 
 	vegetaTransportDefaults := func(transport *http.Transport) *http.Transport {
-		transport.MaxIdleConnsPerHost = vegeta.DefaultMaxConnections
+		transport.MaxIdleConnsPerHost = vegeta.DefaultConnections
 		transport.MaxConnsPerHost = vegeta.DefaultMaxConnections
 		return transport
 	}

--- a/test/e2e/autoscale.go
+++ b/test/e2e/autoscale.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -33,10 +34,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
 	pkgTest "knative.dev/pkg/test"
-	"knative.dev/pkg/test/ingress"
 	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	resourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
@@ -99,31 +98,15 @@ func (ctx *TestContext) SetNames(names *test.ResourceNames) {
 	ctx.names = names
 }
 
-func getVegetaTarget(kubeClientset kubernetes.Interface, domain, endpointOverride string, resolvable bool, paramName string, paramValue int, https bool) (vegeta.Target, error) {
+func getVegetaTarget(domain string, paramName string, paramValue int, https bool) vegeta.Target {
 	scheme := "http"
 	if https {
 		scheme = "https"
 	}
-	if resolvable {
-		return vegeta.Target{
-			Method: http.MethodGet,
-			URL:    fmt.Sprintf("%s://%s?%s=%d", scheme, domain, paramName, paramValue),
-		}, nil
-	}
-
-	// If the domain that the Route controller is configured to assign to Route.Status.Domain
-	// (the domainSuffix) is not resolvable, we need to retrieve the endpoint and spoof
-	// the Host in our requests.
-	endpoint, mapper, err := ingress.GetIngressEndpoint(context.Background(), kubeClientset, endpointOverride)
-	if err != nil {
-		return vegeta.Target{}, err
-	}
-
 	return vegeta.Target{
 		Method: http.MethodGet,
-		URL:    fmt.Sprintf("%s://%s:%s?%s=%d", scheme, endpoint, mapper("80"), paramName, paramValue),
-		Header: http.Header{"Host": []string{domain}},
-	}, nil
+		URL:    fmt.Sprintf("%s://%s?%s=%d", scheme, domain, paramName, paramValue),
+	}
 }
 
 func generateTraffic(
@@ -167,22 +150,41 @@ func generateTraffic(
 	}
 }
 
+func newVegetaHTTPClient(ctx *TestContext, url *url.URL) *http.Client {
+
+	vegetaTransportDefaults := func(transport *http.Transport) *http.Transport {
+		transport.MaxIdleConnsPerHost = vegeta.DefaultMaxConnections
+		transport.MaxConnsPerHost = vegeta.DefaultMaxConnections
+		return transport
+	}
+
+	spoof, err := pkgTest.NewSpoofingClient(
+		context.Background(),
+		ctx.Clients().KubeClient,
+		ctx.t.Logf,
+		url.Hostname(),
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), ctx.t.Logf, ctx.Clients(), test.ServingFlags.HTTPS),
+		vegetaTransportDefaults,
+	)
+
+	if err != nil {
+		ctx.t.Fatal("Error creating spoofing client:", err)
+	}
+	return spoof.Client
+}
+
 func generateTrafficAtFixedConcurrency(ctx *TestContext, concurrency int, stopChan chan struct{}) error {
 	pacer := vegeta.ConstantPacer{} // Sends requests as quickly as possible, capped by MaxWorkers below.
-	tlsConf := vegeta.DefaultTLSConfig
-	if test.ServingFlags.HTTPS {
-		tlsConf = test.TLSClientConfig(context.Background(), ctx.t.Logf, ctx.clients)
-	}
+
 	attacker := vegeta.NewAttacker(
 		vegeta.Timeout(0), // No timeout is enforced at all.
 		vegeta.Workers(uint64(concurrency)),
 		vegeta.MaxWorkers(uint64(concurrency)),
-		vegeta.TLSConfig(tlsConf))
-	target, err := getVegetaTarget(
-		ctx.clients.KubeClient, ctx.resources.Route.Status.URL.URL().Hostname(), pkgTest.Flags.IngressEndpoint, test.ServingFlags.ResolvableDomain, "sleep", autoscaleSleep, test.ServingFlags.HTTPS)
-	if err != nil {
-		return fmt.Errorf("error creating vegeta target: %w", err)
-	}
+		vegeta.Client(newVegetaHTTPClient(ctx, ctx.resources.Route.Status.URL.URL())),
+	)
+
+	target := getVegetaTarget(ctx.resources.Route.Status.URL.URL().Hostname(), "sleep", autoscaleSleep, test.ServingFlags.HTTPS)
 
 	ctx.t.Logf("Maintaining %d concurrent requests.", concurrency)
 	return generateTraffic(ctx, attacker, pacer, stopChan, target)
@@ -190,16 +192,12 @@ func generateTrafficAtFixedConcurrency(ctx *TestContext, concurrency int, stopCh
 
 func generateTrafficAtFixedRPS(ctx *TestContext, rps int, stopChan chan struct{}) error {
 	pacer := vegeta.ConstantPacer{Freq: rps, Per: time.Second}
-	tlsConf := vegeta.DefaultTLSConfig
-	if test.ServingFlags.HTTPS {
-		tlsConf = test.TLSClientConfig(context.Background(), ctx.t.Logf, ctx.clients)
-	}
-	attacker := vegeta.NewAttacker(vegeta.Timeout(0), vegeta.TLSConfig(tlsConf)) // No timeout is enforced at all.
-	target, err := getVegetaTarget(
-		ctx.clients.KubeClient, ctx.resources.Route.Status.URL.URL().Hostname(), pkgTest.Flags.IngressEndpoint, test.ServingFlags.ResolvableDomain, "sleep", autoscaleSleep, test.ServingFlags.HTTPS)
-	if err != nil {
-		return fmt.Errorf("error creating vegeta target: %w", err)
-	}
+	attacker := vegeta.NewAttacker(
+		vegeta.Timeout(0),
+		vegeta.Client(newVegetaHTTPClient(ctx, ctx.resources.Route.Status.URL.URL())),
+	)
+
+	target := getVegetaTarget(ctx.resources.Route.Status.URL.URL().Hostname(), "sleep", autoscaleSleep, test.ServingFlags.HTTPS)
 
 	ctx.t.Logf("Maintaining %v RPS.", rps)
 	return generateTraffic(ctx, attacker, pacer, stopChan, target)

--- a/test/e2e/autoscale_hpa_test.go
+++ b/test/e2e/autoscale_hpa_test.go
@@ -186,7 +186,7 @@ func generateTrafficAtFixedConcurrencyWithLoad(ctx *TestContext, concurrency int
 		vegeta.Client(newVegetaHTTPClient(ctx, ctx.resources.Route.Status.URL.URL())),
 	)
 
-	target := getVegetaTarget(ctx.resources.Route.Status.URL.URL().Hostname(), "sleep", autoscaleSleep, test.ServingFlags.HTTPS)
+	target := getVegetaTarget(ctx.resources.Route.Status.URL.URL().Hostname(), vegetaParam, vegetaValue, test.ServingFlags.HTTPS)
 	ctx.t.Logf("Maintaining %d concurrent requests.", concurrency)
 	return generateTraffic(ctx, attacker, pacer, stopChan, target)
 }

--- a/test/e2e/autoscale_hpa_test.go
+++ b/test/e2e/autoscale_hpa_test.go
@@ -179,21 +179,14 @@ func assertMemoryHPAAutoscaleUpToNumPods(ctx *TestContext, targetPods float64, d
 
 func generateTrafficAtFixedConcurrencyWithLoad(ctx *TestContext, concurrency int, vegetaParam string, vegetaValue int, stopChan chan struct{}) error {
 	pacer := vegeta.ConstantPacer{} // Sends requests as quickly as possible, capped by MaxWorkers below.
-	tlsConf := vegeta.DefaultTLSConfig
-	if test.ServingFlags.HTTPS {
-		tlsConf = test.TLSClientConfig(context.Background(), ctx.t.Logf, ctx.clients)
-	}
 	attacker := vegeta.NewAttacker(
 		vegeta.Timeout(0), // No timeout is enforced at all.
 		vegeta.Workers(uint64(concurrency)),
 		vegeta.MaxWorkers(uint64(concurrency)),
-		vegeta.TLSConfig(tlsConf))
-	target, err := getVegetaTarget(
-		ctx.clients.KubeClient, ctx.resources.Route.Status.URL.URL().Hostname(), pkgTest.Flags.IngressEndpoint, test.ServingFlags.ResolvableDomain, vegetaParam, vegetaValue, test.ServingFlags.HTTPS)
-	if err != nil {
-		return fmt.Errorf("error creating vegeta target: %w", err)
-	}
+		vegeta.Client(newVegetaHTTPClient(ctx, ctx.resources.Route.Status.URL.URL())),
+	)
 
+	target := getVegetaTarget(ctx.resources.Route.Status.URL.URL().Hostname(), "sleep", autoscaleSleep, test.ServingFlags.HTTPS)
 	ctx.t.Logf("Maintaining %d concurrent requests.", concurrency)
 	return generateTraffic(ctx, attacker, pacer, stopChan, target)
 }


### PR DESCRIPTION
Fixes issues discovered in https://github.com/knative/serving/pull/14276

Fixes: https://github.com/knative/serving/issues/14182

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* args for `go test` need to come before the package
* args that configure e2e test needs to come after the package
* have autoscaling vegeta client use the spoof client

From: https://pkg.go.dev/cmd/go#hdr-Test_packages

```
go test [build/test flags] [packages] [build/test flags & test binary flags]
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
