### PR TITLE
For kind testing, drop v1.25 and add v1.28.

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -87,9 +87,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.25.x
         - v1.26.x
         - v1.27.x
+        - v1.28.x
 
         ingress:
         - kourier


### PR DESCRIPTION
Fixes #14385

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

For kind testing, i drop v1.25 and add v1.28.
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
