### PR TITLE
Address linter warnings now that we've bumped to go1.26

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -183,6 +183,9 @@ linters:
       - std-error-handling
     rules:
       - linters:
+          - prealloc
+        path: _test\.go
+      - linters:
           - staticcheck
         text: corev1.Endpoint.* is deprecated
       - linters:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -186,6 +186,9 @@ linters:
           - prealloc
         path: _test\.go
       - linters:
+          - prealloc
+        path: cmd/schema-tweak/overrides.go
+      - linters:
           - staticcheck
         text: corev1.Endpoint.* is deprecated
       - linters:

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -159,6 +159,8 @@ func newConfigValidationController(ctx context.Context, cmw configmap.Watcher) *
 
 func main() {
 	// Set up a signal context with our webhook options
+	//
+	//nolint:gosec // not a leaked secret
 	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
 		ServiceName: webhook.NameFromEnv(),
 		Port:        webhook.PortFromEnv(8443),

--- a/pkg/apis/serving/register.go
+++ b/pkg/apis/serving/register.go
@@ -116,6 +116,7 @@ const (
 
 	// QueueSidecarResourcePercentageAnnotationKey is the percentage of user container resources to be used for queue-proxy
 	// It has to be in [0.1,100]
+	//
 	// Deprecated: Please consider setting resources explicitly for the QP per service, see `QueueSidecarCPUResourceRequestAnnotationKey` for example.
 	QueueSidecarResourcePercentageAnnotationKey = "queue.sidecar." + GroupName + "/resource-percentage"
 

--- a/pkg/apis/serving/v1/revision_validation_test.go
+++ b/pkg/apis/serving/v1/revision_validation_test.go
@@ -909,6 +909,7 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 		rts: &RevisionTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
+					//nolint
 					serving.QueueSidecarResourcePercentageAnnotationKey: "200",
 				},
 			},
@@ -922,13 +923,15 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 		},
 		want: (&apis.FieldError{
 			Message: "expected 0.1 <= 200 <= 100",
-			Paths:   []string{"[" + serving.QueueSidecarResourcePercentageAnnotationKey + "]"},
+			//nolint
+			Paths: []string{"[" + serving.QueueSidecarResourcePercentageAnnotationKey + "]"},
 		}).ViaField("metadata.annotations"),
 	}, {
 		name: "Invalid queue sidecar resource percentage annotation",
 		rts: &RevisionTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
+					//nolint
 					serving.QueueSidecarResourcePercentageAnnotationKey: "50mx",
 				},
 			},
@@ -942,7 +945,8 @@ func TestRevisionTemplateSpecValidation(t *testing.T) {
 		},
 		want: (&apis.FieldError{
 			Message: "invalid value: 50mx",
-			Paths:   []string{fmt.Sprintf("[%s]", serving.QueueSidecarResourcePercentageAnnotationKey)},
+			//nolint
+			Paths: []string{fmt.Sprintf("[%s]", serving.QueueSidecarResourcePercentageAnnotationKey)},
 		}).ViaField("metadata.annotations"),
 	}, {
 		name: "Invalid queue sidecar resource annotations",
@@ -1174,6 +1178,7 @@ func autoscalerConfigCtx(allowInitialScaleZero bool, initialScale int) context.C
 }
 
 func TestValidateQueueSidecarAnnotation(t *testing.T) {
+	//nolint
 	resourcePercentageDeprecationWarning := apis.ErrGeneric("Queue proxy resource percentage annotation is deprecated. Please use the available annotations to explicitly set resource values per service").
 		ViaKey(serving.QueueSidecarResourcePercentageAnnotationKey).At(apis.WarningLevel)
 
@@ -1184,29 +1189,34 @@ func TestValidateQueueSidecarAnnotation(t *testing.T) {
 	}{{
 		name: "too small",
 		annotation: map[string]string{
+			//nolint
 			serving.QueueSidecarResourcePercentageAnnotationKey: "0.01982",
 		},
 		expectErr: (&apis.FieldError{
 			Message: "expected 0.1 <= 0.01982 <= 100",
-			Paths:   []string{fmt.Sprintf("[%s]", serving.QueueSidecarResourcePercentageAnnotationKey)},
+			//nolint
+			Paths: []string{fmt.Sprintf("[%s]", serving.QueueSidecarResourcePercentageAnnotationKey)},
 		}).Also(resourcePercentageDeprecationWarning),
 	}, {
 		name: "too big for Queue sidecar resource percentage annotation",
 		annotation: map[string]string{
-			serving.QueueSidecarResourcePercentageAnnotationKey: "100.0001",
+			serving.QueueSidecarResourcePercentageAnnotationKey: "100.0001", //nolint
 		},
 		expectErr: (&apis.FieldError{
 			Message: "expected 0.1 <= 100.0001 <= 100",
-			Paths:   []string{fmt.Sprintf("[%s]", serving.QueueSidecarResourcePercentageAnnotationKey)},
+			//nolint
+			Paths: []string{fmt.Sprintf("[%s]", serving.QueueSidecarResourcePercentageAnnotationKey)},
 		}).Also(resourcePercentageDeprecationWarning),
 	}, {
 		name: "Invalid queue sidecar resource percentage annotation",
 		annotation: map[string]string{
+			//nolint
 			serving.QueueSidecarResourcePercentageAnnotationKey: "",
 		},
 		expectErr: (&apis.FieldError{
 			Message: "invalid value: ",
-			Paths:   []string{fmt.Sprintf("[%s]", serving.QueueSidecarResourcePercentageAnnotationKey)},
+			//nolint
+			Paths: []string{fmt.Sprintf("[%s]", serving.QueueSidecarResourcePercentageAnnotationKey)},
 		}).Also(resourcePercentageDeprecationWarning),
 	}, {
 		name:       "empty annotation",
@@ -1219,12 +1229,14 @@ func TestValidateQueueSidecarAnnotation(t *testing.T) {
 	}, {
 		name: "valid value for Queue sidecar resource percentage annotation",
 		annotation: map[string]string{
+			//nolint
 			serving.QueueSidecarResourcePercentageAnnotationKey: "0.1",
 		},
 		expectErr: resourcePercentageDeprecationWarning,
 	}, {
 		name: "valid value for Queue sidecar resource percentage annotation",
 		annotation: map[string]string{
+			//nolint
 			serving.QueueSidecarResourcePercentageAnnotationKey: "100",
 		},
 		expectErr: resourcePercentageDeprecationWarning,

--- a/pkg/autoscaler/metrics/http_scrape_client.go
+++ b/pkg/autoscaler/metrics/http_scrape_client.go
@@ -53,7 +53,7 @@ func newHTTPScrapeClient(httpClient *http.Client) *httpScrapeClient {
 
 func (c *httpScrapeClient) Do(req *http.Request) (Stat, error) {
 	req.Header.Add("Accept", netheader.ProtobufMIMEType)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: URL is trusted
 	if err != nil {
 		return emptyStat, err
 	}

--- a/pkg/autoscaler/scaling/autoscaler.go
+++ b/pkg/autoscaler/scaling/autoscaler.go
@@ -124,7 +124,7 @@ func newAutoscaler(
 		delayWindow: delayWindow,
 
 		panicTime:    pt,
-		maxPanicPods: int32(curC), //nolint:gosec // k8s replica count is bounded by int32
+		maxPanicPods: int32(curC),
 		metrics:      metrics,
 	}
 }

--- a/pkg/queue/health/probe.go
+++ b/pkg/queue/health/probe.go
@@ -217,6 +217,7 @@ func GRPCProbe(config GRPCProbeConfigOptions) error {
 	dialer := &net.Dialer{
 		Control: func(network, address string, c syscall.RawConn) error {
 			return c.Control(func(fd uintptr) {
+				//nolint:gosec // G115: fd is a valid OS file descriptor
 				unix.SetsockoptLinger(int(fd), syscall.SOL_SOCKET, syscall.SO_LINGER, &unix.Linger{Onoff: 1, Linger: 1})
 			})
 		},

--- a/pkg/queue/protobuf_stats_reporter.go
+++ b/pkg/queue/protobuf_stats_reporter.go
@@ -88,5 +88,5 @@ func (r *ProtobufStatsReporter) ServeHTTP(w http.ResponseWriter, _ *http.Request
 	}
 
 	w.Header().Set(contentTypeHeader, netheader.ProtobufMIMEType)
-	w.Write(buffer)
+	w.Write(buffer) //nolint:gosec // G705: protobuf stats output, not HTML response
 }

--- a/pkg/queue/readiness/probe.go
+++ b/pkg/queue/readiness/probe.go
@@ -87,7 +87,7 @@ func (gv *gateValue) read() bool {
 
 // NewProbe returns a pointer to a new Probe.
 func NewProbe(probes []*corev1.Probe) *Probe {
-	wrappedProbes := []*wrappedProbe{}
+	wrappedProbes := make([]*wrappedProbe, 0, len(probes))
 	for _, p := range probes {
 		wrappedProbes = append(wrappedProbes, &wrappedProbe{
 			Probe:       p,
@@ -104,7 +104,7 @@ func NewProbe(probes []*corev1.Probe) *Probe {
 // NewProbeWithHTTP2AutoDetection returns a pointer to a new Probe that has HTTP2
 // auto-detection enabled.
 func NewProbeWithHTTP2AutoDetection(probes []*corev1.Probe) *Probe {
-	wrappedProbes := []*wrappedProbe{}
+	wrappedProbes := make([]*wrappedProbe, 0, len(probes))
 	for _, p := range probes {
 		wrappedProbes = append(wrappedProbes, &wrappedProbe{
 			Probe:           p,

--- a/pkg/reconciler/domainmapping/reconciler.go
+++ b/pkg/reconciler/domainmapping/reconciler.go
@@ -19,6 +19,7 @@ package domainmapping
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -208,7 +209,6 @@ func (r *Reconciler) tls(ctx context.Context, dm *v1beta1.DomainMapping) ([]netv
 		return nil, nil, nil
 	}
 
-	acmeChallenges := []netv1alpha1.HTTP01Challenge{}
 	desiredCert := resources.MakeCertificate(dm, certClass(ctx))
 	cert, err := networkaccessor.ReconcileCertificate(ctx, dm, desiredCert, r)
 	if err != nil {
@@ -238,8 +238,8 @@ func (r *Reconciler) tls(ctx context.Context, dm *v1beta1.DomainMapping) ([]netv
 		// Otherwise, mark certificate not ready.
 		dm.Status.MarkCertificateNotReady(cert.Name)
 	}
-	acmeChallenges = append(acmeChallenges, cert.Status.HTTP01Challenges...)
 
+	acmeChallenges := slices.Clone(cert.Status.HTTP01Challenges)
 	sort.Slice(acmeChallenges, func(i, j int) bool {
 		return acmeChallenges[i].URL.String() < acmeChallenges[j].URL.String()
 	})

--- a/pkg/reconciler/revision/resources/queue_test.go
+++ b/pkg/reconciler/revision/resources/queue_test.go
@@ -542,6 +542,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 		rev: revision("bar", "foo",
 			func(revision *v1.Revision) {
 				revision.Annotations = map[string]string{
+					//nolint
 					serving.QueueSidecarResourcePercentageAnnotationKey: "20",
 				}
 				revision.Spec.PodSpec.Containers = []corev1.Container{{
@@ -567,6 +568,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 		rev: revision("bar", "foo",
 			func(revision *v1.Revision) {
 				revision.Annotations = map[string]string{
+					//nolint
 					serving.QueueSidecarResourcePercentageAnnotationKey: "0.2",
 				}
 				revision.Spec.PodSpec.Containers = []corev1.Container{{
@@ -592,6 +594,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 		rev: revision("bar", "foo",
 			func(revision *v1.Revision) {
 				revision.Annotations = map[string]string{
+					//nolint
 					serving.QueueSidecarResourcePercentageAnnotationKey: "foo",
 				}
 				revision.Spec.PodSpec.Containers = []corev1.Container{{
@@ -619,6 +622,7 @@ func TestMakeQueueContainerWithPercentageAnnotation(t *testing.T) {
 		rev: revision("bar", "foo",
 			func(revision *v1.Revision) {
 				revision.Annotations = map[string]string{
+					//nolint
 					serving.QueueSidecarResourcePercentageAnnotationKey: "100",
 				}
 				revision.Spec.PodSpec.Containers = []corev1.Container{{
@@ -729,7 +733,8 @@ func TestMakeQueueContainerWithResourceAnnotations(t *testing.T) {
 				revision.Annotations = map[string]string{
 					serving.QueueSidecarCPUResourceLimitAnnotationKey:    "1",
 					serving.QueueSidecarMemoryResourceLimitAnnotationKey: "4Gi",
-					serving.QueueSidecarResourcePercentageAnnotationKey:  "50",
+					//nolint
+					serving.QueueSidecarResourcePercentageAnnotationKey: "50",
 				}
 				revision.Spec.PodSpec.Containers = []corev1.Container{{
 					Name:           servingContainerName,

--- a/test/e2e/helloworld_test.go
+++ b/test/e2e/helloworld_test.go
@@ -103,6 +103,7 @@ func TestQueueSideCarResourceLimit(t *testing.T) {
 				corev1.ResourceMemory: resource.MustParse("258Mi"),
 			},
 		}), rtesting.WithConfigAnnotations(map[string]string{
+			//nolint
 			serving.QueueSidecarResourcePercentageAnnotationKey: "0.2",
 		}))
 	if err != nil {


### PR DESCRIPTION
- **ignore prealloc in test files**
- **drop unused nolint directive**
- **address linter issues**


/assign @linkvt 