### PR TITLE
bump istio for gateway api tests

### DIFF
--- a/test/e2e-networking-library.sh
+++ b/test/e2e-networking-library.sh
@@ -26,7 +26,7 @@ function stage_gateway_api_resources() {
   mkdir -p "${gateway_dir}"
 
   # TODO: if we switch to istio 1.12 we can reuse stage_istio_head
-  curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION=1.17.2 sh -
+  curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION=1.20.2 sh -
 
   local params="--set values.global.proxy.clusterDomain=${CLUSTER_DOMAIN}"
 


### PR DESCRIPTION
* use 1.20.2

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* I believe that if we want to continue with https://github.com/knative/serving/issues/14569, we need to test with newer Istio. In my testing, it seems like 1.17.x does not properly recognize the appProtocol field
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
