### PR TITLE
Add pod diagnostics before scaling down to zero in scaler

### DIFF
--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -215,6 +215,12 @@ func (pas *PodAutoscalerStatus) MarkScaleTargetInitialized() {
 	podCondSet.Manage(pas).MarkTrue(PodAutoscalerConditionScaleTargetInitialized)
 }
 
+// MarkScaleTargetNotInitialized marks the PA's PodAutoscalerConditionScaleTargetInitialized
+// condition true.
+func (pas *PodAutoscalerStatus) MarkScaleTargetNotInitialized(reason, message string) {
+	podCondSet.Manage(pas).MarkFalse(PodAutoscalerConditionScaleTargetInitialized, reason, message)
+}
+
 // MarkSKSReady marks the PA condition denoting that SKS is ready.
 func (pas *PodAutoscalerStatus) MarkSKSReady() {
 	podCondSet.Manage(pas).MarkTrue(PodAutoscalerConditionSKSReady)

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -114,10 +114,16 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.
 	if err := c.ReconcileMetric(ctx, pa, resolveScrapeTarget(ctx, pa)); err != nil {
 		return fmt.Errorf("error reconciling Metric: %w", err)
 	}
+	podCounter := resourceutil.NewPodAccessor(c.podsLister, pa.Namespace, pa.Labels[serving.RevisionLabelKey])
+
+	pod, err := podCounter.GetAnyPod()
+	if err != nil {
+		return fmt.Errorf("error getting a pod for the revision: %w", err)
+	}
 
 	// Get the appropriate current scale from the metric, and right size
 	// the scaleTargetRef based on it.
-	want, err := c.scaler.scale(ctx, pa, sks, decider.Status.DesiredScale)
+	want, err := c.scaler.scale(ctx, pa, sks, decider.Status.DesiredScale, c.Client, pod)
 	if err != nil {
 		return fmt.Errorf("error scaling target: %w", err)
 	}
@@ -145,7 +151,6 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.
 	}
 
 	// Compare the desired and observed resources to determine our situation.
-	podCounter := resourceutil.NewPodAccessor(c.podsLister, pa.Namespace, pa.Labels[serving.RevisionLabelKey])
 	ready, notReady, pending, terminating, err := podCounter.PodCountsByState()
 	if err != nil {
 		return fmt.Errorf("error getting pod counts: %w", err)

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -556,7 +556,7 @@ func TestScaler(t *testing.T) {
 				test.configMutator(cfg)
 			}
 			ctx = config.ToContext(ctx, cfg)
-			desiredScale, err := revisionScaler.scale(ctx, pa, sks, test.scaleTo)
+			desiredScale, err := revisionScaler.scale(ctx, pa, sks, test.scaleTo, fakeservingclient.Get(ctx), nil)
 			if err != nil {
 				t.Error("Scale got an unexpected error:", err)
 			}
@@ -647,7 +647,7 @@ func TestDisableScaleToZero(t *testing.T) {
 			conf := defaultConfig()
 			conf.Autoscaler.EnableScaleToZero = false
 			ctx = config.ToContext(ctx, conf)
-			desiredScale, err := revisionScaler.scale(ctx, pa, nil /*sks doesn't matter in this test*/, test.scaleTo)
+			desiredScale, err := revisionScaler.scale(ctx, pa, nil /*sks doesn't matter in this test*/, test.scaleTo, fakeservingclient.Get(ctx), nil)
 
 			if err != nil {
 				t.Error("Scale got an unexpected error:", err)

--- a/pkg/resources/pods.go
+++ b/pkg/resources/pods.go
@@ -44,6 +44,18 @@ func NewPodAccessor(lister corev1listers.PodLister, namespace, revisionName stri
 	}
 }
 
+// GetAnyPod returns a pod for the revision that owns the pa, if any
+func (pa PodAccessor) GetAnyPod() (pod *corev1.Pod, err error) {
+	pods, err := pa.podsLister.List(pa.selector)
+	if err != nil {
+		return nil, err
+	}
+	if len(pods) != 0 {
+		return pods[0], nil
+	}
+	return nil, nil
+}
+
 // PodCountsByState returns number of pods for the revision grouped by their state, that is
 // of interest to knative (e.g. ignoring failed or terminated pods).
 func (pa PodAccessor) PodCountsByState() (ready, notReady, pending, terminating int, err error) {


### PR DESCRIPTION
Fixes #14157 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Replaces https://github.com/knative/serving/pull/14835
*  Adds pod diagnostics as it was pending [here](https://github.com/knative/serving/blob/main/pkg/reconciler/autoscaling/kpa/scaler.go#L66), I am wondering what it is needed to remove `activationTimeoutBuffer`.
* The idea is to mark the revision with resourcesAvailable=false and pa with ScaleTargetInitialized=false just before
we apply scaling down to zero and after we have timedout and we failed the activation [here](https://github.com/knative/serving/blob/main/pkg/reconciler/autoscaling/kpa/scaler.go#L205).
This would trigger the following [condition](https://github.com/knative/serving/blob/main/pkg/apis/serving/v1/revision_lifecycle.go#L229) in the revision lifecycle and pa status propagation:
		`if !ps.IsScaleTargetInitialized() && !resUnavailable && ps.ServiceName != "" {`
A revision with no resources available will be set to ready false (due to its condSet) and that will propagate the condition up to the ksvc.

* Tested with:
```
apiVersion: serving.knative.dev/v1
kind: Service
metadata:
  name: hello
spec:
  template:
    metadata:
      annotations:
        serving.knative.dev/progress-deadline: "45s"
    spec:
      timeoutSeconds: 30
      containers:
        - image: ghcr.io/knative/helloworld-go:latest
          ports:
            - containerPort: 8080
          env:
            - name: TARGET
              value: "World"

```
Steps to reproduce. First run the ksvc, let it scale down to zero and then remove the revision image from the local registry. Disable net access so image cannot be fetched, issue a new request.
The status of the Serving resources will become:
```
{
    "apiVersion": "v1",
    "items": [
        {
            "apiVersion": "serving.knative.dev/v1",
            "kind": "Service",
            "metadata": {
                "annotations": {
....
            },
            "status": {
                "address": {
                    "url": "http://hello.default.svc.cluster.local"
                },
                "conditions": [
                    {
                        "lastTransitionTime": "2024-06-12T13:02:06Z",
                        "message": "Revision \"hello-00001\" failed with message: Initial scale was never achieved.",
                        "reason": "RevisionFailed",
                        "status": "False",
                        "type": "ConfigurationsReady"
                    },
                    {
                        "lastTransitionTime": "2024-06-12T13:02:05Z",
                        "message": "Revision \"hello-00001\" failed to become ready.",
                        "reason": "RevisionMissing",
                        "status": "False",
                        "type": "Ready"
                    },
                    {
                        "lastTransitionTime": "2024-06-12T13:02:05Z",
                        "message": "Revision \"hello-00001\" failed to become ready.",
                        "reason": "RevisionMissing",
                        "status": "False",
                        "type": "RoutesReady"
                    }
                ],
    }
}
{
    "apiVersion": "v1",
    "items": [
        {
            "apiVersion": "serving.knative.dev/v1",
            "kind": "Revision",
            "metadata": {
                "annotations": {
                    "serving.knative.dev/creator": "minikube-user",
                    "serving.knative.dev/progress-deadline": "45s",
                    "serving.knative.dev/routes": "hello",
                    "serving.knative.dev/routingStateModified": "2024-06-12T12:57:33Z"
                },
...

            "status": {
                "actualReplicas": 0,
                "conditions": [
                    {
                        "lastTransitionTime": "2024-06-12T13:02:06Z",
                        "message": "The target is not receiving traffic.",
                        "reason": "NoTraffic",
                        "severity": "Info",
                        "status": "False",
                        "type": "Active"
                    },
                    {
                        "lastTransitionTime": "2024-06-12T12:57:51Z",
                        "status": "True",
                        "type": "ContainerHealthy"
                    },
                    {
                        "lastTransitionTime": "2024-06-12T13:02:06Z",
                        "message": "Initial scale was never achieved",
                        "reason": "ProgressDeadlineExceeded",
                        "status": "False",
                        "type": "Ready"
                    },
                    {
                        "lastTransitionTime": "2024-06-12T13:02:06Z",
                        "message": "Initial scale was never achieved",
                        "reason": "ProgressDeadlineExceeded",
                        "status": "False",
                        "type": "ResourcesAvailable"
                    }
                ],
...
}
{
    "apiVersion": "v1",
    "items": [
        {
            "apiVersion": "serving.knative.dev/v1",
            "kind": "Configuration",
            "metadata": {
...
                "name": "hello",
                "namespace": "default",
...
            "status": {
                "conditions": [
                    {
                        "lastTransitionTime": "2024-06-12T13:02:06Z",
                        "message": "Revision \"hello-00001\" failed with message: Initial scale was never achieved.",
                        "reason": "RevisionFailed",
                        "status": "False",
                        "type": "Ready"
                    }
                ],
...
}
{
    "apiVersion": "v1",
    "items": [
        {
            "apiVersion": "autoscaling.internal.knative.dev/v1alpha1",
            "kind": "PodAutoscaler",

  ...
            "spec": {
                "protocolType": "http1",
                "reachability": "Reachable",
                "scaleTargetRef": {
                    "apiVersion": "apps/v1",
                    "kind": "Deployment",
                    "name": "hello-00001-deployment"
                }
            },
            "status": {
                "actualScale": 0,
                "conditions": [
                    {
                        "lastTransitionTime": "2024-06-12T13:02:05Z",
                        "message": "The target is not receiving traffic.",
                        "reason": "NoTraffic",
                        "status": "False",
                        "type": "Active"
                    },
                    {
                        "lastTransitionTime": "2024-06-12T13:02:05Z",
                        "message": "The target is not receiving traffic.",
                        "reason": "NoTraffic",
                        "status": "False",
                        "type": "Ready"
                    },
                    {
                        "lastTransitionTime": "2024-06-12T12:58:51Z",
                        "message": "K8s Service is not ready",
                        "reason": "NotReady",
                        "status": "Unknown",
                        "type": "SKSReady"
                    },
                    {
                "desiredScale": 0,
                "metricsServiceName": "hello-00001-private",
                "observedGeneration": 1,
                "serviceName": "hello-00001"
            }
        }
    ],
}
```
After we bring the image back a new request will work as expected and resource statuses go back to the usual.
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
