### PR TITLE
Prevent a PodAutoscaler's DesiredScale to turn to -1

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -55,7 +55,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientgotesting "k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
 
 	"github.com/google/go-cmp/cmp"
 	"go.opencensus.io/resource"
@@ -2019,41 +2018,41 @@ func TestComputeStatus(t *testing.T) {
 		pcReady: 0,
 		pcWant:  1,
 
-		wantActualScale:  pointer.Int32(0),
-		wantDesiredScale: pointer.Int32(1),
+		wantActualScale:  ptr.Int32(0),
+		wantDesiredScale: ptr.Int32(1),
 	}, {
 		name: "ready",
 
-		haveActual:       pointer.Int32(0),
-		haveDesiredScale: pointer.Int32(1),
+		haveActual:       ptr.Int32(0),
+		haveDesiredScale: ptr.Int32(1),
 
 		pcReady: 1,
 		pcWant:  1,
 
-		wantActualScale:  pointer.Int32(1),
-		wantDesiredScale: pointer.Int32(1),
+		wantActualScale:  ptr.Int32(1),
+		wantDesiredScale: ptr.Int32(1),
 	}, {
 		name: "stable",
 
-		haveActual:       pointer.Int32(1),
-		haveDesiredScale: pointer.Int32(1),
+		haveActual:       ptr.Int32(1),
+		haveDesiredScale: ptr.Int32(1),
 
 		pcReady: 1,
 		pcWant:  1,
 
-		wantActualScale:  pointer.Int32(1),
-		wantDesiredScale: pointer.Int32(1),
+		wantActualScale:  ptr.Int32(1),
+		wantDesiredScale: ptr.Int32(1),
 	}, {
 		name: "no metrics",
 
-		haveActual:       pointer.Int32(1),
-		haveDesiredScale: pointer.Int32(2),
+		haveActual:       ptr.Int32(1),
+		haveDesiredScale: ptr.Int32(2),
 
 		pcReady: 2,
 		pcWant:  -1,
 
-		wantActualScale:  pointer.Int32(2),
-		wantDesiredScale: pointer.Int32(2),
+		wantActualScale:  ptr.Int32(2),
+		wantDesiredScale: ptr.Int32(2),
 	}}
 
 	tc := &testConfigStore{config: defaultConfig()}

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -55,6 +55,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/utils/pointer"
 
 	"github.com/google/go-cmp/cmp"
 	"go.opencensus.io/resource"
@@ -601,7 +602,7 @@ func TestReconcile(t *testing.T) {
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			// SKS does not exist, so we're just creating and have no status.
 			Object: kpa(testNamespace, testRevision, WithPASKSNotReady("No Private Service Name"),
-				WithBufferedTraffic, WithPAMetricsService(privateSvc), withScales(0, unknownScale),
+				WithBufferedTraffic, WithPAMetricsService(privateSvc), withScales(0, defaultScale),
 				WithObservedGeneration(1)),
 		}},
 		WantCreates: []runtime.Object{
@@ -1992,6 +1993,100 @@ func TestComputeActivatorNum(t *testing.T) {
 			got := computeNumActivators(c.pods, c.decider)
 			if got != c.want {
 				t.Errorf("computeNumActivators() = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestComputeStatus(t *testing.T) {
+	cases := []struct {
+		name string
+
+		haveActual       *int32
+		haveDesiredScale *int32
+
+		pcReady int
+		pcWant  int
+
+		wantActualScale  *int32
+		wantDesiredScale *int32
+	}{{
+		name: "initial",
+
+		haveActual:       nil,
+		haveDesiredScale: nil,
+
+		pcReady: 0,
+		pcWant:  1,
+
+		wantActualScale:  pointer.Int32(0),
+		wantDesiredScale: pointer.Int32(1),
+	}, {
+		name: "ready",
+
+		haveActual:       pointer.Int32(0),
+		haveDesiredScale: pointer.Int32(1),
+
+		pcReady: 1,
+		pcWant:  1,
+
+		wantActualScale:  pointer.Int32(1),
+		wantDesiredScale: pointer.Int32(1),
+	}, {
+		name: "stable",
+
+		haveActual:       pointer.Int32(1),
+		haveDesiredScale: pointer.Int32(1),
+
+		pcReady: 1,
+		pcWant:  1,
+
+		wantActualScale:  pointer.Int32(1),
+		wantDesiredScale: pointer.Int32(1),
+	}, {
+		name: "no metrics",
+
+		haveActual:       pointer.Int32(1),
+		haveDesiredScale: pointer.Int32(2),
+
+		pcReady: 2,
+		pcWant:  -1,
+
+		wantActualScale:  pointer.Int32(2),
+		wantDesiredScale: pointer.Int32(2),
+	}}
+
+	tc := &testConfigStore{config: defaultConfig()}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := tc.ToContext(context.Background())
+
+			pa := &autoscalingv1alpha1.PodAutoscaler{
+				Status: autoscalingv1alpha1.PodAutoscalerStatus{
+					ActualScale:  c.haveActual,
+					DesiredScale: c.haveDesiredScale,
+				},
+			}
+			pc := podCounts{
+				ready: c.pcReady,
+				want:  c.pcWant,
+			}
+
+			computeStatus(ctx, pa, pc, logging.FromContext(ctx))
+
+			if c.wantActualScale == nil && pa.Status.ActualScale != nil || c.wantActualScale != nil && pa.Status.ActualScale == nil {
+				t.Errorf("Unexpected ActualScale. Want: %v, Got: %v", c.wantActualScale, pa.Status.ActualScale)
+			}
+			if c.wantActualScale != nil && pa.Status.ActualScale != nil && *c.wantActualScale != *pa.Status.ActualScale {
+				t.Errorf("Unexpected ActualScale. Want: %d, Got: %d", *c.wantActualScale, *pa.Status.ActualScale)
+			}
+
+			if c.wantDesiredScale == nil && pa.Status.DesiredScale != nil || c.wantDesiredScale != nil && pa.Status.DesiredScale == nil {
+				t.Errorf("Unexpected DesiredScale. Want: %v, Got: %v", c.wantDesiredScale, pa.Status.DesiredScale)
+			}
+			if c.wantDesiredScale != nil && pa.Status.DesiredScale != nil && *c.wantDesiredScale != *pa.Status.DesiredScale {
+				t.Errorf("Unexpected DesiredScale. Want: %d, Got: %d", *c.wantDesiredScale, *pa.Status.DesiredScale)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #14669

## Proposed Changes

* This changed the Knative PodAutoscaler logic to never change the DesiredScale from a non-negative to a negative value.
* This happens when leading AutoScaler restarted and it has no metrics. Moments later once it has metrics, it will change it back.
* While this has no functional impact, it causes such a change for every revision which leads to four Kubernetes API calls (update PodAutoscaler in autoscaler, update Revision in controller, and then again PodAutoscaler in autoscaler, update Revision in controller) which has massive impact as QPS slows down overall progression inside these two controllers.

**Release Note**

```release-note
The autoscaler now keeps the desiredScale of a PodAutoscaler at its current value while it initializes and therefore has not yet metrics
```
