### PR TITLE
Call `Stop()` for CertWatcher

### DIFF
--- a/pkg/queue/certificate/watcher_test.go
+++ b/pkg/queue/certificate/watcher_test.go
@@ -47,6 +47,7 @@ func TestCertificateRotation(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to create CertWatcher", err)
 	}
+	defer cw.Stop()
 
 	// CertWatcher should return the expected certificate
 	c, err := cw.GetCertificate(nil)


### PR DESCRIPTION
There is another flake like:

```
panic: Log in goroutine after TestCertificateRotation has completed: 2023-09-06T03:09:19.460Z	ERROR	certificate/watcher.go:98	failed to load certificate file in /tmp/TestCertificateRotation2666368903/001/tls.crt: open /tmp/TestCertificateRotation2666368903/001/tls.crt: no such file or directory
```
- https://github.com/knative/serving/actions/runs/6086537460/job/16530052653
- https://github.com/knative/serving/actions/runs/6091643799/job/16528552045
- https://github.com/knative/serving/actions/runs/6062732554/job/16530329463

As per log message, it tries to print log after `TestCertificateRotation` ended because the CertWatcher hasn't stopped, then panic happens.

**Release Note**

```release-note
NONE
```
