### PR TITLE
[e2e] TestSystemInternalTLS set min-scale to not lose logs

### DIFF
--- a/test/e2e/systeminternaltls/system_internal_tls_test.go
+++ b/test/e2e/systeminternaltls/system_internal_tls_test.go
@@ -66,7 +66,11 @@ func TestSystemInternalTLS(t *testing.T) {
 	test.EnsureTearDown(t, clients, &names)
 
 	t.Log("Creating a new Service")
-	resources, err := v1test.CreateServiceReady(t, clients, &names)
+	resources, err := v1test.CreateServiceReady(t, clients, &names,
+		rtesting.WithConfigAnnotations(map[string]string{
+			// Make sure we don't scale to zero during the test as we're waiting for logs.
+			autoscaling.MinScaleAnnotationKey: "1",
+		}))
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}


### PR DESCRIPTION
* set min-scale in TestSystemInternalTLS to not lose the queue-proxy logs

Sporadically, downstream we see TestSystemInternalTLS failing with

```
    system_internal_tls_test.go:110: TLS not used on requests to queue-proxy: pods "system-internal-tls-mjhqutwi-00001-deployment-6b84b959d7-mjkcs" not found
```

so here we set min-scale: 1 , same as it's already done in TestTLSCertificateRotation for the same reason.