### PR TITLE
Preserve deployment and its template labels and annotations

### DIFF
--- a/pkg/reconciler/revision/cruds_test.go
+++ b/pkg/reconciler/revision/cruds_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2025 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revision
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMergeMetadata(t *testing.T) {
+	tests := []struct {
+		name    string
+		desired map[string]string
+		current map[string]string
+		want    map[string]string
+	}{
+		{
+			name:    "preserve external annotations",
+			desired: map[string]string{"serving.knative.dev/creator": "kubernetes-admin"},
+			current: map[string]string{"kubectl.kubernetes.io/restartedAt": "2025-11-27T12:14:41+01:00"},
+			want:    map[string]string{"serving.knative.dev/creator": "kubernetes-admin", "kubectl.kubernetes.io/restartedAt": "2025-11-27T12:14:41+01:00"},
+		},
+		{
+			name:    "knative annotations from desired win",
+			desired: map[string]string{"serving.knative.dev/lastModifier": "kubernetes-admin"},
+			current: map[string]string{"serving.knative.dev/lastModifier": "old-user"},
+			want:    map[string]string{"serving.knative.dev/lastModifier": "kubernetes-admin"},
+		},
+		{
+			name:    "delete knative annotations not in desired",
+			desired: map[string]string{"serving.knative.dev/creator": "kubernetes-admin"},
+			current: map[string]string{"serving.knative.dev/creator": "kubernetes-admin", "autoscaling.knative.dev/min-scale": "2"},
+			want:    map[string]string{"serving.knative.dev/creator": "kubernetes-admin"},
+		},
+		{
+			name:    "app label from desired wins",
+			desired: map[string]string{"app": "new-revision"},
+			current: map[string]string{"app": "old-revision"},
+			want:    map[string]string{"app": "new-revision"},
+		},
+		{
+			name:    "mixed knative and external metadata",
+			desired: map[string]string{"autoscaling.knative.dev/min-scale": "1", "app": "my-revision"},
+			current: map[string]string{"autoscaling.knative.dev/target-burst-capacity": "0", "deployment.kubernetes.io/revision": "2", "kubectl.kubernetes.io/restartedAt": "2025-11-27T12:14:41+01:00"},
+			want:    map[string]string{"autoscaling.knative.dev/min-scale": "1", "app": "my-revision", "deployment.kubernetes.io/revision": "2", "kubectl.kubernetes.io/restartedAt": "2025-11-27T12:14:41+01:00"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeMetadata(tt.desired, tt.current)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("mergeMetadata() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -211,6 +211,19 @@ func TestReconcile(t *testing.T) {
 		}},
 		Key: "foo/fix-containers",
 	}, {
+		Name: "preserve external deployment and template annotations and labels",
+		Objects: []runtime.Object{
+			Revision("foo", "preserve-annotations",
+				WithLogURL, allUnknownConditions, withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
+			pa("foo", "preserve-annotations", WithReachabilityUnknown),
+			addDeploymentMetadata(deploy(t, "foo", "preserve-annotations"), true),
+			image("foo", "preserve-annotations"),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: addDeploymentMetadata(deploy(t, "foo", "preserve-annotations"), false),
+		}},
+		Key: "foo/preserve-annotations",
+	}, {
 		Name: "failure updating deployment",
 		// Test that we handle an error updating the deployment properly.
 		WantErr: true,
@@ -942,6 +955,23 @@ func changeContainers(deploy *appsv1.Deployment) *appsv1.Deployment {
 	for i := range podSpec.Containers {
 		podSpec.Containers[i].Image = "asdf"
 	}
+	return deploy
+}
+
+func addDeploymentMetadata(deploy *appsv1.Deployment, includeInternalMetadata bool) *appsv1.Deployment {
+	setMetadata := func(m map[string]string, key, value string) {
+		m[key] = value
+		if includeInternalMetadata {
+			m[resources.AppLabelKey] = "app"
+			m["internal.knative.dev/foo"] = "bar"
+		}
+	}
+
+	setMetadata(deploy.Annotations, "external.io/annotation", "external-annotation")
+	setMetadata(deploy.Labels, "external.io/label", "external-label")
+	setMetadata(deploy.Spec.Template.Annotations, "external.io/template-annotation", "external-template-annotation")
+	setMetadata(deploy.Spec.Template.Labels, "external.io/template-label", "external-template-label")
+
 	return deploy
 }
 


### PR DESCRIPTION
Hi,

when running `kubectl rollout restart deployment`, Kubernetes adds the `kubectl.kubernetes.io/restartedAt` annotation to the deployment's pod template to trigger a rolling restart. However, Knative's reconciler was removing this annotation by completely replacing the deployment spec, causing new pods to be immediately terminated instead of completing the rollout.

This change preserves externally-added metadata at both the deployment level and template level during reconciliation:
- Deployment-level labels (was already the case) and annotations (new)
- Pod template labels and annotations (e.g., kubectl.kubernetes.io/restartedAt)


Fixes #14705

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Preserve deployment and template annotations and labels during reconcile
  * knative labels and annotations have priority and will overwrite other labels/annotations

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Preserve deployment and template annotations and labels during reconcile
```

/kind bug


Thanks for the review!