### PR TITLE
[otel] Use new serving observability configmap 

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -25,7 +25,6 @@ import (
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/leaderelection"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/webhook"
 	"knative.dev/pkg/webhook/certificates"
@@ -34,6 +33,7 @@ import (
 	"knative.dev/pkg/webhook/resourcesemantics/defaulting"
 	"knative.dev/pkg/webhook/resourcesemantics/validation"
 	servingv1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
+	o11yconfigmap "knative.dev/serving/pkg/observability/configmap"
 	certconfig "knative.dev/serving/pkg/reconciler/certificate/config"
 
 	// resource validation types
@@ -150,7 +150,7 @@ func newConfigValidationController(ctx context.Context, cmw configmap.Watcher) *
 			netcfg.ConfigMapName:             network.NewConfigFromConfigMap,
 			deployment.ConfigName:            deployment.NewConfigFromConfigMap,
 			apisconfig.FeaturesConfigName:    apisconfig.NewFeaturesConfigFromConfigMap,
-			metrics.ConfigMapName():          metrics.NewObservabilityConfigFromConfigMap,
+			o11yconfigmap.Name():             o11yconfigmap.Parse,
 			logging.ConfigMapName():          logging.NewConfigFromConfigMap,
 			leaderelection.ConfigMapName():   leaderelection.NewConfigFromConfigMap,
 			domainconfig.DomainConfigName:    domainconfig.NewDomainFromConfigMap,

--- a/test/e2e/logging_test.go
+++ b/test/e2e/logging_test.go
@@ -35,11 +35,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	netheader "knative.dev/networking/pkg/http/header"
-	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/system"
 	pkgtest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
 	"knative.dev/serving/pkg/apis/autoscaling"
+	"knative.dev/serving/pkg/observability"
+	o11yconfigmap "knative.dev/serving/pkg/observability/configmap"
 	rtesting "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 	v1test "knative.dev/serving/test/v1"
@@ -52,19 +53,19 @@ func TestRequestLogs(t *testing.T) {
 	clients := Setup(t)
 
 	cm, err := clients.KubeClient.CoreV1().ConfigMaps(system.Namespace()).
-		Get(context.Background(), metrics.ConfigMapName(), metav1.GetOptions{})
+		Get(context.Background(), o11yconfigmap.Name(), metav1.GetOptions{})
 	if err != nil {
 		t.Fatal("Fail to get ConfigMap config-observability:", err)
 	}
 
-	requestLogEnabled := strings.EqualFold(cm.Data[metrics.EnableReqLogKey], "true")
-	probeLogEnabled := strings.EqualFold(cm.Data[metrics.EnableProbeReqLogKey], "true")
+	requestLogEnabled := strings.EqualFold(cm.Data[observability.EnableRequestLogKey], "true")
+	probeLogEnabled := strings.EqualFold(cm.Data[observability.EnableProbeRequestLogKey], "true")
 
 	if !requestLogEnabled && !probeLogEnabled {
 		t.Skip("Skipping verifying request logs because both request and probe logging is disabled")
 	}
 
-	if got, want := cm.Data[metrics.ReqLogTemplateKey], template; got != want {
+	if got, want := cm.Data[observability.RequestLogTemplateKey], template; got != want {
 		t.Skipf("Skipping verifying request logs because the template doesn't match:\n%s", cmp.Diff(want, got))
 	}
 


### PR DESCRIPTION
Stacks onto https://github.com/knative/serving/pull/15956

This changes a few imports from `knative.dev/pkg/metrics` to `knative.dev/serving/pkg/observability`

- **use new observability config instead of knative.dev/pkg/metrics**
