### PR TITLE
Change configuration case for tests

### DIFF
--- a/pkg/apis/serving/v1/route_lifecycle.go
+++ b/pkg/apis/serving/v1/route_lifecycle.go
@@ -193,7 +193,7 @@ const (
 	// AutoTLSNotEnabledMessage is the message which is set on the
 	// RouteConditionCertificateProvisioned condition when it is set to True
 	// because AutoTLS was not enabled.
-	AutoTLSNotEnabledMessage = "autoTLS is not enabled"
+	AutoTLSNotEnabledMessage = "auto-tls is not enabled"
 
 	// TLSNotEnabledForClusterLocalMessage is the message which is set on the
 	// RouteConditionCertificateProvisioned condition when it is set to True
@@ -202,7 +202,7 @@ const (
 )
 
 // MarkTLSNotEnabled sets RouteConditionCertificateProvisioned to true when
-// certificate config such as autoTLS is not enabled or private cluster-local service.
+// certificate config such as auto-tls is not enabled or private cluster-local service.
 func (rs *RouteStatus) MarkTLSNotEnabled(msg string) {
 	routeCondSet.Manage(rs).MarkTrueWithReason(RouteConditionCertificateProvisioned,
 		"TLSNotEnabled", msg)

--- a/pkg/apis/serving/v1beta1/domainmapping_lifecycle.go
+++ b/pkg/apis/serving/v1beta1/domainmapping_lifecycle.go
@@ -62,7 +62,7 @@ const (
 	// AutoTLSNotEnabledMessage is the message which is set on the
 	// DomainMappingConditionCertificateProvisioned condition when it is set to True
 	// because AutoTLS was not enabled.
-	AutoTLSNotEnabledMessage = "autoTLS is not enabled"
+	AutoTLSNotEnabledMessage = "auto-tls is not enabled"
 	// TLSCertificateProvidedExternally indicates that a TLS secret won't be created or managed
 	// instead a reference to an existing TLS secret should have been provided in the DomainMapping spec
 	TLSCertificateProvidedExternally = "TLS certificate was provided externally"

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -100,7 +100,7 @@ func newTestSetup(t *testing.T, configs ...*corev1.ConfigMap) (
 		},
 		Data: map[string]string{
 			"domainTemplate": defaultDomainTemplate,
-			"autoTLS":        "true",
+			"auto-tls":       "true",
 			// Apply to all namespaces
 			"namespace-wildcard-cert-selector": "{}",
 		},
@@ -323,7 +323,7 @@ func TestUpdateDomainTemplate(t *testing.T) {
 		},
 		Data: map[string]string{
 			"namespace-wildcard-cert-selector": "{}",
-			"autoTLS":                          "Enabled",
+			"auto-tls":                         "Enabled",
 		},
 	}
 	ctx, cancel, certEvents, watcher := newTestSetup(t, netCfg)
@@ -348,7 +348,7 @@ func TestUpdateDomainTemplate(t *testing.T) {
 		Data: map[string]string{
 			"domainTemplate":                   "{{.Name}}-suffix.{{.Namespace}}.{{.Domain}}",
 			"namespace-wildcard-cert-selector": "{}",
-			"autoTLS":                          "Enabled",
+			"auto-tls":                         "Enabled",
 		},
 	}
 	watcher.OnChange(netCfg)
@@ -369,7 +369,7 @@ func TestUpdateDomainTemplate(t *testing.T) {
 		Data: map[string]string{
 			"domainTemplate":                   "{{.Name}}.subdomain.{{.Namespace}}.{{.Domain}}",
 			"namespace-wildcard-cert-selector": `{}`,
-			"autoTLS":                          "Enabled",
+			"auto-tls":                         "Enabled",
 		},
 	}
 	watcher.OnChange(netCfg)
@@ -390,7 +390,7 @@ func TestUpdateDomainTemplate(t *testing.T) {
 		},
 		Data: map[string]string{
 			"domainTemplate": "{{.Namespace}}.{{.Name}}.{{.Domain}}",
-			"autoTLS":        "Enabled",
+			"auto-tls":       "Enabled",
 		},
 	}
 	watcher.OnChange(netCfg)
@@ -416,7 +416,7 @@ func TestChangeDefaultDomain(t *testing.T) {
 			Namespace: system.Namespace(),
 		},
 		Data: map[string]string{
-			"autoTLS":                          "Enabled",
+			"auto-tls":                         "Enabled",
 			"namespace-wildcard-cert-selector": "{}",
 		},
 	}
@@ -472,7 +472,7 @@ func TestDomainConfigDomain(t *testing.T) {
 		name:      "no domainmapping without config",
 		domainCfg: map[string]string{},
 		netCfg: map[string]string{
-			"autoTLS": "Enabled",
+			"auto-tls": "Enabled",
 		},
 	}, {
 		name: "default domain",
@@ -480,7 +480,7 @@ func TestDomainConfigDomain(t *testing.T) {
 			"other.com": "selector:\n app: dev",
 		},
 		netCfg: map[string]string{
-			"autoTLS":                          "Enabled",
+			"auto-tls":                         "Enabled",
 			"namespace-wildcard-cert-selector": "{}",
 		},
 		wantCertName: "testns.svc.cluster.local",
@@ -491,7 +491,7 @@ func TestDomainConfigDomain(t *testing.T) {
 			"default.com": "",
 		},
 		netCfg: map[string]string{
-			"autoTLS":                          "Enabled",
+			"auto-tls":                         "Enabled",
 			"namespace-wildcard-cert-selector": "{}",
 		},
 		wantCertName: "testns.default.com",

--- a/pkg/reconciler/nscert/nscert_test.go
+++ b/pkg/reconciler/nscert/nscert_test.go
@@ -99,8 +99,8 @@ func newTestSetup(t *testing.T, configs ...*corev1.ConfigMap) (
 			Namespace: system.Namespace(),
 		},
 		Data: map[string]string{
-			"domainTemplate": defaultDomainTemplate,
-			"auto-tls":       "true",
+			"domain-template": defaultDomainTemplate,
+			"auto-tls":        "true",
 			// Apply to all namespaces
 			"namespace-wildcard-cert-selector": "{}",
 		},
@@ -346,7 +346,7 @@ func TestUpdateDomainTemplate(t *testing.T) {
 			Namespace: system.Namespace(),
 		},
 		Data: map[string]string{
-			"domainTemplate":                   "{{.Name}}-suffix.{{.Namespace}}.{{.Domain}}",
+			"domain-template":                  "{{.Name}}-suffix.{{.Namespace}}.{{.Domain}}",
 			"namespace-wildcard-cert-selector": "{}",
 			"auto-tls":                         "Enabled",
 		},
@@ -367,7 +367,7 @@ func TestUpdateDomainTemplate(t *testing.T) {
 			Namespace: system.Namespace(),
 		},
 		Data: map[string]string{
-			"domainTemplate":                   "{{.Name}}.subdomain.{{.Namespace}}.{{.Domain}}",
+			"domain-template":                  "{{.Name}}.subdomain.{{.Namespace}}.{{.Domain}}",
 			"namespace-wildcard-cert-selector": `{}`,
 			"auto-tls":                         "Enabled",
 		},
@@ -389,8 +389,8 @@ func TestUpdateDomainTemplate(t *testing.T) {
 			Namespace: system.Namespace(),
 		},
 		Data: map[string]string{
-			"domainTemplate": "{{.Namespace}}.{{.Name}}.{{.Domain}}",
-			"auto-tls":       "Enabled",
+			"domain-template": "{{.Namespace}}.{{.Name}}.{{.Domain}}",
+			"auto-tls":        "Enabled",
 		},
 	}
 	watcher.OnChange(netCfg)

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -3121,8 +3121,8 @@ func TestReconcileEnableAutoTLS(t *testing.T) {
 		}},
 		Key: "default/becomes-ready",
 	}, {
-		// This test is a same with "public becomes cluster local" above, but confirm it does not create certs with autoTLS for cluster-local.
-		Name: "public becomes cluster local w/ autoTLS",
+		// This test is a same with "public becomes cluster local" above, but confirm it does not create certs with auto-tls for cluster-local.
+		Name: "public becomes cluster local w/ auto-tls",
 		Objects: []runtime.Object{
 			Route("default", "becomes-local", WithConfigTarget("config"), WithRouteGeneration(1),
 				WithRouteLabel(map[string]string{netapi.VisibilityLabelKey: serving.VisibilityClusterLocal}),

--- a/test/config/ytt/core/overlay-config-autocreate-clusterdomainclaims.yaml
+++ b/test/config/ytt/core/overlay-config-autocreate-clusterdomainclaims.yaml
@@ -6,5 +6,5 @@
 ---
 #@overlay/match-child-defaults missing_ok=True
 data:
-  autocreateClusterDomainClaims: "true"
+  autocreate-cluster-domain-claims: "true"
 

--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -67,14 +67,14 @@ function setup_auto_tls_common() {
 
   setup_custom_domain
 
-  toggle_feature autoTLS Enabled config-network
+  toggle_feature auto-tls Enabled config-network
   toggle_feature autocreate-cluster-domain-claims true config-network
 }
 
 function cleanup_auto_tls_common() {
   cleanup_custom_domain
 
-  toggle_feature autoTLS Disabled config-network
+  toggle_feature auto-tls Disabled config-network
   toggle_feature autocreate-cluster-domain-claims false config-network
   toggle_feature namespace-wildcard-cert-selector "" config-network
   kubectl delete kcert --all -n "${TLS_TEST_NAMESPACE}"

--- a/test/e2e-auto-tls-tests.sh
+++ b/test/e2e-auto-tls-tests.sh
@@ -68,14 +68,14 @@ function setup_auto_tls_common() {
   setup_custom_domain
 
   toggle_feature autoTLS Enabled config-network
-  toggle_feature autocreateClusterDomainClaims true config-network
+  toggle_feature autocreate-cluster-domain-claims true config-network
 }
 
 function cleanup_auto_tls_common() {
   cleanup_custom_domain
 
   toggle_feature autoTLS Disabled config-network
-  toggle_feature autocreateClusterDomainClaims false config-network
+  toggle_feature autocreate-cluster-domain-claims false config-network
   toggle_feature namespace-wildcard-cert-selector "" config-network
   kubectl delete kcert --all -n "${TLS_TEST_NAMESPACE}"
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -50,7 +50,7 @@ fi
 
 if (( HTTPS )); then
   E2E_TEST_FLAGS+=" -https"
-  toggle_feature autoTLS Enabled config-network
+  toggle_feature auto-tls Enabled config-network
   kubectl apply -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/caissuer/
   add_trap "kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
 fi
@@ -133,7 +133,7 @@ toggle_feature autocreate-cluster-domain-claims false config-network || fail_tes
 
 if (( HTTPS )); then
   kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found
-  toggle_feature autoTLS Disabled config-network
+  toggle_feature auto-tls Disabled config-network
 fi
 
 (( failed )) && fail_test

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -64,14 +64,14 @@ if (( SHORT )); then
 fi
 
 
-toggle_feature autocreateClusterDomainClaims true config-network || fail_test
+toggle_feature autocreate-cluster-domain-claims true config-network || fail_test
 go_test_e2e -timeout=30m \
   ${GO_TEST_FLAGS} \
   ./test/conformance/api/... \
   ./test/conformance/runtime/... \
   ./test/e2e \
   ${E2E_TEST_FLAGS} || failed=1
-toggle_feature autocreateClusterDomainClaims false config-network || fail_test
+toggle_feature autocreate-cluster-domain-claims false config-network || fail_test
 
 toggle_feature tag-header-based-routing Enabled
 go_test_e2e -timeout=2m ./test/e2e/tagheader ${E2E_TEST_FLAGS} || failed=1
@@ -81,9 +81,9 @@ toggle_feature allow-zero-initial-scale true config-autoscaler || fail_test
 go_test_e2e -timeout=2m ./test/e2e/initscale ${E2E_TEST_FLAGS} || failed=1
 toggle_feature allow-zero-initial-scale false config-autoscaler || fail_test
 
-toggle_feature autocreateClusterDomainClaims true config-network || fail_test
+toggle_feature autocreate-cluster-domain-claims true config-network || fail_test
 go_test_e2e -timeout=2m ./test/e2e/domainmapping ${E2E_TEST_FLAGS} || failed=1
-toggle_feature autocreateClusterDomainClaims false config-network || fail_test
+toggle_feature autocreate-cluster-domain-claims false config-network || fail_test
 
 kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml > "${TMP_DIR}"/config-gc.yaml
 add_trap "kubectl replace cm 'config-gc' -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml" SIGKILL SIGTERM SIGQUIT
@@ -123,13 +123,13 @@ toggle_feature secure-pod-defaults Disabled
 
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.
-toggle_feature autocreateClusterDomainClaims true config-network || fail_test
+toggle_feature autocreate-cluster-domain-claims true config-network || fail_test
 go_test_e2e -timeout=25m -failfast -parallel=1 ./test/ha \
   ${E2E_TEST_FLAGS} \
   -replicas="${REPLICAS:-1}" \
   -buckets="${BUCKETS:-1}" \
   -spoofinterval="10ms" || failed=1
-toggle_feature autocreateClusterDomainClaims false config-network || fail_test
+toggle_feature autocreate-cluster-domain-claims false config-network || fail_test
 
 if (( HTTPS )); then
   kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found


### PR DESCRIPTION
Configuration changed the case since https://github.com/knative/networking/pull/522 but serving test still uses old case.
This patch update them like `autoTLS`, `domainTemplate` and `autocreateClusterDomainClaims`.

**Release Note**

```release-note
NONE
```
