### PR TITLE
Disable flaky ambient e2e tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -148,7 +148,8 @@ jobs:
       KIND: 1
       INGRESS_CLASS: ${{ matrix.ingress-class || matrix.ingress }}.ingress.networking.knative.dev
       ENABLE_TLS: ${{ matrix.enable-tls || 0 }}
-      AMBIENT: ${{ matrix.ambient || 0 }}
+      # Disabled due to flakiness: https://github.com/knative/serving/issues/14637
+      # AMBIENT: ${{ matrix.ambient || 0 }}
 
     steps:
     - name: Set up Go 1.21.x

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -96,7 +96,8 @@ jobs:
         - kourier-tls
         - istio
         - istio-tls
-        - istio-ambient
+        # Disabled due to flakiness: https://github.com/knative/serving/issues/14637
+        # - istio-ambient
         - contour
         # Disabled due to consistent failures
         # - gateway_istio
@@ -124,10 +125,11 @@ jobs:
           namespace-resources: virtualservices
           enable-tls: 1
 
-        - ingress: istio-ambient
-          namespace-resources: virtualservices
-          ingress-class: istio
-          ambient: 1
+        # Disabled due to flakiness: https://github.com/knative/serving/issues/14637
+        # - ingress: istio-ambient
+        #   namespace-resources: virtualservices
+        #   ingress-class: istio
+        #   ambient: 1
 
         - ingress: kourier-tls
           ingress-class: kourier


### PR DESCRIPTION
Related to https://github.com/knative/serving/issues/14637

## Proposed Changes
I'm proposing to disable the tests until they are more stable. Currently nearly every run needs a few retries until we can get the tests green.

/cc @nak3 
/cc @dprotaso 