### PR TITLE
Drop unnecessary `routing-id` in Knative Service certificate

### DIFF
--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -56,7 +56,6 @@ func (c *Reconciler) createSecret(ctx context.Context, ns *corev1.Namespace) (*c
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(ns, corev1.SchemeGroupVersion.WithKind("Namespace"))},
 			Labels: map[string]string{
 				networking.ServingCertName + "-ctrl": "data-plane-user",
-				"routing-id":                         "0",
 			},
 		},
 	}


### PR DESCRIPTION
Partially #14392 

## Proposed Changes
Drop unnecessary `routing-id` in Knative Service certificate as it is unnecessary on DataPlaneUser certificates. The routing-id label is only read on `data-plane-routing` types: https://github.com/knative/networking/blob/main/pkg/certificates/reconciler/certificates.go#L111C2-L111C2
