### PR TITLE
Create less load for TestActivatorChainHandlerWithFullDuplex

### DIFF
--- a/pkg/activator/handler/main_test.go
+++ b/pkg/activator/handler/main_test.go
@@ -222,7 +222,7 @@ func TestActivatorChainHandlerWithFullDuplex(t *testing.T) {
 			go func(i int) {
 				defer wg.Done()
 
-				for i := 0; i < 1000; i++ {
+				for i := 0; i < 100; i++ {
 					if err := send(c, proxyServer.URL, body, "test-host"); err != nil {
 						t.Errorf("error during request: %v", err)
 					}

--- a/pkg/activator/handler/main_test.go
+++ b/pkg/activator/handler/main_test.go
@@ -203,6 +203,8 @@ func TestActivatorChainHandlerWithFullDuplex(t *testing.T) {
 	defer proxyServer.Close()
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConnsPerHost = 10
+	transport.MaxIdleConns = 100
 
 	// Turning on this will hide the issue
 	transport.DisableKeepAlives = false


### PR DESCRIPTION
Potentially fixes https://github.com/knative/serving/issues/14806

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* This patch drops the time that the test takes from ~1m to ~7s:

> === RUN   TestActivatorChainHandlerWithFullDuplex
    logger.go:130: 2024-01-22T15:05:08.626+0200	DEBUG	configmap/store.go:155	activator config "config-tracing" config was added or updated: &config.Config{Backend:"none", ZipkinEndpoint:"", Debug:false, SampleRate:0.1}
--- PASS: TestActivatorChainHandlerWithFullDuplex (6.73s)
PASS

* User can still reproduce the full duplex error if user comments out: `ah = WrapActivatorHandlerWithFullDuplex(ah, logger)`:

> === RUN   TestActivatorChainHandlerWithFullDuplex
    logger.go:130: 2024-01-22T15:13:32.531+0200	DEBUG	configmap/store.go:155	activator config "config-tracing" config was added or updated: &config.Config{Backend:"none", ZipkinEndpoint:"", Debug:false, SampleRate:0.1}
2024/01/22 15:13:39 httputil: ReverseProxy read error during body copy: read tcp 127.0.0.1:59348->127.0.0.1:38235: use of closed network connection
    main_test.go:227: error during request: failed to read body: unexpected EOF
--- FAIL: TestActivatorChainHandlerWithFullDuplex (7.35s)

FAIL

* Looking at the [job history](https://prow.knative.dev/job-history/gs/knative-prow/pr-logs/directory/unit-tests_serving_main) of the failed tests I see also [this run](https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_serving/14812/unit-tests_serving_main/1748300687101399040):
> 2024/01/19 11:11:32 http: proxy error: dial tcp 127.0.0.1:37727: connect: cannot assign requested address
2024/01/19 11:11:32 http: proxy error: dial tcp 127.0.0.1:37727: connect: cannot assign requested address

I am setting a con limit as in [here](https://github.com/golang/go/issues/16012#issuecomment-224948823), plus lowering the number of requests.

