### PR TITLE
[WIP] Add `parallel 1` for HTTPS test

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -323,10 +323,6 @@ function install() {
     YTT_FILES+=("${REPO_ROOT_DIR}/test/config/tls/cert-secret.yaml")
   fi
 
-  if (( HTTPS )); then
-    YTT_FILES+=("${REPO_ROOT_DIR}/test/config/autotls/certmanager/caissuer")
-  fi
-
   local ytt_result=$(mktemp)
   local ytt_post_install_result=$(mktemp)
   local ytt_flags=""

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -140,6 +140,7 @@ function parse_flags() {
       ;;
     --https)
       readonly HTTPS=1
+      readonly INGRESS_CLASS="kourier.ingress.networking.knative.dev"
       return 1
       ;;
     --short)

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -140,7 +140,6 @@ function parse_flags() {
       ;;
     --https)
       readonly HTTPS=1
-      readonly INGRESS_CLASS="kourier.ingress.networking.knative.dev"
       return 1
       ;;
     --short)

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -140,7 +140,7 @@ function parse_flags() {
       ;;
     --https)
       readonly HTTPS=1
-      readonly INGRESS_CLASS="kourier.ingress.networking.knative.dev"
+      #readonly INGRESS_CLASS="kourier.ingress.networking.knative.dev"
       return 1
       ;;
     --short)

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -323,6 +323,10 @@ function install() {
     YTT_FILES+=("${REPO_ROOT_DIR}/test/config/tls/cert-secret.yaml")
   fi
 
+  if (( HTTPS )); then
+    YTT_FILES+=("${REPO_ROOT_DIR}/test/config/autotls/certmanager/caissuer")
+  fi
+
   local ytt_result=$(mktemp)
   local ytt_post_install_result=$(mktemp)
   local ytt_flags=""

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -140,7 +140,7 @@ function parse_flags() {
       ;;
     --https)
       readonly HTTPS=1
-      #readonly INGRESS_CLASS="kourier.ingress.networking.knative.dev"
+      readonly INGRESS_CLASS="kourier.ingress.networking.knative.dev"
       return 1
       ;;
     --short)

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -53,6 +53,7 @@ if (( HTTPS )); then
   toggle_feature auto-tls Enabled config-network
   kubectl apply -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/caissuer/
   add_trap "kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
+  kubectl wait --timeout=60s certificate -n cert-manager --for=condition=Ready knative-internal-encryption-ca
 fi
 
 if (( MESH )); then
@@ -62,8 +63,6 @@ fi
 if (( SHORT )); then
   GO_TEST_FLAGS+=" -short"
 fi
-
-sleep 300
 
 go_test_e2e -timeout=30m \
   ${GO_TEST_FLAGS} \

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -54,6 +54,7 @@ if (( HTTPS )); then
   kubectl apply -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/caissuer/
   add_trap "kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
   kubectl wait --timeout=60s certificate -n cert-manager --for=condition=Ready knative-internal-encryption-ca
+  kubectl wait --timeout=60s clusterissuer --for=condition=Ready ca-issuer
 fi
 
 sleep 300

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -66,20 +66,13 @@ if (( SHORT )); then
   GO_TEST_FLAGS+=" -short"
 fi
 
+
 go_test_e2e -timeout=30m \
   ${GO_TEST_FLAGS} \
   ./test/conformance/api/... \
   ./test/conformance/runtime/... \
   ./test/e2e \
   ${E2E_TEST_FLAGS} || failed=1
-
-(( failed )) && fail_test
-
-# Remove the kail log file if the test flow passes.
-# This is for preventing too many large log files to be uploaded to GCS in CI.
-rm "${ARTIFACTS}/k8s.log-$(basename "${E2E_SCRIPT}").txt"
-
-success
 
 toggle_feature tag-header-based-routing Enabled
 go_test_e2e -timeout=2m ./test/e2e/tagheader ${E2E_TEST_FLAGS} || failed=1

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -50,6 +50,7 @@ fi
 
 if (( HTTPS )); then
   E2E_TEST_FLAGS+=" -https"
+  GO_TEST_FLAGS+=" -parallel 1"
   toggle_feature auto-tls Enabled config-network
   kubectl apply -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/caissuer/
   add_trap "kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -66,6 +66,9 @@ if (( SHORT )); then
   GO_TEST_FLAGS+=" -short"
 fi
 
+toggle_feature tag-header-based-routing Enabled
+go_test_e2e -timeout=2m ./test/e2e/tagheader ${E2E_TEST_FLAGS} || failed=1
+toggle_feature tag-header-based-routing Disabled
 
 go_test_e2e -timeout=30m \
   ${GO_TEST_FLAGS} \
@@ -73,10 +76,6 @@ go_test_e2e -timeout=30m \
   ./test/conformance/api/... \
   ./test/conformance/runtime/... \
   ${E2E_TEST_FLAGS} || failed=1
-
-toggle_feature tag-header-based-routing Enabled
-go_test_e2e -timeout=2m ./test/e2e/tagheader ${E2E_TEST_FLAGS} || failed=1
-toggle_feature tag-header-based-routing Disabled
 
 toggle_feature allow-zero-initial-scale true config-autoscaler || fail_test
 go_test_e2e -timeout=2m ./test/e2e/initscale ${E2E_TEST_FLAGS} || failed=1

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -53,6 +53,7 @@ if (( HTTPS )); then
   toggle_feature auto-tls Enabled config-network
   kubectl apply -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/caissuer/
   add_trap "kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
+  GO_TEST_FLAGS+=" -parallel 1"
   kubectl wait --timeout=60s certificate -n cert-manager --for=condition=Ready knative-internal-encryption-ca
 fi
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -57,6 +57,8 @@ if (( HTTPS )); then
   kubectl wait --timeout=60s certificate -n cert-manager --for=condition=Ready knative-internal-encryption-ca
 fi
 
+sleep 300
+
 if (( MESH )); then
   GO_TEST_FLAGS+=" -parallel 1"
 fi

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -72,9 +72,9 @@ toggle_feature tag-header-based-routing Disabled
 
 go_test_e2e -timeout=30m \
   ${GO_TEST_FLAGS} \
-  ./test/e2e \
   ./test/conformance/api/... \
   ./test/conformance/runtime/... \
+  ./test/e2e \
   ${E2E_TEST_FLAGS} || failed=1
 
 toggle_feature allow-zero-initial-scale true config-autoscaler || fail_test

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -65,6 +65,7 @@ if (( SHORT )); then
   GO_TEST_FLAGS+=" -short"
 fi
 
+sleep 300
 
 go_test_e2e -timeout=30m \
   ${GO_TEST_FLAGS} \

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -58,8 +58,6 @@ if (( HTTPS )); then
   kubectl wait --timeout=60s clusterissuer --for=condition=Ready ca-issuer
 fi
 
-sleep 300
-
 if (( MESH )); then
   GO_TEST_FLAGS+=" -parallel 1"
 fi

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -50,9 +50,7 @@ fi
 
 if (( HTTPS )); then
   E2E_TEST_FLAGS+=" -https"
-  GO_TEST_FLAGS+=" -parallel 1"
   toggle_feature auto-tls Enabled config-network
-  kubectl -n "${SYSTEM_NAMESPACE}" scale deployment 3scale-kourier-gateway --replicas=2
   kubectl apply -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/caissuer/
   add_trap "kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
 fi
@@ -69,10 +67,10 @@ sleep 300
 
 go_test_e2e -timeout=30m \
   ${GO_TEST_FLAGS} \
+  ./test/conformance/api/... \
+  ./test/conformance/runtime/... \
   ./test/e2e \
   ${E2E_TEST_FLAGS} || failed=1
-#  ./test/conformance/api/... \
-#  ./test/conformance/runtime/... \
 
 (( failed )) && fail_test
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -51,8 +51,6 @@ fi
 if (( HTTPS )); then
   E2E_TEST_FLAGS+=" -https"
   toggle_feature auto-tls Enabled config-network
-  kubectl apply -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/caissuer/
-  add_trap "kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
 fi
 
 if (( MESH )); then
@@ -62,8 +60,6 @@ fi
 if (( SHORT )); then
   GO_TEST_FLAGS+=" -short"
 fi
-
-sleep 300
 
 go_test_e2e -timeout=30m \
   ${GO_TEST_FLAGS} \

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -53,6 +53,7 @@ if (( HTTPS )); then
   toggle_feature auto-tls Enabled config-network
   kubectl apply -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/caissuer/
   add_trap "kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
+  GO_TEST_FLAGS+=" -parallel 1"
   kubectl wait --timeout=60s certificate -n cert-manager --for=condition=Ready knative-internal-encryption-ca
   kubectl wait --timeout=60s clusterissuer --for=condition=Ready ca-issuer
 fi

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -58,6 +58,8 @@ if (( HTTPS )); then
   kubectl wait --timeout=60s clusterissuer --for=condition=Ready ca-issuer
 fi
 
+sleep 300
+
 if (( MESH )); then
   GO_TEST_FLAGS+=" -parallel 1"
 fi

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -53,7 +53,6 @@ if (( HTTPS )); then
   toggle_feature auto-tls Enabled config-network
   kubectl apply -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/caissuer/
   add_trap "kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
-  GO_TEST_FLAGS+=" -parallel 1"
   kubectl wait --timeout=60s certificate -n cert-manager --for=condition=Ready knative-internal-encryption-ca
 fi
 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -51,6 +51,8 @@ fi
 if (( HTTPS )); then
   E2E_TEST_FLAGS+=" -https"
   toggle_feature auto-tls Enabled config-network
+  kubectl apply -f "${E2E_YAML_DIR}"/test/config/autotls/certmanager/caissuer/
+  add_trap "kubectl delete -f ${E2E_YAML_DIR}/test/config/autotls/certmanager/caissuer/ --ignore-not-found" SIGKILL SIGTERM SIGQUIT
 fi
 
 if (( MESH )); then
@@ -60,6 +62,8 @@ fi
 if (( SHORT )); then
   GO_TEST_FLAGS+=" -short"
 fi
+
+sleep 300
 
 go_test_e2e -timeout=30m \
   ${GO_TEST_FLAGS} \

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -58,8 +58,6 @@ if (( HTTPS )); then
   kubectl wait --timeout=60s clusterissuer --for=condition=Ready ca-issuer
 fi
 
-sleep 300
-
 if (( MESH )); then
   GO_TEST_FLAGS+=" -parallel 1"
 fi
@@ -71,9 +69,9 @@ fi
 
 go_test_e2e -timeout=30m \
   ${GO_TEST_FLAGS} \
+  ./test/e2e \
   ./test/conformance/api/... \
   ./test/conformance/runtime/... \
-  ./test/e2e \
   ${E2E_TEST_FLAGS} || failed=1
 
 toggle_feature tag-header-based-routing Enabled


### PR DESCRIPTION
## Proposed Changes

This patch changes to:
* Add `parallel 1` for HTTPS test.
* Wait until CA issuer became READY.
* Use Kourier instead of Istio as it is more stable.

**Release Note**

```release-note
NONE
```
