### PR TITLE
Cleanup knative-internal-tls secrets

### DIFF
--- a/config/core/300-secret.yaml
+++ b/config/core/300-secret.yaml
@@ -22,27 +22,19 @@ metadata:
   labels:
     serving-certs-ctrl: "data-plane"
     networking.internal.knative.dev/certificate-uid: "serving-certs"
-# The data is populated when internal-encryption is enabled.
+# The data is populated when knative-internal-tls is enabled.
 ---
 apiVersion: v1
 kind: Secret
 metadata:
+  # this is the legacy secret
+  # we can drop this once all net-* implementations are using the new `routing-serving-certs` secret
   name: knative-serving-certs
   namespace: knative-serving
   labels:
     serving-certs-ctrl: "data-plane"
     networking.internal.knative.dev/certificate-uid: "serving-certs"
-# The data is populated when internal-encryption is enabled.
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: control-serving-certs
-  namespace: knative-serving
-  labels:
-    serving-certs-ctrl: "control-plane"
-    networking.internal.knative.dev/certificate-uid: "serving-certs"
-# The data is populated when internal-encryption is enabled.
+# The data is populated when knative-internal-tls is enabled.
 ---
 apiVersion: v1
 kind: Secret
@@ -51,6 +43,5 @@ metadata:
   namespace: knative-serving
   labels:
     serving-certs-ctrl: "data-plane-routing"
-    routing-id: "0"
     networking.internal.knative.dev/certificate-uid: "serving-certs"
-# The data is populated when internal-encryption is enabled.
+# The data is populated when knative-internal-tls is enabled.


### PR DESCRIPTION
Partially https://github.com/knative/serving/issues/14392

## Proposed Changes
* Drop `control-serving-certs` secret, as it is unused
* Drop the `routing-id` label with regards to https://github.com/knative/serving/issues/14392
* Rename the comment to the new flag name