### PR TITLE
Add multi-container probing

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "f2fc138e"
+    knative.dev/example-checksum: "632d47dd"
 data:
   _example: |-
     ################################
@@ -50,8 +50,14 @@ data:
     # Indicates whether multi container support is enabled
     #
     # WARNING: Cannot safely be disabled once enabled.
-    # See: https://knative.dev/docs/serving/feature-flags/#multi-containers
+    # See: https://knative.dev/docs/serving/configuration/feature-flags/#multiple-containers
     multi-container: "enabled"
+
+    # Indicates whether multi container probing is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/configuration/feature-flags/#multiple-container-probing
+    multi-container-probing: "disabled"
 
     # Indicates whether Kubernetes affinity support is enabled
     #

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -54,6 +54,7 @@ const (
 func defaultFeaturesConfig() *Features {
 	return &Features{
 		MultiContainer:                   Enabled,
+		MultiContainerProbing:            Disabled,
 		PodSpecAffinity:                  Disabled,
 		PodSpecTopologySpreadConstraints: Disabled,
 		PodSpecDryRun:                    Allowed,
@@ -87,6 +88,7 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 
 	if err := cm.Parse(data,
 		asFlag("multi-container", &nc.MultiContainer),
+		asFlag("multi-container-probing", &nc.MultiContainerProbing),
 		asFlag("kubernetes.podspec-affinity", &nc.PodSpecAffinity),
 		asFlag("kubernetes.podspec-topologyspreadconstraints", &nc.PodSpecTopologySpreadConstraints),
 		asFlag("kubernetes.podspec-dryrun", &nc.PodSpecDryRun),
@@ -124,6 +126,7 @@ func NewFeaturesConfigFromConfigMap(config *corev1.ConfigMap) (*Features, error)
 // Features specifies which features are allowed by the webhook.
 type Features struct {
 	MultiContainer                   Flag
+	MultiContainerProbing            Flag
 	PodSpecAffinity                  Flag
 	PodSpecTopologySpreadConstraints Flag
 	PodSpecDryRun                    Flag

--- a/pkg/apis/config/features_test.go
+++ b/pkg/apis/config/features_test.go
@@ -60,6 +60,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 		wantErr: false,
 		wantFeatures: defaultWith(&Features{
 			MultiContainer:                   Enabled,
+			MultiContainerProbing:            Enabled,
 			PodSpecAffinity:                  Enabled,
 			PodSpecTopologySpreadConstraints: Enabled,
 			PodSpecDryRun:                    Enabled,
@@ -79,6 +80,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 		}),
 		data: map[string]string{
 			"multi-container":                              "Enabled",
+			"multi-container-probing":                      "Enabled",
 			"kubernetes.podspec-affinity":                  "Enabled",
 			"kubernetes.podspec-topologyspreadconstraints": "Enabled",
 			"kubernetes.podspec-dryrun":                    "Enabled",
@@ -113,6 +115,24 @@ func TestFeaturesConfiguration(t *testing.T) {
 		}),
 		data: map[string]string{
 			"multi-container": "Disabled",
+		},
+	}, {
+		name:    "multi-container-probing Allowed",
+		wantErr: false,
+		wantFeatures: defaultWith(&Features{
+			MultiContainerProbing: Allowed,
+		}),
+		data: map[string]string{
+			"multi-container-probing": "Allowed",
+		},
+	}, {
+		name:    "multi-container-probing Disabled",
+		wantErr: false,
+		wantFeatures: defaultWith(&Features{
+			MultiContainerProbing: Disabled,
+		}),
+		data: map[string]string{
+			"multi-container-probing": "Disabled",
 		},
 	}, {
 		name:    "kubernetes.podspec-affinity Allowed",

--- a/pkg/apis/serving/v1/revision_helpers.go
+++ b/pkg/apis/serving/v1/revision_helpers.go
@@ -72,6 +72,7 @@ const (
 // It is never nil and should be exactly the specified container if len(containers) == 1 or
 // if there are multiple containers it returns the container which has Ports
 // as guaranteed by validation.
+// Note: If you change this function, also update GetSidecarContainers.
 func (rs *RevisionSpec) GetContainer() *corev1.Container {
 	switch {
 	case len(rs.Containers) == 1:
@@ -85,6 +86,24 @@ func (rs *RevisionSpec) GetContainer() *corev1.Container {
 	}
 	// Should be unreachable post-validation, but here to ease testing.
 	return &corev1.Container{}
+}
+
+// GetSidecarContainers returns a slice of pointers to all sidecar containers.
+// If len(containers) == 1 OR only one container with a user-port exists, it will return an empty slice.
+// It is the "rest" of GetContainer.
+func (rs *RevisionSpec) GetSidecarContainers() []*corev1.Container {
+	sidecars := []*corev1.Container{}
+	if len(rs.Containers) == 1 {
+		return sidecars
+	}
+
+	for i, c := range rs.Containers {
+		if len(c.Ports) == 0 {
+			sidecars = append(sidecars, &rs.Containers[i])
+		}
+	}
+
+	return sidecars
 }
 
 // SetRoutingState sets the routingState label on this Revision and updates the

--- a/pkg/apis/serving/v1/revision_helpers_test.go
+++ b/pkg/apis/serving/v1/revision_helpers_test.go
@@ -226,6 +226,62 @@ func TestGetContainer(t *testing.T) {
 	}
 }
 
+func TestGetSidecarContainers(t *testing.T) {
+	cases := []struct {
+		name   string
+		status RevisionSpec
+		want   []*corev1.Container
+	}{{
+		name:   "empty revisionSpec should return empty slice",
+		status: RevisionSpec{},
+		want:   []*corev1.Container{},
+	}, {
+		name: "single container should return empty slice",
+		status: RevisionSpec{
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "user-container",
+					Image: "foo",
+				}},
+			},
+		},
+		want: []*corev1.Container{},
+	}, {
+		name: "get sidecars and not user-container",
+		status: RevisionSpec{
+			PodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "user-container",
+					Image: "firstImage",
+					Ports: []corev1.ContainerPort{{
+						ContainerPort: 8888,
+					}},
+				}, {
+					Name:  "secondContainer",
+					Image: "secondImage",
+				}, {
+					Name:  "thirdContainer",
+					Image: "thirdImage",
+				}},
+			},
+		},
+		want: []*corev1.Container{{
+			Name:  "secondContainer",
+			Image: "secondImage",
+		}, {
+			Name:  "thirdContainer",
+			Image: "thirdImage",
+		}},
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if want, got := tc.want, tc.status.GetSidecarContainers(); !equality.Semantic.DeepEqual(want, got) {
+				t.Errorf("GetSidecarContainers: %v want: %v", got, want)
+			}
+		})
+	}
+}
+
 func TestSetRoutingState(t *testing.T) {
 	rev := &Revision{}
 	empty := time.Time{}

--- a/pkg/queue/readiness/probe_encoding.go
+++ b/pkg/queue/readiness/probe_encoding.go
@@ -57,7 +57,7 @@ func EncodeSingleProbe(rp *corev1.Probe) (string, error) {
 
 // EncodeMultipleProbes takes []*corev1.Probe slice and returns marshalled slice of Probe JSON string and an error.
 func EncodeMultipleProbes(rps []*corev1.Probe) (string, error) {
-	if rps == nil || len(rps) == 0 {
+	if len(rps) == 0 {
 		return "", errors.New("cannot encode nil or empty probes")
 	}
 

--- a/pkg/queue/readiness/probe_encoding.go
+++ b/pkg/queue/readiness/probe_encoding.go
@@ -23,22 +23,45 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// DecodeProbe takes a json serialised *corev1.Probe and returns a Probe or an error.
-func DecodeProbe(jsonProbe string) (*corev1.Probe, error) {
-	p := &corev1.Probe{}
-	if err := json.Unmarshal([]byte(jsonProbe), p); err != nil {
-		return nil, err
+// DecodeProbes takes a json serialised *corev1.Probe OR []*corev1.Probe (depending on multiContainerProbes)
+// and returns a slice of probes or an error.
+func DecodeProbes(jsonProbe string, multiContainerProbes bool) ([]*corev1.Probe, error) {
+	probes := []*corev1.Probe{}
+	if multiContainerProbes {
+		if err := json.Unmarshal([]byte(jsonProbe), &probes); err != nil {
+			return nil, err
+		}
+	} else {
+		p := &corev1.Probe{}
+		if err := json.Unmarshal([]byte(jsonProbe), &p); err != nil {
+			return nil, err
+		}
+		probes = append(probes, p)
 	}
-	return p, nil
+
+	return probes, nil
 }
 
-// EncodeProbe takes *corev1.Probe object and returns marshalled Probe JSON string and an error.
-func EncodeProbe(rp *corev1.Probe) (string, error) {
+// EncodeSingleProbe takes a single *corev1.Probe object and returns marshalled Probe JSON string and an error.
+func EncodeSingleProbe(rp *corev1.Probe) (string, error) {
 	if rp == nil {
 		return "", errors.New("cannot encode nil probe")
 	}
 
 	probeJSON, err := json.Marshal(rp)
+	if err != nil {
+		return "", err
+	}
+	return string(probeJSON), nil
+}
+
+// EncodeMultipleProbes takes []*corev1.Probe slice and returns marshalled slice of Probe JSON string and an error.
+func EncodeMultipleProbes(rps []*corev1.Probe) (string, error) {
+	if rps == nil || len(rps) == 0 {
+		return "", errors.New("cannot encode nil or empty probes")
+	}
+
+	probeJSON, err := json.Marshal(rps)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/queue/readiness/probe_encoding_test.go
+++ b/pkg/queue/readiness/probe_encoding_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func TestParseProbeSuccess(t *testing.T) {
+func TestParseSingleProbeSuccess(t *testing.T) {
 	expectedProbe := &corev1.Probe{
 		PeriodSeconds:    1,
 		TimeoutSeconds:   2,
@@ -42,12 +42,49 @@ func TestParseProbeSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to decode probe %#v", err)
 	}
-	gotProbe, err := DecodeProbe(string(probeBytes))
+	gotProbes, err := DecodeProbes(string(probeBytes), false)
 	if err != nil {
-		t.Fatalf("Failed DecodeProbe() %#v", err)
+		t.Fatalf("Failed DecodeProbes() %#v", err)
 	}
-	if d := cmp.Diff(gotProbe, expectedProbe); d != "" {
-		t.Errorf("Probe diff %s; got %v, want %v", d, gotProbe, expectedProbe)
+	if d := cmp.Diff(gotProbes, []*corev1.Probe{expectedProbe}); d != "" {
+		t.Errorf("Probe diff %s; got %v, want %v", d, gotProbes, expectedProbe)
+	}
+}
+
+func TestParseMultipleProbeSuccess(t *testing.T) {
+	expectedProbes := []*corev1.Probe{{
+		PeriodSeconds:    1,
+		TimeoutSeconds:   2,
+		SuccessThreshold: 1,
+		FailureThreshold: 1,
+		ProbeHandler: corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Host: "127.0.0.1",
+				Port: intstr.FromString("8080"),
+			},
+		},
+	}, {
+		PeriodSeconds:    1,
+		TimeoutSeconds:   2,
+		SuccessThreshold: 1,
+		FailureThreshold: 1,
+		ProbeHandler: corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Host: "127.0.0.1",
+				Port: intstr.FromString("8090"),
+			},
+		},
+	}}
+	probeBytes, err := json.Marshal(expectedProbes)
+	if err != nil {
+		t.Fatalf("Failed to decode probe %#v", err)
+	}
+	gotProbes, err := DecodeProbes(string(probeBytes), true)
+	if err != nil {
+		t.Fatalf("Failed DecodeProbes() %#v", err)
+	}
+	if d := cmp.Diff(gotProbes, expectedProbes); d != "" {
+		t.Errorf("Probe diff %s; got %v, want %v", d, gotProbes, expectedProbes)
 	}
 }
 
@@ -56,13 +93,13 @@ func TestParseProbeFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to decode probe %#v", err)
 	}
-	_, err = DecodeProbe(string(probeBytes))
+	_, err = DecodeProbes(string(probeBytes), false)
 	if err == nil {
-		t.Fatal("Expected DecodeProbe() to fail")
+		t.Fatal("Expected DecodeProbes() to fail")
 	}
 }
 
-func TestEncodeProbe(t *testing.T) {
+func TestEncodeSingleProbe(t *testing.T) {
 	probe := &corev1.Probe{
 		SuccessThreshold: 1,
 		ProbeHandler: corev1.ProbeHandler{
@@ -73,7 +110,7 @@ func TestEncodeProbe(t *testing.T) {
 		},
 	}
 
-	jsonProbe, err := EncodeProbe(probe)
+	jsonProbe, err := EncodeSingleProbe(probe)
 
 	if err != nil {
 		t.Fatalf("Expected no errer, got: %#v", err)
@@ -86,8 +123,64 @@ func TestEncodeProbe(t *testing.T) {
 	}
 }
 
-func TestEncodeNilProbe(t *testing.T) {
-	jsonProbe, err := EncodeProbe(nil)
+func TestEncodeMultipleProbes(t *testing.T) {
+	probes := []*corev1.Probe{{
+		SuccessThreshold: 1,
+		ProbeHandler: corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Host: "127.0.0.1",
+				Port: intstr.FromString("8080"),
+			},
+		},
+	}, {
+		SuccessThreshold: 1,
+		ProbeHandler: corev1.ProbeHandler{
+			TCPSocket: &corev1.TCPSocketAction{
+				Host: "127.0.0.1",
+				Port: intstr.FromString("8090"),
+			},
+		},
+	}}
+
+	jsonProbe, err := EncodeMultipleProbes(probes)
+
+	if err != nil {
+		t.Fatalf("Expected no errer, got: %#v", err)
+	}
+
+	wantProbe := `[{"tcpSocket":{"port":"8080","host":"127.0.0.1"},"successThreshold":1},{"tcpSocket":{"port":"8090","host":"127.0.0.1"},"successThreshold":1}]`
+
+	if diff := cmp.Diff(jsonProbe, wantProbe); diff != "" {
+		t.Errorf("Probe diff: %s; got %v, want %v", diff, jsonProbe, wantProbe)
+	}
+}
+
+func TestEncodeSingleNilProbe(t *testing.T) {
+	jsonProbe, err := EncodeSingleProbe(nil)
+
+	if err == nil {
+		t.Error("Expected error")
+	}
+
+	if jsonProbe != "" {
+		t.Error("Expected empty probe string; got", jsonProbe)
+	}
+}
+
+func TestEncodeMultipleNilProbe(t *testing.T) {
+	jsonProbe, err := EncodeMultipleProbes(nil)
+
+	if err == nil {
+		t.Error("Expected error")
+	}
+
+	if jsonProbe != "" {
+		t.Error("Expected empty probe string; got", jsonProbe)
+	}
+}
+
+func TestEncodeMultipleEmptyProbe(t *testing.T) {
+	jsonProbe, err := EncodeMultipleProbes([]*corev1.Probe{})
 
 	if err == nil {
 		t.Error("Expected error")

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -119,6 +119,11 @@ toggle_feature kubernetes.podspec-init-containers Enabled
 go_test_e2e -timeout=2m ./test/e2e/initcontainers ${E2E_TEST_FLAGS} || failed=1
 toggle_feature kubernetes.podspec-init-containers Disabled
 
+# Run multi-container probe tests
+toggle_feature multi-container-probing Enabled
+go_test_e2e -timeout=2m ./test/e2e/multicontainerprobing ${E2E_TEST_FLAGS} || failed=1
+toggle_feature multi-container-probing Disabled
+
 # RUN PVC tests with default storage class.
 toggle_feature kubernetes.podspec-persistent-volume-claim Enabled
 toggle_feature kubernetes.podspec-persistent-volume-write Enabled

--- a/test/e2e/multicontainerprobing/multicontainer_readiness_test.go
+++ b/test/e2e/multicontainerprobing/multicontainer_readiness_test.go
@@ -1,0 +1,97 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2024 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multicontainerprobing
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/spoof"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/test"
+	v1test "knative.dev/serving/test/v1"
+)
+
+func TestMultiContainerReadiness(t *testing.T) {
+	t.Parallel()
+
+	clients := test.Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.ServingContainer,
+		Sidecars: []string{
+			test.SidecarContainer,
+		},
+	}
+
+	containers := []corev1.Container{
+		{
+			Image: pkgTest.ImagePath(names.Image),
+			Ports: []corev1.ContainerPort{{
+				ContainerPort: 8881,
+			}},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/",
+						Port: intstr.FromInt32(8881),
+					}},
+			},
+		}, {
+			Image: pkgTest.ImagePath(names.Sidecars[0]),
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/",
+						Port: intstr.FromInt32(8882),
+					}},
+			},
+		},
+	}
+
+	test.EnsureTearDown(t, clients, &names)
+
+	t.Log("Creating a new Service")
+
+	resources, err := v1test.CreateServiceReady(t, clients, &names, func(svc *v1.Service) {
+		svc.Spec.Template.Spec.Containers = containers
+	})
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	url := resources.Route.Status.URL.URL()
+	if _, err := pkgTest.CheckEndpointState(
+		context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		url,
+		spoof.MatchesAllOf(spoof.IsStatusOK, spoof.MatchesBody(test.MultiContainerResponse)),
+		"MulticontainerServesExpectedText",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("The endpoint %s for Route %s didn't serve the expected text %q: %v", url, names.Route, test.MultiContainerResponse, err)
+	}
+}


### PR DESCRIPTION
Fixes #8949

## Proposed Changes
* Based in this FT: https://docs.google.com/document/d/1tw1udxZ-tUcBB0m0Mc2QUEOZiy5vKdxtiBSyeGjOSq0/edit?usp=sharing
* Adds a new flag `multi-container-probing` to enable the new behaviour
* Adds validation and defaulting for liveness and readiness probes for sidecars
* Enables the QP env `SERVING_READINESS_PROBE` to also allow containing a slice of readiness probes
* Extends the `Probe` implementation to support multiple checks

**Release Note**

```release-note
A new feature (`multi-container-probing`) is introduced to enable liveness and readiness probes for Knative Services with multiple containers
```

**Documentation**
https://github.com/knative/docs/pull/5855
