### PR TITLE
re-enable failng contour/gateway api tests

### DIFF
--- a/test/conformance/api/v1/revision_timeout_test.go
+++ b/test/conformance/api/v1/revision_timeout_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"testing"
 	"time"
 
@@ -106,15 +105,6 @@ func TestRevisionTimeout(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.name == "writes first byte before timeout" &&
-				os.Getenv("INGRESS_CLASS") == "gateway-api.ingress.networking.knative.dev" &&
-				os.Getenv("GATEWAY_API_IMPLEMENTATION") == "contour" &&
-				os.Getenv("KIND") != "" {
-				// TODO (izabelacg) temporary solution until the following issue is addressed
-				// see https://github.com/knative/serving/issues/15089
-				t.Skip("Known test failure with Contour and Gateway API")
-			}
-
 			t.Parallel()
 
 			names := test.ResourceNames{

--- a/test/e2e/destroypod_test.go
+++ b/test/e2e/destroypod_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"testing"
 	"time"
 
@@ -50,14 +49,6 @@ const (
 )
 
 func TestDestroyPodInflight(t *testing.T) {
-	if os.Getenv("INGRESS_CLASS") == "gateway-api.ingress.networking.knative.dev" &&
-		os.Getenv("GATEWAY_API_IMPLEMENTATION") == "contour" &&
-		os.Getenv("KIND") != "" {
-		// TODO (izabelacg) temporary solution until the following issue is addressed
-		// see https://github.com/knative/serving/issues/15092
-		t.Skip("Known test failure with Contour and Gateway API")
-	}
-
 	t.Parallel()
 
 	clients := Setup(t)


### PR DESCRIPTION
Contour has a new release out (1.29) which fixes this issue

Fixes: https://github.com/knative-extensions/net-gateway-api/issues/711
Fixes: https://github.com/knative/serving/issues/15092
Fixes: https://github.com/knative/serving/issues/15089