### PR TITLE
Update linter config to new schema

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,11 +29,11 @@ linters:
 
 linters-settings:
   depguard:
-    include-go-root: true
-    packages:
-      - sync/atomic
-    packages-with-error-message:
-      - sync/atomic: "please use type-safe atomics from go.uber.org/atomic"
+    rules:
+      main:
+        deny:
+          - pkg: sync/atomic
+            desc: "please use type-safe atomics from go.uber.org/atomic"
   importas:
     no-unaliased: true
     alias:


### PR DESCRIPTION
## Context
`golangci-lint` now uses depguard V2 which has a totally different (and breaking) configuration syntax. References:
- https://github.com/golangci/golangci-lint/issues/3906
- https://github.com/OpenPeeDeeP/depguard/issues/56
- https://golangci-lint.run/usage/linters/#depguard

## Proposed Changes
* Update linter depguard config to new schema

/assign @skonto 
/assign @dprotaso 
