### PR TITLE
Add a config flag to use service name in traces

### DIFF
--- a/pkg/queue/sharedmain/main.go
+++ b/pkg/queue/sharedmain/main.go
@@ -104,10 +104,11 @@ type config struct {
 	MetricsCollectorAddress                     string `split_words:"true"` // optional
 
 	// Tracing configuration
-	TracingConfigDebug          bool                      `split_words:"true"` // optional
-	TracingConfigBackend        tracingconfig.BackendType `split_words:"true"` // optional
-	TracingConfigSampleRate     float64                   `split_words:"true"` // optional
-	TracingConfigZipkinEndpoint string                    `split_words:"true"` // optional
+	TracingConfigDebug             bool                      `split_words:"true"` // optional
+	TracingConfigBackend           tracingconfig.BackendType `split_words:"true"` // optional
+	TracingConfigSampleRate        float64                   `split_words:"true"` // optional
+	TracingConfigZipkinEndpoint    string                    `split_words:"true"` // optional
+	TracingConfigUseServingService bool                      `split_words:"true"` // optional
 
 	Env
 }
@@ -194,7 +195,12 @@ func Main(opts ...Option) error {
 	d.Transport = buildTransport(env)
 
 	if env.TracingConfigBackend != tracingconfig.None {
-		oct := tracing.NewOpenCensusTracer(tracing.WithExporterFull(env.ServingPod, env.ServingPodIP, logger))
+		tracingServiceName := env.ServingPod
+		if env.TracingConfigUseServingService {
+			tracingServiceName = env.ServingService
+		}
+
+		oct := tracing.NewOpenCensusTracer(tracing.WithExporterFull(tracingServiceName, env.ServingPodIP, logger))
 		oct.ApplyConfig(&tracingconfig.Config{
 			Backend:        env.TracingConfigBackend,
 			Debug:          env.TracingConfigDebug,

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -423,6 +423,9 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 			Name:  "TRACING_CONFIG_SAMPLE_RATE",
 			Value: fmt.Sprint(cfg.Tracing.SampleRate),
 		}, {
+			Name:  "TRACING_CONFIG_USE_SERVING_SERVICE",
+			Value: fmt.Sprint(cfg.Tracing.UseServingService),
+		}, {
 			Name:  "USER_PORT",
 			Value: strconv.Itoa(int(userPort)),
 		}, {


### PR DESCRIPTION

## Proposed Changes

* Use a flag to use `ServingService`as the trace `service.name` which is added in [this PR](https://github.com/knative/pkg/pull/3164)

Motivation is pretty much the same as in the other PR, copy pasting:

While the OTel migration is in progress it would be very helpful to have a flag which allows users toggling the ServingService to be used as the service.name in traces.
This is related to https://github.com/knative/serving/issues/12969 and would still be relevant after the migration to OTel.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
You can now use the `useServingService` flag in the tracing config to use the `ServingService` as the `service.name` in traces. Current default is to use the `ServingPod` as the `service.name`, and it remains the same if the flag is not set.
```
