### PR TITLE
fix(autoscaling): duplicated "the" in register.go doc-comment

### DIFF
--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -28,7 +28,7 @@ const (
 	// InternalGroupName is the internal autoscaling group name. This is used for CRDs.
 	InternalGroupName = "autoscaling.internal.knative.dev"
 
-	// GroupName is the the public autoscaling group name. This is used for annotations, labels, etc.
+	// GroupName is the public autoscaling group name. This is used for annotations, labels, etc.
 	GroupName = "autoscaling.knative.dev"
 
 	// ClassAnnotationKey is the annotation for the explicit class of autoscaler


### PR DESCRIPTION
One-line typo fix in `pkg/apis/autoscaling/register.go`: "// GroupName is the the public autoscaling group name. This is used for annotations, labels, etc." → "// GroupName is the public autoscaling group name. This is used for annotations, labels, etc.". No code/behavior change.

Signed-off-by: Mira Sato <275437409+oab24413gmai@users.noreply.github.com>