### PR TITLE
Tests for multi-container readiness and liveness probes

### DIFF
--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -441,10 +441,7 @@ func validateContainers(ctx context.Context, containers []corev1.Container, volu
 		} else {
 			allNames.Insert(containers[i].Name)
 		}
-		// Probes are not allowed on other than serving container,
-		// ref: http://bit.ly/probes-condition
 		if len(containers[i].Ports) == 0 {
-			// Note, if we allow readiness/liveness checks on sidecars, we should pass in an *empty* port here, not the main container's port.
 			errs = errs.Also(validateSidecarContainer(WithinSidecarContainer(ctx), containers[i], volumes).ViaFieldIndex("containers", i))
 		} else {
 			errs = errs.Also(ValidateUserContainer(WithinUserContainer(ctx), containers[i], volumes, port).ViaFieldIndex("containers", i))

--- a/pkg/testing/v1/service.go
+++ b/pkg/testing/v1/service.go
@@ -429,6 +429,14 @@ func WithReadinessProbe(p *corev1.Probe) ServiceOption {
 	}
 }
 
+// WithLivenessProbe sets the provided probe to be the liveness
+// probe on the service.
+func WithLivenessProbe(p *corev1.Probe) ServiceOption {
+	return func(s *v1.Service) {
+		s.Spec.Template.Spec.Containers[0].LivenessProbe = p
+	}
+}
+
 // MarkConfigurationNotReconciled calls the function of the same name on the Service's status.
 func MarkConfigurationNotReconciled(service *v1.Service) {
 	service.Status.MarkConfigurationNotReconciled()

--- a/test/conformance/api/v1/service_test.go
+++ b/test/conformance/api/v1/service_test.go
@@ -720,6 +720,9 @@ func TestServiceCreateWithMultipleContainers(t *testing.T) {
 		Ports: []corev1.ContainerPort{{
 			ContainerPort: 8881,
 		}},
+		Env: []corev1.EnvVar{
+			{Name: "FORWARD_PORT", Value: "8882"},
+		},
 	}, {
 		Image: pkgtest.ImagePath(names.Sidecars[0]),
 	}}

--- a/test/conformance/runtime/liveness_probe_test.go
+++ b/test/conformance/runtime/liveness_probe_test.go
@@ -1,0 +1,180 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2024 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	pkgtest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/spoof"
+	resourcenames "knative.dev/serving/pkg/reconciler/revision/resources/names"
+	v1opts "knative.dev/serving/pkg/testing/v1"
+	"knative.dev/serving/test"
+	v1test "knative.dev/serving/test/v1"
+)
+
+const (
+	livenessPath        = "/healthz/liveness"
+	livenessCounterPath = "/healthz/livenessCounter"
+)
+
+func TestLivenessWithFail(t *testing.T) {
+	t.Parallel()
+	if test.ServingFlags.DisableOptionalAPI {
+		t.Skip("Container.livenessProbe is not required by Knative Serving API Specification")
+	}
+	clients := test.Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.Readiness,
+	}
+
+	test.EnsureTearDown(t, clients, &names)
+
+	t.Log("Creating a new Service")
+	resources, err := v1test.CreateServiceReady(t, clients, &names,
+		v1opts.WithLivenessProbe(
+			&corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: livenessPath,
+						Port: intstr.FromInt32(8080),
+					},
+				},
+				PeriodSeconds:    1,
+				FailureThreshold: 3,
+			}))
+
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	// Wait for the liveness probe to be executed a few times before introducing a failure.
+	url := resources.Route.Status.URL.URL()
+	url.Path = livenessCounterPath
+	if _, err = pkgtest.WaitForEndpointState(
+		context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		url,
+		AtLeastNumLivenessChecks(t, 5),
+		"livenessIsReady",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("The endpoint for Route %s at %s didn't return success: %v", names.Route, url, err)
+	}
+
+	// Check that user-container hasn't been restarted yet.
+	deploymentName := resourcenames.Deployment(resources.Revision)
+	podList, err := clients.KubeClient.CoreV1().Pods(test.ServingFlags.TestNamespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal("Unable to get pod list: ", err)
+	}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if strings.Contains(pod.Name, deploymentName) && UserContainerRestarted(pod) {
+			t.Fatal("User container unexpectedly restarted")
+		}
+	}
+
+	t.Log("POST to /start-failing")
+	client, err := pkgtest.NewSpoofingClient(context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		url.Hostname(),
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
+	if err != nil {
+		t.Fatalf("Failed to create spoofing client: %v", err)
+	}
+
+	url.Path = "/start-failing"
+	startFailing, err := http.NewRequest(http.MethodPost, url.String(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Do(startFailing); err != nil {
+		t.Fatalf("POST to /start-failing failed: %v", err)
+	}
+
+	// Wait for the user-container to be restarted.
+	if err := pkgtest.WaitForPodListState(
+		context.Background(),
+		clients.KubeClient,
+		func(p *corev1.PodList) (bool, error) {
+			for i := range p.Items {
+				pod := &p.Items[i]
+				if strings.Contains(pod.Name, deploymentName) && UserContainerRestarted(pod) {
+					return true, nil
+				}
+			}
+			return false, nil
+		},
+		"WaitForContainerRestart", test.ServingFlags.TestNamespace); err != nil {
+		t.Fatalf("Failed waiting for user-container to be restarted: %v", err)
+	}
+
+	// After restart, verify the liveness probe passes a few times again.
+	url.Path = livenessCounterPath
+	if _, err = pkgtest.WaitForEndpointState(
+		context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		url,
+		AtLeastNumLivenessChecks(t, 5),
+		"livenessIsReady",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("The endpoint for Route %s at %s didn't return success: %v", names.Route, url, err)
+	}
+}
+
+func AtLeastNumLivenessChecks(t *testing.T, expectedChecks int) spoof.ResponseChecker {
+	return func(resp *spoof.Response) (bool, error) {
+		actualChecks, err := strconv.Atoi(string(resp.Body))
+		// Some errors are temporarily expected after container restart.
+		if err != nil {
+			t.Logf("Unable to parse num checks, status: %d, body: %s", resp.StatusCode, string(resp.Body))
+		}
+		if actualChecks >= expectedChecks {
+			return true, nil
+		}
+		return false, nil
+	}
+}
+
+func UserContainerRestarted(pod *corev1.Pod) bool {
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == "user-container" && status.RestartCount > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -209,3 +209,21 @@ func RevisionFromConfiguration(clients *test.Clients, configName string) (string
 	}
 	return "", fmt.Errorf("no valid revision name found in configuration %s", configName)
 }
+
+// PrivateServiceName returns the private service name for the given revision.
+func PrivateServiceName(t *testing.T, clients *test.Clients, revision string) string {
+	var privateServiceName string
+
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Second, 1*time.Minute, true, func(context.Context) (bool, error) {
+		sks, err := clients.NetworkingClient.ServerlessServices.Get(context.Background(), revision, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		privateServiceName = sks.Status.PrivateServiceName
+		return privateServiceName != "", nil
+	}); err != nil {
+		t.Fatalf("Error retrieving sks %q: %v", revision, err)
+	}
+
+	return privateServiceName
+}

--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -83,7 +83,7 @@ func TestMinScale(t *testing.T) {
 	}
 
 	revName := latestRevisionName(t, clients, names.Config, "")
-	serviceName := privateServiceName(t, clients, revName)
+	serviceName := PrivateServiceName(t, clients, revName)
 
 	t.Log("Waiting for revision to scale to minScale before becoming ready")
 	if lr, err := waitForDesiredScale(clients, serviceName, gte(minScale)); err != nil {
@@ -116,7 +116,7 @@ func TestMinScale(t *testing.T) {
 	}
 
 	newRevName := latestRevisionName(t, clients, names.Config, revName)
-	newServiceName := privateServiceName(t, clients, newRevName)
+	newServiceName := PrivateServiceName(t, clients, newRevName)
 
 	t.Log("Waiting for new revision to scale to minScale after update")
 	if lr, err := waitForDesiredScale(clients, newServiceName, gte(minScale)); err != nil {
@@ -206,23 +206,6 @@ func latestRevisionName(t *testing.T, clients *test.Clients, configName, oldRevN
 	}
 
 	return config.Status.LatestCreatedRevisionName
-}
-
-func privateServiceName(t *testing.T, clients *test.Clients, revisionName string) string {
-	var privateServiceName string
-
-	if err := wait.PollUntilContextTimeout(context.Background(), time.Second, 1*time.Minute, true, func(context.Context) (bool, error) {
-		sks, err := clients.NetworkingClient.ServerlessServices.Get(context.Background(), revisionName, metav1.GetOptions{})
-		if err != nil {
-			return false, nil
-		}
-		privateServiceName = sks.Status.PrivateServiceName
-		return privateServiceName != "", nil
-	}); err != nil {
-		t.Fatalf("Error retrieving sks %q: %v", revisionName, err)
-	}
-
-	return privateServiceName
 }
 
 // waitForDesiredScale returns the last observed number of pods and/or error if the cond

--- a/test/e2e/multicontainer_test.go
+++ b/test/e2e/multicontainer_test.go
@@ -53,6 +53,9 @@ func TestMultiContainer(t *testing.T) {
 		Ports: []corev1.ContainerPort{{
 			ContainerPort: 8881,
 		}},
+		Env: []corev1.EnvVar{
+			{Name: "FORWARD_PORT", Value: "8882"},
+		},
 	}, {
 		Image: pkgTest.ImagePath(names.Sidecars[0]),
 	}}

--- a/test/e2e/multicontainerprobing/multicontainer_readiness_test.go
+++ b/test/e2e/multicontainerprobing/multicontainer_readiness_test.go
@@ -198,7 +198,7 @@ func TestMultiContainerReadinessDifferentProbeTypes(t *testing.T) {
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/healthz",
+						Path: "/healthz/readiness",
 						Port: intstr.FromInt32(8882),
 					},
 				},
@@ -287,7 +287,7 @@ func TestMultiContainerProbeStartFailingAfterReady(t *testing.T) {
 				FailureThreshold: 3,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/healthz",
+						Path: "/healthz/readiness",
 						Port: intstr.FromInt32(8080),
 					}},
 			},
@@ -299,7 +299,7 @@ func TestMultiContainerProbeStartFailingAfterReady(t *testing.T) {
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/healthz",
+						Path: "/healthz/readiness",
 						Port: intstr.FromInt32(8881),
 					}},
 			},

--- a/test/e2e/multicontainerprobing/multicontainer_readiness_test.go
+++ b/test/e2e/multicontainerprobing/multicontainer_readiness_test.go
@@ -22,13 +22,20 @@ package multicontainerprobing
 import (
 	"context"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
+	"knative.dev/serving/pkg/apis/autoscaling"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
+	"knative.dev/serving/pkg/resources"
+	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
+	"knative.dev/serving/test/e2e"
 	v1test "knative.dev/serving/test/v1"
 )
 
@@ -41,7 +48,9 @@ func TestMultiContainerReadiness(t *testing.T) {
 		Service: test.ObjectNameForTest(t),
 		Image:   test.ServingContainer,
 		Sidecars: []string{
-			test.SidecarContainer,
+			test.ServingContainer,
+			test.ServingContainer,
+			test.Readiness,
 		},
 	}
 
@@ -51,6 +60,11 @@ func TestMultiContainerReadiness(t *testing.T) {
 			Ports: []corev1.ContainerPort{{
 				ContainerPort: 8881,
 			}},
+			Env: []corev1.EnvVar{
+				{Name: "HEALTHCHECK_PORT", Value: "8881"},
+				// A port in the next container to forward requests to.
+				{Name: "FORWARD_PORT", Value: "8882"},
+			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
@@ -58,13 +72,52 @@ func TestMultiContainerReadiness(t *testing.T) {
 						Port: intstr.FromInt32(8881),
 					}},
 			},
-		}, {
+		}, { // Sidecar with readiness probe.
 			Image: pkgTest.ImagePath(names.Sidecars[0]),
+			Env: []corev1.EnvVar{
+				{Name: "HEALTHCHECK_PORT", Value: "8882"},
+				{Name: "FORWARD_PORT", Value: "8883"},
+			},
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/",
 						Port: intstr.FromInt32(8882),
+					}},
+			},
+		}, { // Sidecar with liveness probe.
+			Image: pkgTest.ImagePath(names.Sidecars[1]),
+			Env: []corev1.EnvVar{
+				{Name: "HEALTHCHECK_PORT", Value: "8883"},
+				{Name: "FORWARD_PORT", Value: "8884"},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/",
+						Port: intstr.FromInt32(8883),
+					}},
+			},
+		}, { // Sidecar with both readiness and liveness probes.
+			Image: pkgTest.ImagePath(names.Sidecars[2]),
+			Env: []corev1.EnvVar{
+				{Name: "PORT", Value: "8884"},
+				// Delay readiness. The Knative service should be ready only after all containers
+				// are ready and the subsequent request should pass.
+				{Name: "READY_DELAY", Value: "10s"},
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/healthz",
+						Port: intstr.FromInt32(8884),
+					}},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/healthz",
+						Port: intstr.FromInt32(8884),
 					}},
 			},
 		},
@@ -87,11 +140,204 @@ func TestMultiContainerReadiness(t *testing.T) {
 		clients.KubeClient,
 		t.Logf,
 		url,
-		spoof.MatchesAllOf(spoof.IsStatusOK, spoof.MatchesBody(test.MultiContainerResponse)),
+		spoof.MatchesAllOf(spoof.IsStatusOK, spoof.MatchesBody(test.HelloWorldText)),
 		"MulticontainerServesExpectedText",
 		test.ServingFlags.ResolvableDomain,
 		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
 	); err != nil {
-		t.Fatalf("The endpoint %s for Route %s didn't serve the expected text %q: %v", url, names.Route, test.MultiContainerResponse, err)
+		t.Fatalf("The endpoint %s for Route %s didn't serve the expected text %q: %v", url, names.Route, test.HelloWorldText, err)
+	}
+}
+
+// TestMultiContainerReadinessDifferentProbeTypes check that sidecars can use different probe types.
+func TestMultiContainerReadinessDifferentProbeTypes(t *testing.T) {
+	t.Parallel()
+
+	clients := test.Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.Readiness,
+		Sidecars: []string{
+			test.Readiness,
+			test.Readiness,
+			test.GRPCPing,
+		},
+	}
+
+	containers := []corev1.Container{
+		{
+			Image: pkgTest.ImagePath(names.Image),
+			Ports: []corev1.ContainerPort{{
+				ContainerPort: 8080,
+			}},
+		}, { // Sidecar with TCPSocket readiness and liveness probes.
+			Image: pkgTest.ImagePath(names.Sidecars[0]),
+			Env: []corev1.EnvVar{
+				{Name: "PORT", Value: "8881"},
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					TCPSocket: &corev1.TCPSocketAction{
+						Port: intstr.FromInt32(8881),
+					},
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					TCPSocket: &corev1.TCPSocketAction{
+						Port: intstr.FromInt32(8881),
+					},
+				},
+			},
+		}, { // Sidecar with HTTPGet readiness and Exec liveness probes.
+			Image: pkgTest.ImagePath(names.Sidecars[1]),
+			Env: []corev1.EnvVar{
+				{Name: "PORT", Value: "8882"},
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/healthz",
+						Port: intstr.FromInt32(8882),
+					},
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					Exec: &corev1.ExecAction{
+						Command: []string{"/ko-app/readiness", "probe"},
+					},
+				},
+			},
+		}, { // Sidecar with GRPC readiness and liveness probes.
+			Image: pkgTest.ImagePath(names.Sidecars[2]),
+			Env: []corev1.EnvVar{
+				{Name: "PORT", Value: "8883"},
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					GRPC: &corev1.GRPCAction{
+						Port: 8883,
+					},
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					GRPC: &corev1.GRPCAction{
+						Port: 8883,
+					},
+				},
+			},
+		},
+	}
+
+	test.EnsureTearDown(t, clients, &names)
+
+	t.Log("Creating a new Service")
+
+	resources, err := v1test.CreateServiceReady(t, clients, &names, func(svc *v1.Service) {
+		svc.Spec.Template.Spec.Containers = containers
+	})
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	url := resources.Route.Status.URL.URL()
+	if _, err := pkgTest.CheckEndpointState(
+		context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		url,
+		spoof.MatchesAllOf(spoof.IsStatusOK, spoof.MatchesBody(test.HelloWorldText)),
+		"MulticontainerServesExpectedText",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("The endpoint %s for Route %s didn't serve the expected text %q: %v", url, names.Route, test.HelloWorldText, err)
+	}
+}
+
+func TestMultiContainerProbeStartFailingAfterReady(t *testing.T) {
+	t.Parallel()
+
+	clients := test.Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.Readiness,
+		Sidecars: []string{
+			test.Readiness,
+		},
+	}
+
+	containers := []corev1.Container{
+		{
+			Image: pkgTest.ImagePath(names.Image),
+			Ports: []corev1.ContainerPort{{
+				ContainerPort: 8080,
+			}},
+		}, {
+			Image: pkgTest.ImagePath(names.Sidecars[0]),
+			Env: []corev1.EnvVar{
+				{Name: "PORT", Value: "8881"},
+				// Start as ready and become unready after initial delay.
+				{Name: "UNREADY_DELAY", Value: "10s"},
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/healthz",
+						Port: intstr.FromInt32(8881),
+					}},
+			},
+		},
+	}
+
+	test.EnsureTearDown(t, clients, &names)
+
+	t.Log("Creating a new Service")
+
+	objects, err := v1test.CreateServiceReady(t, clients, &names, func(svc *v1.Service) {
+		svc.Spec.Template.Spec.Containers = containers
+	}, rtesting.WithConfigAnnotations(map[string]string{
+		// Make sure we don't scale to zero during the test.
+		autoscaling.MinScaleAnnotationKey: "1",
+	}))
+	if err != nil {
+		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
+	}
+
+	url := objects.Route.Status.URL.URL()
+	if _, err := pkgTest.CheckEndpointState(
+		context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		url,
+		spoof.MatchesAllOf(spoof.IsStatusOK, spoof.MatchesBody(test.HelloWorldText)),
+		"MulticontainerServesExpectedText",
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS),
+	); err != nil {
+		t.Fatalf("The endpoint %s for Route %s didn't serve the expected text %q: %v", url, names.Route, test.HelloWorldText, err)
+	}
+
+	revName, err := e2e.RevisionFromConfiguration(clients, names.Service)
+	if err != nil {
+		t.Fatal("Unable to get revision: ", err)
+	}
+	privateSvcName := e2e.PrivateServiceName(t, clients, revName)
+	endpoints := clients.KubeClient.CoreV1().Endpoints(test.ServingFlags.TestNamespace)
+
+	var latestReady int
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Second, 60*time.Second, true, func(context.Context) (bool, error) {
+		endpoint, err := endpoints.Get(context.Background(), privateSvcName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		latestReady = resources.ReadyAddressCount(endpoint)
+		return latestReady == 0, nil
+	}); err != nil {
+		t.Fatalf("Service still has endpoints: %d", latestReady)
 	}
 }

--- a/test/e2e/multicontainerprobing/multicontainer_readiness_test.go
+++ b/test/e2e/multicontainerprobing/multicontainer_readiness_test.go
@@ -61,7 +61,6 @@ func TestMultiContainerReadiness(t *testing.T) {
 				ContainerPort: 8881,
 			}},
 			Env: []corev1.EnvVar{
-				{Name: "HEALTHCHECK_PORT", Value: "8881"},
 				// A port in the next container to forward requests to.
 				{Name: "FORWARD_PORT", Value: "8882"},
 			},
@@ -75,7 +74,7 @@ func TestMultiContainerReadiness(t *testing.T) {
 		}, { // Sidecar with readiness probe.
 			Image: pkgTest.ImagePath(names.Sidecars[0]),
 			Env: []corev1.EnvVar{
-				{Name: "HEALTHCHECK_PORT", Value: "8882"},
+				{Name: "PORT", Value: "8882"},
 				{Name: "FORWARD_PORT", Value: "8883"},
 			},
 			ReadinessProbe: &corev1.Probe{
@@ -88,7 +87,7 @@ func TestMultiContainerReadiness(t *testing.T) {
 		}, { // Sidecar with liveness probe.
 			Image: pkgTest.ImagePath(names.Sidecars[1]),
 			Env: []corev1.EnvVar{
-				{Name: "HEALTHCHECK_PORT", Value: "8883"},
+				{Name: "PORT", Value: "8883"},
 				{Name: "FORWARD_PORT", Value: "8884"},
 			},
 			LivenessProbe: &corev1.Probe{

--- a/test/e2e/readiness_test.go
+++ b/test/e2e/readiness_test.go
@@ -58,7 +58,7 @@ func TestReadinessAlternatePort(t *testing.T) {
 					HTTPGet: &corev1.HTTPGetAction{
 						Scheme: "http",
 						Port:   intstr.FromInt(8077),
-						Path:   "/",
+						Path:   "/readiness",
 					},
 				},
 			}))

--- a/test/test_images/grpc-ping/main.go
+++ b/test/test_images/grpc-ping/main.go
@@ -34,6 +34,10 @@ import (
 	ping "knative.dev/serving/test/test_images/grpc-ping/proto"
 )
 
+const (
+	defaultPort = "8080"
+)
+
 var (
 	delay    int64
 	hostname string
@@ -83,7 +87,7 @@ func (s *server) PingStream(stream ping.PingService_PingStreamServer) error {
 }
 
 func main() {
-	log.Print("Starting server on ", os.Getenv("PORT"))
+	log.Print("Starting server on ", getPort())
 
 	delay, _ = strconv.ParseInt(os.Getenv("DELAY"), 10, 64)
 	log.Printf("Using DELAY of %d ms", delay)
@@ -103,6 +107,13 @@ func main() {
 		}
 	}
 
-	s := network.NewServer(":"+os.Getenv("PORT"), http.HandlerFunc(handler))
+	s := network.NewServer(":"+getPort(), http.HandlerFunc(handler))
 	log.Fatal(s.ListenAndServe())
+}
+
+func getPort() string {
+	if port := os.Getenv("PORT"); port != "" {
+		return port
+	}
+	return defaultPort
 }

--- a/test/test_images/multicontainer/servingcontainer/servingcontainer.go
+++ b/test/test_images/multicontainer/servingcontainer/servingcontainer.go
@@ -23,9 +23,12 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strconv"
 
 	"knative.dev/serving/test"
+)
+
+const (
+	defaultPort = "8080"
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -43,10 +46,13 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	flag.Parse()
-	var port int
-	if env := os.Getenv("HEALTHCHECK_PORT"); env != "" {
-		port, _ = strconv.Atoi(env)
+	log.Printf("serving container started on port %d", getPort())
+	test.ListenAndServeGracefully(":"+getPort(), handler)
+}
+
+func getPort() string {
+	if port := os.Getenv("PORT"); port != "" {
+		return port
 	}
-	log.Printf("serving container started on port %d", port)
-	test.ListenAndServeGracefully(":"+strconv.Itoa(port), handler)
+	return defaultPort
 }

--- a/test/test_images/multicontainer/servingcontainer/servingcontainer.go
+++ b/test/test_images/multicontainer/servingcontainer/servingcontainer.go
@@ -46,11 +46,11 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	flag.Parse()
-	log.Printf("serving container started on port %s", getPort())
-	test.ListenAndServeGracefully(":"+getPort(), handler)
+	log.Printf("serving container started on port %s", getServerPort())
+	test.ListenAndServeGracefully(":"+getServerPort(), handler)
 }
 
-func getPort() string {
+func getServerPort() string {
 	if port := os.Getenv("PORT"); port != "" {
 		return port
 	}

--- a/test/test_images/multicontainer/servingcontainer/servingcontainer.go
+++ b/test/test_images/multicontainer/servingcontainer/servingcontainer.go
@@ -31,7 +31,7 @@ const (
 	defaultPort = "8080"
 )
 
-func handler(w http.ResponseWriter, r *http.Request) {
+func handler(w http.ResponseWriter, _ *http.Request) {
 	log.Println("serving container received a request.")
 	res, err := http.Get(os.ExpandEnv("http://localhost:$FORWARD_PORT"))
 	if err != nil {

--- a/test/test_images/multicontainer/servingcontainer/servingcontainer.go
+++ b/test/test_images/multicontainer/servingcontainer/servingcontainer.go
@@ -46,7 +46,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	flag.Parse()
-	log.Printf("serving container started on port %d", getPort())
+	log.Printf("serving container started on port %s", getPort())
 	test.ListenAndServeGracefully(":"+getPort(), handler)
 }
 

--- a/test/test_images/multicontainer/servingcontainer/servingcontainer.go
+++ b/test/test_images/multicontainer/servingcontainer/servingcontainer.go
@@ -22,13 +22,15 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
 
 	"knative.dev/serving/test"
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
 	log.Println("serving container received a request.")
-	res, err := http.Get("http://127.0.0.1:8882")
+	res, err := http.Get(os.ExpandEnv("http://localhost:$FORWARD_PORT"))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -41,6 +43,10 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	flag.Parse()
-	log.Print("serving container started")
-	test.ListenAndServeGracefully(":8881", handler)
+	var port int
+	if env := os.Getenv("HEALTHCHECK_PORT"); env != "" {
+		port, _ = strconv.Atoi(env)
+	}
+	log.Printf("serving container started on port %d", port)
+	test.ListenAndServeGracefully(":"+strconv.Itoa(port), handler)
 }

--- a/test/test_images/readiness/readiness.go
+++ b/test/test_images/readiness/readiness.go
@@ -110,7 +110,7 @@ func execProbeMain() {
 	os.Exit(0)
 }
 
-func handleStartFailing(w http.ResponseWriter, r *http.Request) {
+func handleStartFailing(w http.ResponseWriter, _ *http.Request) {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -118,14 +118,14 @@ func handleStartFailing(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "will now fail readiness")
 }
 
-func handleStartFailingSidecar(w http.ResponseWriter, r *http.Request) {
+func handleStartFailingSidecar(_ http.ResponseWriter, _ *http.Request) {
 	_, err := http.Get(os.ExpandEnv("http://localhost:$FORWARD_PORT/start-failing"))
 	if err != nil {
 		log.Fatalf("GET to /start-failing failed: %v", err)
 	}
 }
 
-func handleReadiness(w http.ResponseWriter, r *http.Request) {
+func handleReadiness(w http.ResponseWriter, _ *http.Request) {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -136,7 +136,7 @@ func handleReadiness(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, test.HelloWorldText)
 }
 
-func handleLiveness(w http.ResponseWriter, r *http.Request) {
+func handleLiveness(w http.ResponseWriter, _ *http.Request) {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -150,7 +150,7 @@ func handleLiveness(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, livenessCounter)
 }
 
-func handleLivenessCounter(w http.ResponseWriter, r *http.Request) {
+func handleLivenessCounter(w http.ResponseWriter, _ *http.Request) {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -164,7 +164,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "no query", http.StatusInternalServerError)
 }
 
-func handleMain(w http.ResponseWriter, r *http.Request) {
+func handleMain(w http.ResponseWriter, _ *http.Request) {
 	fmt.Fprint(w, test.HelloWorldText)
 }
 

--- a/test/test_images/readiness/readiness.go
+++ b/test/test_images/readiness/readiness.go
@@ -126,28 +126,6 @@ func handleStartFailing(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleHealthz(w http.ResponseWriter, r *http.Request) {
-	handleCommon(w, r)
-}
-
-func handleQuery(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Query().Get("probe") == "ok" {
-		handleCommon(w, r)
-	}
-	http.Error(w, "no query", http.StatusInternalServerError)
-}
-
-func handleMain(w http.ResponseWriter, r *http.Request) {
-	handleCommon(w, r)
-}
-
-func getPort() string {
-	if port := os.Getenv("PORT"); port != "" {
-		return port
-	}
-	return defaultPort
-}
-
-func handleCommon(w http.ResponseWriter, r *http.Request) {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -156,4 +134,22 @@ func handleCommon(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	fmt.Fprint(w, test.HelloWorldText)
+}
+
+func handleQuery(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("probe") == "ok" {
+		fmt.Fprint(w, test.HelloWorldText)
+	}
+	http.Error(w, "no query", http.StatusInternalServerError)
+}
+
+func handleMain(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, test.HelloWorldText)
+}
+
+func getPort() string {
+	if port := os.Getenv("PORT"); port != "" {
+		return port
+	}
+	return defaultPort
 }

--- a/test/test_images/readiness/readiness.go
+++ b/test/test_images/readiness/readiness.go
@@ -96,11 +96,11 @@ func main() {
 
 	mainServer.HandleFunc("/query", handleQuery)
 
-	http.ListenAndServe(":"+getPort(), mainServer)
+	http.ListenAndServe(":"+getServerPort(), mainServer)
 }
 
 func execProbeMain() {
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%s/healthz/readiness", getPort()))
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%s/healthz/readiness", getServerPort()))
 	if err != nil {
 		log.Fatal("Failed to probe: ", err)
 	}
@@ -168,7 +168,7 @@ func handleMain(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, test.HelloWorldText)
 }
 
-func getPort() string {
+func getServerPort() string {
 	if port := os.Getenv("PORT"); port != "" {
 		return port
 	}


### PR DESCRIPTION
Fixes #14869
Fixes #12480

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Remove misleading comment about multi-container Probes (they're now allowed for all containers)
* Test readiness/liveness probes with sidecars (sidecar 1: Readiness probe, sidecar 2: Liveness, sidecar 3: Readiness + Liveness)
	- The final HTTP requests propagates through all the containers
	- Delay Readiness for one of the sidecars
* Test for different types of probes (TCPSocket, HTTPGet+Exec, GRPC)
* Test sidecar container being ready and then going unready, checking that Endpoints are properly removed from the private service.
* For liveness probe, test happy-path scenarios for different types of probes for sidecars.
* Test liveness probe "failure" for HTTPGet probe, but only for the user-container.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
