### PR TITLE
Fix crash-looping pods take a long time to terminate/clean

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -187,6 +187,14 @@ func (pa *PodAutoscaler) IsReady() bool {
 		pas.GetCondition(PodAutoscalerConditionReady).IsTrue()
 }
 
+func (pa *PodAutoscaler) IsUnreachable() bool {
+	return pa.Spec.Reachability == ReachabilityUnreachable
+}
+
+func (pa *PodAutoscaler) IsReachable() bool {
+	return pa.Spec.Reachability == ReachabilityReachable
+}
+
 // IsActive returns true if the pod autoscaler has finished scaling.
 func (pas *PodAutoscalerStatus) IsActive() bool {
 	return pas.GetCondition(PodAutoscalerConditionActive).IsTrue()

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -270,6 +270,7 @@ func computeActiveCondition(ctx context.Context, pa *autoscalingv1alpha1.PodAuto
 
 	// If the service is not created yet, it is either queued or inctive if initial scale zero.
 	if !isServiceCreated {
+
 		if minReady == 0 {
 			pa.Status.MarkInactive(noTrafficReason, "The target is not receiving traffic.")
 		} else {
@@ -281,8 +282,12 @@ func computeActiveCondition(ctx context.Context, pa *autoscalingv1alpha1.PodAuto
 
 	// If the target is not initialized, it will be queued.
 	if !pa.Status.IsScaleTargetInitialized() {
-		pa.Status.MarkActivating(
-			"Queued", "Requests to the target are being buffered as resources are provisioned.")
+		if pa.IsUnreachable() {
+			pa.Status.MarkInactive("Unreachable", "The target does not have an active routing state.")
+		} else {
+			pa.Status.MarkActivating(
+				"Queued", "Requests to the target are being buffered as resources are provisioned.")
+		}
 		return
 	}
 

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -328,7 +328,11 @@ func (ks *scaler) scale(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscal
 
 	if desiredScale < 0 && !pa.Status.IsActivating() {
 		logger.Debug("Metrics are not yet being collected.")
-		return desiredScale, nil
+
+		// if the target is unreachable and has no metrics. we still want to be able to scale it to 0
+		if !pa.IsUnreachable() {
+			return desiredScale, nil
+		}
 	}
 
 	min, max := pa.ScaleBounds(asConfig)

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -409,6 +409,27 @@ func TestScaler(t *testing.T) {
 		wantScaling:   false,
 		paMutation: func(k *autoscalingv1alpha1.PodAutoscaler) {
 			paMarkInactive(k, time.Now())
+			WithReachabilityReachable(k)
+		},
+	}, {
+		label:         "negative scale, to zero if unreachable with no metrics",
+		startReplicas: 1,
+		scaleTo:       -1,
+		wantReplicas:  0,
+		wantScaling:   true,
+		paMutation: func(k *autoscalingv1alpha1.PodAutoscaler) {
+			paMarkInactive(k, time.Now().Add(-time.Hour))
+			WithReachabilityUnreachable(k)
+		},
+	}, {
+		label:         "negative scale does not to zero if reachable with no metrics",
+		startReplicas: 1,
+		scaleTo:       -1,
+		wantReplicas:  -1,
+		wantScaling:   false,
+		paMutation: func(k *autoscalingv1alpha1.PodAutoscaler) {
+			paMarkInactive(k, time.Now().Add(-time.Hour))
+			WithReachabilityReachable(k)
 		},
 	}, {
 		label:         "scales up from zero to desired one",
@@ -430,6 +451,7 @@ func TestScaler(t *testing.T) {
 		wantScaling:   false,
 		paMutation: func(k *autoscalingv1alpha1.PodAutoscaler) {
 			paMarkActive(k, time.Now())
+			WithReachabilityReachable(k)
 		},
 	}, {
 		label:         "initial scale attained, but now time to scale down",

--- a/pkg/testing/v1/configuration.go
+++ b/pkg/testing/v1/configuration.go
@@ -138,3 +138,10 @@ func WithConfigRevisionIdleTimeoutSeconds(revisionIdleTimeoutSeconds int64) Conf
 		cfg.Spec.Template.Spec.IdleTimeoutSeconds = ptr.Int64(revisionIdleTimeoutSeconds)
 	}
 }
+
+// WithConfigRevisionIdleTimeoutSeconds sets revision idle timeout
+func WithConfigTEST(key, value string) ConfigOption {
+	return func(cfg *v1.Configuration) {
+		cfg.Spec.Template.ObjectMeta.Annotations[key] = value
+	}
+}

--- a/test/conformance.go
+++ b/test/conformance.go
@@ -53,6 +53,7 @@ const (
 	Timeout             = "timeout"
 	Volumes             = "volumes"
 	SlowStart           = "slowstart"
+	DeadStart           = "deadstart"
 
 	// Constants for test image output.
 	PizzaPlanetText1 = "What a spaceport!"

--- a/test/e2e/dead_start_test.go
+++ b/test/e2e/dead_start_test.go
@@ -1,0 +1,261 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgtest "knative.dev/pkg/test"
+	"knative.dev/serving/pkg/apis/serving"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	rtesting "knative.dev/serving/pkg/testing/v1"
+	v1options "knative.dev/serving/pkg/testing/v1"
+	"knative.dev/serving/test"
+	v1test "knative.dev/serving/test/v1"
+)
+
+// withServiceImage sets the container image to be the provided string.
+func withServiceImage(img string) v1options.ServiceOption {
+	return func(svc *v1.Service) {
+		svc.Spec.Template.Spec.PodSpec.Containers[0].Image = img
+	}
+}
+
+func withConfigImage(img string) rtesting.ConfigOption {
+	return func(cfg *v1.Configuration) {
+		cfg.Spec.Template.Spec.Containers[0].Image = img
+	}
+}
+
+func generationLabelSelector(config string, generation int) string {
+	return fmt.Sprintf("%s=%s,%s=%s", serving.ConfigurationLabelKey, config, "serving.knative.dev/configurationGeneration", strconv.Itoa(generation))
+}
+
+func revisionLabelSelector(revName string) string {
+	return fmt.Sprintf("%s=%s", serving.RevisionLabelKey, revName)
+}
+
+func IsRevisionRestarting(clients *test.Clients) func(r *v1.Revision) (bool, error) {
+	return func(r *v1.Revision) (bool, error) {
+		// serving.knative.dev / revision = dead - start - to - healthy - tbibclgi - 00001
+		pods := clients.KubeClient.CoreV1().Pods(r.GetNamespace())
+		podList, err := pods.List(context.Background(), metav1.ListOptions{
+			LabelSelector: revisionLabelSelector(r.Name),
+			FieldSelector: "status.phase!=Pending",
+		})
+		if err != nil {
+			return false, err
+		}
+
+		// verify the pods are restarting.
+		for i := range podList.Items {
+			conds := podList.Items[i].Status.ContainerStatuses
+			for j := range conds {
+				if conds[j].RestartCount > 0 {
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	}
+}
+
+func IsRevisionScaledZero(clients *test.Clients) func(r *v1.Revision) (bool, error) {
+	return func(r *v1.Revision) (bool, error) {
+		// serving.knative.dev / revision = dead - start - to - healthy - tbibclgi - 00001
+		pods := clients.KubeClient.CoreV1().Pods(r.GetNamespace())
+		podList, err := pods.List(context.Background(), metav1.ListOptions{
+			LabelSelector: revisionLabelSelector(r.Name),
+			FieldSelector: "status.phase!=Pending",
+		})
+		if err != nil {
+			return false, err
+		}
+		gotPods := len(podList.Items)
+
+		return gotPods == 0, nil
+	}
+}
+
+// func latestRevisionName(t *testing.T, clients *test.Clients, configName, oldRevName string) string {
+// 	// Wait for the Config have a LatestCreatedRevisionName
+// 	if err := v1test.WaitForConfigurationState(
+// 		clients.ServingClient, configName,
+// 		func(c *v1.Configuration) (bool, error) {
+// 			return c.Status.LatestCreatedRevisionName != oldRevName, nil
+// 		}, "ConfigurationHasUpdatedCreatedRevision",
+// 	); err != nil {
+// 		t.Fatalf("The Configuration %q has not updated LatestCreatedRevisionName from %q: %v", configName, oldRevName, err)
+// 	}
+
+// 	config, err := clients.ServingClient.Configs.Get(context.Background(), configName, metav1.GetOptions{})
+// 	if err != nil {
+// 		t.Fatal("Failed to get Configuration after it was seen to be live:", err)
+// 	}
+
+// 	return config.Status.LatestCreatedRevisionName
+// }
+
+// This test case creates a service which can never reach a ready state.
+// The service is then udpated with a healthy image and is verified that
+// the healthy revision is ready and the unhealhy revision is scaled to zero.
+func TestDeadStartToHealthy(t *testing.T) {
+	t.Parallel()
+
+	clients := Setup(t)
+
+	names := test.ResourceNames{
+		Config:  test.ObjectNameForTest(t),
+		Service: test.ObjectNameForTest(t),
+		Route:   test.ObjectNameForTest(t),
+		Image:   test.DeadStart,
+	}
+	test.EnsureTearDown(t, clients, &names)
+
+	var err error
+	const minScale = 3
+
+	t.Log("Creating route")
+	if _, err := v1test.CreateRoute(t, clients, names); err != nil {
+		t.Fatal("Failed to create Route:", err)
+	}
+	cfg, err := v1test.CreateConfiguration(t, clients, names,
+		withMinScale(minScale),
+		// rtesting.WithConfigTEST(serving.ProgressDeadlineAnnotationKey, "1s"),
+		rtesting.WithConfigRevisionTimeoutSeconds(1),
+	)
+	if err != nil {
+		t.Fatal("Failed to create Configuration:", err)
+	}
+
+	// time.Sleep(time.Hour)
+	failedRevName := latestRevisionName(t, clients, names.Config, "")
+
+	t.Log("Waiting for revision to restart")
+	if err := v1test.WaitForRevisionState(
+		clients.ServingClient, failedRevName, IsRevisionRestarting(clients), "RevisionIsRestarting",
+	); err != nil {
+		t.Fatalf("The Revision %q is not restarting: %v", failedRevName, err)
+	}
+
+	t.Log("Updating configuration with valid image")
+	if _, err := v1test.PatchConfig(t, clients, cfg, withConfigImage(pkgtest.ImagePath(test.HelloWorld))); err != nil {
+		t.Fatal("Failed to update Configuration:", err)
+	}
+
+	healthyRevName := latestRevisionName(t, clients, names.Config, failedRevName)
+
+	t.Log("Waiting for revision to become ready")
+	if err := v1test.WaitForRevisionState(
+		clients.ServingClient, healthyRevName, v1test.IsRevisionReady, "RevisionIsReady",
+	); err != nil {
+		t.Fatalf("The Revision %q did not become ready: %v", healthyRevName, err)
+	}
+
+	t.Log("Waiting for revision scale zero")
+	if err := v1test.WaitForRevisionState(
+		clients.ServingClient, failedRevName, IsRevisionScaledZero(clients), "RevisionIsScaledZero",
+	); err != nil {
+		t.Fatalf("The Revision %q is not restarting: %v", failedRevName, err)
+	}
+
+	t.Log("Verify revision Active is Unreachable")
+	if err = v1test.CheckRevisionState(clients.ServingClient, failedRevName, func(r *v1.Revision) (bool, error) {
+		cond := r.Status.GetCondition(v1.RevisionConditionActive)
+		t.Logf("Revision %s Active state = %#v", failedRevName, cond)
+		if cond != nil {
+			if cond.Reason == "Unreachable" {
+				return true, nil
+			}
+			return true, fmt.Errorf("The Revision %s Active condition has: (Reason=%q, Message=%q)",
+				failedRevName, cond.Reason, cond.Message)
+		}
+		return false, fmt.Errorf("The Revision %s has empty Active condition", failedRevName)
+	}); err != nil {
+		t.Fatal("Failed to validate revision state:", err)
+	}
+
+}
+
+// This test case updates a healthy service with an image that can never reach a ready state.
+// The healthy revision remains Ready and the DeadStart revision doesnt not scale down until ProgressDeadline is reached.
+func TestDeadStartFromHealthy(t *testing.T) {
+	t.Parallel()
+
+	clients := Setup(t)
+
+	names := test.ResourceNames{
+		Config:  test.ObjectNameForTest(t),
+		Service: test.ObjectNameForTest(t),
+		Route:   test.ObjectNameForTest(t),
+		Image:   test.HelloWorld,
+	}
+	test.EnsureTearDown(t, clients, &names)
+
+	var err error
+	const minScale = 3
+
+	t.Log("Creating route")
+	if _, err := v1test.CreateRoute(t, clients, names); err != nil {
+		t.Fatal("Failed to create Route:", err)
+	}
+
+	cfg, err := v1test.CreateConfiguration(t, clients, names, withMinScale(minScale),
+		// rtesting.WithConfigAnn(serving.ProgressDeadlineAnnotationKey, "45s"),
+		rtesting.WithConfigRevisionTimeoutSeconds(1),
+	)
+	if err != nil {
+		t.Fatal("Failed to create Configuration:", err)
+	}
+
+	healthyRevName := latestRevisionName(t, clients, names.Config, "")
+
+	t.Log("Waiting for revision to become ready")
+	if err := v1test.WaitForRevisionState(
+		clients.ServingClient, healthyRevName, v1test.IsRevisionReady, "RevisionIsReady",
+	); err != nil {
+		t.Fatalf("The Revision %q did not become ready: %v", healthyRevName, err)
+	}
+
+	t.Log("Updating configuration with valid image")
+	if _, err := v1test.PatchConfig(t, clients, cfg, withConfigImage(pkgtest.ImagePath(test.DeadStart))); err != nil {
+		t.Fatal("Failed to update Configuration:", err)
+	}
+
+	failedRevName := latestRevisionName(t, clients, names.Config, healthyRevName)
+
+	t.Log("Waiting for revision to restart")
+	if err := v1test.WaitForRevisionState(
+		clients.ServingClient, failedRevName, IsRevisionRestarting(clients), "RevisionIsRestarting",
+	); err != nil {
+		t.Fatalf("The Revision %q is not restarting: %v", failedRevName, err)
+	}
+
+	for i := 0; i < 100; i++ {
+		fmt.Printf("healthyRevName %v failedRevName %v\n", healthyRevName, failedRevName)
+	}
+
+	// TODO: verify the restart is queued.
+	// it only shutsdown once progressdeadline reached.
+}

--- a/test/test_images/deadstart/README.md
+++ b/test/test_images/deadstart/README.md
@@ -1,0 +1,4 @@
+# Deadstart test image
+
+This directory contains the test image used in the deadstart e2e tests.
+

--- a/test/test_images/deadstart/deadstart.go
+++ b/test/test_images/deadstart/deadstart.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+)
+
+func main() {
+	os.Exit(0)
+
+}

--- a/test/test_images/deadstart/service.yaml
+++ b/test/test_images/deadstart/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: deadstart-test-image
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - image: ko://knative.dev/serving/test/test_images/deadstart


### PR DESCRIPTION
Pods that instantly crash do no scale to 0 until progress deadline is called for the deployment.
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
If pa is not ready and unreachable, It is marked inactive instead of queued. 
This will scale the deployment to 0 even if metrics cannot be retrieved.


