### PR TITLE
add startupProbe validation

### DIFF
--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -545,11 +545,17 @@ func validateSidecarContainer(ctx context.Context, container corev1.Container, v
 			errs = errs.Also(apis.CheckDisallowedFields(*container.ReadinessProbe,
 				*ProbeMask(&corev1.Probe{})).ViaField("readinessProbe"))
 		}
+		if container.StartupProbe != nil {
+			errs = errs.Also(apis.CheckDisallowedFields(*container.StartupProbe,
+				*ProbeMask(&corev1.Probe{})).ViaField("startupProbe"))
+		}
 	} else if cfg.Features.MultiContainerProbing == config.Enabled {
 		// Liveness Probes
 		errs = errs.Also(validateProbe(container.LivenessProbe, nil, false).ViaField("livenessProbe"))
 		// Readiness Probes
 		errs = errs.Also(validateReadinessProbe(container.ReadinessProbe, nil, false).ViaField("readinessProbe"))
+		// Startup Probes
+		errs = errs.Also(validateProbe(container.StartupProbe, nil, false).ViaField("startupProbe"))
 	}
 
 	return errs.Also(validate(ctx, container, volumes))
@@ -591,6 +597,8 @@ func ValidateUserContainer(ctx context.Context, container corev1.Container, volu
 	errs = errs.Also(validateProbe(container.LivenessProbe, &port, true).ViaField("livenessProbe"))
 	// Readiness Probes
 	errs = errs.Also(validateReadinessProbe(container.ReadinessProbe, &port, true).ViaField("readinessProbe"))
+	// Startup Probes
+	errs = errs.Also(validateProbe(container.StartupProbe, &port, true).ViaField("startupProbe"))
 	return errs.Also(validate(ctx, container, volumes))
 }
 

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -2190,7 +2190,8 @@ func TestSidecarContainerValidation(t *testing.T) {
 			},
 		},
 		want: apis.ErrDisallowedFields("livenessProbe", "readinessProbe", "readinessProbe.failureThreshold", "readinessProbe.periodSeconds", "readinessProbe.successThreshold", "readinessProbe.timeoutSeconds",
-			"startupProbe", "startupProbe.failureThreshold", "startupProbe.periodSeconds", "startupProbe.successThreshold", "startupProbe.terminationGracePeriodSeconds", "startupProbe.timeoutSeconds")}, {
+			"startupProbe", "startupProbe.failureThreshold", "startupProbe.periodSeconds", "startupProbe.successThreshold", "startupProbe.terminationGracePeriodSeconds", "startupProbe.timeoutSeconds"),
+	}, {
 		name: "invalid probes (no port defined)",
 		c: corev1.Container{
 			Image: "foo",

--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -2189,8 +2189,8 @@ func TestSidecarContainerValidation(t *testing.T) {
 				TerminationGracePeriodSeconds: ptr.Int64(10),
 			},
 		},
-		want: apis.ErrDisallowedFields("livenessProbe", "readinessProbe", "readinessProbe.failureThreshold", "readinessProbe.periodSeconds", "readinessProbe.successThreshold", "readinessProbe.timeoutSeconds"),
-	}, {
+		want: apis.ErrDisallowedFields("livenessProbe", "readinessProbe", "readinessProbe.failureThreshold", "readinessProbe.periodSeconds", "readinessProbe.successThreshold", "readinessProbe.timeoutSeconds",
+			"startupProbe", "startupProbe.failureThreshold", "startupProbe.periodSeconds", "startupProbe.successThreshold", "startupProbe.terminationGracePeriodSeconds", "startupProbe.timeoutSeconds")}, {
 		name: "invalid probes (no port defined)",
 		c: corev1.Container{
 			Image: "foo",
@@ -2255,7 +2255,7 @@ func TestSidecarContainerValidation(t *testing.T) {
 				TerminationGracePeriodSeconds: ptr.Int64(10),
 			},
 		},
-		want: nil,
+		want: apis.ErrDisallowedFields("startupProbe", "startupProbe.failureThreshold", "startupProbe.periodSeconds", "startupProbe.successThreshold", "startupProbe.terminationGracePeriodSeconds", "startupProbe.timeoutSeconds"),
 	}, {
 		name: "valid with startup probe and multi container probing",
 		c: corev1.Container{
@@ -2268,6 +2268,7 @@ func TestSidecarContainerValidation(t *testing.T) {
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/",
+						Port: intstr.FromInt32(5000),
 					},
 				},
 				TerminationGracePeriodSeconds: ptr.Int64(10),


### PR DESCRIPTION
Fixes #16256

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add startup probe validation in `validateUserContainer` and `validateSidecarContainer`
* Update existing tests that included startup probes but had no expected errors since the validation was missing


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
 Add validation for startup probes in user and sidecar containers 
```
