### PR TITLE
Replace duplicate intMax helpers with builtin max

### DIFF
--- a/pkg/reconciler/autoscaling/hpa/hpa.go
+++ b/pkg/reconciler/autoscaling/hpa/hpa.go
@@ -118,9 +118,9 @@ func activeThreshold(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscaler)
 	min, _ := pa.ScaleBounds(asConfig)
 	if !pa.Status.IsScaleTargetInitialized() {
 		initialScale := getInitialScale(asConfig, pa)
-		return intMax(min, initialScale)
+		return max(min, initialScale)
 	}
-	return intMax(min, 1)
+	return max(min, 1)
 }
 
 // getInitialScale returns the calculated initial scale based on the autoscaler
@@ -132,11 +132,4 @@ func getInitialScale(asConfig *autoscalerconfig.Config, pa *autoscalingv1alpha1.
 		return initialScale
 	}
 	return revisionInitialScale
-}
-
-func intMax(a, b int32) int32 {
-	if a < b {
-		return b
-	}
-	return a
 }

--- a/pkg/reconciler/autoscaling/kpa/kpa.go
+++ b/pkg/reconciler/autoscaling/kpa/kpa.go
@@ -327,9 +327,9 @@ func activeThreshold(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscaler)
 	min, _ := pa.ScaleBounds(asConfig)
 	if !pa.Status.IsScaleTargetInitialized() {
 		initialScale := resources.GetInitialScale(asConfig, pa)
-		return int(intMax(min, initialScale))
+		return int(max(min, initialScale))
 	}
-	return int(intMax(min, 1))
+	return int(max(min, 1))
 }
 
 // resolveScrapeTarget returns metric service name to be scraped based on TBC configuration
@@ -349,13 +349,6 @@ func resolveTBC(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscaler) floa
 	}
 
 	return config.FromContext(ctx).Autoscaler.TargetBurstCapacity
-}
-
-func intMax(a, b int32) int32 {
-	if a < b {
-		return b
-	}
-	return a
 }
 
 func computeNumActivators(readyPods int, decider *scaling.Decider) int32 {

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -338,11 +338,11 @@ func (ks *scaler) scale(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscal
 		return desiredScale, nil
 	}
 
-	min, max := pa.ScaleBounds(asConfig)
+	min, maxScale := pa.ScaleBounds(asConfig)
 	initialScale := kparesources.GetInitialScale(asConfig, pa)
 	// Log reachability as quoted string, since default value is "".
 	logger.Debugf("MinScale = %d, MaxScale = %d, InitialScale = %d, DesiredScale = %d Reachable = %q",
-		min, max, initialScale, desiredScale, pa.Spec.Reachability)
+		min, maxScale, initialScale, desiredScale, pa.Spec.Reachability)
 	// If initial scale has been attained, ignore the initialScale altogether.
 	// Also ignore initialScale if the revision is unreachable (routingState = "reserve"),
 	// allowing it to scale down to 0 immediately.
@@ -351,9 +351,9 @@ func (ks *scaler) scale(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscal
 		if min < initialScale {
 			logger.Debugf("Adjusting min to meet the initial scale: %d -> %d", min, initialScale)
 		}
-		min = intMax(initialScale, min)
+		min = max(initialScale, min)
 	}
-	if newScale := applyBounds(min, max, desiredScale); newScale != desiredScale {
+	if newScale := applyBounds(min, maxScale, desiredScale); newScale != desiredScale {
 		logger.Debugf("Adjusting desiredScale to meet the min and max bounds before applying: %d -> %d", desiredScale, newScale)
 		desiredScale = newScale
 	}

--- a/pkg/reconciler/autoscaling/kpa/scaler.go
+++ b/pkg/reconciler/autoscaling/kpa/scaler.go
@@ -338,22 +338,22 @@ func (ks *scaler) scale(ctx context.Context, pa *autoscalingv1alpha1.PodAutoscal
 		return desiredScale, nil
 	}
 
-	min, maxScale := pa.ScaleBounds(asConfig)
+	minScale, maxScale := pa.ScaleBounds(asConfig)
 	initialScale := kparesources.GetInitialScale(asConfig, pa)
 	// Log reachability as quoted string, since default value is "".
 	logger.Debugf("MinScale = %d, MaxScale = %d, InitialScale = %d, DesiredScale = %d Reachable = %q",
-		min, maxScale, initialScale, desiredScale, pa.Spec.Reachability)
+		minScale, maxScale, initialScale, desiredScale, pa.Spec.Reachability)
 	// If initial scale has been attained, ignore the initialScale altogether.
 	// Also ignore initialScale if the revision is unreachable (routingState = "reserve"),
 	// allowing it to scale down to 0 immediately.
 	if initialScale > 1 && !pa.Status.IsScaleTargetInitialized() && pa.Spec.Reachability != autoscalingv1alpha1.ReachabilityUnreachable {
 		// Ignore initial scale if minScale >= initialScale.
-		if min < initialScale {
-			logger.Debugf("Adjusting min to meet the initial scale: %d -> %d", min, initialScale)
+		if minScale < initialScale {
+			logger.Debugf("Adjusting minScale to meet the initial scale: %d -> %d", minScale, initialScale)
 		}
-		min = max(initialScale, min)
+		minScale = max(initialScale, minScale)
 	}
-	if newScale := applyBounds(min, maxScale, desiredScale); newScale != desiredScale {
+	if newScale := applyBounds(minScale, maxScale, desiredScale); newScale != desiredScale {
 		logger.Debugf("Adjusting desiredScale to meet the min and max bounds before applying: %d -> %d", desiredScale, newScale)
 		desiredScale = newScale
 	}


### PR DESCRIPTION
Fixes #16664

## Proposed Changes

- Replace the duplicated `intMax` helpers in the KPA and HPA reconcilers with Go's built-in `max()` function.
- Remove the now-unused `intMax` helper implementations from both packages.
- Rename the local `max` variable in `kpa/scaler.go` to `maxScale` to avoid shadowing the built-in `max()` function.
