### PR TITLE
add default conditions to PA to avoid potential race conditions (2nd attempt)

### DIFF
--- a/config/core/300-resources/podautoscaler.yaml
+++ b/config/core/300-resources/podautoscaler.yaml
@@ -125,9 +125,32 @@ spec:
             status:
               description: Status communicates the observed state of the PodAutoscaler (from the controller).
               type: object
-              required:
-                - metricsServiceName
-                - serviceName
+              default:
+                conditions:
+                  - lastTransitionTime: "1970-01-01T00:00:00Z"
+                    message: Waiting for controller
+                    reason: Pending
+                    severity: ""
+                    status: Unknown
+                    type: Active
+                  - lastTransitionTime: "1970-01-01T00:00:00Z"
+                    message: Waiting for controller
+                    reason: Pending
+                    severity: ""
+                    status: Unknown
+                    type: Ready
+                  - lastTransitionTime: "1970-01-01T00:00:00Z"
+                    message: Waiting for controller
+                    reason: Pending
+                    severity: ""
+                    status: Unknown
+                    type: SKSReady
+                  - lastTransitionTime: "1970-01-01T00:00:00Z"
+                    message: Waiting for controller
+                    reason: Pending
+                    severity: ""
+                    status: Unknown
+                    type: ScaleTargetInitialized
               properties:
                 actualScale:
                   description: ActualScale shows the actual number of replicas for the revision.

--- a/docs/serving-api.md
+++ b/docs/serving-api.md
@@ -459,6 +459,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>ServiceName is the K8s Service name that serves the revision, scaled by this PA.
 The service is created and owned by the ServerlessService object owned by this PA.</p>
 </td>
@@ -471,6 +472,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>MetricsServiceName is the K8s Service name that provides revision metrics.
 The service is managed by the PA object.</p>
 </td>

--- a/pkg/apis/autoscaling/v1alpha1/pa_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/pa_types.go
@@ -112,14 +112,17 @@ const (
 
 // PodAutoscalerStatus communicates the observed state of the PodAutoscaler (from the controller).
 type PodAutoscalerStatus struct {
+	// +kubebuilder:default={"conditions": {{"type":"Active", "status": "Unknown", "reason": "Pending",  "message": "Waiting for controller", "severity": "", "lastTransitionTime": "1970-01-01T00:00:00Z"}, {"type":"Ready", "status": "Unknown", "reason": "Pending", "message": "Waiting for controller", "severity": "", "lastTransitionTime": "1970-01-01T00:00:00Z"}, {"type":"SKSReady", "status": "Unknown", "reason": "Pending", "message": "Waiting for controller", "severity": "", "lastTransitionTime": "1970-01-01T00:00:00Z"}, {"type":"ScaleTargetInitialized", "status": "Unknown", "reason": "Pending", "message": "Waiting for controller", "severity": "", "lastTransitionTime": "1970-01-01T00:00:00Z"}}}
 	duckv1.Status `json:",inline"`
 
 	// ServiceName is the K8s Service name that serves the revision, scaled by this PA.
 	// The service is created and owned by the ServerlessService object owned by this PA.
+	// +optional
 	ServiceName string `json:"serviceName"`
 
 	// MetricsServiceName is the K8s Service name that provides revision metrics.
 	// The service is managed by the PA object.
+	// +optional
 	MetricsServiceName string `json:"metricsServiceName"`
 
 	// DesiredScale shows the current desired number of replicas for the revision.

--- a/pkg/apis/serving/v1/revision_lifecycle.go
+++ b/pkg/apis/serving/v1/revision_lifecycle.go
@@ -184,7 +184,8 @@ func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *autoscalingv1alpha1.PodA
 		rs.DesiredReplicas = ps.DesiredScale
 	}
 
-	if cond == nil {
+	sksCondition := ps.GetCondition(autoscalingv1alpha1.PodAutoscalerConditionSKSReady)
+	if cond == nil || (cond.IsUnknown() && sksCondition != nil && sksCondition.IsUnknown()) {
 		rs.MarkActiveUnknown(ReasonDeploying, "")
 
 		if !resUnavailable {
@@ -219,6 +220,7 @@ func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *autoscalingv1alpha1.PodA
 		// 2. Initial scale was never achieved, which means we failed to progress
 		//    towards initial scale during the progress deadline period and scaled to 0
 		//		failing to activate.
+		// 3. Need to make sure to wait for SKS to be ready, or at least fail.
 		// So mark the revision as failed at that point.
 		// See #8922 for details. When we try to scale to 0, we force the Deployment's
 		// Progress status to become `true`, since successful scale down means
@@ -228,7 +230,7 @@ func (rs *RevisionStatus) PropagateAutoscalerStatus(ps *autoscalingv1alpha1.PodA
 		// ScaleTargetInitialized down the road, we would have marked resources
 		// unavailable here, and have no way of recovering later.
 		// If the ResourcesAvailable is already false, don't override the message.
-		if !ps.IsScaleTargetInitialized() && !resUnavailable && ps.ServiceName != "" {
+		if !ps.IsScaleTargetInitialized() && !resUnavailable && ps.ServiceName != "" && !sksCondition.IsUnknown() {
 			rs.MarkResourcesAvailableFalse(ReasonProgressDeadlineExceeded,
 				"Initial scale was never achieved")
 		}

--- a/pkg/apis/serving/v1/revision_lifecycle_test.go
+++ b/pkg/apis/serving/v1/revision_lifecycle_test.go
@@ -678,6 +678,9 @@ func TestPropagateAutoscalerStatusNoProgress(t *testing.T) {
 			}, {
 				Type:   autoscalingv1alpha1.PodAutoscalerConditionScaleTargetInitialized,
 				Status: corev1.ConditionUnknown,
+			}, {
+				Type:   autoscalingv1alpha1.PodAutoscalerConditionSKSReady,
+				Status: corev1.ConditionFalse,
 			}},
 		},
 	})
@@ -764,6 +767,7 @@ func TestPropagateAutoscalerStatusReplicas(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			tc.ps.InitializeConditions()
 			r.PropagateAutoscalerStatus(&tc.ps)
 
 			if !cmp.Equal(tc.wantActualReplicas, r.ActualReplicas) {

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -312,6 +312,7 @@ func TestReconcile(t *testing.T) {
 				WithPAStatusService("pa-inactive"),
 				WithNoTraffic("NoTraffic", "This thing is inactive."),
 				WithScaleTargetInitialized,
+				WithPASKSNotReady(""),
 				WithReachabilityUnreachable),
 			readyDeploy(deploy(t, "foo", "pa-inactive")),
 			image("foo", "pa-inactive"),
@@ -335,13 +336,14 @@ func TestReconcile(t *testing.T) {
 				WithRevisionObservedGeneration(1)),
 			pa("foo", "pa-inactive",
 				WithNoTraffic("NoTraffic", "This thing is inactive."),
-				WithPAStatusService("pa-inactive")),
+				WithPAStatusService("pa-inactive"),
+				WithPASKSReady),
 			readyDeploy(deploy(t, "foo", "pa-inactive")),
 			image("foo", "pa-inactive"),
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: Revision("foo", "pa-inactive",
-				WithLogURL, withDefaultContainerStatuses(), MarkDeploying(""),
+				WithLogURL, withDefaultContainerStatuses(), MarkContainerHealthyUnknown(""),
 				// When we reconcile an "all ready" revision when the PA
 				// is inactive, we should see the following change.
 				MarkInactive("NoTraffic", "This thing is inactive."), WithRevisionObservedGeneration(1),


### PR DESCRIPTION
add default conditions to PA to avoid potential race conditions
between revision and autoscaler

Fixes #16036

Proposed Changes
 - Add default conditions  in PodAutoscaler to avoid any potential race conditions
