### PR TITLE
Bubble up KCertificate Status Message when its not ready

### DIFF
--- a/pkg/apis/serving/v1/route_lifecycle.go
+++ b/pkg/apis/serving/v1/route_lifecycle.go
@@ -174,10 +174,11 @@ func (rs *RouteStatus) MarkCertificateReady(name string) {
 
 // MarkCertificateNotReady marks the RouteConditionCertificateProvisioned
 // condition to indicate that the Certificate is not ready.
-func (rs *RouteStatus) MarkCertificateNotReady(name string) {
+func (rs *RouteStatus) MarkCertificateNotReady(c *v1alpha1.Certificate) {
+	certificateCondition := c.Status.GetCondition("Ready")
 	routeCondSet.Manage(rs).MarkUnknown(RouteConditionCertificateProvisioned,
 		"CertificateNotReady",
-		"Certificate %s is not ready.", name)
+		"Certificate %s is not ready. Certificate Message: %s", c.Name, certificateCondition.GetReason())
 }
 
 // MarkCertificateNotOwned changes the RouteConditionCertificateProvisioned

--- a/pkg/apis/serving/v1/route_lifecycle.go
+++ b/pkg/apis/serving/v1/route_lifecycle.go
@@ -178,7 +178,7 @@ func (rs *RouteStatus) MarkCertificateNotReady(c *v1alpha1.Certificate) {
 	certificateCondition := c.Status.GetCondition("Ready")
 	routeCondSet.Manage(rs).MarkUnknown(RouteConditionCertificateProvisioned,
 		"CertificateNotReady",
-		"Certificate %s is not ready. Certificate Message: %s", c.Name, certificateCondition.GetReason())
+		"Certificate %s is not ready: %s", c.Name, certificateCondition.GetReason())
 }
 
 // MarkCertificateNotOwned changes the RouteConditionCertificateProvisioned

--- a/pkg/apis/serving/v1/route_lifecycle_test.go
+++ b/pkg/apis/serving/v1/route_lifecycle_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -438,9 +439,35 @@ func TestCertificateReady(t *testing.T) {
 func TestCertificateNotReady(t *testing.T) {
 	r := &RouteStatus{}
 	r.InitializeConditions()
-	r.MarkCertificateNotReady("cert")
+	r.MarkCertificateNotReady(&netv1alpha1.Certificate{})
 
 	apistest.CheckConditionOngoing(r, RouteConditionCertificateProvisioned, t)
+}
+
+func TestCertificateNotReadyWithBubbledUpMessage(t *testing.T) {
+	cert := &netv1alpha1.Certificate{
+		Status: netv1alpha1.CertificateStatus{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{
+					{
+						Type:   "Ready",
+						Status: "False",
+						Reason: "CommonName Too Long",
+					},
+				},
+			},
+		},
+	}
+
+	r := &RouteStatus{}
+	r.InitializeConditions()
+	r.MarkCertificateNotReady(cert)
+
+	expectedCertMessage := "Certificate Message: CommonName Too Long"
+	certMessage := r.Status.GetCondition("Ready").Message
+	if !strings.Contains(certMessage, expectedCertMessage) {
+		t.Errorf("Literal %q not found in status message: %q", expectedCertMessage, certMessage)
+	}
 }
 
 func TestCertificateProvisionFailed(t *testing.T) {

--- a/pkg/apis/serving/v1/route_lifecycle_test.go
+++ b/pkg/apis/serving/v1/route_lifecycle_test.go
@@ -463,7 +463,7 @@ func TestCertificateNotReadyWithBubbledUpMessage(t *testing.T) {
 	r.InitializeConditions()
 	r.MarkCertificateNotReady(cert)
 
-	expectedCertMessage := "Certificate Message: CommonName Too Long"
+	expectedCertMessage := "CommonName Too Long"
 	certMessage := r.Status.GetCondition("Ready").Message
 	if !strings.Contains(certMessage, expectedCertMessage) {
 		t.Errorf("Literal %q not found in status message: %q", expectedCertMessage, certMessage)

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -265,7 +265,7 @@ func (c *Reconciler) tls(ctx context.Context, host string, r *v1.Route, traffic 
 			tls = append(tls, resources.MakeIngressTLS(cert, dnsNames.List()))
 		} else {
 			acmeChallenges = append(acmeChallenges, cert.Status.HTTP01Challenges...)
-			r.Status.MarkCertificateNotReady(cert.Name)
+			r.Status.MarkCertificateNotReady(cert)
 			// When httpProtocol is enabled, downgrade http scheme.
 			// Explicitly not using the override settings here as to not to muck with
 			// AutoTLS semantics.

--- a/pkg/testing/v1/route.go
+++ b/pkg/testing/v1/route.go
@@ -208,7 +208,7 @@ func MarkUnknownTrafficError(msg string) RouteOption {
 
 // MarkCertificateNotReady calls the method of the same name on .Status
 func MarkCertificateNotReady(r *v1.Route) {
-	r.Status.MarkCertificateNotReady(routenames.Certificate(r))
+	r.Status.MarkCertificateNotReady(&netv1alpha1.Certificate{})
 }
 
 // MarkCertificateNotOwned calls the method of the same name on .Status


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/14250

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* KCert Status Message gets bubbled up to its parent Route when it's not ready

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Certificate generation errors are bubbled up to its parent Route.
```

Based on https://github.com/knative/serving/pull/14257

Further work linked in the above issue
