### PR TITLE
Revert headless service change from k8s private service

### DIFF
--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -188,8 +188,7 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 				Port:       targetPort(sks).IntVal,
 				TargetPort: targetPort(sks),
 			}},
-			Selector:  selector,
-			ClusterIP: corev1.ClusterIPNone,
+			Selector: selector,
 		},
 	}
 }

--- a/pkg/reconciler/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/serverlessservice/resources/services_test.go
@@ -133,7 +133,6 @@ func privateSvcMod(s *corev1.Service) {
 			"app": "sadness",
 		}
 	}
-	s.Spec.ClusterIP = corev1.ClusterIPNone
 	s.Spec.Ports = append(s.Spec.Ports,
 		[]corev1.ServicePort{{
 			Name:       servingv1.AutoscalingQueueMetricsPortName,
@@ -471,7 +470,6 @@ func TestMakePrivateService(t *testing.T) {
 			s.Labels["ava"] = "adore"
 			s.Labels[networking.SKSLabelKey] = "dream-tonight-cherub-rock-mayonnaise-hummer-disarm-rocket-soma-quiet"
 			s.Annotations = map[string]string{"cherub": "rock"}
-			s.Spec.ClusterIP = corev1.ClusterIPNone
 		}, privateSvcMod, func(s *corev1.Service) {
 			// And now patch port to be http2.
 			s.Spec.Ports[0] = corev1.ServicePort{


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/15267

## Proposed Changes

* Revert PR #15170 since it interferes with istio in mesh mode

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
