### PR TITLE
Fix linting errors: use canonical HTTP header casing

### DIFF
--- a/pkg/http/trace.go
+++ b/pkg/http/trace.go
@@ -24,14 +24,14 @@ import (
 // ExtractTraceID extracts the trace ID from the request headers.
 // It supports both W3C Trace Context (traceparent) and B3 (X-B3-TraceId) formats.
 func ExtractTraceID(h http.Header) string {
-	if traceparent := h.Get("traceparent"); traceparent != "" {
+	if traceparent := h.Get("Traceparent"); traceparent != "" {
 		parts := strings.SplitN(traceparent, "-", 3)
 		if len(parts) >= 2 {
 			return parts[1]
 		}
 	}
 
-	if b3TraceID := h.Get("X-B3-TraceId"); b3TraceID != "" {
+	if b3TraceID := h.Get("X-B3-Traceid"); b3TraceID != "" {
 		return b3TraceID
 	}
 

--- a/pkg/http/trace_integration_test.go
+++ b/pkg/http/trace_integration_test.go
@@ -147,7 +147,7 @@ func TestRequestLogTemplateWithTraceID(t *testing.T) {
 	// Test with W3C Trace Context
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/api", nil)
 
-	req.Header.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+	req.Header.Set("Traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
 
 	resp := httptest.NewRecorder()
 	logHandler.ServeHTTP(resp, req)


### PR DESCRIPTION
golangci-lint --fix standardized header names to canonical form.