### PR TITLE
add back selfsigned issuer

### DIFF
--- a/config/core/300-knative-selfsigned-issuer.yaml
+++ b/config/core/300-knative-selfsigned-issuer.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: knative-selfsigned-issuer
+  labels:
+    app.kubernetes.io/name: knative-serving
+    networking.knative.dev/certificate-provider: cert-manager
+spec:
+  ca:
+    secretName: knative-selfsigned-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: knative-selfsigned-ca
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/name: knative-serving
+    networking.knative.dev/certificate-provider: cert-manager
+spec:
+  secretName: knative-selfsigned-ca
+  commonName: knative.dev
+  usages:
+    - server auth
+  isCA: true
+  issuerRef:
+    kind: ClusterIssuer
+    name: selfsigned-cluster-issuer


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* In https://github.com/knative/serving/pull/15066, net-certmanager was rolled into the serving controller. However, I believe it failed to include the Issuer for `knative-selfsigned-issuer`, which is the default issuer in [config-certmanager](https://github.com/knative/serving/blob/main/config/core/configmaps/certmanager.yaml)
* Not sure how far things are backported these days, but this is missing starting in 1.15

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
When enabling system-internal-, cluster-local-domain-, or external-domain- tls without configuring an issuer, the Knative selfsigned issuer is used.
```
