### PR TITLE
PodAutoscaler Active Condition should not affect Reachability

### DIFF
--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -128,11 +128,6 @@ func (r *Revision) GetRoutingStateModified() time.Time {
 	return parsed
 }
 
-// IsReachable returns whether or not the revision can be reached by a route.
-func (r *Revision) IsReachable() bool {
-	return RoutingState(r.Labels[serving.RoutingStateLabelKey]) == RoutingStateActive
-}
-
 // GetProtocol returns the app level network protocol.
 func (r *Revision) GetProtocol() net.ProtocolType {
 	ports := r.Spec.GetContainer().Ports

--- a/pkg/apis/serving/v1/revision_helpers_test.go
+++ b/pkg/apis/serving/v1/revision_helpers_test.go
@@ -22,7 +22,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	net "knative.dev/networking/pkg/apis/networking"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -101,38 +100,6 @@ func TestIsActivationRequired(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got, want := tc.status.IsActivationRequired(), tc.isActivationRequired; got != want {
 				t.Errorf("IsActivationRequired = %v, want: %v", got, want)
-			}
-		})
-	}
-}
-
-func TestRevisionIsReachable(t *testing.T) {
-	tests := []struct {
-		name   string
-		labels map[string]string
-		want   bool
-	}{{
-		name:   "has serving state label",
-		labels: map[string]string{serving.RoutingStateLabelKey: "active"},
-		want:   true,
-	}, {
-		name:   "empty route annotation",
-		labels: map[string]string{serving.RoutingStateLabelKey: ""},
-		want:   false,
-	}, {
-		name:   "no route annotation",
-		labels: nil,
-		want:   false,
-	}}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rev := Revision{ObjectMeta: metav1.ObjectMeta{Labels: tt.labels}}
-
-			got := rev.IsReachable()
-
-			if got != tt.want {
-				t.Errorf("IsReachable = %t, want: %t", got, tt.want)
 			}
 		})
 	}

--- a/pkg/reconciler/revision/resources/pa_test.go
+++ b/pkg/reconciler/revision/resources/pa_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/ptr"
@@ -37,26 +38,22 @@ func TestMakePA(t *testing.T) {
 		want *autoscalingv1alpha1.PodAutoscaler
 	}{{
 		name: "name is bar (Concurrency=1, Reachable=true)",
-		rev: func() *v1.Revision {
-			rev := v1.Revision{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-					Name:      "bar",
-					UID:       "1234",
-					Labels: map[string]string{
-						serving.RoutingStateLabelKey: "active",
-					},
-					Annotations: map[string]string{
-						"a": "b",
-					},
+		rev: &v1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+				UID:       "1234",
+				Labels: map[string]string{
+					serving.RoutingStateLabelKey: string(v1.RoutingStateActive),
 				},
-				Spec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(1),
+				Annotations: map[string]string{
+					"a": "b",
 				},
-			}
-			rev.Status.MarkActiveTrue()
-			return &rev
-		}(),
+			},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(1),
+			},
+		},
 		want: &autoscalingv1alpha1.PodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "foo",
@@ -91,28 +88,27 @@ func TestMakePA(t *testing.T) {
 		},
 	}, {
 		name: "name is baz (Concurrency=0, Reachable=false)",
-		rev: func() *v1.Revision {
-			rev := v1.Revision{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "blah",
-					Name:      "baz",
-					UID:       "4321",
+		rev: &v1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "blah",
+				Name:      "baz",
+				UID:       "4321",
+				Labels: map[string]string{
+					serving.RoutingStateLabelKey: string(v1.RoutingStateReserve),
 				},
-				Spec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(0),
-					PodSpec: corev1.PodSpec{
-						Containers: []corev1.Container{{
-							Ports: []corev1.ContainerPort{{
-								Name:     "h2c",
-								HostPort: int32(443),
-							}},
+			},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(0),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Ports: []corev1.ContainerPort{{
+							Name:     "h2c",
+							HostPort: int32(443),
 						}},
-					},
+					}},
 				},
-			}
-			rev.Status.MarkActiveTrue()
-			return &rev
-		}(),
+			},
+		},
 		want: &autoscalingv1alpha1.PodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "blah",
@@ -143,83 +139,25 @@ func TestMakePA(t *testing.T) {
 				Reachability: autoscalingv1alpha1.ReachabilityUnreachable,
 			}},
 	}, {
-		name: "name is baz (Concurrency=0, Reachable=false, Activating)",
-		rev: func() *v1.Revision {
-			rev := v1.Revision{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "blah",
-					Name:      "baz",
-					UID:       "4321",
-				},
-				Spec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(0),
-					PodSpec: corev1.PodSpec{
-						Containers: []corev1.Container{{
-							Ports: []corev1.ContainerPort{{
-								Name:     "h2c",
-								HostPort: int32(443),
-							}},
-						}},
-					},
-				},
-			}
-			rev.Status.MarkActiveUnknown("reasons", "because")
-			return &rev
-		}(),
-		want: &autoscalingv1alpha1.PodAutoscaler{
+		name: "unknown routing state",
+		rev: &v1.Revision{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "blah",
-				Name:      "baz",
-				Labels: map[string]string{
-					serving.RevisionLabelKey: "baz",
-					serving.RevisionUID:      "4321",
-					AppLabelKey:              "baz",
-				},
-				Annotations: map[string]string{},
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         v1.SchemeGroupVersion.String(),
-					Kind:               "Revision",
-					Name:               "baz",
-					UID:                "4321",
-					Controller:         ptr.Bool(true),
-					BlockOwnerDeletion: ptr.Bool(true),
-				}},
+				Name:      "batman",
+				UID:       "4321",
 			},
-			Spec: autoscalingv1alpha1.PodAutoscalerSpec{
-				ContainerConcurrency: 0,
-				ScaleTargetRef: corev1.ObjectReference{
-					APIVersion: "apps/v1",
-					Kind:       "Deployment",
-					Name:       "baz-deployment",
-				},
-				ProtocolType: networking.ProtocolH2C,
-				Reachability: autoscalingv1alpha1.ReachabilityUnknown,
-			}},
-	}, {
-		name: "name is batman (Activating, Revision failed)",
-		rev: func() *v1.Revision {
-			rev := v1.Revision{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "blah",
-					Name:      "batman",
-					UID:       "4321",
-				},
-				Spec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(0),
-					PodSpec: corev1.PodSpec{
-						Containers: []corev1.Container{{
-							Ports: []corev1.ContainerPort{{
-								Name:     "h2c",
-								HostPort: int32(443),
-							}},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(0),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Ports: []corev1.ContainerPort{{
+							Name:     "h2c",
+							HostPort: int32(443),
 						}},
-					},
+					}},
 				},
-			}
-			rev.Status.MarkActiveUnknown("reasons", "because")
-			rev.Status.MarkResourcesAvailableFalse("foo", "bar")
-			return &rev
-		}(),
+			},
+		},
 		want: &autoscalingv1alpha1.PodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "blah",
@@ -248,50 +186,45 @@ func TestMakePA(t *testing.T) {
 				},
 				ProtocolType: networking.ProtocolH2C,
 				// When the Revision has failed, we mark the PA as unreachable.
-				Reachability: autoscalingv1alpha1.ReachabilityUnreachable,
+				Reachability: autoscalingv1alpha1.ReachabilityUnknown,
 			}},
 	}, {
-		name: "name is robin (Activating, Revision routable but failed)",
-		rev: func() *v1.Revision {
-			rev := v1.Revision{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "blah",
-					Name:      "robin",
-					UID:       "4321",
-					Labels: map[string]string{
-						serving.RoutingStateLabelKey: "active",
-					},
+		name: "pending routing state",
+		rev: &v1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "blah",
+				Name:      "batman",
+				UID:       "4321",
+				Labels: map[string]string{
+					serving.RoutingStateLabelKey: string(v1.RoutingStatePending),
 				},
-				Spec: v1.RevisionSpec{
-					ContainerConcurrency: ptr.Int64(0),
-					PodSpec: corev1.PodSpec{
-						Containers: []corev1.Container{{
-							Ports: []corev1.ContainerPort{{
-								Name:     "h2c",
-								HostPort: int32(443),
-							}},
+			},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(0),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Ports: []corev1.ContainerPort{{
+							Name:     "h2c",
+							HostPort: int32(443),
 						}},
-					},
+					}},
 				},
-			}
-			rev.Status.MarkActiveUnknown("reasons", "because")
-			rev.Status.MarkResourcesAvailableFalse("foo", "bar")
-			return &rev
-		}(),
+			},
+		},
 		want: &autoscalingv1alpha1.PodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "blah",
-				Name:      "robin",
+				Name:      "batman",
 				Labels: map[string]string{
-					serving.RevisionLabelKey: "robin",
+					serving.RevisionLabelKey: "batman",
 					serving.RevisionUID:      "4321",
-					AppLabelKey:              "robin",
+					AppLabelKey:              "batman",
 				},
 				Annotations: map[string]string{},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         v1.SchemeGroupVersion.String(),
 					Kind:               "Revision",
-					Name:               "robin",
+					Name:               "batman",
 					UID:                "4321",
 					Controller:         ptr.Bool(true),
 					BlockOwnerDeletion: ptr.Bool(true),
@@ -302,12 +235,135 @@ func TestMakePA(t *testing.T) {
 				ScaleTargetRef: corev1.ObjectReference{
 					APIVersion: "apps/v1",
 					Kind:       "Deployment",
-					Name:       "robin-deployment",
+					Name:       "batman-deployment",
 				},
 				ProtocolType: networking.ProtocolH2C,
-				// Reachability trumps failure of Revisions.
+				// When the Revision has failed, we mark the PA as unreachable.
 				Reachability: autoscalingv1alpha1.ReachabilityUnknown,
 			}},
+	}, {
+		name: "failed deployment",
+		rev: &v1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "blah",
+				Name:      "batman",
+				UID:       "4321",
+				Labels: map[string]string{
+					serving.RoutingStateLabelKey: string(v1.RoutingStateActive),
+				},
+			},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(0),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Ports: []corev1.ContainerPort{{
+							Name:     "h2c",
+							HostPort: int32(443),
+						}},
+					}},
+				},
+			},
+			Status: v1.RevisionStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{{
+						Type:   v1.RevisionConditionResourcesAvailable,
+						Status: corev1.ConditionFalse,
+					}},
+				},
+			},
+		},
+		want: &autoscalingv1alpha1.PodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   "blah",
+				Name:        "batman",
+				Annotations: map[string]string{},
+				Labels: map[string]string{
+					serving.RevisionLabelKey: "batman",
+					serving.RevisionUID:      "4321",
+					AppLabelKey:              "batman",
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         v1.SchemeGroupVersion.String(),
+					Kind:               "Revision",
+					Name:               "batman",
+					UID:                "4321",
+					Controller:         ptr.Bool(true),
+					BlockOwnerDeletion: ptr.Bool(true),
+				}},
+			},
+			Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+				ContainerConcurrency: 0,
+				ScaleTargetRef: corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "batman-deployment",
+				},
+				ProtocolType: networking.ProtocolH2C,
+				Reachability: autoscalingv1alpha1.ReachabilityUnreachable,
+			},
+		},
+	}, {
+		// Crashlooping container that never starts
+		name: "failed container",
+		rev: &v1.Revision{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "blah",
+				Name:      "batman",
+				UID:       "4321",
+				Labels: map[string]string{
+					serving.RoutingStateLabelKey: string(v1.RoutingStateActive),
+				},
+			},
+			Spec: v1.RevisionSpec{
+				ContainerConcurrency: ptr.Int64(0),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Ports: []corev1.ContainerPort{{
+							Name:     "h2c",
+							HostPort: int32(443),
+						}},
+					}},
+				},
+			},
+			Status: v1.RevisionStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{{
+						Type:   v1.RevisionConditionContainerHealthy,
+						Status: corev1.ConditionFalse,
+					}},
+				},
+			},
+		},
+		want: &autoscalingv1alpha1.PodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   "blah",
+				Name:        "batman",
+				Annotations: map[string]string{},
+				Labels: map[string]string{
+					serving.RevisionLabelKey: "batman",
+					serving.RevisionUID:      "4321",
+					AppLabelKey:              "batman",
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion:         v1.SchemeGroupVersion.String(),
+					Kind:               "Revision",
+					Name:               "batman",
+					UID:                "4321",
+					Controller:         ptr.Bool(true),
+					BlockOwnerDeletion: ptr.Bool(true),
+				}},
+			},
+			Spec: autoscalingv1alpha1.PodAutoscalerSpec{
+				ContainerConcurrency: 0,
+				ScaleTargetRef: corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "batman-deployment",
+				},
+				ProtocolType: networking.ProtocolH2C,
+				Reachability: autoscalingv1alpha1.ReachabilityUnreachable,
+			},
+		},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/14115

`PodAutoscaler.Spec.Reachability` was added a long time ago. Since then we've added a `ScaleTargetInitialized` condition to make it easier to know if we've scaled up from zero successfully - and this simplified various condition checks in the autoscaler etc.

Given that the `PodAutoscaler's` `Active` condition would toggle `Reachability` as @SaschaSchwarze0 pointed out.

I believe we don't need this circular logic - reachability should be set depending on the revision's routing state with the exception of failing to progress the deployment/start a users container.

