### PR TITLE
[wip] sus out webhook flakes

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -25,6 +25,9 @@
 # project $PROJECT_ID, start knative in it, run the tests and delete the
 # cluster.
 
+
+export ENABLE_GKE_TELEMETRY=true
+
 source $(dirname "$0")/e2e-common.sh
 
 # Script entry point.
@@ -67,55 +70,63 @@ if (( SHORT )); then
   GO_TEST_FLAGS+=("-short")
 fi
 
-go_test_e2e -timeout=50m \
-  "${GO_TEST_FLAGS[@]}" \
-  ./test/conformance/api/... \
-  ./test/conformance/runtime/... \
-  ./test/e2e \
-  "${E2E_TEST_FLAGS[@]}" || failed=1
+for i in {1..5}; do
 
-toggle_feature tag-header-based-routing Enabled
-go_test_e2e -timeout=2m ./test/e2e/tagheader "${E2E_TEST_FLAGS[@]}" || failed=1
-toggle_feature tag-header-based-routing Disabled
+  go_test_e2e -timeout=50m \
+    "${GO_TEST_FLAGS[@]}" \
+    ./test/conformance/api/... \
+    ./test/conformance/runtime/... \
+    ./test/e2e \
+    "${E2E_TEST_FLAGS[@]}" || failed=1
 
-toggle_feature allow-zero-initial-scale true config-autoscaler || fail_test
-go_test_e2e -timeout=2m ./test/e2e/initscale "${E2E_TEST_FLAGS[@]}" || failed=1
-toggle_feature allow-zero-initial-scale false config-autoscaler || fail_test
+  if [[ "$failed" -eq 1 ]]; then
+    break
+  fi
 
-go_test_e2e -timeout=2m ./test/e2e/domainmapping "${E2E_TEST_FLAGS[@]}" || failed=1
+done
 
-toggle_feature cluster-local-domain-tls enabled config-network || fail_test
-go_test_e2e -timeout=2m ./test/e2e/clusterlocaldomaintls "${E2E_TEST_FLAGS[@]}" || failed=1
-toggle_feature cluster-local-domain-tls disabled config-network || fail_test
+# toggle_feature tag-header-based-routing Enabled
+# go_test_e2e -timeout=2m ./test/e2e/tagheader "${E2E_TEST_FLAGS[@]}" || failed=1
+# toggle_feature tag-header-based-routing Disabled
+#
+# toggle_feature allow-zero-initial-scale true config-autoscaler || fail_test
+# go_test_e2e -timeout=2m ./test/e2e/initscale "${E2E_TEST_FLAGS[@]}" || failed=1
+# toggle_feature allow-zero-initial-scale false config-autoscaler || fail_test
+#
+# go_test_e2e -timeout=2m ./test/e2e/domainmapping "${E2E_TEST_FLAGS[@]}" || failed=1
+#
+# toggle_feature cluster-local-domain-tls enabled config-network || fail_test
+# go_test_e2e -timeout=2m ./test/e2e/clusterlocaldomaintls "${E2E_TEST_FLAGS[@]}" || failed=1
+# toggle_feature cluster-local-domain-tls disabled config-network || fail_test
 
-toggle_feature system-internal-tls enabled config-network || fail_test
-toggle_feature "logging.enable-request-log" true config-observability || fail_test
-toggle_feature "logging.request-log-template" "TLS: {{.Request.TLS}}" config-observability || fail_test
-# with current implementation, Activator must be restarted when configuring system-internal-tls. See https://github.com/knative/serving/issues/13754
-restart_pod "${SYSTEM_NAMESPACE}" "app=activator"
+# toggle_feature system-internal-tls enabled config-network || fail_test
+# toggle_feature "logging.enable-request-log" true config-observability || fail_test
+# toggle_feature "logging.request-log-template" "TLS: {{.Request.TLS}}" config-observability || fail_test
+# # with current implementation, Activator must be restarted when configuring system-internal-tls. See https://github.com/knative/serving/issues/13754
+# restart_pod "${SYSTEM_NAMESPACE}" "app=activator"
 
-# we need to restart the pod in order to start the net-certmanager-controller
-if (( ! HTTPS )); then
-  restart_pod "${SYSTEM_NAMESPACE}" "app=controller"
-fi
-go_test_e2e -timeout=3m ./test/e2e/systeminternaltls "${E2E_TEST_FLAGS[@]}" || failed=1
-toggle_feature system-internal-tls disabled config-network || fail_test
-toggle_feature "logging.enable-request-log" false config-observability || fail_test
-toggle_feature "logging.request-log-template" '' config-observability || fail_test
-# with the current implementation, Activator is always in the request path, and needs to be restarted after configuring system-internal-tls
-restart_pod "${SYSTEM_NAMESPACE}" "app=activator"
+# # we need to restart the pod in order to start the net-certmanager-controller
+# if (( ! HTTPS )); then
+#   restart_pod "${SYSTEM_NAMESPACE}" "app=controller"
+# fi
+# go_test_e2e -timeout=3m ./test/e2e/systeminternaltls "${E2E_TEST_FLAGS[@]}" || failed=1
+# toggle_feature system-internal-tls disabled config-network || fail_test
+# toggle_feature "logging.enable-request-log" false config-observability || fail_test
+# toggle_feature "logging.request-log-template" '' config-observability || fail_test
+# # with the current implementation, Activator is always in the request path, and needs to be restarted after configuring system-internal-tls
+# restart_pod "${SYSTEM_NAMESPACE}" "app=activator"
 
-# we need to restart the pod to stop the net-certmanager-controller
-if (( ! HTTPS )); then
-  restart_pod "${SYSTEM_NAMESPACE}" "app=controller"
-  kubectl get leases -n "${SYSTEM_NAMESPACE}" -o json | jq -r '.items[] | select(.metadata.name | test("controller.knative.dev.serving.pkg.reconciler.certificate.reconciler")).metadata.name' | xargs kubectl delete lease -n "${SYSTEM_NAMESPACE}"
-fi
+# # we need to restart the pod to stop the net-certmanager-controller
+# if (( ! HTTPS )); then
+#   restart_pod "${SYSTEM_NAMESPACE}" "app=controller"
+#   kubectl get leases -n "${SYSTEM_NAMESPACE}" -o json | jq -r '.items[] | select(.metadata.name | test("controller.knative.dev.serving.pkg.reconciler.certificate.reconciler")).metadata.name' | xargs kubectl delete lease -n "${SYSTEM_NAMESPACE}"
+# fi
 
-kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml > "${TMP_DIR}"/config-gc.yaml
-add_trap "kubectl replace cm 'config-gc' -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml" SIGKILL SIGTERM SIGQUIT
-immediate_gc
-go_test_e2e -timeout=2m ./test/e2e/gc "${E2E_TEST_FLAGS[@]}" || failed=1
-kubectl replace cm "config-gc" -n "${SYSTEM_NAMESPACE}" -f "${TMP_DIR}"/config-gc.yaml
+# kubectl get cm "config-gc" -n "${SYSTEM_NAMESPACE}" -o yaml > "${TMP_DIR}"/config-gc.yaml
+# add_trap "kubectl replace cm 'config-gc' -n ${SYSTEM_NAMESPACE} -f ${TMP_DIR}/config-gc.yaml" SIGKILL SIGTERM SIGQUIT
+# immediate_gc
+# go_test_e2e -timeout=2m ./test/e2e/gc "${E2E_TEST_FLAGS[@]}" || failed=1
+# kubectl replace cm "config-gc" -n "${SYSTEM_NAMESPACE}" -f "${TMP_DIR}"/config-gc.yaml
 
 # Run scale tests.
 # Note that we use a very high -parallel because each ksvc is run as its own
@@ -124,49 +135,49 @@ kubectl replace cm "config-gc" -n "${SYSTEM_NAMESPACE}" -f "${TMP_DIR}"/config-g
 # TODO - Renable once we get this reliably passing on GKE 1.21
 # go_test_e2e -timeout=20m -parallel=300 ./test/scale "${E2E_TEST_FLAGS[@]}" || failed=1
 
-# Run HPA tests
-go_test_e2e -timeout=30m -tags=hpa ./test/e2e "${E2E_TEST_FLAGS[@]}" || failed=1
+# # Run HPA tests
+# go_test_e2e -timeout=30m -tags=hpa ./test/e2e "${E2E_TEST_FLAGS[@]}" || failed=1
+#
+# # Run initContainers tests with alpha enabled avoiding any issues with the testing options guard above
+# # InitContainers test uses emptyDir.
+# toggle_feature kubernetes.podspec-init-containers Enabled
+# go_test_e2e -timeout=2m ./test/e2e/initcontainers "${E2E_TEST_FLAGS[@]}" || failed=1
+# toggle_feature kubernetes.podspec-init-containers Disabled
 
-# Run initContainers tests with alpha enabled avoiding any issues with the testing options guard above
-# InitContainers test uses emptyDir.
-toggle_feature kubernetes.podspec-init-containers Enabled
-go_test_e2e -timeout=2m ./test/e2e/initcontainers "${E2E_TEST_FLAGS[@]}" || failed=1
-toggle_feature kubernetes.podspec-init-containers Disabled
+# # Run multi-container probe tests
+# toggle_feature multi-container-probing Enabled
+# go_test_e2e -timeout=2m ./test/e2e/multicontainerprobing "${E2E_TEST_FLAGS[@]}" || failed=1
+# toggle_feature multi-container-probing Disabled
 
-# Run multi-container probe tests
-toggle_feature multi-container-probing Enabled
-go_test_e2e -timeout=2m ./test/e2e/multicontainerprobing "${E2E_TEST_FLAGS[@]}" || failed=1
-toggle_feature multi-container-probing Disabled
+# # RUN PVC tests with default storage class.
+# toggle_feature kubernetes.podspec-persistent-volume-claim Enabled
+# toggle_feature kubernetes.podspec-persistent-volume-write Enabled
+# toggle_feature kubernetes.podspec-securitycontext Enabled
+# go_test_e2e -timeout=5m ./test/e2e/pvc "${E2E_TEST_FLAGS[@]}" || failed=1
+# toggle_feature kubernetes.podspec-securitycontext Disabled
+# toggle_feature kubernetes.podspec-persistent-volume-write Disabled
+# toggle_feature kubernetes.podspec-persistent-volume-claim Disabled
 
-# RUN PVC tests with default storage class.
-toggle_feature kubernetes.podspec-persistent-volume-claim Enabled
-toggle_feature kubernetes.podspec-persistent-volume-write Enabled
-toggle_feature kubernetes.podspec-securitycontext Enabled
-go_test_e2e -timeout=5m ./test/e2e/pvc "${E2E_TEST_FLAGS[@]}" || failed=1
-toggle_feature kubernetes.podspec-securitycontext Disabled
-toggle_feature kubernetes.podspec-persistent-volume-write Disabled
-toggle_feature kubernetes.podspec-persistent-volume-claim Disabled
-
-# RUN secure pod defaults test in a separate install.
-toggle_feature secure-pod-defaults Enabled
-go_test_e2e -timeout=3m ./test/e2e/securedefaults "${E2E_TEST_FLAGS[@]}" || failed=1
-toggle_feature secure-pod-defaults Disabled
+# # RUN secure pod defaults test in a separate install.
+# toggle_feature secure-pod-defaults Enabled
+# go_test_e2e -timeout=3m ./test/e2e/securedefaults "${E2E_TEST_FLAGS[@]}" || failed=1
+# toggle_feature secure-pod-defaults Disabled
 
 # Run HA tests separately as they're stopping core Knative Serving pods.
 # Define short -spoofinterval to ensure frequent probing while stopping pods.
-go_test_e2e -timeout=30m -failfast -parallel=1 ./test/ha \
-  "${E2E_TEST_FLAGS[@]}" \
-  -replicas="${REPLICAS:-1}" \
-  -buckets="${BUCKETS:-1}" \
-  -spoofinterval="10ms" || failed=1
-
-if (( HTTPS )); then
-  kubectl delete -f "${E2E_YAML_DIR}"/test/config/externaldomaintls/certmanager/caissuer/ --ignore-not-found
-  toggle_feature external-domain-tls Disabled config-network
-  # we need to restart the pod to stop the net-certmanager-controller
-  restart_pod "${SYSTEM_NAMESPACE}" "app=controller"
-  kubectl get leases -n "${SYSTEM_NAMESPACE}" -o json | jq -r '.items[] | select(.metadata.name | test("controller.knative.dev.serving.pkg.reconciler.certificate.reconciler")).metadata.name' | xargs kubectl delete lease -n "${SYSTEM_NAMESPACE}"
-fi
+# go_test_e2e -timeout=30m -failfast -parallel=1 ./test/ha \
+#   "${E2E_TEST_FLAGS[@]}" \
+#   -replicas="${REPLICAS:-1}" \
+#   -buckets="${BUCKETS:-1}" \
+#   -spoofinterval="10ms" || failed=1
+#
+# if (( HTTPS )); then
+#   kubectl delete -f "${E2E_YAML_DIR}"/test/config/externaldomaintls/certmanager/caissuer/ --ignore-not-found
+#   toggle_feature external-domain-tls Disabled config-network
+#   # we need to restart the pod to stop the net-certmanager-controller
+#   restart_pod "${SYSTEM_NAMESPACE}" "app=controller"
+#   kubectl get leases -n "${SYSTEM_NAMESPACE}" -o json | jq -r '.items[] | select(.metadata.name | test("controller.knative.dev.serving.pkg.reconciler.certificate.reconciler")).metadata.name' | xargs kubectl delete lease -n "${SYSTEM_NAMESPACE}"
+# fi
 
 (( failed )) && fail_test
 


### PR DESCRIPTION
Seeing the following in tests

>  readiness_test.go:74: Failed to create initial Service: readiness-alternate-port-zukonale: Internal error occurred: failed calling webhook "webhook.serving.knative.dev": failed to call webhook: Post "https://webhook.2e6d1a97-616a-4f80-ac14-de10d5463179.svc:443/defaulting?timeout=10s": EOF
--- FAIL: TestReadinessAlternatePort (0.26s)