### PR TITLE
Keep queue-proxy admin server on HTTP for PreStop hooks

### DIFF
--- a/pkg/queue/sharedmain/main.go
+++ b/pkg/queue/sharedmain/main.go
@@ -255,7 +255,7 @@ func Main(opts ...Option) error {
 	}
 
 	if env.Observability.Runtime.ProfilingEnabled() {
-		logger.Info("Rutime profiling enabled")
+		logger.Info("Runtime profiling enabled")
 		pprof := runtime.NewProfilingServer()
 		pprof.SetEnabled(true)
 		httpServers["profile"] = pprof.Server
@@ -267,16 +267,13 @@ func Main(opts ...Option) error {
 
 	if tlsEnabled {
 		tlsServers["main"] = mainServer(":"+env.QueueServingTLSPort, mainHandler)
-		tlsServers["admin"] = adminServer(":"+strconv.Itoa(networking.QueueAdminPort), adminHandler)
+		// Keep admin server on HTTP even with TLS enabled since it's only accessed locally by kubelet
 
 		certWatcher, err = certificate.NewCertWatcher(certPath, keyPath, 1*time.Minute, logger)
 		if err != nil {
 			logger.Fatal("failed to create certWatcher", zap.Error(err))
 		}
 		defer certWatcher.Stop()
-
-		// Drop admin http server since the admin TLS server is listening on the same port
-		delete(httpServers, "admin")
 	}
 
 	logger.Info("Starting queue-proxy")


### PR DESCRIPTION
Fixes #16162 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

The queue-proxy admin server now always serves HTTP on port 8022, even when system-internal-tls is enabled. This simplifies the PreStop hook configuration and fixes graceful shutdown issues.

Why this approach:
- PreStop hooks are called by kubelet locally within the pod (localhost)
- No network traffic leaves the pod, so TLS isn't needed for security
- Simpler implementation with no dynamic scheme configuration
- Prevents TLS handshake errors during pod shutdown

This fixes the issue where pods would receive HTTP 502 errors during  scale-down operations when system-internal-tls was enabled. The error occurred because the PreStop hook was trying to connect with HTTP to a TLS-enabled admin server, causing immediate SIGTERM and dropped requests.
