### PR TITLE
Add revision-failure test image

### DIFF
--- a/test/test_images/revisionfailure/revisionfailure.go
+++ b/test/test_images/revisionfailure/revisionfailure.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"knative.dev/serving/test"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	log.Print("Hello world received a request.")
+	fmt.Fprintf(w, "Hello %v! How about some tasty noodles?", os.Getenv("NAME"))
+}
+
+func main() {
+	flag.Parse()
+	log.Print("Hello world app started.")
+
+	entries, err := os.ReadDir("/etc/config")
+	if err != nil {
+		log.Fatal("failed to read failure list", err)
+	}
+
+	for _, e := range entries {
+		if e.Name() == os.Getenv("K_REVISION") {
+			log.Fatalf("you want me to fail")
+		}
+	}
+
+	test.ListenAndServeGracefully(":8080", handler)
+}

--- a/test/test_images/revisionfailure/service.yaml
+++ b/test/test_images/revisionfailure/service.yaml
@@ -1,0 +1,28 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: revision-failure
+  namespace: default
+spec:
+  template:
+    spec:
+      timeoutSeconds: 30
+      containers:
+      - image: ko://knative.dev/serving/test/test_images/revisionfailure
+        env:
+        - name: NAME
+          value: "$NAME"
+        volumeMounts:
+        - name: failure-list
+          mountPath: /etc/config
+      volumes:
+      - name: failure-list
+        configMap:
+          name: revision-failure
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: revision-failure
+# data:
+#   revision-failure-00001: "1"


### PR DESCRIPTION
This let's you control which revisions fail on startup by updating a config map with the revision name as the key

eg. `kubectl patch configmap revision-failure -p '{"data":{"revision-failure-00001":"1"}}'`

This is useful for debugging so thought it would be worth contributing
