### PR TITLE
Feature Proposal: Scale Buffer

### DIFF
--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -221,6 +221,13 @@ const (
 	// min-scale value while also preserving the ability to scale to zero.
 	// ActivationScale must be >= 2.
 	ActivationScaleKey = GroupName + "/activation-scale"
+
+	// ScaleBuffer is the number of replicas that should be added to the desired scale
+	// to provide a static buffer of replicas to handle sudden spikes in traffic.
+	// This is useful for services that have a high startup time or for services that
+	// have a high variance in traffic. For example, if ScaleBuffer = 2, the desired
+	// scale would be the desired scale + 2.
+	ScaleBufferAnnotationKey = GroupName + "/scale-buffer"
 )
 
 var (
@@ -279,5 +286,9 @@ var (
 	}
 	WindowAnnotation = kmap.KeyPriority{
 		WindowAnnotationKey,
+	}
+	ScaleBufferAnnotation = kmap.KeyPriority{
+		ScaleBufferAnnotationKey,
+		GroupName + "/scaleBuffer",
 	}
 )

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle.go
@@ -128,6 +128,11 @@ func (pa *PodAutoscaler) TargetBC() (float64, bool) {
 	return pa.annotationFloat64(autoscaling.TargetBurstCapacityAnnotation)
 }
 
+// ScaleBuffer returns the contents of the scale-buffer annotation or a default.
+func (pa *PodAutoscaler) ScaleBuffer() (int32, bool) {
+	return pa.annotationInt32(autoscaling.ScaleBufferAnnotation)
+}
+
 func (pa *PodAutoscaler) annotationDuration(k kmap.KeyPriority) (time.Duration, bool) {
 	if _, s, ok := k.Get(pa.Annotations); ok {
 		d, err := time.ParseDuration(s)

--- a/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_lifecycle_test.go
@@ -1024,6 +1024,42 @@ func TestActivationScaleAnnotation(t *testing.T) {
 		})
 	}
 }
+func TestScaleBufferAnnotation(t *testing.T) {
+	cases := []struct {
+		name        string
+		annotations map[string]string
+		wantValue   int32
+		wantOK      bool
+	}{{
+		name:        "not present",
+		annotations: map[string]string{},
+		wantValue:   0,
+		wantOK:      false,
+	}, {
+		name:        "present",
+		annotations: map[string]string{autoscaling.ScaleBufferAnnotationKey: "5"},
+		wantValue:   5,
+		wantOK:      true,
+	}, {
+		name:        "invalid",
+		annotations: map[string]string{autoscaling.ScaleBufferAnnotationKey: "5s"},
+		wantValue:   0,
+		wantOK:      false,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			autoscaler := pa(tc.annotations)
+			gotValue, gotOK := autoscaler.ScaleBuffer()
+			if gotValue != tc.wantValue {
+				t.Errorf("got = %v, want: %v", gotValue, tc.wantValue)
+			}
+			if gotOK != tc.wantOK {
+				t.Errorf("OK = %v, want: %v", gotOK, tc.wantOK)
+			}
+		})
+	}
+}
 
 func pa(annotations map[string]string) *PodAutoscaler {
 	return &PodAutoscaler{

--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -197,6 +197,8 @@ func (a *autoscaler) Scale(logger *zap.SugaredLogger, now time.Time) ScaleResult
 	// We want to keep desired pod count in the  [maxScaleDown, maxScaleUp] range.
 	desiredStablePodCount := int32(math.Min(math.Max(dspc, maxScaleDown), maxScaleUp))
 	desiredPanicPodCount := int32(math.Min(math.Max(dppc, maxScaleDown), maxScaleUp))
+	desiredStablePodCount += spec.ScaleBuffer
+	desiredPanicPodCount += spec.ScaleBuffer
 
 	//	If ActivationScale > 1, then adjust the desired pod counts
 	if a.deciderSpec.ActivationScale > 1 {

--- a/pkg/autoscaler/scaling/multiscaler.go
+++ b/pkg/autoscaler/scaling/multiscaler.go
@@ -82,6 +82,12 @@ type DeciderSpec struct {
 	// min-scale value while also preserving the ability to scale to zero.
 	// ActivationScale must be >= 2.
 	ActivationScale int32
+	// ScaleBuffer is the number of replicas that should be added to the desired scale
+	// to provide a static buffer of replicas to handle sudden spikes in traffic.
+	// This is useful for services that have a high startup time or for services that
+	// have a high variance in traffic. For example, if ScaleBuffer = 2, the desired
+	// scale would be the desired scale + 2.
+	ScaleBuffer int32
 }
 
 // DeciderStatus is the current scale recommendation.

--- a/pkg/http/request_log.go
+++ b/pkg/http/request_log.go
@@ -146,6 +146,7 @@ func (h *RequestLogHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		err := recover()
 		latency := time.Since(startTime).Seconds()
 		if err != nil {
+			fmt.Printf("error: %e", err)
 			h.write(t, h.inputGetter(r, &RequestLogResponse{
 				Code:    http.StatusInternalServerError,
 				Latency: latency,

--- a/pkg/reconciler/autoscaling/kpa/resources/decider.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider.go
@@ -71,6 +71,11 @@ func MakeDecider(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig
 		activationScale = mnzr
 	}
 
+	var scaleBuffer int32
+	if sb, ok := pa.ScaleBuffer(); ok {
+		scaleBuffer = sb
+	}
+
 	return &scaling.Decider{
 		ObjectMeta: *pa.ObjectMeta.DeepCopy(),
 		Spec: scaling.DeciderSpec{
@@ -87,6 +92,7 @@ func MakeDecider(pa *autoscalingv1alpha1.PodAutoscaler, config *autoscalerconfig
 			InitialScale:        GetInitialScale(config, pa),
 			Reachable:           pa.Spec.Reachability != autoscalingv1alpha1.ReachabilityUnreachable,
 			ActivationScale:     activationScale,
+			ScaleBuffer:         scaleBuffer,
 		},
 	}
 }

--- a/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
+++ b/pkg/reconciler/autoscaling/kpa/resources/decider_test.go
@@ -171,6 +171,16 @@ func TestMakeDecider(t *testing.T) {
 				d.Spec.ActivationScale = 3
 				d.Annotations[autoscaling.ActivationScaleKey] = "3"
 			}),
+	}, {
+		name: "with scale-buffer annotation",
+		pa: pa(func(pa *autoscalingv1alpha1.PodAutoscaler) {
+			pa.Annotations[autoscaling.ScaleBufferAnnotationKey] = "3"
+		}),
+		want: decider(withTarget(100.0), withPanicThreshold(2.0), withTotal(100), withScaleBufferAnnotation("3"),
+			func(d *scaling.Decider) {
+				d.Spec.ScaleBuffer = 3
+				d.Annotations[autoscaling.ScaleBufferAnnotationKey] = "3"
+			}),
 	}}
 
 	for _, tc := range cases {
@@ -307,6 +317,7 @@ func decider(options ...deciderOption) *scaling.Decider {
 			StableWindow:        config.StableWindow,
 			InitialScale:        1,
 			Reachable:           true,
+			ScaleBuffer:         0,
 		},
 	}
 	for _, fn := range options {
@@ -379,6 +390,12 @@ func withMetricAnnotation(metric string) deciderOption {
 func withPanicThresholdPercentageAnnotation(percentage string) deciderOption {
 	return func(decider *scaling.Decider) {
 		decider.Annotations[autoscaling.PanicThresholdPercentageAnnotationKey] = percentage
+	}
+}
+
+func withScaleBufferAnnotation(scaleBuffer string) deciderOption {
+	return func(decider *scaling.Decider) {
+		decider.Annotations[autoscaling.ScaleBufferAnnotationKey] = scaleBuffer
 	}
 }
 


### PR DESCRIPTION
Proposal: Introduce a "Scale Buffer", which ensures that `n` extra service instances are always running.

We have had a number of customers which desire control over the number of instances that are available to serve requests. This is particularly important with GPU instances, which typically can only process a single request at a time. Specifically, they have voiced need for a feature that is able to ensure that `n` instances are always available to serve requests, above what the autoscale suggests. This ensures that even at low volumes, there is enough capacity.

This proposal introduces a `scale-buffer` annotation on the service manifest, which statically adds `n` to the desired pod count above the autoscaler suggestion for a KPA. Even though logic is pretty simple, we currently have this running in our KNative fork and it is working well. I figured it could be useful to others that are also running low-concurrency/no-concurrency workloads in the KNative community. Happy to amend it as needed if the maintainers wish to accept it as a proposal.