### PR TITLE
Do not run TestTLSCertificateRotation in parallel with other tests

### DIFF
--- a/test/e2e/systeminternaltls/system_internal_tls_test.go
+++ b/test/e2e/systeminternaltls/system_internal_tls_test.go
@@ -122,8 +122,6 @@ func TestTLSCertificateRotation(t *testing.T) {
 		t.Skip("Skip this test for non-kourier/contour ingress.")
 	}
 
-	t.Parallel()
-
 	clients := test.Setup(t)
 
 	names := test.ResourceNames{


### PR DESCRIPTION
This test deletes the serving-tests/serving-certs during the test run. This might break the other test TestSystemInternalTLS because it waits for certain log lines to appear in the service pods. Deleting the serving-certs secret causes the application pods to be deleted so that the new cert can be mounted. And waiting for given log lines then fails because the pod no longer exists:
```
system_internal_tls_test.go:110: TLS not used on requests to queue-proxy: pods
"system-internal-tls-wgvxqtyx-00001-deployment-6fdc4c8c7d-4ll8q" not found
```

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
