### PR TITLE
feat: use knative.dev/pkg/tls for reconciler TLS configuration

### DIFF
--- a/pkg/reconciler/revision/resolve.go
+++ b/pkg/reconciler/revision/resolve.go
@@ -18,7 +18,6 @@ package revision
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -30,6 +29,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
+	knativetls "knative.dev/pkg/tls"
 )
 
 type digestResolver struct {
@@ -43,7 +43,7 @@ const (
 	// https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/#trusting-tls-in-a-cluster
 	k8sCertPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
-	tlsMinVersionEnvKey = "TAG_TO_DIGEST_TLS_MIN_VERSION"
+	tlsEnvPrefix = "TAG_TO_DIGEST_"
 )
 
 // newResolverTransport returns an http.Transport that appends the certs bundle
@@ -62,29 +62,18 @@ func newResolverTransport(path string, maxIdleConns, maxIdleConnsPerHost int) (*
 		return nil, errors.New("failed to append k8s cert bundle to cert pool")
 	}
 
+	cfg, err := knativetls.DefaultConfigFromEnv(tlsEnvPrefix)
+	if err != nil {
+		return nil, err
+	}
+
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.MaxIdleConns = maxIdleConns
 	transport.MaxIdleConnsPerHost = maxIdleConnsPerHost
-	//nolint:gosec // quay.io still required 1.2 - bump if they've moved up
-	transport.TLSClientConfig = &tls.Config{
-		MinVersion: tlsMinVersionFromEnv(tls.VersionTLS12),
-		RootCAs:    pool,
-	}
+	transport.TLSClientConfig = cfg
+	transport.TLSClientConfig.RootCAs = pool
 
 	return transport, nil
-}
-
-func tlsMinVersionFromEnv(defaultTLSMinVersion uint16) uint16 {
-	switch tlsMinVersion := os.Getenv(tlsMinVersionEnvKey); tlsMinVersion {
-	case "1.2":
-		return tls.VersionTLS12
-	case "1.3":
-		return tls.VersionTLS13
-	case "":
-		return defaultTLSMinVersion
-	default:
-		panic(fmt.Sprintf("the environment variable %q has to be either '1.2' or '1.3'", tlsMinVersionEnvKey))
-	}
 }
 
 // Resolve resolves the image references that use tags to digests.

--- a/pkg/reconciler/revision/resolve_test.go
+++ b/pkg/reconciler/revision/resolve_test.go
@@ -509,7 +509,7 @@ func TestNewResolverTransport_TLSMinVersion(t *testing.T) {
 		name           string
 		envOverride    string
 		expectedMinTLS uint16
-		expectedPanic  bool
+		wantErr        bool
 	}{{
 		name:           "TLS 1.2",
 		envOverride:    "1.2",
@@ -519,30 +519,38 @@ func TestNewResolverTransport_TLSMinVersion(t *testing.T) {
 		envOverride:    "1.3",
 		expectedMinTLS: tls.VersionTLS13,
 	}, {
-		name:           "default TLS 1.2",
+		name:           "default TLS 1.3",
 		envOverride:    "",
-		expectedMinTLS: tls.VersionTLS12,
+		expectedMinTLS: tls.VersionTLS13,
+	}, {
+		name:        "invalid version",
+		envOverride: "1.1",
+		wantErr:     true,
 	}}
 
 	tmpDir := t.TempDir()
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv(tlsMinVersionEnvKey, tc.envOverride)
+			t.Setenv(tlsEnvPrefix+"TLS_MIN_VERSION", tc.envOverride)
 
-			// noop for this test
 			path, err := writeCertFile(tmpDir, "cert.pem", []byte(certPEM))
 			if err != nil {
 				t.Fatal("Failed to write cert bundle file:", err)
 			}
 
-			// The actual test.
-			if tr, err := newResolverTransport(path, 100, 100); err != nil {
-				t.Error("Got unexpected err:", err)
-			} else if err == nil {
-				if diff := cmp.Diff(tc.expectedMinTLS, tr.TLSClientConfig.MinVersion); diff != "" {
-					t.Errorf("expected min TLS version does not match: %s", diff)
+			tr, err := newResolverTransport(path, 100, 100)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("Expected error, got nil")
 				}
+				return
+			}
+			if err != nil {
+				t.Fatal("Got unexpected err:", err)
+			}
+			if diff := cmp.Diff(tc.expectedMinTLS, tr.TLSClientConfig.MinVersion); diff != "" {
+				t.Errorf("expected min TLS version does not match: %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Replace the hand-rolled `tlsMinVersionFromEnv` helper in the revision reconciler with the shared `knative.dev/pkg/tls` package, allowing TLS settings to be configured via `TAG_TO_DIGEST_TLS_MIN_VERSION`, `TAG_TO_DIGEST_TLS_MAX_VERSION`, `TAG_TO_DIGEST_TLS_CIPHER_SUITES`, and `TAG_TO_DIGEST_TLS_CURVE_PREFERENCES` environment variables. The default minimum version is bumped to TLS 1.3 now that quay.io supports it.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The tag-to-digest resolver now reads TLS settings from environment variables (TAG_TO_DIGEST_TLS_MIN_VERSION, TAG_TO_DIGEST_TLS_MAX_VERSION, TAG_TO_DIGEST_TLS_CIPHER_SUITES, TAG_TO_DIGEST_TLS_CURVE_PREFERENCES) via the shared knative.dev/pkg/tls package. The default minimum TLS version is bumped from 1.2 to 1.3.
```
