### PR TITLE
Drop k8s v1.28 from kind testing and update cluster version to 1.30 in e2e

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -82,8 +82,9 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.28.x
         - v1.29.x
+        - v1.30.x
+        - v1.31.x
 
         ingress:
         - kourier

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -82,8 +82,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.29.x
         - v1.30.x
+        - v1.31.x
 
         ingress:
         - kourier

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -82,8 +82,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
+        - v1.29.x
         - v1.30.x
-        - v1.31.x
 
         ingress:
         - kourier

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -170,7 +170,7 @@ jobs:
         path: ~/artifacts
 
     - name: setup kind
-      uses: chainguard-dev/actions/setup-kind@1f79ee3c1d554f67a5344933e2cadfa4b58d300d
+      uses: chainguard-dev/actions/setup-kind@main
       with:
         k8s-version: ${{ matrix.k8s-version }}
         kind-worker-count: 4

--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -82,7 +82,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.29.x
         - v1.30.x
         - v1.31.x
 

--- a/test/e2e-external-domain-tls-tests.sh
+++ b/test/e2e-external-domain-tls-tests.sh
@@ -162,7 +162,7 @@ function delete_dns_record() {
 }
 
 # Script entry point.
-initialize "$@" --num-nodes=4 --enable-ha --cluster-version=1.28
+initialize "$@" --num-nodes=4 --enable-ha --cluster-version=1.29
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-external-domain-tls-tests.sh
+++ b/test/e2e-external-domain-tls-tests.sh
@@ -162,7 +162,7 @@ function delete_dns_record() {
 }
 
 # Script entry point.
-initialize "$@" --num-nodes=4 --enable-ha --cluster-version=1.29
+initialize "$@" --num-nodes=4 --enable-ha --cluster-version=1.30
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -28,7 +28,7 @@
 source $(dirname "$0")/e2e-common.sh
 
 # Script entry point.
-initialize --num-nodes=4 --enable-ha --cluster-version=1.28 "$@"
+initialize --num-nodes=4 --enable-ha --cluster-version=1.29 "$@"
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -28,7 +28,7 @@
 source $(dirname "$0")/e2e-common.sh
 
 # Script entry point.
-initialize --num-nodes=4 --enable-ha --cluster-version=1.29 "$@"
+initialize --num-nodes=4 --enable-ha --cluster-version=1.30 "$@"
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -42,7 +42,7 @@ function stage_test_resources() {
 # Skip installing istio as an add-on.
 # Skip installing a pvc as it is not used in upgrade tests
 # Skip installing a resource quota as it is not used in upgrade tests
-PVC=0 QUOTA=0 initialize "$@" --num-nodes=4 --cluster-version=1.28 \
+PVC=0 QUOTA=0 initialize "$@" --num-nodes=4 --cluster-version=1.29 \
   --install-latest-release
 
 # TODO(#2656): Reduce the timeout after we get this test to consistently passing.

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -42,7 +42,7 @@ function stage_test_resources() {
 # Skip installing istio as an add-on.
 # Skip installing a pvc as it is not used in upgrade tests
 # Skip installing a resource quota as it is not used in upgrade tests
-PVC=0 QUOTA=0 initialize "$@" --num-nodes=4 --cluster-version=1.29 \
+PVC=0 QUOTA=0 initialize "$@" --num-nodes=4 --cluster-version=1.30 \
   --install-latest-release
 
 # TODO(#2656): Reduce the timeout after we get this test to consistently passing.

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -38,7 +38,7 @@ declare ARTIFACTS
 
 ns="default"
 
-initialize --num-nodes=10 --cluster-version=1.29 "$@"
+initialize --num-nodes=10 --cluster-version=1.30 "$@"
 
 function run_job() {
   local name=$1

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -38,7 +38,7 @@ declare ARTIFACTS
 
 ns="default"
 
-initialize --num-nodes=10 --cluster-version=1.28 "$@"
+initialize --num-nodes=10 --cluster-version=1.29 "$@"
 
 function run_job() {
   local name=$1


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Similar to https://github.com/knative/serving/pull/14904
* Versions prior to 1.30 are in maintenance https://kubernetes.io/releases/, Knative [does not support them](https://github.com/knative/community/blob/main/mechanics/RELEASE-VERSIONING-PRINCIPLES.md#k8s-minimum-version-principle) when a cut is done (1.17 is coming soon):

> We (the community) support the range of upstream minor Kubernetes versions that are Kubernetes community supported at the time of the cut. This excludes releases which have entered maintenance mode. Only the latest patch release of the minor version is tested for support. Support for versions prior to that are best effort, or by vendors.
Adoption of newer K8s minimum versions will also be on a best-effort basis. When a Kubernetes version is released it's availability in downstream distributions is often lagging. When these delays affect our planned min K8s version we'll update the version table below and make it known in the release's notes.

From a vendors pov (stable channels):
- OCP is on 1.30
- [EKS on 1.31](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)
- [AKS on 1.31](https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli)
- [GKE on 1.30](https://cloud.google.com/kubernetes-engine/docs/release-notes)