### PR TITLE
feat: add TerminationGracePeriodSeconds support to liveness probe

### DIFF
--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -925,6 +925,17 @@ func validateProbe(p *corev1.Probe, port *corev1.ContainerPort, isUserContainer 
 	} else if len(handlers) > 1 {
 		errs = errs.Also(apis.ErrMultipleOneOf(handlers...))
 	}
+
+	// Validate TerminationGracePeriodSeconds if set
+	if p.TerminationGracePeriodSeconds != nil {
+		if *p.TerminationGracePeriodSeconds < 0 {
+			errs = errs.Also(&apis.FieldError{
+				Message: "terminationGracePeriodSeconds must be non-negative",
+				Paths:   []string{"terminationGracePeriodSeconds"},
+			})
+		}
+	}
+
 	return errs
 }
 

--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -138,6 +138,7 @@ func (rs *RevisionSpec) applyDefault(ctx context.Context, container *corev1.Cont
 	}
 	rs.applyReadinessProbeDefaults(container)
 	rs.applyGRPCProbeDefaults(container)
+	rs.applyLivenessProbeDefaults(container)
 
 	if rs.PodSpec.EnableServiceLinks == nil && apis.IsInCreate(ctx) {
 		rs.PodSpec.EnableServiceLinks = cfg.Defaults.EnableServiceLinks
@@ -200,6 +201,14 @@ func (*RevisionSpec) applyGRPCProbeDefaults(container *corev1.Container) {
 	}
 	if container.StartupProbe != nil && container.StartupProbe.GRPC != nil && container.StartupProbe.GRPC.Service == nil {
 		container.StartupProbe.GRPC.Service = ptr.String("")
+	}
+}
+
+// applyLivenessProbeDefaults applies default TerminationGracePeriodSeconds to liveness probe
+func (*RevisionSpec) applyLivenessProbeDefaults(container *corev1.Container) {
+	if container.LivenessProbe != nil && container.LivenessProbe.TerminationGracePeriodSeconds == nil {
+		// Default to 1 second for liveness probe termination grace period
+		container.LivenessProbe.TerminationGracePeriodSeconds = ptr.Int64(1)
 	}
 }
 


### PR DESCRIPTION
Addresses issue #15823.

Adds validation and defaulting for the  field in liveness probes for Knative revisions.

Changes:
- pkg/apis/serving/k8s_validation.go: Added validation for  (must be non-negative)
- pkg/apis/serving/v1/revision_defaults.go: Added defaulting function  that sets  when liveness probe is configured but  is not set
- Called  in 

The field was already allowed via ProbeMask in fieldmask.go (line 392), but lacked validation and defaulting.

Closes #15823.