### PR TITLE
use the /scale subresource to when updating replica count

### DIFF
--- a/config/core/200-roles/clusterrole.yaml
+++ b/config/core/200-roles/clusterrole.yaml
@@ -67,3 +67,6 @@ rules:
     resources: ["clusterroles"]
     verbs: ["delete"]
     resourceNames: ["knative-serving-certmanager"]
+  - apiGroups: ["*"]
+    resources: ["*/scale"]
+    verbs: ["patch"]

--- a/docs/serving-api.md
+++ b/docs/serving-api.md
@@ -565,18 +565,6 @@ Kubernetes meta/v1.LabelSelector
 <td>
 </td>
 </tr>
-<tr>
-<td>
-<code>template</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core">
-Kubernetes core/v1.PodTemplateSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
 </table>
 </td>
 </tr>
@@ -627,18 +615,6 @@ int32
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code><br/>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podtemplatespec-v1-core">
-Kubernetes core/v1.PodTemplateSpec
 </a>
 </em>
 </td>

--- a/pkg/apis/autoscaling/v1alpha1/podscalable_types.go
+++ b/pkg/apis/autoscaling/v1alpha1/podscalable_types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
@@ -43,9 +42,8 @@ type PodScalable struct {
 // PodScalableSpec is the specification for the desired state of a
 // PodScalable (or at least our shared portion).
 type PodScalableSpec struct {
-	Replicas *int32                 `json:"replicas,omitempty"`
-	Selector *metav1.LabelSelector  `json:"selector"`
-	Template corev1.PodTemplateSpec `json:"template"`
+	Replicas *int32                `json:"replicas,omitempty"`
+	Selector *metav1.LabelSelector `json:"selector"`
 }
 
 // PodScalableStatus is the observed state of a PodScalable (or at
@@ -79,19 +77,6 @@ func (t *PodScalable) Populate() {
 				Operator: "In",
 				Values:   []string{"baz", "blah"},
 			}},
-		},
-		Template: corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					"foo": "bar",
-				},
-			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{
-					Name:  "container-name",
-					Image: "container-image:latest",
-				}},
-			},
 		},
 	}
 	t.Status = PodScalableStatus{

--- a/pkg/apis/autoscaling/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/autoscaling/v1alpha1/zz_generated.deepcopy.go
@@ -299,7 +299,6 @@ func (in *PodScalableSpec) DeepCopyInto(out *PodScalableSpec) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
-	in.Template.DeepCopyInto(&out.Template)
 	return
 }
 

--- a/pkg/reconciler/autoscaling/kpa/kpa_test.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa_test.go
@@ -264,7 +264,7 @@ func TestReconcile(t *testing.T) {
 	minScalePatch := clientgotesting.PatchActionImpl{
 		ActionImpl: clientgotesting.ActionImpl{Namespace: testNamespace},
 		Name:       deployName,
-		Patch:      []byte(fmt.Sprintf(`[{"op":"replace","path":"/spec/replicas","value":%d}]`, defaultScale)),
+		Patch:      fmt.Appendf(nil, `[{"op":"add","path":"/spec/replicas","value":%d}]`, defaultScale),
 	}
 
 	inactiveKPAMinScale := func(g int32) *autoscalingv1alpha1.PodAutoscaler {
@@ -1030,7 +1030,7 @@ func TestReconcile(t *testing.T) {
 		WantPatches: []clientgotesting.PatchActionImpl{{
 			ActionImpl: clientgotesting.ActionImpl{Namespace: testNamespace},
 			Name:       deployName,
-			Patch:      []byte(fmt.Sprintf(`[{"op":"replace","path":"/spec/replicas","value":%d}]`, 20)),
+			Patch:      fmt.Appendf(nil, `[{"op":"add","path":"/spec/replicas","value":%d}]`, 20),
 		}},
 	}, {
 		Name: "initial scale reached, mark PA as active",
@@ -1058,7 +1058,7 @@ func TestReconcile(t *testing.T) {
 		WantPatches: []clientgotesting.PatchActionImpl{{
 			ActionImpl: clientgotesting.ActionImpl{Namespace: testNamespace},
 			Name:       deployName,
-			Patch:      []byte(fmt.Sprintf(`[{"op":"replace","path":"/spec/replicas","value":%d}]`, 20)),
+			Patch:      fmt.Appendf(nil, `[{"op":"add","path":"/spec/replicas","value":%d}]`, 20),
 		}},
 	}, {
 		Name: "initial scale zero: scale to zero",

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -298,7 +298,10 @@ func (ks *scaler) handleScaleToZero(ctx context.Context, pa *autoscalingv1alpha1
 	}
 }
 
-func (ks *scaler) applyScale(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscaler, desiredScale int32,
+func (ks *scaler) applyScale(
+	ctx context.Context,
+	pa *autoscalingv1alpha1.PodAutoscaler,
+	desiredScale int32,
 	ps *autoscalingv1alpha1.PodScalable,
 ) error {
 	logger := logging.FromContext(ctx)
@@ -308,19 +311,15 @@ func (ks *scaler) applyScale(ctx context.Context, pa *autoscalingv1alpha1.PodAut
 		return err
 	}
 
-	psNew := ps.DeepCopy()
-	psNew.Spec.Replicas = &desiredScale
-	patch, err := duck.CreatePatch(ps, psNew)
-	if err != nil {
-		return err
-	}
-	patchBytes, err := patch.MarshalJSON()
-	if err != nil {
-		return err
-	}
+	patch := fmt.Sprintf(`[{"op":"add","path":"/spec/replicas","value":%d}]`, desiredScale)
 
-	_, err = ks.dynamicClient.Resource(*gvr).Namespace(pa.Namespace).Patch(ctx, ps.Name, types.JSONPatchType,
-		patchBytes, metav1.PatchOptions{})
+	_, err = ks.dynamicClient.Resource(*gvr).Namespace(pa.Namespace).Patch(
+		ctx,
+		ps.Name,
+		types.JSONPatchType,
+		[]byte(patch),
+		metav1.PatchOptions{},
+		"scale")
 	if err != nil {
 		return fmt.Errorf("failed to apply scale %d to scale target %s: %w", desiredScale, name, err)
 	}

--- a/pkg/reconciler/autoscaling/kpa/scaler_test.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler_test.go
@@ -785,7 +785,7 @@ func checkReplicas(t *testing.T, dynamicClient *fakedynamic.FakeDynamicClient, d
 			if patch.GetName() != deployment.Name {
 				continue
 			}
-			want := fmt.Sprintf(`[{"op":"replace","path":"/spec/replicas","value":%d}]`, expectedScale)
+			want := fmt.Sprintf(`[{"op":"add","path":"/spec/replicas","value":%d}]`, expectedScale)
 			if got := string(patch.GetPatch()); got != want {
 				t.Errorf("Patch = %s, wanted %s", got, want)
 			}


### PR DESCRIPTION
This replaces https://github.com/knative/serving/pull/16419

Fixes https://github.com/knative/serving/issues/15528

Some notable differences 
- don't use the scale client `Get` since that is an API call - we don't want to do that for every scale call.
  - use the existing PodScalable resource which has the currentScale
- Drop `spec.template` from `PodScalable` since we don't need it to scale the resource
  - This saves memory in the autoscaler and controller
- This has the added benefit of not having to DeepCopy and computing a
JSONPatch via diffing two json byte strings which would take about 400ms

For now we expected the `spec.replicas` to be the patch required to update the replica count.

Note: we don't use the scale client to `Get` the resource prior since it will hit the API server

## Release Note
```release-note
Autoscaler now supports CRDs that implement the `/scale` subresource for updating
```
