### PR TITLE
Replace all usages of deprecated wait.PollImmediate with wait.PollUntilContextTimeout

### DIFF
--- a/vendor/knative.dev/networking/pkg/prober/prober.go
+++ b/vendor/knative.dev/networking/pkg/prober/prober.go
@@ -186,7 +186,7 @@ func (m *Manager) doAsync(ctx context.Context, target string, arg interface{}, p
 			result bool
 			inErr  error
 		)
-		err := wait.PollImmediate(period, timeout, func() (bool, error) {
+		err := wait.PollUntilContextTimeout(ctx, period, timeout, true, func(ctx context.Context) (bool, error) {
 			result, inErr = Do(ctx, m.transport, target, ops...)
 			// Do not return error, which is from verifierError, as retry is expected until timeout.
 			return result, nil

--- a/vendor/knative.dev/pkg/injection/sharedmain/main.go
+++ b/vendor/knative.dev/pkg/injection/sharedmain/main.go
@@ -74,7 +74,7 @@ func GetLoggingConfig(ctx context.Context) (*logging.Config, error) {
 	// These timeout and retry interval are set by heuristics.
 	// e.g. istio sidecar needs a few seconds to configure the pod network.
 	var lastErr error
-	if err := wait.PollImmediate(1*time.Second, 5*time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 5*time.Second, true, func(ctx context.Context) (bool, error) {
 		loggingConfigMap, lastErr = kubeclient.Get(ctx).CoreV1().ConfigMaps(system.Namespace()).Get(ctx, logging.ConfigMapName(), metav1.GetOptions{})
 		return lastErr == nil || apierrors.IsNotFound(lastErr), nil
 	}); err != nil {

--- a/vendor/knative.dev/pkg/reconciler/testing/context.go
+++ b/vendor/knative.dev/pkg/reconciler/testing/context.go
@@ -120,7 +120,7 @@ func RunAndSyncInformers(ctx context.Context, informers ...controller.Informer) 
 		return wf, err
 	}
 
-	err = wait.PollImmediate(time.Microsecond, wait.ForeverTestTimeout, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Microsecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
 		if watchesPending.Load() == 0 {
 			return true, nil
 		}

--- a/vendor/knative.dev/pkg/test/ha/ha.go
+++ b/vendor/knative.dev/pkg/test/ha/ha.go
@@ -78,7 +78,7 @@ func WaitForNewLeaders(ctx context.Context, t *testing.T, client kubernetes.Inte
 	defer span.End()
 
 	var leaders sets.Set[string]
-	err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
 		currLeaders, err := GetLeaders(ctx, t, client, deploymentName, namespace)
 		if err != nil {
 			return false, err
@@ -105,7 +105,7 @@ func WaitForNewLeader(ctx context.Context, client kubernetes.Interface, lease, n
 	span := logging.GetEmitableSpan(ctx, "WaitForNewLeader/"+lease)
 	defer span.End()
 	var leader string
-	err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
 		lease, err := client.CoordinationV1().Leases(namespace).Get(ctx, lease, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("error getting lease %s: %w", lease, err)

--- a/vendor/knative.dev/pkg/test/spoof/spoof.go
+++ b/vendor/knative.dev/pkg/test/spoof/spoof.go
@@ -167,7 +167,7 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker, check
 	}
 
 	var resp *Response
-	err := wait.PollImmediate(sc.RequestInterval, sc.RequestTimeout, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), sc.RequestInterval, sc.RequestTimeout, true, func(ctx context.Context) (bool, error) {
 		// Starting span to capture zipkin trace.
 		traceContext, span := trace.StartSpan(req.Context(), "SpoofingClient-Trace")
 		defer span.End()


### PR DESCRIPTION


Fixes #14692 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Replace usages of deprecated wait.PollImmediate with wait.PollUntilContextTimeout

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
