### PR TITLE
Drop k8s v1.27 from kind testing and update cluster version to 1.28 in e2e

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -87,8 +87,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.27.x
         - v1.28.x
+        - v1.29.x
 
         ingress:
         - kourier

--- a/test/e2e-external-domain-tls-tests.sh
+++ b/test/e2e-external-domain-tls-tests.sh
@@ -159,7 +159,7 @@ function delete_dns_record() {
 }
 
 # Script entry point.
-initialize "$@" --num-nodes=4 --enable-ha --cluster-version=1.27
+initialize "$@" --num-nodes=4 --enable-ha --cluster-version=1.28
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -28,7 +28,7 @@
 source $(dirname $0)/e2e-common.sh
 
 # Script entry point.
-initialize --num-nodes=4 --enable-ha --cluster-version=1.27 "$@"
+initialize --num-nodes=4 --enable-ha --cluster-version=1.28 "$@"
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -42,7 +42,7 @@ function stage_test_resources() {
 # Skip installing istio as an add-on.
 # Skip installing a pvc as it is not used in upgrade tests
 # Skip installing a resource quota as it is not used in upgrade tests
-PVC=0 QUOTA=0 initialize "$@" --num-nodes=4 --cluster-version=1.27 \
+PVC=0 QUOTA=0 initialize "$@" --num-nodes=4 --cluster-version=1.28 \
   --install-latest-release
 
 # TODO(#2656): Reduce the timeout after we get this test to consistently passing.

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -38,7 +38,7 @@ declare ARTIFACTS
 
 ns="default"
 
-initialize --num-nodes=10 --cluster-version=1.27 "$@"
+initialize --num-nodes=10 --cluster-version=1.28 "$@"
 
 function run_job() {
   local name=$1


### PR DESCRIPTION
## Proposed Changes

* Drop k8s v1.27 from kind testing
* Add k8s v1.29 to kind testing
* Use k8s v1.28 in prow
