### PR TITLE
Fix comment about Cgroup limit

### DIFF
--- a/test/conformance/runtime/cgroup_test.go
+++ b/test/conformance/runtime/cgroup_test.go
@@ -66,8 +66,8 @@ func TestMustHaveCgroupConfigured(t *testing.T) {
 
 	cgroups := ri.Host.Cgroups
 
-	// These are used to check the ratio of 'period' to 'quota'. It needs to
-	// be equal to the 'cpuLimit (limit = period / quota)
+	// These are used to check the ratio of 'quota' to 'period'. It needs to
+	// be equal to the 'cpuLimit (limit = quota / period)
 	var period, quota *int
 
 	for _, cgroup := range cgroups {


### PR DESCRIPTION
This patch correct comment about Cgruop limit.

`limit = quota / period` is correct as you can see actual code around L#106.

**Release Note**

```release-note
NONE
```
