### PR TITLE
Run E2E tests against K8s 1.34 as well

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -84,6 +84,7 @@ jobs:
         k8s-version:
         - v1.32.x
         - v1.33.x
+        - v1.34.x
 
         ingress:
         - kourier


### PR DESCRIPTION
We're seeing issues on 1.34 with one of the conformance tests. Trying to see if this reproduces in serving's CI.