### PR TITLE
Pin version of the chainguard kind setup action

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -170,7 +170,7 @@ jobs:
         path: ~/artifacts
 
     - name: setup kind
-      uses: chainguard-dev/actions/setup-kind@main
+      uses: chainguard-dev/actions/setup-kind@1f79ee3c1d554f67a5344933e2cadfa4b58d300d
       with:
         k8s-version: ${{ matrix.k8s-version }}
         kind-worker-count: 4


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* See comment https://github.com/knative/serving/pull/15656#issuecomment-2553092676 for the reason of this PR.
If we move with #15655 and https://github.com/knative/pkg/pull/3124 we dont need this PR. In the meantime we have PRs failing. 

* Commit taken from https://github.com/chainguard-dev/actions/commits/main/. 
