### PR TITLE
ci: pin registry image to immutable SHA digest

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -53,7 +53,7 @@ jobs:
         docker run -d --restart=always \
           -p $REGISTRY_PORT:$REGISTRY_PORT \
           -v ~/artifacts/registry:/var/lib/registry \
-          --name $REGISTRY_NAME registry:3.0.0
+          --name $REGISTRY_NAME registry:3.0.0@sha256:6c5666b861f3505b116bb9aa9b25175e71210414bd010d92035ff64018f9457e
 
         # Make the $REGISTRY_NAME -> 127.0.0.1, to tell `ko` to publish to
         # local reigstry, even when pushing $REGISTRY_NAME:$REGISTRY_PORT/some/image


### PR DESCRIPTION
Fixes #16502

## Changes

Pin the local Docker registry image to an immutable SHA digest in `kind-e2e.yaml`.

Using a mutable tag (`registry:2`) pulls whatever Docker Hub resolves at job runtime, breaking reproducibility. This pins to `registry:3.0.0@sha256:6c5666b861f3505b116bb9aa9b25175e71210414bd010d92035ff64018f9457e`, ensuring CI always pulls the exact same image.