### PR TITLE
[release-1.21] bump to trigger point release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module knative.dev/serving
 
+// bump to trigger point release to fix
+// https://github.com/knative/serving/issues/16402
+
 go 1.24.0
 
 require (


### PR DESCRIPTION
Bump serving to trigger release to rebuild with 1.25.7

Part of https://github.com/knative/serving/issues/16402