### PR TITLE
Trust DataPlaneUserSAN from Activator to Queue-Proxy

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -169,7 +169,7 @@ func main() {
 	if tlsEnabled {
 		logger.Info("Knative Internal TLS is enabled")
 		certCache = certificate.NewCertCache(ctx)
-		transport = pkgnet.NewProxyAutoTLSTransport(env.MaxIdleProxyConns, env.MaxIdleProxyConnsPerHost, &certCache.TLSConf)
+		transport = pkgnet.NewProxyAutoTLSTransport(env.MaxIdleProxyConns, env.MaxIdleProxyConnsPerHost, certCache.TLSContext())
 	}
 
 	// Start throttler.

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	knative.dev/caching v0.0.0-20231012110827-8551914fdf65
 	knative.dev/hack v0.0.0-20231010131532-fc76874b28c6
 	knative.dev/networking v0.0.0-20231012062439-c0863403c83b
-	knative.dev/pkg v0.0.0-20231016092905-cf06733aa47b
+	knative.dev/pkg v0.0.0-20231016185203-283df0be0668
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -931,8 +931,8 @@ knative.dev/hack v0.0.0-20231010131532-fc76874b28c6 h1:K9saPnpWTK1xH/Dpx1aE4CA+4
 knative.dev/hack v0.0.0-20231010131532-fc76874b28c6/go.mod h1:yk2OjGDsbEnQjfxdm0/HJKS2WqTLEFg/N6nUs6Rqx3Q=
 knative.dev/networking v0.0.0-20231012062439-c0863403c83b h1:yGtVPNHek3rmKb50k7G9fG/NuuC4FRzESVrWmPFU9AM=
 knative.dev/networking v0.0.0-20231012062439-c0863403c83b/go.mod h1:uEvP4spV82HGB8loxo8nH/LGmwsd9jUGWvDVC+tH4O4=
-knative.dev/pkg v0.0.0-20231016092905-cf06733aa47b h1:ELB4gahWrQ+C1flcudcX3v7ThYYOD3Tnm8+ISod2bwQ=
-knative.dev/pkg v0.0.0-20231016092905-cf06733aa47b/go.mod h1:khuxKBM4WqjcCIeCIm+4VDNBmzMsl0ZspXGMm5i/fFA=
+knative.dev/pkg v0.0.0-20231016185203-283df0be0668 h1:rYlTKNUZbMsSHQID0A7sZbrtXlD+REKN6F94ceMnA5c=
+knative.dev/pkg v0.0.0-20231016185203-283df0be0668/go.mod h1:khuxKBM4WqjcCIeCIm+4VDNBmzMsl0ZspXGMm5i/fFA=
 pgregory.net/rapid v1.1.0 h1:CMa0sjHSru3puNx+J0MIAuiiEV4N0qj8/cMWGBBCsjw=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=

--- a/pkg/activator/certificate/tls_context.go
+++ b/pkg/activator/certificate/tls_context.go
@@ -47,7 +47,7 @@ func dialTLSContext(ctx context.Context, network, addr string, cr *CertCache) (n
 	cr.certificatesMux.RUnlock()
 
 	revID := handler.RevIDFrom(ctx)
-	san := certificates.DataPlaneUserName(revID.Namespace)
+	san := certificates.DataPlaneUserSAN(revID.Namespace)
 
 	tlsConf.VerifyConnection = verifySAN(san)
 	return pkgnet.DialTLSWithBackOff(ctx, network, addr, tlsConf)

--- a/pkg/activator/certificate/tls_context.go
+++ b/pkg/activator/certificate/tls_context.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificate
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+
+	"knative.dev/networking/pkg/certificates"
+	pkgnet "knative.dev/pkg/network"
+	"knative.dev/serving/pkg/activator/handler"
+)
+
+// TLSContext returns DialTLSContextFunc.
+func (cr *CertCache) TLSContext() pkgnet.DialTLSContextFunc {
+	return cr.dialTLSContext
+}
+
+// dialTLSContext handles TLS dialer
+func (cr *CertCache) dialTLSContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	return dialTLSContext(ctx, network, addr, cr)
+}
+
+// dialTLSContext handles verify SAN before calling DialTLSWithBackOff.
+func dialTLSContext(ctx context.Context, network, addr string, cr *CertCache) (net.Conn, error) {
+	cr.certificatesMux.Lock()
+	// Clone the certificate Pool such that the one used by the client will be different from the one that will get updated is CA is replaced.
+	tlsConf := cr.TLSConf.Clone()
+	tlsConf.RootCAs = tlsConf.RootCAs.Clone()
+	cr.certificatesMux.Unlock()
+
+	revID := handler.RevIDFrom(ctx)
+	san := certificates.DataPlaneUserName(revID.Namespace)
+
+	tlsConf.VerifyConnection = verifySAN(san)
+	return pkgnet.DialTLSWithBackOff(ctx, network, addr, tlsConf)
+}
+
+func verifySAN(san string) func(tls.ConnectionState) error {
+	return func(cs tls.ConnectionState) error {
+		if len(cs.PeerCertificates) == 0 {
+			return errors.New("No PeerCertificates provided")
+		}
+		for _, name := range cs.PeerCertificates[0].DNSNames {
+			if name == san {
+				return nil
+			}
+		}
+		return fmt.Errorf("SAN %q does not have a matching name in %v", san, cs.PeerCertificates[0].DNSNames)
+	}
+}

--- a/pkg/activator/certificate/tls_context.go
+++ b/pkg/activator/certificate/tls_context.go
@@ -56,13 +56,13 @@ func dialTLSContext(ctx context.Context, network, addr string, cr *CertCache) (n
 func verifySAN(san string) func(tls.ConnectionState) error {
 	return func(cs tls.ConnectionState) error {
 		if len(cs.PeerCertificates) == 0 {
-			return errors.New("No PeerCertificates provided")
+			return errors.New("no PeerCertificates provided")
 		}
 		for _, name := range cs.PeerCertificates[0].DNSNames {
 			if name == san {
 				return nil
 			}
 		}
-		return fmt.Errorf("SAN %q does not have a matching name in %v", san, cs.PeerCertificates[0].DNSNames)
+		return fmt.Errorf("san %q does not have a matching name in %v", san, cs.PeerCertificates[0].DNSNames)
 	}
 }

--- a/pkg/activator/certificate/tls_context.go
+++ b/pkg/activator/certificate/tls_context.go
@@ -40,11 +40,11 @@ func (cr *CertCache) dialTLSContext(ctx context.Context, network, addr string) (
 
 // dialTLSContext handles verify SAN before calling DialTLSWithBackOff.
 func dialTLSContext(ctx context.Context, network, addr string, cr *CertCache) (net.Conn, error) {
-	cr.certificatesMux.Lock()
+	cr.certificatesMux.RLock()
 	// Clone the certificate Pool such that the one used by the client will be different from the one that will get updated is CA is replaced.
 	tlsConf := cr.TLSConf.Clone()
 	tlsConf.RootCAs = tlsConf.RootCAs.Clone()
-	cr.certificatesMux.Unlock()
+	cr.certificatesMux.RUnlock()
 
 	revID := handler.RevIDFrom(ctx)
 	san := certificates.DataPlaneUserName(revID.Namespace)

--- a/pkg/activator/certificate/tls_context_test.go
+++ b/pkg/activator/certificate/tls_context_test.go
@@ -1,0 +1,56 @@
+package certificate
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+)
+
+// TestVerifySAN tests verifySAN.
+func TestVerifySAN(t *testing.T) {
+	tests := []struct {
+		name   string
+		san    string
+		expErr bool
+	}{{
+		name:   "first SAN",
+		san:    "knative-knative-serving",
+		expErr: false,
+	}, {
+		name:   "second SAN",
+		san:    "data-plane.knative.dev",
+		expErr: false,
+	}, {
+		name:   "non existent SAN",
+		san:    "foo",
+		expErr: true,
+	}}
+
+	// tlsCrt contains two SANs knative-knative-serving and data-plane.knative.dev.
+	block, _ := pem.Decode(tlsCrt)
+	if block == nil {
+		t.Fatal("failed to parse certificate PEM")
+	}
+
+	serverCert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	tlsConnectionState := tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{serverCert},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := verifySAN(test.san)(tlsConnectionState)
+			if test.expErr && err == nil {
+				t.Fatalf("failed to verify SAN")
+			}
+			if !test.expErr && err != nil {
+				t.Fatalf("failed to verify SAN: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/activator/certificate/tls_context_test.go
+++ b/pkg/activator/certificate/tls_context_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package certificate
 
 import (

--- a/vendor/knative.dev/pkg/apiextensions/storageversion/migrator.go
+++ b/vendor/knative.dev/pkg/apiextensions/storageversion/migrator.go
@@ -68,6 +68,11 @@ func (m *Migrator) Migrate(ctx context.Context, gr schema.GroupResource) error {
 		return fmt.Errorf("unable to determine storage version for %s", gr)
 	}
 
+	// don't migrate storage version if CRD has a single valid storage in its status
+	if len(crd.Status.StoredVersions) == 1 && crd.Status.StoredVersions[0] == version {
+		return nil
+	}
+
 	if err := m.migrateResources(ctx, gr.WithVersion(version)); err != nil {
 		return err
 	}

--- a/vendor/knative.dev/pkg/environment/client_config.go
+++ b/vendor/knative.dev/pkg/environment/client_config.go
@@ -44,12 +44,8 @@ func (c *ClientConfig) InitFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.ServerURL, "server", "",
 		"The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 
-	if f := fs.Lookup("kubeconfig"); f != nil {
-		c.Kubeconfig = f.Value.String()
-	} else {
-		fs.StringVar(&c.Kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"),
-			"Path to a kubeconfig. Only required if out-of-cluster.")
-	}
+	fs.StringVar(&c.Kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"),
+		"Path to a kubeconfig. Only required if out-of-cluster.")
 
 	fs.IntVar(&c.Burst, "kube-api-burst", int(envVarOrDefault("KUBE_API_BURST", 0)), "Maximum burst for throttle.")
 

--- a/vendor/knative.dev/pkg/network/h2c.go
+++ b/vendor/knative.dev/pkg/network/h2c.go
@@ -59,13 +59,11 @@ func newH2CTransport(disableCompression bool) http.RoundTripper {
 
 // newH2Transport constructs a neew H2 transport. That transport will handles HTTPS traffic
 // with TLS config.
-func newH2Transport(disableCompression bool, tlsConf *tls.Config) http.RoundTripper {
+func newH2Transport(disableCompression bool, tlsContext DialTLSContextFunc) http.RoundTripper {
 	return &http2.Transport{
 		DisableCompression: disableCompression,
-		DialTLS: func(netw, addr string, tlsConf *tls.Config) (net.Conn, error) {
-			return DialTLSWithBackOff(context.Background(),
-				netw, addr, tlsConf)
+		DialTLSContext: func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error) {
+			return tlsContext(ctx, network, addr)
 		},
-		TLSClientConfig: tlsConf,
 	}
 }

--- a/vendor/knative.dev/pkg/network/transports.go
+++ b/vendor/knative.dev/pkg/network/transports.go
@@ -131,7 +131,6 @@ type DialTLSContextFunc func(ctx context.Context, network, addr string) (net.Con
 
 func newHTTPSTransport(disableKeepAlives, disableCompression bool, maxIdle, maxIdlePerHost int, tlsContext DialTLSContextFunc) http.RoundTripper {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.DialContext = DialWithBackOff
 	transport.DisableKeepAlives = disableKeepAlives
 	transport.MaxIdleConns = maxIdle
 	transport.MaxIdleConnsPerHost = maxIdlePerHost

--- a/vendor/knative.dev/pkg/network/transports.go
+++ b/vendor/knative.dev/pkg/network/transports.go
@@ -149,7 +149,7 @@ func NewProberTransport() http.RoundTripper {
 		NewH2CTransport())
 }
 
-// NewProxyAutoTLSTransport is same with NewProxyAutoTransport but it has tls.Config to create HTTPS request.
+// NewProxyAutoTLSTransport is same with NewProxyAutoTransport but it has DialTLSContextFunc to create HTTPS request.
 func NewProxyAutoTLSTransport(maxIdle, maxIdlePerHost int, tlsContext DialTLSContextFunc) http.RoundTripper {
 	return newAutoTransport(
 		newHTTPSTransport(false /*disable keep-alives*/, true /*disable auto-compression*/, maxIdle, maxIdlePerHost, tlsContext),

--- a/vendor/knative.dev/pkg/test/upgrade/shell/executor.go
+++ b/vendor/knative.dev/pkg/test/upgrade/shell/executor.go
@@ -185,7 +185,9 @@ func (w testingWriter) Write(p []byte) (n int, err error) {
 	// Strip trailing newline because t.Log always adds one.
 	p = bytes.TrimRight(p, "\n")
 
-	w.t.Logf("%s", p)
+	for _, line := range strings.Split(string(p), "\n") {
+		w.t.Logf(line)
+	}
 
 	return n, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1340,7 +1340,7 @@ knative.dev/networking/pkg/http/stats
 knative.dev/networking/pkg/ingress
 knative.dev/networking/pkg/k8s
 knative.dev/networking/pkg/prober
-# knative.dev/pkg v0.0.0-20231016092905-cf06733aa47b
+# knative.dev/pkg v0.0.0-20231016185203-283df0be0668
 ## explicit; go 1.18
 knative.dev/pkg/apiextensions/storageversion
 knative.dev/pkg/apiextensions/storageversion/cmd/migrate


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/14402

### Proposed Changes

This patch changes activator to trust a new SAN `kn-user-<ns>` instead of legacy SAN.

**Release Note**

```release-note
internal encryption verifies a new SAN `kn-user-<ns>`.
```
