### PR TITLE
If connection is Hijack()ed, suspend first byte timeout

### DIFF
--- a/pkg/http/handler/timeout.go
+++ b/pkg/http/handler/timeout.go
@@ -198,6 +198,15 @@ func (tw *timeoutWriter) Flush() {
 // http.Hijacker interface, which is required for net/http/httputil/reverseproxy
 // to handle connection upgrade/switching protocol.  Otherwise returns an error.
 func (tw *timeoutWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	tw.mu.Lock()
+	if tw.timedOut {
+		tw.mu.Unlock()
+		return nil, nil, http.ErrHandlerTimeout
+	}
+
+	tw.lastWriteTime = tw.clock.Now()
+	tw.mu.Unlock()
+
 	return websocket.HijackIfPossible(tw.w)
 }
 


### PR DESCRIPTION
No `Write()` was ever observed on hijacked connections, so the first byte timeout would always expire and close websocket connections. This approach sets the last write time when a connection is Hijacked.

Fixes #16169

Note that there seems to have been a similar fix in version 1.7, but I think at some point there was a regression on this behavior. I added a unit test as a result.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Websockets are not disconnected at `revision-timeout-seconds`
```
