### PR TITLE
[test/performance] round computed rate in real-traffic-test

### DIFF
--- a/test/performance/benchmarks/real-traffic-test/main.go
+++ b/test/performance/benchmarks/real-traffic-test/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"math/rand"
 	"net/http"
 	"os"
@@ -298,7 +299,7 @@ func checkSLA(results *vegeta.Metrics, rate vegeta.ConstantPacer) error {
 	}
 
 	// SLA 2: making sure the defined vegeta rates is met
-	if results.Rate == rate.Rate(time.Second) {
+	if math.Round(results.Rate) == rate.Rate(time.Second) {
 		log.Printf("SLA 2 passed. vegeta rate is %f", rate.Rate(time.Second))
 	} else {
 		return fmt.Errorf("SLA 2 failed. vegeta rate is %f, expected Rate is %f", results.Rate, rate.Rate(time.Second))


### PR DESCRIPTION
real-traffic-test benchmark SLA 2 fails frequently just because the computed rate is not _exactly_ the expected value , e.g. **https://prow.knative.dev/view/gs/knative-prow/logs/performance-tests_serving_main_periodic/1862287597506662400**

```
SLA 2 failed. vegeta rate is 2000.006921, expected Rate is 2000.000000
```

Let's do the same here as we already to in https://github.com/knative/serving/blob/main/test/performance/benchmarks/rollout-probe/main.go#L234 , and add tolerance to the rate comparison to fit within the nearest integer.

* round computed Rate on real-traffic-test benchmark