### PR TITLE
feat: set IngressRule.Tag from traffic target name

### DIFF
--- a/pkg/reconciler/route/resources/ingress.go
+++ b/pkg/reconciler/route/resources/ingress.go
@@ -155,7 +155,7 @@ func makeIngressSpec(
 				return netv1alpha1.IngressSpec{}, err
 			}
 			domainRules := makeIngressRules(domains, r.Namespace,
-				visibility, tc.Targets[name], ro.RolloutsByTag(name), networkConfig.SystemInternalTLSEnabled())
+				visibility, tc.Targets[name], ro.RolloutsByTag(name), networkConfig.SystemInternalTLSEnabled(), name)
 
 			// Apply tag header routing and ACME merging to each rule
 			for i := range domainRules {
@@ -240,30 +240,32 @@ func makeIngressRules(domains sets.Set[string], ns string,
 	targets traffic.RevisionTargets,
 	roCfgs []*traffic.ConfigurationRollout,
 	encryption bool,
+	tag string,
 ) []netv1alpha1.IngressRule {
 	basePath := makeBaseIngressPath(ns, targets, roCfgs, encryption)
 
 	// ClusterLocal: keep multi-host (no ACME challenges needed)
 	if visibility == netv1alpha1.IngressVisibilityClusterLocal {
-		return []netv1alpha1.IngressRule{makeIngressRuleForHosts(sets.List(domains), visibility, basePath)}
+		return []netv1alpha1.IngressRule{makeIngressRuleForHosts(sets.List(domains), visibility, basePath, tag)}
 	}
 
 	// ExternalIP: create one rule per domain (enables per-host ACME challenge merging)
 	domainList := sets.List(domains)
 	rules := make([]netv1alpha1.IngressRule, 0, len(domainList))
 	for _, domain := range domainList {
-		rules = append(rules, makeIngressRuleForHosts([]string{domain}, visibility, basePath))
+		rules = append(rules, makeIngressRuleForHosts([]string{domain}, visibility, basePath, tag))
 	}
 	return rules
 }
 
-func makeIngressRuleForHosts(hosts []string, visibility netv1alpha1.IngressVisibility, basePath *netv1alpha1.HTTPIngressPath) netv1alpha1.IngressRule {
+func makeIngressRuleForHosts(hosts []string, visibility netv1alpha1.IngressVisibility, basePath *netv1alpha1.HTTPIngressPath, tag string) netv1alpha1.IngressRule {
 	return netv1alpha1.IngressRule{
 		Hosts:      hosts,
 		Visibility: visibility,
 		HTTP: &netv1alpha1.HTTPIngressRuleValue{
 			Paths: []netv1alpha1.HTTPIngressPath{*basePath},
 		},
+		Tag: tag,
 	}
 }
 

--- a/pkg/reconciler/route/resources/ingress_test.go
+++ b/pkg/reconciler/route/resources/ingress_test.go
@@ -400,6 +400,7 @@ func TestMakeIngressWithActualRollout(t *testing.T) {
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityClusterLocal,
+		Tag:        "hammer",
 	}, {
 		Hosts: []string{
 			"hammer-test-route." + ns + ".example.com",
@@ -454,6 +455,7 @@ func TestMakeIngressWithActualRollout(t *testing.T) {
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
+		Tag:        "hammer",
 	}}
 	if got, want := ing.Spec.Rules, wantRules; !cmp.Equal(got, want) {
 		t.Errorf("Rules mismatch: diff(-want,+got)\n%s", cmp.Diff(want, got))
@@ -562,6 +564,7 @@ func TestMakeIngressSpecCorrectRules(t *testing.T) {
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityClusterLocal,
+		Tag:        "v1",
 	}, {
 		Hosts: []string{
 			"v1-test-route." + ns + ".example.com",
@@ -583,6 +586,7 @@ func TestMakeIngressSpecCorrectRules(t *testing.T) {
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
+		Tag:        "v1",
 	}}
 
 	tc := &traffic.Config{Targets: targets}
@@ -811,6 +815,7 @@ func TestMakeIngressSpecCorrectRulesWithTagBasedRouting(t *testing.T) {
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityClusterLocal,
+		Tag:        "v1",
 	}, {
 		Hosts: []string{
 			"v1-test-route." + ns + ".example.com",
@@ -835,6 +840,7 @@ func TestMakeIngressSpecCorrectRulesWithTagBasedRouting(t *testing.T) {
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
+		Tag:        "v1",
 	}}
 
 	ctx := testContext()
@@ -869,7 +875,7 @@ func TestMakeIngressRuleVanilla(t *testing.T) {
 	}
 	ro := tc.BuildRollout()
 	rules := makeIngressRules(domains, ns,
-		netv1alpha1.IngressVisibilityExternalIP, targets, ro.RolloutsByTag(traffic.DefaultTarget), false /* internal encryption */)
+		netv1alpha1.IngressVisibilityExternalIP, targets, ro.RolloutsByTag(traffic.DefaultTarget), false /* internal encryption */, traffic.DefaultTarget)
 
 	// ExternalIP visibility creates one rule per host
 	if len(rules) != 2 {
@@ -930,7 +936,7 @@ func TestMakeIngressRuleZeroPercentTarget(t *testing.T) {
 	}
 	ro := tc.BuildRollout()
 	rules := makeIngressRules(domains, ns,
-		netv1alpha1.IngressVisibilityExternalIP, targets, ro.RolloutsByTag(traffic.DefaultTarget), false /* internal encryption */)
+		netv1alpha1.IngressVisibilityExternalIP, targets, ro.RolloutsByTag(traffic.DefaultTarget), false /* internal encryption */, traffic.DefaultTarget)
 
 	if len(rules) != 1 {
 		t.Fatalf("Expected 1 rule, got %d", len(rules))
@@ -985,7 +991,7 @@ func TestMakeIngressRuleTwoTargets(t *testing.T) {
 	ro := tc.BuildRollout()
 	domains := sets.New("test.org")
 	rules := makeIngressRules(domains, ns, netv1alpha1.IngressVisibilityExternalIP,
-		targets, ro.RolloutsByTag("a-tag"), false /* internal encryption */)
+		targets, ro.RolloutsByTag("a-tag"), false /* internal encryption */, "a-tag")
 
 	if len(rules) != 1 {
 		t.Fatalf("Expected 1 rule, got %d", len(rules))
@@ -1021,6 +1027,7 @@ func TestMakeIngressRuleTwoTargets(t *testing.T) {
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
+		Tag:        "a-tag",
 	}
 
 	if !cmp.Equal(expected, rules[0]) {
@@ -1196,6 +1203,7 @@ func TestMakeIngressWithActivatorCA(t *testing.T) {
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityClusterLocal,
+		Tag:        "v1",
 	}, {
 		Hosts: []string{
 			"v1-test-route." + ns + ".example.com",
@@ -1217,6 +1225,7 @@ func TestMakeIngressWithActivatorCA(t *testing.T) {
 			}},
 		},
 		Visibility: netv1alpha1.IngressVisibilityExternalIP,
+		Tag:        "v1",
 	}}
 
 	tc := &traffic.Config{Targets: targets}

--- a/pkg/reconciler/route/route_test.go
+++ b/pkg/reconciler/route/route_test.go
@@ -681,6 +681,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 				}},
 			},
 			Visibility: v1alpha1.IngressVisibilityClusterLocal,
+			Tag:        "test-revision-1",
 		}, {
 			Hosts: []string{
 				"test-revision-1-test-route.test.test-domain.dev",
@@ -702,6 +703,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 				}},
 			},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			Tag:        "test-revision-1",
 		}, {
 			Hosts: []string{
 				"test-revision-2-test-route.test",
@@ -725,6 +727,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 				}},
 			},
 			Visibility: v1alpha1.IngressVisibilityClusterLocal,
+			Tag:        "test-revision-2",
 		}, {
 			Hosts: []string{
 				"test-revision-2-test-route.test.test-domain.dev",
@@ -746,6 +749,7 @@ func TestCreateRouteWithDuplicateTargets(t *testing.T) {
 				}},
 			},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			Tag:        "test-revision-2",
 		}},
 	}
 
@@ -885,6 +889,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 				}},
 			},
 			Visibility: v1alpha1.IngressVisibilityClusterLocal,
+			Tag:        "bar",
 		}, {
 			Hosts: []string{"bar-test-route.test.test-domain.dev"},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
@@ -904,6 +909,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 				}},
 			},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			Tag:        "bar",
 		}, {
 			Hosts: []string{
 				"foo-test-route.test",
@@ -927,6 +933,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 				}},
 			},
 			Visibility: v1alpha1.IngressVisibilityClusterLocal,
+			Tag:        "foo",
 		}, {
 			Hosts: []string{"foo-test-route.test.test-domain.dev"},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
@@ -946,6 +953,7 @@ func TestCreateRouteWithNamedTargets(t *testing.T) {
 				}},
 			},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			Tag:        "foo",
 		}},
 	}
 
@@ -1183,6 +1191,7 @@ func TestCreateRouteWithNamedTargetsAndTagBasedRouting(t *testing.T) {
 				}},
 			},
 			Visibility: v1alpha1.IngressVisibilityClusterLocal,
+			Tag:        "bar",
 		}, {
 			Hosts: []string{
 				"bar-test-route.test.test-domain.dev",
@@ -1207,6 +1216,7 @@ func TestCreateRouteWithNamedTargetsAndTagBasedRouting(t *testing.T) {
 				}},
 			},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			Tag:        "bar",
 		}, {
 			Hosts: []string{
 				"foo-test-route.test",
@@ -1233,6 +1243,7 @@ func TestCreateRouteWithNamedTargetsAndTagBasedRouting(t *testing.T) {
 				}},
 			},
 			Visibility: v1alpha1.IngressVisibilityClusterLocal,
+			Tag:        "foo",
 		}, {
 			Hosts: []string{"foo-test-route.test.test-domain.dev"},
 			HTTP: &v1alpha1.HTTPIngressRuleValue{
@@ -1255,6 +1266,7 @@ func TestCreateRouteWithNamedTargetsAndTagBasedRouting(t *testing.T) {
 				}},
 			},
 			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			Tag:        "foo",
 		}},
 	}
 

--- a/vendor/knative.dev/networking/config/ingress.yaml
+++ b/vendor/knative.dev/networking/config/ingress.yaml
@@ -203,6 +203,9 @@ spec:
                                           - type: integer
                                           - type: string
                                         x-kubernetes-int-or-string: true
+                      tag:
+                        description: Tag is the name of the traffic tag associated with this rule.
+                        type: string
                       visibility:
                         description: |-
                           Visibility signifies whether this rule should `ClusterLocal`. If it's not

--- a/vendor/knative.dev/networking/pkg/apis/networking/v1alpha1/ingress_types.go
+++ b/vendor/knative.dev/networking/pkg/apis/networking/v1alpha1/ingress_types.go
@@ -177,6 +177,10 @@ type IngressRule struct {
 	// HTTP represents a rule to apply against incoming requests. If the
 	// rule is satisfied, the request is routed to the specified backend.
 	HTTP *HTTPIngressRuleValue `json:"http,omitempty"`
+
+	// Tag is the name of the traffic tag associated with this rule.
+	// +optional
+	Tag string `json:"tag,omitzero"`
 }
 
 // HTTPIngressRuleValue is a list of http selectors pointing to backends.


### PR DESCRIPTION
Populate the new Tag field when building IngressRules so that downstream ingress controllers can trace generated resources back to their originating traffic tag.

## Proposed Changes

When a Knative Service has traffic tags, tagged HTTPRoutes are generated but have no metadata indicating which tag they belong to. This makes it difficult for external tools to identify the traffic tag from HTTPRoute resources.

The root cause is that `IngressRule` does not carry the tag name — it is only encoded in the hostname, forcing downstream controllers to reverse-parse it with fragile template-based heuristics.

This PR populates the new `IngressRule.Tag` field (added in knative/networking) with the traffic target name during route reconciliation, so that downstream ingress controllers can propagate the tag as labels on generated resources (e.g. HTTPRoute, HTTPProxy).

* :gift: Add `tag string` parameter to `makeIngressRules()` and `makeIngressRuleForHosts()`
* :gift: Set `IngressRule.Tag` from the traffic target name in `makeIngressSpec()`
* :broom: Update tests to reflect the new `Tag` field on `IngressRule`

## Related PRs

- https://github.com/knative/networking/pull/1116 (must be merged first — adds the `Tag` field to `IngressRule`)

## Context

In https://github.com/knative-extensions/net-gateway-api/pull/931, we attempted to add a tag label to HTTPRoute by reverse-parsing the hostname using the tag template. However, since the tag template format is highly configurable, this approach turned out to be fragile. We concluded that the upstream `IngressRule` should carry the tag name explicitly rather than relying on hostname heuristics.

**Release Note**

```release-note
Populate `IngressRule.Tag` with the traffic target name so that downstream ingress controllers can identify the originating traffic tag on generated resources.
```
