### PR TITLE
Prevent cross-service revision traffic routing

### DIFF
--- a/pkg/apis/serving/v1/route_lifecycle.go
+++ b/pkg/apis/serving/v1/route_lifecycle.go
@@ -155,6 +155,23 @@ func (rs *RouteStatus) MarkRevisionFailed(name string) {
 		"Revision %q failed to become ready.", name)
 }
 
+// MarkRevisionNotOwned marks the RouteConditionAllTrafficAssigned condition
+// to indicate the Revision does not belong to the expected Service.
+func (rs *RouteStatus) MarkRevisionNotOwned(revisionName, expectedService, actualService string) {
+	if actualService == "" {
+		// Revision was created from a standalone Configuration (no known service)
+		routeCondSet.Manage(rs).MarkFalse(RouteConditionAllTrafficAssigned,
+			"RevisionNotOwned",
+			"Revision %q does not belong to Service %q.", revisionName, expectedService)
+	} else {
+		// Revision belongs to a different Service
+		routeCondSet.Manage(rs).MarkFalse(RouteConditionAllTrafficAssigned,
+			"RevisionNotOwned",
+			"Revision %q belongs to Service %q, not Service %q.",
+			revisionName, actualService, expectedService)
+	}
+}
+
 // MarkMissingTrafficTarget marks the RouteConditionAllTrafficAssigned
 // condition to indicate a reference traffic target was not found.
 func (rs *RouteStatus) MarkMissingTrafficTarget(kind, name string) {

--- a/pkg/apis/serving/v1/route_lifecycle_test.go
+++ b/pkg/apis/serving/v1/route_lifecycle_test.go
@@ -344,6 +344,34 @@ func TestTargetRevisionFailedToBeReadyFlow(t *testing.T) {
 	apistest.CheckConditionFailed(r, RouteConditionReady, t)
 }
 
+func TestRevisionNotOwnedFlow(t *testing.T) {
+	r := &RouteStatus{}
+	r.InitializeConditions()
+	apistest.CheckConditionOngoing(r, RouteConditionAllTrafficAssigned, t)
+	apistest.CheckConditionOngoing(r, RouteConditionIngressReady, t)
+	apistest.CheckConditionOngoing(r, RouteConditionReady, t)
+
+	// Revision belongs to a different Service
+	r.MarkRevisionNotOwned("other-rev", "my-service", "other-service")
+	apistest.CheckConditionFailed(r, RouteConditionAllTrafficAssigned, t)
+	apistest.CheckConditionOngoing(r, RouteConditionIngressReady, t)
+	apistest.CheckConditionFailed(r, RouteConditionReady, t)
+}
+
+func TestRevisionNotOwnedByStandaloneConfigFlow(t *testing.T) {
+	r := &RouteStatus{}
+	r.InitializeConditions()
+	apistest.CheckConditionOngoing(r, RouteConditionAllTrafficAssigned, t)
+	apistest.CheckConditionOngoing(r, RouteConditionIngressReady, t)
+	apistest.CheckConditionOngoing(r, RouteConditionReady, t)
+
+	// Revision has no service label (standalone Configuration)
+	r.MarkRevisionNotOwned("standalone-rev", "my-service", "")
+	apistest.CheckConditionFailed(r, RouteConditionAllTrafficAssigned, t)
+	apistest.CheckConditionOngoing(r, RouteConditionIngressReady, t)
+	apistest.CheckConditionFailed(r, RouteConditionReady, t)
+}
+
 func TestIngressFailureRecovery(t *testing.T) {
 	r := &RouteStatus{}
 	r.InitializeConditions()


### PR DESCRIPTION
Fixes #11916 

Services can no longer route traffic to revisions belonging to different services. When a Service-owned Route references a revision with a different serving.knative.dev/service label, the Route will show Ready=False with reason RevisionNotOwned.

Standalone Routes (not owned by a Service) are unaffected and can still reference any revision.

## Changes

- Validate revision ownership when building traffic configuration
- New `RevisionNotOwned` condition reason when validation fails
- Standalone Routes (not owned by a Service) are unaffected

## Open Question

Should we also add validation at the webhook level for faster user feedback?

This would require using the revision informer in the webhook which would probably increase the memory footprint a bit (didn't test it).
The current implementation validates at reconciliation time only, which is consistent with how other traffic errors (e.g., `RevisionMissing`) are handled so I'm fine keeping the implementation like this.

## Release Note

```release-note
Services can no longer route traffic to revisions belonging to different services; attempting to do so will result in Ready=False with reason RevisionNotOwned.
```
