### PR TITLE
don't run internal encryption tests with contour

### DIFF
--- a/test/e2e/systeminternaltls/system_internal_tls_test.go
+++ b/test/e2e/systeminternaltls/system_internal_tls_test.go
@@ -44,8 +44,8 @@ func TestInternalEncryption(t *testing.T) {
 		t.Skip("Alpha features not enabled")
 	}
 
-	if !(strings.Contains(test.ServingFlags.IngressClass, "kourier") || strings.Contains(test.ServingFlags.IngressClass, "contour")) {
-		t.Skip("Skip this test for non-kourier or non-contour ingress.")
+	if !(strings.Contains(test.ServingFlags.IngressClass, "kourier")) {
+		t.Skip("Skip this test for non-kourier ingress.")
 	}
 
 	t.Parallel()


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* currently, the net-contour support for system-internal-tls is broken. I'm working on some Knative and Contour upstream changes to address this: https://github.com/knative-extensions/net-contour/pull/980
* Since some changes are dependent on Contour itself, the feedback loop on this support might be kinda slow. So in the meantime, it probably will make things go smoother for the rest of serving if we just don't test this on net-contour for now.
* Example: contour update failing because of this: https://github.com/knative/serving/pull/14490

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
N/A
```
