### PR TITLE
feat: use knative.dev/pkg/tls for activator TLS configuration

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"log"
@@ -50,6 +49,7 @@ import (
 	k8sruntime "knative.dev/pkg/observability/runtime/k8s"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
+	knativetls "knative.dev/pkg/tls"
 	"knative.dev/pkg/version"
 	"knative.dev/pkg/websocket"
 	"knative.dev/serving/pkg/activator"
@@ -292,7 +292,7 @@ func main() {
 		"profile": pprof.Server,
 	}
 
-	errCh := make(chan error, len(servers))
+	errCh := make(chan error, len(servers)+1)
 	for name, server := range servers {
 		go func(name string, s *http.Server) {
 			// Don't forward ErrServerClosed as that indicates we're already shutting down.
@@ -306,17 +306,21 @@ func main() {
 	// At this moment activator with TLS does not disable HTTP.
 	// See also https://github.com/knative/serving/issues/12808.
 	if tlsEnabled {
-		name, server := "https", pkgnet.NewServer(":"+strconv.Itoa(networking.BackendHTTPSPort), ah)
-		go func(name string, s *http.Server) {
-			s.TLSConfig = &tls.Config{
-				MinVersion:     tls.VersionTLS13,
-				GetCertificate: certCache.GetCertificate,
-			}
+		tlsCfg, err := knativetls.DefaultConfigFromEnv("ACTIVATOR_")
+		if err != nil {
+			logger.Fatalw("Failed to read TLS configuration from environment", zap.Error(err))
+		}
+
+		server := pkgnet.NewServer(":"+strconv.Itoa(networking.BackendHTTPSPort), ah)
+		servers["https"] = server
+		go func(s *http.Server) {
+			s.TLSConfig = tlsCfg
+			s.TLSConfig.GetCertificate = certCache.GetCertificate
 			// Don't forward ErrServerClosed as that indicates we're already shutting down.
 			if err := s.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
-				errCh <- fmt.Errorf("%s server failed: %w", name, err)
+				errCh <- fmt.Errorf("https server failed: %w", err)
 			}
-		}(name, server)
+		}(server)
 	}
 
 	// Wait for the signal to drain.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Replace the hardcoded tls.VersionTLS13 in the activator's HTTPS server with the shared knative.dev/pkg/tls package, allowing TLS settings to be configured via ACTIVATOR_TLS_MIN_VERSION, ACTIVATOR_TLS_MAX_VERSION, ACTIVATOR_TLS_CIPHER_SUITES, and ACTIVATOR_TLS_CURVE_PREFERENCES environment variables. The default remains TLS 1.3 when no env var is set.

knative/pkg patch: https://github.com/knative/pkg/pull/3324

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The activator now reads TLS settings from environment variables (ACTIVATOR_TLS_MIN_VERSION, ACTIVATOR_TLS_MAX_VERSION, ACTIVATOR_TLS_CIPHER_SUITES, ACTIVATOR_TLS_CURVE_PREFERENCES) via the shared knative.dev/pkg/tls package instead of hardcoding TLS 1.3.
```
