### PR TITLE
Fix golangci exclude config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,8 +1,6 @@
 run:
   timeout: 10m
   allow-parallel-runners: true
-  exclude-dirs:
-  - pkg/client
   build-tags:
   - e2e
   - hpa
@@ -20,6 +18,8 @@ issues:
   uniq-by-line: true
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-dirs:
+    - pkg/client # Excludes generated client
   exclude-rules:
   - path: test # Excludes /test, *_test.go etc.
     linters:


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Fix golangci exclude config

We had an issue downstream with linter and generated clients. Hence after comparing linter's configs, there's an issue with current one in Serving. PTAL
 

```
➜  serving git:(main) golangci-lint config verify
jsonschema: "run" does not validate with "/properties/run/additionalProperties": additional properties 'exclude-dirs' not allowed
Failed executing command with error: the configuration contains invalid elements
➜  serving git:(main) golangci-lint version
golangci-lint has version 1.63.4 built with go1.23.4 from c114969 on 2025-01-03T19:29:37Z
```
https://golangci-lint.run/usage/configuration/#issues-configuration

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix golangci exclude config
```

/assign @dprotaso 