### PR TITLE
fix otelhttp setup in activator

### DIFF
--- a/pkg/activator/handler/main_test.go
+++ b/pkg/activator/handler/main_test.go
@@ -88,9 +88,9 @@ func BenchmarkHandlerChain(b *testing.B) {
 	// Make sure to update this if the activator's main file changes.
 	ah := New(ctx, fakeThrottler{}, rt, false, logger, false /* TLS */, tp)
 	ah = concurrencyReporter.Handler(ah)
-	ah = NewTracingHandler(tp, ah)
+	ah = NewTracingAttributeHandler(tp, ah)
 	ah, _ = pkghttp.NewRequestLogHandler(ah, io.Discard, "", nil, false)
-	ah = NewMetricHandler(activatorPodName, ah)
+	ah = NewMetricAttributeHandler(activatorPodName, ah)
 	ah = NewContextHandler(ctx, ah, configStore)
 	ah = &ProbeHandler{NextHandler: ah}
 	ah = netprobe.NewHandler(ah)
@@ -204,9 +204,9 @@ func TestActivatorChainHandlerWithFullDuplex(t *testing.T) {
 	})
 	var ah http.Handler
 	ah = concurrencyReporter.Handler(proxyWithMiddleware)
-	ah = NewTracingHandler(tp, ah)
+	ah = NewTracingAttributeHandler(tp, ah)
 	ah, _ = pkghttp.NewRequestLogHandler(ah, io.Discard, "", nil, false)
-	ah = NewMetricHandler(activatorPodName, ah)
+	ah = NewMetricAttributeHandler(activatorPodName, ah)
 	ah = WrapActivatorHandlerWithFullDuplex(ah, logger)
 	ah = NewContextHandler(ctx, ah, configStore)
 	ah = &ProbeHandler{NextHandler: ah}

--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -24,8 +24,9 @@ import (
 	"knative.dev/serving/pkg/metrics"
 )
 
-// NewMetricHandler creates a handler that collects and reports request metrics.
-func NewMetricHandler(podName string, next http.Handler) *MetricHandler {
+// NewMetricAttributeHandler creates a handler that adds serving attributes
+// to the otelhttp labeler
+func NewMetricAttributeHandler(podName string, next http.Handler) *MetricHandler {
 	return &MetricHandler{
 		nextHandler: next,
 		podName:     podName,

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -64,7 +64,7 @@ func TestRequestMetricHandler(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.label, func(t *testing.T) {
-			handler := NewMetricHandler(testPod, test.baseHandler)
+			handler := NewMetricAttributeHandler(testPod, test.baseHandler)
 
 			labeler := &otelhttp.Labeler{}
 
@@ -121,7 +121,7 @@ func BenchmarkMetricHandler(b *testing.B) {
 
 	reqCtx = otelhttp.ContextWithLabeler(reqCtx, &otelhttp.Labeler{})
 
-	handler := NewMetricHandler("benchPod", baseHandler)
+	handler := NewMetricAttributeHandler("benchPod", baseHandler)
 
 	resp := httptest.NewRecorder()
 	b.Run("sequential", func(b *testing.B) {

--- a/pkg/activator/handler/tracing_handler.go
+++ b/pkg/activator/handler/tracing_handler.go
@@ -23,8 +23,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-func NewTracingHandler(tp trace.TracerProvider, next http.Handler) http.Handler {
-	shim := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+// NewTracingAttributeHandler creates a handler that adds serving attributes
+// to the span
+func NewTracingAttributeHandler(tp trace.TracerProvider, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		defer func() {
 			// otelhttp middleware creates the labeler
 			labeler, _ := otelhttp.LabelerFromContext(r.Context())
@@ -36,8 +38,4 @@ func NewTracingHandler(tp trace.TracerProvider, next http.Handler) http.Handler 
 
 		next.ServeHTTP(rw, r)
 	})
-
-	return otelhttp.NewHandler(shim, "activate",
-		otelhttp.WithTracerProvider(tp),
-	)
 }

--- a/pkg/activator/handler/tracing_handler_test.go
+++ b/pkg/activator/handler/tracing_handler_test.go
@@ -30,7 +30,7 @@ import (
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
-func TestTracingHandler(t *testing.T) {
+func TestTracingAttributeHandler(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	tp := trace.NewTracerProvider(
 		trace.WithSyncer(exporter),
@@ -43,7 +43,8 @@ func TestTracingHandler(t *testing.T) {
 		labeler, _ := otelhttp.LabelerFromContext(r.Context())
 		labeler.Add(attribute.Bool("x", true))
 	})
-	handler := NewTracingHandler(tp, baseHandler)
+	handler := NewTracingAttributeHandler(tp, baseHandler)
+	handler = otelhttp.NewHandler(handler, "op", otelhttp.WithTracerProvider(tp))
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)


### PR DESCRIPTION
Attributes weren't showing up on the traces - this fixes the issue.

Also I noticed otelhttp metrics weren't being emitted so we've wired in the right MeterProvider.

