### PR TITLE
use cgr.dev/chainguard/static:latest which is nonroot

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,3 @@
 # Use :nonroot base image for all containers
-defaultBaseImage: gcr.io/distroless/static:nonroot
 baseImageOverrides:
   knative.dev/serving/vendor/github.com/tsenart/vegeta/v12: ubuntu:latest


### PR DESCRIPTION
cgr.dev has been around for a while now so the concerns I had in https://github.com/knative/community/issues/1165 are sorta alleviated since it's not backed by Github registry anymore ;)

Probably good to switch serving over to it (it's ko's default image)