### PR TITLE
re-enable contour gateway tests

### DIFF
--- a/test/conformance/api/v1/route_test.go
+++ b/test/conformance/api/v1/route_test.go
@@ -22,7 +22,6 @@ package v1
 import (
 	"context"
 	"net/url"
-	"os"
 	"testing"
 
 	pkgtest "knative.dev/pkg/test"
@@ -138,14 +137,6 @@ func TestRouteGetAndList(t *testing.T) {
 }
 
 func TestRouteCreation(t *testing.T) {
-	if os.Getenv("INGRESS_CLASS") == "gateway-api.ingress.networking.knative.dev" &&
-		os.Getenv("GATEWAY_API_IMPLEMENTATION") == "contour" &&
-		os.Getenv("KIND") != "" {
-		// TODO (izabelacg) temporary solution until the following issue is addressed
-		// see https://github.com/knative/serving/issues/15090
-		t.Skip("Known test failure with Contour and Gateway API")
-	}
-
 	if test.ServingFlags.DisableOptionalAPI {
 		t.Skip("Route create/patch/replace APIs are not required by Knative Serving API Specification")
 	}

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -21,7 +21,6 @@ package v1
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -97,14 +96,6 @@ func TestServiceCreateListAndDelete(t *testing.T) {
 //     a. Update Labels
 //     b. Update Annotations
 func TestServiceCreateAndUpdate(t *testing.T) {
-	if os.Getenv("INGRESS_CLASS") == "gateway-api.ingress.networking.knative.dev" &&
-		os.Getenv("GATEWAY_API_IMPLEMENTATION") == "contour" &&
-		os.Getenv("KIND") != "" {
-		// TODO (izabelacg) temporary solution until the following issue is addressed
-		// see https://github.com/knative/serving/issues/15091
-		t.Skip("Known test failure with Contour and Gateway API")
-	}
-
 	t.Parallel()
 	clients := test.Setup(t)
 


### PR DESCRIPTION
Fixes: https://github.com/knative/serving/issues/15091
Fixes: https://github.com/knative/serving/issues/15090

Blocked on the latest net-gateway-api changes merging: https://github.com/knative/serving/pull/15136

/hold