### PR TITLE
Add IPv6 support for EndpointSlice creation and port replacement

### DIFF
--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"strconv"
@@ -184,8 +185,11 @@ func (a *activationHandler) proxyRequest(revID types.NamespacedName, w http.Resp
 // TODO: endpointsToDests() should support HTTPS instead of this overwrite but it needs metadata request to be encrypted.
 // This code should be removed when https://github.com/knative/serving/issues/12821 was solved.
 func useSecurePort(target string, port int) string {
-	target = strings.Split(target, ":")[0]
-	return target + ":" + strconv.Itoa(port)
+	host, _, err := net.SplitHostPort(target)
+	if err != nil {
+		host = target
+	}
+	return net.JoinHostPort(host, strconv.Itoa(port))
 }
 
 func WrapActivatorHandlerWithFullDuplex(h http.Handler, logger *zap.SugaredLogger) http.HandlerFunc {

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -290,6 +290,34 @@ func setupConfigStore(t testing.TB, logger *zap.SugaredLogger) *activatorconfig.
 	return configStore
 }
 
+func TestUseSecurePort(t *testing.T) {
+	tests := map[string]struct {
+		target string
+		port   int
+		want   string
+	}{
+		"ipv4": {
+			target: "10.0.0.1:8012",
+			port:   8112,
+			want:   "10.0.0.1:8112",
+		},
+		"ipv6": {
+			target: "[2001:db8::1]:8012",
+			port:   8112,
+			want:   "[2001:db8::1]:8112",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := useSecurePort(tc.target, tc.port)
+			if got != tc.want {
+				t.Errorf("useSecurePort(%q, %d) = %q, want %q", tc.target, tc.port, got, tc.want)
+			}
+		})
+	}
+}
+
 func BenchmarkHandler(b *testing.B) {
 	ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(b)
 	b.Cleanup(cancel)

--- a/pkg/autoscaler/statforwarder/forwarder_test.go
+++ b/pkg/autoscaler/statforwarder/forwarder_test.go
@@ -509,3 +509,28 @@ func TestIsBucketOwner(t *testing.T) {
 		t.Errorf("IsBktOwner(not-in-record) = %v, want true", got)
 	}
 }
+
+func TestAddressTypeForIP(t *testing.T) {
+	tests := map[string]struct {
+		ip   string
+		want discoveryv1.AddressType
+	}{
+		"ipv4": {
+			ip:   "10.0.0.1",
+			want: discoveryv1.AddressTypeIPv4,
+		},
+		"ipv6": {
+			ip:   "2001:db8::1",
+			want: discoveryv1.AddressTypeIPv6,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := addressTypeForIP(tc.ip)
+			if got != tc.want {
+				t.Errorf("addressTypeForIP(%q) = %v, want %v", tc.ip, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/autoscaler/statforwarder/leases.go
+++ b/pkg/autoscaler/statforwarder/leases.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"strconv"
 
 	"go.uber.org/zap"
@@ -245,7 +246,7 @@ func (f *leaseTracker) createOrUpdateEndpoints(ctx context.Context, ns, n string
 				discoveryv1.LabelServiceName: n,
 			},
 		},
-		AddressType: discoveryv1.AddressTypeIPv4,
+		AddressType: addressTypeForIP(f.selfIP),
 		Endpoints: []discoveryv1.Endpoint{{
 			Addresses: []string{f.selfIP},
 			Conditions: discoveryv1.EndpointConditions{
@@ -306,4 +307,12 @@ func (f *leaseTracker) createOrUpdateEndpoints(ctx context.Context, ns, n string
 	}
 
 	return nil
+}
+
+func addressTypeForIP(ip string) discoveryv1.AddressType {
+	addr, err := netip.ParseAddr(ip)
+	if err == nil && addr.Is6() {
+		return discoveryv1.AddressTypeIPv6
+	}
+	return discoveryv1.AddressTypeIPv4
 }


### PR DESCRIPTION
The autoscaler stat forwarder hardcoded AddressTypeIPv4 when creating EndpointSlices, which breaks on IPv6-only or dual-stack clusters. Additionally, useSecurePort used strings.Split on ":" to extract the host, which breaks on bracketed IPv6 addresses like [::1]:8012.

The issue in useSecurePort was spotted by AI, it does make sense to me though.

Reported by @matejvasek and verified locally in my IPv6 kind cluster, thanks again!
PR for fixing kourier will also follow.

## Proposed Changes
- Add addressTypeForIP helper to dynamically determine AddressType
- Fix useSecurePort to use net.SplitHostPort/net.JoinHostPort
- Add tests for both functions with IPv4 and IPv6 cases

/kind bug

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add IPv6 support for autoscaler EndpointSlice creation and activator port replacement
```
