### PR TITLE
Add support for hostipc, hostpid and hostnetwork

### DIFF
--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -1042,6 +1042,9 @@ spec:
                           description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
+                        hostIPC:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
+                          type: boolean
                         serviceAccountName:
                           description: |-
                             ServiceAccountName is the name of the ServiceAccount to use to run this pod.

--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -968,6 +968,10 @@ spec:
                             description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
+                        hostIPC:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
+                          type: boolean
+                          x-kubernetes-preserve-unknown-fields: true
                         idleTimeoutSeconds:
                           description: |-
                             IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed
@@ -1042,9 +1046,6 @@ spec:
                           description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
-                        hostIPC:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
-                          type: boolean
                         serviceAccountName:
                           description: |-
                             ServiceAccountName is the name of the ServiceAccount to use to run this pod.

--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -972,6 +972,14 @@ spec:
                           description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
                           type: boolean
                           x-kubernetes-preserve-unknown-fields: true
+                        hostNetwork:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostnetwork
+                          type: boolean
+                          x-kubernetes-preserve-unknown-fields: true
+                        hostPID:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostpid
+                          type: boolean
+                          x-kubernetes-preserve-unknown-fields: true
                         idleTimeoutSeconds:
                           description: |-
                             IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -949,6 +949,14 @@ spec:
                   description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
                   type: boolean
                   x-kubernetes-preserve-unknown-fields: true
+                hostNetwork:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-hostnetwork
+                  type: boolean
+                  x-kubernetes-preserve-unknown-fields: true
+                hostPID:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-hostpid
+                  type: boolean
+                  x-kubernetes-preserve-unknown-fields: true
                 idleTimeoutSeconds:
                   description: |-
                     IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -1019,6 +1019,9 @@ spec:
                   description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                hostIPC:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
+                  type: boolean
                 serviceAccountName:
                   description: |-
                     ServiceAccountName is the name of the ServiceAccount to use to run this pod.

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -945,6 +945,10 @@ spec:
                     description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                hostIPC:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
+                  type: boolean
+                  x-kubernetes-preserve-unknown-fields: true
                 idleTimeoutSeconds:
                   description: |-
                     IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed
@@ -1019,9 +1023,6 @@ spec:
                   description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
-                hostIPC:
-                  description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
-                  type: boolean
                 serviceAccountName:
                   description: |-
                     ServiceAccountName is the name of the ServiceAccount to use to run this pod.

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -1062,6 +1062,9 @@ spec:
                           description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
+                        hostIPC:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
+                          type: boolean
                         serviceAccountName:
                           description: |-
                             ServiceAccountName is the name of the ServiceAccount to use to run this pod.

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -988,6 +988,10 @@ spec:
                             description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
+                        hostIPC:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
+                          type: boolean
+                          x-kubernetes-preserve-unknown-fields: true
                         idleTimeoutSeconds:
                           description: |-
                             IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed
@@ -1062,9 +1066,6 @@ spec:
                           description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
-                        hostIPC:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
-                          type: boolean
                         serviceAccountName:
                           description: |-
                             ServiceAccountName is the name of the ServiceAccount to use to run this pod.

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -992,6 +992,14 @@ spec:
                           description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
                           type: boolean
                           x-kubernetes-preserve-unknown-fields: true
+                        hostNetwork:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostnetwork
+                          type: boolean
+                          x-kubernetes-preserve-unknown-fields: true
+                        hostPID:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostpid
+                          type: boolean
+                          x-kubernetes-preserve-unknown-fields: true
                         idleTimeoutSeconds:
                           description: |-
                             IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "632d47dd"
+    knative.dev/example-checksum: "552d0483"
 data:
   _example: |-
     ################################

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -138,6 +138,11 @@ data:
     # See: https://knative.dev/docs/serving/configuration/feature-flags/#kubernetes-share-process-namespace
     kubernetes.podspec-shareprocessnamespace: "disabled"
 
+    # Indicates whether hostIPC support is enabled
+    #
+    # Disabled by default
+    kubernetes.podspec-hostipc: "disabled"
+
     # Indicates whether Kubernetes PriorityClassName support is enabled
     #
     # WARNING: Cannot safely be disabled once enabled.

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "552d0483"
+    knative.dev/example-checksum: "9ff569ad"
 data:
   _example: |-
     ################################
@@ -140,8 +140,21 @@ data:
 
     # Indicates whether hostIPC support is enabled
     #
-    # Disabled by default
+    # WARNING: Cannot safely be disabled once enabled.
+    # See https://knative.dev/docs/serving/configuration/feature-flags/#kubernetes-host-ipc
     kubernetes.podspec-hostipc: "disabled"
+
+    # Indicates whether hostPID support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See https://knative.dev/docs/serving/configuration/feature-flags/#kubernetes-host-pid
+    kubernetes.podspec-hostpid: "disabled"
+
+    # Indicates whether hostNetwork support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See See https://knative.dev/docs/serving/configuration/feature-flags/#kubernetes-host-network
+    kubernetes.podspec-hostnetwork: "disabled"
 
     # Indicates whether Kubernetes PriorityClassName support is enabled
     #

--- a/hack/schemapatch-config.yaml
+++ b/hack/schemapatch-config.yaml
@@ -66,6 +66,7 @@ k8s.io/api/core/v1.PodSpec:
     - InitContainers
     - NodeSelector
     - PriorityClassName
+    - HostIPC
     - RuntimeClassName
     - SchedulerName
     - SecurityContext
@@ -140,6 +141,12 @@ k8s.io/api/core/v1.PodSpec:
         # Part of a feature flag - so we want to omit the schema and preserve unknown fields
         - kubebuilder:validation:DropProperties
         - kubebuilder:pruning:PreserveUnknownFields
+    HostIPC:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-hostipc"
+      additionalMarkers:
+      # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+      - kubebuilder:validation:DropProperties
+      - kubebuilder:pruning:PreserveUnknownFields
     Tolerations:
       description: "This is accessible behind a feature flag - kubernetes.podspec-tolerations"
       itemOverride:

--- a/hack/schemapatch-config.yaml
+++ b/hack/schemapatch-config.yaml
@@ -67,6 +67,8 @@ k8s.io/api/core/v1.PodSpec:
     - NodeSelector
     - PriorityClassName
     - HostIPC
+    - HostPID
+    - HostNetwork
     - RuntimeClassName
     - SchedulerName
     - SecurityContext
@@ -147,6 +149,18 @@ k8s.io/api/core/v1.PodSpec:
       # Part of a feature flag - so we want to omit the schema and preserve unknown fields
       - kubebuilder:validation:DropProperties
       - kubebuilder:pruning:PreserveUnknownFields
+    HostPID:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-hostpid"
+      additionalMarkers:
+        # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+        - kubebuilder:validation:DropProperties
+        - kubebuilder:pruning:PreserveUnknownFields
+    HostNetwork:
+      description: "This is accessible behind a feature flag - kubernetes.podspec-hostnetwork"
+      additionalMarkers:
+        # Part of a feature flag - so we want to omit the schema and preserve unknown fields
+        - kubebuilder:validation:DropProperties
+        - kubebuilder:pruning:PreserveUnknownFields
     Tolerations:
       description: "This is accessible behind a feature flag - kubernetes.podspec-tolerations"
       itemOverride:

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -64,6 +64,7 @@ func defaultFeaturesConfig() *Features {
 		PodSpecRuntimeClassName:          Disabled,
 		PodSpecSecurityContext:           Disabled,
 		PodSpecShareProcessNamespace:     Disabled,
+		PodSpecHostIPC:                   Disabled,
 		PodSpecPriorityClassName:         Disabled,
 		PodSpecSchedulerName:             Disabled,
 		ContainerSpecAddCapabilities:     Disabled,
@@ -98,11 +99,13 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 		asFlag("kubernetes.podspec-runtimeclassname", &nc.PodSpecRuntimeClassName),
 		asFlag("kubernetes.podspec-securitycontext", &nc.PodSpecSecurityContext),
 		asFlag("kubernetes.podspec-shareprocessnamespace", &nc.PodSpecShareProcessNamespace),
+		asFlag("kubernetes.podspec-hostipc", &nc.PodSpecHostIPC),
 		asFlag("kubernetes.podspec-priorityclassname", &nc.PodSpecPriorityClassName),
 		asFlag("kubernetes.podspec-schedulername", &nc.PodSpecSchedulerName),
 		asFlag("kubernetes.containerspec-addcapabilities", &nc.ContainerSpecAddCapabilities),
 		asFlag("kubernetes.podspec-tolerations", &nc.PodSpecTolerations),
 		asFlag("kubernetes.podspec-volumes-emptydir", &nc.PodSpecVolumesEmptyDir),
+		asFlag("kubernetes.podspec-hostipc", &nc.PodSpecHostIPC),
 		asFlag("kubernetes.podspec-init-containers", &nc.PodSpecInitContainers),
 		asFlag("kubernetes.podspec-persistent-volume-claim", &nc.PodSpecPersistentVolumeClaim),
 		asFlag("kubernetes.podspec-persistent-volume-write", &nc.PodSpecPersistentVolumeWrite),
@@ -136,6 +139,7 @@ type Features struct {
 	PodSpecRuntimeClassName          Flag
 	PodSpecSecurityContext           Flag
 	PodSpecShareProcessNamespace     Flag
+	PodSpecHostIPC                   Flag
 	PodSpecPriorityClassName         Flag
 	PodSpecSchedulerName             Flag
 	ContainerSpecAddCapabilities     Flag

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -65,6 +65,8 @@ func defaultFeaturesConfig() *Features {
 		PodSpecSecurityContext:           Disabled,
 		PodSpecShareProcessNamespace:     Disabled,
 		PodSpecHostIPC:                   Disabled,
+		PodSpecHostPID:                   Disabled,
+		PodSpecHostNetwork:               Disabled,
 		PodSpecPriorityClassName:         Disabled,
 		PodSpecSchedulerName:             Disabled,
 		ContainerSpecAddCapabilities:     Disabled,
@@ -106,6 +108,8 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 		asFlag("kubernetes.podspec-tolerations", &nc.PodSpecTolerations),
 		asFlag("kubernetes.podspec-volumes-emptydir", &nc.PodSpecVolumesEmptyDir),
 		asFlag("kubernetes.podspec-hostipc", &nc.PodSpecHostIPC),
+		asFlag("kubernetes.podspec-hostpid", &nc.PodSpecHostPID),
+		asFlag("kubernetes.podspec-hostnetwork", &nc.PodSpecHostNetwork),
 		asFlag("kubernetes.podspec-init-containers", &nc.PodSpecInitContainers),
 		asFlag("kubernetes.podspec-persistent-volume-claim", &nc.PodSpecPersistentVolumeClaim),
 		asFlag("kubernetes.podspec-persistent-volume-write", &nc.PodSpecPersistentVolumeWrite),
@@ -140,6 +144,8 @@ type Features struct {
 	PodSpecSecurityContext           Flag
 	PodSpecShareProcessNamespace     Flag
 	PodSpecHostIPC                   Flag
+	PodSpecHostPID                   Flag
+	PodSpecHostNetwork               Flag
 	PodSpecPriorityClassName         Flag
 	PodSpecSchedulerName             Flag
 	ContainerSpecAddCapabilities     Flag

--- a/pkg/apis/config/features_test.go
+++ b/pkg/apis/config/features_test.go
@@ -69,6 +69,9 @@ func TestFeaturesConfiguration(t *testing.T) {
 			PodSpecRuntimeClassName:          Enabled,
 			PodSpecSecurityContext:           Enabled,
 			PodSpecShareProcessNamespace:     Enabled,
+			PodSpecHostIPC:                   Enabled,
+			PodSpecHostPID:                   Enabled,
+			PodSpecHostNetwork:               Enabled,
 			PodSpecTolerations:               Enabled,
 			PodSpecPriorityClassName:         Enabled,
 			PodSpecSchedulerName:             Enabled,
@@ -90,6 +93,8 @@ func TestFeaturesConfiguration(t *testing.T) {
 			"kubernetes.podspec-securitycontext":           "Enabled",
 			"kubernetes.podspec-shareprocessnamespace":     "Enabled",
 			"kubernetes.podspec-hostipc":                   "Enabled",
+			"kubernetes.podspec-hostpid":                   "Enabled",
+			"kubernetes.podspec-hostnetwork":               "Enabled",
 			"kubernetes.podspec-tolerations":               "Enabled",
 			"kubernetes.podspec-priorityclassname":         "Enabled",
 			"kubernetes.podspec-schedulername":             "Enabled",
@@ -596,22 +601,58 @@ func TestFeaturesConfiguration(t *testing.T) {
 				"kubernetes.podspec-dnsconfig": "Disabled",
 			},
 		}, {
-			name:    "security context Allowed",
+			name:    "kubernetes.podspec-hostipc Enabled",
 			wantErr: false,
 			wantFeatures: defaultWith(&Features{
-				PodSpecSecurityContext: Allowed,
+				PodSpecHostIPC: Enabled,
 			}),
 			data: map[string]string{
-				"kubernetes.podspec-hostipc": "Allowed",
+				"kubernetes.podspec-hostipc": "Enabled",
 			},
 		}, {
-			name:    "security context disabled",
+			name:    "kubernetes.podspec-hostipc Disabled",
 			wantErr: false,
 			wantFeatures: defaultWith(&Features{
-				PodSpecSecurityContext: Disabled,
+				PodSpecHostIPC: Disabled,
 			}),
 			data: map[string]string{
 				"kubernetes.podspec-hostipc": "Disabled",
+			},
+		}, {
+			name:    "kubernetes.podspec-hostpid Enabled",
+			wantErr: false,
+			wantFeatures: defaultWith(&Features{
+				PodSpecHostPID: Enabled,
+			}),
+			data: map[string]string{
+				"kubernetes.podspec-hostpid": "Enabled",
+			},
+		}, {
+			name:    "kubernetes.podspec-hostpid Disabled",
+			wantErr: false,
+			wantFeatures: defaultWith(&Features{
+				PodSpecHostPID: Disabled,
+			}),
+			data: map[string]string{
+				"kubernetes.podspec-hostpid": "Disabled",
+			},
+		}, {
+			name:    "kubernetes.podspec-hostnetwork Enabled",
+			wantErr: false,
+			wantFeatures: defaultWith(&Features{
+				PodSpecHostNetwork: Enabled,
+			}),
+			data: map[string]string{
+				"kubernetes.podspec-hostnetwork": "Enabled",
+			},
+		}, {
+			name:    "kubernetes.podspec-hostnetwork Disabled",
+			wantErr: false,
+			wantFeatures: defaultWith(&Features{
+				PodSpecHostNetwork: Disabled,
+			}),
+			data: map[string]string{
+				"kubernetes.podspec-hostnetwork": "Disabled",
 			},
 		}}
 

--- a/pkg/apis/config/features_test.go
+++ b/pkg/apis/config/features_test.go
@@ -89,6 +89,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 			"kubernetes.podspec-runtimeclassname":          "Enabled",
 			"kubernetes.podspec-securitycontext":           "Enabled",
 			"kubernetes.podspec-shareprocessnamespace":     "Enabled",
+			"kubernetes.podspec-hostipc":                   "Enabled",
 			"kubernetes.podspec-tolerations":               "Enabled",
 			"kubernetes.podspec-priorityclassname":         "Enabled",
 			"kubernetes.podspec-schedulername":             "Enabled",
@@ -593,6 +594,24 @@ func TestFeaturesConfiguration(t *testing.T) {
 			}),
 			data: map[string]string{
 				"kubernetes.podspec-dnsconfig": "Disabled",
+			},
+		}, {
+			name:    "security context Allowed",
+			wantErr: false,
+			wantFeatures: defaultWith(&Features{
+				PodSpecSecurityContext: Allowed,
+			}),
+			data: map[string]string{
+				"kubernetes.podspec-hostipc": "Allowed",
+			},
+		}, {
+			name:    "security context disabled",
+			wantErr: false,
+			wantFeatures: defaultWith(&Features{
+				PodSpecSecurityContext: Disabled,
+			}),
+			data: map[string]string{
+				"kubernetes.podspec-hostipc": "Disabled",
 			},
 		}}
 

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -274,8 +274,6 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.NodeName = ""
 	out.HostNetwork = false
 	out.HostPID = false
-	out.HostIPC = false
-	out.ShareProcessNamespace = nil
 	out.Hostname = ""
 	out.Subdomain = ""
 	out.Priority = nil

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -266,14 +266,18 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	if cfg.Features.PodSpecHostIPC != config.Disabled {
 		out.HostIPC = in.HostIPC
 	}
+	if cfg.Features.PodSpecHostPID != config.Disabled {
+		out.HostPID = in.HostPID
+	}
+	if cfg.Features.PodSpecHostNetwork != config.Disabled {
+		out.HostNetwork = in.HostNetwork
+	}
 	// Disallowed fields
 	// This list is unnecessary, but added here for clarity
 	out.RestartPolicy = ""
 	out.TerminationGracePeriodSeconds = nil
 	out.ActiveDeadlineSeconds = nil
 	out.NodeName = ""
-	out.HostNetwork = false
-	out.HostPID = false
 	out.Hostname = ""
 	out.Subdomain = ""
 	out.Priority = nil

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -263,7 +263,9 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	if cfg.Features.PodSpecDNSConfig != config.Disabled {
 		out.DNSConfig = in.DNSConfig
 	}
-
+	if cfg.Features.PodSpecHostIPC != config.Disabled {
+		out.HostIPC = in.HostIPC
+	}
 	// Disallowed fields
 	// This list is unnecessary, but added here for clarity
 	out.RestartPolicy = ""
@@ -273,6 +275,7 @@ func PodSpecMask(ctx context.Context, in *corev1.PodSpec) *corev1.PodSpec {
 	out.HostNetwork = false
 	out.HostPID = false
 	out.HostIPC = false
+	out.ShareProcessNamespace = nil
 	out.Hostname = ""
 	out.Subdomain = ""
 	out.Priority = nil


### PR DESCRIPTION
Fixes #12830 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds support for hostpid, hostipc, hostnetwork to make sure Kserve workloads are unblocked when utilizing MPS based gpu sharing. This long standing issue was faced recently here: https://github.com/kserve/kserve/issues/3791 and blocks adoption of serverless mode in KServe. With this patch we move to close the gap between our podpsec support and [Kserve's](https://github.com/kserve/kserve/blob/master/pkg/apis/serving/v1beta1/podspec.go).
* Continues work in https://github.com/knative/serving/pull/13310
* TODO: add documentation, also I noticed that `kubernetes.podspec-shareprocessnamespace` lacks documentation (pointer in the features yaml is broken), I will fix in the same docs PR.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow hostPID, hostNetwork and HostIPC to be set for a Knative Service (feature flags: kubernetes.podspec-hostpid, kubernetes.podspec-hostnetwrok, kubernetes.podspec-hostipc). All features are disabled by default. 

```
