### PR TITLE
[WIP] Relax minScale when in rollout for specific workloads

### DIFF
--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -49,6 +49,9 @@ const (
 
 	// AllowHTTPFullDuplexFeatureKey gates the use of http1 full duplex per workload
 	AllowHTTPFullDuplexFeatureKey = "features.knative.dev/http-full-duplex"
+
+	// SkipMinScaleDuringRollout gates skipping minScale when we are in a rollout
+	SkipMinScaleDuringRollout = "features.knative.dev/skip-min-scale-during-rollout"
 )
 
 // Feature config map keys that are used in schema-tweak

--- a/pkg/reconciler/autoscaling/kpa/controller.go
+++ b/pkg/reconciler/autoscaling/kpa/controller.go
@@ -28,6 +28,7 @@ import (
 	"knative.dev/serving/pkg/client/injection/ducks/autoscaling/v1alpha1/podscalable"
 	metricinformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/metric"
 	painformer "knative.dev/serving/pkg/client/injection/informers/autoscaling/v1alpha1/podautoscaler"
+	serviceinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/service"
 	pareconciler "knative.dev/serving/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler"
 
 	"knative.dev/pkg/configmap"
@@ -57,6 +58,7 @@ func NewController(
 	podsInformer := filteredpodinformer.Get(ctx, serving.RevisionUID)
 	metricInformer := metricinformer.Get(ctx)
 	psInformerFactory := podscalable.Get(ctx)
+	serviceInformer := serviceinformer.Get(ctx)
 
 	onlyKPAClass := pkgreconciler.AnnotationFilterFunc(
 		autoscaling.ClassAnnotationKey, autoscaling.KPA, false /*allowUnset*/)
@@ -67,6 +69,7 @@ func NewController(
 			NetworkingClient: networkingclient.Get(ctx),
 			SKSLister:        sksInformer.Lister(),
 			MetricLister:     metricInformer.Lister(),
+			ServiceInformer:  serviceInformer.Lister(),
 		},
 		podsLister: podsInformer.Lister(),
 		deciders:   deciders,

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 
 	"go.opencensus.io/stats"
 	"go.uber.org/zap"
@@ -30,7 +31,9 @@ import (
 	"knative.dev/pkg/ptr"
 	pkgreconciler "knative.dev/pkg/reconciler"
 	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
+	apicfg "knative.dev/serving/pkg/apis/config"
 	"knative.dev/serving/pkg/apis/serving"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/autoscaler/scaling"
 	pareconciler "knative.dev/serving/pkg/client/injection/reconciler/autoscaling/v1alpha1/podautoscaler"
 	"knative.dev/serving/pkg/metrics"
@@ -82,6 +85,7 @@ var (
 func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscaler) pkgreconciler.Event {
 	ctx, cancel := context.WithTimeout(ctx, pkgreconciler.DefaultTimeout)
 	defer cancel()
+	inRollout := false
 
 	logger := logging.FromContext(ctx)
 
@@ -93,6 +97,18 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.
 		logger.Warnw("Error retrieving SKS for Scaler", zap.Error(err))
 	}
 
+	// Decide if it is a rollout for non BYO services.
+	if shouldSkipMinScale(pa) {
+		svcName := pa.Labels["serving.knative.dev/service"]
+		svc, err := c.ServiceInformer.Services(pa.Namespace).Get(svcName)
+		if err == nil && svc != nil {
+			sc := svc.Status
+			scr := sc.GetCondition(servingv1.ServiceConditionReady)
+			if scr.IsUnknown() && scr.Reason == "RolloutInProgress" && sc.LatestCreatedRevisionName == pa.Name {
+				inRollout = true
+			}
+		}
+	}
 	// Having an SKS and its PrivateServiceName is a prerequisite for all upcoming steps.
 	if sks == nil || sks.Status.PrivateServiceName == "" {
 		// Before we can reconcile decider and get real number of activators
@@ -101,7 +117,8 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.
 			return fmt.Errorf("error reconciling SKS: %w", err)
 		}
 		pa.Status.MarkSKSNotReady(noPrivateServiceName) // In both cases this is true.
-		computeStatus(ctx, pa, podCounts{want: scaleUnknown}, logger)
+
+		computeStatus(ctx, pa, podCounts{want: scaleUnknown}, logger, inRollout)
 		return nil
 	}
 
@@ -117,7 +134,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.
 
 	// Get the appropriate current scale from the metric, and right size
 	// the scaleTargetRef based on it.
-	want, err := c.scaler.scale(ctx, pa, sks, decider.Status.DesiredScale)
+	want, err := c.scaler.scale(ctx, pa, sks, decider.Status.DesiredScale, inRollout)
 	if err != nil {
 		return fmt.Errorf("error scaling target: %w", err)
 	}
@@ -185,7 +202,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.
 		terminating: terminating,
 	}
 	logger.Infof("Observed pod counts=%#v", pc)
-	computeStatus(ctx, pa, pc, logger)
+	computeStatus(ctx, pa, pc, logger, inRollout)
 	return nil
 }
 
@@ -218,7 +235,7 @@ func (c *Reconciler) reconcileDecider(ctx context.Context, pa *autoscalingv1alph
 	return decider, nil
 }
 
-func computeStatus(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscaler, pc podCounts, logger *zap.SugaredLogger) {
+func computeStatus(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscaler, pc podCounts, logger *zap.SugaredLogger, inRollout bool) {
 	//nolint:gosec // bound by 0 < x < max(int32)
 	pa.Status.ActualScale = ptr.Int32(int32(pc.ready))
 
@@ -232,7 +249,7 @@ func computeStatus(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscaler, p
 	}
 
 	reportMetrics(pa, pc)
-	computeActiveCondition(ctx, pa, pc)
+	computeActiveCondition(ctx, pa, pc, inRollout)
 	logger.Debugf("PA Status after reconcile: %#v", pa.Status.Status)
 }
 
@@ -268,7 +285,7 @@ func reportMetrics(pa *autoscalingv1alpha1.PodAutoscaler, pc podCounts) {
 //	| -1   | >= min | 0     | active     | inactive   | <-- this case technically is impossible.
 //	| -1   | >= min | >0    | activating | active     |
 //	| -1   | >= min | >0    | active     | active     |
-func computeActiveCondition(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscaler, pc podCounts) {
+func computeActiveCondition(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscaler, pc podCounts, inRollout bool) {
 	minReady := activeThreshold(ctx, pa)
 	if pc.ready >= minReady && pa.Status.ServiceName != "" {
 		pa.Status.MarkScaleTargetInitialized()
@@ -285,18 +302,30 @@ func computeActiveCondition(ctx context.Context, pa *autoscalingv1alpha1.PodAuto
 		}
 
 	case pc.ready < minReady:
-		if pc.want > 0 || !pa.Status.IsInactive() {
-			pa.Status.MarkActivating(
-				"Queued", "Requests to the target are being buffered as resources are provisioned.")
+		// If we are in a rollout ignore minScale
+		if shouldSkipMinScale(pa) && pc.ready >= 1 && minReady > 1 {
+			if inRollout || !pa.Status.IsScaleTargetInitialized() {
+				if pc.want > 0 || !pa.Status.IsInactive() {
+					pa.Status.MarkActive()
+					if pa.Status.ServiceName != "" {
+						pa.Status.MarkScaleTargetInitialized()
+					}
+				}
+			}
 		} else {
-			// This is for the initialScale 0 case. In the first iteration, minReady is 0,
-			// but for the following iterations, minReady is 1. pc.want will continue being
-			// -1 until we start receiving metrics, so we will end up here.
-			// Even though PA is already been marked as inactive in the first iteration, we
-			// still need to set it again. Otherwise reconciliation will fail with NewObservedGenFailure
-			// because we cannot go through one iteration of reconciliation without setting
-			// some status.
-			pa.Status.MarkInactive(noTrafficReason, "The target is not receiving traffic.")
+			if pc.want > 0 || !pa.Status.IsInactive() {
+				pa.Status.MarkActivating(
+					"Queued", "Requests to the target are being buffered as resources are provisioned.")
+			} else {
+				// This is for the initialScale 0 case. In the first iteration, minReady is 0,
+				// but for the following iterations, minReady is 1. pc.want will continue being
+				// -1 until we start receiving metrics, so we will end up here.
+				// Even though PA is already been marked as inactive in the first iteration, we
+				// still need to set it again. Otherwise reconciliation will fail with NewObservedGenFailure
+				// because we cannot go through one iteration of reconciliation without setting
+				// some status.
+				pa.Status.MarkInactive(noTrafficReason, "The target is not receiving traffic.")
+			}
 		}
 
 	case pc.ready >= minReady:
@@ -357,4 +386,11 @@ func computeNumActivators(readyPods int, decider *scaling.Decider) int32 {
 	}
 
 	return int32(math.Max(minActivators, math.Ceil(capacityToCover/decider.Spec.ActivatorCapacity)))
+}
+
+func shouldSkipMinScale(pa *autoscalingv1alpha1.PodAutoscaler) bool {
+	if v, ok := pa.Annotations[apicfg.SkipMinScaleDuringRollout]; ok {
+		return strings.EqualFold(v, "Enabled")
+	}
+	return false
 }

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -556,7 +556,7 @@ func TestScaler(t *testing.T) {
 				test.configMutator(cfg)
 			}
 			ctx = config.ToContext(ctx, cfg)
-			desiredScale, err := revisionScaler.scale(ctx, pa, sks, test.scaleTo)
+			desiredScale, err := revisionScaler.scale(ctx, pa, sks, test.scaleTo, false)
 			if err != nil {
 				t.Error("Scale got an unexpected error:", err)
 			}
@@ -647,7 +647,7 @@ func TestDisableScaleToZero(t *testing.T) {
 			conf := defaultConfig()
 			conf.Autoscaler.EnableScaleToZero = false
 			ctx = config.ToContext(ctx, conf)
-			desiredScale, err := revisionScaler.scale(ctx, pa, nil /*sks doesn't matter in this test*/, test.scaleTo)
+			desiredScale, err := revisionScaler.scale(ctx, pa, nil /*sks doesn't matter in this test*/, test.scaleTo, false)
 			if err != nil {
 				t.Error("Scale got an unexpected error:", err)
 			}

--- a/pkg/reconciler/autoscaling/reconciler.go
+++ b/pkg/reconciler/autoscaling/reconciler.go
@@ -27,6 +27,7 @@ import (
 	autoscalingv1alpha1 "knative.dev/serving/pkg/apis/autoscaling/v1alpha1"
 	clientset "knative.dev/serving/pkg/client/clientset/versioned"
 	listers "knative.dev/serving/pkg/client/listers/autoscaling/v1alpha1"
+	slisters "knative.dev/serving/pkg/client/listers/serving/v1"
 	"knative.dev/serving/pkg/reconciler/autoscaling/config"
 	"knative.dev/serving/pkg/reconciler/autoscaling/resources"
 	anames "knative.dev/serving/pkg/reconciler/autoscaling/resources/names"
@@ -42,6 +43,7 @@ type Base struct {
 	NetworkingClient netclientset.Interface
 	SKSLister        nlisters.ServerlessServiceLister
 	MetricLister     listers.MetricLister
+	ServiceInformer  slisters.ServiceLister
 }
 
 // ReconcileSKS reconciles a ServerlessService based on the given PodAutoscaler.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* When in roll out skip minScale until traffic shifts for workloads with a specific annotation `features.knative.dev/skip-min-scale-during-rollout: "Enabled"`. Although we dont provide guarantees for a smooth traffic transition this can help with certain use cases where expensive resources are used e.g. gpu and we can don't optimize for latency e.g. batch or there is latency tolerance in general. We rely on the activator to manage pending requests. Although does not fix https://github.com/knative/serving/issues/12971 it unblocks some scenarios until  the functionality of the progressive rollout repo is ready. Created the PR to discuss the idea as well.
* Here is an example where:
a) we start with minScale=2 and `serving.knative.dev/rollout-duration: "380s"`.
b) we upgrade the minScale to 210 and wait until traffic shifts, and we enter a roll-out. Note here that normally the new revision will serve traffic but will never be active without this patch, eventually progressdeadline will expire if there are no resources. 
c) While traffic is shifting the new revision will skip minScale.
d) Later on since there is no traffic both revisions have no replicas (the initial drevision is scaled down too) and we have exited the roll-out.
e) When a request comes in the minScale is respected again for the latest revision, since we exited the roll-out, and we operate as usual.

```
NAME                  CONFIG NAME     GENERATION   READY   REASON   ACTUAL REPLICAS   DESIRED REPLICAS
helloworld-go-00001   helloworld-go   1            True             2                 2

NAME                  CONFIG NAME     GENERATION   READY     REASON   ACTUAL REPLICAS   DESIRED REPLICAS
helloworld-go-00001   helloworld-go   1            True               2                 2
helloworld-go-00002   helloworld-go   2            Unknown            0                 210

NAME                  CONFIG NAME     GENERATION   READY     REASON   ACTUAL REPLICAS   DESIRED REPLICAS
helloworld-go-00001   helloworld-go   1            True               2                 2
helloworld-go-00002   helloworld-go   2            Unknown            0                 210

stavros@groot:~/go/src/knative.dev/serving$ oc get revision
NAME                  CONFIG NAME     GENERATION   READY   REASON   ACTUAL REPLICAS   DESIRED REPLICAS
helloworld-go-00001   helloworld-go   1            True             2                 2
helloworld-go-00002   helloworld-go   2            True             3                 1

NAME                  CONFIG NAME     GENERATION   READY   REASON   ACTUAL REPLICAS   DESIRED REPLICAS
helloworld-go-00001   helloworld-go   1            True             2                 2
helloworld-go-00002   helloworld-go   2            True             0                 0

NAME                  CONFIG NAME     GENERATION   READY   REASON   ACTUAL REPLICAS   DESIRED REPLICAS
helloworld-go-00001   helloworld-go   1            True             0                 0
helloworld-go-00002   helloworld-go   2            True             0                 0

NAME                  CONFIG NAME     GENERATION   READY   REASON   ACTUAL REPLICAS   DESIRED REPLICAS
helloworld-go-00001   helloworld-go   1            True             0                 0
helloworld-go-00002   helloworld-go   2            True             0                 210

NAME                  CONFIG NAME     GENERATION   READY   REASON   ACTUAL REPLICAS   DESIRED REPLICAS
helloworld-go-00001   helloworld-go   1            True             0                 0
helloworld-go-00002   helloworld-go   2            True             1                 210
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow to relax minScale when in roll-out for specific workloads.
```
