### PR TITLE
Set AppProtocol on Services

### DIFF
--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -60,9 +60,10 @@ func MakeK8sPlaceholderService(ctx context.Context, route *v1.Route, tagName str
 			ExternalName:    domainName,
 			SessionAffinity: corev1.ServiceAffinityNone,
 			Ports: []corev1.ServicePort{{
-				Name:       netapi.ServicePortNameH2C,
-				Port:       int32(80),
-				TargetPort: intstr.FromInt(80),
+				Name:        netapi.ServicePortNameH2C,
+				AppProtocol: &netapi.AppProtocolH2C,
+				Port:        int32(80),
+				TargetPort:  intstr.FromInt(80),
 			}},
 		},
 	}, nil
@@ -129,8 +130,9 @@ func MakeK8sService(ctx context.Context, route *v1.Route, tagName string, ingres
 					IP: balancer.IP,
 				}},
 				Ports: []corev1.EndpointPort{{
-					Name: netapi.ServicePortNameH2C,
-					Port: int32(80),
+					Name:        netapi.ServicePortNameH2C,
+					AppProtocol: &netapi.AppProtocolH2C,
+					Port:        int32(80),
 				}},
 			}},
 		}

--- a/pkg/reconciler/route/resources/service.go
+++ b/pkg/reconciler/route/resources/service.go
@@ -101,9 +101,10 @@ func MakeK8sService(ctx context.Context, route *v1.Route, tagName string, ingres
 			ObjectMeta: makeServiceObjectMeta(hostname, route),
 			Spec: corev1.ServiceSpec{
 				Ports: []corev1.ServicePort{{
-					Name:       netapi.ServicePortNameH2C,
-					Port:       int32(80),
-					TargetPort: intstr.FromInt(80),
+					Name:        netapi.ServicePortNameH2C,
+					AppProtocol: &netapi.AppProtocolH2C,
+					Port:        int32(80),
+					TargetPort:  intstr.FromInt(80),
 				}},
 			},
 		},

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -124,8 +124,9 @@ func TestMakeK8SService(t *testing.T) {
 				IP: "some-ip",
 			}},
 			Ports: []corev1.EndpointPort{{
-				Name: netapi.ServicePortNameH2C,
-				Port: int32(80),
+				Name:        netapi.ServicePortNameH2C,
+				AppProtocol: &netapi.AppProtocolH2C,
+				Port:        int32(80),
 			}},
 		}},
 	}, {
@@ -201,8 +202,9 @@ func TestMakeK8SService(t *testing.T) {
 				IP: "some-ip",
 			}},
 			Ports: []corev1.EndpointPort{{
-				Name: netapi.ServicePortNameH2C,
-				Port: int32(80),
+				Name:        netapi.ServicePortNameH2C,
+				AppProtocol: &netapi.AppProtocolH2C,
+				Port:        int32(80),
 			}},
 		}},
 	}, {

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -395,9 +395,10 @@ func TestMakePlaceholderService(t *testing.T) {
 				ExternalName:    tt.expectedExternalName,
 				SessionAffinity: corev1.ServiceAffinityNone,
 				Ports: []corev1.ServicePort{{
-					Name:       netapi.ServicePortNameH2C,
-					Port:       int32(80),
-					TargetPort: intstr.FromInt(80),
+					Name:        netapi.ServicePortNameH2C,
+					AppProtocol: &netapi.AppProtocolH2C,
+					Port:        int32(80),
+					TargetPort:  intstr.FromInt(80),
 				}},
 			}
 

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -54,9 +54,10 @@ var (
 	}
 
 	expectedPorts = []corev1.ServicePort{{
-		Name:       netapi.ServicePortNameH2C,
-		Port:       int32(80),
-		TargetPort: intstr.FromInt(80),
+		Name:        netapi.ServicePortNameH2C,
+		AppProtocol: &netapi.AppProtocolH2C,
+		Port:        int32(80),
+		TargetPort:  intstr.FromInt(80),
 	}}
 )
 

--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -60,10 +60,11 @@ func MakePublicService(sks *v1alpha1.ServerlessService) *corev1.Service {
 
 func makePublicServicePorts(sks *v1alpha1.ServerlessService) []corev1.ServicePort {
 	ports := []corev1.ServicePort{{
-		Name:       pkgnet.ServicePortName(sks.Spec.ProtocolType),
-		Protocol:   corev1.ProtocolTCP,
-		Port:       int32(pkgnet.ServicePort(sks.Spec.ProtocolType)),
-		TargetPort: targetPort(sks),
+		Name:        pkgnet.ServicePortName(sks.Spec.ProtocolType),
+		Protocol:    corev1.ProtocolTCP,
+		AppProtocol: pkgnet.AppProtocol(sks.Spec.ProtocolType),
+		Port:        int32(pkgnet.ServicePort(sks.Spec.ProtocolType)),
+		TargetPort:  targetPort(sks),
 	}, {
 		// The HTTPS port is used when activator-ca is enabled.
 		// Although it is not used by default, we put it here as it should be harmless
@@ -144,9 +145,10 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{
-				Name:     pkgnet.ServicePortName(sks.Spec.ProtocolType),
-				Protocol: corev1.ProtocolTCP,
-				Port:     pkgnet.ServiceHTTPPort,
+				Name:        pkgnet.ServicePortName(sks.Spec.ProtocolType),
+				Protocol:    corev1.ProtocolTCP,
+				AppProtocol: pkgnet.AppProtocol(sks.Spec.ProtocolType),
+				Port:        pkgnet.ServiceHTTPPort,
 				// This one is matching the public one, since this is the
 				// port queue-proxy listens on.
 				TargetPort: targetPort(sks),

--- a/pkg/reconciler/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/serverlessservice/resources/services_test.go
@@ -182,10 +182,11 @@ func TestMakePublicService(t *testing.T) {
 		}),
 		want: svc(networking.ServiceTypePublic, func(s *corev1.Service) {
 			s.Spec.Ports = []corev1.ServicePort{{
-				Name:       pkgnet.ServicePortNameH2C,
-				Protocol:   corev1.ProtocolTCP,
-				Port:       pkgnet.ServiceHTTP2Port,
-				TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
+				Name:        pkgnet.ServicePortNameH2C,
+				Protocol:    corev1.ProtocolTCP,
+				AppProtocol: &pkgnet.AppProtocolH2C,
+				Port:        pkgnet.ServiceHTTP2Port,
+				TargetPort:  intstr.FromInt(networking.BackendHTTP2Port),
 			}, {
 				Name:       pkgnet.ServicePortNameHTTPS,
 				Protocol:   corev1.ProtocolTCP,
@@ -202,10 +203,11 @@ func TestMakePublicService(t *testing.T) {
 		}),
 		want: svc(networking.ServiceTypePublic, func(s *corev1.Service) {
 			s.Spec.Ports = []corev1.ServicePort{{
-				Name:       pkgnet.ServicePortNameH2C,
-				Protocol:   corev1.ProtocolTCP,
-				Port:       pkgnet.ServiceHTTP2Port,
-				TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
+				Name:        pkgnet.ServicePortNameH2C,
+				Protocol:    corev1.ProtocolTCP,
+				AppProtocol: &pkgnet.AppProtocolH2C,
+				Port:        pkgnet.ServiceHTTP2Port,
+				TargetPort:  intstr.FromInt(networking.BackendHTTP2Port),
 			}, {
 				Name:       pkgnet.ServicePortNameHTTPS,
 				Protocol:   corev1.ProtocolTCP,
@@ -222,10 +224,11 @@ func TestMakePublicService(t *testing.T) {
 		}),
 		want: svc(networking.ServiceTypePublic, func(s *corev1.Service) {
 			s.Spec.Ports = []corev1.ServicePort{{
-				Name:       pkgnet.ServicePortNameH2C,
-				Protocol:   corev1.ProtocolTCP,
-				Port:       pkgnet.ServiceHTTP2Port,
-				TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
+				Name:        pkgnet.ServicePortNameH2C,
+				Protocol:    corev1.ProtocolTCP,
+				AppProtocol: &pkgnet.AppProtocolH2C,
+				Port:        pkgnet.ServiceHTTP2Port,
+				TargetPort:  intstr.FromInt(networking.BackendHTTP2Port),
 			}, {
 				Name:       pkgnet.ServicePortNameHTTPS,
 				Protocol:   corev1.ProtocolTCP,
@@ -470,10 +473,11 @@ func TestMakePrivateService(t *testing.T) {
 		}, privateSvcMod, func(s *corev1.Service) {
 			// And now patch port to be http2.
 			s.Spec.Ports[0] = corev1.ServicePort{
-				Name:       pkgnet.ServicePortNameH2C,
-				Protocol:   corev1.ProtocolTCP,
-				Port:       pkgnet.ServiceHTTPPort,
-				TargetPort: intstr.FromInt(networking.BackendHTTP2Port),
+				Name:        pkgnet.ServicePortNameH2C,
+				Protocol:    corev1.ProtocolTCP,
+				AppProtocol: &pkgnet.AppProtocolH2C,
+				Port:        pkgnet.ServiceHTTPPort,
+				TargetPort:  intstr.FromInt(networking.BackendHTTP2Port),
 			}
 			s.Spec.Ports[5] = corev1.ServicePort{
 				Name:       pkgnet.ServicePortNameH2C + "-istio",

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -803,6 +803,7 @@ func deploy(namespace, name string, opts ...deploymentOption) *appsv1.Deployment
 func withHTTP2Priv(svc *corev1.Service) {
 	svc.Spec.Ports[0].Name = "http2"
 	svc.Spec.Ports[0].TargetPort = intstr.FromInt(networking.BackendHTTP2Port)
+	svc.Spec.Ports[0].AppProtocol = &pkgnet.AppProtocolH2C
 
 	svc.Spec.Ports[5].Name = "http2-istio"
 	svc.Spec.Ports[5].Port = networking.BackendHTTP2Port
@@ -812,6 +813,7 @@ func withHTTP2Priv(svc *corev1.Service) {
 func withHTTP2(svc *corev1.Service) {
 	svc.Spec.Ports[0].Port = pkgnet.ServiceHTTP2Port
 	svc.Spec.Ports[0].Name = "http2"
+	svc.Spec.Ports[0].AppProtocol = &pkgnet.AppProtocolH2C
 	svc.Spec.Ports[0].TargetPort = intstr.FromInt(networking.BackendHTTP2Port)
 }
 

--- a/pkg/testing/functional.go
+++ b/pkg/testing/functional.go
@@ -256,9 +256,10 @@ func WithExternalName(name string) K8sServiceOption {
 	return func(svc *corev1.Service) {
 		svc.Spec.ExternalName = name
 		svc.Spec.Ports = []corev1.ServicePort{{
-			Name:       networking.ServicePortNameH2C,
-			Port:       int32(80),
-			TargetPort: intstr.FromInt(80),
+			Name:        networking.ServicePortNameH2C,
+			AppProtocol: &networking.AppProtocolH2C,
+			Port:        int32(80),
+			TargetPort:  intstr.FromInt(80),
 		}}
 	}
 }


### PR DESCRIPTION
Part of #14569

Depends on https://github.com/knative/networking/pull/904

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* sets AppProtocol to "kubernetes.io/h2c" on Services when applicable

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
TBD
```
