### PR TITLE
Add affinity-rules feature to configmap config-deployment

### DIFF
--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "593aef61"
+    knative.dev/example-checksum: "e2f637c6"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -107,4 +107,4 @@ data:
     #         weight: 100
     # `
     # This may be "none" or "prefer-spread-revision-over-nodes" (default)
-    # affinity: "prefer-spread-revision-over-nodes"
+    # default-affinity-type: "prefer-spread-revision-over-nodes"

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "ed77183a"
+    knative.dev/example-checksum: "92f3969b"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -91,7 +91,7 @@ data:
     # Sets rootCA for the queue proxy - used by QPOptions
     # If omitted, or empty, no rootCA is added to the golang rootCAs
     queue-sidecar-rootca: ""
-    
+
     # If specified, sets the pod's scheduling constraints
     # Affinity is a group of affinity scheduling rules.
     #

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -92,7 +92,7 @@ data:
     # If omitted, or empty, no rootCA is added to the golang rootCAs
     queue-sidecar-rootca: ""
 
-    # If set to "true", it automatically configures pod anti-affinity requirements for all Knative services.
+    # If set, it automatically configures pod anti-affinity requirements for all Knative services.
     # It employs the `preferredDuringSchedulingIgnoredDuringExecution` weighted pod affinity term,
     # aligning with the Knative revision label. It yields the configuration below in all workloads' deployments:
     # `
@@ -106,5 +106,5 @@ data:
     #               serving.knative.dev/revision: {{revision-name}}
     #         weight: 100
     # `
-    #
-    # enable-pod-anti-affinity-rule: "true"
+    # This may be "none" or "prefer-spread-revision-over-nodes" (default)
+    # affinity: "prefer-spread-revision-over-nodes"

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -107,4 +107,4 @@ data:
     #         weight: 100
     # `
     #
-    # pod-anti-affinity-rules: "Enabled"
+    # pod-anti-affinity-rules: true

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -92,15 +92,19 @@ data:
     # If omitted, or empty, no rootCA is added to the golang rootCAs
     queue-sidecar-rootca: ""
 
-    # If specified, sets the pod's scheduling constraints
-    # Affinity is a group of affinity scheduling rules.
+    # If set to "true", it automatically configures pod anti-affinity requirements for all Knative services.
+    # It employs the `preferredDuringSchedulingIgnoredDuringExecution` weighted pod affinity term,
+    # aligning with the Knative revision label. It yields the configuration below in all workloads' deployments:
+    # `
+    #   affinity:
+    #     podAntiAffinity:
+    #       preferredDuringSchedulingIgnoredDuringExecution:
+    #       - podAffinityTerm:
+    #           topologyKey: kubernetes.io/hostname
+    #           labelSelector:
+    #             matchLabels:
+    #               serving.knative.dev/revision: {{revision-name}}
+    #         weight: 100
+    # `
     #
-    # affinity-rules: |
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: workload
-                operator: In
-                values:
-                - staging
+    # pod-anti-affinity-rules: "Enabled"

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "1b231253"
+    knative.dev/example-checksum: "593aef61"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "92f3969b"
+    knative.dev/example-checksum: "aae75411"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "68c006d3"
+    knative.dev/example-checksum: "1b231253"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -107,4 +107,4 @@ data:
     #         weight: 100
     # `
     #
-    # enable-pod-anti-affinity-rule: true
+    # enable-pod-anti-affinity-rule: "true"

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "aae75411"
+    knative.dev/example-checksum: "ed91aac5"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "ed91aac5"
+    knative.dev/example-checksum: "68c006d3"
 data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -107,4 +107,4 @@ data:
     #         weight: 100
     # `
     #
-    # pod-anti-affinity-rules: true
+    # enable-pod-anti-affinity-rule: true

--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -91,3 +91,16 @@ data:
     # Sets rootCA for the queue proxy - used by QPOptions
     # If omitted, or empty, no rootCA is added to the golang rootCAs
     queue-sidecar-rootca: ""
+    
+    # If specified, sets the pod's scheduling constraints
+    # Affinity is a group of affinity scheduling rules.
+    #
+    # affinity-rules: |
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: workload
+                operator: In
+                values:
+                - staging

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -172,7 +172,7 @@ func NewConfigFromMap(configMap map[string]string) (*Config, error) {
 		case None, PreferSpreadRevisionOverNodes:
 			nc.DefaultAffinityType = opt
 		default:
-			return nil, fmt.Errorf("unsupported `affinity` value %q", affinity)
+			return nil, fmt.Errorf("unsupported %s value: %q", defaultAffinityTypeKey, affinity)
 		}
 	}
 	return nc, nil

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -69,6 +69,8 @@ const (
 	queueSidecarRooCAKey          = "queue-sidecar-rootca"
 
 	enablePodAntiAffinityRule = "enable-pod-anti-affinity-rule"
+
+	EnablePodAntiAffinityRuleDefault = true
 )
 
 var (
@@ -96,9 +98,6 @@ var (
 	// QueueSidecarEphemeralStorageLimitDefault is the default limit.ephemeral-storage to set for the
 	// queue sidecar.
 	QueueSidecarEphemeralStorageLimitDefault = resource.MustParse("1024Mi")
-
-	// EnablePodAntiAffinityRuleDefault is the default value for the EnablePodAntiAffinityRule flag.
-	EnablePodAntiAffinityRuleDefault = true
 )
 
 func defaultConfig() *Config {
@@ -107,7 +106,7 @@ func defaultConfig() *Config {
 		DigestResolutionTimeout:        digestResolutionTimeoutDefault,
 		RegistriesSkippingTagResolving: sets.New("kind.local", "ko.local", "dev.local"),
 		QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
-		EnablePodAntiAffinityRule:      false,
+		EnablePodAntiAffinityRule:      EnablePodAntiAffinityRuleDefault,
 	}
 	// The following code is needed for ConfigMap testing.
 	// defaultConfig must match the example in deployment.yaml which includes: `queue-sidecar-token-audiences: ""`

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -98,7 +98,7 @@ var (
 	QueueSidecarEphemeralStorageLimitDefault = resource.MustParse("1024Mi")
 
 	// EnablePodAntiAffinityRuleDefault is the default value for the EnablePodAntiAffinityRule flag.
-	EnablePodAntiAffinityRuleDefault = false
+	EnablePodAntiAffinityRuleDefault = true
 )
 
 func defaultConfig() *Config {

--- a/pkg/deployment/config_test.go
+++ b/pkg/deployment/config_test.go
@@ -132,6 +132,7 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			QueueSidecarTokenAudiences:     sets.New("foo", "bar", "boo-srv"),
 			ProgressDeadline:               ProgressDeadlineDefault,
+			EnablePodAntiAffinityRule:      EnablePodAntiAffinityRuleDefault,
 		},
 		data: map[string]string{
 			QueueSidecarImageKey:              defaultSidecarImage,
@@ -147,6 +148,7 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			QueueSidecarTokenAudiences:     sets.New(""),
 			ProgressDeadline:               444 * time.Second,
+			EnablePodAntiAffinityRule:      EnablePodAntiAffinityRuleDefault,
 		},
 		data: map[string]string{
 			QueueSidecarImageKey: defaultSidecarImage,
@@ -161,6 +163,7 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			QueueSidecarTokenAudiences:     sets.New(""),
 			ProgressDeadline:               ProgressDeadlineDefault,
+			EnablePodAntiAffinityRule:      EnablePodAntiAffinityRuleDefault,
 		},
 		data: map[string]string{
 			QueueSidecarImageKey:       defaultSidecarImage,
@@ -175,6 +178,7 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			QueueSidecarTokenAudiences:     sets.New(""),
 			ProgressDeadline:               ProgressDeadlineDefault,
+			EnablePodAntiAffinityRule:      EnablePodAntiAffinityRuleDefault,
 		},
 		data: map[string]string{
 			QueueSidecarImageKey:              defaultSidecarImage,
@@ -194,6 +198,7 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarMemoryLimit:             quantity("654m"),
 			QueueSidecarEphemeralStorageLimit:   quantity("321M"),
 			QueueSidecarTokenAudiences:          sets.New(""),
+			EnablePodAntiAffinityRule:           EnablePodAntiAffinityRuleDefault,
 		},
 		data: map[string]string{
 			QueueSidecarImageKey:                   defaultSidecarImage,
@@ -270,6 +275,7 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarEphemeralStorageRequest: quantity("9M"),
 			QueueSidecarEphemeralStorageLimit:   quantity("10M"),
 			QueueSidecarTokenAudiences:          sets.New(""),
+			EnablePodAntiAffinityRule:           EnablePodAntiAffinityRuleDefault,
 		},
 	}, {
 		name: "newer key case takes priority",
@@ -311,6 +317,7 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarEphemeralStorageRequest: quantity("20M"),
 			QueueSidecarEphemeralStorageLimit:   quantity("21M"),
 			QueueSidecarTokenAudiences:          sets.New("foo"),
+			EnablePodAntiAffinityRule:           EnablePodAntiAffinityRuleDefault,
 		},
 	}}
 

--- a/pkg/deployment/config_test.go
+++ b/pkg/deployment/config_test.go
@@ -81,7 +81,7 @@ func TestControllerConfiguration(t *testing.T) {
 		wantConfig *Config
 		data       map[string]string
 	}{{
-		name: "controller configuration with no affinity rule specified",
+		name: "controller configuration with no default affinity type specified",
 		wantConfig: &Config{
 			RegistriesSkippingTagResolving: sets.New("kind.local", "ko.local", "dev.local"),
 			DigestResolutionTimeout:        digestResolutionTimeoutDefault,
@@ -95,21 +95,21 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarImageKey: defaultSidecarImage,
 		},
 	}, {
-		name:    "controller configuration with empty string for the affinity rule",
+		name:    "controller configuration with empty string set for the default affinity type",
 		wantErr: true,
 		data: map[string]string{
 			QueueSidecarImageKey:   defaultSidecarImage,
 			defaultAffinityTypeKey: "",
 		},
 	}, {
-		name:    "controller configuration with unsupported affinity value",
+		name:    "controller configuration with unsupported value for default affinity type",
 		wantErr: true,
 		data: map[string]string{
 			QueueSidecarImageKey:   defaultSidecarImage,
 			defaultAffinityTypeKey: "coconut",
 		},
 	}, {
-		name: "controller configuration with the default affinity rule set",
+		name: "controller configuration with the default affinity type set",
 		wantConfig: &Config{
 			RegistriesSkippingTagResolving: sets.New("kind.local", "ko.local", "dev.local"),
 			DigestResolutionTimeout:        digestResolutionTimeoutDefault,
@@ -124,7 +124,7 @@ func TestControllerConfiguration(t *testing.T) {
 			defaultAffinityTypeKey: string(PreferSpreadRevisionOverNodes),
 		},
 	}, {
-		name: "controller configuration with affinity deactivated",
+		name: "controller configuration with default affinity type deactivated",
 		wantConfig: &Config{
 			RegistriesSkippingTagResolving: sets.New("kind.local", "ko.local", "dev.local"),
 			DigestResolutionTimeout:        digestResolutionTimeoutDefault,

--- a/pkg/deployment/config_test.go
+++ b/pkg/deployment/config_test.go
@@ -89,7 +89,7 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			QueueSidecarTokenAudiences:     sets.New(""),
 			ProgressDeadline:               ProgressDeadlineDefault,
-			Affinity:                       affinityDefault,
+			DefaultAffinityType:            defaultAffinityTypeValue,
 		},
 		data: map[string]string{
 			QueueSidecarImageKey: defaultSidecarImage,
@@ -98,15 +98,15 @@ func TestControllerConfiguration(t *testing.T) {
 		name:    "controller configuration with empty string for the affinity rule",
 		wantErr: true,
 		data: map[string]string{
-			QueueSidecarImageKey: defaultSidecarImage,
-			affinityKey:          "",
+			QueueSidecarImageKey:   defaultSidecarImage,
+			defaultAffinityTypeKey: "",
 		},
 	}, {
 		name:    "controller configuration with unsupported affinity value",
 		wantErr: true,
 		data: map[string]string{
-			QueueSidecarImageKey: defaultSidecarImage,
-			affinityKey:          "coconut",
+			QueueSidecarImageKey:   defaultSidecarImage,
+			defaultAffinityTypeKey: "coconut",
 		},
 	}, {
 		name: "controller configuration with the default affinity rule set",
@@ -117,11 +117,11 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			QueueSidecarTokenAudiences:     sets.New(""),
 			ProgressDeadline:               ProgressDeadlineDefault,
-			Affinity:                       affinityDefault,
+			DefaultAffinityType:            defaultAffinityTypeValue,
 		},
 		data: map[string]string{
-			QueueSidecarImageKey: defaultSidecarImage,
-			affinityKey:          string(PreferSpreadRevisionOverNodes),
+			QueueSidecarImageKey:   defaultSidecarImage,
+			defaultAffinityTypeKey: string(PreferSpreadRevisionOverNodes),
 		},
 	}, {
 		name: "controller configuration with affinity deactivated",
@@ -132,11 +132,11 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			QueueSidecarTokenAudiences:     sets.New(""),
 			ProgressDeadline:               ProgressDeadlineDefault,
-			Affinity:                       None,
+			DefaultAffinityType:            None,
 		},
 		data: map[string]string{
-			QueueSidecarImageKey: defaultSidecarImage,
-			affinityKey:          string(None),
+			QueueSidecarImageKey:   defaultSidecarImage,
+			defaultAffinityTypeKey: string(None),
 		},
 	}, {
 		name: "controller configuration with bad registries",
@@ -147,7 +147,7 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			QueueSidecarTokenAudiences:     sets.New("foo", "bar", "boo-srv"),
 			ProgressDeadline:               ProgressDeadlineDefault,
-			Affinity:                       affinityDefault,
+			DefaultAffinityType:            defaultAffinityTypeValue,
 		},
 		data: map[string]string{
 			QueueSidecarImageKey:              defaultSidecarImage,
@@ -163,7 +163,7 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			QueueSidecarTokenAudiences:     sets.New(""),
 			ProgressDeadline:               444 * time.Second,
-			Affinity:                       affinityDefault,
+			DefaultAffinityType:            defaultAffinityTypeValue,
 		},
 		data: map[string]string{
 			QueueSidecarImageKey: defaultSidecarImage,
@@ -178,7 +178,7 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			QueueSidecarTokenAudiences:     sets.New(""),
 			ProgressDeadline:               ProgressDeadlineDefault,
-			Affinity:                       affinityDefault,
+			DefaultAffinityType:            defaultAffinityTypeValue,
 		},
 		data: map[string]string{
 			QueueSidecarImageKey:       defaultSidecarImage,
@@ -193,7 +193,7 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			QueueSidecarTokenAudiences:     sets.New(""),
 			ProgressDeadline:               ProgressDeadlineDefault,
-			Affinity:                       affinityDefault,
+			DefaultAffinityType:            defaultAffinityTypeValue,
 		},
 		data: map[string]string{
 			QueueSidecarImageKey:              defaultSidecarImage,
@@ -213,7 +213,7 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarMemoryLimit:             quantity("654m"),
 			QueueSidecarEphemeralStorageLimit:   quantity("321M"),
 			QueueSidecarTokenAudiences:          sets.New(""),
-			Affinity:                            affinityDefault,
+			DefaultAffinityType:                 defaultAffinityTypeValue,
 		},
 		data: map[string]string{
 			QueueSidecarImageKey:                   defaultSidecarImage,
@@ -290,7 +290,7 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarEphemeralStorageRequest: quantity("9M"),
 			QueueSidecarEphemeralStorageLimit:   quantity("10M"),
 			QueueSidecarTokenAudiences:          sets.New(""),
-			Affinity:                            affinityDefault,
+			DefaultAffinityType:                 defaultAffinityTypeValue,
 		},
 	}, {
 		name: "newer key case takes priority",
@@ -332,7 +332,7 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarEphemeralStorageRequest: quantity("20M"),
 			QueueSidecarEphemeralStorageLimit:   quantity("21M"),
 			QueueSidecarTokenAudiences:          sets.New("foo"),
-			Affinity:                            affinityDefault,
+			DefaultAffinityType:                 defaultAffinityTypeValue,
 		},
 	}}
 

--- a/pkg/deployment/config_test.go
+++ b/pkg/deployment/config_test.go
@@ -92,7 +92,8 @@ func TestControllerConfiguration(t *testing.T) {
 			EnablePodAntiAffinityRule:      EnablePodAntiAffinityRuleDefault,
 		},
 		data: map[string]string{
-			QueueSidecarImageKey: defaultSidecarImage,
+			QueueSidecarImageKey:      defaultSidecarImage,
+			enablePodAntiAffinityRule: "true",
 		},
 	}, {
 		name:    "controller configuration with empty string for the pod anti-affinity toggle",

--- a/pkg/deployment/config_test.go
+++ b/pkg/deployment/config_test.go
@@ -92,8 +92,7 @@ func TestControllerConfiguration(t *testing.T) {
 			EnablePodAntiAffinityRule:      EnablePodAntiAffinityRuleDefault,
 		},
 		data: map[string]string{
-			QueueSidecarImageKey:      defaultSidecarImage,
-			enablePodAntiAffinityRule: "true",
+			QueueSidecarImageKey: defaultSidecarImage,
 		},
 	}, {
 		name:    "controller configuration with empty string for the pod anti-affinity toggle",

--- a/pkg/deployment/config_test.go
+++ b/pkg/deployment/config_test.go
@@ -80,7 +80,7 @@ func TestControllerConfiguration(t *testing.T) {
 		wantConfig *Config
 		data       map[string]string
 	}{{
-		name: "controller configuration with no affinity rules",
+		name: "controller configuration with no pod anti-affinity toggle specified",
 		wantConfig: &Config{
 			RegistriesSkippingTagResolving: sets.New("kind.local", "ko.local", "dev.local"),
 			DigestResolutionTimeout:        digestResolutionTimeoutDefault,
@@ -88,45 +88,27 @@ func TestControllerConfiguration(t *testing.T) {
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			QueueSidecarTokenAudiences:     sets.New(""),
 			ProgressDeadline:               ProgressDeadlineDefault,
-			AffinityRules:                  nil,
+			EnablePodAntiAffinityRule:      EnablePodAntiAffinityRuleDefault,
 		},
 		data: map[string]string{
 			QueueSidecarImageKey: defaultSidecarImage,
 		},
 	}, {
-		name: "controller configuration with empty affinity rules",
-		wantConfig: &Config{
-			RegistriesSkippingTagResolving: sets.New("kind.local", "ko.local", "dev.local"),
-			DigestResolutionTimeout:        digestResolutionTimeoutDefault,
-			QueueSidecarImage:              defaultSidecarImage,
-			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
-			QueueSidecarTokenAudiences:     sets.New(""),
-			ProgressDeadline:               ProgressDeadlineDefault,
-			AffinityRules:                  nil,
-		},
-		data: map[string]string{
-			QueueSidecarImageKey: defaultSidecarImage,
-			affinityRules:        "",
-		},
-	}, {
-		name:    "controller configuration with bad affinity rules",
+		name:    "controller configuration with empty string for the pod anti-affinity toggle",
 		wantErr: true,
 		data: map[string]string{
-			QueueSidecarImageKey: defaultSidecarImage,
-			affinityRules:        "coconut",
+			QueueSidecarImageKey:      defaultSidecarImage,
+			enablePodAntiAffinityRule: "",
 		},
 	}, {
-		name:    "controller configuration with bad pod anti affinity rules",
+		name:    "controller configuration with wrong type for the pod anti-affinity toggle",
 		wantErr: true,
 		data: map[string]string{
-			QueueSidecarImageKey: defaultSidecarImage,
-			affinityRules: `
-podAntiAffinity:
-  requiredDuringSchedulingIgnoredDuringExecution: true
-`,
+			QueueSidecarImageKey:      defaultSidecarImage,
+			enablePodAntiAffinityRule: "coconut",
 		},
 	}, {
-		name: "controller configuration with good affinity rules",
+		name: "controller configuration with the pod anti-affinity toggle on",
 		wantConfig: &Config{
 			RegistriesSkippingTagResolving: sets.New("kind.local", "ko.local", "dev.local"),
 			DigestResolutionTimeout:        digestResolutionTimeoutDefault,
@@ -134,29 +116,11 @@ podAntiAffinity:
 			QueueSidecarCPURequest:         &QueueSidecarCPURequestDefault,
 			QueueSidecarTokenAudiences:     sets.New(""),
 			ProgressDeadline:               ProgressDeadlineDefault,
-			AffinityRules: &corev1.Affinity{
-				PodAntiAffinity: &corev1.PodAntiAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
-						TopologyKey: "kubernetes.io/hostname",
-						LabelSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"app": "duck",
-							},
-						},
-					}},
-				},
-			},
+			EnablePodAntiAffinityRule:      true,
 		},
 		data: map[string]string{
-			QueueSidecarImageKey: defaultSidecarImage,
-			affinityRules: `
-podAntiAffinity:
-  requiredDuringSchedulingIgnoredDuringExecution:
-  - topologyKey: kubernetes.io/hostname
-    labelSelector:
-      matchLabels:
-        app: duck
-`,
+			QueueSidecarImageKey:      defaultSidecarImage,
+			enablePodAntiAffinityRule: "true",
 		},
 	}, {
 		name: "controller configuration with bad registries",

--- a/pkg/deployment/config_test.go
+++ b/pkg/deployment/config_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package deployment
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/deployment/zz_generated.deepcopy.go
+++ b/pkg/deployment/zz_generated.deepcopy.go
@@ -22,7 +22,6 @@ limitations under the License.
 package deployment
 
 import (
-	v1 "k8s.io/api/core/v1"
 	sets "k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -72,11 +71,6 @@ func (in *Config) DeepCopyInto(out *Config) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
-	}
-	if in.AffinityRules != nil {
-		in, out := &in.AffinityRules, &out.AffinityRules
-		*out = new(v1.Affinity)
-		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/deployment/zz_generated.deepcopy.go
+++ b/pkg/deployment/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package deployment
 
 import (
+	v1 "k8s.io/api/core/v1"
 	sets "k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -71,6 +72,11 @@ func (in *Config) DeepCopyInto(out *Config) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.AffinityRules != nil {
+		in, out := &in.AffinityRules, &out.AffinityRules
+		*out = new(v1.Affinity)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	apiconfig "knative.dev/serving/pkg/apis/config"
+	deploymentconfig "knative.dev/serving/pkg/deployment"
 )
 
 const certVolumeName = "server-certs"
@@ -150,7 +151,7 @@ func rewriteUserLivenessProbe(p *corev1.Probe, userPort int) {
 	}
 }
 
-func makeDefaultPodAntiAffinity(revisionLabelValue string) *corev1.PodAntiAffinity {
+func makePreferSpreadRevisionOverNodes(revisionLabelValue string) *corev1.PodAntiAffinity {
 	return &corev1.PodAntiAffinity{
 		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
 			Weight: 100,
@@ -226,8 +227,8 @@ func makePodSpec(rev *v1.Revision, cfg *config.Config) (*corev1.PodSpec, error) 
 		}
 	}
 
-	if cfg.Deployment.EnablePodAntiAffinityRule && cfg.Features.PodSpecAffinity == apiconfig.Disabled {
-		podSpec.Affinity = &corev1.Affinity{PodAntiAffinity: makeDefaultPodAntiAffinity(rev.Name)}
+	if cfg.Deployment.Affinity != deploymentconfig.PreferSpreadRevisionOverNodes && cfg.Features.PodSpecAffinity == apiconfig.Disabled {
+		podSpec.Affinity = &corev1.Affinity{PodAntiAffinity: makePreferSpreadRevisionOverNodes(rev.Name)}
 	}
 
 	return podSpec, nil

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -227,7 +227,7 @@ func makePodSpec(rev *v1.Revision, cfg *config.Config) (*corev1.PodSpec, error) 
 		}
 	}
 
-	if cfg.Deployment.Affinity != deploymentconfig.PreferSpreadRevisionOverNodes && cfg.Features.PodSpecAffinity == apiconfig.Disabled {
+	if cfg.Deployment.Affinity == deploymentconfig.PreferSpreadRevisionOverNodes && cfg.Features.PodSpecAffinity == apiconfig.Disabled {
 		podSpec.Affinity = &corev1.Affinity{PodAntiAffinity: makePreferSpreadRevisionOverNodes(rev.Name)}
 	}
 

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -227,10 +227,7 @@ func makePodSpec(rev *v1.Revision, cfg *config.Config) (*corev1.PodSpec, error) 
 	}
 
 	if cfg.Deployment.EnablePodAntiAffinityRule && cfg.Features.PodSpecAffinity == apiconfig.Disabled {
-		revisionLabelValue := rev.Labels[serving.RevisionLabelKey]
-		if revisionLabelValue != "" {
-			podSpec.Affinity = &corev1.Affinity{PodAntiAffinity: makeDefaultPodAntiAffinity(revisionLabelValue)}
-		}
+		podSpec.Affinity = &corev1.Affinity{PodAntiAffinity: makeDefaultPodAntiAffinity(rev.Name)}
 	}
 
 	return podSpec, nil

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -227,7 +227,7 @@ func makePodSpec(rev *v1.Revision, cfg *config.Config) (*corev1.PodSpec, error) 
 		}
 	}
 
-	if cfg.Deployment.Affinity == deploymentconfig.PreferSpreadRevisionOverNodes && rev.Spec.Affinity == nil {
+	if cfg.Deployment.DefaultAffinityType == deploymentconfig.PreferSpreadRevisionOverNodes && rev.Spec.Affinity == nil {
 		podSpec.Affinity = &corev1.Affinity{PodAntiAffinity: makePreferSpreadRevisionOverNodes(rev.Name)}
 	}
 

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -227,10 +227,8 @@ func makePodSpec(rev *v1.Revision, cfg *config.Config) (*corev1.PodSpec, error) 
 		}
 	}
 
-	if cfg.Deployment.Affinity == deploymentconfig.PreferSpreadRevisionOverNodes {
-		if cfg.Features.PodSpecAffinity == apiconfig.Disabled || (cfg.Features.PodSpecAffinity == apiconfig.Enabled && rev.Spec.Affinity == nil) {
-			podSpec.Affinity = &corev1.Affinity{PodAntiAffinity: makePreferSpreadRevisionOverNodes(rev.Name)}
-		}
+	if cfg.Deployment.Affinity == deploymentconfig.PreferSpreadRevisionOverNodes && rev.Spec.Affinity == nil {
+		podSpec.Affinity = &corev1.Affinity{PodAntiAffinity: makePreferSpreadRevisionOverNodes(rev.Name)}
 	}
 
 	return podSpec, nil

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -227,8 +227,10 @@ func makePodSpec(rev *v1.Revision, cfg *config.Config) (*corev1.PodSpec, error) 
 		}
 	}
 
-	if cfg.Deployment.Affinity == deploymentconfig.PreferSpreadRevisionOverNodes && cfg.Features.PodSpecAffinity == apiconfig.Disabled {
-		podSpec.Affinity = &corev1.Affinity{PodAntiAffinity: makePreferSpreadRevisionOverNodes(rev.Name)}
+	if cfg.Deployment.Affinity == deploymentconfig.PreferSpreadRevisionOverNodes {
+		if cfg.Features.PodSpecAffinity == apiconfig.Disabled || (cfg.Features.PodSpecAffinity == apiconfig.Enabled && rev.Spec.Affinity == nil) {
+			podSpec.Affinity = &corev1.Affinity{PodAntiAffinity: makePreferSpreadRevisionOverNodes(rev.Name)}
+		}
 	}
 
 	return podSpec, nil

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -1434,11 +1434,6 @@ func TestMakePodSpec(t *testing.T) {
 			WithContainerStatuses([]v1.ContainerStatus{{
 				ImageDigest: "busybox@sha256:deadbeef",
 			}}),
-			func(revision *v1.Revision) {
-				revision.Labels = map[string]string{
-					serving.RevisionLabelKey: "bar",
-				}
-			},
 		),
 		fc: apicfg.Features{
 			PodSpecAffinity: apicfg.Disabled,
@@ -1470,11 +1465,6 @@ func TestMakePodSpec(t *testing.T) {
 			WithContainerStatuses([]v1.ContainerStatus{{
 				ImageDigest: "busybox@sha256:deadbeef",
 			}}),
-			func(revision *v1.Revision) {
-				revision.Labels = map[string]string{
-					serving.RevisionLabelKey: "bar",
-				}
-			},
 		),
 		fc: apicfg.Features{
 			PodSpecAffinity: apicfg.Disabled,
@@ -1501,11 +1491,6 @@ func TestMakePodSpec(t *testing.T) {
 			WithContainerStatuses([]v1.ContainerStatus{{
 				ImageDigest: "busybox@sha256:deadbeef",
 			}}),
-			func(revision *v1.Revision) {
-				revision.Labels = map[string]string{
-					serving.RevisionLabelKey: "bar",
-				}
-			},
 		),
 		fc: apicfg.Features{
 			PodSpecAffinity: apicfg.Enabled,

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -1435,7 +1435,7 @@ func TestMakePodSpec(t *testing.T) {
 				),
 			}),
 	}, {
-		name: "with default affinity rules",
+		name: "with default affinity type set",
 		rev: revision("bar", "foo",
 			withContainers([]corev1.Container{{
 				Name:           servingContainerName,
@@ -1466,7 +1466,7 @@ func TestMakePodSpec(t *testing.T) {
 			},
 		),
 	}, {
-		name: "with affinity rules deactivated",
+		name: "with default affinity type deactivated",
 		rev: revision("bar", "foo",
 			withContainers([]corev1.Container{{
 				Name:           servingContainerName,
@@ -1492,7 +1492,7 @@ func TestMakePodSpec(t *testing.T) {
 			},
 		),
 	}, {
-		name: "with affinity rules set by the user and the operator",
+		name: "with affinity rules set by both the user and the operator",
 		rev: revision("bar", "foo",
 			withContainers([]corev1.Container{{
 				Name:           servingContainerName,

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -1450,7 +1450,7 @@ func TestMakePodSpec(t *testing.T) {
 			PodSpecAffinity: apicfg.Disabled,
 		},
 		dc: deployment.Config{
-			Affinity: deployment.PreferSpreadRevisionOverNodes,
+			DefaultAffinityType: deployment.PreferSpreadRevisionOverNodes,
 		},
 		want: podSpec(
 			[]corev1.Container{
@@ -1481,7 +1481,7 @@ func TestMakePodSpec(t *testing.T) {
 			PodSpecAffinity: apicfg.Disabled,
 		},
 		dc: deployment.Config{
-			Affinity: deployment.None,
+			DefaultAffinityType: deployment.None,
 		},
 		want: podSpec(
 			[]corev1.Container{
@@ -1511,7 +1511,7 @@ func TestMakePodSpec(t *testing.T) {
 			PodSpecAffinity: apicfg.Enabled,
 		},
 		dc: deployment.Config{
-			Affinity: deployment.PreferSpreadRevisionOverNodes,
+			DefaultAffinityType: deployment.PreferSpreadRevisionOverNodes,
 		},
 		want: podSpec(
 			[]corev1.Container{

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -1424,7 +1424,7 @@ func TestMakePodSpec(t *testing.T) {
 				),
 			}),
 	}, {
-		name: "with default pod anti-affinity rules",
+		name: "with default affinity rules",
 		rev: revision("bar", "foo",
 			withContainers([]corev1.Container{{
 				Name:           servingContainerName,
@@ -1439,7 +1439,7 @@ func TestMakePodSpec(t *testing.T) {
 			PodSpecAffinity: apicfg.Disabled,
 		},
 		dc: deployment.Config{
-			EnablePodAntiAffinityRule: true,
+			Affinity: deployment.PreferSpreadRevisionOverNodes,
 		},
 		want: podSpec(
 			[]corev1.Container{
@@ -1455,7 +1455,7 @@ func TestMakePodSpec(t *testing.T) {
 			},
 		),
 	}, {
-		name: "with pod anti-affinity rules toggle off",
+		name: "with affinity rules deactivated",
 		rev: revision("bar", "foo",
 			withContainers([]corev1.Container{{
 				Name:           servingContainerName,
@@ -1470,7 +1470,7 @@ func TestMakePodSpec(t *testing.T) {
 			PodSpecAffinity: apicfg.Disabled,
 		},
 		dc: deployment.Config{
-			EnablePodAntiAffinityRule: false,
+			Affinity: deployment.None,
 		},
 		want: podSpec(
 			[]corev1.Container{
@@ -1481,7 +1481,7 @@ func TestMakePodSpec(t *testing.T) {
 			},
 		),
 	}, {
-		name: "with pod anti-affinity rules toggle on for both users and operators",
+		name: "with affinity rules on for both users and operators",
 		rev: revision("bar", "foo",
 			withContainers([]corev1.Container{{
 				Name:           servingContainerName,
@@ -1496,7 +1496,7 @@ func TestMakePodSpec(t *testing.T) {
 			PodSpecAffinity: apicfg.Enabled,
 		},
 		dc: deployment.Config{
-			EnablePodAntiAffinityRule: true,
+			Affinity: deployment.PreferSpreadRevisionOverNodes,
 		},
 		want: podSpec(
 			[]corev1.Container{


### PR DESCRIPTION
## Proposed Changes

* Add new field `default-affinity-type` to the config-deployment configmap that allows operators to set pod anti-affinity rules to all Knative services. The following pod anti-affinity rule get then added automatically in the deployments spec:
```yaml
affinity:
  podAntiAffinity:
    preferredDuringSchedulingIgnoredDuringExecution:
    - podAffinityTerm:
        topologyKey: kubernetes.io/hostname
        labelSelector:
          matchLabels:
            serving.knative.dev/revision: {{revision-name}}
      weight: 100
```

* the affinity type is set to `prefer-spread-revision-over-nodes` by default


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Pod anti-affinity rules are set by default for all Knative services. The feature can be deactivated using the property `default-affinity-type` in the config-deployment configmap.
```
