### PR TITLE
Keep the number of ReplicaSets to a minimum

### DIFF
--- a/config/core/configmaps/deployment.yaml
+++ b/config/core/configmaps/deployment.yaml
@@ -27,6 +27,7 @@ data:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
   queue-sidecar-image: ko://knative.dev/serving/cmd/queue
+  revisionHistoryLimit: "2"
   _example: |-
     ################################
     #                              #

--- a/pkg/deployment/config.go
+++ b/pkg/deployment/config.go
@@ -19,6 +19,7 @@ package deployment
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -241,6 +242,17 @@ func NewConfigFromMap(configMap map[string]string) (*Config, error) {
 			}
 		}
 	}
+
+	if val, ok := configMap["revisionHistoryLimit"]; ok {
+		limit, err := strconv.Atoi(val)
+		if err != nil {
+			return nil, fmt.Errorf("invalid revisionHistoryLimit value %s: %w", val, err)
+		}
+		nc.RevisionHistoryLimit = int32(limit)
+	} else {
+		nc.RevisionHistoryLimit = 2 // Default value if not set
+	}
+
 	return nc, nil
 }
 
@@ -309,4 +321,7 @@ type Config struct {
 
 	// RuntimeClassNames specifies which runtime the Pod will use
 	RuntimeClassNames map[string]RuntimeClassNameLabelSelector
+
+	// RevisionHistoryLimit is the maximum number of old replicas to retain.
+	RevisionHistoryLimit int32
 }

--- a/pkg/reconciler/revision/resources/deploy.go
+++ b/pkg/reconciler/revision/resources/deploy.go
@@ -376,6 +376,12 @@ func MakeDeployment(rev *v1.Revision, cfg *config.Config) (*appsv1.Deployment, e
 	labels := makeLabels(rev)
 	anns := makeAnnotations(rev)
 
+	// Set revisionHistoryLimit from config-deployment.yaml or use default
+	revisionHistoryLimit := int32(cfg.Deployment.RevisionHistoryLimit) // e.g., 2 or 0
+	if revisionHistoryLimit == 0 {
+		revisionHistoryLimit = 2 // Default to 2 if not configured as 0
+	}
+
 	// Slowly but steadily roll the deployment out, to have the least possible impact.
 	maxUnavailable := intstr.FromInt(0)
 	return &appsv1.Deployment{
@@ -390,6 +396,7 @@ func MakeDeployment(rev *v1.Revision, cfg *config.Config) (*appsv1.Deployment, e
 			Replicas:                ptr.Int32(replicaCount),
 			Selector:                makeSelector(rev),
 			ProgressDeadlineSeconds: ptr.Int32(progressDeadline),
+			RevisionHistoryLimit:    ptr.Int32(revisionHistoryLimit),
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RollingUpdateDeploymentStrategyType,
 				RollingUpdate: &appsv1.RollingUpdateDeployment{


### PR DESCRIPTION
Fixes [#15639](https://github.com/knative/serving/issues/15639)

For deployments in k8s the default for .spec.revisionHistoryLimit is set to 10. This means that k8s will keep the latest 10 replicasets for an deployment.

This will help reduce the size of etcd database in a controlplane cluster.

**Release Note**

- Changing the k8s replicaset to minimum.