### PR TITLE
fix(activator): Correctly return noop value from probePodIPs based on changes

### DIFF
--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -1522,67 +1522,296 @@ func TestServiceMoreThanOne(t *testing.T) {
 
 // More focused test around the probing of pods and the handling of different behaviors
 func TestProbePodIPs(t *testing.T) {
+	type input struct {
+		current                 dests
+		healthy                 sets.String
+		meshMode                netcfg.MeshCompatibilityMode
+		enableProbeOptimization bool
+		hostResponses           map[string][]activatortest.FakeResponse
+	}
+
+	type expected struct {
+		healthy   sets.String
+		noop      bool
+		notMesh   bool
+		success   bool
+		numProbes int32
+	}
+
+	type test struct {
+		name     string
+		input    input
+		expected expected
+	}
+
+	tests := []test{
+		{
+			name: "all healthy", // Test skipping probes when all endpoints are healthy
+			input: input{
+				current: dests{
+					ready:    sets.NewString("10.10.1.1"),
+					notReady: sets.NewString("10.10.1.2"),
+				},
+				healthy: sets.NewString("10.10.1.1", "10.10.1.2"),
+			},
+			expected: expected{
+				healthy:   sets.NewString("10.10.1.1", "10.10.1.2"),
+				noop:      true,
+				notMesh:   false,
+				success:   true,
+				numProbes: 0,
+			},
+		},
+		{
+			name: "one pod fails probe", // Test that we probe all pods when one fails
+			input: input{
+				current: dests{
+					notReady: sets.NewString("10.10.1.1", "10.10.1.2", "10.10.1.3"),
+				},
+				hostResponses: map[string][]activatortest.FakeResponse{
+					"10.10.1.1": {{
+						Err: errors.New("podIP transport error"),
+					}},
+					"10.10.1.2": {{
+						Code:  http.StatusOK,
+						Body:  queue.Name,
+						Delay: 250 * time.Millisecond,
+					}},
+				},
+				enableProbeOptimization: true,
+			},
+			expected: expected{
+				healthy:   sets.NewString("10.10.1.2", "10.10.1.3"),
+				noop:      false,
+				notMesh:   true,
+				success:   false,
+				numProbes: 3,
+			},
+		},
+		{
+			name: "ready pods skipped without mesh auto",
+			input: input{
+				current: dests{
+					ready:    sets.NewString("10.10.1.1"),
+					notReady: sets.NewString("10.10.1.2"),
+				},
+				enableProbeOptimization: true,
+				meshMode:                netcfg.MeshCompatibilityModeDisabled,
+			},
+			expected: expected{
+				healthy:   sets.NewString("10.10.1.1", "10.10.1.2"),
+				noop:      false,
+				notMesh:   true,
+				success:   true,
+				numProbes: 1,
+			},
+		},
+		{
+			name: "ready pods not skipped with mesh auto",
+			input: input{
+				current: dests{
+					ready:    sets.NewString("10.10.1.1"),
+					notReady: sets.NewString("10.10.1.2"),
+				},
+				enableProbeOptimization: true,
+				meshMode:                netcfg.MeshCompatibilityModeAuto,
+			},
+			expected: expected{
+				healthy:   sets.NewString("10.10.1.1", "10.10.1.2"),
+				noop:      false,
+				notMesh:   true,
+				success:   true,
+				numProbes: 2,
+			},
+		},
+		{
+			name: "only ready pods healthy without probe optimization", // NOTE: prior test is effectively this one with probe optimization
+			input: input{
+				current: dests{
+					ready:    sets.NewString("10.10.1.1"),
+					notReady: sets.NewString("10.10.1.2"),
+				},
+				enableProbeOptimization: false,
+				meshMode:                netcfg.MeshCompatibilityModeAuto,
+			},
+			expected: expected{
+				healthy:   sets.NewString("10.10.1.1"),
+				noop:      false,
+				notMesh:   true,
+				success:   true,
+				numProbes: 2,
+			},
+		},
+		{
+			name: "removes non-existent pods from healthy",
+			input: input{
+				current: dests{
+					ready:    sets.NewString("10.10.1.1"),
+					notReady: sets.NewString("10.10.1.2"),
+				},
+				healthy:                 sets.NewString("10.10.1.1", "10.10.1.2", "10.10.1.3"),
+				enableProbeOptimization: true,
+				meshMode:                netcfg.MeshCompatibilityModeDisabled,
+			},
+			expected: expected{
+				healthy:   sets.NewString("10.10.1.1", "10.10.1.2"),
+				noop:      false,
+				notMesh:   false,
+				success:   true,
+				numProbes: 0,
+			},
+		},
+		{
+			name: "non-probe additions count as changes", // Testing case where ready pods are added but probes do not add more
+			input: input{
+				current: dests{
+					ready:    sets.NewString("10.10.1.1", "10.10.1.2"),
+					notReady: sets.NewString("10.10.1.3"),
+				},
+				healthy:                 sets.NewString("10.10.1.1"),
+				enableProbeOptimization: false,
+				meshMode:                netcfg.MeshCompatibilityModeDisabled,
+			},
+			expected: expected{
+				healthy:   sets.NewString("10.10.1.1", "10.10.1.2"),
+				noop:      false,
+				notMesh:   true,
+				success:   true,
+				numProbes: 1,
+			},
+		},
+		{
+			name: "non-probe removals count as changes", // Testing case where non-existent pods are removed with no probe changes
+			input: input{
+				current: dests{
+					ready:    sets.NewString("10.10.1.1"),
+					notReady: sets.NewString("10.10.1.3"),
+				},
+				healthy:                 sets.NewString("10.10.1.1", "10.10.1.2"),
+				enableProbeOptimization: false,
+				meshMode:                netcfg.MeshCompatibilityModeDisabled,
+			},
+			expected: expected{
+				healthy:   sets.NewString("10.10.1.1"),
+				noop:      false,
+				notMesh:   true,
+				success:   true,
+				numProbes: 1,
+			},
+		},
+		{
+			name: "no changes with probes",
+			input: input{
+				current: dests{
+					ready:    sets.NewString("10.10.1.1"),
+					notReady: sets.NewString("10.10.1.3"),
+				},
+				healthy:                 sets.NewString("10.10.1.1"),
+				enableProbeOptimization: false,
+				meshMode:                netcfg.MeshCompatibilityModeDisabled,
+			},
+			expected: expected{
+				healthy:   sets.NewString("10.10.1.1"),
+				noop:      true,
+				notMesh:   true,
+				success:   true,
+				numProbes: 1,
+			},
+		},
+		{
+			name: "no changes without probes",
+			input: input{
+				current: dests{
+					ready: sets.NewString("10.10.1.1", "10.10.1.3"),
+				},
+				healthy:                 sets.NewString("10.10.1.1", "10.10.1.3"),
+				enableProbeOptimization: false,
+				meshMode:                netcfg.MeshCompatibilityModeDisabled,
+			},
+			expected: expected{
+				healthy:   sets.NewString("10.10.1.1", "10.10.1.3"),
+				noop:      true,
+				notMesh:   false,
+				success:   true,
+				numProbes: 0,
+			},
+		},
+		{
+			name: "mesh probe error",
+			input: input{
+				current: dests{
+					ready:    sets.NewString("10.10.1.1"),
+					notReady: sets.NewString("10.10.1.3"),
+				},
+				healthy:                 sets.NewString("10.10.1.1"),
+				enableProbeOptimization: true,
+				meshMode:                netcfg.MeshCompatibilityModeAuto,
+				hostResponses: map[string][]activatortest.FakeResponse{
+					"10.10.1.3": {{
+						Code: http.StatusServiceUnavailable,
+					}},
+				},
+			},
+			expected: expected{
+				healthy:   sets.NewString("10.10.1.1"),
+				noop:      true,
+				notMesh:   false,
+				success:   false,
+				numProbes: 1,
+			},
+		},
+	}
+
 	fakeRT := activatortest.FakeRoundTripper{
 		ExpectHost: testRevision,
-		ProbeHostResponses: map[string][]activatortest.FakeResponse{
-			"10.10.1.1": {{
-				Code: http.StatusInternalServerError,
-				Err:  errors.New("podIP transport error"),
-			}},
-			"10.10.1.2": {{
-				Code:  http.StatusOK,
-				Body:  queue.Name,
-				Delay: 250 * time.Millisecond,
-			}},
-			"10.10.1.3": {{
-				Code: http.StatusOK,
-				Body: queue.Name,
-			}},
-		},
+		ProbeResponses: []activatortest.FakeResponse{{
+			Code: http.StatusOK,
+			Body: queue.Name,
+		}},
 	}
 
 	// Minimally constructed revisionWatcher just to have what is needed for probing
 	rw := &revisionWatcher{
-		clusterIPHealthy:        true,
-		podsAddressable:         true,
-		rev:                     types.NamespacedName{Namespace: testNamespace, Name: testRevision},
-		logger:                  TestLogger(t),
-		transport:               pkgnetwork.RoundTripperFunc(fakeRT.RT),
-		meshMode:                netcfg.MeshCompatibilityModeAuto,
-		enableProbeOptimisation: true,
+		rev:       types.NamespacedName{Namespace: testNamespace, Name: testRevision},
+		logger:    TestLogger(t),
+		transport: pkgnetwork.RoundTripperFunc(fakeRT.RT),
 	}
 
-	// Initial state for tests
-	cur := dests{
-		ready:    sets.NewString("10.10.1.3", "10.10.1.2"),
-		notReady: sets.NewString("10.10.1.1"),
+	// Helper function to run the test and validate the results
+	testFunc := func(testName string, input input, expected expected) {
+		rw.enableProbeOptimisation = input.enableProbeOptimization
+		rw.meshMode = input.meshMode
+		rw.healthyPods = input.healthy
+
+		fakeRT.ProbeHostResponses = input.hostResponses
+		fakeRT.NumProbes.Store(0)
+
+		healthy, noop, notMesh, err := rw.probePodIPs(input.current.ready, input.current.notReady)
+		if !healthy.Equal(expected.healthy) {
+			t.Errorf("%s: Healthy does not match, got %v, want %v diff: %s",
+				testName, healthy, expected.healthy, cmp.Diff(healthy, expected.healthy))
+		}
+		if noop != expected.noop {
+			t.Errorf("%s: Unexpected value for noop, got %t, want %t", testName, noop, expected.noop)
+		}
+		if notMesh != expected.notMesh {
+			t.Errorf("%s: Unexpected value for notMesh, got %t, want %t",
+				testName, notMesh, expected.notMesh)
+		}
+		if err != nil && expected.success {
+			t.Errorf("%s: Unexpected error, got %v, want nil", testName, err)
+		} else if err == nil && !expected.success {
+			t.Errorf("%s: Unexpected error, got %v, want non-nil", testName, err)
+		}
+		if numProbes := fakeRT.NumProbes.Load(); numProbes != expected.numProbes {
+			t.Errorf("%s: Unexpected number of probes, got %d, want %d",
+				testName, numProbes, expected.numProbes)
+		}
 	}
 
-	// Test all pods healthy (skips probes)
-	rw.healthyPods = cur.ready.Union(cur.notReady)
-	healthy, noop, notMesh, err := rw.probePodIPs(cur.ready, cur.notReady)
-	if !healthy.Equal(rw.healthyPods) {
-		t.Errorf("Healthy does not match, got %#v, want %#v diff: %s", healthy, rw.healthyPods, cmp.Diff(healthy, cur.ready))
-	}
-	if !noop || notMesh || err != nil {
-		t.Errorf("Unexpected values: noop=%t (true), notMesh=%t (false), err=%s (nil)", noop, notMesh, err)
-	}
-	if numProbes := fakeRT.NumProbes.Load(); numProbes != 0 {
-		t.Errorf("Unexpected number of probes, got %d, want %d", numProbes, 0)
-	}
-
-	// Test one pod probe errors (using mesh compatibly auto and probe optimization), even if one
-	// pod errors all probes should still be completed
-	fakeRT.NumProbes.Store(0)
-	rw.healthyPods = sets.NewString()
-	healthy, noop, notMesh, err = rw.probePodIPs(cur.ready, cur.notReady)
-	if !healthy.Equal(cur.ready) {
-		t.Errorf("Healthy does not match, got %#v, want %#v diff: %s", healthy, cur.ready, cmp.Diff(healthy, cur.ready))
-	}
-	if noop || !notMesh || err == nil {
-		t.Errorf("Unexpected values: noop=%t (false), notMesh=%t (true), err=%s (non-nil)", noop, notMesh, err)
-	}
-	if numProbes := fakeRT.NumProbes.Load(); numProbes != 3 {
-		t.Errorf("Unexpected number of probes, got %d, want %d", numProbes, 3)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testFunc(t.Name(), test.input, test.expected)
+		})
 	}
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*NOTE: This builds off of #14303 and includes those commits as well.*

Update the activator `probePodIPs` to handle cases where the healthy pods are updated, but the update is not propagated due to the `noop` return value being set to true.  This issue is specific to certain combinations of activator/revision options such as the mesh mode and probe optimization.  Instead of specific unchanged logic for just the probes this uses the set `Equal` operation to check for unchanged which covers all possible code paths for updates. 

Tests have been expanded to include more explicit coverage of different combinations of options and states to probePodIPs to help cover this behavior moving forward.  There is one test case `no changes without probes` that now shows different behavior than prior code.  Prior code would return a false for noop.  After reviewing the calling code this did not seem to make sense
for a non-probing non-updating call to update the endpoints (especially given the other non-probe changes are now accounted for).  So this was left as it is now with the simple unchanged value logic.

This patch has been running in a production environment without issues for awhile now and has not shown the prior problematic behavior from #14200 thus far.

Ref https://github.com/knative/serving/issues/14200

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Activator correctly propagates pod health when triggered by changes other than pod probes.
```
