### PR TITLE
Suppress 'default value insecure' warning when secure-pod-defaults is enabled.

### DIFF
--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -995,7 +995,7 @@ func warnDefaultContainerSecurityContext(ctx context.Context, psc *corev1.PodSec
 	}
 
 	// if the user has explicitly enabled the feature, we don't need to warn
-	if slices.Contains([]config.Flag{config.Enabled, config.AllowRootBounded}, config.FromContextOrDefaults(ctx).Features.PodSpecSecurityContext) {
+	if slices.Contains([]config.Flag{config.Enabled, config.AllowRootBounded}, config.FromContextOrDefaults(ctx).Features.SecurePodDefaults) {
 		return nil
 	}
 


### PR DESCRIPTION

## Proposed Changes

* As a follow up to PR: #16042 that added new options for secure-pod-defaults, suppress the "Knative may default this to secure in a future release" warning when the feature secure-pod-default is `AllowRootBounded` or `Enabled`

