### PR TITLE
hack: remove deprecated GO111MODULE=on

### DIFF
--- a/hack/update-checksums.sh
+++ b/hack/update-checksums.sh
@@ -18,8 +18,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export GO111MODULE=on
-
 if [ -z "${GOPATH:-}" ]; then
   export GOPATH=$(go env GOPATH)
 fi

--- a/hack/update-reference-docs.sh
+++ b/hack/update-reference-docs.sh
@@ -18,8 +18,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export GO111MODULE=on
-
 if [ -z "${GOPATH:-}" ]; then
   export GOPATH=$(go env GOPATH)
 fi


### PR DESCRIPTION
Fixes #16498

## Changes

Remove the `export GO111MODULE=on` line from `hack/update-checksums.sh` and `hack/update-reference-docs.sh`.

`GO111MODULE` has been a no-op since Go 1.16 and is deprecated in Go 1.25. All other `hack/` scripts already omit it.