### PR TITLE
Use RFC 1123 instead of RFC 1035 for names validation

### DIFF
--- a/pkg/apis/serving/v1/configuration_validation_test.go
+++ b/pkg/apis/serving/v1/configuration_validation_test.go
@@ -186,7 +186,7 @@ func TestConfigurationValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrInvalidValue("not a DNS 1035 label: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]",
+		want: apis.ErrInvalidValue("not a DNS label: [must not contain dots]",
 			"spec.template.metadata.name"),
 	}, {
 		name: "invalid generate name for configuration spec",
@@ -209,7 +209,7 @@ func TestConfigurationValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrInvalidValue("not a DNS 1035 label prefix: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]",
+		want: apis.ErrInvalidValue("not a DNS label prefix: [must not contain dots]",
 			"spec.template.metadata.generateName"),
 	}, {
 		name: "valid generate name for configuration spec",

--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -136,16 +136,16 @@ func (r *Revision) ValidateLabels() (errs *apis.FieldError) {
 // validateRevisionName validates name and generateName for the revisionTemplate
 func validateRevisionName(ctx context.Context, name, generateName string) *apis.FieldError {
 	if generateName != "" {
-		if msgs := validation.NameIsDNS1035Label(generateName, true); len(msgs) > 0 {
+		if msgs := validation.NameIsDNSLabel(generateName, true); len(msgs) > 0 {
 			return apis.ErrInvalidValue(
-				fmt.Sprint("not a DNS 1035 label prefix: ", msgs),
+				fmt.Sprint("not a DNS label prefix: ", msgs),
 				"metadata.generateName")
 		}
 	}
 	if name != "" {
-		if msgs := validation.NameIsDNS1035Label(name, false); len(msgs) > 0 {
+		if msgs := validation.NameIsDNSLabel(name, false); len(msgs) > 0 {
 			return apis.ErrInvalidValue(
-				fmt.Sprint("not a DNS 1035 label: ", msgs),
+				fmt.Sprint("not a DNS label: ", msgs),
 				"metadata.name")
 		}
 		om := apis.ParentMeta(ctx)

--- a/pkg/apis/serving/v1/revision_validation_test.go
+++ b/pkg/apis/serving/v1/revision_validation_test.go
@@ -866,7 +866,7 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrInvalidValue("not a DNS 1035 label: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]",
+		want: apis.ErrInvalidValue("not a DNS label: [a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
 			"metadata.name"),
 	}, {
 		name: "invalid generate name for revision template",
@@ -883,7 +883,7 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 				},
 			},
 		},
-		want: apis.ErrInvalidValue("not a DNS 1035 label prefix: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]",
+		want: apis.ErrInvalidValue("not a DNS label prefix: [a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
 			"metadata.generateName"),
 	}, {
 		name: "invalid metadata.annotations for scale",
@@ -1225,12 +1225,12 @@ func TestValidateRevisionName(t *testing.T) {
 	}{{
 		name:            "invalid revision generateName - dots",
 		revGenerateName: "foo.bar",
-		expectErr: apis.ErrInvalidValue("not a DNS 1035 label prefix: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]",
+		expectErr: apis.ErrInvalidValue("not a DNS label prefix: [must not contain dots]",
 			"metadata.generateName"),
 	}, {
 		name:    "invalid revision name - dots",
 		revName: "foo.bar",
-		expectErr: apis.ErrInvalidValue("not a DNS 1035 label: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]",
+		expectErr: apis.ErrInvalidValue("not a DNS label: [must not contain dots]",
 			"metadata.name"),
 	}, {
 		name: "invalid name (not prefixed)",

--- a/pkg/apis/serving/v1/revision_validation_test.go
+++ b/pkg/apis/serving/v1/revision_validation_test.go
@@ -1253,6 +1253,12 @@ func TestValidateRevisionName(t *testing.T) {
 			Name: "valid",
 		},
 		revName: "valid-name",
+	}, {
+		name: "valid name - starts with a digit",
+		objectMeta: metav1.ObjectMeta{
+			Name: "1valid",
+		},
+		revName: "1valid-name",
 	}}
 
 	for _, c := range cases {


### PR DESCRIPTION
Hello :wave:

When trying to create a Knative Service with a name starting with a digit:

```shell
kn service create 1valid --image gcr.io/knative-samples/helloworld-go --port 8080
```

We are facing errors because of the validation webhook:

> `Error: admission webhook "validation.webhook.serving.knative.dev" denied the request: validation failed: not a DNS 1035 label: [a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')]: metadata.name`

What I've found while debugging is that it seems "OK" to create a ksvc with a name starting with a digit, but the problem is in the revision name validation (hence the `metadata.name` at the end of the error) because a DNS record is generated from that revision. But, since the `Revision` name has to start with the `Service` name, we transitively cannot give the ksvc a name starting with a digit.

This is a little deceptive for users, as there is nothing in the documentation (as far as I can tell) stating that this restriction applies. However, I've found that such a strict restriction (added https://github.com/knative/serving/pull/3019 and https://github.com/knative/serving/pull/3045) might have not much sense as of today. I've read the [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.1), and it seems the restriction is introduced to follow the ARPANET host names rules :sweat_smile::

> The labels must follow the rules for ARPANET host names.  They must start with a letter, end with a letter or digit, and have as interior characters only letters, digits, and hyphen.

This restriction is blocking if someone tries to use something like an UUID as their ksvc names (like me :grin:), as only UUIDs starting with a letter will work.

That's why I'm proposing to use the [RFC 1123](https://datatracker.ietf.org/doc/html/rfc1123#section-2) validation, already available in the validation package used under the hood (https://github.com/kubernetes/apimachinery/blob/v0.33.3/pkg/api/validation/generic.go#L45) instead of RFC 1035, to be able to create Knative Services with a name starting with a digit. The RFC 1123 is indeed "more lax", and I don't think allowing names starting with a digit is a problem (feel free to correct me if I'm wrong).

To be honest, I'm not sure how the change I'm adding here plays with the `ValidateObjectMetadata` defined in https://github.com/knative/pkg/blob/release-1.19/apis/metadata_validation.go#L39, and called here: https://github.com/knative/serving/blob/knative-v1.19.0/pkg/apis/serving/metadata_validation.go#L39.

I'm assuming that, to be consistent, this validation in https://github.com/knative/pkg/ should also be changed. If my change is OK for you, I'm happy to do also the changes there.

Thanks!

## Proposed Changes

* validate revision and configuration names using RFC 1123 instead of RFC 1035, to be able to create ksvc with a name starting with a digit

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Validate Revision and Configuration names using RFC 1123 instead of RFC 1035
```