### PR TITLE
fix securityContext for Knative Service Pod (user-container and queue-proxy)

### DIFF
--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -208,6 +208,10 @@ func (rs *RevisionSpec) defaultSecurityContext(psc *corev1.PodSecurityContext, c
 		}
 	}
 
+	if psc.RunAsNonRoot == nil {
+		updatedSC.RunAsNonRoot = ptr.Bool(true)
+	}
+
 	if *updatedSC != (corev1.SecurityContext{}) {
 		container.SecurityContext = updatedSC
 	}

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -900,6 +900,7 @@ func TestRevisionDefaulting(t *testing.T) {
 						ReadinessProbe: defaultProbe,
 						Resources:      defaultResources,
 						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot:             ptr.Bool(true),
 							AllowPrivilegeEscalation: ptr.Bool(false),
 							SeccompProfile: &corev1.SeccompProfile{
 								Type: corev1.SeccompProfileTypeRuntimeDefault,
@@ -913,6 +914,7 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name:      "sidecar",
 						Resources: defaultResources,
 						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot:             ptr.Bool(true),
 							AllowPrivilegeEscalation: ptr.Bool(false),
 							SeccompProfile: &corev1.SeccompProfile{
 								Type: corev1.SeccompProfileTypeRuntimeDefault,
@@ -925,6 +927,7 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name:      "special-sidecar",
 						Resources: defaultResources,
 						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot:             ptr.Bool(true),
 							AllowPrivilegeEscalation: ptr.Bool(true),
 							SeccompProfile: &corev1.SeccompProfile{
 								Type: corev1.SeccompProfileTypeRuntimeDefault,
@@ -938,6 +941,7 @@ func TestRevisionDefaulting(t *testing.T) {
 					InitContainers: []corev1.Container{{
 						Name: "special-init",
 						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot:             ptr.Bool(true),
 							AllowPrivilegeEscalation: ptr.Bool(true),
 							SeccompProfile: &corev1.SeccompProfile{
 								Type:             corev1.SeccompProfileTypeLocalhost,
@@ -1000,6 +1004,7 @@ func TestRevisionDefaulting(t *testing.T) {
 						ReadinessProbe: defaultProbe,
 						Resources:      defaultResources,
 						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot:             ptr.Bool(true),
 							AllowPrivilegeEscalation: ptr.Bool(false),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
@@ -1009,6 +1014,7 @@ func TestRevisionDefaulting(t *testing.T) {
 					InitContainers: []corev1.Container{{
 						Name: "init",
 						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot:             ptr.Bool(true),
 							AllowPrivilegeEscalation: ptr.Bool(false),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -86,6 +86,9 @@ var (
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
 	}
 )
 


### PR DESCRIPTION
Fixes #14365

Related to:
* https://github.com/knative-extensions/net-contour/pull/955
* https://github.com/knative-extensions/net-certmanager/pull/584

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add seccompProfile type to queue proxy security context.
* Add runAsNonRoot to secure-pod-defaults
* I believe this PR added much of the security context sections. But when I install a Knative Service on a cluster that enforces Pod Security Standards, and I enabled `secure-pod-defaults`, I still get errors.
```
 status:
  conditions:
  - lastTransitionTime: "2023-09-13T15:13:42Z"
    lastUpdateTime: "2023-09-13T15:13:42Z"
    message: Created new replica set "tomato-00001-deployment-5db9b9f88d"
    reason: NewReplicaSetCreated
    status: "True"
    type: Progressing
  - lastTransitionTime: "2023-09-13T15:13:42Z"
    lastUpdateTime: "2023-09-13T15:13:42Z"
    message: Deployment does not have minimum availability.
    reason: MinimumReplicasUnavailable
    status: "False"
    type: Available
  - lastTransitionTime: "2023-09-13T15:13:42Z"
    lastUpdateTime: "2023-09-13T15:13:42Z"
    message: 'admission webhook "pod-security-webhook.kubernetes.io" denied the request:
      pods "tomato-00001-deployment-5db9b9f88d-w8gd4" is forbidden: violates PodSecurity
      "restricted:latest": runAsNonRoot != true (pod or container "user-container"
      must set securityContext.runAsNonRoot=true), seccompProfile (pod or container
      "queue-proxy" must set securityContext.seccompProfile.type to "RuntimeDefault"
      or "Localhost")'
    reason: FailedCreate
    status: "True"
    type: ReplicaFailure
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
TBD
```
