### PR TITLE
remove special logic for user-agent header with istio mtls

### DIFF
--- a/config/core/deployments/activator.yaml
+++ b/config/core/deployments/activator.yaml
@@ -99,17 +99,11 @@ spec:
         readinessProbe:
           httpGet:
             port: 8012
-            httpHeaders:
-            - name: k-kubelet-probe
-              value: "activator"
           periodSeconds: 5
           failureThreshold: 5
         livenessProbe:
           httpGet:
             port: 8012
-            httpHeaders:
-            - name: k-kubelet-probe
-              value: "activator"
           periodSeconds: 10
           failureThreshold: 12
           initialDelaySeconds: 15

--- a/config/core/deployments/autoscaler.yaml
+++ b/config/core/deployments/autoscaler.yaml
@@ -106,15 +106,9 @@ spec:
         readinessProbe:
           httpGet:
             port: 8080
-            httpHeaders:
-            - name: k-kubelet-probe
-              value: "autoscaler"
         livenessProbe:
           httpGet:
             port: 8080
-            httpHeaders:
-            - name: k-kubelet-probe
-              value: "autoscaler"
           failureThreshold: 6
 
 ---

--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -106,17 +106,11 @@ spec:
           httpGet:
             scheme: HTTPS
             port: 8443
-            httpHeaders:
-            - name: k-kubelet-probe
-              value: "webhook"
         livenessProbe:
           periodSeconds: 1
           httpGet:
             scheme: HTTPS
             port: 8443
-            httpHeaders:
-            - name: k-kubelet-probe
-              value: "webhook"
           failureThreshold: 6
           initialDelaySeconds: 20
 

--- a/pkg/queue/handler_test.go
+++ b/pkg/queue/handler_test.go
@@ -217,7 +217,7 @@ func TestIgnoreProbe(t *testing.T) {
 	h := ProxyHandler(breaker, stats, false /*tracingEnabled*/, proxy)
 
 	req := httptest.NewRequest(http.MethodPost, "http://prob.in", nil)
-	req.Header.Set(netheader.KubeletProbeKey, "1") // Mark it a probe.
+	req.Header.Set("User-Agent", netheader.KubeProbeUAPrefix+"1.29") // Mark it a probe.
 	go h(httptest.NewRecorder(), req)
 	go h(httptest.NewRecorder(), req)
 

--- a/pkg/queue/handler_test.go
+++ b/pkg/queue/handler_test.go
@@ -217,7 +217,7 @@ func TestIgnoreProbe(t *testing.T) {
 	h := ProxyHandler(breaker, stats, false /*tracingEnabled*/, proxy)
 
 	req := httptest.NewRequest(http.MethodPost, "http://prob.in", nil)
-	req.Header.Set("User-Agent", netheader.KubeProbeUAPrefix+"1.29") // Mark it a probe.
+	req.Header.Set(netheader.KubeletProbeKey, "1") // Mark it a probe.
 	go h(httptest.NewRecorder(), req)
 	go h(httptest.NewRecorder(), req)
 

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	netheader "knative.dev/networking/pkg/http/header"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/ptr"
 	"knative.dev/serving/pkg/apis/autoscaling"
@@ -136,22 +135,6 @@ func certVolume(secret string) corev1.Volume {
 				SecretName: secret,
 			},
 		},
-	}
-}
-
-func addLivenessProbeHeader(p *corev1.Probe) {
-	if p == nil {
-		return
-	}
-	switch {
-	case p.HTTPGet != nil:
-		// With mTLS enabled, Istio rewrites probes, but doesn't spoof the kubelet
-		// user agent, so we need to inject an extra header to be able to distinguish
-		// between probes and real requests.
-		p.HTTPGet.HTTPHeaders = append(p.HTTPGet.HTTPHeaders, corev1.HTTPHeader{
-			Name:  netheader.KubeletProbeKey,
-			Value: queue.Name,
-		})
 	}
 }
 
@@ -272,10 +255,6 @@ func makeContainer(container corev1.Container, rev *v1.Revision) corev1.Containe
 			// container instead of via kubelet.
 			container.ReadinessProbe = nil
 		}
-	}
-
-	if container.LivenessProbe != nil {
-		addLivenessProbeHeader(container.LivenessProbe)
 	}
 
 	return container

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -917,7 +917,7 @@ func TestMakePodSpec(t *testing.T) {
 					container.Image = "busybox@sha256:deadbeef"
 				}),
 				queueContainer(
-					withEnvVar("SERVING_READINESS_PROBE", `{"httpGet":{"path":"/","port":8080,"host":"127.0.0.1","scheme":"HTTP","httpHeaders":[{"name":"K-Kubelet-Probe","value":"queue"}]}}`),
+					withEnvVar("SERVING_READINESS_PROBE", `{"httpGet":{"path":"/","port":8080,"host":"127.0.0.1","scheme":"HTTP"}}`),
 				),
 			}),
 	}, {
@@ -1014,10 +1014,6 @@ func TestMakePodSpec(t *testing.T) {
 						HTTPGet: &corev1.HTTPGetAction{
 							Path: "/",
 							Port: intstr.FromInt(v1.DefaultUserPort),
-							HTTPHeaders: []corev1.HTTPHeader{{
-								Name:  netheader.KubeletProbeKey,
-								Value: queue.Name,
-							}},
 						},
 					}),
 				),
@@ -1410,7 +1406,7 @@ func TestMakePodSpec(t *testing.T) {
 				),
 				queueContainer(
 					withEnvVar("ENABLE_MULTI_CONTAINER_PROBES", "true"),
-					withEnvVar("SERVING_READINESS_PROBE", `[{"httpGet":{"path":"/","port":8080,"host":"127.0.0.1","scheme":"HTTP","httpHeaders":[{"name":"K-Kubelet-Probe","value":"queue"}]}},{"httpGet":{"path":"/","port":8090,"host":"127.0.0.1","scheme":"HTTP","httpHeaders":[{"name":"K-Kubelet-Probe","value":"queue"}]}}]`),
+					withEnvVar("SERVING_READINESS_PROBE", `[{"httpGet":{"path":"/","port":8080,"host":"127.0.0.1","scheme":"HTTP"}},{"httpGet":{"path":"/","port":8090,"host":"127.0.0.1","scheme":"HTTP"}}]`),
 				),
 			}),
 	}}

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -481,11 +481,6 @@ func applyReadinessProbeDefaults(p *corev1.Probe, port int32) {
 		if p.HTTPGet.Scheme == "" {
 			p.HTTPGet.Scheme = corev1.URISchemeHTTP
 		}
-
-		p.HTTPGet.HTTPHeaders = append(p.HTTPGet.HTTPHeaders, corev1.HTTPHeader{
-			Name:  netheader.KubeletProbeKey,
-			Value: queue.Name,
-		})
 	case p.TCPSocket != nil:
 		p.TCPSocket.Host = localAddress
 		p.TCPSocket.Port = intstr.FromInt32(port)

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -758,10 +758,6 @@ func TestProbeGenerationHTTPDefaults(t *testing.T) {
 				Path:   "/",
 				Port:   intstr.FromInt(int(v1.DefaultUserPort)),
 				Scheme: corev1.URISchemeHTTP,
-				HTTPHeaders: []corev1.HTTPHeader{{
-					Name:  netheader.KubeletProbeKey,
-					Value: queue.Name,
-				}},
 			},
 		},
 		PeriodSeconds:  1,
@@ -833,10 +829,6 @@ func TestProbeGenerationHTTP(t *testing.T) {
 				Path:   probePath,
 				Port:   intstr.FromInt(userPort),
 				Scheme: corev1.URISchemeHTTPS,
-				HTTPHeaders: []corev1.HTTPHeader{{
-					Name:  netheader.KubeletProbeKey,
-					Value: queue.Name,
-				}},
 			},
 		},
 		PeriodSeconds:  2,


### PR DESCRIPTION
# Changes

- Remove logic that adds a custom header (k-kubelet-probe) in requests coming from kubelet with istio mtls

Fixes #14981 