### PR TITLE
Validation added for initialScale greater than maxScale (#14153)

### DIFF
--- a/pkg/apis/autoscaling/annotation_validation_test.go
+++ b/pkg/apis/autoscaling/annotation_validation_test.go
@@ -368,12 +368,17 @@ func TestValidateAnnotations(t *testing.T) {
 	}, {
 		name:        "initial scale is less than 0",
 		annotations: map[string]string{InitialScaleAnnotationKey: "-1"},
-		expectErr:   "invalid value: -1: " + InitialScaleAnnotationKey + " must be greater than 0",
+		expectErr:   "expected 0 <= -1 <= 2147483647: autoscaling.knative.dev/initial-scale\ninvalid value: -1: autoscaling.knative.dev/initial-scale must be greater than 0",
 	}, {
 		name:        "initial scale non-parseable",
 		annotations: map[string]string{InitialScaleAnnotationKey: "invalid"},
 		expectErr:   "invalid value: invalid: autoscaling.knative.dev/initial-scale",
-	}}
+	},
+		{
+			name:        "initial scale greater than max scale",
+			annotations: map[string]string{InitialScaleAnnotationKey: "3", MaxScaleAnnotationKey: "2"},
+			expectErr:   "max-scale=2 is less than initial-scale=3: autoscaling.knative.dev/initial-scale, autoscaling.knative.dev/max-scale",
+		}}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			cfg := defaultConfig()


### PR DESCRIPTION
Fixes #14153

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*  Added a validation for initialScale > maxScale
*  As initialScale > maxScale not making sense at all. As it is not depending on traffic.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
none
```
