### PR TITLE
Prevent duplicate hosts in Ingress rules when using ACME

### DIFF
--- a/pkg/reconciler/domainmapping/resources/ingress_test.go
+++ b/pkg/reconciler/domainmapping/resources/ingress_test.go
@@ -198,6 +198,16 @@ func TestMakeIngress(t *testing.T) {
 					Visibility: netv1alpha1.IngressVisibilityExternalIP,
 					HTTP: &netv1alpha1.HTTPIngressRuleValue{
 						Paths: []netv1alpha1.HTTPIngressPath{{
+							Path: "/.well-known/acme-challenge/challenge-token",
+							Splits: []netv1alpha1.IngressBackendSplit{{
+								IngressBackend: netv1alpha1.IngressBackend{
+									ServiceNamespace: "test-ns",
+									ServiceName:      "cm-solver",
+									ServicePort:      intstr.FromInt(8090),
+								},
+								Percent: 100,
+							}},
+						}, {
 							RewriteHost: "the-rewrite-host",
 							Splits: []netv1alpha1.IngressBackendSplit{{
 								Percent: 100,
@@ -209,22 +219,6 @@ func TestMakeIngress(t *testing.T) {
 									ServiceNamespace: "the-namespace",
 									ServicePort:      intstr.FromInt(80),
 								},
-							}},
-						}},
-					},
-				}, {
-					Hosts:      []string{"mapping.com"},
-					Visibility: netv1alpha1.IngressVisibilityExternalIP,
-					HTTP: &netv1alpha1.HTTPIngressRuleValue{
-						Paths: []netv1alpha1.HTTPIngressPath{{
-							Path: "/.well-known/acme-challenge/challenge-token",
-							Splits: []netv1alpha1.IngressBackendSplit{{
-								IngressBackend: netv1alpha1.IngressBackend{
-									ServiceNamespace: "test-ns",
-									ServiceName:      "cm-solver",
-									ServicePort:      intstr.FromInt(8090),
-								},
-								Percent: 100,
 							}},
 						}},
 					},


### PR DESCRIPTION
The basic idea is that we don't create ingress rules with multiple hosts for external visibility, as we need to be able merge ACME rules into these hosts.
I don't really like that though as it puts the knowledge of exactly 1 host per external rule in two places (rule creation and ACME rule merging).

Another alternative would be that we accept the incorrect rule merging with multiple hosts that we had before:
```yml
rules:
  - hosts: a, b
    paths:
      - acme-of-a
      - acme-of-b
```
This would result in 4 possible routes in the Ingress:
- host `a` with path `acme-of-a` - correct
- host `b` with path `acme-of-a` - wrong
- host `a` with path `acme-of-b` - wrong
- host `b` with path `acme-of-b` - correct

This won't be a problem in practice though as the ACME server would not try to do a request to host `a` with path `acme-of-b`.
This would be a simple loop over existing rules, check if it contains a matching host and merge it inside there (while still preventing double duplicate rules that we had before #16259 )

Let me know what you think of this approach in general. 

/cc @dprotaso


<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
