### PR TITLE
remove duplicate 'additionalPrinterColumns' in domain-mapping resource

### DIFF
--- a/config/core/300-resources/domain-mapping.yaml
+++ b/config/core/300-resources/domain-mapping.yaml
@@ -150,16 +150,6 @@ spec:
                 url:
                   description: URL is the URL of this DomainMapping.
                   type: string
-      additionalPrinterColumns:
-        - name: URL
-          type: string
-          jsonPath: .status.url
-        - name: Ready
-          type: string
-          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
-        - name: Reason
-          type: string
-          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
   names:
     kind: DomainMapping
     plural: domainmappings


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* remove duplicate 'additionalPrinterColumns' in domain-mapping resource,  was seeing

```
error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 153: mapping key "additionalPrinterColumns" already defined at line 31
```


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
