### PR TITLE
autoscaler: ignore ScaleDownDelay if not reachable

### DIFF
--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -247,13 +247,13 @@ func (a *autoscaler) Scale(logger *zap.SugaredLogger, now time.Time) ScaleResult
 		logger.Debug("Operating in stable mode.")
 	}
 
-	// Delay scale down decisions, if a ScaleDownDelay was specified.
+	// Delay scale down decisions if reachable and if a ScaleDownDelay was specified.
 	// We only do this if there's a non-nil delayWindow because although a
 	// one-element delay window is _almost_ the same as no delay at all, it is
 	// not the same in the case where two Scale()s happen in the same time
 	// interval (because the largest will be picked rather than the most recent
 	// in that case).
-	if a.delayWindow != nil {
+	if a.deciderSpec.Reachable && a.delayWindow != nil {
 		a.delayWindow.Record(now, desiredPodCount)
 		delayedPodCount := a.delayWindow.Current()
 		if delayedPodCount != desiredPodCount {

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -130,7 +130,6 @@ func TestAutoscalerScaleDownDelay(t *testing.T) {
 }
 
 func TestAutoscalerScaleDownDelayNotReachable(t *testing.T) {
-
 	pc := &fakePodCounter{}
 	metrics := &metricClient{}
 	spec := &DeciderSpec{

--- a/pkg/autoscaler/scaling/autoscaler_test.go
+++ b/pkg/autoscaler/scaling/autoscaler_test.go
@@ -76,6 +76,7 @@ func TestAutoscalerScaleDownDelay(t *testing.T) {
 		MaxScaleUpRate:   10,
 		PanicThreshold:   100,
 		ScaleDownDelay:   5 * time.Minute,
+		Reachable:        true,
 	}
 	as := New(context.Background(), testNamespace, testRevision, metrics, pc, spec)
 
@@ -125,6 +126,51 @@ func TestAutoscalerScaleDownDelay(t *testing.T) {
 			ScaleValid:      true,
 			DesiredPodCount: 0, // everything scrolled out, drop to 0
 		})
+	})
+}
+
+func TestAutoscalerScaleDownDelayNotReachable(t *testing.T) {
+
+	pc := &fakePodCounter{}
+	metrics := &metricClient{}
+	spec := &DeciderSpec{
+		TargetValue:      10,
+		MaxScaleDownRate: 10,
+		MaxScaleUpRate:   10,
+		PanicThreshold:   100,
+		ScaleDownDelay:   5 * time.Minute,
+		Reachable:        true,
+	}
+	as := New(context.Background(), testNamespace, testRevision, metrics, pc, spec)
+
+	now := time.Time{}
+
+	// scale up.
+	metrics.SetStableAndPanicConcurrency(40, 40)
+	expectScale(t, as, now.Add(2*time.Second), ScaleResult{
+		ScaleValid:      true,
+		DesiredPodCount: 4,
+	})
+	// one minute passes at reduced concurrency - should not scale down (less than delay).
+	metrics.SetStableAndPanicConcurrency(0, 0)
+	expectScale(t, as, now.Add(1*time.Minute), ScaleResult{
+		ScaleValid:      true,
+		DesiredPodCount: 4,
+	})
+	// mark as unreachable to simulate another revision coming up
+	unreachableSpec := &DeciderSpec{
+		TargetValue:      10,
+		MaxScaleDownRate: 10,
+		MaxScaleUpRate:   10,
+		PanicThreshold:   100,
+		ScaleDownDelay:   5 * time.Minute,
+		Reachable:        false,
+	}
+	as.Update(unreachableSpec)
+	// 2 seconds pass at reduced concurrency - now we scale down.
+	expectScale(t, as, now.Add(2*time.Second), ScaleResult{
+		ScaleValid:      true,
+		DesiredPodCount: 0,
 	})
 }
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* autoscaler: ignore ScaleDownDelay if not reachable
    * addresses an issue we noticed where old revisions would hang around for the full scale down delay even if zero traffic is being directed to them, resulting in unnecessary resource utilization (especially if the scale down delay is large)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
autoscaling: ignore ScaleDownDelay if the revision is not reachable
```
