### PR TITLE
Modify the description of ConfigMap  config-defaults

### DIFF
--- a/config/core/configmaps/defaults.yaml
+++ b/config/core/configmaps/defaults.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "e7973912"
+    knative.dev/example-checksum: "5b64ff5c"
 data:
   _example: |
     ################################

--- a/config/core/configmaps/defaults.yaml
+++ b/config/core/configmaps/defaults.yaml
@@ -50,7 +50,7 @@ data:
     # This value must be greater than or equal to revision-timeout-seconds.
     # If omitted, the system default is used (600 seconds).
     #
-    # If this value is increased, the activator's terminationGraceTimeSeconds
+    # If this value is increased, the activator's terminationGracePeriodSeconds
     # should also be increased to prevent in-flight requests being disrupted.
     max-revision-timeout-seconds: "600"  # 10 minutes
 


### PR DESCRIPTION
TerminationGrace`Period`Seconds is more appropriate than terminationGrace`Time`Seconds.
The ConfigMap description probably explain about fallowing value.

https://github.com/knative/serving/blob/6dc7097b740f6b0e6ae744abad5e84338a1b8066/config/core/deployments/activator.yaml#L124

I believe this PR makes the comment more understandable.

Thank you.
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Modified terminationGraceTimeSeconds in the config map description to terminationGracePeriodSeconds.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```


