### PR TITLE
Fix configuration metadata inconsistency

### DIFF
--- a/pkg/reconciler/labeler/accessors.go
+++ b/pkg/reconciler/labeler/accessors.go
@@ -129,9 +129,9 @@ func updateRouteAnnotation(acc kmeta.Accessor, routeName string, diffAnn map[str
 			return
 		}
 		valSet.Delete(routeName)
-		sorted := valSet.UnsortedList()
-		sort.Strings(sorted)
-		diffAnn[serving.RoutesAnnotationKey] = strings.Join(sorted, ",")
+		routeNames := valSet.UnsortedList()
+		sort.Strings(routeNames)
+		diffAnn[serving.RoutesAnnotationKey] = strings.Join(routeNames, ",")
 
 	case !has && !remove:
 		if len(valSet) == 0 {
@@ -139,9 +139,9 @@ func updateRouteAnnotation(acc kmeta.Accessor, routeName string, diffAnn map[str
 			return
 		}
 		valSet.Insert(routeName)
-		sorted := valSet.UnsortedList()
-		sort.Strings(sorted)
-		diffAnn[serving.RoutesAnnotationKey] = strings.Join(sorted, ",")
+		routeNames := valSet.UnsortedList()
+		sort.Strings(routeNames)
+		diffAnn[serving.RoutesAnnotationKey] = strings.Join(routeNames, ",")
 	}
 }
 

--- a/pkg/reconciler/labeler/accessors.go
+++ b/pkg/reconciler/labeler/accessors.go
@@ -18,6 +18,7 @@ package labeler
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -128,7 +129,9 @@ func updateRouteAnnotation(acc kmeta.Accessor, routeName string, diffAnn map[str
 			return
 		}
 		valSet.Delete(routeName)
-		diffAnn[serving.RoutesAnnotationKey] = strings.Join(valSet.UnsortedList(), ",")
+		sorted := valSet.UnsortedList()
+		sort.Strings(sorted)
+		diffAnn[serving.RoutesAnnotationKey] = strings.Join(sorted, ",")
 
 	case !has && !remove:
 		if len(valSet) == 0 {
@@ -136,7 +139,9 @@ func updateRouteAnnotation(acc kmeta.Accessor, routeName string, diffAnn map[str
 			return
 		}
 		valSet.Insert(routeName)
-		diffAnn[serving.RoutesAnnotationKey] = strings.Join(valSet.UnsortedList(), ",")
+		sorted := valSet.UnsortedList()
+		sort.Strings(sorted)
+		diffAnn[serving.RoutesAnnotationKey] = strings.Join(sorted, ",")
 	}
 }
 

--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -49,9 +49,9 @@ func MakeConfigurationFromExisting(service *v1.Service, existing *v1.Configurati
 	routeName := names.Route(service)
 	set := labeler.GetListAnnValue(existing.Annotations, serving.RoutesAnnotationKey)
 	set.Insert(routeName)
-	sorted := set.UnsortedList()
-	sort.Strings(sorted)
-	anns[serving.RoutesAnnotationKey] = strings.Join(sorted, ",")
+	routeNames := set.UnsortedList()
+	sort.Strings(routeNames)
+	anns[serving.RoutesAnnotationKey] = strings.Join(routeNames, ",")
 
 	return &v1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/service/resources/configuration.go
+++ b/pkg/reconciler/service/resources/configuration.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -48,7 +49,9 @@ func MakeConfigurationFromExisting(service *v1.Service, existing *v1.Configurati
 	routeName := names.Route(service)
 	set := labeler.GetListAnnValue(existing.Annotations, serving.RoutesAnnotationKey)
 	set.Insert(routeName)
-	anns[serving.RoutesAnnotationKey] = strings.Join(set.UnsortedList(), ",")
+	sorted := set.UnsortedList()
+	sort.Strings(sorted)
+	anns[serving.RoutesAnnotationKey] = strings.Join(sorted, ",")
 
 	return &v1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixes #15594 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Sorts routes list for the `serving.knative.dev/routes` anno to avoid triggering non-required reconciliations.
* I [benchmarked](https://gist.github.com/skonto/6519de797b40287b7b6cc0c5c939b83a) different sorting options:
a) ```sets.List(valSet)``` <- this sorts the set behind the scenes.
b)  
    ``` 
     set := valSet.UnsortedList() 
     sort.Strings(set)
   ```
I think the overhead is low but b) seems ~10% faster. For a small number of routes, the common case, the diff is negligible (sorting is trivial), does not matter if a) or b) is used. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixes a problem in configuration reconciliation where labeler creates a different order of the route names listed via the annotation `serving.knative.dev/routes` compared to the configuration reconciler.
```
