### PR TITLE
Do not delete ingress Secret in tests for internal tls

### DIFF
--- a/test/e2e/systeminternaltls/system_internal_tls_test.go
+++ b/test/e2e/systeminternaltls/system_internal_tls_test.go
@@ -227,12 +227,6 @@ func TestTLSCertificateRotation(t *testing.T) {
 		t.Fatalf("Failed to delete secret %s in system namespacee", config.ServingRoutingCertName)
 	}
 	checkEndpointState(t, clients, url)
-
-	t.Log("Deleting secret in ingress namespace")
-	if err := clients.KubeClient.CoreV1().Secrets(ingressNS).Delete(context.Background(), config.ServingRoutingCertName, v1.DeleteOptions{}); err != nil {
-		t.Fatalf("Failed to delete secret %s in ingress namespacee", config.ServingRoutingCertName)
-	}
-	checkEndpointState(t, clients, url)
 }
 
 func checkEndpointState(t *testing.T, clients *test.Clients, url *url.URL) {


### PR DESCRIPTION
This test relies on trusting certificates as described in https://github.com/knative/serving/issues/14609
This is currently not implemented in net-istio, and is tracked as https://github.com/knative-extensions/net-istio/issues/1328

Part of #15276

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
