### PR TITLE
ignore v1.Endpoint.* deprecation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -179,6 +179,9 @@ linters:
       - std-error-handling
     rules:
       - linters:
+          - staticcheck
+        text: corev1.Endpoint.* is deprecated
+      - linters:
           - gosec
           - noctx
           - protogetter


### PR DESCRIPTION
Part of https://github.com/knative/serving/issues/7701

Without this change the linter will fail when the upstream bump (https://github.com/knative/pkg) comes
