### PR TITLE
Fix EnsureCleanup to properly skip clean up when requested

### DIFF
--- a/test/cleanup.go
+++ b/test/cleanup.go
@@ -73,12 +73,17 @@ func TearDown(clients *Clients, names *ResourceNames) {
 // EnsureCleanup will run the provided cleanup function when the test ends,
 // either via t.Cleanup or on interrupt via CleanupOnInterrupt.
 func EnsureCleanup(t *testing.T, cleanup func()) {
-	if ServingFlags.SkipCleanupOnFail {
-		t.Log("skipping cleanup")
-		return
+	f := func() {
+		if t.Failed() && ServingFlags.SkipCleanupOnFail {
+			t.Log("skipping cleanup")
+			return
+		}
+
+		cleanup()
 	}
-	t.Cleanup(cleanup)
-	CleanupOnInterrupt(cleanup)
+
+	t.Cleanup(f)
+	CleanupOnInterrupt(f)
 }
 
 // EnsureTearDown will delete created names when the test ends, either via


### PR DESCRIPTION
EnsureCleanup is called after creating some resource to
register clean up handlers. No invocation of this function
uses defer so typically the test has not failed. When passing
in the SkipCleanupOnFail=true flag we were then never skipping
said cleanup because of it.
