### PR TITLE
Don't scrape pods via HTTP if the activator in path

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -280,6 +280,8 @@ func (a *autoscaler) Scale(logger *zap.SugaredLogger, now time.Time) ScaleResult
 	case spec.TargetBurstCapacity > 0:
 		totCap := float64(originalReadyPodsCount) * spec.TotalValue
 		excessBCF = math.Floor(totCap - spec.TargetBurstCapacity - observedPanicValue)
+	case spec.TargetBurstCapacity == -1:
+		a.metricClient.Pause(metricKey)
 	}
 
 	if debugEnabled {


### PR DESCRIPTION
Fixes #7324

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Never scrape if TBC=-1. The activator will always be in path in this case, so we never need to scrape really.

*Start/Stop scraping if activator is in path or not. This is a little more tricky as we need to make sure that we start scraping timely once we notice the activator will be taken off the path.
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
