### PR TITLE
SecurePodDefaults limits container capabilities

### DIFF
--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -725,14 +725,14 @@ func CapabilitiesMask(ctx context.Context, in *corev1.Capabilities) *corev1.Capa
 	// Allowed fields
 	out.Drop = in.Drop
 
-	if config.FromContextOrDefaults(ctx).Features.SecurePodDefaults == config.Enabled {
+	if config.FromContextOrDefaults(ctx).Features.ContainerSpecAddCapabilities == config.Enabled {
+		out.Add = in.Add
+	} else if config.FromContextOrDefaults(ctx).Features.SecurePodDefaults == config.Enabled {
 		if len(in.Add) == 1 && in.Add[0] == "NET_BIND_SERVICE" {
 			out.Add = in.Add
 		} else {
 			out.Add = nil
 		}
-	} else if config.FromContextOrDefaults(ctx).Features.ContainerSpecAddCapabilities != config.Disabled {
-		out.Add = in.Add
 	}
 
 	return out

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -725,7 +725,13 @@ func CapabilitiesMask(ctx context.Context, in *corev1.Capabilities) *corev1.Capa
 	// Allowed fields
 	out.Drop = in.Drop
 
-	if config.FromContextOrDefaults(ctx).Features.ContainerSpecAddCapabilities != config.Disabled {
+	if config.FromContextOrDefaults(ctx).Features.SecurePodDefaults == config.Enabled {
+		if len(in.Add) == 1 && in.Add[0] == "NET_BIND_SERVICE" {
+			out.Add = in.Add
+		} else {
+			out.Add = nil
+		}
+	} else if config.FromContextOrDefaults(ctx).Features.ContainerSpecAddCapabilities != config.Disabled {
 		out.Add = in.Add
 	}
 

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -51,7 +51,7 @@ func TestVolumeMask(t *testing.T) {
 	}
 }
 
-func TestCapabilitiesMask_SecureEnabled(t *testing.T) {
+func TestCapabilitiesMask_SecurePodDefaultsEnabled(t *testing.T) {
 	// Ensures users can only add NET_BIND_SERVICE or nil capabilities
 	tests := []struct {
 		name string
@@ -66,7 +66,7 @@ func TestCapabilitiesMask_SecureEnabled(t *testing.T) {
 			Add: nil,
 		},
 	}, {
-		name: "allow NET_BIND_SERVICE capability",
+		name: "allows NET_BIND_SERVICE capability",
 		in: &corev1.Capabilities{
 			Add: []corev1.Capability{"NET_BIND_SERVICE"},
 		},
@@ -876,7 +876,8 @@ func TestPodSecurityContextMask_FeatureEnabled(t *testing.T) {
 	}
 }
 
-func TestPodSecurityContextMask_SecureEnabled(t *testing.T) {
+func TestPodSecurityContextMask_SecurePodDefaultsEnabled(t *testing.T) {
+
 	// Ensure that users can opt out of better security by explicitly
 	// requesting the Kubernetes default, which is "Unconfined".
 	want := &corev1.PodSecurityContext{

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -51,6 +51,68 @@ func TestVolumeMask(t *testing.T) {
 	}
 }
 
+func TestCapabilitiesMask_SecureEnabled(t *testing.T) {
+	// Ensures users can only add NET_BIND_SERVICE or nil capabilities
+	tests := []struct {
+		name string
+		in   *corev1.Capabilities
+		want *corev1.Capabilities
+	}{{
+		name: "empty",
+		in: &corev1.Capabilities{
+			Add: nil,
+		},
+		want: &corev1.Capabilities{
+			Add: nil,
+		},
+	}, {
+		name: "allow NET_BIND_SERVICE capability",
+		in: &corev1.Capabilities{
+			Add: []corev1.Capability{"NET_BIND_SERVICE"},
+		},
+		want: &corev1.Capabilities{
+			Add: []corev1.Capability{"NET_BIND_SERVICE"},
+		},
+	}, {
+		name: "prevents restricted fields",
+		in: &corev1.Capabilities{
+			Add: []corev1.Capability{"CHOWN"},
+		},
+		want: &corev1.Capabilities{
+			Add: nil,
+		},
+	}}
+
+	for _, test := range tests {
+		ctx := config.ToContext(context.Background(),
+			&config.Config{
+				Features: &config.Features{
+					SecurePodDefaults: config.Enabled,
+				},
+			},
+		)
+
+		t.Run(test.name, func(t *testing.T) {
+			got := CapabilitiesMask(ctx, test.in)
+
+			if &test.want == &got {
+				t.Error("Input and output share addresses. Want different addresses")
+			}
+
+			if diff, err := kmp.SafeDiff(test.want, got); err != nil {
+				t.Error("Got error comparing output, err =", err)
+			} else if diff != "" {
+				t.Error("CapabilitiesMask (-want, +got):", diff)
+			}
+
+			if got = CapabilitiesMask(ctx, nil); got != nil {
+				t.Errorf("CapabilitiesMask = %v, want: nil", got)
+			}
+		})
+	}
+
+}
+
 func TestVolumeSourceMask(t *testing.T) {
 	want := &corev1.VolumeSource{
 		Secret:    &corev1.SecretVolumeSource{},


### PR DESCRIPTION
## Context
Enabling the `secure-pod-defaults` flag makes containers adopt the `restricted` profile for [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) by default. As part of enabling the restricted profile: 
```
Containers must drop ALL capabilities, and are only permitted to add back the NET_BIND_SERVICE capability.
```

## Proposed Changes
* This change makes it if secure-pod-defaults is enabled, containers can only have `nil` or `NET_BIND_SERVICE` capabilities. Note that `addcapabilities` flag takes precedence over `secure-pod-defaults`

**Release Note**

```release-note
Validating webhook will now allow adding the NET_BIND_SERVICE or nil capabilities when secure pods defaults feature is enabled
```
