### PR TITLE
Add distinct logging for timeout types 

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -230,7 +230,7 @@ func main() {
 		return apiconfig.DefaultRevisionTimeoutSeconds * time.Second,
 			apiconfig.DefaultRevisionResponseStartTimeoutSeconds * time.Second,
 			apiconfig.DefaultRevisionIdleTimeoutSeconds * time.Second
-	})
+	}, logger)
 	ah = concurrencyReporter.Handler(ah)
 	ah = activatorhandler.NewTracingAttributeHandler(tp, ah)
 	reqLogHandler, err := pkghttp.NewRequestLogHandler(ah, logging.NewSyncFileWriter(os.Stdout), "",

--- a/pkg/http/handler/timeout_test.go
+++ b/pkg/http/handler/timeout_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
 	"k8s.io/utils/clock"
 	clocktest "k8s.io/utils/clock/testing"
 )
@@ -223,6 +224,7 @@ func testTimeoutScenario(t *testing.T, scenarios []timeoutHandlerTestScenario) {
 				body:        scenario.timeoutMessage,
 				timeoutFunc: StaticTimeoutFunc(scenario.timeout, scenario.responseStartTimeout, scenario.idleTimeout),
 				clock:       fakeClock,
+				logger:      zap.NewNop().Sugar(),
 			}
 
 			defer func() {
@@ -350,7 +352,7 @@ func TestResponseStartTimeoutAfterResponseStarted(t *testing.T) {
 
 	// Create timeout handler with a responseStartTimeout
 	timeoutHandler := NewTimeoutHandler(handler, "timeout",
-		StaticTimeoutFunc(30*time.Second, 50*time.Millisecond, 0))
+		StaticTimeoutFunc(30*time.Second, 50*time.Millisecond, 0), zap.NewNop().Sugar())
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rr := httptest.NewRecorder()
@@ -604,7 +606,7 @@ func BenchmarkTimeoutHandler(b *testing.B) {
 			w.Write(write)
 		}
 	})
-	handler := NewTimeoutHandler(baseHandler, "test", StaticTimeoutFunc(10*time.Minute, 10*time.Minute, 10*time.Minute))
+	handler := NewTimeoutHandler(baseHandler, "test", StaticTimeoutFunc(10*time.Minute, 10*time.Minute, 10*time.Minute), zap.NewNop().Sugar())
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
 
 	b.Run("sequential", func(b *testing.B) {

--- a/pkg/queue/sharedmain/handlers.go
+++ b/pkg/queue/sharedmain/handlers.go
@@ -76,7 +76,7 @@ func mainHandler(
 	composedHandler = queue.ForwardedShimHandler(composedHandler)
 	composedHandler = handler.NewTimeoutHandler(composedHandler, "request timeout", func(r *http.Request) (time.Duration, time.Duration, time.Duration) {
 		return timeout, responseStartTimeout, idleTimeout
-	})
+	}, logger)
 
 	composedHandler = queue.NewRouteTagHandler(composedHandler)
 	composedHandler = withFullDuplex(composedHandler, env.EnableHTTPFullDuplex, logger)

--- a/vendor/knative.dev/pkg/network/error_handler.go
+++ b/vendor/knative.dev/pkg/network/error_handler.go
@@ -17,6 +17,8 @@ limitations under the License.
 package network
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"os"
 
@@ -27,8 +29,13 @@ import (
 // httputil's reverse proxy.
 //
 // Deprecated: Use handler.Error instead.
+
 func ErrorHandler(logger *zap.SugaredLogger) func(http.ResponseWriter, *http.Request, error) {
 	return func(w http.ResponseWriter, req *http.Request, err error) {
+		if errors.Is(err, context.Canceled) {
+			logger.Debugw("request context canceled", zap.Error(err))
+			return
+		}
 		ss := readSockStat(logger)
 		logger.Errorw("error reverse proxying request; sockstat: "+ss, zap.Error(err))
 		http.Error(w, err.Error(), http.StatusBadGateway)


### PR DESCRIPTION
Fixes #15752 
Fixes #13746 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add distinct logging for each timeout type
* Change context cancellation logging from ERROR to DEBUG 


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
