### PR TITLE
change private K8s service to be a headless service

### DIFF
--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -188,7 +188,8 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 				Port:       targetPort(sks).IntVal,
 				TargetPort: targetPort(sks),
 			}},
-			Selector: selector,
+			Selector:  selector,
+			ClusterIP: "None",
 		},
 	}
 }

--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -189,7 +189,7 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 				TargetPort: targetPort(sks),
 			}},
 			Selector:  selector,
-			ClusterIP: "None",
+			ClusterIP: corev1.ClusterIPNone,
 		},
 	}
 }

--- a/pkg/reconciler/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/serverlessservice/resources/services_test.go
@@ -133,7 +133,7 @@ func privateSvcMod(s *corev1.Service) {
 			"app": "sadness",
 		}
 	}
-	s.Spec.ClusterIP = "None"
+	s.Spec.ClusterIP = corev1.ClusterIPNone
 	s.Spec.Ports = append(s.Spec.Ports,
 		[]corev1.ServicePort{{
 			Name:       servingv1.AutoscalingQueueMetricsPortName,
@@ -471,7 +471,7 @@ func TestMakePrivateService(t *testing.T) {
 			s.Labels["ava"] = "adore"
 			s.Labels[networking.SKSLabelKey] = "dream-tonight-cherub-rock-mayonnaise-hummer-disarm-rocket-soma-quiet"
 			s.Annotations = map[string]string{"cherub": "rock"}
-			s.Spec.ClusterIP = "None"
+			s.Spec.ClusterIP = corev1.ClusterIPNone
 		}, privateSvcMod, func(s *corev1.Service) {
 			// And now patch port to be http2.
 			s.Spec.Ports[0] = corev1.ServicePort{

--- a/pkg/reconciler/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/serverlessservice/resources/services_test.go
@@ -133,6 +133,7 @@ func privateSvcMod(s *corev1.Service) {
 			"app": "sadness",
 		}
 	}
+	s.Spec.ClusterIP = "None"
 	s.Spec.Ports = append(s.Spec.Ports,
 		[]corev1.ServicePort{{
 			Name:       servingv1.AutoscalingQueueMetricsPortName,
@@ -470,6 +471,7 @@ func TestMakePrivateService(t *testing.T) {
 			s.Labels["ava"] = "adore"
 			s.Labels[networking.SKSLabelKey] = "dream-tonight-cherub-rock-mayonnaise-hummer-disarm-rocket-soma-quiet"
 			s.Annotations = map[string]string{"cherub": "rock"}
+			s.Spec.ClusterIP = "None"
 		}, privateSvcMod, func(s *corev1.Service) {
 			// And now patch port to be http2.
 			s.Spec.Ports[0] = corev1.ServicePort{


### PR DESCRIPTION
Related to #13201 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* change private K8s service to be a headless service

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The Private Kubernetes service has been transitioned to a headless service, resulting in the freeing up of an iptable entry on a node.
```
