### PR TITLE
Do not skip TestTargetBurstCapacity when `dataplane-trust` is not specified

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -385,7 +385,7 @@ function install() {
 
   if (( ENABLE_TLS )); then
     echo "Patch to config-network to enable internal encryption"
-    toggle_feature internal-encryption true config-network
+    toggle_feature dataplane-trust minimal config-network
     if [[ "$INGRESS_CLASS" == "kourier.ingress.networking.knative.dev" ]]; then
       echo "Point Kourier local gateway to custom server certificates"
       toggle_feature cluster-cert-secret server-certs config-kourier

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -385,7 +385,7 @@ function install() {
 
   if (( ENABLE_TLS )); then
     echo "Patch to config-network to enable internal encryption"
-    toggle_feature dataplane-trust minimal config-network
+    toggle_feature internal-encryption true config-network
     if [[ "$INGRESS_CLASS" == "kourier.ingress.networking.knative.dev" ]]; then
       echo "Point Kourier local gateway to custom server certificates"
       toggle_feature cluster-cert-secret server-certs config-kourier

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -176,7 +176,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 
 	// TODO: Remove this when "activator always stay in path" is eliminated.
 	dataplaneTrustMode := cm.Data[netcfg.DataplaneTrustKey]
-	if dataplaneTrustMode != "" && !strings.EqualFold(dataplaneTrustMode, string(netcfg.TrustDisabled)) && strings.EqualFold(cm.Data[netcfg.InternalEncryptionKey], "true") {
+	if (dataplaneTrustMode != "" && !strings.EqualFold(dataplaneTrustMode, string(netcfg.TrustDisabled))) || strings.EqualFold(cm.Data[netcfg.InternalEncryptionKey], "true") {
 		t.Skip("Skipping TestTargetBurstCapacity as activator always stay in path.")
 	}
 

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -173,9 +173,14 @@ func TestTargetBurstCapacity(t *testing.T) {
 	if err != nil {
 		t.Fatal("Fail to get ConfigMap config-network:", err)
 	}
-	if !strings.EqualFold(cm.Data[netcfg.DataplaneTrustKey], string(netcfg.TrustDisabled)) {
-		// TODO: Remove this when https://github.com/knative/serving/issues/12797 was done.
-		t.Skip("Skipping TestTargetBurstCapacity as activator-ca is specified. See issue/12797.")
+
+	// TODO: Remove this when "activator always stay in path" is eliminated.
+	dataplaneTrustMode := cm.Data[netcfg.DataplaneTrustKey]
+	if strings.EqualFold(dataplaneTrustMode, string(netcfg.TrustMinimal)) ||
+		strings.EqualFold(dataplaneTrustMode, string(netcfg.TrustEnabled)) ||
+		strings.EqualFold(dataplaneTrustMode, string(netcfg.TrustMutual)) ||
+		strings.EqualFold(dataplaneTrustMode, string(netcfg.TrustIdentity)) {
+		t.Skip("Skipping TestTargetBurstCapacity as activator always stay in path.")
 	}
 
 	cfg, err := autoscalerCM(ctx.clients)

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -176,10 +176,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 
 	// TODO: Remove this when "activator always stay in path" is eliminated.
 	dataplaneTrustMode := cm.Data[netcfg.DataplaneTrustKey]
-	if strings.EqualFold(dataplaneTrustMode, string(netcfg.TrustMinimal)) ||
-		strings.EqualFold(dataplaneTrustMode, string(netcfg.TrustEnabled)) ||
-		strings.EqualFold(dataplaneTrustMode, string(netcfg.TrustMutual)) ||
-		strings.EqualFold(dataplaneTrustMode, string(netcfg.TrustIdentity)) {
+	if dataplaneTrustMode != "" && !strings.EqualFold(dataplaneTrustMode, string(netcfg.TrustDisabled)) {
 		t.Skip("Skipping TestTargetBurstCapacity as activator always stay in path.")
 	}
 

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -176,7 +176,7 @@ func TestTargetBurstCapacity(t *testing.T) {
 
 	// TODO: Remove this when "activator always stay in path" is eliminated.
 	dataplaneTrustMode := cm.Data[netcfg.DataplaneTrustKey]
-	if dataplaneTrustMode != "" && !strings.EqualFold(dataplaneTrustMode, string(netcfg.TrustDisabled)) {
+	if dataplaneTrustMode != "" && !strings.EqualFold(dataplaneTrustMode, string(netcfg.TrustDisabled)) && strings.EqualFold(cm.Data[netcfg.InternalEncryptionKey], "true") {
 		t.Skip("Skipping TestTargetBurstCapacity as activator always stay in path.")
 	}
 


### PR DESCRIPTION
`TestTargetBurstCapacity` is always skipped since bf48e64 regardless of the on/off of internal encryption.
As `cm.Data[netcfg.DataplaneTrustKey]` is read by k8s client directory, it needs to verify the empty string.


**Release Note**

```release-note
NONE
```
