### PR TITLE
Fix kourier tls runtime tests

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -210,18 +210,13 @@ jobs:
 
     - name: Test ${{ matrix.test-suite }}
       run: |
-        FEATURE_FLAGS="-enable-alpha -enable-beta"
-        if [[ "${{ matrix.ingress}}" == "kourier-tls" ]] && [[ "${{ matrix.test-suite }}" == "runtime" ]]; then
-          # Disabled due to flakiness: https://github.com/knative/serving/issues/15697
-          FEATURE_FLAGS="$FEATURE_FLAGS -disable-optional-api"
-        fi
         gotestsum --format testname -- \
           -race -count=1 -parallel=1 -tags=e2e \
           -timeout=30m \
           ${{ matrix.test-path }} \
           -skip-cleanup-on-fail \
           -disable-logstream \
-          $FEATURE_FLAGS \
+          -enable-alpha -enable-beta \
           --ingress-class=${{ matrix.ingress-class || matrix.ingress }}.ingress.networking.knative.dev \
           ${{ matrix.test-flags }}
 

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -61,11 +61,11 @@ type fakeThrottler struct {
 	err error
 }
 
-func (ft fakeThrottler) Try(_ context.Context, _ types.NamespacedName, f func(string) error) error {
+func (ft fakeThrottler) Try(_ context.Context, _ types.NamespacedName, f func(string, bool) error) error {
 	if ft.err != nil {
 		return ft.err
 	}
-	return f("10.10.10.10:1234")
+	return f("10.10.10.10:1234", false)
 }
 
 func TestActivationHandler(t *testing.T) {


### PR DESCRIPTION
Fixes #15697 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* See comment [here](https://github.com/knative/serving/issues/15697#issuecomment-2615699783) for why this fix is needed.
* Brings back the disabled tests
* Makes activator handler aware of whether we are hitting a cluster IP or a Pod IP.