### PR TITLE
Drop K8s 1.26 in GH actions and use K8s version 1.27 in prow

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -87,7 +87,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.26.x
         - v1.27.x
         - v1.28.x
 

--- a/test/e2e-external-domain-tls-tests.sh
+++ b/test/e2e-external-domain-tls-tests.sh
@@ -159,7 +159,7 @@ function delete_dns_record() {
 }
 
 # Script entry point.
-initialize "$@" --num-nodes=4 --enable-ha --cluster-version=1.26
+initialize "$@" --num-nodes=4 --enable-ha --cluster-version=1.27
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -28,7 +28,7 @@
 source $(dirname $0)/e2e-common.sh
 
 # Script entry point.
-initialize --num-nodes=4 --enable-ha --cluster-version=1.26 "$@"
+initialize --num-nodes=4 --enable-ha --cluster-version=1.27 "$@"
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -42,7 +42,7 @@ function stage_test_resources() {
 # Skip installing istio as an add-on.
 # Skip installing a pvc as it is not used in upgrade tests
 # Skip installing a resource quota as it is not used in upgrade tests
-PVC=0 QUOTA=0 initialize "$@" --num-nodes=4 --cluster-version=1.26 \
+PVC=0 QUOTA=0 initialize "$@" --num-nodes=4 --cluster-version=1.27 \
   --install-latest-release
 
 # TODO(#2656): Reduce the timeout after we get this test to consistently passing.

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -38,7 +38,7 @@ declare ARTIFACTS
 
 ns="default"
 
-initialize --num-nodes=10 --cluster-version=1.26 "$@"
+initialize --num-nodes=10 --cluster-version=1.27 "$@"
 
 
 function run_job() {


### PR DESCRIPTION
@dprotaso not sure if you wanted to keep those as good-first-issues, but as it is more a chore than actual fun, I went ahead 🙃

## Proposed Changes
* Drop K8s 1.26 in GH actions and use K8s version 1.27 in prow

Fixes #14670

/assign @dprotaso 


