### PR TITLE
checkout the repo prior to restoring the cache

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -156,6 +156,10 @@ jobs:
     - name: setup-go
       uses: knative/actions/setup-go@main
 
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
+
     - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: |
@@ -186,10 +190,6 @@ jobs:
         chmod +x ./gotestsum
         sudo mv gotestsum /usr/local/bin
         echo "::endgroup::"
-
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        fetch-depth: 0
 
     - name: Install Serving & Ingress
       run: |


### PR DESCRIPTION
We get lots of warnings due to the cache restore

<img width="1012" height="140" alt="Screenshot 2026-02-06 at 11 56 32 AM" src="https://github.com/user-attachments/assets/a21294be-d08f-48c6-a8f2-b86e6ed1926a" />
