### PR TITLE
Istio now handles PreStop hooks correctly so we can drop our workaround

### DIFF
--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -65,10 +65,6 @@ var (
 		ContainerPort: networking.BackendHTTPSPort,
 	}
 	queueNonServingPorts = []corev1.ContainerPort{{
-		// Provides health checks and lifecycle hooks.
-		Name:          v1.QueueAdminPortName,
-		ContainerPort: networking.QueueAdminPort,
-	}, {
 		Name:          v1.AutoscalingQueueMetricsPortName,
 		ContainerPort: networking.AutoscalingQueueMetricsPort,
 	}, {

--- a/pkg/reconciler/serverlessservice/resources/services.go
+++ b/pkg/reconciler/serverlessservice/resources/services.go
@@ -169,18 +169,6 @@ func MakePrivateService(sks *v1alpha1.ServerlessService, selector map[string]str
 				Port:       networking.UserQueueMetricsPort,
 				TargetPort: intstr.FromString(servingv1.UserQueueMetricsPortName),
 			}, {
-				// When run with the Istio mesh, Envoy blocks traffic to any ports not
-				// recognized, and has special treatment for probes, but not PreStop hooks.
-				// That results in the PreStop hook /wait-for-drain in queue-proxy not
-				// reachable, thus triggering SIGTERM immediately during shutdown and
-				// causing requests to be dropped.
-				//
-				// So we expose this port here to work around this Istio bug.
-				Name:       servingv1.QueueAdminPortName,
-				Protocol:   corev1.ProtocolTCP,
-				Port:       networking.QueueAdminPort,
-				TargetPort: intstr.FromInt(networking.QueueAdminPort),
-			}, {
 				// When run with the Istio mesh and with the pod-addressability feature
 				// enabled, this mirrors the target port to the "outer" service port to
 				// instruct Istio to open the respective listener on the pod.

--- a/pkg/reconciler/serverlessservice/resources/services_test.go
+++ b/pkg/reconciler/serverlessservice/resources/services_test.go
@@ -145,11 +145,6 @@ func privateSvcMod(s *corev1.Service) {
 			Port:       networking.UserQueueMetricsPort,
 			TargetPort: intstr.FromString(servingv1.UserQueueMetricsPortName),
 		}, {
-			Name:       servingv1.QueueAdminPortName,
-			Protocol:   corev1.ProtocolTCP,
-			Port:       networking.QueueAdminPort,
-			TargetPort: intstr.FromInt(networking.QueueAdminPort),
-		}, {
 			Name:       pkgnet.ServicePortNameHTTP1 + "-istio",
 			Protocol:   corev1.ProtocolTCP,
 			Port:       networking.BackendHTTPPort,
@@ -479,7 +474,7 @@ func TestMakePrivateService(t *testing.T) {
 				Port:        pkgnet.ServiceHTTPPort,
 				TargetPort:  intstr.FromInt(networking.BackendHTTP2Port),
 			}
-			s.Spec.Ports[5] = corev1.ServicePort{
+			s.Spec.Ports[4] = corev1.ServicePort{
 				Name:       pkgnet.ServicePortNameH2C + "-istio",
 				Protocol:   corev1.ProtocolTCP,
 				Port:       networking.BackendHTTP2Port,

--- a/pkg/reconciler/serverlessservice/serverlessservice_test.go
+++ b/pkg/reconciler/serverlessservice/serverlessservice_test.go
@@ -805,9 +805,9 @@ func withHTTP2Priv(svc *corev1.Service) {
 	svc.Spec.Ports[0].TargetPort = intstr.FromInt(networking.BackendHTTP2Port)
 	svc.Spec.Ports[0].AppProtocol = &pkgnet.AppProtocolH2C
 
-	svc.Spec.Ports[5].Name = "http2-istio"
-	svc.Spec.Ports[5].Port = networking.BackendHTTP2Port
-	svc.Spec.Ports[5].TargetPort = intstr.FromInt(networking.BackendHTTP2Port)
+	svc.Spec.Ports[4].Name = "http2-istio"
+	svc.Spec.Ports[4].Port = networking.BackendHTTP2Port
+	svc.Spec.Ports[4].TargetPort = intstr.FromInt(networking.BackendHTTP2Port)
 }
 
 func withHTTP2(svc *corev1.Service) {


### PR DESCRIPTION
Related to https://github.com/knative/serving/pull/16163

Previously we had a workaround in our serverless service in order to allow our prestop hook to work when Istio Mesh was enabled.

This isn't needed anymore since Istio 1.25 see: https://github.com/istio/istio/commit/0e30509be5a69a82d74907dab1da0d11da2b7cd8
