### PR TITLE
feat: bubble up kcert status message when it's failed

### DIFF
--- a/pkg/apis/serving/v1/route_lifecycle.go
+++ b/pkg/apis/serving/v1/route_lifecycle.go
@@ -166,10 +166,11 @@ func (rs *RouteStatus) MarkMissingTrafficTarget(kind, name string) {
 // MarkCertificateProvisionFailed marks the
 // RouteConditionCertificateProvisioned condition to indicate that the
 // Certificate provisioning failed.
-func (rs *RouteStatus) MarkCertificateProvisionFailed(name string) {
+func (rs *RouteStatus) MarkCertificateProvisionFailed(c *v1alpha1.Certificate) {
+	certificateCondition := c.Status.GetCondition(apis.ConditionReady)
 	routeCondSet.Manage(rs).MarkFalse(RouteConditionCertificateProvisioned,
 		"CertificateProvisionFailed",
-		"Certificate %s fails to be provisioned.", name)
+		"Certificate %s fails to be provisioned: %s", c.Name, certificateCondition.GetReason())
 }
 
 // MarkCertificateReady marks the RouteConditionCertificateProvisioned

--- a/pkg/apis/serving/v1/route_lifecycle_test.go
+++ b/pkg/apis/serving/v1/route_lifecycle_test.go
@@ -428,54 +428,85 @@ func TestRouteNotOwnedStuff(t *testing.T) {
 	apistest.CheckConditionFailed(r, RouteConditionReady, t)
 }
 
-func TestCertificateReady(t *testing.T) {
-	r := &RouteStatus{}
-	r.InitializeConditions()
-	r.MarkCertificateReady("cert")
+func TestCertificateProvision(t *testing.T) {
+	message := "CommonName Too Long"
 
-	apistest.CheckConditionSucceeded(r, RouteConditionCertificateProvisioned, t)
-}
+	cases := []struct {
+		name   string
+		cert   *netv1alpha1.Certificate
+		status corev1.ConditionStatus
 
-func TestCertificateNotReady(t *testing.T) {
-	r := &RouteStatus{}
-	r.InitializeConditions()
-	r.MarkCertificateNotReady(&netv1alpha1.Certificate{})
-
-	apistest.CheckConditionOngoing(r, RouteConditionCertificateProvisioned, t)
-}
-
-func TestCertificateNotReadyWithBubbledUpMessage(t *testing.T) {
-	cert := &netv1alpha1.Certificate{
-		Status: netv1alpha1.CertificateStatus{
-			Status: duckv1.Status{
-				Conditions: duckv1.Conditions{
-					{
-						Type:   "Ready",
-						Status: "False",
-						Reason: "CommonName Too Long",
-					},
+		wantMessage string
+	}{{
+		name:        "Ready with empty message",
+		cert:        &netv1alpha1.Certificate{},
+		status:      corev1.ConditionTrue,
+		wantMessage: "",
+	}, {
+		name:        "NotReady with empty message",
+		cert:        &netv1alpha1.Certificate{},
+		status:      corev1.ConditionUnknown,
+		wantMessage: "",
+	}, {
+		name: "NotReady with bubbled up message",
+		cert: &netv1alpha1.Certificate{
+			Status: netv1alpha1.CertificateStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{{
+						Type:   apis.ConditionReady,
+						Status: corev1.ConditionUnknown,
+						Reason: message,
+					}},
 				},
 			},
 		},
+		status:      corev1.ConditionUnknown,
+		wantMessage: message,
+	}, {
+		name:        "Failed with empty message",
+		cert:        &netv1alpha1.Certificate{},
+		status:      corev1.ConditionFalse,
+		wantMessage: "",
+	}, {
+		name: "Failed with bubbled up message",
+		cert: &netv1alpha1.Certificate{
+			Status: netv1alpha1.CertificateStatus{
+				Status: duckv1.Status{
+					Conditions: duckv1.Conditions{{
+						Type:   apis.ConditionReady,
+						Status: corev1.ConditionFalse,
+						Reason: message,
+					}},
+				},
+			},
+		},
+		status:      corev1.ConditionFalse,
+		wantMessage: message,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &RouteStatus{}
+			r.InitializeConditions()
+
+			if tc.status == corev1.ConditionTrue {
+				r.MarkCertificateReady(tc.cert.Name)
+			} else if tc.status == corev1.ConditionFalse {
+				r.MarkCertificateProvisionFailed(tc.cert)
+			} else {
+				r.MarkCertificateNotReady(tc.cert)
+			}
+
+			if err := apistest.CheckCondition(r, RouteConditionCertificateProvisioned, tc.status); err != nil {
+				t.Error(err)
+			}
+
+			certMessage := r.Status.GetCondition(apis.ConditionReady).Message
+			if !strings.Contains(certMessage, tc.wantMessage) {
+				t.Errorf("Literal %q not found in status message: %q", tc.wantMessage, certMessage)
+			}
+		})
 	}
-
-	r := &RouteStatus{}
-	r.InitializeConditions()
-	r.MarkCertificateNotReady(cert)
-
-	expectedCertMessage := "CommonName Too Long"
-	certMessage := r.Status.GetCondition("Ready").Message
-	if !strings.Contains(certMessage, expectedCertMessage) {
-		t.Errorf("Literal %q not found in status message: %q", expectedCertMessage, certMessage)
-	}
-}
-
-func TestCertificateProvisionFailed(t *testing.T) {
-	r := &RouteStatus{}
-	r.InitializeConditions()
-	r.MarkCertificateProvisionFailed("cert")
-
-	apistest.CheckConditionFailed(r, RouteConditionCertificateProvisioned, t)
 }
 
 func TestRouteNotOwnCertificate(t *testing.T) {

--- a/pkg/testing/v1/route.go
+++ b/pkg/testing/v1/route.go
@@ -203,6 +203,11 @@ func MarkCertificateNotReady(r *v1.Route) {
 	r.Status.MarkCertificateNotReady(&netv1alpha1.Certificate{})
 }
 
+// MarkCertificateProvisionFailed calls the method of the same name on .Status
+func MarkCertificateProvisionFailed(r *v1.Route) {
+	r.Status.MarkCertificateProvisionFailed(&netv1alpha1.Certificate{})
+}
+
 // MarkCertificateNotOwned calls the method of the same name on .Status
 func MarkCertificateNotOwned(r *v1.Route) {
 	r.Status.MarkCertificateNotOwned(routenames.Certificate(r))


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/14530

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* KCert Status Message gets bubbled up to its parent Route when it's failed

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Certificate generation errors are bubbled up to its parent Route.
```
