### PR TITLE
Remove /tmp and /var/log from reserved paths (#14686)

### DIFF
--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -44,9 +44,6 @@ var (
 		"/",
 		"/dev",
 		"/dev/log", // Should be a domain socket
-		"/tmp",
-		"/var",
-		"/var/log",
 	)
 
 	reservedContainerNames = sets.NewString(

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -2227,7 +2227,7 @@ func getCommonContainerValidationTestCases() []containerValidationTestCase {
 			c: corev1.Container{
 				Image: "foo",
 				VolumeMounts: []corev1.VolumeMount{{
-					MountPath: "//var//log//",
+					MountPath: "//dev//",
 					Name:      "the-name",
 					ReadOnly:  true,
 				}},
@@ -2245,7 +2245,7 @@ func getCommonContainerValidationTestCases() []containerValidationTestCase {
 				},
 			},
 			want: (&apis.FieldError{
-				Message: `mountPath "/var/log" is a reserved path`,
+				Message: `mountPath "/dev" is a reserved path`,
 				Paths:   []string{"mountPath"},
 			}).ViaFieldIndex("volumeMounts", 0),
 		}, {


### PR DESCRIPTION
Fixes #14686

## Proposed Changes

As discussed in #14686, the runtime contract  REQUIRES `/tmp` to be a read-writeable folder and `/var/log` MAY BE writeable.
Since this can be achieved with many different means **users should be able to mount volumes at these locations** (e.g. `/tmp` for sharing data between containers, `/var/log` for [shipping logs with a sidecar](https://blog.cubieserver.de/2023/vector-logging-sidecar/) etc.)

> /tmp 	MUST be Read-write. SHOULD be backed by tmpfs if disk load is a concern.
> /var/log 	MAY be a directory with write permissions for logs storage. Implementations MAY permit the creation of additional subdirectories and log rotation and renaming.

https://github.com/knative/specs/blob/a8e7926c041baa58366f4939df9f3fdc866dbbb5/specs/serving/runtime-contract.md#default-filesystems

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Remove /tmp and /var/log from reserved paths
```
