### PR TITLE
bump e2e timeout to be higher - so mesh tests pass

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -67,7 +67,7 @@ if (( SHORT )); then
   GO_TEST_FLAGS+=("-short")
 fi
 
-go_test_e2e -timeout=40m \
+go_test_e2e -timeout=50m \
   "${GO_TEST_FLAGS[@]}" \
   ./test/conformance/api/... \
   ./test/conformance/runtime/... \


### PR DESCRIPTION
e2e tests in mesh mode failed due to timeout - bumping the timeout to be higher

/assign @nader-ziada @dsimansk 