### PR TITLE
Bump K8s cluster verison

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -82,8 +82,8 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.31.x
         - v1.32.x
+        - v1.33.x
 
         ingress:
         - kourier

--- a/test/e2e-external-domain-tls-tests.sh
+++ b/test/e2e-external-domain-tls-tests.sh
@@ -162,7 +162,7 @@ function delete_dns_record() {
 }
 
 # Script entry point.
-initialize "$@" --num-nodes=4 --enable-ha --cluster-version=1.31
+initialize "$@" --num-nodes=4 --enable-ha
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -28,7 +28,7 @@
 source $(dirname "$0")/e2e-common.sh
 
 # Script entry point.
-initialize --num-nodes=4 --enable-ha --cluster-version=1.31 "$@"
+initialize --num-nodes=4 --enable-ha "$@"
 
 # Run the tests
 header "Running tests"

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -42,8 +42,7 @@ function stage_test_resources() {
 # Skip installing istio as an add-on.
 # Skip installing a pvc as it is not used in upgrade tests
 # Skip installing a resource quota as it is not used in upgrade tests
-PVC=0 QUOTA=0 initialize "$@" --num-nodes=4 --cluster-version=1.31 \
-  --install-latest-release
+PVC=0 QUOTA=0 initialize "$@" --num-nodes=4 --install-latest-release
 
 # TODO(#2656): Reduce the timeout after we get this test to consistently passing.
 TIMEOUT=30m

--- a/test/performance/performance-tests.sh
+++ b/test/performance/performance-tests.sh
@@ -38,7 +38,7 @@ declare ARTIFACTS
 
 ns="default"
 
-initialize --num-nodes=10 --cluster-version=1.31 "$@"
+initialize --num-nodes=10 "$@"
 
 function run_job() {
   local name=$1


### PR DESCRIPTION
Next release is targeting a minimum k8s version of 1.32

https://github.com/knative/community/blob/main/mechanics/RELEASE-SCHEDULE.md#upcoming-releases

Dropped the explicit cluster version in hack since we will update the k8s version in the hack script.