### PR TITLE
Test istio with system-internal-tls enabled

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -95,6 +95,7 @@ jobs:
         - kourier
         - kourier-tls
         - istio
+        - istio-tls
         - istio-ambient
         - contour
         # Disabled due to consistent failures
@@ -117,6 +118,11 @@ jobs:
 
         - ingress: istio
           namespace-resources: virtualservices
+
+        - ingress: istio-tls
+          ingress-class: istio
+          namespace-resources: virtualservices
+          enable-tls: 1
 
         - ingress: istio-ambient
           namespace-resources: virtualservices

--- a/test/e2e/systeminternaltls/system_internal_tls_test.go
+++ b/test/e2e/systeminternaltls/system_internal_tls_test.go
@@ -38,8 +38,8 @@ import (
 	v1test "knative.dev/serving/test/v1"
 )
 
-// TestInternalEncrytion tests the TLS connections between system components.
-func TestInternalEncryption(t *testing.T) {
+// TestSystemInternalTLS tests the TLS connections between system components.
+func TestSystemInternalTLS(t *testing.T) {
 	if !test.ServingFlags.EnableAlphaFeatures {
 		t.Skip("Alpha features not enabled")
 	}
@@ -127,7 +127,7 @@ func scanPodLogs(req *rest.Request, matcher func(string) bool) (matchCount int, 
 
 	podLogs, err := req.Stream(context.Background())
 	if err != nil {
-		err = fmt.Errorf("Failed to stream activator logs: %w", err)
+		err = fmt.Errorf("failed to stream activator logs: %w", err)
 		return
 	}
 
@@ -135,7 +135,7 @@ func scanPodLogs(req *rest.Request, matcher func(string) bool) (matchCount int, 
 	_, err = io.Copy(buf, podLogs)
 	podLogs.Close()
 	if err != nil {
-		err = fmt.Errorf("Failed to read activator logs from buffer: %w", err)
+		err = fmt.Errorf("failed to read activator logs from buffer: %w", err)
 		return
 	}
 
@@ -147,7 +147,7 @@ func scanPodLogs(req *rest.Request, matcher func(string) bool) (matchCount int, 
 	}
 
 	if err = scanner.Err(); err != nil {
-		err = fmt.Errorf("Failed scanning activator logs: %w", err)
+		err = fmt.Errorf("failed scanning activator logs: %w", err)
 		return
 	}
 

--- a/test/e2e/systeminternaltls/system_internal_tls_test.go
+++ b/test/e2e/systeminternaltls/system_internal_tls_test.go
@@ -44,8 +44,9 @@ func TestInternalEncryption(t *testing.T) {
 		t.Skip("Alpha features not enabled")
 	}
 
-	if !(strings.Contains(test.ServingFlags.IngressClass, "kourier")) {
-		t.Skip("Skip this test for non-kourier ingress.")
+	if !(strings.Contains(test.ServingFlags.IngressClass, "kourier") ||
+		strings.Contains(test.ServingFlags.IngressClass, "istio")) {
+		t.Skip("Skip this test for non-kourier or non-istio ingress.")
 	}
 
 	t.Parallel()


### PR DESCRIPTION
Fixes https://github.com/knative-extensions/net-istio/issues/1063

# Changes
* Adds istio with `system-internal-tls` enabled to test matrix
* Runs the system-internal-tls tests for istio


