### PR TITLE
Fix defective revision can lead to pods never being removed

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -173,6 +173,7 @@ func (pa *PodAutoscaler) ProgressDeadline() (time.Duration, bool) {
 	return pa.annotationDuration(serving.ProgressDeadlineAnnotation)
 }
 
+// RevisionTimeout returns the revision timeout annotation value, or false if not present.
 func (pa *PodAutoscaler) RevisionTimeout() (time.Duration, bool) {
 	return pa.annotationDuration(serving.RevisionTimeoutAnnotation)
 }
@@ -191,6 +192,8 @@ func (pa *PodAutoscaler) IsReady() bool {
 		pas.GetCondition(PodAutoscalerConditionReady).IsTrue()
 }
 
+// CanFailActivationOnUnreachableRevision checks whether the pod autoscaler is Unreachable and has been activating
+// for at least the specified idle period
 func (pa *PodAutoscaler) CanFailActivationOnUnreachableRevision(now time.Time, idlePeriod time.Duration) bool {
 	return pa.Spec.Reachability == ReachabilityUnreachable && pa.Status.CanFailActivation(now, idlePeriod)
 }

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -173,6 +173,10 @@ func (pa *PodAutoscaler) ProgressDeadline() (time.Duration, bool) {
 	return pa.annotationDuration(serving.ProgressDeadlineAnnotation)
 }
 
+func (pa *PodAutoscaler) RevisionTimeout() (time.Duration, bool) {
+	return pa.annotationDuration(serving.RevisionTimeoutAnnotation)
+}
+
 // InitialScale returns the initial scale on the revision if present, or false if not present.
 func (pa *PodAutoscaler) InitialScale() (int32, bool) {
 	// The value is validated in the webhook.
@@ -185,6 +189,10 @@ func (pa *PodAutoscaler) IsReady() bool {
 	pas := pa.Status
 	return pa.Generation == pas.ObservedGeneration &&
 		pas.GetCondition(PodAutoscalerConditionReady).IsTrue()
+}
+
+func (pa *PodAutoscaler) CanFailActivationOnUnreachableRevision(now time.Time, idlePeriod time.Duration) bool {
+	return pa.Spec.Reachability == ReachabilityUnreachable && pa.Status.CanFailActivation(now, idlePeriod)
 }
 
 // IsActive returns true if the pod autoscaler has finished scaling.

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -145,6 +145,7 @@ const (
 	// ProgressDeadlineAnnotationKey is the label key for the per revision progress deadline to set for the deployment
 	ProgressDeadlineAnnotationKey = GroupName + "/progress-deadline"
 
+	// RevisionTimeoutAnnotationKey is the label key for the revision timeout to set for the pod autoscaler
 	RevisionTimeoutAnnotationKey = GroupName + "/revision-timeout"
 )
 

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -144,6 +144,8 @@ const (
 
 	// ProgressDeadlineAnnotationKey is the label key for the per revision progress deadline to set for the deployment
 	ProgressDeadlineAnnotationKey = GroupName + "/progress-deadline"
+
+	RevisionTimeoutAnnotationKey = GroupName + "/revision-timeout"
 )
 
 var (
@@ -201,5 +203,8 @@ var (
 	}
 	ProgressDeadlineAnnotation = kmap.KeyPriority{
 		ProgressDeadlineAnnotationKey,
+	}
+	RevisionTimeoutAnnotation = kmap.KeyPriority{
+		RevisionTimeoutAnnotationKey,
 	}
 )

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -101,6 +101,7 @@ const (
 	paStableWindow           = 45 * time.Second
 	progressDeadline         = 121 * time.Second
 	stableWindow             = 5 * time.Minute
+	defaultRevisionTimeout   = 45
 )
 
 func defaultConfigMapData() map[string]string {
@@ -1782,7 +1783,9 @@ func newTestRevision(namespace, name string) *v1.Revision {
 				serving.ConfigurationLabelKey: "test-service",
 			},
 		},
-		Spec: v1.RevisionSpec{},
+		Spec: v1.RevisionSpec{
+			TimeoutSeconds: ptr.Int64(defaultRevisionTimeout),
+		},
 	}
 }
 

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -328,6 +328,7 @@ func (ks *scaler) applyScale(ctx context.Context, pa *autoscalingv1alpha1.PodAut
 func (ks *scaler) scale(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscaler, sks *netv1alpha1.ServerlessService, desiredScale int32) (int32, error) {
 	asConfig := config.FromContext(ctx).Autoscaler
 	logger := logging.FromContext(ctx)
+
 	if desiredScale < 0 && !pa.Status.IsActivating() {
 		logger.Debug("Metrics are not yet being collected.")
 		return desiredScale, nil

--- a/pkg/reconciler/revision/resources/meta.go
+++ b/pkg/reconciler/revision/resources/meta.go
@@ -19,9 +19,11 @@ package resources
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/pkg/kmap"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"strconv"
 )
 
 var (
@@ -56,7 +58,9 @@ func makeLabels(revision *v1.Revision) map[string]string {
 }
 
 func makeAnnotations(revision *v1.Revision) map[string]string {
-	return kmeta.FilterMap(revision.GetAnnotations(), excludeAnnotations.Has)
+	annotations := kmap.Filter(revision.GetAnnotations(), excludeAnnotations.Has)
+	annotations[serving.RevisionTimeoutAnnotation.Key()] = strconv.FormatInt(*revision.Spec.TimeoutSeconds, 10) + "s"
+	return annotations
 }
 
 // makeSelector constructs the Selector we will apply to K8s resources.

--- a/pkg/reconciler/revision/resources/meta.go
+++ b/pkg/reconciler/revision/resources/meta.go
@@ -59,7 +59,9 @@ func makeLabels(revision *v1.Revision) map[string]string {
 
 func makeAnnotations(revision *v1.Revision) map[string]string {
 	annotations := kmap.Filter(revision.GetAnnotations(), excludeAnnotations.Has)
-	annotations[serving.RevisionTimeoutAnnotation.Key()] = strconv.FormatInt(*revision.Spec.TimeoutSeconds, 10) + "s"
+	if revision.Spec.TimeoutSeconds != nil {
+		annotations[serving.RevisionTimeoutAnnotation.Key()] = strconv.FormatInt(*revision.Spec.TimeoutSeconds, 10) + "s"
+	}
 	return annotations
 }
 


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/13677

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Requests in the activator times out by checking the spec.revisionTimeout field at the Revision
* The idea here is to allow scale to 0 when revisionTime has passed, instead of allowing this only when the progressDeadline has passed.
* After revisionTimeout seconds there are not requests queued at the activator, because they already timed out. So, there is no need to not allow scaling to 0
* There another edge case when revisionTimeout is less than the StableWindow (when in panic mode) , that prevents a revision from scaling to 0. See changes in the autoscaler.go

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
https://github.com/knative/serving/issues/13677 fixed
```
