### PR TITLE
fix: replace deprecated git.io goreleaser link in vendored gen-crd-api-reference-docs

### DIFF
--- a/vendor/github.com/ahmetb/gen-crd-api-reference-docs/.travis.yml
+++ b/vendor/github.com/ahmetb/gen-crd-api-reference-docs/.travis.yml
@@ -17,7 +17,7 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
-    script: curl -sL https://git.io/goreleaser | bash
+    script: curl -sL https://raw.githubusercontent.com/goreleaser/goreleaser/main/scripts/get.sh | bash
   # use github release feature to upload dist/
   - provider: releases
     skip_cleanup: true


### PR DESCRIPTION
## Proposed change

Replace `https://git.io/goreleaser` with the canonical goreleaser install script in `vendor/github.com/ahmetb/gen-crd-api-reference-docs/.travis.yml`. The git.io shortener is deprecated and was retired; using a direct URL avoids relying on redirects.

Fixes #16570

## Context

- Same pattern as updating other git.io links to stable destinations.
- This file is part of a vendored dependency; the change keeps the example Travis deploy script on a reliable URL.

## Release note

N/A (vendor metadata; upstream CI example only).
