### PR TITLE
Add endpointslices/restricted permission to ClusterRole

### DIFF
--- a/config/core/200-roles/clusterrole.yaml
+++ b/config/core/200-roles/clusterrole.yaml
@@ -27,6 +27,9 @@ rules:
   - apiGroups: [""]
     resources: ["endpoints/restricted"] # Permission for RestrictedEndpointsAdmission
     verbs: ["create"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices/restricted"] # Permission for RestrictedEndpointsAdmission
+    verbs: ["create"]
   - apiGroups: [""]
     resources: ["namespaces/finalizers"] # finalizers are needed for the owner reference of the webhook
     verbs: ["update"]


### PR DESCRIPTION
Related to #16448 and still used in
https://github.com/openshift/kubernetes/blob/2034d92b4a3a51d42e306ba405fc10a89768ac69/openshift-kube-apiserver/admission/network/restrictedendpoints/endpoint_admission.go#L242-L243
