### PR TITLE
Reduce deployment updates

### DIFF
--- a/pkg/reconciler/revision/table_test.go
+++ b/pkg/reconciler/revision/table_test.go
@@ -224,6 +224,16 @@ func TestReconcile(t *testing.T) {
 		}},
 		Key: "foo/preserve-annotations",
 	}, {
+		Name: "do not update deployments with no spec changes",
+		Objects: []runtime.Object{
+			Revision("foo", "preserve-annotations",
+				WithLogURL, allUnknownConditions, withDefaultContainerStatuses(), WithRevisionObservedGeneration(1)),
+			pa("foo", "preserve-annotations", WithReachabilityUnknown),
+			addDeploymentMetadata(deploy(t, "foo", "preserve-annotations"), false),
+			image("foo", "preserve-annotations"),
+		},
+		Key: "foo/preserve-annotations",
+	}, {
 		Name: "failure updating deployment",
 		// Test that we handle an error updating the deployment properly.
 		WantErr: true,


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* eliminate redundant deployment updates 
* if anything modifies the deployment spec of a knative managed deployment the current logic will do a redundant deployment update every reconile. This is i.e. visible when running with net-istio, which adds 
```
        service.istio.io/canonical-name:
        service.istio.io/canonical-revision:
```
to `spec.template.metadata.labels` causing the semantic equality check to fail every reconile.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
