### PR TITLE
Use a different 'static' image that supports s390x and ppc

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,3 +1,4 @@
 # Use :nonroot base image for all containers
+defaultBaseImage: ghcr.io/wolfi-dev/static:alpine
 baseImageOverrides:
-  knative.dev/serving/vendor/github.com/tsenart/vegeta/v12: ubuntu:latest
+  github.com/tsenart/vegeta/v12: ubuntu:latest


### PR DESCRIPTION
Updated image is recommended by Chainguard
Details here: https://www.chainguard.dev/unchained/changes-to-static-git-and-busybox-developer-images-2

`ko` by default builds for the platforms that the base image supports

## Release Note
```release-note
Support s390x/ppc when building our controllers
```
