### PR TITLE
Validate networking annotations on RevisionTemplateSpec

### DIFF
--- a/pkg/apis/serving/v1/revision_validation.go
+++ b/pkg/apis/serving/v1/revision_validation.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/api/validation"
+	"knative.dev/networking/pkg/apis/networking"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmap"
 	"knative.dev/pkg/kmp"
@@ -66,6 +67,7 @@ func (rts *RevisionTemplateSpec) Validate(ctx context.Context) *apis.FieldError 
 	errs := rts.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec")
 	errs = errs.Also(autoscaling.ValidateAnnotations(ctx, config.FromContextOrDefaults(ctx).Autoscaler,
 		rts.GetAnnotations()).ViaField("metadata.annotations"))
+	errs = errs.Also(networking.ValidateAnnotations(rts.GetAnnotations()).ViaField("metadata.annotations"))
 
 	// If the RevisionTemplateSpec has a name specified, then check that
 	// it follows the requirements on the name.

--- a/pkg/apis/serving/v1/revision_validation_test.go
+++ b/pkg/apis/serving/v1/revision_validation_test.go
@@ -1092,6 +1092,57 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 			Message: "progress-deadline=-1m3s must be positive",
 			Paths:   []string{serving.ProgressDeadlineAnnotationKey},
 		}).ViaField("metadata.annotations"),
+	}, {
+		name: "invalid networking.knative.dev/visibility annotation",
+		rts: &RevisionTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"networking.knative.dev/visibility": "cluster-local",
+				},
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "helloworld",
+					}},
+				},
+			},
+		},
+		want: apis.ErrInvalidKeyName("networking.knative.dev/visibility", "metadata.annotations"),
+	}, {
+		name: "invalid unknown networking.knative.dev annotation",
+		rts: &RevisionTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"networking.knative.dev/foo": "bar",
+				},
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "helloworld",
+					}},
+				},
+			},
+		},
+		want: apis.ErrInvalidKeyName("networking.knative.dev/foo", "metadata.annotations"),
+	}, {
+		name: "valid networking.knative.dev/ingress.class annotation",
+		rts: &RevisionTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"networking.knative.dev/ingress.class": "istio.ingress.networking.knative.dev",
+				},
+			},
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Image: "helloworld",
+					}},
+				},
+			},
+		},
+		want: nil,
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #13053

## Proposed Changes

* Add validation in `RevisionTemplateSpec.Validate()` to reject unknown `networking.knative.dev/*` annotations early at Service creation time
* Reuse existing `networking.ValidateAnnotations()` from the networking package for consistency with SKS validation
* Add test cases for invalid and valid networking annotations on RevisionTemplate


## Background

When users mistakenly place `networking.knative.dev/visibility: cluster-local` as an annotation on `spec.template.metadata.annotations` (instead of as a label on the Service's `metadata.labels`), the annotation propagates through Revision → PodAutoscaler → ServerlessService, where SKS validation rejects it. This caused services to silently get stuck in "Unknown" state with no clear error message.

With this fix, users now get an immediate validation error:
```
validation failed: invalid key name "networking.knative.dev/visibility": spec.template.metadata.annotations
```

<details>
<summary>Example of broken resource (click to expand)</summary>

```yaml
apiVersion: serving.knative.dev/v1
kind: Service
metadata:
  name: my-service
spec:
  template:
    metadata:
      annotations:
        # WRONG: This causes the service to get stuck!
        # visibility should be a LABEL on the Service metadata, not here
        networking.knative.dev/visibility: cluster-local
    spec:
      containers:
        - image: gcr.io/knative-samples/helloworld-go
```

**Correct usage:**
```yaml
apiVersion: serving.knative.dev/v1
kind: Service
metadata:
  name: my-service
  labels:
    networking.knative.dev/visibility: cluster-local  # Correct!
spec:
  template:
    spec:
      containers:
        - image: gcr.io/knative-samples/helloworld-go
```

</details>


## Release Note

```release-note
Services with invalid networking.knative.dev/* annotations on the revision template now fail immediately with a clear error instead of getting stuck.
```
