### PR TITLE
Make route domain error specific

### DIFF
--- a/pkg/apis/serving/v1/route_lifecycle.go
+++ b/pkg/apis/serving/v1/route_lifecycle.go
@@ -117,6 +117,12 @@ func (rs *RouteStatus) MarkUnknownTrafficError(msg string) {
 	routeCondSet.Manage(rs).MarkUnknown(RouteConditionAllTrafficAssigned, "Unknown", msg)
 }
 
+// MarkRevisionTargetTrafficError marks the RouteConditionAllTrafficAssigned condition
+// to indicate an error has occurred wrt a revision target.
+func (rs *RouteStatus) MarkRevisionTargetTrafficError(reason, msg string) {
+	routeCondSet.Manage(rs).MarkFalse(RouteConditionAllTrafficAssigned, reason, msg)
+}
+
 // MarkConfigurationNotReady marks the RouteConditionAllTrafficAssigned
 // condition to indiciate the Revision is not yet ready.
 func (rs *RouteStatus) MarkConfigurationNotReady(name string) {

--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -44,7 +44,7 @@ import (
 const HTTPScheme string = "http"
 
 var (
-	DomainNameError = errors.New("domain name error")
+	ErrorDomainName = errors.New("domain name error")
 )
 
 // GetAllDomainsAndTags returns all of the domains and tags(including subdomains) associated with a Route
@@ -124,12 +124,12 @@ func DomainNameFromTemplate(ctx context.Context, r metav1.ObjectMeta, name strin
 	}
 
 	if err := templ.Execute(&buf, data); err != nil {
-		return "", fmt.Errorf("%w: error executing the DomainTemplate: %w", DomainNameError, err)
+		return "", fmt.Errorf("%w: error executing the DomainTemplate: %w", ErrorDomainName, err)
 	}
 
 	urlErrs := validation.IsFullyQualifiedDomainName(field.NewPath("url"), buf.String())
 	if urlErrs != nil {
-		return "", fmt.Errorf("%w: invalid domain name %q: %s", DomainNameError, buf.String(), urlErrs.ToAggregate())
+		return "", fmt.Errorf("%w: invalid domain name %q: %w", ErrorDomainName, buf.String(), urlErrs.ToAggregate())
 	}
 
 	return buf.String(), nil
@@ -152,7 +152,7 @@ func HostnameFromTemplate(ctx context.Context, name, tag string) (string, error)
 	networkConfig := config.FromContext(ctx).Network
 	buf := bytes.Buffer{}
 	if err := networkConfig.GetTagTemplate().Execute(&buf, data); err != nil {
-		return "", fmt.Errorf("%w: error executing the TagTemplate: %w", DomainNameError, err)
+		return "", fmt.Errorf("%w: error executing the TagTemplate: %w", ErrorDomainName, err)
 	}
 	return buf.String(), nil
 }

--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -134,7 +134,7 @@ func DomainNameFromTemplate(ctx context.Context, r metav1.ObjectMeta, name strin
 
 	urlErrs := validation.IsFullyQualifiedDomainName(field.NewPath("url"), buf.String())
 	if urlErrs != nil {
-		return "", DomainNameError{msg: fmt.Sprintf("invalid domain name %q: %q", buf.String(), urlErrs.ToAggregate())}
+		return "", DomainNameError{msg: fmt.Sprintf("invalid domain name %q: %s", buf.String(), urlErrs.ToAggregate())}
 	}
 
 	return buf.String(), nil

--- a/pkg/reconciler/route/domains/domains.go
+++ b/pkg/reconciler/route/domains/domains.go
@@ -129,12 +129,12 @@ func DomainNameFromTemplate(ctx context.Context, r metav1.ObjectMeta, name strin
 	}
 
 	if err := templ.Execute(&buf, data); err != nil {
-		return "", DomainNameError{msg: fmt.Errorf("error executing the DomainTemplate: %w", err).Error()}
+		return "", DomainNameError{msg: fmt.Sprintf("error executing the DomainTemplate: %q", err.Error())}
 	}
 
 	urlErrs := validation.IsFullyQualifiedDomainName(field.NewPath("url"), buf.String())
 	if urlErrs != nil {
-		return "", DomainNameError{msg: fmt.Errorf("invalid domain name %q: %w", buf.String(), urlErrs.ToAggregate()).Error()}
+		return "", DomainNameError{msg: fmt.Sprintf("invalid domain name %q: %q", buf.String(), urlErrs.ToAggregate())}
 	}
 
 	return buf.String(), nil

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -118,7 +118,11 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconcil
 	traffic, err := c.configureTraffic(ctx, r)
 	if traffic == nil || err != nil {
 		if err != nil {
-			r.Status.MarkUnknownTrafficError(err.Error())
+			if errors.As(err, &domains.DomainNameError{}) {
+				r.Status.MarkRevisionTargetTrafficError("ErrorConfig", err.Error())
+			} else {
+				r.Status.MarkUnknownTrafficError(err.Error())
+			}
 		}
 		// Traffic targets aren't ready, no need to configure child resources.
 		return err

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -79,6 +79,8 @@ type Reconciler struct {
 	enqueueAfter func(interface{}, time.Duration)
 }
 
+const errorConfigMsg = "ErrorConfig"
+
 // Check that our Reconciler implements routereconciler.Interface
 var _ routereconciler.Interface = (*Reconciler)(nil)
 
@@ -119,7 +121,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconcil
 	if traffic == nil || err != nil {
 		if err != nil {
 			if errors.As(err, &domains.DomainNameError{}) {
-				r.Status.MarkRevisionTargetTrafficError("ErrorConfig", err.Error())
+				r.Status.MarkRevisionTargetTrafficError(errorConfigMsg, err.Error())
 			} else {
 				r.Status.MarkUnknownTrafficError(err.Error())
 			}

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -120,7 +120,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconcil
 	traffic, err := c.configureTraffic(ctx, r)
 	if traffic == nil || err != nil {
 		if err != nil {
-			if errors.As(err, &domains.DomainNameError{}) {
+			if errors.Is(err, domains.DomainNameError) {
 				r.Status.MarkRevisionTargetTrafficError(errorConfigMsg, err.Error())
 			} else {
 				r.Status.MarkUnknownTrafficError(err.Error())

--- a/pkg/reconciler/route/route.go
+++ b/pkg/reconciler/route/route.go
@@ -120,7 +120,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1.Route) pkgreconcil
 	traffic, err := c.configureTraffic(ctx, r)
 	if traffic == nil || err != nil {
 		if err != nil {
-			if errors.Is(err, domains.DomainNameError) {
+			if errors.Is(err, domains.ErrorDomainName) {
 				r.Status.MarkRevisionTargetTrafficError(errorConfigMsg, err.Error())
 			} else {
 				r.Status.MarkUnknownTrafficError(err.Error())

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -2048,7 +2048,7 @@ func TestReconcile(t *testing.T) {
 			Object: Route("default", "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long",
 				WithConfigTarget("config"), WithRouteObservedGeneration,
 				WithRouteFinalizer, WithInitRouteConditions,
-				MarkRevisionTargetTrafficError(errorConfigMsg, domains.DomainNameError.Error()+`: invalid domain name "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long.default.example.com": url: Invalid value: "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long": must be no more than 63 characters`),
+				MarkRevisionTargetTrafficError(errorConfigMsg, domains.ErrorDomainName.Error()+`: invalid domain name "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long.default.example.com": url: Invalid value: "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long": must be no more than 63 characters`),
 				WithHost("tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long.default.svc.cluster.local"),
 			),
 		}},

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -2047,7 +2047,7 @@ func TestReconcile(t *testing.T) {
 			Object: Route("default", "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long",
 				WithConfigTarget("config"), WithRouteObservedGeneration,
 				WithRouteFinalizer, WithInitRouteConditions,
-				MarkRevisionTargetTrafficError("ErrorConfig", `invalid domain name "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long.default.example.com": url: Invalid value: "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long": must be no more than 63 characters`),
+				MarkRevisionTargetTrafficError(errorConfigMsg, `invalid domain name "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long.default.example.com": url: Invalid value: "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long": must be no more than 63 characters`),
 				WithHost("tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long.default.svc.cluster.local"),
 			),
 		}},

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -2047,7 +2047,7 @@ func TestReconcile(t *testing.T) {
 			Object: Route("default", "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long",
 				WithConfigTarget("config"), WithRouteObservedGeneration,
 				WithRouteFinalizer, WithInitRouteConditions,
-				MarkUnknownTrafficError(`invalid domain name "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long.default.example.com": url: Invalid value: "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long": must be no more than 63 characters`),
+				MarkRevisionTargetTrafficError("ErrorConfig", `invalid domain name "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long.default.example.com": url: Invalid value: "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long": must be no more than 63 characters`),
 				WithHost("tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long.default.svc.cluster.local"),
 			),
 		}},

--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -53,6 +53,7 @@ import (
 	routereconciler "knative.dev/serving/pkg/client/injection/reconciler/serving/v1/route"
 	kaccessor "knative.dev/serving/pkg/reconciler/accessor"
 	"knative.dev/serving/pkg/reconciler/route/config"
+	"knative.dev/serving/pkg/reconciler/route/domains"
 	"knative.dev/serving/pkg/reconciler/route/resources"
 	"knative.dev/serving/pkg/reconciler/route/traffic"
 
@@ -2047,7 +2048,7 @@ func TestReconcile(t *testing.T) {
 			Object: Route("default", "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long",
 				WithConfigTarget("config"), WithRouteObservedGeneration,
 				WithRouteFinalizer, WithInitRouteConditions,
-				MarkRevisionTargetTrafficError(errorConfigMsg, `invalid domain name "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long.default.example.com": url: Invalid value: "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long": must be no more than 63 characters`),
+				MarkRevisionTargetTrafficError(errorConfigMsg, domains.DomainNameError.Error()+`: invalid domain name "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long.default.example.com": url: Invalid value: "tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long": must be no more than 63 characters`),
 				WithHost("tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo-long.default.svc.cluster.local"),
 			),
 		}},

--- a/pkg/testing/v1/route.go
+++ b/pkg/testing/v1/route.go
@@ -191,10 +191,10 @@ func MarkTrafficAssigned(r *v1.Route) {
 	r.Status.MarkTrafficAssigned()
 }
 
-// MarkUnknownTrafficError calls the method of the same name on .Status
-func MarkUnknownTrafficError(msg string) RouteOption {
+// MarkRevisionTargetTrafficError calls the method of the same name on .Status
+func MarkRevisionTargetTrafficError(reason, msg string) RouteOption {
 	return func(r *v1.Route) {
-		r.Status.MarkUnknownTrafficError(msg)
+		r.Status.MarkRevisionTargetTrafficError(reason, msg)
 	}
 }
 


### PR DESCRIPTION
Fixes #12149

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Makes route error propagation more specific.
Instead of:
```
                    {
                        "lastTransitionTime": "2024-04-03T07:58:25Z",
                        "message": "invalid domain name \"wathola-receiver-test-continuous-events-propagation-with-prober-zxmkp.example.com\": url: Invalid value: \"wathola-receiver-test-continuous-events-propagation-with-prober-zxmkp\": must be no more than 63 characters",
                        "reason": "Unknown",
                        "status": "Unknown",
                        "type": "Ready"
                    }
```
we get:

```
                 {
                        "lastTransitionTime": "2024-04-03T10:07:57Z",
                        "message": "invalid domain name \"wathola-receiver-test-continuous-events-propagation-with-prober-zxmkp.example.com\": url: Invalid value: \"wathola-receiver-test-continuous-events-propagation-with-prober-zxmkp\": must be no more than 63 characters",
                        "reason": "ErrorConfig",
                        "status": "False",
                        "type": "Ready"
                    }
```
* In the future we could make this way permanent errors more specific in other code paths too.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

