### PR TITLE
Add terminationGracePeriodSeconds support to user and sidecar container probes (#15823)

### DIFF
--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
+
 	"knative.dev/serving/pkg/apis/config"
 )
 
@@ -384,6 +385,7 @@ func ProbeMask(in *corev1.Probe) *corev1.Probe {
 	out.PeriodSeconds = in.PeriodSeconds
 	out.SuccessThreshold = in.SuccessThreshold
 	out.FailureThreshold = in.FailureThreshold
+	out.TerminationGracePeriodSeconds = in.TerminationGracePeriodSeconds
 
 	return out
 }

--- a/pkg/apis/serving/fieldmask_test.go
+++ b/pkg/apis/serving/fieldmask_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/ptr"
+
 	"knative.dev/serving/pkg/apis/config"
 )
 
@@ -395,12 +396,13 @@ func TestVolumeMountMask_FeatMountPropagation(t *testing.T) {
 
 func TestProbeMask(t *testing.T) {
 	want := &corev1.Probe{
-		ProbeHandler:        corev1.ProbeHandler{},
-		InitialDelaySeconds: 42,
-		TimeoutSeconds:      42,
-		PeriodSeconds:       42,
-		SuccessThreshold:    42,
-		FailureThreshold:    42,
+		ProbeHandler:                  corev1.ProbeHandler{},
+		InitialDelaySeconds:           42,
+		TimeoutSeconds:                42,
+		PeriodSeconds:                 42,
+		SuccessThreshold:              42,
+		FailureThreshold:              42,
+		TerminationGracePeriodSeconds: ptr.Int64(30),
 	}
 	in := want
 

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -1822,6 +1822,7 @@ func TestUserContainerValidation(t *testing.T) {
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{},
 				},
+				TerminationGracePeriodSeconds: ptr.Int64(10),
 			},
 		},
 		want: nil,
@@ -1859,6 +1860,7 @@ func TestUserContainerValidation(t *testing.T) {
 						Path: "/",
 					},
 				},
+				TerminationGracePeriodSeconds: ptr.Int64(10),
 			},
 		},
 		want: nil,
@@ -1913,6 +1915,7 @@ func TestUserContainerValidation(t *testing.T) {
 						Port: intstr.FromInt(5000),
 					},
 				},
+				TerminationGracePeriodSeconds: ptr.Int64(10),
 			},
 		},
 		want: nil,
@@ -2173,6 +2176,18 @@ func TestSidecarContainerValidation(t *testing.T) {
 					TCPSocket: &corev1.TCPSocketAction{},
 				},
 			},
+			StartupProbe: &corev1.Probe{
+				PeriodSeconds:    1,
+				TimeoutSeconds:   1,
+				SuccessThreshold: 1,
+				FailureThreshold: 3,
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/",
+					},
+				},
+				TerminationGracePeriodSeconds: ptr.Int64(10),
+			},
 		},
 		want: apis.ErrDisallowedFields("livenessProbe", "readinessProbe", "readinessProbe.failureThreshold", "readinessProbe.periodSeconds", "readinessProbe.successThreshold", "readinessProbe.timeoutSeconds"),
 	}, {
@@ -2219,6 +2234,43 @@ func TestSidecarContainerValidation(t *testing.T) {
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{},
 				},
+			},
+		},
+		cfgOpts: []configOption{withMultiContainerProbesEnabled()},
+		want:    nil,
+	}, {
+		name: "invalid with startup probe",
+		c: corev1.Container{
+			Image: "foo",
+			StartupProbe: &corev1.Probe{
+				PeriodSeconds:    1,
+				TimeoutSeconds:   1,
+				SuccessThreshold: 1,
+				FailureThreshold: 3,
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/",
+					},
+				},
+				TerminationGracePeriodSeconds: ptr.Int64(10),
+			},
+		},
+		want: nil,
+	}, {
+		name: "valid with startup probe and multi container probing",
+		c: corev1.Container{
+			Image: "foo",
+			StartupProbe: &corev1.Probe{
+				PeriodSeconds:    1,
+				TimeoutSeconds:   1,
+				SuccessThreshold: 1,
+				FailureThreshold: 3,
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/",
+					},
+				},
+				TerminationGracePeriodSeconds: ptr.Int64(10),
 			},
 		},
 		cfgOpts: []configOption{withMultiContainerProbesEnabled()},
@@ -2283,6 +2335,7 @@ func TestSidecarContainerValidation(t *testing.T) {
 						Port: intstr.FromInt(5000),
 					},
 				},
+				TerminationGracePeriodSeconds: ptr.Int64(10),
 			},
 		},
 		cfgOpts: []configOption{withMultiContainerProbesEnabled()},


### PR DESCRIPTION
Fixes #

#15823

## Proposed Changes

Add `terminationGracePeriodSeconds` in the probe Mask used for the container probes. This will allw it to be configurable for the container probes. I add the issue https://github.com/knative/serving/issues/16256 to validate the the startup probes for user and sidecar containers.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add  `terminationGracePeriodSeconds` support for user and sidecar container probes
```
