### PR TITLE
Fix #16260: Allow unreachable revisions with initialScale > 1 to scale to 0

### DIFF
--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -345,7 +345,9 @@ func (ks *scaler) scale(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscal
 	logger.Debugf("MinScale = %d, MaxScale = %d, InitialScale = %d, DesiredScale = %d Reachable = %q",
 		min, max, initialScale, desiredScale, pa.Spec.Reachability)
 	// If initial scale has been attained, ignore the initialScale altogether.
-	if initialScale > 1 && !pa.Status.IsScaleTargetInitialized() {
+	// Also ignore initialScale if the revision is unreachable (routingState = "reserve"),
+	// allowing it to scale down to 0 immediately.
+	if initialScale > 1 && !pa.Status.IsScaleTargetInitialized() && pa.Spec.Reachability != autoscalingv1alpha1.ReachabilityUnreachable {
 		// Ignore initial scale if minScale >= initialScale.
 		if min < initialScale {
 			logger.Debugf("Adjusting min to meet the initial scale: %d -> %d", min, initialScale)


### PR DESCRIPTION
Revisions with initialScale > 1 that are no longer referenced by any Route (routingState = 'reserve', mapped to Reachability = Unreachable) were previously unable to scale down to 0, causing resource waste when old revisions were replaced by new ones.

This change modifies the initialScale logic in scaler.go to ignore the initialScale constraint when a revision's Reachability is Unreachable. This allows revisions in reserve state to scale down to 0 immediately, freeing up resources promptly when they are no longer needed.

The fix adds a check for pa.Spec.Reachability != ReachabilityUnreachable before applying the initialScale constraint, ensuring that:
- Revisions with routingState = 'reserve' can scale down to 0 immediately
- The initialScale logic only applies to revisions that are still referenced by Routes (routingState = 'active')
- Resources are freed promptly when old revisions are replaced

A new test case has been added to verify the behavior: revisions with initialScale > 1 and Reachability = Unreachable can now scale to 0.

Fixes #16260 



<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow unreachable revisions with initialScale > 1 to scale to 0
```
