### PR TITLE
Add support to ignore request in metrics

### DIFF
--- a/pkg/queue/request_metric.go
+++ b/pkg/queue/request_metric.go
@@ -109,8 +109,8 @@ func (h *requestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	startTime := time.Now()
 
 	defer func() {
-		// Filter probe requests for revision metrics.
-		if netheader.IsProbe(r) {
+		// Filter probe requests and requests marked by ignore metrics header for revision metrics.
+		if netheader.IsProbe(r) || netheader.IsMetricsIgnored(r) {
 			return
 		}
 
@@ -177,8 +177,8 @@ func (h *appRequestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		pkgmetrics.Record(h.statsCtx, queueDepthM.M(int64(h.breaker.InFlight())))
 	}
 	defer func() {
-		// Filter probe requests for revision metrics.
-		if netheader.IsProbe(r) {
+		// Filter probe requests and requests marked by ignore metrics header for revision metrics.
+		if netheader.IsProbe(r) || netheader.IsMetricsIgnored(r) {
 			return
 		}
 

--- a/vendor/knative.dev/networking/pkg/http/header/header.go
+++ b/vendor/knative.dev/networking/pkg/http/header/header.go
@@ -78,6 +78,9 @@ const (
 	// load balancers to not load balance the respective request but to
 	// send it to the request's target directly.
 	PassthroughLoadbalancingKey = "K-Passthrough-Lb"
+
+	// IgnoreMetricsKey is used to mark requests that should not be counted in metrics.
+	IgnoreMetricsKey = "K-Ignore-Metrics"
 )
 
 // User Agent Key & Values
@@ -133,6 +136,11 @@ func IsProbe(r *http.Request) bool {
 func IsKubeletProbe(r *http.Request) bool {
 	return strings.HasPrefix(r.Header.Get("User-Agent"), KubeProbeUAPrefix) ||
 		r.Header.Get(KubeletProbeKey) != ""
+}
+
+// IsMetricsIgnored returns true if the request is marked to be ignored by metrics.
+func IsMetricsIgnored(r *http.Request) bool {
+  return r.Header.Get(IgnoreMetricsKey) != ""
 }
 
 // RewriteHostIn removes the `Host` header from the inbound (server) request


### PR DESCRIPTION
Fixes #14581, #15646

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Added possibility to mark request to be ignored in metrics using header `K-Ignore-Metrics`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Added `K-Ignore-Metrics` header to ignore request in metrics.
```
