### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ 'main', 'release-*' ]
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
Fixes #16555

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Currently the score for the Token Permissions is 0 because the top level permissions and a few job level permissions are missing in the workflows. With this change, the score will move to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

* Add top-level `permissions: contents: read` to workflows that were missing it.
* Tighten job-level permissions, retaining `write` only where necessary.
* ~Tests~ (not applicable — workflow permission changes only)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
