### PR TITLE
Implemented the extension interface to make controller pluggable

### DIFF
--- a/pkg/reconciler/extension/extension.go
+++ b/pkg/reconciler/extension/extension.go
@@ -25,13 +25,19 @@ import (
 
 // Extension enables pluggable extensive features added into the controller
 type Extension interface {
+	// TransformRevision transforms the existing revision.
 	TransformRevision(*v1.Revision) *v1.Revision
+	// PostRevisionReconcile implements a custom reconcile loop the after the revision is created.
 	PostRevisionReconcile(context.Context, *autoscalingv1alpha1.PodAutoscaler, *autoscalingv1alpha1.PodAutoscaler) error
+	// PostConfigurationReconcile implements a custom reconcile loop after the configuration is created.
 	PostConfigurationReconcile(context.Context, *v1.Service, *v1.Configuration) error
+	// TransformService transforms the existing service.
 	TransformService(*v1.Service) *v1.Service
+	// UpdateExtensionStatus updates the status of the custom resources in the extension.
 	UpdateExtensionStatus(context.Context, *v1.Service) (bool, error)
 }
 
+// NoExtension means an empty Extension
 func NoExtension() Extension {
 	return &nilExtension{}
 }
@@ -39,22 +45,27 @@ func NoExtension() Extension {
 type nilExtension struct {
 }
 
+// TransformRevision return the same revision without any changes.
 func (nilExtension) TransformRevision(revision *v1.Revision) *v1.Revision {
 	return revision
 }
 
+// PostRevisionReconcile does nothing as an empty extension.
 func (nilExtension) PostRevisionReconcile(context.Context, *autoscalingv1alpha1.PodAutoscaler, *autoscalingv1alpha1.PodAutoscaler) error {
 	return nil
 }
 
+// PostConfigurationReconcile does nothing as an empty extension.
 func (nilExtension) PostConfigurationReconcile(context.Context, *v1.Service, *v1.Configuration) error {
 	return nil
 }
 
+// TransformService return the same service without any changes.
 func (nilExtension) TransformService(service *v1.Service) *v1.Service {
 	return service
 }
 
+// UpdateExtensionStatus does nothing as an empty extension.
 func (nilExtension) UpdateExtensionStatus(context.Context, *v1.Service) (bool, error) {
 	return true, nil
 }

--- a/pkg/reconciler/extension/extension.go
+++ b/pkg/reconciler/extension/extension.go
@@ -23,8 +23,8 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
-// Extension enables pluggable extensive features added into the controller
-type Extension interface {
+// ServingExtension enables pluggable extensive features added into the controller
+type ServingExtension interface {
 	// TransformRevision transforms the existing revision.
 	TransformRevision(*v1.Revision) *v1.Revision
 	// PostRevisionReconcile implements a custom reconcile loop the after the revision is created.
@@ -37,8 +37,8 @@ type Extension interface {
 	UpdateExtensionStatus(context.Context, *v1.Service) (bool, error)
 }
 
-// NoExtension means an empty Extension
-func NoExtension() Extension {
+// NoExtension means an empty ServingExtension
+func NoExtension() ServingExtension {
 	return &nilExtension{}
 }
 

--- a/pkg/reconciler/extension/extension.go
+++ b/pkg/reconciler/extension/extension.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extension
+
+import (
+	"context"
+
+	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+)
+
+// Extension enables pluggable extensive features added into the controller
+type Extension interface {
+	TransformRevision(*v1.Revision) *v1.Revision
+	PostRevisionReconcile(context.Context, *autoscalingv1alpha1.PodAutoscaler, *autoscalingv1alpha1.PodAutoscaler) error
+	PostConfigurationReconcile(context.Context, *v1.Service, *v1.Configuration) error
+	TransformService(*v1.Service) *v1.Service
+	UpdateExtensionStatus(context.Context, *v1.Service) (bool, error)
+}
+
+func NoExtension() Extension {
+	return &nilExtension{}
+}
+
+type nilExtension struct {
+}
+
+func (nilExtension) TransformRevision(revision *v1.Revision) *v1.Revision {
+	return revision
+}
+
+func (nilExtension) PostRevisionReconcile(context.Context, *autoscalingv1alpha1.PodAutoscaler, *autoscalingv1alpha1.PodAutoscaler) error {
+	return nil
+}
+
+func (nilExtension) PostConfigurationReconcile(context.Context, *v1.Service, *v1.Configuration) error {
+	return nil
+}
+
+func (nilExtension) TransformService(service *v1.Service) *v1.Service {
+	return service
+}
+
+func (nilExtension) UpdateExtensionStatus(context.Context, *v1.Service) (bool, error) {
+	return true, nil
+}

--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -67,7 +67,7 @@ type reconcilerOption func(*Reconciler)
 func newControllerWithOptions(
 	ctx context.Context,
 	cmw configmap.Watcher,
-	extension extension.Extension,
+	extension extension.ServingExtension,
 	opts ...reconcilerOption,
 ) *controller.Impl {
 	logger := logging.FromContext(ctx)

--- a/pkg/reconciler/revision/controller.go
+++ b/pkg/reconciler/revision/controller.go
@@ -44,6 +44,7 @@ import (
 	apisconfig "knative.dev/serving/pkg/apis/config"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/deployment"
+	"knative.dev/serving/pkg/reconciler/extension"
 	"knative.dev/serving/pkg/reconciler/revision/config"
 )
 
@@ -58,7 +59,7 @@ func NewController(
 	ctx context.Context,
 	cmw configmap.Watcher,
 ) *controller.Impl {
-	return newControllerWithOptions(ctx, cmw)
+	return newControllerWithOptions(ctx, cmw, extension.NoExtension())
 }
 
 type reconcilerOption func(*Reconciler)
@@ -66,6 +67,7 @@ type reconcilerOption func(*Reconciler)
 func newControllerWithOptions(
 	ctx context.Context,
 	cmw configmap.Watcher,
+	extension extension.Extension,
 	opts ...reconcilerOption,
 ) *controller.Impl {
 	logger := logging.FromContext(ctx)
@@ -82,6 +84,8 @@ func newControllerWithOptions(
 		podAutoscalerLister: paInformer.Lister(),
 		imageLister:         imageInformer.Lister(),
 		deploymentLister:    deploymentInformer.Lister(),
+
+		extension: extension,
 	}
 
 	impl := revisionreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -63,7 +63,7 @@ type Reconciler struct {
 	deploymentLister    appsv1listers.DeploymentLister
 
 	resolver  resolver
-	extension extension.Extension
+	extension extension.ServingExtension
 }
 
 // Check that our Reconciler implements the necessary interfaces.

--- a/pkg/reconciler/revision/revision.go
+++ b/pkg/reconciler/revision/revision.go
@@ -41,6 +41,7 @@ import (
 	pkgreconciler "knative.dev/pkg/reconciler"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	palisters "knative.dev/serving/pkg/client/listers/autoscaling/v1alpha1"
+	"knative.dev/serving/pkg/reconciler/extension"
 	"knative.dev/serving/pkg/reconciler/revision/config"
 )
 
@@ -61,7 +62,8 @@ type Reconciler struct {
 	imageLister         cachinglisters.ImageLister
 	deploymentLister    appsv1listers.DeploymentLister
 
-	resolver resolver
+	resolver  resolver
+	extension extension.Extension
 }
 
 // Check that our Reconciler implements the necessary interfaces.

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"knative.dev/serving/pkg/reconciler/extension"
 	"math/rand"
 	"testing"
 	"time"
@@ -37,6 +36,7 @@ import (
 	fakeservingclient "knative.dev/serving/pkg/client/injection/client/fake"
 	fakepainformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler/fake"
 	fakerevisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision/fake"
+	"knative.dev/serving/pkg/reconciler/extension"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"

--- a/pkg/reconciler/revision/revision_test.go
+++ b/pkg/reconciler/revision/revision_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"knative.dev/serving/pkg/reconciler/extension"
 	"math/rand"
 	"testing"
 	"time"
@@ -92,7 +93,7 @@ func newTestController(t *testing.T, configs []*corev1.ConfigMap, opts ...reconc
 	opts = append([]reconcilerOption{func(r *Reconciler) {
 		r.resolver = &nopResolver{}
 	}}, opts...)
-	controller := newControllerWithOptions(ctx, configMapWatcher, opts...)
+	controller := newControllerWithOptions(ctx, configMapWatcher, extension.NoExtension(), opts...)
 
 	for _, cm := range append([]*corev1.ConfigMap{{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -45,6 +45,7 @@ import (
 	"knative.dev/serving/pkg/autoscaler/config/autoscalerconfig"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	revisionreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/revision"
+	"knative.dev/serving/pkg/reconciler/extension"
 	"knative.dev/serving/pkg/reconciler/revision/config"
 	"knative.dev/serving/pkg/reconciler/revision/resources"
 
@@ -716,6 +717,8 @@ func TestReconcile(t *testing.T) {
 			imageLister:         listers.GetImageLister(),
 			deploymentLister:    listers.GetDeploymentLister(),
 			resolver:            &nopResolver{},
+
+			extension: extension.NoExtension(),
 		}
 
 		return revisionreconciler.NewReconciler(ctx, logging.FromContext(ctx), servingclient.Get(ctx),

--- a/pkg/reconciler/service/controller.go
+++ b/pkg/reconciler/service/controller.go
@@ -46,7 +46,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 func newControllerWithOptions(
 	ctx context.Context,
 	cmw configmap.Watcher,
-	extension extension.Extension,
+	extension extension.ServingExtension,
 ) *controller.Impl {
 	logger := logging.FromContext(ctx)
 	serviceInformer := kserviceinformer.Get(ctx)

--- a/pkg/reconciler/service/controller.go
+++ b/pkg/reconciler/service/controller.go
@@ -18,7 +18,6 @@ package service
 
 import (
 	"context"
-	"knative.dev/serving/pkg/reconciler/extension"
 
 	cfgmap "knative.dev/serving/pkg/apis/config"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
@@ -27,6 +26,7 @@ import (
 	routeinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/route"
 	kserviceinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/service"
 	ksvcreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/service"
+	"knative.dev/serving/pkg/reconciler/extension"
 
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"

--- a/pkg/reconciler/service/service.go
+++ b/pkg/reconciler/service/service.go
@@ -54,7 +54,7 @@ type Reconciler struct {
 	routeLister         listers.RouteLister
 
 	enqueueAfter func(interface{}, time.Duration)
-	extension    extension.Extension
+	extension    extension.ServingExtension
 }
 
 // Check that our Reconciler implements ksvcreconciler.Interface

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -19,6 +19,7 @@ package service
 import (
 	"context"
 	"errors"
+	"knative.dev/serving/pkg/reconciler/extension"
 	"testing"
 	"time"
 
@@ -780,6 +781,7 @@ func TestReconcile(t *testing.T) {
 			configurationLister: listers.GetConfigurationLister(),
 			revisionLister:      listers.GetRevisionLister(),
 			routeLister:         listers.GetRouteLister(),
+			extension:           extension.NoExtension(),
 		}
 
 		return ksvcreconciler.NewReconciler(ctx, logging.FromContext(ctx), servingclient.Get(ctx),

--- a/pkg/reconciler/service/service_test.go
+++ b/pkg/reconciler/service/service_test.go
@@ -19,7 +19,6 @@ package service
 import (
 	"context"
 	"errors"
-	"knative.dev/serving/pkg/reconciler/extension"
 	"testing"
 	"time"
 
@@ -43,6 +42,7 @@ import (
 	servingclient "knative.dev/serving/pkg/client/injection/client"
 	ksvcreconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/service"
 	configresources "knative.dev/serving/pkg/reconciler/configuration/resources"
+	"knative.dev/serving/pkg/reconciler/extension"
 	"knative.dev/serving/pkg/reconciler/service/resources"
 
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
Fixes #12971

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Added the interface and implemented an empty one to make the controller extensive.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
