### PR TITLE
Clean up certificate leases

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -108,6 +108,7 @@ restart_pod "${SYSTEM_NAMESPACE}" "app=activator"
 # we need to restart the pod to stop the net-certmanager-controller
 if (( ! HTTPS )); then
   restart_pod "${SYSTEM_NAMESPACE}" "app=controller"
+  kubectl get leases -n "${SYSTEM_NAMESPACE}" -o json | jq -r '.items[] | select(.metadata.name | test("controller.knative.dev.serving.pkg.reconciler.certificate.reconciler")).metadata.name' | xargs kubectl delete lease -n "${SYSTEM_NAMESPACE}"
 fi
 
 kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml > "${TMP_DIR}"/config-gc.yaml
@@ -164,6 +165,7 @@ if (( HTTPS )); then
   toggle_feature external-domain-tls Disabled config-network
   # we need to restart the pod to stop the net-certmanager-controller
   restart_pod "${SYSTEM_NAMESPACE}" "app=controller"
+  kubectl get leases -n "${SYSTEM_NAMESPACE}" -o json | jq -r '.items[] | select(.metadata.name | test("controller.knative.dev.serving.pkg.reconciler.certificate.reconciler")).metadata.name' | xargs kubectl delete lease -n "${SYSTEM_NAMESPACE}"
 fi
 
 (( failed )) && fail_test


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/15238

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* The tests in Serving fail because they compare the previous leader set with the new and they find the certificate lease's old owner when they do the intersection of the two sets. As described above this is due to the certificate lease not being updated with the empty holder identity when controller shuts down.  See https://github.com/knative/serving/pull/15321#issuecomment-2176434523. 
* After deleting pods the new ones will not set any lease but we want to make sure old relics are removed.
* This is temporary until client-go lib fixes this, https://github.com/kubernetes/client-go/issues/1362.
