### PR TITLE
Use InternalTLSEnabled() instead of internal-encryption

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -159,7 +159,7 @@ func main() {
 	}
 
 	// Enable TLS against queue-proxy when internal-encryption is enabled.
-	tlsEnabled := networkConfig.InternalEncryption
+	tlsEnabled := networkConfig.InternalTLSEnabled()
 
 	var certCache *certificate.CertCache
 

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -193,7 +193,7 @@ func makePodSpec(rev *v1.Revision, cfg *config.Config) (*corev1.PodSpec, error) 
 		extraVolumes = append(extraVolumes, *tokenVolume)
 	}
 
-	if cfg.Network.InternalEncryption {
+	if cfg.Network.InternalTLSEnabled() {
 		queueContainer.VolumeMounts = append(queueContainer.VolumeMounts, varCertVolumeMount)
 		extraVolumes = append(extraVolumes, certVolume(networking.ServingCertName))
 	}

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -139,7 +139,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, rev *v1.Revision) pkgrec
 	}
 
 	// Deploy certificate when internal-encryption is enabled.
-	if config.FromContext(ctx).Network.InternalEncryption {
+	if config.FromContext(ctx).Network.InternalTLSEnabled() {
 		if err := c.reconcileSecret(ctx, rev); err != nil {
 			return err
 		}

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -385,7 +385,7 @@ function install() {
 
   if (( ENABLE_TLS )); then
     echo "Patch to config-network to enable internal encryption"
-    toggle_feature internal-encryption true config-network
+    toggle_feature dataplane-trust minimal config-network
     if [[ "$INGRESS_CLASS" == "kourier.ingress.networking.knative.dev" ]]; then
       echo "Point Kourier local gateway to custom server certificates"
       toggle_feature cluster-cert-secret server-certs config-kourier


### PR DESCRIPTION
This patch changes to use `InternalTLSEnabled()` instead of `internal-encryption` to verify config key.

**Release Note**

```release-note
NOE
```
