### PR TITLE
Bound buffer for reading stats

### DIFF
--- a/pkg/autoscaler/metrics/http_scrape_client.go
+++ b/pkg/autoscaler/metrics/http_scrape_client.go
@@ -82,7 +82,9 @@ func statFromProto(body io.Reader) (Stat, error) {
 	b := pool.Get().(*bytes.Buffer)
 	b.Reset()
 	defer pool.Put(b)
-	_, err := b.ReadFrom(body)
+	// 6 8-byte fields (+2 bytes marshalling), one hostname, 20 bytes extra space
+	r := io.LimitedReader{R: body, N: 6*10 + 256 + 20}
+	_, err := b.ReadFrom(&r)
 	if err != nil {
 		return emptyStat, fmt.Errorf("reading body failed: %w", err)
 	}

--- a/pkg/autoscaler/metrics/http_scrape_client_test.go
+++ b/pkg/autoscaler/metrics/http_scrape_client_test.go
@@ -95,6 +95,21 @@ func TestHTTPScrapeClientScrapeProtoErrorCases(t *testing.T) {
 		responseCode: http.StatusOK,
 		responseType: "text/html",
 		expectedErr:  errUnsupportedMetricType.Error(),
+	}, {
+		name:         "LongStat",
+		responseCode: http.StatusOK,
+		responseType: "application/protobuf",
+		stat: Stat{
+			// We don't expect PodName to be 600 characters long
+			PodName:                          strings.Repeat("a123456789", 60),
+			AverageConcurrentRequests:        1.1,
+			AverageProxiedConcurrentRequests: 1.1,
+			RequestCount:                     33.2,
+			ProxiedRequestCount:              33.2,
+			ProcessUptime:                    12345.678,
+			Timestamp:                        1697431278,
+		},
+		expectedErr: "unmarshalling failed: unexpected EOF",
 	}}
 
 	for _, test := range testCases {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Bound the bytes read from the queue-proxy by the autoscaler.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Applied an upper bound to the statistics data read from the queue-proxy by the autoscaler.
```
