### PR TITLE
Add PullIfNotPresent to multiple container test

### DIFF
--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -726,8 +726,9 @@ func TestServiceCreateWithMultipleContainers(t *testing.T) {
 
 	// Please see the comment in test/v1/configuration.go.
 	if !test.ServingFlags.DisableOptionalAPI {
-		containers[0].ImagePullPolicy = corev1.PullIfNotPresent
-		containers[1].ImagePullPolicy = corev1.PullIfNotPresent
+		for _, c := range containers {
+			c.ImagePullPolicy = corev1.PullIfNotPresent
+		}
 	}
 
 	// Setup initial Service

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -724,6 +724,12 @@ func TestServiceCreateWithMultipleContainers(t *testing.T) {
 		Image: pkgtest.ImagePath(names.Sidecars[0]),
 	}}
 
+	// Please see the comment in test/v1/configuration.go.
+	if !test.ServingFlags.DisableOptionalAPI {
+		containers[0].ImagePullPolicy = corev1.PullIfNotPresent
+		containers[1].ImagePullPolicy = corev1.PullIfNotPresent
+	}
+
 	// Setup initial Service
 	if _, err := v1test.CreateServiceReady(t, clients, &names, func(svc *v1.Service) {
 		svc.Spec.Template.Spec.Containers = containers

--- a/test/e2e/multicontainer_test.go
+++ b/test/e2e/multicontainer_test.go
@@ -59,8 +59,9 @@ func TestMultiContainer(t *testing.T) {
 
 	// Please see the comment in test/v1/configuration.go.
 	if !test.ServingFlags.DisableOptionalAPI {
-		containers[0].ImagePullPolicy = corev1.PullIfNotPresent
-		containers[1].ImagePullPolicy = corev1.PullIfNotPresent
+		for _, c := range containers {
+			c.ImagePullPolicy = corev1.PullIfNotPresent
+		}
 	}
 
 	test.EnsureTearDown(t, clients, &names)

--- a/test/e2e/multicontainer_test.go
+++ b/test/e2e/multicontainer_test.go
@@ -57,6 +57,12 @@ func TestMultiContainer(t *testing.T) {
 		Image: pkgTest.ImagePath(names.Sidecars[0]),
 	}}
 
+	// Please see the comment in test/v1/configuration.go.
+	if !test.ServingFlags.DisableOptionalAPI {
+		containers[0].ImagePullPolicy = corev1.PullIfNotPresent
+		containers[1].ImagePullPolicy = corev1.PullIfNotPresent
+	}
+
 	test.EnsureTearDown(t, clients, &names)
 	t.Log("Creating a new Service")
 


### PR DESCRIPTION
## Proposed Changes

When e2e test creates ksvc, it explicitly sets `corev1.PullIfNotPresent` in ksvc(ConfigurationSpec).

https://github.com/knative/serving/blob/45b119b5fcbbe07ddbf3909aae4e5201a1358995/test/v1/configuration.go#L122-L133

However, multiple containers test overrides the container spec and missed to set the `corev1.PullIfNotPresent`.
Due to that, e2e test on KinD or minikube, which uses local image fails due to `ImagePullBackOff`.

**Release Note**

```release-note
NONE
```
