### PR TITLE
Disable logstream so the Github Action Log Viewer works

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -216,6 +216,7 @@ jobs:
           -timeout=30m \
           ${{ matrix.test-path }} \
           -skip-cleanup-on-fail \
+          -disable-logstream \
           -enable-alpha -enable-beta \
           --ingress-class=${{ matrix.ingress-class || matrix.ingress }}.ingress.networking.knative.dev \
           ${{ matrix.test-flags }}


### PR DESCRIPTION
gotestsum now prints the entire test output into the github
action group. It does this for successful tests.

Because the logstream is very verbose this breaks the Github
Action UI.

The change in this PR disables the logstream because it is
already available to download through cluster logs which
are attached to the Github Action output as an artifact


/assign @izabelacg 