### PR TITLE
Revision sets to True when deploy has the minimum number

### DIFF
--- a/pkg/reconciler/revision/reconcile_resources.go
+++ b/pkg/reconciler/revision/reconcile_resources.go
@@ -120,7 +120,7 @@ func (c *Reconciler) reconcileDeployment(ctx context.Context, rev *v1.Revision) 
 		}
 	}
 
-	if deployment.Status.ReadyReplicas > 0 {
+	if deployment.Spec.Replicas != nil && deployment.Status.ReadyReplicas >= *deployment.Spec.Replicas {
 		rev.Status.MarkContainerHealthyTrue()
 	}
 

--- a/test/v1/revision.go
+++ b/test/v1/revision.go
@@ -79,6 +79,11 @@ func IsRevisionReady(r *v1.Revision) (bool, error) {
 	return r.IsReady(), nil
 }
 
+// IsRevisionContainerHealthy will indicate whether the revision has marked the container healthy.
+func IsRevisionContainerHealthy(r *v1.Revision) (bool, error) {
+	return r.Status.GetCondition(v1.RevisionConditionContainerHealthy).IsTrue(), nil
+}
+
 // IsRevisionFailed will check the status condition sof the revision and return true if the revision is
 // marked as failed, otherwise it will return false.
 func IsRevisionFailed(r *v1.Revision) (bool, error) {

--- a/test/v1/revision.go
+++ b/test/v1/revision.go
@@ -81,7 +81,10 @@ func IsRevisionReady(r *v1.Revision) (bool, error) {
 
 // IsRevisionContainerHealthy will indicate whether the revision has marked the container healthy.
 func IsRevisionContainerHealthy(r *v1.Revision) (bool, error) {
-	return r.Status.GetCondition(v1.RevisionConditionContainerHealthy).IsTrue(), nil
+	if r.Status.GetCondition(v1.RevisionConditionContainerHealthy).IsTrue() {
+		return true, nil
+	}
+	return false, nil
 }
 
 // IsRevisionFailed will check the status condition sof the revision and return true if the revision is

--- a/test/v1/revision.go
+++ b/test/v1/revision.go
@@ -79,14 +79,6 @@ func IsRevisionReady(r *v1.Revision) (bool, error) {
 	return r.IsReady(), nil
 }
 
-// IsRevisionContainerHealthy will indicate whether the revision has marked the container healthy.
-func IsRevisionContainerHealthy(r *v1.Revision) (bool, error) {
-	if r.Status.GetCondition(v1.RevisionConditionContainerHealthy).IsTrue() {
-		return true, nil
-	}
-	return false, nil
-}
-
 // IsRevisionFailed will check the status condition sof the revision and return true if the revision is
 // marked as failed, otherwise it will return false.
 func IsRevisionFailed(r *v1.Revision) (bool, error) {


### PR DESCRIPTION
Fixes #15889

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Revision is set to healthy, when the deployment has the minimum number of replicas running and ready.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Revision is set to healthy, when the deployment has the minimum number of replicas running and ready.
```
