### PR TITLE
Fix roundToNDigits to use Round instead of Floor

### DIFF
--- a/pkg/autoscaler/aggregation/bucketing.go
+++ b/pkg/autoscaler/aggregation/bucketing.go
@@ -129,7 +129,7 @@ func (t *TimedFloat64Buckets) isEmptyLocked(now time.Time) bool {
 
 func roundToNDigits(n int, f float64) float64 {
 	p := math.Pow10(n)
-	return math.Floor(f*p) / p
+	return math.Round(f*p) / p
 }
 
 const (

--- a/pkg/autoscaler/aggregation/bucketing_test.go
+++ b/pkg/autoscaler/aggregation/bucketing_test.go
@@ -400,7 +400,7 @@ func TestWeightedFloat64BucketsResizeWindow(t *testing.T) {
 	if got, want := sum, wantInitial; got != want {
 		t.Fatalf("Initial data set Sum = %v, want: %v", got, want)
 	}
-	if got, want := roundToNDigits(3, buckets.WindowAverage(now)), 5.811; /*computed a mano*/ got != want {
+	if got, want := roundToNDigits(3, buckets.WindowAverage(now)), 5.812; /*computed a mano*/ got != want {
 		t.Fatalf("Initial data set Sum = %v, want: %v", got, want)
 	}
 
@@ -627,10 +627,13 @@ func TestRoundToNDigits(t *testing.T) {
 	if got, want := roundToNDigits(6, 3.6e-17), 0.; got != want {
 		t.Errorf("Rounding = %v, want: %v", got, want)
 	}
+	if got, want := roundToNDigits(3, -3.6e-17), 0.; got != want {
+		t.Errorf("Rounding = %v, want: %v", got, want)
+	}
 	if got, want := roundToNDigits(3, 0.0004), 0.; got != want {
 		t.Errorf("Rounding = %v, want: %v", got, want)
 	}
-	if got, want := roundToNDigits(3, 1.2345), 1.234; got != want {
+	if got, want := roundToNDigits(3, 1.2345), 1.235; got != want {
 		t.Errorf("Rounding = %v, want: %v", got, want)
 	}
 	if got, want := roundToNDigits(4, 1.2345), 1.2345; got != want {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Previously, `roundToNDigits` used math.Floor which always rounds down. This caused incorrect behavior for small negative numbers, where values like -3.6e-17 would round to a negative number instead of 0.

Since this function is used to calculate an average value of non-negative numbers, getting a negative result can be surprising.

Using math.Round ensures proper rounding to the nearest integer, which correctly rounds very small negative values to 0 when appropriate.

This fix is important for the autoscaler's aggregation calculations where small floating-point errors near zero should not produce negative results.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
