### PR TITLE
Fix configuration timeout defaulting 

### DIFF
--- a/pkg/apis/serving/v1/configuration_defaults.go
+++ b/pkg/apis/serving/v1/configuration_defaults.go
@@ -20,7 +20,9 @@ import (
 	"context"
 
 	"knative.dev/pkg/apis"
+	"knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
+	cconfig "knative.dev/serving/pkg/reconciler/configuration/config"
 )
 
 type configSpecKey struct{}
@@ -67,5 +69,16 @@ func (cs *ConfigurationSpec) SetDefaults(ctx context.Context) {
 			return
 		}
 	}
+
+	configurationConfig := cconfig.FromContext(ctx)
+	apisConfig := config.Config{}
+	if configurationConfig != nil && configurationConfig.Defaults != nil {
+		apisConfig.Defaults = configurationConfig.Defaults.DeepCopy()
+	}
+	if configurationConfig != nil && configurationConfig.Features != nil {
+		apisConfig.Features = configurationConfig.Features.DeepCopy()
+	}
+	ctx = config.ToContext(ctx, &apisConfig)
+
 	cs.Template.SetDefaults(ctx)
 }


### PR DESCRIPTION
Fixes #15616 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* As per title. We inject the right context for revision config to be properly updated with the latest values.
* This affects `revision-response-start-timeout-seconds`, revision-idle-timeout-seconds" so that when equal to the revision-`revision-timeout-seconds` in the defaults cm they will not be set to 300, instead they are set to nil (`0` at the QP side). Semantically this is correct as when the timeouts are equal we don't need both anyway.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
