### PR TITLE
Added Platform Specific `ko` build instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -153,10 +153,22 @@ Kubernetes cluster in your designated environment, if necessary.
 
 ### Deploy Knative Serving
 
-This step includes building Knative Serving, creating and pushing developer
-images, and deploying them to your Kubernetes cluster. If you're developing
-locally, set `KO_DOCKER_REPO=ko.local` (or `KO_DOCKER_REPO=kind.local` respectively)
-to avoid needing to push your images to an off-machine registry.
+- This step includes building Knative Serving, creating and pushing developer
+  images, and deploying them to your Kubernetes cluster. If you're developing
+  locally, set `KO_DOCKER_REPO=ko.local` (or `KO_DOCKER_REPO=kind.local` respectively)
+  to avoid needing to push your images to an off-machine registry.
+
+- By default, `ko` will build container images for the architecture of your local machine, 
+  but if you need to build images for a different platform (OS and architecture), 
+  you can provide `--platform` flag as follows: 
+
+  ```shell
+  # Synopsis
+  ko apply -f FILENAME [flags]
+
+  # Usage
+  ko apply --selector knative.dev/crd-install=true -Rf config/core/ --platform linux/arm64
+  ```
 
 Run:
 


### PR DESCRIPTION
Added Platform Specific `ko` build instructions, so that it is possible to develop container images for a different platform (OS and architecture).

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* I faced the issues in building `linux/arm64` architecture specific container images for `knative-serving`. Since there were no instructions mentioned for platform specific build, I thought of adding it. 
* This will help in multi-platform container image deployment.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
No breaking changes.
```
