### PR TITLE
Update DEVELOPMENT.md to Include local registry workaround for ImagePullBackOff

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -67,7 +67,8 @@ If you're working on and changing `.proto` files:
    - If developing locally with Docker or Minikube, you can set
      `KO_DOCKER_REPO=ko.local` (preferred) or use the `-L` flag to `ko` to build
      and push locally (in this case, authentication is not needed). If
-     developing with kind you can set `KO_DOCKER_REPO=kind.local`.
+     developing with Kind you can set `KO_DOCKER_REPO=kind.local`.
+   - If you encounter an `ImagePullBackOff` error while using Minikube or Kind, it may be due to the cluster's inability to pull locally built images because of image pull policies. To resolve this issue, consider enabling the local registry: for [Minikube](https://minikube.sigs.k8s.io/docs/handbook/registry) or for [Kind](https://kind.sigs.k8s.io/docs/user/local-registry/).
 
 **Note**: You'll need to be authenticated with your `KO_DOCKER_REPO` before
 pushing images. Run `gcloud auth configure-docker` if you are using Google


### PR DESCRIPTION
## Proposed Changes

Adds a section to the "Create a cluster and a repo" part of DEVELOPMENT.md to provide guidance for resolving `ImagePullBackOff` errors encountered when running e2e tests on Minikube or KinD with locally built images. Links to enable local registry are included for both environments.

This PR stems from the conclusion drawn during the discussions on [this PR](https://github.com/knative/serving/pull/14317).