### PR TITLE
Enable cluster local TLS tests for Contour

### DIFF
--- a/test/e2e/clusterlocaldomaintls/cluster_local_domain_tls_test.go
+++ b/test/e2e/clusterlocaldomaintls/cluster_local_domain_tls_test.go
@@ -46,8 +46,8 @@ func TestClusterLocalDomainTLSClusterLocalVisibility(t *testing.T) {
 		t.Skip("Alpha features not enabled")
 	}
 
-	if !strings.Contains(test.ServingFlags.IngressClass, "kourier") ||
-		strings.Contains(test.ServingFlags.IngressClass, "contour") {
+	if !strings.Contains(test.ServingFlags.IngressClass, "kourier") &&
+		!strings.Contains(test.ServingFlags.IngressClass, "contour") {
 		t.Skip("Skip this test for non-kourier/contour ingress.")
 	}
 
@@ -97,8 +97,9 @@ func TestClusterLocalDomainTLSClusterExternalVisibility(t *testing.T) {
 		t.Skip("Alpha features not enabled")
 	}
 
-	if !(strings.Contains(test.ServingFlags.IngressClass, "kourier")) {
-		t.Skip("Skip this test for non-kourier ingress.")
+	if !strings.Contains(test.ServingFlags.IngressClass, "kourier") &&
+		!strings.Contains(test.ServingFlags.IngressClass, "contour") {
+		t.Skip("Skip this test for non-kourier/contour ingress.")
 	}
 
 	t.Parallel()

--- a/test/e2e/clusterlocaldomaintls/cluster_local_domain_tls_test.go
+++ b/test/e2e/clusterlocaldomaintls/cluster_local_domain_tls_test.go
@@ -46,8 +46,9 @@ func TestClusterLocalDomainTLSClusterLocalVisibility(t *testing.T) {
 		t.Skip("Alpha features not enabled")
 	}
 
-	if !(strings.Contains(test.ServingFlags.IngressClass, "kourier")) {
-		t.Skip("Skip this test for non-kourier ingress.")
+	if !strings.Contains(test.ServingFlags.IngressClass, "kourier") ||
+		strings.Contains(test.ServingFlags.IngressClass, "contour") {
+		t.Skip("Skip this test for non-kourier/contour ingress.")
 	}
 
 	t.Parallel()

--- a/test/e2e/systeminternaltls/system_internal_tls_test.go
+++ b/test/e2e/systeminternaltls/system_internal_tls_test.go
@@ -51,9 +51,8 @@ func TestSystemInternalTLS(t *testing.T) {
 		t.Skip("Alpha features not enabled")
 	}
 
-	if !strings.Contains(test.ServingFlags.IngressClass, "kourier") ||
-		strings.Contains(test.ServingFlags.IngressClass, "contour") {
-
+	if !strings.Contains(test.ServingFlags.IngressClass, "kourier") &&
+		!strings.Contains(test.ServingFlags.IngressClass, "contour") {
 		t.Skip("Skip this test for non-kourier/contour ingress.")
 	}
 
@@ -118,8 +117,9 @@ func TestTLSCertificateRotation(t *testing.T) {
 		t.Skip("Alpha features not enabled")
 	}
 
-	if !(strings.Contains(test.ServingFlags.IngressClass, "kourier")) {
-		t.Skip("Skip this test for non-kourier ingress.")
+	if !strings.Contains(test.ServingFlags.IngressClass, "kourier") &&
+		!strings.Contains(test.ServingFlags.IngressClass, "contour") {
+		t.Skip("Skip this test for non-kourier/contour ingress.")
 	}
 
 	t.Parallel()


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/14375

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
 
* Enable cluster local tls test
* Depends on https://github.com/knative-extensions/net-contour/pull/1112

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Contour now supports TLS encryption of cluster local routes
```
