### PR TITLE
Fix error handling in request log template execution

### DIFF
--- a/pkg/http/request_log.go
+++ b/pkg/http/request_log.go
@@ -180,6 +180,7 @@ func (h *RequestLogHandler) write(t *template.Template, in *RequestLogTemplateIn
 		// Template execution failed. Write an error message with some basic information about the request.
 		fmt.Fprintf(h.writer, "Invalid request log template: method: %v, response code: %v, latency: %v, url: %v\n",
 			in.Request.Method, in.Response.Code, in.Response.Latency, in.Request.URL)
+		return
 	}
 	h.writer.Write(w.Bytes())
 }


### PR DESCRIPTION
Fixes #15981 

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Fix error handling in request log template execution
  * Add missing return statement after template execution error to prevent writing partial buffer contents after the error message has been logged.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix request log output corruption when using invalid log templates
```
