### PR TITLE
Change the cert manager version

### DIFF
--- a/third_party/cert-manager-latest/download-cert-manager.sh
+++ b/third_party/cert-manager-latest/download-cert-manager.sh
@@ -17,7 +17,7 @@
 #!/usr/bin/env bash
 
 # Download and unpack cert-manager
-CERT_MANAGER_VERSION=1.8.0
+CERT_MANAGER_VERSION=1.13.0
 YAML_URL=https://github.com/jetstack/cert-manager/releases/download/v${CERT_MANAGER_VERSION}/cert-manager.yaml
 
 # Download the cert-manager yaml file


### PR DESCRIPTION
 currently using v1.8 which is really old change it with the current version of cert-manager which is syncing from the net-cert-manager repo.

Fixes: #14383