### PR TITLE
test: add missing readiness and startup probe tests for init containers

### DIFF
--- a/pkg/apis/serving/k8s_validation_test.go
+++ b/pkg/apis/serving/k8s_validation_test.go
@@ -2582,6 +2582,38 @@ func TestInitContainerValidation(t *testing.T) {
 			Paths:   []string{"livenessProbe"},
 		},
 	}, {
+		name: "has readiness probe",
+		c: corev1.Container{
+			Image: "foo",
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					TCPSocket: &corev1.TCPSocketAction{
+						Port: intstr.FromString("http"),
+					},
+				},
+			},
+		},
+		want: &apis.FieldError{
+			Message: "field not allowed in an init container",
+			Paths:   []string{"readinessProbe"},
+		},
+	}, {
+		name: "has startup probe",
+		c: corev1.Container{
+			Image: "foo",
+			StartupProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					TCPSocket: &corev1.TCPSocketAction{
+						Port: intstr.FromString("http"),
+					},
+				},
+			},
+		},
+		want: &apis.FieldError{
+			Message: "field not allowed in an init container",
+			Paths:   []string{"startupProbe"},
+		},
+	}, {
 		name: "disallowed container fields",
 		c: corev1.Container{
 			Image:     "foo",


### PR DESCRIPTION
Follows up on #16594 which added startupProbe validation across the board.

`TestInitContainerValidation` already tests that `livenessProbe` is rejected on init containers (correct, since k8s doesnt support probes there), but `readinessProbe` and `startupProbe` had no test coverage for the same behavior - even tho the validation code handles them just fine.

## Proposed Changes

* Add "has readiness probe" test case to `TestInitContainerValidation`
* Add "has startup probe" test case to `TestInitContainerValidation`

Both expect "field not allowed in an init container" error, consistent with the existing liveness probe test.

**Reproduce the gap:**
```
go test ./pkg/apis/serving/... -run TestInitContainerValidation -v
# no test for readinessProbe or startupProbe disallowed on init containers
```

**Release Note**

```release-note
NONE
```