### PR TITLE
Fix flaky TestMinScaleAnnotationChange by waiting for scale convergence

### DIFF
--- a/test/e2e/minscale_readiness_test.go
+++ b/test/e2e/minscale_readiness_test.go
@@ -418,6 +418,14 @@ func TestMinScaleAnnotationChange(t *testing.T) {
 	serviceName := PrivateServiceName(t, clients, revName)
 	revClient := clients.ServingClient.Revisions
 
+	// Wait for the KPA to reconcile and scale to converge before
+	// asserting stability. The Service can report Ready before the
+	// deployment has reached the desired replica count.
+	// See: https://github.com/knative/serving/issues/16653
+	if lr, err := waitForDesiredScale(clients, serviceName, eq(minScale[0])); err != nil {
+		t.Fatalf("The revision %q never reached scale %d: last observed %d", revName, minScale[0], lr)
+	}
+
 	t.Log("Holding revision at minScale after becoming ready")
 	if lr, ok := ensureDesiredScale(clients, t, serviceName, eq(minScale[0])); !ok {
 		t.Fatalf("The revision %q observed scale %d < %d after becoming ready", revName, lr, minScale)


### PR DESCRIPTION
## What

Fix the recurring flaky `TestMinScaleAnnotationChange` e2e test by adding a `waitForDesiredScale` call before `ensureDesiredScale`.

## Why

The test calls `ensureDesiredScale` (which asserts scale stability for 30s) immediately after the Configuration reports `Ready`. However, the KPA reconciles scale asynchronously — the deployment may not have reached the target replica count yet when `Ready` is reported. If the scale is briefly at 0 during KPA convergence, `ensureDesiredScale` catches that transient state and hard-fails.

This has been auto-reported as flaky twice and auto-closed both times without a real fix:
- #16527 (April 2026 — auto-closed)
- #16653 (June 2026 — auto-closed)
- Nightly failure July 21, 2026: [build log](https://prow.knative.dev/view/gs/knative-prow/logs/nightly_serving_main_periodic/2079495419083100160)

## Fix

Add `waitForDesiredScale` (polls up to 3 min for convergence) before `ensureDesiredScale` (asserts stability for 30s). This matches the pattern already used in the annotation-change loop body (line 443), which does not exhibit this flake.

## Other call sites

Lines 134, 203, 308, and 341 in the same file have the same `ensureDesiredScale`-without-convergence-wait pattern. These could also be flaky but are not currently failing. Happy to fix those in a follow-up PR if maintainers agree.

/kind bug