### PR TITLE
Run system-internal-tls tests only for kourier

### DIFF
--- a/test/e2e/systeminternaltls/system_internal_tls_test.go
+++ b/test/e2e/systeminternaltls/system_internal_tls_test.go
@@ -225,6 +225,12 @@ func TestTLSCertificateRotation(t *testing.T) {
 		t.Fatalf("Failed to delete secret %s in system namespacee", config.ServingRoutingCertName)
 	}
 	checkEndpointState(t, clients, url)
+
+	t.Log("Deleting secret in ingress namespace")
+	if err := clients.KubeClient.CoreV1().Secrets(ingressNS).Delete(context.Background(), config.ServingRoutingCertName, v1.DeleteOptions{}); err != nil {
+		t.Fatalf("Failed to delete secret %s in ingress namespacee", config.ServingRoutingCertName)
+	}
+	checkEndpointState(t, clients, url)
 }
 
 func checkEndpointState(t *testing.T, clients *test.Clients, url *url.URL) {

--- a/test/e2e/systeminternaltls/system_internal_tls_test.go
+++ b/test/e2e/systeminternaltls/system_internal_tls_test.go
@@ -51,9 +51,8 @@ func TestSystemInternalTLS(t *testing.T) {
 		t.Skip("Alpha features not enabled")
 	}
 
-	if !(strings.Contains(test.ServingFlags.IngressClass, "kourier") ||
-		strings.Contains(test.ServingFlags.IngressClass, "istio")) {
-		t.Skip("Skip this test for non-kourier or non-istio ingress.")
+	if !(strings.Contains(test.ServingFlags.IngressClass, "kourier")) {
+		t.Skip("Skip this test for non-kourier ingress.")
 	}
 
 	t.Parallel()
@@ -117,9 +116,8 @@ func TestTLSCertificateRotation(t *testing.T) {
 		t.Skip("Alpha features not enabled")
 	}
 
-	if !(strings.Contains(test.ServingFlags.IngressClass, "kourier") ||
-		strings.Contains(test.ServingFlags.IngressClass, "istio")) {
-		t.Skip("Skip this test for non-kourier or non-istio ingress.")
+	if !(strings.Contains(test.ServingFlags.IngressClass, "kourier")) {
+		t.Skip("Skip this test for non-kourier ingress.")
 	}
 
 	t.Parallel()


### PR DESCRIPTION
Fixes https://github.com/knative-extensions/net-istio/issues/1328

## Proposed Changes
* Run system-internal-tls tests only for kourier, as it is not supported with istio (see [docs](https://knative.dev/docs/serving/encryption/system-internal-tls/#before-you-begin) and https://github.com/knative-extensions/net-istio/issues/1328#issuecomment-2147206952)
* Reverts the https://github.com/knative/serving/commit/f84265a866261dffddb857caf313430b6cdcae23, which is now no longer neede

/assign @mgencur 
/assign @skonto 
