### PR TITLE
[release-1.13] Don't drop traffic when upgrading a deployment fails

### DIFF
--- a/pkg/apis/serving/k8s_lifecycle.go
+++ b/pkg/apis/serving/k8s_lifecycle.go
@@ -50,6 +50,7 @@ func TransformDeploymentStatus(ds *appsv1.DeploymentStatus) *duckv1.Status {
 	// The absence of this condition means no failure has occurred. If we find it
 	// below, we'll overwrite this.
 	depCondSet.Manage(s).MarkTrue(DeploymentConditionReplicaSetReady)
+	depCondSet.Manage(s).MarkUnknown(DeploymentConditionProgressing, "Deploying", "")
 
 	conds := []appsv1.DeploymentConditionType{
 		appsv1.DeploymentProgressing,

--- a/pkg/apis/serving/k8s_lifecycle.go
+++ b/pkg/apis/serving/k8s_lifecycle.go
@@ -51,28 +51,40 @@ func TransformDeploymentStatus(ds *appsv1.DeploymentStatus) *duckv1.Status {
 	// below, we'll overwrite this.
 	depCondSet.Manage(s).MarkTrue(DeploymentConditionReplicaSetReady)
 
-	for _, cond := range ds.Conditions {
-		// TODO(jonjohnsonjr): Should we care about appsv1.DeploymentAvailable here?
-		switch cond.Type {
-		case appsv1.DeploymentProgressing:
-			switch cond.Status {
-			case corev1.ConditionUnknown:
-				depCondSet.Manage(s).MarkUnknown(DeploymentConditionProgressing, cond.Reason, cond.Message)
-			case corev1.ConditionTrue:
-				depCondSet.Manage(s).MarkTrue(DeploymentConditionProgressing)
-			case corev1.ConditionFalse:
-				depCondSet.Manage(s).MarkFalse(DeploymentConditionProgressing, cond.Reason, cond.Message)
+	conds := []appsv1.DeploymentConditionType{
+		appsv1.DeploymentProgressing,
+		appsv1.DeploymentReplicaFailure,
+	}
+
+	for _, wantType := range conds {
+		for _, cond := range ds.Conditions {
+			if wantType != cond.Type {
+				continue
 			}
-		case appsv1.DeploymentReplicaFailure:
-			switch cond.Status {
-			case corev1.ConditionUnknown:
-				depCondSet.Manage(s).MarkUnknown(DeploymentConditionReplicaSetReady, cond.Reason, cond.Message)
-			case corev1.ConditionTrue:
-				depCondSet.Manage(s).MarkFalse(DeploymentConditionReplicaSetReady, cond.Reason, cond.Message)
-			case corev1.ConditionFalse:
-				depCondSet.Manage(s).MarkTrue(DeploymentConditionReplicaSetReady)
+
+			switch cond.Type {
+			case appsv1.DeploymentProgressing:
+				switch cond.Status {
+				case corev1.ConditionUnknown:
+					depCondSet.Manage(s).MarkUnknown(DeploymentConditionProgressing, cond.Reason, cond.Message)
+				case corev1.ConditionTrue:
+					depCondSet.Manage(s).MarkTrue(DeploymentConditionProgressing)
+				case corev1.ConditionFalse:
+					depCondSet.Manage(s).MarkFalse(DeploymentConditionProgressing, cond.Reason, cond.Message)
+				}
+			case appsv1.DeploymentReplicaFailure:
+				switch cond.Status {
+				case corev1.ConditionUnknown:
+					depCondSet.Manage(s).MarkUnknown(DeploymentConditionReplicaSetReady, cond.Reason, cond.Message)
+				case corev1.ConditionTrue:
+					depCondSet.Manage(s).MarkFalse(DeploymentConditionReplicaSetReady, cond.Reason, cond.Message)
+				case corev1.ConditionFalse:
+					depCondSet.Manage(s).MarkTrue(DeploymentConditionReplicaSetReady)
+				}
 			}
+
 		}
 	}
+
 	return s
 }

--- a/pkg/apis/serving/k8s_lifecycle_test.go
+++ b/pkg/apis/serving/k8s_lifecycle_test.go
@@ -40,12 +40,14 @@ func TestTransformDeploymentStatus(t *testing.T) {
 			Conditions: []apis.Condition{{
 				Type:   DeploymentConditionProgressing,
 				Status: corev1.ConditionUnknown,
+				Reason: "Deploying",
 			}, {
 				Type:   DeploymentConditionReplicaSetReady,
 				Status: corev1.ConditionTrue,
 			}, {
 				Type:   DeploymentConditionReady,
 				Status: corev1.ConditionUnknown,
+				Reason: "Deploying",
 			}},
 		},
 	}, {

--- a/pkg/apis/serving/k8s_lifecycle_test.go
+++ b/pkg/apis/serving/k8s_lifecycle_test.go
@@ -147,7 +147,7 @@ func TestTransformDeploymentStatus(t *testing.T) {
 				Type:    appsv1.DeploymentReplicaFailure,
 				Status:  corev1.ConditionTrue,
 				Reason:  "ReplicaSetReason",
-				Message: "Something bag happened",
+				Message: "Something bad happened",
 			}},
 		},
 		want: &duckv1.Status{
@@ -158,12 +158,45 @@ func TestTransformDeploymentStatus(t *testing.T) {
 				Type:    DeploymentConditionReplicaSetReady,
 				Status:  corev1.ConditionFalse,
 				Reason:  "ReplicaSetReason",
-				Message: "Something bag happened",
+				Message: "Something bad happened",
 			}, {
 				Type:    DeploymentConditionReady,
 				Status:  corev1.ConditionFalse,
 				Reason:  "ReplicaSetReason",
-				Message: "Something bag happened",
+				Message: "Something bad happened",
+			}},
+		},
+	}, {
+		name: "replica failure has priority over progressing",
+		ds: &appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:    appsv1.DeploymentReplicaFailure,
+				Status:  corev1.ConditionTrue,
+				Reason:  "ReplicaSetReason",
+				Message: "Something really bad happened",
+			}, {
+				Type:    appsv1.DeploymentProgressing,
+				Status:  corev1.ConditionFalse,
+				Reason:  "ProgressingReason",
+				Message: "Something bad happened",
+			}},
+		},
+		want: &duckv1.Status{
+			Conditions: []apis.Condition{{
+				Type:    DeploymentConditionProgressing,
+				Status:  corev1.ConditionFalse,
+				Reason:  "ProgressingReason",
+				Message: "Something bad happened",
+			}, {
+				Type:    DeploymentConditionReplicaSetReady,
+				Status:  corev1.ConditionFalse,
+				Reason:  "ReplicaSetReason",
+				Message: "Something really bad happened",
+			}, {
+				Type:    DeploymentConditionReady,
+				Status:  corev1.ConditionFalse,
+				Reason:  "ReplicaSetReason",
+				Message: "Something really bad happened",
 			}},
 		},
 	}}

--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -19,7 +19,6 @@ package v1
 import (
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	net "knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/kmeta"
@@ -143,10 +142,4 @@ func (r *Revision) GetProtocol() net.ProtocolType {
 func (rs *RevisionStatus) IsActivationRequired() bool {
 	c := revisionCondSet.Manage(rs).GetCondition(RevisionConditionActive)
 	return c != nil && c.Status != corev1.ConditionTrue
-}
-
-// IsReplicaSetFailure returns true if the deployment replicaset failed to create
-func (rs *RevisionStatus) IsReplicaSetFailure(deploymentStatus *appsv1.DeploymentStatus) bool {
-	ds := serving.TransformDeploymentStatus(deploymentStatus)
-	return ds != nil && ds.GetCondition(serving.DeploymentConditionReplicaSetReady).IsFalse()
 }

--- a/pkg/apis/serving/v1/revision_helpers_test.go
+++ b/pkg/apis/serving/v1/revision_helpers_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 
@@ -266,47 +265,5 @@ func TestSetRoutingState(t *testing.T) {
 	rev.Annotations[serving.RoutingStateModifiedAnnotationKey] = "invalid"
 	if got, want := rev.GetRoutingStateModified(), empty; got != want {
 		t.Error("Expected default value for unparsable annotationm but got:", got)
-	}
-}
-
-func TestIsReplicaSetFailure(t *testing.T) {
-	revisionStatus := RevisionStatus{}
-	cases := []struct {
-		name                string
-		status              appsv1.DeploymentStatus
-		IsReplicaSetFailure bool
-	}{{
-		name:   "empty deployment status should not be a failure",
-		status: appsv1.DeploymentStatus{},
-	}, {
-		name: "Ready deployment status should not be a failure",
-		status: appsv1.DeploymentStatus{
-			Conditions: []appsv1.DeploymentCondition{{
-				Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue,
-			}},
-		},
-	}, {
-		name: "ReplicasetFailure true should be a failure",
-		status: appsv1.DeploymentStatus{
-			Conditions: []appsv1.DeploymentCondition{{
-				Type: appsv1.DeploymentReplicaFailure, Status: corev1.ConditionTrue,
-			}},
-		},
-		IsReplicaSetFailure: true,
-	}, {
-		name: "ReplicasetFailure false should not be a failure",
-		status: appsv1.DeploymentStatus{
-			Conditions: []appsv1.DeploymentCondition{{
-				Type: appsv1.DeploymentReplicaFailure, Status: corev1.ConditionFalse,
-			}},
-		},
-	}}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got, want := revisionStatus.IsReplicaSetFailure(&tc.status), tc.IsReplicaSetFailure; got != want {
-				t.Errorf("IsReplicaSetFailure = %v, want: %v", got, want)
-			}
-		})
 	}
 }

--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -222,14 +222,6 @@ func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *autoscalingv1alpha1.PodA
 		rs.MarkActiveFalse(cond.Reason, cond.Message)
 	case corev1.ConditionTrue:
 		rs.MarkActiveTrue()
-
-		// Precondition for PA being active is SKS being active and
-		// that implies that |service.endpoints| > 0.
-		//
-		// Note: This is needed for backwards compatibility as we're adding the new
-		// ScaleTargetInitialized condition to gate readiness.
-		rs.MarkResourcesAvailableTrue()
-		rs.MarkContainerHealthyTrue()
 	}
 }
 

--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -170,6 +170,8 @@ func (rs *RevisionStatus) PropagateDeploymentStatus(original *appsv1.DeploymentS
 
 // PropagateAutoscalerStatus propagates autoscaler's status to the revision's status.
 func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *autoscalingv1alpha1.PodAutoscalerStatus) {
+	resUnavailable := rs.GetCondition(RevisionConditionResourcesAvailable).IsFalse()
+
 	// Reflect the PA status in our own.
 	cond := ps.GetCondition(autoscalingv1alpha1.PodAutoscalerConditionReady)
 	rs.ActualReplicas = nil
@@ -183,18 +185,27 @@ func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *autoscalingv1alpha1.PodA
 	}
 
 	if cond == nil {
-		rs.MarkActiveUnknown("Deploying", "")
+		rs.MarkActiveUnknown(ReasonDeploying, "")
+
+		if !resUnavailable {
+			rs.MarkResourcesAvailableUnknown(ReasonDeploying, "")
+		}
 		return
 	}
 
 	// Don't mark the resources available, if deployment status already determined
 	// it isn't so.
-	resUnavailable := rs.GetCondition(RevisionConditionResourcesAvailable).IsFalse()
 	if ps.IsScaleTargetInitialized() && !resUnavailable {
 		// Precondition for PA being initialized is SKS being active and
 		// that implies that |service.endpoints| > 0.
 		rs.MarkResourcesAvailableTrue()
 		rs.MarkContainerHealthyTrue()
+	}
+
+	// Mark resource unavailable if we don't have a Service Name and the deployment is ready
+	// This can happen when we have initial scale set to 0
+	if rs.GetCondition(RevisionConditionResourcesAvailable).IsTrue() && ps.ServiceName == "" {
+		rs.MarkResourcesAvailableUnknown(ReasonDeploying, "")
 	}
 
 	switch cond.Status {

--- a/pkg/apis/serving/v1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1/revision_lifecycle_test.go
@@ -537,6 +537,7 @@ func TestPropagateAutoscalerStatus(t *testing.T) {
 
 	// PodAutoscaler becomes ready, making us active.
 	r.PropagateAutoscalerStatus(&autoscalingv1alpha1.PodAutoscalerStatus{
+		ServiceName: "some-service",
 		Status: duckv1.Status{
 			Conditions: duckv1.Conditions{{
 				Type:   autoscalingv1alpha1.PodAutoscalerConditionReady,
@@ -552,6 +553,7 @@ func TestPropagateAutoscalerStatus(t *testing.T) {
 
 	// PodAutoscaler flipping back to Unknown causes Active become ongoing immediately.
 	r.PropagateAutoscalerStatus(&autoscalingv1alpha1.PodAutoscalerStatus{
+		ServiceName: "some-service",
 		Status: duckv1.Status{
 			Conditions: duckv1.Conditions{{
 				Type:   autoscalingv1alpha1.PodAutoscalerConditionReady,
@@ -567,6 +569,7 @@ func TestPropagateAutoscalerStatus(t *testing.T) {
 
 	// PodAutoscaler becoming unready makes Active false, but doesn't affect readiness.
 	r.PropagateAutoscalerStatus(&autoscalingv1alpha1.PodAutoscalerStatus{
+		ServiceName: "some-service",
 		Status: duckv1.Status{
 			Conditions: duckv1.Conditions{{
 				Type:   autoscalingv1alpha1.PodAutoscalerConditionReady,
@@ -685,6 +688,7 @@ func TestPropagateAutoscalerStatusRace(t *testing.T) {
 
 	// The PodAutoscaler might have been ready but it's scaled down already.
 	r.PropagateAutoscalerStatus(&autoscalingv1alpha1.PodAutoscalerStatus{
+		ServiceName: "some-service",
 		Status: duckv1.Status{
 			Conditions: duckv1.Conditions{{
 				Type:   autoscalingv1alpha1.PodAutoscalerConditionReady,

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -221,7 +221,7 @@ func markScaleTargetInitialized(pa *autoscalingv1alpha1.PodAutoscaler) {
 
 func kpa(ns, n string, opts ...PodAutoscalerOption) *autoscalingv1alpha1.PodAutoscaler {
 	rev := newTestRevision(ns, n)
-	kpa := revisionresources.MakePA(rev)
+	kpa := revisionresources.MakePA(rev, nil)
 	kpa.Generation = 1
 	kpa.Annotations[autoscaling.ClassAnnotationKey] = "kpa.autoscaling.knative.dev"
 	kpa.Annotations[autoscaling.MetricAnnotationKey] = "concurrency"
@@ -1303,7 +1303,7 @@ func TestGlobalResyncOnUpdateAutoscalerConfigMap(t *testing.T) {
 	rev := newTestRevision(testNamespace, testRevision)
 	newDeployment(ctx, t, fakedynamicclient.Get(ctx), testRevision+"-deployment", 3)
 
-	kpa := revisionresources.MakePA(rev)
+	kpa := revisionresources.MakePA(rev, nil)
 	sks := aresources.MakeSKS(kpa, nv1a1.SKSOperationModeServe, minActivators)
 	sks.Status.PrivateServiceName = "bogus"
 	sks.Status.InitializeConditions()
@@ -1372,7 +1372,7 @@ func TestReconcileDeciderCreatesAndDeletes(t *testing.T) {
 
 	newDeployment(ctx, t, fakedynamicclient.Get(ctx), testRevision+"-deployment", 3)
 
-	kpa := revisionresources.MakePA(rev)
+	kpa := revisionresources.MakePA(rev, nil)
 	sks := sks(testNamespace, testRevision, WithDeployRef(kpa.Spec.ScaleTargetRef.Name), WithSKSReady)
 	fakenetworkingclient.Get(ctx).NetworkingV1alpha1().ServerlessServices(testNamespace).Create(ctx, sks, metav1.CreateOptions{})
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(ctx, kpa, metav1.CreateOptions{})
@@ -1446,7 +1446,7 @@ func TestUpdate(t *testing.T) {
 	fakekubeclient.Get(ctx).CoreV1().Pods(testNamespace).Create(ctx, pod, metav1.CreateOptions{})
 	fakefilteredpodsinformer.Get(ctx, serving.RevisionUID).Informer().GetIndexer().Add(pod)
 
-	kpa := revisionresources.MakePA(rev)
+	kpa := revisionresources.MakePA(rev, nil)
 	kpa.SetDefaults(context.Background())
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(ctx, kpa, metav1.CreateOptions{})
 	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
@@ -1525,7 +1525,7 @@ func TestControllerCreateError(t *testing.T) {
 			createErr: want,
 		})
 
-	kpa := revisionresources.MakePA(newTestRevision(testNamespace, testRevision))
+	kpa := revisionresources.MakePA(newTestRevision(testNamespace, testRevision), nil)
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(ctx, kpa, metav1.CreateOptions{})
 	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
 
@@ -1568,7 +1568,7 @@ func TestControllerUpdateError(t *testing.T) {
 			createErr: want,
 		})
 
-	kpa := revisionresources.MakePA(newTestRevision(testNamespace, testRevision))
+	kpa := revisionresources.MakePA(newTestRevision(testNamespace, testRevision), nil)
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(ctx, kpa, metav1.CreateOptions{})
 	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
 
@@ -1610,7 +1610,7 @@ func TestControllerGetError(t *testing.T) {
 			getErr: want,
 		})
 
-	kpa := revisionresources.MakePA(newTestRevision(testNamespace, testRevision))
+	kpa := revisionresources.MakePA(newTestRevision(testNamespace, testRevision), nil)
 	fakeservingclient.Get(ctx).AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(ctx, kpa, metav1.CreateOptions{})
 	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
 
@@ -1649,7 +1649,7 @@ func TestScaleFailure(t *testing.T) {
 
 	// Only put the KPA in the lister, which will prompt failures scaling it.
 	rev := newTestRevision(testNamespace, testRevision)
-	kpa := revisionresources.MakePA(rev)
+	kpa := revisionresources.MakePA(rev, nil)
 	fakepainformer.Get(ctx).Informer().GetIndexer().Add(kpa)
 
 	newDeployment(ctx, t, fakedynamicclient.Get(ctx), testRevision+"-deployment", 3)

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -640,7 +640,7 @@ func TestDisableScaleToZero(t *testing.T) {
 
 func newKPA(ctx context.Context, t *testing.T, servingClient clientset.Interface, revision *v1.Revision) *autoscalingv1alpha1.PodAutoscaler {
 	t.Helper()
-	pa := revisionresources.MakePA(revision)
+	pa := revisionresources.MakePA(revision, nil)
 	pa.Status.InitializeConditions()
 	_, err := servingClient.AutoscalingV1alpha1().PodAutoscalers(testNamespace).Create(ctx, pa, metav1.CreateOptions{})
 	if err != nil {

--- a/pkg/reconciler/revision/cruds.go
+++ b/pkg/reconciler/revision/cruds.go
@@ -115,7 +115,11 @@ func (c *Reconciler) createImageCache(ctx context.Context, rev *v1.Revision, con
 	return c.cachingclient.CachingV1alpha1().Images(image.Namespace).Create(ctx, image, metav1.CreateOptions{})
 }
 
-func (c *Reconciler) createPA(ctx context.Context, rev *v1.Revision) (*autoscalingv1alpha1.PodAutoscaler, error) {
-	pa := resources.MakePA(rev)
+func (c *Reconciler) createPA(
+	ctx context.Context,
+	rev *v1.Revision,
+	deployment *appsv1.Deployment,
+) (*autoscalingv1alpha1.PodAutoscaler, error) {
+	pa := resources.MakePA(rev, deployment)
 	return c.client.AutoscalingV1alpha1().PodAutoscalers(pa.Namespace).Create(ctx, pa, metav1.CreateOptions{})
 }

--- a/test/upgrade/deployment_failure.go
+++ b/test/upgrade/deployment_failure.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/upgrade/deployment_failure.go
+++ b/test/upgrade/deployment_failure.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2024 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade
+
+import (
+	"context"
+
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
+	"knative.dev/pkg/test/helpers"
+	pkgupgrade "knative.dev/pkg/test/upgrade"
+	"knative.dev/serving/pkg/apis/autoscaling"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/test"
+	"knative.dev/serving/test/e2e"
+	v1test "knative.dev/serving/test/v1"
+)
+
+func DeploymentFailurePostUpgrade() pkgupgrade.Operation {
+	return pkgupgrade.NewOperation("DeploymentFailurePostUpgrade", func(c pkgupgrade.Context) {
+		clients := e2e.Setup(c.T)
+
+		names := test.ResourceNames{
+			Service: "deployment-upgrade-failure",
+			Image:   test.HelloWorld,
+		}
+
+		service, err := clients.ServingClient.Services.Get(context.Background(), names.Service, metav1.GetOptions{})
+		if err != nil {
+			c.T.Fatal("Failed to get Service: ", err)
+		}
+
+		// Deployment failures should surface to the Service Ready Condition
+		if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceFailed, "ServiceIsNotReady"); err != nil {
+			c.T.Fatal("Service did not transition to Ready=False", err)
+		}
+
+		// Traffic should still work since the deployment has an active replicaset
+		url := service.Status.URL.URL()
+		assertServiceResourcesUpdated(c.T, clients, names, url, test.HelloWorldText)
+	})
+}
+
+func DeploymentFailurePreUpgrade() pkgupgrade.Operation {
+	return pkgupgrade.NewOperation("DeploymentFailurePreUpgrade", func(c pkgupgrade.Context) {
+		c.T.Log("Creating Service")
+		ctx := context.Background()
+
+		clients := e2e.Setup(c.T)
+		names := &test.ResourceNames{
+			Service: "deployment-upgrade-failure",
+			Image:   test.HelloWorld,
+		}
+
+		resources, err := v1test.CreateServiceReady(c.T, clients, names, func(s *v1.Service) {
+			s.Spec.Template.Annotations = map[string]string{
+				autoscaling.MinScaleAnnotation.Key(): "1",
+				autoscaling.MaxScaleAnnotation.Key(): "1",
+			}
+		})
+
+		if err != nil {
+			c.T.Fatal("Failed to create Service:", err)
+		}
+
+		url := resources.Service.Status.URL.URL()
+		// This polls until we get a 200 with the right body.
+		assertServiceResourcesUpdated(c.T, clients, *names, url, test.HelloWorldText)
+
+		// Setup webhook that fails when deployment is updated
+		// Failing to update the Deployment shouldn't cause a traffic drop
+		// note: the deployment is only updated if the controllers change the spec
+		//       and this happens when the queue proxy image is changed when upgrading
+		c.T.Log("Creating Failing Webhook")
+		noSideEffects := admissionv1.SideEffectClassNone
+
+		selector := &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"serving.knative.dev/service": names.Service,
+			},
+		}
+
+		// Create a broken webhook that breaks scheduling Pods
+		_, err = clients.KubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(
+			ctx,
+			&admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "broken-webhook",
+				},
+				Webhooks: []admissionv1.MutatingWebhook{{
+					AdmissionReviewVersions: []string{"v1"},
+					Name:                    "webhook.non-existing.dev",
+					ClientConfig: admissionv1.WebhookClientConfig{
+						Service: &admissionv1.ServiceReference{
+							Name:      helpers.AppendRandomString("non-existing"),
+							Namespace: helpers.AppendRandomString("non-existing"),
+						},
+					},
+					ObjectSelector: selector,
+					TimeoutSeconds: ptr.Int32(5),
+					SideEffects:    &noSideEffects,
+					Rules: []admissionv1.RuleWithOperations{{
+						Operations: []admissionv1.OperationType{"CREATE"},
+						Rule: admissionv1.Rule{
+							APIGroups:   []string{""}, // core
+							APIVersions: []string{"v1"},
+							Resources:   []string{"pods"},
+						},
+					}},
+				}},
+			},
+			metav1.CreateOptions{},
+		)
+
+		if err != nil {
+			c.T.Fatal("Failed to create bad webhook:", err)
+		}
+	})
+}

--- a/test/upgrade/postupgrade.go
+++ b/test/upgrade/postupgrade.go
@@ -42,6 +42,7 @@ func ServingPostUpgradeTests() []pkgupgrade.Operation {
 		CreateNewServicePostUpgradeTest(),
 		InitialScalePostUpgradeTest(),
 		CRDStoredVersionPostUpgradeTest(),
+		DeploymentFailurePostUpgrade(),
 	}
 }
 

--- a/test/upgrade/preupgrade.go
+++ b/test/upgrade/preupgrade.go
@@ -35,6 +35,7 @@ func ServingPreUpgradeTests() []pkgupgrade.Operation {
 		ServicePreUpgradeAndScaleToZeroTest(),
 		BYORevisionPreUpgradeTest(),
 		InitialScalePreUpgradeTest(),
+		DeploymentFailurePreUpgrade(),
 	}
 }
 


### PR DESCRIPTION
Part of https://github.com/knative/serving/pull/14795

Depends on 1.12 point release with the following fix - https://github.com/knative/serving/pull/14840