### PR TITLE
Fix request hanging after response start timeout expires

### DIFF
--- a/pkg/http/handler/timeout.go
+++ b/pkg/http/handler/timeout.go
@@ -138,9 +138,11 @@ func (h *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			idleTimeout.Reset(timeToNextTimeout)
 		case <-responseStartTimeoutCh:
+			// If the response has already started, we need to continue
+			// processing other timeouts and wait for the handler to complete.
+			responseStartTimeoutDrained = true
 			timedOut := tw.tryResponseStartTimeoutAndWriteError(h.body)
 			if timedOut {
-				responseStartTimeoutDrained = true
 				return
 			}
 		}


### PR DESCRIPTION

Fixes #15352

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

When a response starts before the responseStartTimeout but the timeout still fires, the timeout handler would not properly continue processing the request. This caused requests to hang indefinitely if they started responding just before the responseStartTimeout expired.

The issue occurred because after handling the responseStartTimeout case, the select loop would continue but without properly waiting for the handler to complete. Setting responseStartTimeoutDrained ensures the timer is properly cleaned up and the loop continues to process other events (completion, overall timeout, or idle timeout).

Fixes requests that start responding before responseStartTimeout but take longer than responseStartTimeout to complete.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
