### PR TITLE
Set controller reconcillers to the correct number in tests

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -33,6 +33,7 @@ import (
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
+	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/reconciler/certificate"
 	"knative.dev/serving/pkg/reconciler/configuration"
 	"knative.dev/serving/pkg/reconciler/domainmapping"
@@ -102,8 +103,7 @@ func shouldEnableNetCertManagerController(ctx context.Context, client *kubernete
 		log.Fatalf("Failed to construct network config: %v", err)
 	}
 
-	return netCfg.ExternalDomainTLS || netCfg.SystemInternalTLSEnabled() || (netCfg.ClusterLocalDomainTLS == netcfg.EncryptionEnabled) ||
-		netCfg.NamespaceWildcardCertSelector != nil
+	return networking.IsNetCertManagerControllerRequired(netCfg)
 }
 
 func certManagerCRDsExist(client *versioned.Clientset) (bool, error) {

--- a/pkg/networking/util.go
+++ b/pkg/networking/util.go
@@ -44,3 +44,9 @@ func GetHTTPOption(ctx context.Context, networkConfig *netcfg.Config, annotation
 		return "", nil
 	}
 }
+
+// IsNetCertManagerControllerRequired returns true if we need the netCertManagerController running
+func IsNetCertManagerControllerRequired(netCfg *netcfg.Config) bool {
+	return netCfg.ExternalDomainTLS || netCfg.SystemInternalTLSEnabled() || (netCfg.ClusterLocalDomainTLS == netcfg.EncryptionEnabled) ||
+		netCfg.NamespaceWildcardCertSelector != nil
+}

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -42,7 +42,7 @@ func TestControllerHA(t *testing.T) {
 	clients := e2e.Setup(t)
 
 	reconcilers := NumControllerReconcilers
-	if isInternalEncryptionOn(t, clients.KubeClient) {
+	if isNetCertmanagerControllerReconcilerOn(t, clients.KubeClient) {
 		reconcilers = NumControllerReconcilers + 1
 	}
 	if err := pkgTest.WaitForDeploymentScale(context.Background(), clients.KubeClient, controllerDeploymentName, system.Namespace(), test.ServingFlags.Replicas); err != nil {

--- a/test/ha/controller_test.go
+++ b/test/ha/controller_test.go
@@ -41,12 +41,16 @@ const (
 func TestControllerHA(t *testing.T) {
 	clients := e2e.Setup(t)
 
+	reconcilers := NumControllerReconcilers
+	if isInternalEncryptionOn(t, clients.KubeClient) {
+		reconcilers = NumControllerReconcilers + 1
+	}
 	if err := pkgTest.WaitForDeploymentScale(context.Background(), clients.KubeClient, controllerDeploymentName, system.Namespace(), test.ServingFlags.Replicas); err != nil {
 		t.Fatalf("Deployment %s not scaled to %d: %v", controllerDeploymentName, test.ServingFlags.Replicas, err)
 	}
 
 	// TODO(mattmoor): Once we switch to the new sharded leader election, we should use more than a single bucket here, but the test is still interesting.
-	leaders, err := pkgHa.WaitForNewLeaders(context.Background(), t, clients.KubeClient, controllerDeploymentName, system.Namespace(), sets.New[string](), NumControllerReconcilers*test.ServingFlags.Buckets)
+	leaders, err := pkgHa.WaitForNewLeaders(context.Background(), t, clients.KubeClient, controllerDeploymentName, system.Namespace(), sets.New[string](), reconcilers*test.ServingFlags.Buckets)
 	if err != nil {
 		t.Fatal("Failed to get leader:", err)
 	}

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -30,6 +30,7 @@ import (
 	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
+	"knative.dev/serving/pkg/networking"
 	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 	"knative.dev/serving/test/e2e"
@@ -105,7 +106,7 @@ func readyEndpointsDoNotContain(ip string) func(*corev1.Endpoints) (bool, error)
 	}
 }
 
-func isInternalEncryptionOn(t *testing.T, client kubernetes.Interface) bool {
+func isNetCertmanagerControllerReconcilerOn(t *testing.T, client kubernetes.Interface) bool {
 	var cm *corev1.ConfigMap
 	var err error
 	if cm, err = client.CoreV1().ConfigMaps(system.Namespace()).Get(context.Background(), "config-network", metav1.GetOptions{}); err != nil {
@@ -116,6 +117,5 @@ func isInternalEncryptionOn(t *testing.T, client kubernetes.Interface) bool {
 		t.Fatalf("Failed to construct network config: %v", err)
 	}
 
-	return netCfg.ExternalDomainTLS || netCfg.SystemInternalTLSEnabled() || (netCfg.ClusterLocalDomainTLS == netcfg.EncryptionEnabled) ||
-		netCfg.NamespaceWildcardCertSelector != nil
+	return networking.IsNetCertManagerControllerRequired(netCfg)
 }

--- a/test/ha/ha.go
+++ b/test/ha/ha.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
+	netcfg "knative.dev/networking/pkg/config"
+	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
 	rtesting "knative.dev/serving/pkg/testing/v1"
@@ -101,4 +103,19 @@ func readyEndpointsDoNotContain(ip string) func(*corev1.Endpoints) (bool, error)
 		}
 		return true, nil
 	}
+}
+
+func isInternalEncryptionOn(t *testing.T, client kubernetes.Interface) bool {
+	var cm *corev1.ConfigMap
+	var err error
+	if cm, err = client.CoreV1().ConfigMaps(system.Namespace()).Get(context.Background(), "config-network", metav1.GetOptions{}); err != nil {
+		t.Fatalf("Failed to get cm config-network: %v", err)
+	}
+	netCfg, err := netcfg.NewConfigFromMap(cm.Data)
+	if err != nil {
+		t.Fatalf("Failed to construct network config: %v", err)
+	}
+
+	return netCfg.ExternalDomainTLS || netCfg.SystemInternalTLSEnabled() || (netCfg.ClusterLocalDomainTLS == netcfg.EncryptionEnabled) ||
+		netCfg.NamespaceWildcardCertSelector != nil
 }


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* See https://github.com/knative/serving/issues/15238, this is an upper 
* Let's be precise
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
