### PR TITLE
drop unnecessary 'kn.activator.proxy' metric/span attribute

### DIFF
--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -228,7 +228,6 @@ func (cr *ConcurrencyReporter) reportToMetricsBackend(key types.NamespacedName, 
 			metrics.ConfigurationNameKey.With(configurationName),
 			metrics.RevisionNameKey.With(revName),
 			metrics.K8sNamespaceKey.With(ns),
-			metrics.ActivatorKeyValue,
 		)),
 	)
 }

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -565,7 +565,6 @@ func TestMetricsReported(t *testing.T) {
 		metrics.ConfigurationNameKey.With("config-"+rev1.Name),
 		metrics.RevisionNameKey.With(rev1.Name),
 		metrics.K8sNamespaceKey.With(rev1.Namespace),
-		metrics.ActivatorKeyValue,
 	)
 
 	metricstest.AssertMetrics(

--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -51,7 +51,6 @@ func (h *MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		metrics.ConfigurationNameKey.With(configurationName),
 		metrics.RevisionNameKey.With(rev.Name),
 		metrics.K8sNamespaceKey.With(rev.Namespace),
-		metrics.ActivatorKeyValue,
 	)
 
 	h.nextHandler.ServeHTTP(w, r)

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -96,7 +96,6 @@ func TestRequestMetricHandler(t *testing.T) {
 					metrics.ConfigurationNameKey.With(rev.Labels[serving.ConfigurationLabelKey]),
 					metrics.RevisionNameKey.With(rev.Name),
 					metrics.K8sNamespaceKey.With(rev.Namespace),
-					metrics.ActivatorKeyValue,
 				}
 
 				if diff := cmp.Diff(want, got, cmpOpts...); diff != "" {

--- a/pkg/metrics/key.go
+++ b/pkg/metrics/key.go
@@ -28,5 +28,4 @@ var (
 	RouteTagNameKey      = attributekey.String("kn.route.tag")
 	K8sNamespaceKey      = attributekey.String("k8s.namespace.name")
 	K8sPodIPKey          = attributekey.String("k8s.pod.ip")
-	ActivatorKeyValue    = attributekey.Bool("kn.activator.proxy").With(true)
 )


### PR DESCRIPTION
I was trying to be smart when adding this attribute because I thought the 'tag' would appear in child spans and we could see filter traces that went through the activator. OTel doesn't work that way - it's just adding stuff to the current span (which is already associated with the activator service).

Also regarding metrics - you could use this a filter but it's not necessary since you filter the activator using the container/pod name.

/assign @Cali0707 
cc @evankanderson 