### PR TITLE
fix: skip MarkRevisionCreationFailed for transient network errors

### DIFF
--- a/pkg/apis/serving/v1/configuration_lifecycle.go
+++ b/pkg/apis/serving/v1/configuration_lifecycle.go
@@ -109,6 +109,17 @@ func (cs *ConfigurationStatus) MarkRevisionCreationFailed(message string) {
 		"Revision creation failed with message: %s.", message)
 }
 
+// MarkRevisionCreationRetrying marks the ConfigurationConditionReady condition
+// as Unknown to indicate a transient error occurred during Revision creation
+// and the reconciler will retry. Using Unknown (not False) prevents clients
+// from treating retryable infrastructure blips as permanent failures.
+func (cs *ConfigurationStatus) MarkRevisionCreationRetrying(message string) {
+	configCondSet.Manage(cs).MarkUnknown(
+		ConfigurationConditionReady,
+		"RevisionCreationRetrying",
+		"Revision creation failed transiently and will be retried: %s.", message)
+}
+
 // MarkLatestReadyDeleted marks the ConfigurationConditionReady condition to
 // indicate that the Revision was deleted.
 func (cs *ConfigurationStatus) MarkLatestReadyDeleted() {

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -18,13 +18,15 @@ package configuration
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
+	"net/url"
 	"sort"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -65,9 +67,9 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, config *v1.Configuration
 
 	// First, fetch the revision that should exist for the current generation.
 	lcr, isBYOName, err := c.latestCreatedRevision(ctx, config)
-	if errors.IsNotFound(err) {
+	if apierrs.IsNotFound(err) {
 		lcr, err = c.createRevision(ctx, config)
-		if errors.IsAlreadyExists(err) {
+		if apierrs.IsAlreadyExists(err) {
 			// Newer revisions with a consistent naming scheme can theoretically hit this
 			// path during normal operation so we don't actually report any failures to
 			// the user.
@@ -76,11 +78,12 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, config *v1.Configuration
 			return fmt.Errorf("failed to create Revision: %w", err)
 		} else if err != nil {
 			recorder.Eventf(config, corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision: %v", err)
-			config.Status.MarkRevisionCreationFailed(err.Error())
-
+			if !isTransientCreateError(err) {
+				config.Status.MarkRevisionCreationFailed(err.Error())
+			}
 			return fmt.Errorf("failed to create Revision: %w", err)
 		}
-	} else if errors.IsAlreadyExists(err) {
+	} else if apierrs.IsAlreadyExists(err) {
 		// If we get an already-exists error from latestCreatedRevision it means
 		// that the Revision name already exists for another Configuration or at
 		// the wrong generation of this configuration.
@@ -239,10 +242,10 @@ func CheckNameAvailability(ctx context.Context, config *v1.Configuration, lister
 	if name == "" {
 		return nil, nil
 	}
-	errConflict := errors.NewAlreadyExists(v1.Resource("revisions"), name)
+	errConflict := apierrs.NewAlreadyExists(v1.Resource("revisions"), name)
 
 	rev, err := lister.Revisions(config.Namespace).Get(name)
-	if errors.IsNotFound(err) {
+	if apierrs.IsNotFound(err) {
 		// Does not exist, we must be good!
 		// note: for the name to change the generation must change.
 		return nil, err
@@ -293,7 +296,7 @@ func (c *Reconciler) latestCreatedRevision(ctx context.Context, config *v1.Confi
 		return list[0], false, nil
 	}
 
-	return nil, false, errors.NewNotFound(v1.Resource("revisions"), "revision for "+config.Name)
+	return nil, false, apierrs.NewNotFound(v1.Resource("revisions"), "revision for "+config.Name)
 }
 
 func (c *Reconciler) createRevision(ctx context.Context, config *v1.Configuration) (*v1.Revision, error) {
@@ -308,4 +311,20 @@ func (c *Reconciler) createRevision(ctx context.Context, config *v1.Configuratio
 	logger.Infof("Created Revision: %#v", created)
 
 	return created, nil
+}
+
+// isTransientCreateError returns true for errors that are likely transient
+// (network blips, webhook timeouts, API server overload) and should not cause
+// the Configuration status to be marked as permanently failed. The reconciler
+// will retry, and the status should stay Unknown rather than flip to False.
+func isTransientCreateError(err error) bool {
+	if apierrs.IsInternalError(err) ||
+		apierrs.IsServiceUnavailable(err) ||
+		apierrs.IsServerTimeout(err) ||
+		apierrs.IsTimeout(err) ||
+		apierrs.IsTooManyRequests(err) {
+		return true
+	}
+	var urlErr *url.Error
+	return stderrors.As(err, &urlErr)
 }

--- a/pkg/reconciler/configuration/configuration.go
+++ b/pkg/reconciler/configuration/configuration.go
@@ -18,9 +18,7 @@ package configuration
 
 import (
 	"context"
-	stderrors "errors"
 	"fmt"
-	"net/url"
 	"sort"
 	"strconv"
 
@@ -78,7 +76,9 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, config *v1.Configuration
 			return fmt.Errorf("failed to create Revision: %w", err)
 		} else if err != nil {
 			recorder.Eventf(config, corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision: %v", err)
-			if !isTransientCreateError(err) {
+			if isTransientCreateError(err) {
+				config.Status.MarkRevisionCreationRetrying(err.Error())
+			} else {
 				config.Status.MarkRevisionCreationFailed(err.Error())
 			}
 			return fmt.Errorf("failed to create Revision: %w", err)
@@ -314,17 +314,20 @@ func (c *Reconciler) createRevision(ctx context.Context, config *v1.Configuratio
 }
 
 // isTransientCreateError returns true for errors that are likely transient
-// (network blips, webhook timeouts, API server overload) and should not cause
-// the Configuration status to be marked as permanently failed. The reconciler
-// will retry, and the status should stay Unknown rather than flip to False.
+// (webhook timeouts, API server overload, rate limiting) and should result in
+// a retry rather than a permanent RevisionFailed status. Only HTTP status codes
+// whose semantics are definitively transient are included here.
+//
+// NOTE: IsInternalError (HTTP 500) is included because webhook infrastructure
+// failures surface as InternalError (e.g. "failed calling webhook: context
+// deadline exceeded"). A webhook that permanently rejects a spec typically
+// returns Forbidden or Invalid, not InternalError. However, a webhook service
+// that is permanently unreachable (deleted, wrong DNS) also surfaces as
+// InternalError, so there is no perfect distinction at this layer.
 func isTransientCreateError(err error) bool {
-	if apierrs.IsInternalError(err) ||
+	return apierrs.IsInternalError(err) ||
 		apierrs.IsServiceUnavailable(err) ||
 		apierrs.IsServerTimeout(err) ||
 		apierrs.IsTimeout(err) ||
-		apierrs.IsTooManyRequests(err) {
-		return true
-	}
-	var urlErr *url.Error
-	return stderrors.As(err, &urlErr)
+		apierrs.IsTooManyRequests(err)
 }

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -19,7 +19,6 @@ package configuration
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -375,7 +374,7 @@ func TestReconcile(t *testing.T) {
 		WithReactors: []clientgotesting.ReactionFunc{
 			func(action clientgotesting.Action) (bool, runtime.Object, error) {
 				if action.Matches("create", "revisions") {
-					return true, nil, apierrs.NewInternalError(fmt.Errorf("failed calling webhook: context deadline exceeded"))
+					return true, nil, apierrs.NewInternalError(errors.New("failed calling webhook: context deadline exceeded"))
 				}
 				return false, nil, nil
 			},

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 	"testing"
 	"time"
 
@@ -367,10 +366,11 @@ func TestReconcile(t *testing.T) {
 		},
 		Key: "foo/create-revision-failure",
 	}, {
-		Name: "transient failure creating revision (internal server error) - status not marked failed",
+		Name: "transient failure creating revision (webhook timeout) - status set to Unknown not False",
 		Ctx:  config.ToContext(context.Background(), config.FromContext(testCtx)),
-		// Webhook timeouts and other internal server errors are transient; the
-		// reconciler should retry without marking the Configuration as failed.
+		// Webhook timeouts surface as InternalError; the reconciler should set
+		// Ready=Unknown/RevisionCreationRetrying so clients keep waiting rather
+		// than treating the blip as a permanent failure.
 		WantErr: true,
 		WithReactors: []clientgotesting.ReactionFunc{
 			func(action clientgotesting.Action) (bool, runtime.Object, error) {
@@ -388,46 +388,14 @@ func TestReconcile(t *testing.T) {
 		},
 		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 			Object: cfg("transient-create-failure-internal", "foo", 99998,
-				WithConfigObservedGenFailure),
+				MarkRevisionCreationRetrying("Internal error occurred: failed calling webhook: context deadline exceeded"),
+				WithConfigObservedGen),
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision: Internal error occurred: failed calling webhook: context deadline exceeded"),
 			Eventf(corev1.EventTypeWarning, "InternalError", "failed to create Revision: Internal error occurred: failed calling webhook: context deadline exceeded"),
 		},
 		Key: "foo/transient-create-failure-internal",
-	}, {
-		Name: "transient failure creating revision (network/url error) - status not marked failed",
-		Ctx:  config.ToContext(context.Background(), config.FromContext(testCtx)),
-		// Network-level transport errors (GOAWAY, Content-Length mismatch) are
-		// transient; the reconciler should retry without marking Configuration as failed.
-		WantErr: true,
-		WithReactors: []clientgotesting.ReactionFunc{
-			func(action clientgotesting.Action) (bool, runtime.Object, error) {
-				if action.Matches("create", "revisions") {
-					return true, nil, &url.Error{
-						Op:  "Post",
-						URL: "https://webhook.knative-serving.svc:443/defaulting",
-						Err: errors.New("http2: server sent GOAWAY and closed the connection"),
-					}
-				}
-				return false, nil, nil
-			},
-		},
-		Objects: []runtime.Object{
-			cfg("transient-create-failure-network", "foo", 99998),
-		},
-		WantCreates: []runtime.Object{
-			rev("transient-create-failure-network", "foo", 99998),
-		},
-		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
-			Object: cfg("transient-create-failure-network", "foo", 99998,
-				WithConfigObservedGenFailure),
-		}},
-		WantEvents: []string{
-			Eventf(corev1.EventTypeWarning, "CreationFailed", `Failed to create Revision: Post "https://webhook.knative-serving.svc:443/defaulting": http2: server sent GOAWAY and closed the connection`),
-			Eventf(corev1.EventTypeWarning, "InternalError", `failed to create Revision: Post "https://webhook.knative-serving.svc:443/defaulting": http2: server sent GOAWAY and closed the connection`),
-		},
-		Key: "foo/transient-create-failure-network",
 	}, {
 		Name: "failure updating configuration status",
 		Ctx:  config.ToContext(context.Background(), config.FromContext(testCtx)),

--- a/pkg/reconciler/configuration/configuration_test.go
+++ b/pkg/reconciler/configuration/configuration_test.go
@@ -19,6 +19,8 @@ package configuration
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/url"
 	"testing"
 	"time"
 
@@ -364,6 +366,68 @@ func TestReconcile(t *testing.T) {
 			Eventf(corev1.EventTypeWarning, "InternalError", "failed to create Revision: inducing failure for create revisions"),
 		},
 		Key: "foo/create-revision-failure",
+	}, {
+		Name: "transient failure creating revision (internal server error) - status not marked failed",
+		Ctx:  config.ToContext(context.Background(), config.FromContext(testCtx)),
+		// Webhook timeouts and other internal server errors are transient; the
+		// reconciler should retry without marking the Configuration as failed.
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			func(action clientgotesting.Action) (bool, runtime.Object, error) {
+				if action.Matches("create", "revisions") {
+					return true, nil, apierrs.NewInternalError(fmt.Errorf("failed calling webhook: context deadline exceeded"))
+				}
+				return false, nil, nil
+			},
+		},
+		Objects: []runtime.Object{
+			cfg("transient-create-failure-internal", "foo", 99998),
+		},
+		WantCreates: []runtime.Object{
+			rev("transient-create-failure-internal", "foo", 99998),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: cfg("transient-create-failure-internal", "foo", 99998,
+				WithConfigObservedGenFailure),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeWarning, "CreationFailed", "Failed to create Revision: Internal error occurred: failed calling webhook: context deadline exceeded"),
+			Eventf(corev1.EventTypeWarning, "InternalError", "failed to create Revision: Internal error occurred: failed calling webhook: context deadline exceeded"),
+		},
+		Key: "foo/transient-create-failure-internal",
+	}, {
+		Name: "transient failure creating revision (network/url error) - status not marked failed",
+		Ctx:  config.ToContext(context.Background(), config.FromContext(testCtx)),
+		// Network-level transport errors (GOAWAY, Content-Length mismatch) are
+		// transient; the reconciler should retry without marking Configuration as failed.
+		WantErr: true,
+		WithReactors: []clientgotesting.ReactionFunc{
+			func(action clientgotesting.Action) (bool, runtime.Object, error) {
+				if action.Matches("create", "revisions") {
+					return true, nil, &url.Error{
+						Op:  "Post",
+						URL: "https://webhook.knative-serving.svc:443/defaulting",
+						Err: errors.New("http2: server sent GOAWAY and closed the connection"),
+					}
+				}
+				return false, nil, nil
+			},
+		},
+		Objects: []runtime.Object{
+			cfg("transient-create-failure-network", "foo", 99998),
+		},
+		WantCreates: []runtime.Object{
+			rev("transient-create-failure-network", "foo", 99998),
+		},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: cfg("transient-create-failure-network", "foo", 99998,
+				WithConfigObservedGenFailure),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeWarning, "CreationFailed", `Failed to create Revision: Post "https://webhook.knative-serving.svc:443/defaulting": http2: server sent GOAWAY and closed the connection`),
+			Eventf(corev1.EventTypeWarning, "InternalError", `failed to create Revision: Post "https://webhook.knative-serving.svc:443/defaulting": http2: server sent GOAWAY and closed the connection`),
+		},
+		Key: "foo/transient-create-failure-network",
 	}, {
 		Name: "failure updating configuration status",
 		Ctx:  config.ToContext(context.Background(), config.FromContext(testCtx)),

--- a/pkg/testing/v1/configuration.go
+++ b/pkg/testing/v1/configuration.go
@@ -62,6 +62,16 @@ func WithConfigObservedGen(cfg *v1.Configuration) {
 	cfg.Status.ObservedGeneration = cfg.Generation
 }
 
+// WithConfigObservedGenFailure marks the Configuration ready condition as Unknown
+// to indicate the reconciler saw a new generation but returned an error before
+// completing all status updates (e.g. transient create failure).
+func WithConfigObservedGenFailure(cfg *v1.Configuration) {
+	WithConfigObservedGen(cfg)
+	condSet := cfg.GetConditionSet()
+	condSet.Manage(&cfg.Status).MarkUnknown(condSet.GetTopLevelConditionType(),
+		"NewObservedGenFailure", "unsuccessfully observed a new generation")
+}
+
 // WithLatestCreated initializes the .status.latestCreatedRevisionName to be the name
 // of the latest revision that the Configuration would have created.
 func WithLatestCreated(name string) ConfigOption {

--- a/pkg/testing/v1/configuration.go
+++ b/pkg/testing/v1/configuration.go
@@ -62,14 +62,11 @@ func WithConfigObservedGen(cfg *v1.Configuration) {
 	cfg.Status.ObservedGeneration = cfg.Generation
 }
 
-// WithConfigObservedGenFailure marks the Configuration ready condition as Unknown
-// to indicate the reconciler saw a new generation but returned an error before
-// completing all status updates (e.g. transient create failure).
-func WithConfigObservedGenFailure(cfg *v1.Configuration) {
-	WithConfigObservedGen(cfg)
-	condSet := cfg.GetConditionSet()
-	condSet.Manage(&cfg.Status).MarkUnknown(condSet.GetTopLevelConditionType(),
-		"NewObservedGenFailure", "unsuccessfully observed a new generation")
+// MarkRevisionCreationRetrying calls .Status.MarkRevisionCreationRetrying.
+func MarkRevisionCreationRetrying(msg string) ConfigOption {
+	return func(cfg *v1.Configuration) {
+		cfg.Status.MarkRevisionCreationRetrying(msg)
+	}
 }
 
 // WithLatestCreated initializes the .status.latestCreatedRevisionName to be the name


### PR DESCRIPTION
## Problem

Fixes #10511

Transient infrastructure errors during revision creation (webhook timeouts, API server overload) were being set as `Ready=False/RevisionFailed`, causing `kn` and other clients to report permanent failures for conditions that the controller would successfully retry.

## Solution

### New lifecycle method

Added `MarkRevisionCreationRetrying(message string)` to `ConfigurationStatus`. This sets `Ready=Unknown` (not `False`) with reason `RevisionCreationRetrying`. Clients watching for `Ready=False` continue waiting; the error message and a warning event still surface the retry state for operators.

### Transient error detection

`isTransientCreateError` in the configuration reconciler returns `true` for HTTP codes whose semantics are definitively transient:

| Error | HTTP | Example |
|---|---|---|
| `IsInternalError` | 500 | `failed calling webhook: context deadline exceeded` |
| `IsServiceUnavailable` | 503 | API server overloaded |
| `IsServerTimeout` | 504 | Server-side timeout |
| `IsTimeout` | 408 | Request timeout |
| `IsTooManyRequests` | 429 | Rate limiting |

**`*url.Error` was explicitly excluded.** `url.Error` wraps permanent failures (TLS certificate mismatch, DNS failure for a non-existent webhook service, invalid URL) alongside transient ones, so it cannot reliably classify a failure as retriable. Using it would silently suppress `RevisionFailed` for permanently broken webhook configurations.

A comment in the code documents the known ambiguity of `IsInternalError`: a webhook service that is permanently unreachable (deleted service, wrong DNS) also surfaces as `InternalError`. A webhook that actively *rejects* the spec typically returns `Forbidden` or `Invalid`, not `InternalError`.

### Observability

The retry state is visible in `.status.conditions` (`RevisionCreationRetrying`) and in Kubernetes events (`CreationFailed` warning). Both fire on every retry. A follow-up is needed to add an escalation mechanism (e.g. attempt counter or duration threshold after which the status is demoted to `False`) — this is tracked in the issue.

## Tests

- Existing `"failure creating revision"` test unchanged — non-API errors (like `InduceFailure` plain errors) still produce `RevisionFailed/False`
- New test `"transient failure creating revision (webhook timeout)"` — verifies `Ready=Unknown/RevisionCreationRetrying` for `apierrs.NewInternalError`
- `MarkRevisionCreationRetrying` test helper added to `pkg/testing/v1/configuration.go`
- All `pkg/...` tests pass