### PR TITLE
hack/boilerplate: add set -o nounset and set -o pipefail

### DIFF
--- a/hack/boilerplate/add-boilerplate.sh
+++ b/hack/boilerplate/add-boilerplate.sh
@@ -25,7 +25,9 @@ Example: (from repository root)
 EOF
 )
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 if [[ -z $1 || -z $2 ]]; then
   echo "${USAGE}"


### PR DESCRIPTION
Fixes #16500

## Changes

Replace `set -e` with `set -o errexit -o nounset -o pipefail` in `hack/boilerplate/add-boilerplate.sh`, consistent with every other script in `hack/`.

Without `nounset`, undefined variable references silently expand to empty strings. Without `pipefail`, a failing command inside a pipeline (e.g. `grep … | xargs …`) is masked.