### PR TITLE
feat: add support for CSI volumes

### DIFF
--- a/cmd/schema-tweak/overrides.go
+++ b/cmd/schema-tweak/overrides.go
@@ -244,6 +244,9 @@ func revSpecOverrides(prefixPath string) []entry {
 		}, {
 			name: "hostPath",
 			flag: config.FeaturePodSpecHostPath,
+		}, {
+			name: "csi",
+			flag: config.FeaturePodSpecCSI,
 		}},
 	}, {
 		path: "volumes.secret",

--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -1163,6 +1163,10 @@ spec:
                                     description: optional specify whether the ConfigMap or its keys must be defined
                                     type: boolean
                                 x-kubernetes-map-type: atomic
+                              csi:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-volumes-csi
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               emptyDir:
                                 description: |-
                                   This is accessible behind a feature flag - kubernetes.podspec-volumes-emptydir

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -1139,6 +1139,10 @@ spec:
                             description: optional specify whether the ConfigMap or its keys must be defined
                             type: boolean
                         x-kubernetes-map-type: atomic
+                      csi:
+                        description: This is accessible behind a feature flag - kubernetes.podspec-volumes-csi
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       emptyDir:
                         description: |-
                           This is accessible behind a feature flag - kubernetes.podspec-volumes-emptydir

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -1181,6 +1181,10 @@ spec:
                                     description: optional specify whether the ConfigMap or its keys must be defined
                                     type: boolean
                                 x-kubernetes-map-type: atomic
+                              csi:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-volumes-csi
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               emptyDir:
                                 description: |-
                                   This is accessible behind a feature flag - kubernetes.podspec-volumes-emptydir

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "63a13754"
+    knative.dev/example-checksum: "634edbdf"
 data:
   _example: |-
     ################################
@@ -207,6 +207,11 @@ data:
     # 1. Enabled: enabling HostPath volume support
     # 2. Disabled: disabling HostPath volume support
     kubernetes.podspec-volumes-hostpath: "disabled"
+
+    # Controls whether volume support for CSI is enabled or not.
+    # 1. Enabled: enabling CSI volume support
+    # 2. Disabled: disabling CSI volume support
+    kubernetes.podspec-volumes-csi: "disabled"
 
     # Controls whether init containers support is enabled or not.
     # 1. Enabled: enabling init containers support

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -65,6 +65,7 @@ const (
 	FeaturePodSpecHostNetwork               = "kubernetes.podspec-hostnetwork"
 	FeaturePodSpecHostPID                   = "kubernetes.podspec-hostpid"
 	FeaturePodSpecHostPath                  = "kubernetes.podspec-volumes-hostpath"
+	FeaturePodSpecCSI                       = "kubernetes.podspec-volumes-csi"
 	FeaturePodSpecInitContainers            = "kubernetes.podspec-init-containers"
 	FeaturePodSpecNodeSelector              = "kubernetes.podspec-nodeselector"
 	FeaturePodSpecPVClaim                   = "kubernetes.podspec-persistent-volume-claim"
@@ -99,6 +100,7 @@ func defaultFeaturesConfig() *Features {
 		PodSpecTolerations:               Disabled,
 		PodSpecVolumesEmptyDir:           Enabled,
 		PodSpecVolumesHostPath:           Disabled,
+		PodSpecVolumesCSI:                Disabled,
 		PodSpecPersistentVolumeClaim:     Disabled,
 		PodSpecPersistentVolumeWrite:     Disabled,
 		QueueProxyMountPodInfo:           Disabled,
@@ -137,6 +139,7 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 		asFlag(FeaturePodSpecHostNetwork, &nc.PodSpecHostNetwork),
 		asFlag(FeaturePodSpecHostPID, &nc.PodSpecHostPID),
 		asFlag(FeaturePodSpecHostPath, &nc.PodSpecVolumesHostPath),
+		asFlag(FeaturePodSpecCSI, &nc.PodSpecVolumesCSI),
 		asFlag(FeaturePodSpecInitContainers, &nc.PodSpecInitContainers),
 		asFlag(FeaturePodSpecNodeSelector, &nc.PodSpecNodeSelector),
 		asFlag(FeaturePodSpecPVClaim, &nc.PodSpecPersistentVolumeClaim),
@@ -180,6 +183,7 @@ type Features struct {
 	PodSpecTolerations               Flag
 	PodSpecVolumesEmptyDir           Flag
 	PodSpecVolumesHostPath           Flag
+	PodSpecVolumesCSI                Flag
 	PodSpecInitContainers            Flag
 	PodSpecPersistentVolumeClaim     Flag
 	PodSpecPersistentVolumeWrite     Flag

--- a/pkg/apis/config/features_test.go
+++ b/pkg/apis/config/features_test.go
@@ -456,6 +456,24 @@ func TestFeaturesConfiguration(t *testing.T) {
 			"kubernetes.podspec-volumes-hostpath": "Enabled",
 		},
 	}, {
+		name:    "kubernetes.podspec-volumes-csi Disabled",
+		wantErr: false,
+		wantFeatures: defaultWith(&Features{
+			PodSpecVolumesCSI: Disabled,
+		}),
+		data: map[string]string{
+			"kubernetes.podspec-volumes-csi": "Disabled",
+		},
+	}, {
+		name:    "kubernetes.podspec-volumes-csi Enabled",
+		wantErr: false,
+		wantFeatures: defaultWith(&Features{
+			PodSpecVolumesCSI: Enabled,
+		}),
+		data: map[string]string{
+			"kubernetes.podspec-volumes-csi": "Enabled",
+		},
+	}, {
 		name:    "kubernetes.podspec-persistent-volume-claim Disabled",
 		wantErr: false,
 		wantFeatures: defaultWith(&Features{

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -70,6 +70,10 @@ func VolumeSourceMask(ctx context.Context, in *corev1.VolumeSource) *corev1.Volu
 		out.HostPath = in.HostPath
 	}
 
+	if cfg.Features.PodSpecVolumesCSI != config.Disabled {
+		out.CSI = in.CSI
+	}
+
 	// Too many disallowed fields to list
 
 	return out

--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -129,6 +129,10 @@ func validateVolume(ctx context.Context, volume corev1.Volume) *apis.FieldError 
 		errs = errs.Also(&apis.FieldError{Message: fmt.Sprintf("HostPath volume support is disabled, "+
 			"but found HostPath volume %s", volume.Name)})
 	}
+	if volume.CSI != nil && features.PodSpecVolumesCSI != config.Enabled {
+		errs = errs.Also(&apis.FieldError{Message: fmt.Sprintf("CSI volume support is disabled, "+
+			"but found CSI volume %s", volume.Name)})
+	}
 	errs = errs.Also(apis.CheckDisallowedFields(volume, *VolumeMask(ctx, &volume)))
 	if volume.Name == "" {
 		errs = apis.ErrMissingField("name")
@@ -169,6 +173,10 @@ func validateVolume(ctx context.Context, volume corev1.Volume) *apis.FieldError 
 		specified = append(specified, "hostPath")
 	}
 
+	if vs.CSI != nil {
+		specified = append(specified, "csi")
+	}
+
 	if len(specified) == 0 {
 		fieldPaths := []string{"secret", "configMap", "projected"}
 		cfg := config.FromContextOrDefaults(ctx)
@@ -180,6 +188,9 @@ func validateVolume(ctx context.Context, volume corev1.Volume) *apis.FieldError 
 		}
 		if cfg.Features.PodSpecVolumesHostPath == config.Enabled {
 			fieldPaths = append(fieldPaths, "hostPath")
+		}
+		if cfg.Features.PodSpecVolumesCSI == config.Enabled {
+			fieldPaths = append(fieldPaths, "csi")
 		}
 		errs = errs.Also(apis.ErrMissingOneOf(fieldPaths...))
 	} else if len(specified) > 1 {

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -2951,16 +2951,14 @@ func TestVolumeValidation(t *testing.T) {
 		},
 		want: (&apis.FieldError{
 			Message: `CSI volume support is disabled, but found CSI volume foo`,
-		}).Also(
-			&apis.FieldError{Message: "must not set the field(s)", Paths: []string{"csi"}
-		})
+		}).Also(&apis.FieldError{Message: "must not set the field(s)", Paths: []string{"csi"}}),
 	}, {
 		name: "missing CSI volume when required",
 		v: corev1.Volume{
 			Name: "foo",
 		},
 		cfgOpts: []configOption{withPodSpecVolumesCSIEnabled()},
-		want:    apis.ErrMissingOneOf("secret", "configMap", "projected", "emptyDir", "hostPath", "csi"),
+		want:    apis.ErrMissingOneOf("secret", "configMap", "projected", "emptyDir", "csi"),
 	}, {
 		name: "valid PVC with PVC feature enabled",
 		v: corev1.Volume{

--- a/pkg/reconciler/route/resources/service_test.go
+++ b/pkg/reconciler/route/resources/service_test.go
@@ -435,6 +435,7 @@ func testConfig() *config.Config {
 			PodSpecTolerations:           apiConfig.Disabled,
 			PodSpecVolumesEmptyDir:       apiConfig.Disabled,
 			PodSpecVolumesHostPath:       apiConfig.Disabled,
+			PodSpecVolumesCSI:            apiConfig.Disabled,
 			PodSpecPersistentVolumeClaim: apiConfig.Disabled,
 			PodSpecPersistentVolumeWrite: apiConfig.Disabled,
 			PodSpecInitContainers:        apiConfig.Disabled,


### PR DESCRIPTION
Fixes #11069

# Description
This feature introduces support for Container Storage Interface (CSI) volumes in Knative Serving, enabling users to integrate with a wide variety of storage solutions through the Kubernetes CSI standard. This enhancement allows Knative services to leverage enterprise storage systems, cloud provider volumes, and other storage implementations that support the CSI specification, while maintaining Knative's serverless principles.

## Proposed Changes
* Add support for CSI volume type in Knative Serving
* Enable users to mount CSI volumes into their Knative service containers
* Update relevant documentation and examples to include usage of CSI volumes
* Add feature flag control for CSI volume support

**Release Note**

```release-note
Adding support for CSI (Container Storage Interface) volumes. This feature allows users to mount CSI-compatible storage volumes into their Knative service containers. It enables integration with enterprise storage solutions and cloud provider storage services that implement the CSI specification. The feature is behind the flag `kubernetes.podspec-volumes-csi`.
```
