### PR TITLE
Deflake TestProbePodIPs

### DIFF
--- a/pkg/activator/net/revision_backends_test.go
+++ b/pkg/activator/net/revision_backends_test.go
@@ -1649,7 +1649,7 @@ func TestProbePodIPs(t *testing.T) {
 					"10.10.1.2": {{
 						Code:  http.StatusOK,
 						Body:  queue.Name,
-						Delay: 250 * time.Millisecond,
+						Delay: 100 * time.Millisecond,
 					}},
 				},
 				enableProbeOptimization: true,


### PR DESCRIPTION
Fixes #16185

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes
Currently, in this [test case](https://github.com/knative/serving/blob/a2a2441bb8488b6059fd0d4af3f290ea979e67d4/pkg/activator/net/revision_backends_test.go#L1652), the synthetic delay for probing the pod is 250 ms, and the probe timeout is [300 ms](https://github.com/knative/serving/blob/a2a2441bb8488b6059fd0d4af3f290ea979e67d4/pkg/activator/net/revision_backends.go#L90). It makes the test flaky when the test runner is under load. We can decrease (or remove) the delay to deflake the test.

Also, to verify that it is the reason for flakiness, I ran some stress tests on TestProbePodIPs before and after the change:

250ms delay:
```
$ stress -p 256 ./net.test -test.run TestProbePodIPs
5s: 316 runs so far, 0 failures, 256 active

/tmp/go-stress-20251025T175448-1541118487
--- FAIL: TestProbePodIPs (0.30s)
    revision_backends_test.go:1862: TestProbePodIPs/one_pod_fails_probe: Healthy does not match, got map[10.10.1.3:{}], want map[10.10.1.2:{} 10.10.1.3:{}] diff:   sets.Set[string](
        - 	{"10.10.1.3": {}},
        + 	{"10.10.1.2": {}, "10.10.1.3": {}},
          )
FAIL


ERROR: exit status 1
```

100ms delay:

```
$ stress -p 256 ./net.test -test.run TestProbePodIPs
5s: 316 runs so far, 0 failures, 256 active
10s: 728 runs so far, 0 failures, 256 active
15s: 1227 runs so far, 0 failures, 256 active
20s: 1667 runs so far, 0 failures, 256 active
25s: 2136 runs so far, 0 failures, 256 active
30s: 2596 runs so far, 0 failures, 256 active
35s: 3052 runs so far, 0 failures, 256 active
40s: 3514 runs so far, 0 failures, 255 active
45s: 3969 runs so far, 0 failures, 256 active
50s: 4437 runs so far, 0 failures, 256 active
55s: 4892 runs so far, 0 failures, 256 active
1m0s: 5354 runs so far, 0 failures, 256 active
1m5s: 5821 runs so far, 0 failures, 256 active
1m10s: 6272 runs so far, 0 failures, 256 active
1m15s: 6733 runs so far, 0 failures, 256 active
1m20s: 7190 runs so far, 0 failures, 256 active
```

NOTE: I still don't know the purpose of using a delay in this test case. If it is not necessary, we can just remove it, as even 100 ms of delay can cause flakiness.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
