### PR TITLE
Respect revision timeout defaults in cm

### DIFF
--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -53,6 +53,22 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 		rs.TimeoutSeconds = ptr.Int64(cfg.Defaults.RevisionTimeoutSeconds)
 	}
 
+	// Default IdleTimeoutSeconds only in case we have a non-zero default and the latter is not larger than the revision timeout.
+	// A zero default or a zero value set from the user or a nil value skips timer setup at the QP side.
+	if rs.IdleTimeoutSeconds == nil {
+		if cfg.Defaults.RevisionIdleTimeoutSeconds < *rs.TimeoutSeconds && cfg.Defaults.RevisionIdleTimeoutSeconds != 0 {
+			rs.IdleTimeoutSeconds = ptr.Int64(cfg.Defaults.RevisionIdleTimeoutSeconds)
+		}
+	}
+
+	// Default ResponseStartTimeoutSeconds only in case we have a non-zero default and the latter is not larger than the revision timeout.
+	// A zero default or a zero value set from the user or a nil value skips timer setup at the QP side.
+	if rs.ResponseStartTimeoutSeconds == nil {
+		if cfg.Defaults.RevisionRequestStartTimeoutSeconds < *rs.TimeoutSeconds && cfg.Defaults.RevisionRequestStartTimeoutSeconds != 0 {
+			rs.ResponseStartTimeoutSeconds = ptr.Int64(cfg.Defaults.RevisionRequestStartTimeoutSeconds)
+		}
+	}
+
 	// Default ContainerConcurrency based on our configmap.
 	if rs.ContainerConcurrency == nil {
 		rs.ContainerConcurrency = ptr.Int64(cfg.Defaults.ContainerConcurrency)

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -96,6 +96,40 @@ func TestRevisionDefaulting(t *testing.T) {
 			},
 		},
 	}, {
+		name: "all revision timeouts set",
+		in:   &Revision{Spec: RevisionSpec{PodSpec: corev1.PodSpec{Containers: []corev1.Container{{}}}}},
+		wc: func(ctx context.Context) context.Context {
+			s := config.NewStore(logger)
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: config.FeaturesConfigName}})
+			s.OnConfigChanged(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: config.DefaultsConfigName,
+				},
+				Data: map[string]string{
+					"revision-timeout-seconds":                "423",
+					"revision-idle-timeout-seconds":           "100",
+					"revision-response-start-timeout-seconds": "50",
+				},
+			})
+			return s.ToContext(ctx)
+		},
+		want: &Revision{
+			Spec: RevisionSpec{
+				ContainerConcurrency:        ptr.Int64(0),
+				TimeoutSeconds:              ptr.Int64(423),
+				ResponseStartTimeoutSeconds: ptr.Int64(50),
+				IdleTimeoutSeconds:          ptr.Int64(100),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:           config.DefaultUserContainerName,
+						Resources:      defaultResources,
+						ReadinessProbe: defaultProbe,
+					}},
+				},
+			},
+		},
+	}, {
 		name: "with context, in create, expect ESL set",
 		in:   &Revision{Spec: RevisionSpec{PodSpec: corev1.PodSpec{Containers: []corev1.Container{{}}}}},
 		wc: func(ctx context.Context) context.Context {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* See discussion here: https://cloud-native.slack.com/archives/C04LMU0AX60/p1690977838372249.
* If global defaults for `revision-idle-timeout-seconds` & `revision-response-start-timeout-seconds` are set to a positive value less than the revision timeout we need to respect that and set some timer.
* We avoid creating timers we don't need, as previously.
/kind bug


