### PR TITLE
update schema-config

### DIFF
--- a/hack/schemapatch-config.yaml
+++ b/hack/schemapatch-config.yaml
@@ -91,13 +91,20 @@ k8s.io/api/core/v1.PodSpec:
       description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
     HostAliases:
       description: "This is accessible behind a feature flag - kubernetes.podspec-hostaliases"
+      additionalMarkers:
+        - kubebuilder:validation:DropListMapMarkers
       itemOverride:
         description: "This is accessible behind a feature flag - kubernetes.podspec-hostaliases"
         additionalMarkers:
         # # Part of a feature flag - so we want to omit the schema and preserve unknown fields
         - kubebuilder:validation:DropProperties
         - kubebuilder:pruning:PreserveUnknownFields
+    Containers:
+      additionalMarkers:
+        - kubebuilder:validation:DropListMapMarkers
     InitContainers:
+      additionalMarkers:
+        - kubebuilder:validation:DropListMapMarkers
       itemOverride:
         description: "This is accessible behind a feature flag - kubernetes.podspec-init-containers"
         additionalMarkers:


### PR DESCRIPTION
Newer K8s API include list-type markers that break since we relax the container name requirement. We also need to drop list type markers for host aliases because we prune the entire schema

Unblocks https://github.com/knative/serving/pull/15462

