### PR TITLE
[performance/real-traffic-test] Enable AllowHTTPFullDuplexFeature

### DIFF
--- a/test/performance/benchmarks/real-traffic-test/main.go
+++ b/test/performance/benchmarks/real-traffic-test/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"math/rand"
 	"net/http"
 	"os"
@@ -298,7 +299,7 @@ func checkSLA(results *vegeta.Metrics, rate vegeta.ConstantPacer) error {
 	}
 
 	// SLA 2: making sure the defined vegeta rates is met
-	if results.Rate == rate.Rate(time.Second) {
+	if math.Round(results.Rate) == rate.Rate(time.Second) {
 		log.Printf("SLA 2 passed. vegeta rate is %f", rate.Rate(time.Second))
 	} else {
 		return fmt.Errorf("SLA 2 failed. vegeta rate is %f, expected Rate is %f", results.Rate, rate.Rate(time.Second))


### PR DESCRIPTION
## Proposed Changes

WithConfigAnnotations was added to `sos` when the first `activatorInPath` was true, so it affected all further svcs, not just the current one. 

* fixes TargetBurstCapacityKey annotation to be set only when activatorInPath is true
* enables AllowHTTPFullDuplexFeature to see if it helps with the random EOF errors
* rounds SLA 2, rate calculation to nearest integer