### PR TITLE
fix: Fixed liveness periodseconds to 10 so that crashloopback off doe…

### DIFF
--- a/config/core/deployments/webhook.yaml
+++ b/config/core/deployments/webhook.yaml
@@ -107,7 +107,7 @@ spec:
             scheme: HTTPS
             port: 8443
         livenessProbe:
-          periodSeconds: 1
+          periodSeconds: 10
           httpGet:
             scheme: HTTPS
             port: 8443


### PR DESCRIPTION
Fixes #15255

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Increase periodseconds of livenessprobe to 10 as found in the issue


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adjust liveness probe to account for stale leases - otherwise webhook would crashloop forever
```
