### PR TITLE
Add e2e test for Contour when CORS policy is enabled

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -115,6 +115,13 @@ immediate_gc
 go_test_e2e -timeout=2m ./test/e2e/gc ${E2E_TEST_FLAGS} || failed=1
 kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f "${TMP_DIR}"/config-gc.yaml
 
+# Run tests with CORS policy enabled for Contour
+if [[ "${INGRESS_CLASS}" == *"contour"* ]]; then
+  toggle_feature cors-policy "allowOrigin:\n - '*'\nallowMethods:\n - GET\n - OPTIONS\n" config-contour || fail_test
+  go_test_e2e -timeout=2m ./test/e2e/corspolicy ${E2E_TEST_FLAGS} || failed=1
+  toggle_feature cors-policy "" config-contour || fail_test
+fi
+
 # Run scale tests.
 # Note that we use a very high -parallel because each ksvc is run as its own
 # sub-test. If this is not larger than the maximum scale tested then the test

--- a/test/e2e/corspolicy/cors_policy_test.go
+++ b/test/e2e/corspolicy/cors_policy_test.go
@@ -21,14 +21,12 @@ package corspolicy
 
 import (
 	"context"
-	v1test "knative.dev/serving/test/v1"
-	//"knative.dev/pkg/apis"
-	pkgTest "knative.dev/pkg/test"
-	//"knative.dev/serving/pkg/resources"
 	"net/http"
 	"testing"
 
+	pkgTest "knative.dev/pkg/test"
 	"knative.dev/serving/test"
+	v1test "knative.dev/serving/test/v1"
 )
 
 const (

--- a/test/e2e/corspolicy/cors_policy_test.go
+++ b/test/e2e/corspolicy/cors_policy_test.go
@@ -56,19 +56,19 @@ func TestCorsPolicy(t *testing.T) {
 		t.Fatalf("The Service %s was not marked as Ready to serve traffic: %v", names.Service, err)
 	}
 
-	serviceUrl := resources.Route.Status.URL.URL()
-	t.Logf("The domain of request is %s.", serviceUrl.Hostname())
+	serviceURL := resources.Route.Status.URL.URL()
+	t.Logf("The domain of request is %s.", serviceURL.Hostname())
 	client, err := pkgTest.NewSpoofingClient(context.Background(),
 		clients.KubeClient,
 		t.Logf,
-		serviceUrl.Hostname(),
+		serviceURL.Hostname(),
 		test.ServingFlags.ResolvableDomain,
 		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
 	if err != nil {
 		t.Fatalf("Failed to create spoofing client: %v", err)
 	}
 
-	request, err := http.NewRequest(http.MethodOptions, serviceUrl.String(), nil)
+	request, err := http.NewRequest(http.MethodOptions, serviceURL.String(), nil)
 	request.Header.Add("Origin", "any-domain.com")
 	request.Header.Add("Access-Control-Request-Method", "GET,OPTIONS")
 	if err != nil {

--- a/test/e2e/corspolicy/cors_policy_test.go
+++ b/test/e2e/corspolicy/cors_policy_test.go
@@ -1,0 +1,96 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2024 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package corspolicy
+
+import (
+	"context"
+	v1test "knative.dev/serving/test/v1"
+	//"knative.dev/pkg/apis"
+	pkgTest "knative.dev/pkg/test"
+	//"knative.dev/serving/pkg/resources"
+	"net/http"
+	"testing"
+
+	"knative.dev/serving/test"
+)
+
+const (
+	allowOriginHeaderKey  = "Access-Control-Allow-Origin"
+	allowMethodsHeaderKey = "Access-Control-Allow-Methods"
+)
+
+func TestCorsPolicy(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.HelloWorld,
+	}
+
+	test.EnsureTearDown(t, clients, &names)
+
+	t.Log("Creating a new Service")
+	resources, err := v1test.CreateServiceReady(t, clients, &names)
+	if err != nil {
+		t.Fatalf("Failed to create Service: %v: %v", names.Service, err)
+	}
+
+	t.Log("Wait for the service domains to be ready")
+	if err := v1test.WaitForServiceState(clients.ServingClient, names.Service, v1test.IsServiceReady, "ServiceIsReady"); err != nil {
+		t.Fatalf("The Service %s was not marked as Ready to serve traffic: %v", names.Service, err)
+	}
+
+	serviceUrl := resources.Route.Status.URL.URL()
+	t.Logf("The domain of request is %s.", serviceUrl.Hostname())
+	client, err := pkgTest.NewSpoofingClient(context.Background(),
+		clients.KubeClient,
+		t.Logf,
+		serviceUrl.Hostname(),
+		test.ServingFlags.ResolvableDomain,
+		test.AddRootCAtoTransport(context.Background(), t.Logf, clients, test.ServingFlags.HTTPS))
+	if err != nil {
+		t.Fatalf("Failed to create spoofing client: %v", err)
+	}
+
+	request, err := http.NewRequest(http.MethodOptions, serviceUrl.String(), nil)
+	request.Header.Add("Origin", "any-domain.com")
+	request.Header.Add("Access-Control-Request-Method", "GET,OPTIONS")
+	if err != nil {
+		t.Fatalf("Failed to create a request: %v", err)
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		t.Fatalf("Unexpected error when sending request to service: %v", err)
+	}
+
+	expectedStatus := http.StatusOK
+	if got, want := response.StatusCode, expectedStatus; got != want {
+		t.Errorf("Service response StatusCode = %v, want %v", got, want)
+	}
+
+	if respHeader := response.Header[allowOriginHeaderKey]; respHeader == nil {
+		t.Errorf("CORS headers not found in response: %s", allowOriginHeaderKey)
+	}
+	if respHeader := response.Header[allowMethodsHeaderKey]; respHeader == nil {
+		t.Errorf("CORS headers not found in response: %s", allowMethodsHeaderKey)
+	}
+}


### PR DESCRIPTION
## Proposed Changes

* Add e2e test for Contour when CORS policy is enabled

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
