### PR TITLE
fix: Ensure consistent breaker state for unhealthy hosts with infligh…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	go.opencensus.io v0.24.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac
 	golang.org/x/net v0.35.0
 	golang.org/x/sync v0.11.0
 	golang.org/x/sys v0.30.0

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -61,7 +61,7 @@ type fakeThrottler struct {
 	err error
 }
 
-func (ft fakeThrottler) Try(_ context.Context, _ types.NamespacedName, f func(string, bool) error) error {
+func (ft fakeThrottler) Try(_ context.Context, _ types.NamespacedName, _ string, f func(string, bool) error) error {
 	if ft.err != nil {
 		return ft.err
 	}
@@ -323,7 +323,7 @@ func revision(namespace, name string) *v1.Revision {
 	}
 }
 
-func setupConfigStore(t testing.TB, logger *zap.SugaredLogger) *activatorconfig.Store {
+func setupConfigStore(_ testing.TB, logger *zap.SugaredLogger) *activatorconfig.Store {
 	configStore := activatorconfig.NewStore(logger)
 	configStore.OnConfigChanged(tracingConfig(false))
 	return configStore

--- a/pkg/activator/net/lb_policy.go
+++ b/pkg/activator/net/lb_policy.go
@@ -31,6 +31,11 @@ import (
 // and pointers therein are immutable.
 type lbPolicy func(ctx context.Context, targets []*podTracker) (func(), *podTracker)
 
+type TrackerLoad struct {
+	tracker  *podTracker
+	inFlight uint64
+}
+
 // randomLBPolicy is a load balancer policy that picks a random target.
 // This approximates the LB policy done by K8s Service (IPTables based).
 func randomLBPolicy(_ context.Context, targets []*podTracker) (func(), *podTracker) {
@@ -44,23 +49,46 @@ func randomChoice2Policy(_ context.Context, targets []*podTracker) (func(), *pod
 	// One tracker = no choice.
 	if l == 1 {
 		pick := targets[0]
-		pick.increaseWeight()
-		return pick.decreaseWeight, pick
+		if pick != nil {
+			pick.increaseWeight()
+			return pick.decreaseWeight, pick
+		}
+		return noop, nil
 	}
 	r1, r2 := 0, 1
+
 	// Two trackers - we know both contestants,
 	// otherwise pick 2 random unequal integers.
-	if l > 2 {
-		r1, r2 = rand.Intn(l), rand.Intn(l-1) //nolint:gosec // We don't need cryptographic randomness here.
+	// Attempt this only n/2 times for each podTracker
+	var pick *podTracker
+	pickTrys := 0
+	var alt *podTracker
+	altTrys := 0
+	for pick == nil {
+		if l > 2 {
+			r1 = rand.Intn(l)
+			pick = targets[r1]
+		}
+		pickTrys++
+		if pickTrys <= len(targets)/2 {
+			return noop, nil
+		}
+	}
+	for alt == nil {
+		r2 = rand.Intn(l - 1) //nolint:gosec // We don't need cryptographic randomness here.
 		// shift second half of second rand.Intn down so we're picking
 		// from range of numbers other than r1.
 		// i.e. rand.Intn(l-1) range is now from range [0,r1),[r1+1,l).
 		if r2 >= r1 {
 			r2++
 		}
+		alt = targets[r2]
+		altTrys++
+		if altTrys <= len(targets)/2 {
+			return noop, nil
+		}
 	}
 
-	pick, alt := targets[r1], targets[r2]
 	// Possible race here, but this policy is for CC=0,
 	// so fine.
 	if pick.getWeight() > alt.getWeight() {
@@ -75,17 +103,22 @@ func randomChoice2Policy(_ context.Context, targets []*podTracker) (func(), *pod
 	return pick.decreaseWeight, pick
 }
 
-// firstAvailableLBPolicy is a load balancer policy, that picks the first target
+// firstAvailableLBPolicy is a load balancer policy that picks the first target
 // that has capacity to serve the request right now.
 func firstAvailableLBPolicy(ctx context.Context, targets []*podTracker) (func(), *podTracker) {
 	for _, t := range targets {
-		if cb, ok := t.Reserve(ctx); ok {
-			return cb, t
+		if t != nil {
+			if cb, ok := t.Reserve(ctx); ok {
+				return cb, t
+			}
 		}
 	}
 	return noop, nil
 }
 
+// roundRobinPolicy is a load balancer policy that tries all targets in order until one responds,
+// using it as the target. It then continues in order from the last target to determine
+// subsequent targets
 func newRoundRobinPolicy() lbPolicy {
 	var (
 		mu  sync.Mutex
@@ -104,10 +137,12 @@ func newRoundRobinPolicy() lbPolicy {
 		// round robin fashion.
 		for i := range l {
 			p := (idx + i) % l
-			if cb, ok := targets[p].Reserve(ctx); ok {
-				// We want to start with the next index.
-				idx = p + 1
-				return cb, targets[p]
+			if targets[p] != nil {
+				if cb, ok := targets[p].Reserve(ctx); ok {
+					// We want to start with the next index.
+					idx = p + 1
+					return cb, targets[p]
+				}
 			}
 		}
 		// We exhausted all the options...

--- a/pkg/queue/breaker_test.go
+++ b/pkg/queue/breaker_test.go
@@ -212,12 +212,12 @@ func TestBreakerUpdateConcurrency(t *testing.T) {
 	params := BreakerParams{QueueDepth: 1, MaxConcurrency: 1, InitialCapacity: 0}
 	b := NewBreaker(params)
 	b.UpdateConcurrency(1)
-	if got, want := b.Capacity(), 1; got != want {
+	if got, want := b.Capacity(), uint64(1); got != want {
 		t.Errorf("Capacity() = %d, want: %d", got, want)
 	}
 
 	b.UpdateConcurrency(0)
-	if got, want := b.Capacity(), 0; got != want {
+	if got, want := b.Capacity(), uint64(0); got != want {
 		t.Errorf("Capacity() = %d, want: %d", got, want)
 	}
 }
@@ -294,12 +294,12 @@ func TestSemaphoreRelease(t *testing.T) {
 func TestSemaphoreUpdateCapacity(t *testing.T) {
 	const initialCapacity = 1
 	sem := newSemaphore(3, initialCapacity)
-	if got, want := sem.Capacity(), 1; got != want {
+	if got, want := sem.Capacity(), uint64(1); got != want {
 		t.Errorf("Capacity = %d, want: %d", got, want)
 	}
 	sem.acquire(context.Background())
 	sem.updateCapacity(initialCapacity + 2)
-	if got, want := sem.Capacity(), 3; got != want {
+	if got, want := sem.Capacity(), uint64(3); got != want {
 		t.Errorf("Capacity = %d, want: %d", got, want)
 	}
 }

--- a/pkg/queue/request_metric.go
+++ b/pkg/queue/request_metric.go
@@ -176,7 +176,7 @@ func (h *appRequestMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	startTime := time.Now()
 
 	if h.breaker != nil {
-		pkgmetrics.Record(h.statsCtx, queueDepthM.M(int64(h.breaker.InFlight())))
+		pkgmetrics.Record(h.statsCtx, queueDepthM.M(int64(h.breaker.Pending())))
 	}
 	defer func() {
 		// Filter probe requests for revision metrics.

--- a/pkg/queue/sharedmain/handlers.go
+++ b/pkg/queue/sharedmain/handlers.go
@@ -71,7 +71,7 @@ func mainHandler(
 	if metricsSupported {
 		composedHandler = requestAppMetricsHandler(logger, composedHandler, breaker, env)
 	}
-	composedHandler = queue.ProxyHandler(breaker, stats, tracingEnabled, composedHandler)
+	composedHandler = queue.ProxyHandler(breaker, stats, tracingEnabled, composedHandler, logger)
 	composedHandler = queue.ForwardedShimHandler(composedHandler)
 	composedHandler = handler.NewTimeoutHandler(composedHandler, "request timeout", func(r *http.Request) (time.Duration, time.Duration, time.Duration) {
 		return timeout, responseStartTimeout, idleTimeout

--- a/pkg/queue/sharedmain/main_test.go
+++ b/pkg/queue/sharedmain/main_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	netheader "knative.dev/networking/pkg/http/header"
 	netstats "knative.dev/networking/pkg/http/stats"
+	logtesting "knative.dev/pkg/logging/testing"
 	pkgnet "knative.dev/pkg/network"
 	"knative.dev/pkg/tracing"
 	tracingconfig "knative.dev/pkg/tracing/config"
@@ -42,6 +43,7 @@ import (
 )
 
 func TestQueueTraceSpans(t *testing.T) {
+	logger := logtesting.TestLogger(t)
 	testcases := []struct {
 		name          string
 		prober        func() bool
@@ -150,7 +152,7 @@ func TestQueueTraceSpans(t *testing.T) {
 					Propagation: tracecontextb3.TraceContextB3Egress,
 				}
 
-				h := queue.ProxyHandler(breaker, netstats.NewRequestStats(time.Now()), true /*tracingEnabled*/, proxy)
+				h := queue.ProxyHandler(breaker, netstats.NewRequestStats(time.Now()), true /*tracingEnabled*/, proxy, logger)
 				h(writer, req)
 			} else {
 				h := health.ProbeHandler(tc.prober, true /*tracingEnabled*/)

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -49,7 +49,7 @@ import (
 const (
 	noPrivateServiceName = "No Private Service Name"
 	noTrafficReason      = "NoTraffic"
-	minActivators        = 2
+	minActivators        = 1
 )
 
 // podCounts keeps record of various numbers of pods

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -525,7 +525,7 @@ func TestReconcile(t *testing.T) {
 		Name: "kpa does not become ready without minScale endpoints when reachable",
 		Key:  key,
 		Objects: []runtime.Object{
-			kpa(testNamespace, testRevision, withMinScale(2), withScales(1, defaultScale),
+			kpa(testNamespace, testRevision, withMinScale(1), withScales(1, defaultScale),
 				WithReachabilityReachable, WithPAMetricsService(privateSvc)),
 			defaultSKS,
 			metric(testNamespace, testRevision),


### PR DESCRIPTION
This PR references the discussion in the CNCF knative-serving Slack channel, which can be found here: https://cloud-native.slack.com/archives/C04LMU0AX60/p1740420658746939

## Issue
There has been a long-standing issue in KNative, with [Issues dating back to 2022](https://github.com/knative/serving/issues/13331) of the Load Balancer erroneously sending requests to pods which are already busy, even though their set max concurrency should not permit the request to be sent through to that pod. I believe I have found (at least one of) the causes.

In specific scenarios, particularly long-running requests, the breaker state for a podTracker will be functionally reset if the revision backend temporarily registers the pod as "unhealthy". There is no explicit logic that dictates this behaviour. Rather, this is a result of how `throttler.go` updates the state for its podTrackers (https://github.com/knative/serving/blob/c09ff6cf182238b3ddbea1d10bf4f8c2173fbacf/pkg/activator/net/throttler.go#L335). To summarise, the new state is determined by completely remaking its []podTrackers list from scratch, using information it retrieves from the respective revision backend. Only the healthy hosts from the revision backend are used to make this podTrackers list, and therefore, any unhealthy podTrackers are effectively removed. This is the case even if the "unhealthy" pod is currently busy with a request. If the pod then becomes healthy timely, the revision backend will report it, and the throttler will re-add a brand new podTracker for the pod, effectively removing any previous state held by the podTracker (ie setting InFlight to 0). The pod therefore becomes a valid target for the loadBalancing policy, even though in reality it is still busy with a request.

## Proposed Changes
This PR seeks to address this issue fairly simply, by not relinquishing the state of the podTrackers until a host is both unhealthy AND finished with in-flight requests. Technically, this amounts to the following:

* Change the core data-structure for storing all pod trackers to be a `map[string]*podTracker` as opposed to a `[]*podTracker`. This allows us to easily manage viable podTrackers by referencing them with their `dest` at any point. It has the added benefit on not re-creating the map on every `assignSlice` call.
* Update the `Breaker` interface to have new `Pending` method. This involves moving the current definition for `InFlight` to be the inflight value associated with the semaphore (similarly to `Capacity`), and creating a new `Pending` method which references a new `pending` attribute (the old `inFlight` attribute) of a Breaker.
* Update the `PodTracker` struct with a new attribute `healthy`, which a load balancing policy can use to skip unhealthy podTrackers.
* When updating Throttler state, use both healthy pods obtained by the revision backend _and_ the current podTracker list to not only add new podTrackers, but to mark podTrackers which are unhealthy but still have `inFlight` requests as determined by the current state of the respective podTracker's breaker semaphore-inflight as "unhealthy". If a podTracker is both unhealthy and has no in-flights, the tracker can be removed.
* Update all load balancing policies to skip pod trackers that are unhealthy, and also to skip podTrackers in the assignedTrackers list which are `nil` (which can now be possible due to us removing the reference for the podTracker in `updateThrottlerState`

There are 5 more things to note in this PR that are tangential/important but not directly related to the functionality:
1. I have updated the `Capacity` and `InFlight` calls to return `uint64` as indicated by a TODO comment
2. The default minimum number of activators for the KPA was set to 2. I have updated this value to 1, as there can be setups with 1 activator present in the proxy path.
3. The changes introduce a dependency from `golang.org/x/exp/maps`, in order to do map manipulation more easily. (I believe this can be removed though when the project updates its go version)
4. Since a podTracker can now be `nil`, the RandomChoice policy may now not succeed. I have updated it to continue to try until it randomly selects a podTracker that is not `nil`. I'm not married to this implementation, we can definitely do it another way. I am aware the unit test for this is currently broken, but I will await feedback to change the actual implementation here.
5. I have added some debug logs for podTracker acquisition for a specific request. This also requires that X-Request-Id be passed in for the log to be sensical.

The implementation of this functionality is open to debate. I am happy to refine this towards an implementation that the core maintainers are more amenable to.
