### PR TITLE
bump min-scale timeout

### DIFF
--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -144,7 +144,7 @@ func TestMinScaleTransition(t *testing.T) {
 	t.Logf("Waiting for %v pods to be created", minScale)
 	var podList *corev1.PodList
 
-	err = wait.PollUntilContextTimeout(ctx, time.Second, time.Minute, true, func(context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 10*time.Second, 2*time.Minute, true, func(context.Context) (bool, error) {
 		revLabel, err := labels.NewRequirement(serving.RevisionLabelKey, selection.Equals, []string{secondRevision})
 		if err != nil {
 			return false, fmt.Errorf("unable to create rev label: %w", err)


### PR DESCRIPTION
In CI we're seeing only one pod spin up. Increasing
the timeout to see if this gives other pods time to
also spin up

Fixes: https://github.com/knative/serving/issues/16240