### PR TITLE
Fix timeoutSeconds

### DIFF
--- a/pkg/http/handler/timeout.go
+++ b/pkg/http/handler/timeout.go
@@ -127,9 +127,8 @@ func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		case <-timeout.C():
 			timeoutDrained = true
-			if tw.tryTimeoutAndWriteError(h.body) {
-				return
-			}
+			tw.timeoutAndWriteError(h.body)
+			return
 		case now := <-idleTimeoutCh:
 			timedOut, timeToNextTimeout := tw.tryIdleTimeoutAndWriteError(now, revIdleTimeout, h.body)
 			if timedOut {

--- a/pkg/http/handler/timeout.go
+++ b/pkg/http/handler/timeout.go
@@ -127,7 +127,9 @@ func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		case <-timeout.C():
 			timeoutDrained = true
+			tw.mu.Lock()
 			tw.timeoutAndWriteError(h.body)
+			tw.mu.Unlock()
 			return
 		case now := <-idleTimeoutCh:
 			timedOut, timeToNextTimeout := tw.tryIdleTimeoutAndWriteError(now, revIdleTimeout, h.body)

--- a/pkg/http/handler/timeout_test.go
+++ b/pkg/http/handler/timeout_test.go
@@ -34,8 +34,6 @@ func TestTimeoutWriterAllowsForAdditionalWritesBeforeTimeout(t *testing.T) {
 	clock := clock.RealClock{}
 	handler := &timeoutWriter{w: recorder, clock: clock}
 	handler.WriteHeader(http.StatusOK)
-	handler.tryTimeoutAndWriteError("error")
-	handler.tryResponseStartTimeoutAndWriteError("error")
 	handler.tryIdleTimeoutAndWriteError(clock.Now(), 10*time.Second, "error")
 	if _, err := io.WriteString(handler, "test"); err != nil {
 		t.Fatalf("handler.Write() = %v, want no error", err)


### PR DESCRIPTION
Fixes #15486 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Enforces killing the connection when timeout expires.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
