### PR TITLE
Change dry-run behavior

### DIFF
--- a/pkg/webhook/validate_unstructured.go
+++ b/pkg/webhook/validate_unstructured.go
@@ -73,7 +73,8 @@ func validateRevisionTemplate(ctx context.Context, uns *unstructured.Unstructure
 	// TODO(https://github.com/knative/serving/issues/3425): remove this guard once variations
 	// of this are well-tested. Only run extra validation for the dry-run test.
 	// This will be in place to while the feature is tested for compatibility and later removed.
-	if mode != DryRunStrict && mode != DryRunEnabled {
+	// Allow dry-run if specified in request (dry-run=server) and creating the resource
+	if mode != DryRunStrict && mode != DryRunEnabled && !apis.IsDryRun(ctx) {
 		return nil
 	}
 
@@ -96,6 +97,10 @@ func validateRevisionTemplate(ctx context.Context, uns *unstructured.Unstructure
 	}
 	if templ == nil || templ == (&v1.RevisionTemplateSpec{}) {
 		return nil // Don't need to validate empty templates
+	}
+
+	if apis.IsInCreate(ctx) && !apis.IsDryRun(ctx) {
+		return nil // Don't validate create requests unless specified as a dry-run
 	}
 
 	if apis.IsInUpdate(ctx) {


### PR DESCRIPTION
Fixes #8857

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
- Will always run dry-run if specified in user request
- Will only do dry-run validation on resource creation if user specifies in command

```
