### PR TITLE
Use registry.localhost in e2e CI workflow

### DIFF
--- a/.github/workflows/kind-e2e.yaml
+++ b/.github/workflows/kind-e2e.yaml
@@ -12,13 +12,13 @@ defaults:
     shell: bash
 
 env:
-  # https://github.com/google/go-containerregistry/pull/125 allows insecure registry for
-  # '*.local' hostnames. This works both for `ko` and our own tag-to-digest resolution logic,
-  # thus allowing us to test without bypassing tag-to-digest resolution.
+  # go-containerregistry treats '*.localhost' hostnames as insecure (plain HTTP),
+  # which lets both `ko` and our own tag-to-digest resolution logic work against
+  # the local registry without TLS.
   CLUSTER_DOMAIN: c${{ github.run_id }}.local
-  REGISTRY_NAME: registry.local
+  REGISTRY_NAME: registry.localhost
   REGISTRY_PORT: 5000
-  KO_DOCKER_REPO: registry.local:5000/knative
+  KO_DOCKER_REPO: registry.localhost:5000/knative
   GOTESTSUM_VERSION: 1.12.0
   KO_FLAGS: --platform=linux/amd64
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -182,6 +182,7 @@ jobs:
         k8s-version: ${{ matrix.k8s-version }}
         kind-worker-count: 4
         cluster-suffix: c${{ github.run_id }}.local
+        registry-authority: registry.localhost:5000
         registry-volume: $HOME/artifacts/registry
 
     - name: Install Dependencies


### PR DESCRIPTION
## Summary

go-containerregistry [PR #2281](https://github.com/google/go-containerregistry/pull/2281) (in v0.21.6) narrowed the insecure HTTP fallback from `*.local` to `*.localhost` only. ko v0.19.0 picked this up, breaking the e2e workflow's local registry push:

```
Get "https://registry.local:5000/v2/": http: server gave HTTP response to HTTPS client
```

Renaming the registry from `registry.local` to `registry.localhost` fixes this.

Might need to cherry-pick this onto release branches in case they also use the latest ko version.

## Changes

- Update `registry.local` to `registry.localhost` in e2e workflow
- Pass `registry-authority` to `setup-kind` to match