### PR TITLE
Check for nil before calling deep-equal

### DIFF
--- a/pkg/activator/certificate/cache_test.go
+++ b/pkg/activator/certificate/cache_test.go
@@ -141,7 +141,7 @@ func TestReconcile(t *testing.T) {
 		cr.certificatesMux.RLock()
 		defer cr.certificatesMux.RUnlock()
 		cert, err := cr.GetCertificate(nil)
-		return err == nil && reflect.DeepEqual(newCert.Certificate, cert.Certificate), nil
+		return err == nil && cert != nil && reflect.DeepEqual(newCert.Certificate, cert.Certificate), nil
 	}); err != nil {
 		t.Fatalf("timeout to update the cert: %v", err)
 	}


### PR DESCRIPTION
## Proposed Changes
* Adds nil check before comparing to avoid nil-pointer as in [build](https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_serving/14995/unit-tests_serving_main/1767113984319688704)

/assign @skonto 
