### PR TITLE
Drop the k8s service name from kubectl get revision output

### DIFF
--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -45,9 +45,6 @@ spec:
         - name: Config Name
           type: string
           jsonPath: ".metadata.labels['serving\\.knative\\.dev/configuration']"
-        - name: K8s Service Name
-          type: string
-          jsonPath: ".status.serviceName"
         - name: Generation
           type: string # int in string form :(
           jsonPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"


### PR DESCRIPTION
The K8s Service name has the same name as the revision.  We dropped this field from the status so this column has always been showing an empty string.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
`kubectl get revision`  - no longer shows an empty column for `K8S Service Name`
```
