### PR TITLE
test/e2e: WaitForScaleToZero assertion isn't strict enough

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -84,7 +84,13 @@ func WaitForScaleToZero(t *testing.T, deploymentName string, clients *test.Clien
 		clients.KubeClient,
 		deploymentName,
 		func(d *appsv1.Deployment) (bool, error) {
-			return d.Status.ReadyReplicas == 0, nil
+			return (d.Spec.Replicas == nil || *d.Spec.Replicas == 0) &&
+					d.Status.Replicas == 0 &&
+					d.Status.UpdatedReplicas == 0 &&
+					d.Status.ReadyReplicas == 0 &&
+					d.Status.AvailableReplicas == 0 &&
+					d.Status.UnavailableReplicas == 0,
+				nil
 		},
 		"DeploymentIsScaledDown",
 		test.ServingFlags.TestNamespace,


### PR DESCRIPTION
`ReadyReplicas=0` isn't strict enough to ensure we scaled to zero and that there are no pods.