### PR TITLE
drop code clearing out the user agent

### DIFF
--- a/pkg/http/proxy.go
+++ b/pkg/http/proxy.go
@@ -47,12 +47,6 @@ func NewHeaderPruningReverseProxy(target, hostOverride string, headersToRemove [
 				req.Header.Add(netheader.PassthroughLoadbalancingKey, "true")
 			}
 
-			// Copied from httputil.NewSingleHostReverseProxy.
-			if _, ok := req.Header[netheader.UserAgentKey]; !ok {
-				// explicitly disable User-Agent so it's not set to default value
-				req.Header.Set(netheader.UserAgentKey, "")
-			}
-
 			for _, h := range headersToRemove {
 				req.Header.Del(h)
 			}


### PR DESCRIPTION
This is now handled properly in the go standard library
https://github.com/golang/go/commit/f001df540b3fc66a475985c1b7c810e7df063c8f

Fixes: https://github.com/knative/serving/issues/15738

/assign @dsimansk 