### PR TITLE
[wip] activator waits for initialDelaySeconds before probing

### DIFF
--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -1442,7 +1442,6 @@ func TestCheckDestsDelay(t *testing.T) {
 			} else if got, want := len(u.Dests), 1; got != want {
 				if updates < 2 {
 					updates++
-					continue
 				} else {
 					t.Fatalf("NumReady = %d, want: %d, update.Dests = %v", got, want, u.Dests)
 				}


### PR DESCRIPTION
Fixes #13611

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* if initialDelaySeconds is present on a revision, activator won't probe until that time has passed
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
TBD
```
