### PR TITLE
Fix marking activator endpoints populated into sks condition accurately 

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -268,6 +268,9 @@ func (ks *scaler) handleScaleToZero(ctx context.Context, pa *autoscalingv1alpha1
 			// Compute the difference between time we've been proxying with the timeout.
 			// If it's positive, that's the time we need to sleep, if negative -- we
 			// can scale to zero.
+			// It is positive if no activator endpoints, because the condition with type name
+			// "ActivatorEndpointsPopulated" will be false or nil.
+			// We can not scale to zero when no activator endpoints.
 			pf := sks.Status.ProxyFor()
 			to := cfgAS.ScaleToZeroGracePeriod - pf
 			if to <= 0 {

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -292,7 +292,7 @@ func (r *reconciler) reconcilePublicEndpoints(ctx context.Context, sks *netv1alp
 	}
 	// If we have no backends or if we're in the proxy mode, then
 	// activator backs this revision.
-	if !foundServingEndpoints || sks.Spec.Mode == netv1alpha1.SKSOperationModeProxy {
+	if !foundServingEndpoints || mode == netv1alpha1.SKSOperationModeProxy {
 		sks.Status.MarkActivatorEndpointsPopulated()
 	} else {
 		sks.Status.MarkActivatorEndpointsRemoved()

--- a/pkg/reconciler/serverlessservice/serverlessservice.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice.go
@@ -292,7 +292,8 @@ func (r *reconciler) reconcilePublicEndpoints(ctx context.Context, sks *netv1alp
 	}
 	// If we have no backends or if we're in the proxy mode, then
 	// activator backs this revision.
-	if !foundServingEndpoints || mode == netv1alpha1.SKSOperationModeProxy {
+	// If no activator, force serve mode and remove.
+	if mode == netv1alpha1.SKSOperationModeProxy {
 		sks.Status.MarkActivatorEndpointsPopulated()
 	} else {
 		sks.Status.MarkActivatorEndpointsRemoved()

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -447,7 +447,7 @@ func TestReconcile(t *testing.T) {
 		Name: "OnCreate-no-activator-eps-proxy",
 		Key:  "on/cnaeps",
 		Objects: []runtime.Object{
-			SKS("on", "cnaeps", WithDeployRef("blah"), withProxyMode),
+			SKS("on", "cnaeps", WithDeployRef("blah"), WithProxyMode),
 			deploy("on", "blah"),
 			endpointspriv("on", "cnaeps"), // This should be ignored.
 			activatorEndpoints(),
@@ -458,8 +458,8 @@ func TestReconcile(t *testing.T) {
 			endpointspub("on", "cnaeps"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: SKS("on", "cnaeps", WithDeployRef("blah"), withProxyMode,
-				markNoEndpoints, WithPubService, WithPrivateService),
+			Object: SKS("on", "cnaeps", WithDeployRef("blah"), WithProxyMode,
+				markNoHealthyEndpoints, WithPubService, WithPrivateService),
 		}},
 	}, {
 		Name:    "create-svc-fail-priv",
@@ -768,12 +768,12 @@ func markTransitioning(s string) SKSOption {
 }
 
 func markNoEndpoints(sks *nv1a1.ServerlessService) {
-	sks.Status.MarkEndpointsNotReady("NoHealthyBackends")
+	markNoHealthyEndpoints(sks)
 	sks.Status.MarkActivatorEndpointsPopulated()
 }
 
-func markNoActivatorEndpoints(sks *nv1a1.ServerlessService) {
-	sks.Status.MarkActivatorEndpointsRemoved()
+func markNoHealthyEndpoints(sks *nv1a1.ServerlessService) {
+	sks.Status.MarkEndpointsNotReady("NoHealthyBackends")
 }
 
 func withHTTP2Protocol(sks *nv1a1.ServerlessService) {

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -115,7 +115,7 @@ func TestReconcile(t *testing.T) {
 		Name: "force serve mode, no endpoints",
 		Key:  "force/serve",
 		Objects: []runtime.Object{
-			SKS("force", "serve", withProxyMode, markHappy, WithPubService, WithPrivateService, WithDeployRef("bar")),
+			SKS("force", "serve", WithProxyMode, markHappy, WithPubService, WithPrivateService, WithDeployRef("bar")),
 			deploy("force", "bar"),
 			svcpub("force", "serve"),
 			svcpriv("force", "serve"),
@@ -770,6 +770,10 @@ func markTransitioning(s string) SKSOption {
 func markNoEndpoints(sks *nv1a1.ServerlessService) {
 	sks.Status.MarkEndpointsNotReady("NoHealthyBackends")
 	sks.Status.MarkActivatorEndpointsPopulated()
+}
+
+func markNoActivatorEndpoints(sks *nv1a1.ServerlessService) {
+	sks.Status.MarkActivatorEndpointsRemoved()
 }
 
 func withHTTP2Protocol(sks *nv1a1.ServerlessService) {


### PR DESCRIPTION
Fixes #15278

* marking activator endpoints populated into sks condition accurately
While reconciling SKS, the reconciler will reconcile Public Endpoints and mark Activator Endpoints Populated into Condition at last. If no backends or if we're in the proxy mode, the activator will be considered to back this revision. But in fact, if no activator found, the mode will be forced into "Serve", and not be put in path. Would it be better to exclude this scenario when marking “ActivatorEndpointsPopulated” Condition?

> 
> ```
>  // Otherwise check how long SKS was in proxy mode.
>  // Compute the difference between time we've been proxying with the timeout.
>  // If it's positive, that's the time we need to sleep, if negative -- we
>  // can scale to zero.
>  pf := sks.Status.ProxyFor()
>  to := cfgAS.ScaleToZeroGracePeriod - pf
>  if to <= 0 {
>  logger.Info("Fast path scaling to 0, in proxy mode for: ", pf)
>	return desiredScale, true
>  }
> ```
The Condition with type name "ActivatorEndpointsPopulated" in SKS status  is used to determine whether the interval for scaling to 0 is reached. If there are no endpoints, is it best not to scale down to 0?


**Release Note**

```release-note
NONE
```

