### PR TITLE
Allow serve mode when system-internal-tls is enabled

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -126,12 +126,6 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pa *autoscalingv1alpha1.
 	mode := nv1alpha1.SKSOperationModeProxy
 
 	switch {
-	// When activator CA is enabled, force activator always in path.
-	// TODO: This is a temporary state and to be fixed.
-	// See also issues/11906 and issues/12797.
-	case config.FromContext(ctx).Network.SystemInternalTLSEnabled():
-		mode = nv1alpha1.SKSOperationModeProxy
-
 	// If the want == -1 and PA is inactive that implies the autoscaler
 	// has no knowledge of the revision (due to restart) but it was previously
 	// scaled down (inactive). In this instance we want to remain in Proxy Mode

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -128,13 +128,6 @@ func initialScaleZeroASConfig() *autoscalerconfig.Config {
 	return ac
 }
 
-func activatorCertsNetConfig() *netcfg.Config {
-	nc, _ := netcfg.NewConfigFromMap(map[string]string{
-		netcfg.SystemInternalTLSKey: "enabled",
-	})
-	return nc
-}
-
 func defaultConfig() *config.Config {
 	ac, _ := asconfig.NewConfigFromMap(defaultConfigMapData())
 	deploymentConfig, _ := deployment.NewConfigFromMap(map[string]string{
@@ -1157,40 +1150,6 @@ func TestReconcile(t *testing.T) {
 				withScales(2, 2), WithReachabilityReachable, WithPAStatusService(testRevision),
 				WithPAMetricsService(privateSvc), WithObservedGeneration(1),
 			),
-		}},
-	}, {
-		Name: "we have enough burst capacity, but keep proxy mode as activator CA is enabled",
-		Key:  key,
-		Ctx: context.WithValue(context.WithValue(context.Background(), netConfigKey{}, activatorCertsNetConfig()), deciderKey{},
-			decider(testNamespace, testRevision, defaultScale, /* desiredScale */
-				1 /* ebc */)),
-		Objects: []runtime.Object{
-			kpa(testNamespace, testRevision, WithPASKSReady, WithTraffic, markScaleTargetInitialized,
-				WithPAMetricsService(privateSvc), withScales(1, defaultScale),
-				WithPAStatusService(testRevision), WithObservedGeneration(1)),
-			defaultProxySKS,
-			metric(testNamespace, testRevision),
-			defaultDeployment,
-			defaultReady,
-		},
-		// No update from ProxySKS.
-	}, {
-		Name: "we have enough burst capacity, but switch to keep proxy mode as activator CA is turned on",
-		Key:  key,
-		Ctx: context.WithValue(context.WithValue(context.Background(), netConfigKey{}, activatorCertsNetConfig()), deciderKey{},
-			decider(testNamespace, testRevision, defaultScale, /* desiredScale */
-				1 /* ebc */)),
-		Objects: []runtime.Object{
-			kpa(testNamespace, testRevision, WithPASKSReady, WithTraffic, markScaleTargetInitialized,
-				WithPAMetricsService(privateSvc), withScales(1, defaultScale),
-				WithPAStatusService(testRevision), WithObservedGeneration(1)),
-			defaultSKS,
-			metric(testNamespace, testRevision),
-			defaultDeployment,
-			defaultReady,
-		},
-		WantUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: defaultProxySKS,
 		}},
 	}}
 


### PR DESCRIPTION
Hi,

## Proposed Changes

* Allow serve mode when system-internal-tls is enabled
  * right now Proxy mode is always forced when using system-internal-tls
  * after a review from Dave the decision is to not force proxy mode anymore.


[Quote from Dave](https://github.com/knative/networking/pull/1093#issuecomment-3586778511):
> Meaning I say we don't require the configuration knob and just say implementations must support multiple sans for this feature to work properly.
> 
> Going through our implementations
> 
>     Istio (unsupported since you have mTLS with sidecars/ambient)
>     Contour (supports multiple-sans)
>     Kourier (supports multiple-sans)
>     Gateway API (supports this through extended BackendTLSPolicy features - this is not implemented)


## Release Note

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow activator to be out of the request path when system-internal-tls is enabled
```

## Questions
1. Should this change result in a docs change, even if I marked it as alpha flag for now?

Thanks for the feedback!

/kind enhancement
/cc @Fedosin 