### PR TITLE
hack: add missing set -o nounset to generate-yamls.sh

### DIFF
--- a/hack/generate-yamls.sh
+++ b/hack/generate-yamls.sh
@@ -36,6 +36,7 @@
 # * `$KO_DOCKER_REPO` If not set, use ko.local as the registry.
 
 set -o errexit
+set -o nounset
 set -o pipefail
 
 readonly YAML_REPO_ROOT=${1:?"First argument must be the repo root dir"}


### PR DESCRIPTION
Fixes #16504

## Changes

Add `set -o nounset` to `hack/generate-yamls.sh`, bringing it in line with every other script in `hack/` which already uses the full `set -o errexit -o nounset -o pipefail` pattern.

Without `nounset`, undefined variable references silently expand to empty strings instead of failing fast with a clear error.