### PR TITLE
Add support for Kubernetes “image” volume type

### DIFF
--- a/cmd/schema-tweak/overrides.go
+++ b/cmd/schema-tweak/overrides.go
@@ -251,6 +251,9 @@ func revSpecOverrides(prefixPath string) []entry {
 		}, {
 			name: "csi",
 			flag: config.FeaturePodSpecVolumesCSI,
+		}, {
+			name: "image",
+			flag: config.FeaturePodSpecVolumesImage,
 		}},
 	}, {
 		path: "volumes.secret",

--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -1181,6 +1181,11 @@ spec:
                                   This is accessible behind a feature flag - kubernetes.podspec-volumes-hostpath
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
+                              image:
+                                description: |-
+                                  This is accessible behind a feature flag - kubernetes.podspec-volumes-image
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               name:
                                 description: |-
                                   name of the volume.

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -1157,6 +1157,11 @@ spec:
                           This is accessible behind a feature flag - kubernetes.podspec-volumes-hostpath
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      image:
+                        description: |-
+                          This is accessible behind a feature flag - kubernetes.podspec-volumes-image
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       name:
                         description: |-
                           name of the volume.

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -1199,6 +1199,11 @@ spec:
                                   This is accessible behind a feature flag - kubernetes.podspec-volumes-hostpath
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
+                              image:
+                                description: |-
+                                  This is accessible behind a feature flag - kubernetes.podspec-volumes-image
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               name:
                                 description: |-
                                   name of the volume.

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "82cbbba9"
+    knative.dev/example-checksum: "0f9b4ade"
 data:
   _example: |-
     ################################
@@ -199,6 +199,11 @@ data:
     # 1. Enabled: enabling EmptyDir volume support
     # 2. Disabled: disabling EmptyDir volume support
     kubernetes.podspec-volumes-emptydir: "enabled"
+
+    # Controls whether volume support for image is enabled or not.
+    # 1. Enabled: enabling image volume support
+    # 2. Disabled: disabling image volume support
+    kubernetes.podspec-volumes-image: "disabled"
 
     # Controls whether volume support for HostPath is enabled or not.
     # WARNING: Cannot safely be disabled once enabled.

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -77,6 +77,7 @@ const (
 	FeaturePodSpecShareProcessNamespace     = "kubernetes.podspec-shareprocessnamespace"
 	FeaturePodSpecTolerations               = "kubernetes.podspec-tolerations"
 	FeaturePodSpecTopologySpreadConstraints = "kubernetes.podspec-topologyspreadconstraints"
+	FeaturePodSpecVolumesImage              = "kubernetes.podspec-volumes-image"
 )
 
 func defaultFeaturesConfig() *Features {
@@ -103,6 +104,7 @@ func defaultFeaturesConfig() *Features {
 		PodSpecVolumesHostPath:           Disabled,
 		PodSpecVolumesMountPropagation:   Disabled,
 		PodSpecVolumesCSI:                Disabled,
+		PodSpecVolumesImage:              Disabled,
 		PodSpecPersistentVolumeClaim:     Disabled,
 		PodSpecPersistentVolumeWrite:     Disabled,
 		QueueProxyMountPodInfo:           Disabled,
@@ -142,6 +144,7 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 		asFlag(FeaturePodSpecHostPID, &nc.PodSpecHostPID),
 		asFlag(FeaturePodSpecHostPath, &nc.PodSpecVolumesHostPath),
 		asFlag(FeaturePodSpecVolumesCSI, &nc.PodSpecVolumesCSI),
+		asFlag(FeaturePodSpecVolumesImage, &nc.PodSpecVolumesImage),
 		asFlag(FeaturePodSpecInitContainers, &nc.PodSpecInitContainers),
 		asFlag(FeaturePodSpecVolumesMountPropagation, &nc.PodSpecVolumesMountPropagation),
 		asFlag(FeaturePodSpecNodeSelector, &nc.PodSpecNodeSelector),
@@ -188,6 +191,7 @@ type Features struct {
 	PodSpecVolumesHostPath           Flag
 	PodSpecVolumesMountPropagation   Flag
 	PodSpecVolumesCSI                Flag
+	PodSpecVolumesImage              Flag
 	PodSpecInitContainers            Flag
 	PodSpecPersistentVolumeClaim     Flag
 	PodSpecPersistentVolumeWrite     Flag

--- a/pkg/apis/config/features_test.go
+++ b/pkg/apis/config/features_test.go
@@ -438,6 +438,24 @@ func TestFeaturesConfiguration(t *testing.T) {
 			"kubernetes.podspec-volumes-emptydir": "Enabled",
 		},
 	}, {
+		name:    "kubernetes.podspec-volumes-image Disabled",
+		wantErr: false,
+		wantFeatures: defaultWith(&Features{
+			PodSpecVolumesImage: Disabled,
+		}),
+		data: map[string]string{
+			"kubernetes.podspec-volumes-image": "Disabled",
+		},
+	}, {
+		name:    "kubernetes.podspec-volumes-image Enabled",
+		wantErr: false,
+		wantFeatures: defaultWith(&Features{
+			PodSpecVolumesImage: Enabled,
+		}),
+		data: map[string]string{
+			"kubernetes.podspec-volumes-image": "Enabled",
+		},
+	}, {
 		name:    "kubernetes.podspec-volumes-hostpath Disabled",
 		wantErr: false,
 		wantFeatures: defaultWith(&Features{

--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -74,6 +74,10 @@ func VolumeSourceMask(ctx context.Context, in *corev1.VolumeSource) *corev1.Volu
 		out.CSI = in.CSI
 	}
 
+	if cfg.Features.PodSpecVolumesImage != config.Disabled {
+		out.Image = in.Image
+	}
+
 	// Too many disallowed fields to list
 
 	return out
@@ -777,6 +781,22 @@ func NamespacedObjectReferenceMask(in *corev1.ObjectReference) *corev1.ObjectRef
 	out.FieldPath = ""
 	out.ResourceVersion = ""
 	out.UID = ""
+
+	return out
+}
+
+// ImageVolumeSourceMask performs a _shallow_ copy of Kubernetes ImageVolumeSource
+// bringing over only the fields allowed in the Knative API.
+func ImageVolumeSourceMask(in *corev1.ImageVolumeSource) *corev1.ImageVolumeSource {
+	if in == nil {
+		return nil
+	}
+
+	out := new(corev1.ImageVolumeSource)
+
+	// Allowed fields
+	out.Reference = in.Reference
+	out.PullPolicy = in.PullPolicy
 
 	return out
 }


### PR DESCRIPTION
Fixes #15488

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Kubernetes v1.31 introduced image volumes that allow mounting OCI images directly into Pods.
This patch extends Knative Serving to recognize and validate this new type.

Highlights

• Feature gate
    – New config-map key kubernetes.podspec-volumes-image and flag PodSpecVolumesImage (disabled by default).

• API / field-mask updates
    – VolumeSourceMask now preserves .image when the gate is enabled. 
    – Added ImageVolumeSourceMask helper for shallow-copying allowed fields.

• Validation
    – validateVolume checks feature-gate state, treats image as a mutually-exclusive source and performs per-field checks via validateImageVolumeSource.

• Schema-tweak overrides
    – Whitelisted volumes.image behind the new feature gate so generated CRD/OpenAPI stays in sync.

• Tests
    – Added helper to enable the feature in tests.
    – Expanded TestVolumeValidation with positive/negative cases for the image volume.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Knative Serving now supports Kubernetes’ new "image" volume type.
```
