### PR TITLE
Fix labels and annotations propagation to k8s service on update

### DIFF
--- a/pkg/reconciler/route/table_test.go
+++ b/pkg/reconciler/route/table_test.go
@@ -786,7 +786,7 @@ func TestReconcile(t *testing.T) {
 				},
 				withReadyIngress,
 			),
-			simpleK8sService(Route("default", "different-domain", WithConfigTarget("config"))),
+			simpleK8sService(Route("default", "different-domain", WithConfigTarget("config"), WithRouteLabel(map[string]string{"app": "prod"}))),
 		},
 		WantUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: simpleIngress(

--- a/pkg/testing/v1/service.go
+++ b/pkg/testing/v1/service.go
@@ -145,10 +145,19 @@ func WithServiceAnnotation(k, v string) ServiceOption {
 	}
 }
 
-// WithServiceAnnotationRemoved adds the given annotation to the service.
+// WithServiceAnnotationRemoved removes the given annotation from the service.
 func WithServiceAnnotationRemoved(k string) ServiceOption {
 	return func(svc *v1.Service) {
 		svc.Annotations = kmeta.FilterMap(svc.Annotations, func(s string) bool {
+			return k == s
+		})
+	}
+}
+
+// WithServiceLabelRemoved removes the given label from the service.
+func WithServiceLabelRemoved(k string) ServiceOption {
+	return func(svc *v1.Service) {
+		svc.Labels = kmeta.FilterMap(svc.Labels, func(s string) bool {
 			return k == s
 		})
 	}


### PR DESCRIPTION
Fixes #15891

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Fix labels and annotations propagation to k8s service on update

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix labels and annotations propagation to k8s service on update
```

/cc @dprotaso @Fedosin 

At least a few tests would be useful here. I'll add those based on initial feedback. 