### PR TITLE
Fix e2e script to disable cors policy for Contour tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -119,7 +119,9 @@ kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f "${TMP_DIR}"/config-gc.
 if [[ "${INGRESS_CLASS}" == *"contour"* ]]; then
   toggle_feature cors-policy "allowOrigin:\n - '*'\nallowMethods:\n - GET\n - OPTIONS\n" config-contour || fail_test
   go_test_e2e -timeout=2m ./test/e2e/corspolicy ${E2E_TEST_FLAGS} || failed=1
-  toggle_feature cors-policy "" config-contour || fail_test
+  kubectl patch cm config-contour -n "${SYSTEM_NAMESPACE}" --type=json -p '[{"op": "remove", "path": "/data/cors-policy"}]' || fail_test
+  echo "Waiting 30s for change to get picked up."
+  sleep 30
 fi
 
 # Run scale tests.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -118,7 +118,7 @@ kubectl replace cm "config-gc" -n ${SYSTEM_NAMESPACE} -f "${TMP_DIR}"/config-gc.
 # Run tests with CORS policy enabled for Contour
 if [[ "${INGRESS_CLASS}" == *"contour"* ]]; then
   toggle_feature cors-policy "allowOrigin:\n - '*'\nallowMethods:\n - GET\n - OPTIONS\n" config-contour || fail_test
-  go_test_e2e -timeout=2m ./test/e2e/corspolicy ${E2E_TEST_FLAGS} || failed=1
+  go_test_e2e -timeout=5m ./test/e2e/corspolicy ${E2E_TEST_FLAGS} || failed=1
   kubectl patch cm config-contour -n "${SYSTEM_NAMESPACE}" --type=json -p '[{"op": "remove", "path": "/data/cors-policy"}]' || fail_test
   echo "Waiting 30s for change to get picked up."
   sleep 30


### PR DESCRIPTION
## Proposed Changes

* modify e2e-tests script to disable CORS feature by removing the config field instead of setting it to an empty string

### Context

Previously, setting the config field to an empty string resulted in parsing errors, leading to net-contour-controller pods entering an error state and causing subsequent tests to fail. This other PR is blocked on this change due to test failures: https://github.com/knative/serving/pull/15204



