### PR TITLE
Clean up feature keys

### DIFF
--- a/pkg/webhook/podspec_dryrun_test.go
+++ b/pkg/webhook/podspec_dryrun_test.go
@@ -32,6 +32,7 @@ import (
 	"knative.dev/pkg/logging"
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/ptr"
+	"knative.dev/serving/pkg/apis/config"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
@@ -52,7 +53,7 @@ func TestExtraServiceValidation(t *testing.T) {
 		Name:      "valid",
 		Namespace: "foo",
 		Annotations: map[string]string{
-			"features.knative.dev/podspec-dryrun": "enabled",
+			config.DryRunFeatureKey: "enabled",
 		},
 	}
 
@@ -152,7 +153,7 @@ func TestConfigurationValidation(t *testing.T) {
 		Name:      "valid",
 		Namespace: "foo",
 		Annotations: map[string]string{
-			"features.knative.dev/podspec-dryrun": "enabled",
+			config.DryRunFeatureKey: "enabled",
 		},
 	}
 
@@ -186,7 +187,7 @@ func TestConfigurationValidation(t *testing.T) {
 					"serving.knative.dev/service": "skip-me",
 				},
 				Annotations: map[string]string{
-					"features.knative.dev/podspec-dryrun": "enabled",
+					config.DryRunFeatureKey: "enabled",
 				},
 			},
 			Spec: goodConfigSpec,

--- a/pkg/webhook/validate_unstructured.go
+++ b/pkg/webhook/validate_unstructured.go
@@ -30,10 +30,7 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
-// PodSpecDryRunAnnotation gates the podspec dryrun feature and runs with the value 'enabled'
-const PodSpecDryRunAnnotation = "features.knative.dev/podspec-dryrun"
-
-// DryRunMode represents possible values of the PodSpecDryRunAnnotation
+// DryRunMode represents possible values of the config.DryRunFeatureKey annotation
 type DryRunMode string
 
 const (
@@ -62,7 +59,7 @@ func ValidateConfiguration(ctx context.Context, uns *unstructured.Unstructured) 
 func validateRevisionTemplate(ctx context.Context, uns *unstructured.Unstructured) error {
 	content := uns.UnstructuredContent()
 
-	mode := DryRunMode(uns.GetAnnotations()[PodSpecDryRunAnnotation])
+	mode := DryRunMode(uns.GetAnnotations()[config.DryRunFeatureKey])
 	features := config.FromContextOrDefaults(ctx).Features
 	switch features.PodSpecDryRun {
 	case config.Enabled:

--- a/pkg/webhook/validate_unstructured_test.go
+++ b/pkg/webhook/validate_unstructured_test.go
@@ -39,7 +39,7 @@ var (
 		"name":      "valid",
 		"namespace": "foo",
 		"annotations": map[string]interface{}{
-			"features.knative.dev/podspec-dryrun": "enabled",
+			config.DryRunFeatureKey: "enabled",
 		},
 	}
 )
@@ -139,7 +139,7 @@ func TestDryRunFeatureFlag(t *testing.T) {
 				"name":      "valid",
 				"namespace": "foo",
 				"annotations": map[string]interface{}{
-					"features.knative.dev/podspec-dryrun": "strict",
+					config.DryRunFeatureKey: "strict",
 				},
 			},
 			"spec": true, // Invalid, spec is expected to be a struct
@@ -153,7 +153,7 @@ func TestDryRunFeatureFlag(t *testing.T) {
 				"name":      "invalid",
 				"namespace": "foo",
 				"annotations": map[string]interface{}{
-					"features.knative.dev/podspec-dryrun": "enabled",
+					config.DryRunFeatureKey: "enabled",
 				},
 			},
 			"spec": true, // Invalid, spec is expected to be a struct
@@ -167,7 +167,7 @@ func TestDryRunFeatureFlag(t *testing.T) {
 				"name":      "invalid",
 				"namespace": "foo",
 				"annotations": map[string]interface{}{
-					"features.knative.dev/podspec-dryrun": "strict",
+					config.DryRunFeatureKey: "strict",
 				},
 			},
 			"spec": true, // Invalid, spec is expected to be a struct
@@ -206,7 +206,7 @@ func TestSkipUpdate(t *testing.T) {
 	validService := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				"features.knative.dev/podspec-dryrun": "enabled",
+				config.DryRunFeatureKey: "enabled",
 			},
 		},
 		Spec: v1.ServiceSpec{

--- a/test/e2e/service_validation_test.go
+++ b/test/e2e/service_validation_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"knative.dev/serving/pkg/apis/config"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/webhook"
 	"knative.dev/serving/test"
@@ -51,7 +52,7 @@ func TestServiceValidationWithInvalidPodSpec(t *testing.T) {
 
 	// Setup Service
 	service, err := v1test.CreateService(t, clients, names,
-		WithServiceAnnotation(webhook.PodSpecDryRunAnnotation, string(webhook.DryRunStrict)))
+		WithServiceAnnotation(config.DryRunFeatureKey, string(webhook.DryRunStrict)))
 	if err != nil {
 		t.Fatal("Create Service:", err)
 	}


### PR DESCRIPTION


<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* `DryRunFeatureKey`  is not used. We keep it and use it directly as we do with `QueueProxyPodInfoFeatureKey` instead of having a duplicate const.