### PR TITLE
Fix Serving Metric Names to match Design Document

### DIFF
--- a/pkg/queue/request_metric.go
+++ b/pkg/queue/request_metric.go
@@ -59,7 +59,7 @@ func NewAppRequestMetricsHandler(
 	)
 
 	handler.duration, err = meter.Float64Histogram(
-		"kn.queueproxy.app.duration",
+		"kn.serving.invocation.duration",
 		metric.WithDescription("The duration of task execution"),
 		metric.WithUnit("s"),
 		metric.WithExplicitBucketBoundaries(latencyBounds...),
@@ -69,7 +69,7 @@ func NewAppRequestMetricsHandler(
 	}
 
 	handler.queueLen, err = meter.Int64Gauge(
-		"kn.queueproxy.depth",
+		"kn.serving.queue.depth",
 		metric.WithDescription("Number of current requests in the queue"),
 		metric.WithUnit("{request}"),
 	)

--- a/pkg/queue/request_metric_test.go
+++ b/pkg/queue/request_metric_test.go
@@ -115,7 +115,7 @@ func assertMetrics(t *testing.T, reader *metric.ManualReader, status int) {
 		metricstest.MetricsEqual(
 			scopeName,
 			metricdata.Metrics{
-				Name:        "kn.queueproxy.depth",
+				Name:        "kn.serving.queue.depth",
 				Unit:        "{request}",
 				Description: "Number of current requests in the queue",
 				Data: metricdata.Gauge[int64]{
@@ -125,7 +125,7 @@ func assertMetrics(t *testing.T, reader *metric.ManualReader, status int) {
 				},
 			},
 			metricdata.Metrics{
-				Name:        "kn.queueproxy.app.duration",
+				Name:        "kn.serving.invocation.duration",
 				Unit:        "s",
 				Description: "The duration of task execution",
 				Data: metricdata.Histogram[float64]{


### PR DESCRIPTION
Part of https://github.com/knative/serving/issues/16216

The [Knative OTel migration design document](https://docs.google.com/document/d/1QQ_ubc0RjeZbRHdN4rQR85Z7RZfTSjz4GoKsE0dZ2Z0/edit?tab=t.0
) has the mapping of old metrics and new metrics.

The implementation didn't match the design document.

We now map
- `kn.queueproxy.app.duration` -> `kn.serving.invocation.duration`
- `kn.queueproxy.depth` -> `kn.serving.queue.depth`


```release-note
Fix metric names to match the original design document `kn.queueproxy.app.duration` becomes `kn.serving.invocation.duration` and `kn.queueproxy.depth` becomes `kn.serving.queue.depth`
```


