### PR TITLE
Add `t.Parallel` on `TestShouldHaveStdinEOF`

### DIFF
--- a/test/conformance/runtime/file_descriptor_test.go
+++ b/test/conformance/runtime/file_descriptor_test.go
@@ -28,6 +28,7 @@ import (
 // TestShouldHaveStdinEOF verifies using the runtime test container that reading from the
 // stdin file descriptor results in EOF.
 func TestShouldHaveStdinEOF(t *testing.T) {
+	t.Parallel()
 	clients := test.Setup(t)
 
 	_, ri, err := fetchRuntimeInfo(t, clients)


### PR DESCRIPTION
This patch makes a tiny change which adds `t.Parallel()` on `TestShouldHaveStdinEOF`

**Release Note**

```release-note
NONE
```
