### PR TITLE
[wip] queue returns latest probe result to activator

### DIFF
--- a/pkg/queue/health/handler.go
+++ b/pkg/queue/health/handler.go
@@ -54,6 +54,14 @@ func ProbeHandler(prober func() bool, tracingEnabled bool) http.HandlerFunc {
 			return
 		}
 
+		/*
+			- upon starting the queue, fire up the probe, use the periodseconds on the probe, or a default of 10
+			- upon probe handler request, read from chan for latest probe result
+			- when probe gets a success, stop probing
+
+			what to do when periodSeconds is zero? I guess just probe agressively right away?
+
+		*/
 		if !prober() {
 			probeSpan.Annotate([]trace.Attribute{
 				trace.StringAttribute("queueproxy.probe.error", "container not ready")}, "error")


### PR DESCRIPTION


Fixes #13611 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Instead of triggering a new probe on every request from activator, queue now probes on it's own cadence, and returns cached result to activator when probe requests comes in

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
TBD
```
