### PR TITLE
Support http1 full duplex per workload

### DIFF
--- a/pkg/activator/handler/context.go
+++ b/pkg/activator/handler/context.go
@@ -55,8 +55,12 @@ func RevIDFrom(ctx context.Context) types.NamespacedName {
 	return ctx.Value(revCtxKey{}).(*revCtx).revID
 }
 
-func RevAnnotations(ctx context.Context, annotation string) string {
-	rev := ctx.Value(revCtxKey{}).(*revCtx).revision
+func RevAnnotation(ctx context.Context, annotation string) string {
+	v := ctx.Value(revCtxKey{})
+	if v == nil {
+		return ""
+	}
+	rev := v.(*revCtx).revision
 	if rev != nil && rev.GetAnnotations() != nil {
 		return rev.GetAnnotations()[annotation]
 	}

--- a/pkg/activator/handler/context.go
+++ b/pkg/activator/handler/context.go
@@ -23,6 +23,7 @@ package handler
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/types"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )

--- a/pkg/activator/handler/context.go
+++ b/pkg/activator/handler/context.go
@@ -23,7 +23,6 @@ package handler
 
 import (
 	"context"
-
 	"k8s.io/apimachinery/pkg/types"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
@@ -53,4 +52,12 @@ func RevisionFrom(ctx context.Context) *v1.Revision {
 // RevIDFrom retrieves the the revisionID from the context.
 func RevIDFrom(ctx context.Context) types.NamespacedName {
 	return ctx.Value(revCtxKey{}).(*revCtx).revID
+}
+
+func RevAnnotations(ctx context.Context, annotation string) string {
+	rev := ctx.Value(revCtxKey{}).(*revCtx).revision
+	if rev != nil && rev.GetAnnotations() != nil {
+		return rev.GetAnnotations()[annotation]
+	}
+	return ""
 }

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -37,7 +37,6 @@ import (
 	"knative.dev/pkg/tracing/propagation/tracecontextb3"
 	"knative.dev/serving/pkg/activator"
 	activatorconfig "knative.dev/serving/pkg/activator/config"
-	apicfg "knative.dev/serving/pkg/apis/config"
 	pkghttp "knative.dev/serving/pkg/http"
 	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/queue"
@@ -87,15 +86,14 @@ func (a *activationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	revID := RevIDFrom(r.Context())
-	revEnableHTTP1FullDuplex := RevAnnotations(r.Context(), apicfg.AllowHTTPFullDuplexFeatureKey) == "Enabled"
-
 	if err := a.throttler.Try(tryContext, revID, func(dest string) error {
 		trySpan.End()
+
 		proxyCtx, proxySpan := r.Context(), (*trace.Span)(nil)
 		if tracingEnabled {
 			proxyCtx, proxySpan = trace.StartSpan(r.Context(), "activator_proxy")
 		}
-		a.proxyRequest(revID, revEnableHTTP1FullDuplex, w, r.WithContext(proxyCtx), dest, tracingEnabled, a.usePassthroughLb)
+		a.proxyRequest(revID, w, r.WithContext(proxyCtx), dest, tracingEnabled, a.usePassthroughLb)
 		proxySpan.End()
 
 		return nil
@@ -114,7 +112,7 @@ func (a *activationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (a *activationHandler) proxyRequest(revID types.NamespacedName, enableHTTP1FullDuplex bool, w http.ResponseWriter,
+func (a *activationHandler) proxyRequest(revID types.NamespacedName, w http.ResponseWriter,
 	r *http.Request, target string, tracingEnabled bool, usePassthroughLb bool) {
 	netheader.RewriteHostIn(r)
 	r.Header.Set(netheader.ProxyKey, activator.Name)
@@ -126,25 +124,10 @@ func (a *activationHandler) proxyRequest(revID types.NamespacedName, enableHTTP1
 	}
 
 	var proxy *httputil.ReverseProxy
-	var proxyHandler http.Handler
 	if a.tls {
 		proxy = pkghttp.NewHeaderPruningReverseProxy(useSecurePort(target), hostOverride, activator.RevisionHeaders, true /* uss HTTPS */)
 	} else {
 		proxy = pkghttp.NewHeaderPruningReverseProxy(target, hostOverride, activator.RevisionHeaders, false /* use HTTPS */)
-	}
-
-	if enableHTTP1FullDuplex {
-		proxyWithFullDuplex := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			rc := http.NewResponseController(w)
-			_ = rc.EnableFullDuplex()
-			proxy.ServeHTTP(w, r)
-		})
-		tmpHandler := struct{ http.Handler }{}
-		tmpHandler.Handler = proxyWithFullDuplex
-		proxyHandler = tmpHandler
-
-	} else {
-		proxyHandler = proxy
 	}
 
 	proxy.BufferPool = a.bufferPool
@@ -157,7 +140,7 @@ func (a *activationHandler) proxyRequest(revID types.NamespacedName, enableHTTP1
 		pkghandler.Error(a.logger.With(zap.String(logkey.Key, revID.String())))(w, req, err)
 	}
 
-	proxyHandler.ServeHTTP(w, r)
+	proxy.ServeHTTP(w, r)
 }
 
 // useSecurePort replaces the default port with HTTPS port (8112).

--- a/pkg/activator/handler/main_test.go
+++ b/pkg/activator/handler/main_test.go
@@ -121,7 +121,11 @@ func BenchmarkHandlerChain(b *testing.B) {
 	})
 }
 
-func TestProxyWithChainHandler(t *testing.T) {
+// TestActivatorChainHandlerWithFullDuplex tests activator's chain handler with the new http1 full duplex support against the issue
+// https://github.com/golang/go/issues/40747, where reverse proxy failed with read errors.
+// The test uses the reproducer in https://github.com/golang/go/issues/40747#issuecomment-733552061.
+// We enable full duplex by setting the annotation `features.knative.dev/http-full-duplex` at the revision level.
+func TestActivatorChainHandlerWithFullDuplex(t *testing.T) {
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 	rev := revision(testNamespace, testRevName)
 	defer reset()

--- a/pkg/activator/handler/main_test.go
+++ b/pkg/activator/handler/main_test.go
@@ -18,9 +18,14 @@ package handler
 
 import (
 	"bytes"
+	"fmt"
 	"io"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"sync"
 	"testing"
 
 	netprobe "knative.dev/networking/pkg/http/probe"
@@ -28,6 +33,7 @@ import (
 	pkgnet "knative.dev/pkg/network"
 	rtesting "knative.dev/pkg/reconciler/testing"
 	"knative.dev/serving/pkg/activator"
+	apiconfig "knative.dev/serving/pkg/apis/config"
 	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
 	pkghttp "knative.dev/serving/pkg/http"
 )
@@ -113,4 +119,153 @@ func BenchmarkHandlerChain(b *testing.B) {
 			}
 		})
 	})
+}
+
+func TestProxyWithChainHandler(t *testing.T) {
+	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
+	rev := revision(testNamespace, testRevName)
+	rev.Annotations = map[string]string{apiconfig.AllowHTTPFullDuplexFeatureKey: "Enabled"}
+	t.Cleanup(cancel)
+
+	logger := logging.FromContext(ctx)
+	configStore := setupConfigStore(t, logger)
+	revisionInformer(ctx, rev)
+
+	// Buffer equal to the activator.
+	statCh := make(chan []asmetrics.StatMessage)
+	concurrencyReporter := NewConcurrencyReporter(ctx, activatorPodName, statCh)
+	go concurrencyReporter.Run(ctx.Done())
+
+	// Just read and ignore all stat messages.
+	go func() {
+		for {
+			select {
+			case <-statCh:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// The server responding with the sent body.
+	echoServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, req *http.Request) {
+			body, err := ioutil.ReadAll(req.Body)
+			if err != nil {
+				log.Printf("error reading body: %v", err)
+				http.Error(w, fmt.Sprintf("error reading body: %v", err), http.StatusInternalServerError)
+				return
+			}
+
+			if _, err := w.Write(body); err != nil {
+				log.Printf("error writing body: %v", err)
+			}
+		},
+	))
+	defer echoServer.Close()
+
+	// The server proxying requests to the echo server.
+	echoURL, err := url.Parse(echoServer.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse echo URL: %v", err)
+	}
+
+	proxy := pkghttp.NewHeaderPruningReverseProxy(echoURL.Host, "", []string{}, false)
+	proxy.FlushInterval = 0
+	proxyWithMiddleware := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxy.ServeHTTP(w, r)
+	})
+	var ah http.Handler
+	ah = concurrencyReporter.Handler(proxyWithMiddleware)
+	ah = NewTracingHandler(ah)
+	ah, _ = pkghttp.NewRequestLogHandler(ah, io.Discard, "", nil, false)
+	ah = NewMetricHandler(activatorPodName, ah)
+	ah = WrapActivatorHandlerWithFullDuplex(ah, logger)
+	ah = NewContextHandler(ctx, ah, configStore)
+	ah = &ProbeHandler{NextHandler: ah}
+	ah = netprobe.NewHandler(ah)
+	ah = &HealthHandler{HealthCheck: func() error { return nil }, NextHandler: ah, Logger: logger}
+
+	bodySize := 32 * 1024
+	parallelism := 32
+
+	proxyServer := httptest.NewServer(ah)
+
+	defer proxyServer.Close()
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	// Turning on this will hide the issue
+	transport.DisableKeepAlives = false
+	c := &http.Client{
+		Transport: transport,
+	}
+
+	body := make([]byte, bodySize)
+	for i := 0; i < cap(body); i++ {
+		body[i] = 42
+	}
+
+	for i := 0; i < 10; i++ {
+		var wg sync.WaitGroup
+		wg.Add(parallelism)
+		for i := 0; i < parallelism; i++ {
+			go func(i int) {
+				defer wg.Done()
+
+				for i := 0; i < 1000; i++ {
+					if err := send(c, proxyServer.URL, body, "test-host"); err != nil {
+						t.Errorf("error during request: %v", err)
+					}
+				}
+			}(i)
+		}
+
+		wg.Wait()
+	}
+
+}
+
+func send(client *http.Client, url string, body []byte, rHost string) error {
+	r := bytes.NewBuffer(body)
+	req, err := http.NewRequest("POST", url, r)
+
+	if rHost != "" {
+		req.Host = rHost
+	}
+
+	req.Header.Set(activator.RevisionHeaderNamespace, testNamespace)
+	req.Header.Set(activator.RevisionHeaderName, testRevName)
+
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bd := io.Reader(resp.Body)
+
+	rec, err := ioutil.ReadAll(bd)
+
+	if err != nil {
+		return fmt.Errorf("failed to read body: %w", err)
+	}
+
+	if _, err = io.Copy(io.Discard, resp.Body); err != nil {
+		return fmt.Errorf("failed to discard body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	if len(rec) != len(body) {
+		return fmt.Errorf("unexpected body length: %d", len(rec))
+	}
+
+	return nil
 }

--- a/pkg/activator/handler/main_test.go
+++ b/pkg/activator/handler/main_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -155,7 +154,7 @@ func TestActivatorChainHandlerWithFullDuplex(t *testing.T) {
 	// The server responding with the sent body.
 	echoServer := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, req *http.Request) {
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			if err != nil {
 				log.Printf("error reading body: %v", err)
 				http.Error(w, fmt.Sprintf("error reading body: %v", err), http.StatusInternalServerError)
@@ -254,7 +253,7 @@ func send(client *http.Client, url string, body []byte, rHost string) error {
 
 	bd := io.Reader(resp.Body)
 
-	rec, err := ioutil.ReadAll(bd)
+	rec, err := io.ReadAll(bd)
 
 	if err != nil {
 		return fmt.Errorf("failed to read body: %w", err)

--- a/pkg/activator/handler/main_test.go
+++ b/pkg/activator/handler/main_test.go
@@ -124,6 +124,7 @@ func BenchmarkHandlerChain(b *testing.B) {
 func TestProxyWithChainHandler(t *testing.T) {
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 	rev := revision(testNamespace, testRevName)
+	defer reset()
 	rev.Annotations = map[string]string{apiconfig.AllowHTTPFullDuplexFeatureKey: "Enabled"}
 	t.Cleanup(cancel)
 

--- a/pkg/activator/handler/main_test.go
+++ b/pkg/activator/handler/main_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -125,6 +126,10 @@ func BenchmarkHandlerChain(b *testing.B) {
 // The test uses the reproducer in https://github.com/golang/go/issues/40747#issuecomment-733552061.
 // We enable full duplex by setting the annotation `features.knative.dev/http-full-duplex` at the revision level.
 func TestActivatorChainHandlerWithFullDuplex(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("Testing this on Mac requires to loosen some restrictions, see https://github.com/knative/serving/pull/14568#issuecomment-1893151202 for more")
+	}
+
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 	rev := revision(testNamespace, testRevName)
 	defer reset()

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -46,6 +46,9 @@ const (
 
 	// DryRunFeatureKey gates the podspec dryrun feature and runs with the value 'enabled'
 	DryRunFeatureKey = "features.knative.dev/podspec-dryrun"
+
+	// AllowHTTPFullDuplexFeatureKey gates the use of http1 full duplex per workload
+	AllowHTTPFullDuplexFeatureKey = "features.knative.dev/http-full-duplex"
 )
 
 func defaultFeaturesConfig() *Features {

--- a/pkg/http/handler/timeout.go
+++ b/pkg/http/handler/timeout.go
@@ -163,12 +163,13 @@ type timeoutWriter struct {
 	lastWriteTime time.Time
 }
 
+var _ http.Flusher = (*timeoutWriter)(nil)
+var _ http.ResponseWriter = (*timeoutWriter)(nil)
+
+// Unwrap returns the underlying writer
 func (tw *timeoutWriter) Unwrap() http.ResponseWriter {
 	return tw.w
 }
-
-var _ http.Flusher = (*timeoutWriter)(nil)
-var _ http.ResponseWriter = (*timeoutWriter)(nil)
 
 func (tw *timeoutWriter) Flush() {
 	// The inner handler of timeoutHandler can call Flush at any time including after

--- a/pkg/http/handler/timeout.go
+++ b/pkg/http/handler/timeout.go
@@ -163,6 +163,10 @@ type timeoutWriter struct {
 	lastWriteTime time.Time
 }
 
+func (tw *timeoutWriter) Unwrap() http.ResponseWriter {
+	return tw.w
+}
+
 var _ http.Flusher = (*timeoutWriter)(nil)
 var _ http.ResponseWriter = (*timeoutWriter)(nil)
 

--- a/pkg/http/response_recorder.go
+++ b/pkg/http/response_recorder.go
@@ -53,6 +53,7 @@ func NewResponseRecorder(w http.ResponseWriter, responseCode int) *ResponseRecor
 	}
 }
 
+// Unwrap returns the underlying writer
 func (rr *ResponseRecorder) Unwrap() http.ResponseWriter {
 	return rr.writer
 }

--- a/pkg/http/response_recorder.go
+++ b/pkg/http/response_recorder.go
@@ -53,6 +53,10 @@ func NewResponseRecorder(w http.ResponseWriter, responseCode int) *ResponseRecor
 	}
 }
 
+func (rr *ResponseRecorder) Unwrap() http.ResponseWriter {
+	return rr.writer
+}
+
 // Flush flushes the buffer to the client.
 func (rr *ResponseRecorder) Flush() {
 	rr.writer.(http.Flusher).Flush()

--- a/pkg/queue/sharedmain/handlers.go
+++ b/pkg/queue/sharedmain/handlers.go
@@ -84,7 +84,7 @@ func mainHandler(
 		composedHandler = tracing.HTTPSpanMiddleware(composedHandler)
 	}
 
-	composedHandler = wrapQPHandlerWithFullDuplex(composedHandler, env.EnableHTTPFullDuplex, logger)
+	composedHandler = withFullDuplex(composedHandler, env.EnableHTTPFullDuplex, logger)
 
 	drainer := &pkghandler.Drainer{
 		QuietPeriod: drainSleepDuration,
@@ -127,13 +127,14 @@ func adminHandler(ctx context.Context, logger *zap.SugaredLogger, drainer *pkgha
 	return mux
 }
 
-func wrapQPHandlerWithFullDuplex(h http.Handler, enableFullDuplex bool, logger *zap.SugaredLogger) http.HandlerFunc {
+func withFullDuplex(h http.Handler, enableFullDuplex bool, logger *zap.SugaredLogger) http.Handler {
+	if !enableFullDuplex {
+		return h
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if enableFullDuplex {
-			rc := http.NewResponseController(w)
-			if err := rc.EnableFullDuplex(); err != nil {
-				logger.Errorw("Unable to enable full duplex", zap.Error(err))
-			}
+		rc := http.NewResponseController(w)
+		if err := rc.EnableFullDuplex(); err != nil {
+			logger.Errorw("Unable to enable full duplex", zap.Error(err))
 		}
 		h.ServeHTTP(w, r)
 	})

--- a/pkg/queue/sharedmain/handlers.go
+++ b/pkg/queue/sharedmain/handlers.go
@@ -79,7 +79,7 @@ func mainHandler(
 	}
 	// Create queue handler chain.
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first.
-	var composedHandler http.Handler = proxyHandler
+	composedHandler := proxyHandler
 
 	metricsSupported := supportsMetrics(ctx, logger, env)
 	if metricsSupported {

--- a/pkg/queue/sharedmain/handlers.go
+++ b/pkg/queue/sharedmain/handlers.go
@@ -71,7 +71,7 @@ func mainHandler(
 	if metricsSupported {
 		composedHandler = requestAppMetricsHandler(logger, composedHandler, breaker, env)
 	}
-	composedHandler = queue.ProxyHandler(breaker, stats, false, composedHandler)
+	composedHandler = queue.ProxyHandler(breaker, stats, tracingEnabled, composedHandler)
 	composedHandler = queue.ForwardedShimHandler(composedHandler)
 	composedHandler = handler.NewTimeoutHandler(composedHandler, "request timeout", func(r *http.Request) (time.Duration, time.Duration, time.Duration) {
 		return timeout, responseStartTimeout, idleTimeout

--- a/pkg/queue/sharedmain/main.go
+++ b/pkg/queue/sharedmain/main.go
@@ -86,7 +86,9 @@ type config struct {
 	RevisionIdleTimeoutSeconds          int    `split_words:"true"`                      // optional
 	ServingReadinessProbe               string `split_words:"true"`                      // optional
 	EnableProfiling                     bool   `split_words:"true"`                      // optional
+	EnableHTTPFullDuplex                bool   `split_words:"true"`                      // optional
 	EnableHTTP2AutoDetection            bool   `envconfig:"ENABLE_HTTP2_AUTO_DETECTION"` // optional
+	// See https://github.com/knative/serving/issues/12387
 
 	// Logging configuration
 	ServingLoggingConfig         string `split_words:"true" required:"true"`

--- a/pkg/queue/sharedmain/main.go
+++ b/pkg/queue/sharedmain/main.go
@@ -82,13 +82,13 @@ type config struct {
 	QueueServingTLSPort                 string `split_words:"true" required:"true"`
 	UserPort                            string `split_words:"true" required:"true"`
 	RevisionTimeoutSeconds              int    `split_words:"true" required:"true"`
-	RevisionResponseStartTimeoutSeconds int    `split_words:"true"`                      // optional
-	RevisionIdleTimeoutSeconds          int    `split_words:"true"`                      // optional
-	ServingReadinessProbe               string `split_words:"true"`                      // optional
-	EnableProfiling                     bool   `split_words:"true"`                      // optional
-	EnableHTTPFullDuplex                bool   `split_words:"true"`                      // optional
-	EnableHTTP2AutoDetection            bool   `envconfig:"ENABLE_HTTP2_AUTO_DETECTION"` // optional
+	RevisionResponseStartTimeoutSeconds int    `split_words:"true"` // optional
+	RevisionIdleTimeoutSeconds          int    `split_words:"true"` // optional
+	ServingReadinessProbe               string `split_words:"true"` // optional
+	EnableProfiling                     bool   `split_words:"true"` // optional
 	// See https://github.com/knative/serving/issues/12387
+	EnableHTTPFullDuplex     bool `split_words:"true"`                      // optional
+	EnableHTTP2AutoDetection bool `envconfig:"ENABLE_HTTP2_AUTO_DETECTION"` // optional
 
 	// Logging configuration
 	ServingLoggingConfig         string `split_words:"true" required:"true"`

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -189,6 +189,9 @@ var (
 			Name:  "ENABLE_HTTP2_AUTO_DETECTION",
 			Value: "false",
 		}, {
+			Name:  "ENABLE_HTTP_FULL_DUPLEX",
+			Value: "false",
+		}, {
 			Name:  "ROOT_CA",
 			Value: "",
 		}},

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -303,6 +304,8 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		}
 	}
 
+	fullDuplexFeature, fullDuplexExists := rev.Annotations[apicfg.AllowHTTPFullDuplexFeatureKey]
+
 	useQPResourceDefaults := cfg.Features.QueueProxyResourceDefaults == apicfg.Enabled
 	c := &corev1.Container{
 		Name:            QueueContainerName,
@@ -418,6 +421,9 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		}, {
 			Name:  "ENABLE_HTTP2_AUTO_DETECTION",
 			Value: strconv.FormatBool(cfg.Features.AutoDetectHTTP2 == apicfg.Enabled),
+		}, {
+			Name:  "ENABLE_HTTP_FULL_DUPLEX",
+			Value: strconv.FormatBool(fullDuplexExists && strings.EqualFold(fullDuplexFeature, string(apicfg.Enabled))),
 		}, {
 			Name:  "ROOT_CA",
 			Value: cfg.Deployment.QueueSidecarRootCA,

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -391,6 +391,16 @@ func TestMakeQueueContainer(t *testing.T) {
 			})
 		}),
 	}, {
+		name: "HTTP1 full duplex enabled",
+		rev: revision("bar", "foo",
+			withContainers(containers),
+			WithRevisionAnnotations(map[string]string{apicfg.AllowHTTPFullDuplexFeatureKey: string(apicfg.Enabled)})),
+		want: queueContainer(func(c *corev1.Container) {
+			c.Env = env(map[string]string{
+				"ENABLE_HTTP_FULL_DUPLEX": "true",
+			})
+		}),
+	}, {
 		name: "set root ca",
 		rev: revision("bar", "foo",
 			withContainers(containers)),
@@ -1041,6 +1051,7 @@ func TestTCPProbeGeneration(t *testing.T) {
 var defaultEnv = map[string]string{
 	"CONTAINER_CONCURRENCY":                            "0",
 	"ENABLE_HTTP2_AUTO_DETECTION":                      "false",
+	"ENABLE_HTTP_FULL_DUPLEX":                          "false",
 	"ENABLE_PROFILING":                                 "false",
 	"METRICS_DOMAIN":                                   metrics.Domain(),
 	"METRICS_COLLECTOR_ADDRESS":                        "",


### PR DESCRIPTION
Fixes #12387 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Workloads annotated with `features.knative.dev/http-full-duplex=Enabled` will get the support for http1 full duplex end-to-end on the data path. Activator and QP  h2c handlers dont seem to create an issue on the http1 case.
* This feature requires a build with golang 1.21.x.
* Handlers that override the writer methods need to be controlled with the new Golang fix. Check [this](https://github.com/skonto/test-reverse-proxy/blob/main/pkg/rp/rev_test.go#L164) for more.
Note: If any of the wrappers is removed then you get ~1 request failure over tens of thousands of requests.
Had to run the [test](https://github.com/skonto/test-reverse-proxy/tree/main#test-with-knative-serving) multiple times to get one failure, each run creates ~30K requests over a period ~1m. 
* Tested with [this repo](https://github.com/skonto/test-reverse-proxy/tree/main), [sample run](https://gist.github.com/skonto/0e4d61da67bf6a84ee60294f7fe5bc72). Might have to add an integration test though.
* Tested this both in serve/proxy mode.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Http1 full duplex is now supported. Workloads need to be annotated with `features.knative.dev/http-full-duplex`.
```
